### PR TITLE
Disable the engine Changelog check

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -215,7 +215,6 @@ branches:
           - "Build and Test (ubuntu-18.04)"
           - "Build and Test (windows-latest)"
           - "Docs Check"
-          - "Changelog Check"
           - "Rust Check"
           - "Rust Lint"
           - "Rust Test Native (macOS-latest)"


### PR DESCRIPTION
### Pull Request Description
Following the merge, both Engine and GUI came with their own changelog CI check.
We'll be unifying to the GUI's one, so for now the Engine's check should be disable.
