### PR TITLE
add platform independent path separator and a way to create paths from Luna

### DIFF
--- a/stdlib/Std/src/Base.luna
+++ b/stdlib/Std/src/Base.luna
@@ -162,6 +162,8 @@ native class Text:
         Just val: val
         Nothing:  errorStr ("Could not convert " + self + " to a Real")
 
+    def addPathSegment segment: self + pathSeparator + segment
+
 ## Class for representing arbitrary binary data. Does not attempt to interpret the data in any way.
 native class Binary:
     ## Concatenates two pieces of binary data together.

--- a/stdlib/package.yaml
+++ b/stdlib/package.yaml
@@ -20,6 +20,7 @@ dependencies:
     - luna-syntax-text-parser
     - mtl
     - transformers
+    - filepath
     - exceptions
     - typelevel
     - luna-passes

--- a/stdlib/src/Luna/Builtin/Std.hs
+++ b/stdlib/src/Luna/Builtin/Std.hs
@@ -11,6 +11,7 @@ import           Control.DeepSeq                              (rnf)
 import qualified Control.Exception                            as Exception
 import           Control.Monad.Except
 import           Control.Monad.Trans.State                    (evalStateT, get)
+import           System.FilePath                              (pathSeparator)
 
 import qualified Data.Aeson                                   as Aeson
 import qualified Data.Bifunctor                               as Bifunc
@@ -890,12 +891,18 @@ systemStd std = do
     let hSetBufferingVal :: Handle -> BufferMode -> LunaEff ()
         hSetBufferingVal = withExceptions .: Handle.hSetBuffering
     hSetBuffering' <- typeRepForIO (toLunaValue std hSetBufferingVal) [LCons "FileHandle" [], LCons "BufferMode" []] (LCons "None" [])
+
+    let pathSepVal :: Text
+        pathSepVal = convert pathSeparator
+    pathSep <- typeRepForPure (toLunaValue std pathSepVal) [] (LCons "Text" [])
+
     let systemFuncs = Map.fromList [ ("putStr", printLn)
                                    , ("errorStr", err)
                                    , ("runError", runErr)
                                    , ("primReadFile", readFileF)
                                    , ("expandPath", expandPathF)
                                    , ("readBinary", readBinaryF)
+                                   , ("pathSeparator", pathSep)
                                    , ("primWriteFile", writeFile')
                                    , ("parseJSON", parseJSON)
                                    , ("parseMsgPack", parseMsgPack)


### PR DESCRIPTION
This is necessary for writing portable code between windows and posix systems.