### PR TITLE
Developers must be able to lock DOM position while panning

### DIFF
--- a/lib/rust/ensogl/core/src/display/scene.rs
+++ b/lib/rust/ensogl/core/src/display/scene.rs
@@ -506,8 +506,6 @@ impl DomLayers {
         canvas.set_style_or_warn("height", "100vh", logger);
         canvas.set_style_or_warn("width", "100vw", logger);
         canvas.set_style_or_warn("display", "block", logger);
-        // Position must not be "static" to have z-index working.
-        canvas.set_style_or_warn("position", "absolute", logger);
         canvas.set_style_or_warn("z-index", "3", logger);
         canvas.set_style_or_warn("pointer-events", "none", logger);
         dom.append_or_panic(&canvas);

--- a/lib/rust/ensogl/core/src/display/scene.rs
+++ b/lib/rust/ensogl/core/src/display/scene.rs
@@ -488,28 +488,34 @@ impl DomLayers {
         let fullscreen_vis = DomScene::new(logger);
         let back = DomScene::new(logger);
         let panel = DomScene::new(logger);
+
+        panel.dom.set_class_name("panel");
+        panel.dom.set_style_or_warn("pointer-events", "auto", logger);
+        panel.dom.set_style_or_warn("z-index", "0", logger);
+
+        back.dom.set_class_name("back");
+        back.dom.set_style_or_warn("pointer-events", "auto", logger);
+        back.dom.set_style_or_warn("z-index", "1", logger);
+
+        fullscreen_vis.dom.set_class_name("fullscreen_vis");
+        fullscreen_vis.dom.set_style_or_warn("z-index", "2", logger);
+
         canvas.set_style_or_warn("height", "100vh", logger);
         canvas.set_style_or_warn("width", "100vw", logger);
         canvas.set_style_or_warn("display", "block", logger);
         // Position must not be "static" to have z-index working.
         canvas.set_style_or_warn("position", "absolute", logger);
-        canvas.set_style_or_warn("z-index", "2", logger);
+        canvas.set_style_or_warn("z-index", "3", logger);
         canvas.set_style_or_warn("pointer-events", "none", logger);
+
         front.dom.set_class_name("front");
-        front.dom.set_style_or_warn("z-index", "3", logger);
-        back.dom.set_class_name("back");
-        back.dom.set_style_or_warn("pointer-events", "auto", logger);
-        back.dom.set_style_or_warn("z-index", "0", logger);
-        panel.dom.set_class_name("panel");
-        panel.dom.set_style_or_warn("pointer-events", "auto", logger);
-        panel.dom.set_style_or_warn("z-index", "0", logger);
-        fullscreen_vis.dom.set_class_name("fullscreen_vis");
-        fullscreen_vis.dom.set_style_or_warn("z-index", "1", logger);
+        front.dom.set_style_or_warn("z-index", "4", logger);
+
+        dom.append_or_panic(&panel.dom);
+        dom.append_or_panic(&back.dom);
+        dom.append_or_panic(&fullscreen_vis.dom);
         dom.append_or_panic(&canvas);
         dom.append_or_panic(&front.dom);
-        dom.append_or_panic(&back.dom);
-        dom.append_or_panic(&panel.dom);
-        dom.append_or_panic(&fullscreen_vis.dom);
         Self { back, panel, fullscreen_vis, front, canvas }
     }
 }

--- a/lib/rust/ensogl/core/src/display/scene.rs
+++ b/lib/rust/ensogl/core/src/display/scene.rs
@@ -474,7 +474,9 @@ pub struct DomLayers {
     /// Back DOM scene layer.
     pub back:           DomScene,
     /// Back DOM scene layer with fullscreen visualization. Kept separately from `back`, because
-    /// the fullscreen visualizations should not share camera with main view.
+    /// the fullscreen visualizations should not share camera with main view. This layer is placed
+    /// behind `canvas` because mouse cursor is drawn on `canvas` layer, and would be covered by
+    /// `fullscreen_vis` elements otherwise.
     pub fullscreen_vis: DomScene,
     /// Front DOM scene layer.
     pub front:          DomScene,
@@ -949,7 +951,7 @@ impl SceneData {
         // setups now, so we are using here the main camera only.
         let camera = self.camera();
         let fullscreen_vis_camera = self.layers.panel.camera();
-        // We are using the same camera as `fullscreen_vis`.
+        // We are using unnavigable camera to disable panning behavior.
         let welcome_screen_camera = self.layers.panel.camera();
         let changed = camera.update(scene);
         if changed {

--- a/lib/rust/ensogl/core/src/display/scene.rs
+++ b/lib/rust/ensogl/core/src/display/scene.rs
@@ -467,7 +467,9 @@ impl Dom {
 /// elements.
 #[derive(Clone, CloneRef, Debug)]
 pub struct DomLayers {
-    /// Bottom-most DOM scene layer with disabled panning.
+    /// Bottom-most DOM scene layer with disabled panning. This layer is placed at the bottom
+    /// because mouse cursor is drawn on `canvas` layer, and would be covered by Welcome Screen
+    /// elements otherwise.
     pub welcome_screen: DomScene,
     /// Back DOM scene layer.
     pub back:           DomScene,
@@ -948,8 +950,8 @@ impl SceneData {
         // setups now, so we are using here the main camera only.
         let camera = self.camera();
         let fullscreen_vis_camera = self.layers.panel.camera();
-        // for now, we use the same camera as `fullscreen_vis`, it might change in the future
-        let panel_camera = self.layers.panel.camera();
+        // We are using the same camera as `fullscreen_vis`.
+        let welcome_screen_camera = self.layers.panel.camera();
         let changed = camera.update(scene);
         if changed {
             self.frp.camera_changed_source.emit(());
@@ -960,7 +962,7 @@ impl SceneData {
         let fs_vis_camera_changed = fullscreen_vis_camera.update(scene);
         if fs_vis_camera_changed {
             self.dom.layers.fullscreen_vis.update_view_projection(&fullscreen_vis_camera);
-            self.dom.layers.welcome_screen.update_view_projection(&panel_camera);
+            self.dom.layers.welcome_screen.update_view_projection(&welcome_screen_camera);
         }
 
         // Updating all other cameras (the main camera was already updated, so it will be skipped).

--- a/lib/rust/ensogl/core/src/display/scene.rs
+++ b/lib/rust/ensogl/core/src/display/scene.rs
@@ -469,6 +469,8 @@ impl Dom {
 pub struct DomLayers {
     /// Back DOM scene layer.
     pub back:           DomScene,
+    /// Back DOM scene layer with disabled panning. It shares camera from `fullscreen_vis`.
+    pub panel:          DomScene,
     /// Back DOM scene layer with fullscreen visualization. Kept separately from `back`, because
     /// the fullscreen visualizations should not share camera with main view.
     pub fullscreen_vis: DomScene,
@@ -485,6 +487,7 @@ impl DomLayers {
         let front = DomScene::new(logger);
         let fullscreen_vis = DomScene::new(logger);
         let back = DomScene::new(logger);
+        let panel = DomScene::new(logger);
         canvas.set_style_or_warn("height", "100vh", logger);
         canvas.set_style_or_warn("width", "100vw", logger);
         canvas.set_style_or_warn("display", "block", logger);
@@ -497,13 +500,17 @@ impl DomLayers {
         back.dom.set_class_name("back");
         back.dom.set_style_or_warn("pointer-events", "auto", logger);
         back.dom.set_style_or_warn("z-index", "0", logger);
+        panel.dom.set_class_name("panel");
+        panel.dom.set_style_or_warn("pointer-events", "auto", logger);
+        panel.dom.set_style_or_warn("z-index", "0", logger);
         fullscreen_vis.dom.set_class_name("fullscreen_vis");
         fullscreen_vis.dom.set_style_or_warn("z-index", "1", logger);
         dom.append_or_panic(&canvas);
         dom.append_or_panic(&front.dom);
         dom.append_or_panic(&back.dom);
+        dom.append_or_panic(&panel.dom);
         dom.append_or_panic(&fullscreen_vis.dom);
-        Self { back, fullscreen_vis, front, canvas }
+        Self { back, panel, fullscreen_vis, front, canvas }
     }
 }
 
@@ -947,6 +954,7 @@ impl SceneData {
         let fs_vis_camera_changed = fullscreen_vis_camera.update(scene);
         if fs_vis_camera_changed {
             self.dom.layers.fullscreen_vis.update_view_projection(&fullscreen_vis_camera);
+            self.dom.layers.panel.update_view_projection(&fullscreen_vis_camera);
         }
 
         // Updating all other cameras (the main camera was already updated, so it will be skipped).

--- a/lib/rust/ensogl/core/src/display/scene.rs
+++ b/lib/rust/ensogl/core/src/display/scene.rs
@@ -469,7 +469,7 @@ impl Dom {
 pub struct DomLayers {
     /// Back DOM scene layer.
     pub back:           DomScene,
-    /// Back DOM scene layer with disabled panning. It shares camera from `fullscreen_vis`.
+    /// Back DOM scene layer with disabled panning.
     pub panel:          DomScene,
     /// Back DOM scene layer with fullscreen visualization. Kept separately from `back`, because
     /// the fullscreen visualizations should not share camera with main view.
@@ -950,6 +950,8 @@ impl SceneData {
         // setups now, so we are using here the main camera only.
         let camera = self.camera();
         let fullscreen_vis_camera = self.layers.panel.camera();
+        // for now, we use the same camera as `fullscreen_vis`, it might change in the future
+        let panel_camera = self.layers.panel.camera();
         let changed = camera.update(scene);
         if changed {
             self.frp.camera_changed_source.emit(());
@@ -960,7 +962,7 @@ impl SceneData {
         let fs_vis_camera_changed = fullscreen_vis_camera.update(scene);
         if fs_vis_camera_changed {
             self.dom.layers.fullscreen_vis.update_view_projection(&fullscreen_vis_camera);
-            self.dom.layers.panel.update_view_projection(&fullscreen_vis_camera);
+            self.dom.layers.panel.update_view_projection(&panel_camera);
         }
 
         // Updating all other cameras (the main camera was already updated, so it will be skipped).

--- a/lib/rust/ensogl/core/src/display/scene.rs
+++ b/lib/rust/ensogl/core/src/display/scene.rs
@@ -467,10 +467,10 @@ impl Dom {
 /// elements.
 #[derive(Clone, CloneRef, Debug)]
 pub struct DomLayers {
+    /// Bottom-most DOM scene layer with disabled panning.
+    pub welcome_screen: DomScene,
     /// Back DOM scene layer.
     pub back:           DomScene,
-    /// Back DOM scene layer with disabled panning.
-    pub panel:          DomScene,
     /// Back DOM scene layer with fullscreen visualization. Kept separately from `back`, because
     /// the fullscreen visualizations should not share camera with main view.
     pub fullscreen_vis: DomScene,
@@ -487,18 +487,21 @@ impl DomLayers {
         let front = DomScene::new(logger);
         let fullscreen_vis = DomScene::new(logger);
         let back = DomScene::new(logger);
-        let panel = DomScene::new(logger);
+        let welcome_screen = DomScene::new(logger);
 
-        panel.dom.set_class_name("panel");
-        panel.dom.set_style_or_warn("pointer-events", "auto", logger);
-        panel.dom.set_style_or_warn("z-index", "0", logger);
+        welcome_screen.dom.set_class_name("panel");
+        welcome_screen.dom.set_style_or_warn("pointer-events", "auto", logger);
+        welcome_screen.dom.set_style_or_warn("z-index", "0", logger);
+        dom.append_or_panic(&welcome_screen.dom);
 
         back.dom.set_class_name("back");
         back.dom.set_style_or_warn("pointer-events", "auto", logger);
         back.dom.set_style_or_warn("z-index", "1", logger);
+        dom.append_or_panic(&back.dom);
 
         fullscreen_vis.dom.set_class_name("fullscreen_vis");
         fullscreen_vis.dom.set_style_or_warn("z-index", "2", logger);
+        dom.append_or_panic(&fullscreen_vis.dom);
 
         canvas.set_style_or_warn("height", "100vh", logger);
         canvas.set_style_or_warn("width", "100vw", logger);
@@ -507,16 +510,13 @@ impl DomLayers {
         canvas.set_style_or_warn("position", "absolute", logger);
         canvas.set_style_or_warn("z-index", "3", logger);
         canvas.set_style_or_warn("pointer-events", "none", logger);
+        dom.append_or_panic(&canvas);
 
         front.dom.set_class_name("front");
         front.dom.set_style_or_warn("z-index", "4", logger);
-
-        dom.append_or_panic(&panel.dom);
-        dom.append_or_panic(&back.dom);
-        dom.append_or_panic(&fullscreen_vis.dom);
-        dom.append_or_panic(&canvas);
         dom.append_or_panic(&front.dom);
-        Self { back, panel, fullscreen_vis, front, canvas }
+
+        Self { back, welcome_screen, fullscreen_vis, front, canvas }
     }
 }
 
@@ -962,7 +962,7 @@ impl SceneData {
         let fs_vis_camera_changed = fullscreen_vis_camera.update(scene);
         if fs_vis_camera_changed {
             self.dom.layers.fullscreen_vis.update_view_projection(&fullscreen_vis_camera);
-            self.dom.layers.panel.update_view_projection(&panel_camera);
+            self.dom.layers.welcome_screen.update_view_projection(&panel_camera);
         }
 
         // Updating all other cameras (the main camera was already updated, so it will be skipped).

--- a/lib/rust/ensogl/core/src/display/scene.rs
+++ b/lib/rust/ensogl/core/src/display/scene.rs
@@ -485,26 +485,24 @@ pub struct DomLayers {
 impl DomLayers {
     /// Constructor.
     pub fn new(logger: &Logger, dom: &web_sys::HtmlDivElement) -> Self {
-        let canvas = web::create_canvas();
-        let front = DomScene::new(logger);
-        let fullscreen_vis = DomScene::new(logger);
-        let back = DomScene::new(logger);
         let welcome_screen = DomScene::new(logger);
-
         welcome_screen.dom.set_class_name("panel");
         welcome_screen.dom.set_style_or_warn("pointer-events", "auto", logger);
         welcome_screen.dom.set_style_or_warn("z-index", "0", logger);
         dom.append_or_panic(&welcome_screen.dom);
 
+        let back = DomScene::new(logger);
         back.dom.set_class_name("back");
         back.dom.set_style_or_warn("pointer-events", "auto", logger);
         back.dom.set_style_or_warn("z-index", "1", logger);
         dom.append_or_panic(&back.dom);
 
+        let fullscreen_vis = DomScene::new(logger);
         fullscreen_vis.dom.set_class_name("fullscreen_vis");
         fullscreen_vis.dom.set_style_or_warn("z-index", "2", logger);
         dom.append_or_panic(&fullscreen_vis.dom);
 
+        let canvas = web::create_canvas();
         canvas.set_style_or_warn("height", "100vh", logger);
         canvas.set_style_or_warn("width", "100vw", logger);
         canvas.set_style_or_warn("display", "block", logger);
@@ -512,6 +510,7 @@ impl DomLayers {
         canvas.set_style_or_warn("pointer-events", "none", logger);
         dom.append_or_panic(&canvas);
 
+        let front = DomScene::new(logger);
         front.dom.set_class_name("front");
         front.dom.set_style_or_warn("z-index", "4", logger);
         dom.append_or_panic(&front.dom);


### PR DESCRIPTION
### Pull Request Description

#### New DOM Layer 

Added new `welcome_screen` DOM layer which will contain Welcome Screen elements and prevent them from moving while panning the view.

To use it in code, one can use the following lines to disable panning behavior for view

```rust
display_object.add_child(&dom);
app.display.scene().dom.layers.welcome_screen.manage(&dom);
```

This was tested manually while implementing Welcome Screen in Rust.

#### Changing Z-levels of other levels

Z-levels of other layers updated (incremented by one), as the new layer uses "bottom-most" Z-level.

#### Fixing pointer-events

Also `pointer-events` property of all DOM layers was set to `none`. 

As layers are `div` elements that cover the whole viewport, levels with `pointer-events: auto` will block all mouse events for all underlying layers. That happened before, as `back` layer with `pointer-events: auto` blocked all mouse clicks designated to the bottom-most `welcome_screen` layer.

IDE is still working correctly, because it uses either `mousedown` handlers or elements with manually set `pointer-events: auto` (visualizations as one example).

Testing this change is in progress.

### Important Notes

Questions: 
- [x] Is it correct to use `fullscreen_vis`'s camera? Does it have any implications?
   We decided that it is a good temporary solution to get fixed-pos camera.
- [x] Is there a better naming for this layer?
   We decided to go with `welcome_screen` name, as more universal names lead to confusion.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/develop/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/develop/docs/style-guide/yaml.md) style guides.
- [ ] All code has been tested where possible.
