### PR TITLE
Set Locale in Tests

### DIFF
--- a/test/Tests/src/Data/Locale_Spec.enso
+++ b/test/Tests/src/Data/Locale_Spec.enso
@@ -3,6 +3,15 @@ from Standard.Base import all
 import Standard.Base.Data.Locale
 import Standard.Test
 
+polyglot java import java.util.Locale as JavaLocale
+
+with_locale locale ~test =
+    default_locale = JavaLocale.getDefault
+    JavaLocale.setDefault locale.java_locale
+    result = test
+    JavaLocale.setDefault default_locale
+    result
+
 spec = Test.group "Locale" <|
     en_gb = Locale.new "en" "GB"
     Test.specify "allow constructing a locale with optional parts" <|
@@ -25,11 +34,13 @@ spec = Test.group "Locale" <|
         locale = Locale.from_language_tag "en-US-x-lvariant-UTF-8"
         locale.variant . should_equal "UTF_8"
     Test.specify "should allow getting the display language" <|
-        display = Locale.from_language_tag "en-GB" . display_language
-        display . should_equal "English"
+        here.with_locale Locale.us <|
+            display = Locale.from_language_tag "en-GB" . display_language
+            display . should_equal "English"
     Test.specify "should allow getting the display country" <|
-        display = Locale.from_language_tag "en-GB" . display_country
-        display . should_equal "United Kingdom"
+        here.with_locale Locale.us <|
+            display = Locale.from_language_tag "en-GB" . display_country
+            display . should_equal "United Kingdom"
     Test.specify "should allow getting the display variant" <|
         display = Locale.from_language_tag "en-GB-x-lvariant-UTF8" . display_variant
         display . should_equal "UTF8"

--- a/test/Tests/src/Data/Locale_Spec.enso
+++ b/test/Tests/src/Data/Locale_Spec.enso
@@ -8,8 +8,9 @@ polyglot java import java.util.Locale as JavaLocale
 with_locale locale ~test =
     default_locale = JavaLocale.getDefault
     JavaLocale.setDefault locale.java_locale
-    result = test
-    JavaLocale.setDefault default_locale
+    result = Panic.recover test . catch_primitive e->
+        JavaLocale.setDefault default_locale
+        Panic.throw e
     result
 
 spec = Test.group "Locale" <|

--- a/test/Tests/src/Main.enso
+++ b/test/Tests/src/Main.enso
@@ -83,4 +83,3 @@ main = Test.Suite.run_main <|
     Time_Spec.spec
     Uri_Spec.spec
     Vector_Spec.spec
-


### PR DESCRIPTION
### Pull Request Description

Some locale tests expect that the user machine has `en_US` locale setting. PR fixes the test by setting the expected locale for the test.

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/develop/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/develop/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
