### PR TITLE
Update References to Luna to be Enso

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Issues with the IDE?
-    url: https://github.com/luna/ide/issues/new/choose
+    url: https://github.com/enso-org/ide/issues/new/choose
     about: Please report problems with the IDE here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,5 +14,5 @@
 Please include the following checklist in your PR:
 
 - [ ] The documentation has been updated if necessary.
-- [ ] All code conforms to the [Scala](https://github.com/luna/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/luna/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guides.
+- [ ] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/main/docs/style-guide/rust.md) style guides.
 - [ ] All code has been tested where possible.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        repository: 'luna/luna.github.io'
+        repository: 'enso/enso-org.github.io'
         ref: 'sources'
         token: ${{ secrets.ENSO_PAT }}
     - name: set identity email

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ compiler, type-checker, runtime and language server. These components implement
 Enso the language in its entirety, and are usable in isolation.
 
 ### Getting Started
-Enso is distributed as 
+Enso is distributed as
 [pre-built packages](https://github.com/enso-org/enso/releases)
 for MacOS, Linux and Windows, as well as universal `.jar` packages that can run
 anywhere that [GraalVM](https://graalvm.org) can. See the
@@ -96,7 +96,7 @@ the decisions that have been made through Enso's evolution.
 ### License
 This repository is licensed under the
 [Apache 2.0](https://opensource.org/licenses/apache-2.0), as specified in the
-[LICENSE](https://github.com/luna/enso/blob/main/LICENSE) file.
+[LICENSE](https://github.com/enso-org/enso/blob/main/LICENSE) file.
 
 This license set was choosen to both provide you with a complete freedom to use
 Enso, create libraries, and release them under any license of your choice, while
@@ -120,6 +120,6 @@ If you believe that you have found a security vulnerability in Enso, or that
 you have a bug report that poses a security risk to Enso's users, please take
 a look at our [security guidelines](./docs/SECURITY.md) for a course of action.
 
-<a href="https://github.com/luna/enso/graphs/contributors">
+<a href="https://github.com/enso-org/enso/graphs/contributors">
   <img src="https://opencollective.com/enso-language/contributors.svg?width=890&button=false">
 </a>

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -92,7 +92,7 @@ about cool technology! You will find that people will be eager to assume good
 intent and forgive as long as there is an atmosphere of trust.
 
 The enforcement policies listed above apply to all official Enso venues. This
-includes the official discord and GitHub repositories under `luna`.
+includes the official discord and GitHub repositories under `enso-org`.
 
 > Adapted from the [Node.js Policy on Trolling](http://blog.izs.me/post/30036893703/policy-on-trolling)
 > as well as the [Contributor Covenant v1.3.0](https://www.contributor-covenant.org/version/1/3/0/).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -45,8 +45,8 @@ so you will only have to sign it once at the start of your contributions.
 If you're wanting to get involved with Enso's development and are looking for
 somewhere to start, you can check out the following tags in our issues:
 
-- [Good First Issue](https://github.com/luna/enso/labels/Status%3A%20Good%20First%20Issue)
-- [Help Wanted](https://github.com/luna/enso/labels/Status%3A%20Help%20Wanted)
+- [Good First Issue](https://github.com/enso-org/enso/labels/Status%3A%20Good%20First%20Issue)
+- [Help Wanted](https://github.com/enso-org/enso/labels/Status%3A%20Help%20Wanted)
 
 You can use the "Size" and "Difficulty" labels that should be assigned to every
 issue to get a better idea of how much work a given issue might be.
@@ -62,7 +62,7 @@ language, the compiler, and the runtime in a way that ensures that they get
 seen and discussed by all the major stakeholders involved.
 
 If, on the other hand, you're asking for a smaller feature, please feel free to
-submit a [feature request](https://github.com/luna/enso/issues/new?assignees=&labels=Type%3A+Enhancement&template=feature-request.md&title=)
+submit a [feature request](https://github.com/enso-org/enso/issues/new?assignees=&labels=Type%3A+Enhancement&template=feature-request.md&title=)
 to the repository.
 
 ## Bug Reports
@@ -76,13 +76,13 @@ users of Enso, please look at our [security guidelines](./SECURITY.md).**
 
 Even though GitHub search can be a bit hard to use sometimes, we'd appreciate if
 you could
-[search](https://github.com/luna/enso/search?q=&type=Issues&utf8=%E2%9C%93) for
+[search](https://github.com/enso-org/enso/search?q=&type=Issues&utf8=%E2%9C%93) for
 your issue before filing a bug as it's possible that someone else has already
 reported the issue. We know the search isn't the best, and it can be hard to
 know what to search for, so we really don't mind if you do submit a duplicate!
 
 Opening an issue is as easy as following
-[this link](https://github.com/luna/enso/issues/new?template=bug-report.md)
+[this link](https://github.com/enso-org/enso/issues/new?template=bug-report.md)
 and filling out the fields. The template is intended to collect all the
 information we need to best diagnose the issue, so please take the time to fill
 it out accurately.
@@ -137,7 +137,7 @@ inkling where to look!. You can clone Enso using two methods:
   read-only.
 
 ```
-git clone https://github.com/luna/enso.git
+git clone https://github.com/enso-org/enso.git
 ```
 
 - **Via SSH:** For those who plan on regularly making direct commits, cloning
@@ -145,7 +145,7 @@ git clone https://github.com/luna/enso.git
   SSH Keys with GitHub).
 
 ```
-git clone git@github.com:luna/enso.git
+git clone git@github.com:enso-org/enso.git
 ```
 
 ### Building Enso
@@ -259,7 +259,7 @@ performance, so it is not part of our roadmap currently.
 If you would like to experiment with it, you can execute the `buildNativeImage`
 command in the sbt shell while inside the `runner` project. Please note
 that while the command is available at the moment, and you are welcome to
-[report an issue](https://github.com/luna/enso/issues/new?assignees=&labels=Type%3A+Bug&template=bug-report.md&title=)
+[report an issue](https://github.com/enso-org/enso/issues/new?assignees=&labels=Type%3A+Bug&template=bug-report.md&title=)
 with the functionality, any bugs you report will _not_ be considered high
 priority.
 
@@ -333,7 +333,7 @@ filing an issue with us.
   above for instructions.
 
 If your problem was not listed above, please
-[file a bug report](https://github.com/luna/enso/issues/new?assignees=&labels=Type%3A+Bug&template=bug-report.md&title=)
+[file a bug report](https://github.com/enso-org/enso/issues/new?assignees=&labels=Type%3A+Bug&template=bug-report.md&title=)
 in our issue tracker and we will get back to you as soon as possible.
 
 ### Running Enso
@@ -426,7 +426,7 @@ Documentation pull requests will be reviewed in exactly the same way as normal
 pull requests.
 
 To find documentation-related issues, sort by the
-[Category: Documentation](hhttps://github.com/luna/enso/labels/Category%3A%20Documentation)
+[Category: Documentation](hhttps://github.com/enso-org/enso/labels/Category%3A%20Documentation)
 label.
 
 ## Issue Triage
@@ -436,25 +436,25 @@ times, a bug might go stale because something has changed in the meantime.
 It can be helpful to go through older bug reports and make sure that they are
 still valid. Load up an older issue, double check that it's still true, and
 leave a comment letting us know if it is or is not. The
-[least recently updated](https://github.com/luna/enso/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-asc)
+[least recently updated](https://github.com/enso-org/enso/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-asc)
 sort is good for finding issues like this.
 
 Contributors with sufficient permissions can help by adding labels to help with
 issue triage.
 
 If you're looking for somewhere to start, take a look at the
-[Difficulty: Beginner](https://github.com/luna/enso/labels/Difficulty%3A%20Beginner)
+[Difficulty: Beginner](https://github.com/enso-org/enso/labels/Difficulty%3A%20Beginner)
 issue label, as well as the
-[Status: Help Wanted](https://github.com/luna/enso/labels/Status%3A%20Help%20Wanted)
+[Status: Help Wanted](https://github.com/enso-org/enso/labels/Status%3A%20Help%20Wanted)
 and
-[Status: Good First Issue](https://github.com/luna/enso/labels/Status%3A%20Good%20First%20Issue) labels.
+[Status: Good First Issue](https://github.com/enso-org/enso/labels/Status%3A%20Good%20First%20Issue) labels.
 
 ## Out-of-Tree Contributions
 As helpful as contributing to Enso directly is, it can also be just as helpful
 to contribute in other ways outside this repository:
 
 - Answer questions in the [Discord](https://chat.luna-lang.org) or on
-  [StackOverflow](https://stackoverflow.com/questions/tagged/luna).
+  [StackOverflow](https://stackoverflow.com/questions/tagged/enso).
 
 ## Helpful Documentation and Links
 For people new to Enso, and just starting to contribute, or even for more

--- a/docs/distribution/README.md
+++ b/docs/distribution/README.md
@@ -11,6 +11,6 @@ Documents in this section deal with the process of packaging both Enso and its
 dependencies, and Enso projects for use by our users.
 
 - [**Distribution:**](./distribution.md) Information on how we distribute Enso
-  to our users, and for use by the [IDE](https://github.com/luna/ide).
+  to our users, and for use by the [IDE](https://github.com/enso-org/ide).
 - [**Packaging:**](./packaging.md) Information on the structure of an Enso
   project/package.

--- a/docs/getting-enso.md
+++ b/docs/getting-enso.md
@@ -8,7 +8,7 @@ order: 5
 
 # Getting Enso
 Enso packages can currently be obtained from the per-commit CI builds.
-See [the build workflow on GitHub Actions](https://github.com/luna/enso/actions?query=workflow%3A%22Enso+CI%22).
+See [the build workflow on GitHub Actions](https://github.com/enso-lang/enso/actions?query=workflow%3A%22Enso+CI%22).
 The artifact of interest is `enso-<version>` (currently `enso-0.0.1`).
 
 <!-- MarkdownTOC levels="2,3" autolink="true" -->
@@ -26,7 +26,7 @@ GraalVM. You can get the Community Edition pre-built distributions from
 It is important to run Enso with exactly the version specified here. Given that
 Graal is still a relatively young project, even the minor version changes
 introduce breaking API changes. The current version of GraalVM required for
-Enso is `20.1.0`.
+Enso is `20.1.0`, and it must be the Java 8 build.
 
 Before running the Enso packages, make sure that the `JAVA_HOME` environment
 variable points to the correct home location of the Graal distribution.
@@ -35,14 +35,14 @@ variable points to the correct home location of the Graal distribution.
 The distribution contains two main executables of interest:
 
 1. The project manager. This executable is currently used for testing the IDE,
-   though in the future it will rarely be run directly and rather will be 
+   though in the future it will rarely be run directly and rather will be
    launched automatically by the IDE. To run the project manager, run the
    `bin/project-manager` script (Linux and MacOS) or the
    `bin/project-manager.bat` script (Windows).
 2. The Enso CLI. This allows to create and run Enso projects from the command
    line. To launch the Enso CLI, run the `bin/enso` script (Linux and MacOS) or
    the `bin/enso.bat` script (Windows).
-   
+
 Again, it is necessary for you to set the `JAVA_HOME` variable correctly.
 
 ## Troubleshooting

--- a/docs/getting-enso.md
+++ b/docs/getting-enso.md
@@ -8,7 +8,7 @@ order: 5
 
 # Getting Enso
 Enso packages can currently be obtained from the per-commit CI builds.
-See [the build workflow on GitHub Actions](https://github.com/enso-lang/enso/actions?query=workflow%3A%22Enso+CI%22).
+See [the build workflow on GitHub Actions](https://github.com/enso-org/enso/actions?query=workflow%3A%22Enso+CI%22).
 The artifact of interest is `enso-<version>` (currently `enso-0.0.1`).
 
 <!-- MarkdownTOC levels="2,3" autolink="true" -->

--- a/docs/infrastructure/java-11.md
+++ b/docs/infrastructure/java-11.md
@@ -26,7 +26,7 @@ it. Thus, we want to move to using Graal builds for Java 11.
 ## Migration progress
 The overall steps of the migration and their status are outlined in this
 section. The task is tracked as issue
-[#671](https://github.com/luna/enso/issues/671).
+[#671](https://github.com/enso-org/enso/issues/671).
 
 ### Build configuration
 Currently, the only modification was the removal of the option

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -93,7 +93,7 @@ The process for creating an RFC can be outlined as follows:
    about the drawbacks or alternatives are likely to meet a poor reception. One
    of the key points for considering RFCs is how they fit with the vision for
    Enso as a whole.
-4. Submit a [Pull Request](https://github.com/luna/enso/pulls). Please give
+4. Submit a [Pull Request](https://github.com/enso-org/enso/pulls). Please give
    the PR a descriptive title (`RFC: My Feature`). The Pull Request will be
    open for feedback and discussion from the community and core team, and the
    author should be open to revising it in response to this feedback. The RFC
@@ -160,7 +160,7 @@ and from the old.
 Some accepted RFCs are vital features that need to be implemented as soon as
 possible, while others can wait until a so-inclined developer comes along. Every
 accepted RFC is assigned a tracking issue in the
-[Luna](https://github.com/luna/enso/) repository, and is then assigned a
+[Enso](https://github.com/enso-org/enso/) repository, and is then assigned a
 priority via the Enso repository triage process.
 
 The author of an RFC is not obligated to implement it. Of course, the RFC author

--- a/docs/runtime/runtime-features.md
+++ b/docs/runtime/runtime-features.md
@@ -182,7 +182,7 @@ essentially ruling it out in this category.
 
 With GraalVM supporting not only our primary interoperability targets, but also
 the whole JVM ecosystem and any language that targets LLVM, it is an absolute
-dream for ensuring that Luna can seamlessly communicate with a whole host of
+dream for ensuring that Enso can seamlessly communicate with a whole host of
 other programming languages.
 
 ### Implementation Performance
@@ -248,9 +248,8 @@ it has been extended significantly to better support Enso's use-cases.
   (`expandOptionalArgs`, which expands all defaulted arguments in a call with
   the defaults as the values). Needs to account for on-demand opt, metadata
   handling.
-- A description of how a Luna process should manage source files in server mode,
+- A description of how a Enso process should manage source files in server mode,
   including a description of changesets (dual payload, text diff or AST diff).
-- https://github.com/luna/luna/issues/365
 -->
 
 ## Filesystem Driver
@@ -357,8 +356,8 @@ to provide a seamless interface to foreign code from inside Enso.
 <!-- TODO
 - A design for standard, unsafe, C-level FFI using JNI.
 - A design for what types can be exposed across the C-FFI boundary.
-- A design for how to expose foreign languages to Luna in a safe fashion.
-- An analysis of how Luna can minimise the conversions that take place when
+- A design for how to expose foreign languages to Enso in a safe fashion.
+- An analysis of how Enso can minimise the conversions that take place when
   going between languages.
 -->
 

--- a/docs/style-guide/haskell.md
+++ b/docs/style-guide/haskell.md
@@ -462,7 +462,7 @@ We have our own exception framework based on `ExceptT` that encodes exception
 usage at the type level. This ensures that all synchronous exceptions must be
 dealt with.
 
-It is defined in [`lib/exception/`](https://github.com/luna/luna/tree/master/lib/exception)
+It is defined in [`lib/exception/`](https://github.com/enso-org/luna/tree/master/lib/exception)
 and contains utilities for declaring that a function throws an exception, as
 well as throwing and catching exceptions.
 
@@ -642,7 +642,7 @@ extension (linked from the extension's table below).
 The following language extensions are considered to be so safe, or to have such
 high utility, that they are considered to be Enso's set of default extensions.
 You can find said set of extensions for Enso itself defined in a
-[common configuration file](https://github.com/luna/luna/blob/master/config/hpack-common.yaml).
+[common configuration file](https://github.com/enso-org/luna/blob/master/config/hpack-common.yaml).
 
 #### AllowAmbiguousTypes
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/capability/CapabilityApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/capability/CapabilityApi.scala
@@ -5,7 +5,7 @@ import org.enso.jsonrpc.{Error, HasParams, HasResult, Method, Unused}
 
 /**
   * The capability JSON RPC API provided by the language server.
-  * See [[https://github.com/luna/enso/blob/main/docs/language-server/README.md]]
+  * See [[https://github.com/enso-org/enso/blob/main/docs/language-server/README.md]]
   * for message specifications.
   */
 object CapabilityApi {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/FileManagerApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/FileManagerApi.scala
@@ -4,7 +4,7 @@ import org.enso.jsonrpc.{Error, HasParams, HasResult, Method, Unused}
 
 /**
   * The file manager JSON RPC API provided by the language server.
-  * See [[https://github.com/luna/enso/blob/main/docs/language-server/README.md]]
+  * See [[https://github.com/enso-org/enso/blob/main/docs/language-server/README.md]]
   * for message specifications.
   */
 object FileManagerApi {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/io/InputOutputApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/io/InputOutputApi.scala
@@ -4,7 +4,7 @@ import org.enso.jsonrpc.{HasParams, HasResult, Method, Unused}
 /**
   * The input/output JSON RPC API provided by the language server.
   *
-  * @see [[https://github.com/luna/enso/blob/main/docs/language-server/README.md]]
+  * @see [[https://github.com/enso-org/enso/blob/main/docs/language-server/README.md]]
   */
 object InputOutputApi {
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/monitoring/MonitoringApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/monitoring/MonitoringApi.scala
@@ -4,7 +4,7 @@ import org.enso.jsonrpc.{HasParams, HasResult, Method, Unused}
 
 /**
   * The monitoring JSON RPC API provided by the language server.
-  * See [[https://github.com/luna/enso/blob/main/docs/language-server/README.md]]
+  * See [[https://github.com/enso-org/enso/blob/main/docs/language-server/README.md]]
   * for message specifications.
   */
 object MonitoringApi {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/ErrorApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/ErrorApi.scala
@@ -5,7 +5,7 @@ import org.enso.jsonrpc.Error
 /**
   * Generic errors provided by the language server.
   *
-  * @see [[https://github.com/luna/enso/blob/main/docs/language-server/protocol-language-server.md#errors---language-server]]
+  * @see [[https://github.com/enso-org/enso/blob/main/docs/language-server/protocol-language-server.md#errors---language-server]]
   */
 object ErrorApi {
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ExecutionApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ExecutionApi.scala
@@ -8,7 +8,7 @@ import org.enso.languageserver.data.CapabilityRegistration
 /**
   * The execution JSON RPC API provided by the language server.
   *
-  * @see [[https://github.com/luna/enso/blob/main/docs/language-server/README.md]]
+  * @see [[https://github.com/enso-org/enso/blob/main/docs/language-server/README.md]]
   */
 object ExecutionApi {
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/VisualisationApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/VisualisationApi.scala
@@ -7,7 +7,7 @@ import org.enso.jsonrpc.{HasParams, HasResult, Method, Unused}
 /**
   * The visualisation JSON RPC API provided by the language server.
   *
-  * @see [[https://github.com/luna/enso/blob/main/docs/language-server/README.md]]
+  * @see [[https://github.com/enso-org/enso/blob/main/docs/language-server/README.md]]
   */
 object VisualisationApi {
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/session/SessionApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/session/SessionApi.scala
@@ -6,7 +6,7 @@ import org.enso.jsonrpc.{Error, HasParams, HasResult, Method}
 
 /**
   * The connection management JSON RPC API provided by the language server.
-  * See [[https://github.com/luna/enso/blob/main/docs/language-server/protocol-language-server.md#connection-management]]
+  * See [[https://github.com/enso-org/enso/blob/main/docs/language-server/protocol-language-server.md#connection-management]]
   * for message specifications.
   */
 object SessionApi {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/TextApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/TextApi.scala
@@ -6,7 +6,7 @@ import org.enso.jsonrpc.{Error, HasParams, HasResult, Method, Unused}
 
 /**
   * The text editing JSON RPC API provided by the language server.
-  * See [[https://github.com/luna/enso/blob/main/docs/language-server/README.md]]
+  * See [[https://github.com/enso-org/enso/blob/main/docs/language-server/README.md]]
   * for message specifications.
   */
 object TextApi {

--- a/lib/project-manager/src/main/resources/application.conf
+++ b/lib/project-manager/src/main/resources/application.conf
@@ -47,7 +47,7 @@ project-manager {
   }
 
   tutorials {
-    github-organisation = "luna-packages"
+    github-organisation = "enso-packages"
   }
 }
 

--- a/lib/project-manager/src/main/scala/org/enso/projectmanager/protocol/ProjectManagementApi.scala
+++ b/lib/project-manager/src/main/scala/org/enso/projectmanager/protocol/ProjectManagementApi.scala
@@ -7,7 +7,7 @@ import org.enso.projectmanager.data.{ProjectMetadata, Socket}
 
 /**
   * The project management JSON RPC API provided by the project manager.
-  * See [[https://github.com/luna/enso/blob/main/docs/language-server/README.md]]
+  * See [[https://github.com/enso-org/enso/blob/main/docs/language-server/README.md]]
   * for message specifications.
   */
 object ProjectManagementApi {

--- a/lib/project-manager/src/test/resources/application.conf
+++ b/lib/project-manager/src/test/resources/application.conf
@@ -47,7 +47,7 @@ project-manager {
   }
 
   tutorials {
-    github-organisation = "luna-packages"
+    github-organisation = "enso-packages"
   }
 }
 

--- a/lib/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectManagementApiSpec.scala
+++ b/lib/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectManagementApiSpec.scala
@@ -39,7 +39,7 @@ class ProjectManagementApiSpec extends BaseServerSpec with FlakySpec {
               "method": "project/create",
               "id": 1,
               "params": {
-                "name": "luna-test-project4/#$$%^@!"
+                "name": "enso-test-project4/#$$%^@!"
               }
             }
           """)

--- a/parser/flexer/Cargo.toml
+++ b/parser/flexer/Cargo.toml
@@ -7,10 +7,10 @@ authors = [
 ]
 edition = "2018"
 
-description = "A finite-automata-based lexing engine."
-readme = "README.md"
-homepage = "https://github.com/luna/enso"
-repository = "https://github.com/luna/enso"
+description  = "A finite-automata-based lexing engine."
+readme       = "README.md"
+homepage     = "https://github.com/enso-org/enso"
+repository   = "https://github.com/enso-org/enso"
 license-file = "../../LICENSE"
 
 keywords = ["lexer", "finite-automata"]
@@ -18,10 +18,10 @@ keywords = ["lexer", "finite-automata"]
 publish = false
 
 [lib]
-name = "flexer"
+name       = "flexer"
 crate-type = ["dylib", "rlib"]
-test = true
-bench = true
+test       = true
+bench      = true
 
 [dependencies]
 itertools = "0.8"

--- a/tools/performance/comparative-benchmark/benchmarks/haskell/package.yaml
+++ b/tools/performance/comparative-benchmark/benchmarks/haskell/package.yaml
@@ -1,9 +1,9 @@
 name:                haskell-benchmark
 version:             0.1.0.0
-github:              "https://github.com/luna/enso"
+github:              "https://github.com/enso-org/enso"
 author:              "Ara Adkins"
-maintainer:          "ara.adkins@luna-lang.org"
-copyright:           "Luna Team 2019"
+maintainer:          "ara.adkins@enso.org"
+copyright:           "Enso Team 2020"
 
 description: A benchmark for comparing Haskell to Enso.
 


### PR DESCRIPTION
### Pull Request Description
This PR updates the enso repo to stop referring to "luna" and use "enso" instead. 

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/luna/enso/blob/main/docs/style-guide/scala.md), [Java](https://github.com/luna/enso/blob/main/docs/style-guide/java.md), and [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md) style guides.
- [x] All code has been tested where possible.
