### PR TITLE
Fix codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,32 +2,32 @@
 * @4e6 @MichaelMauderer @PabloBuchu @jdunkerley
 
 # Rust Libraries
-/lib/rust/* @MichaelMauderer @4e6 @mwu-tow @farmaazon
-/lib/rust/ensogl/* @MichaelMauderer @wdanilo @farmaazon
+/lib/rust/ @MichaelMauderer @4e6 @mwu-tow @farmaazon
+/lib/rust/ensogl/ @MichaelMauderer @wdanilo @farmaazon
 
 # Scala Libraries
-/lib/scala/* @4e6
+/lib/scala/ @4e6
 
 # GUI
 /run @MichaelMauderer @wdanilo
-/build/* @MichaelMauderer @wdanilo
-/app/gui/* @MichaelMauderer @wdanilo @farmaazon @mwu-tow
-/app/gui/view/* @MichaelMauderer @wdanilo @farmaazon
-/app/ide-desktop/* @MichaelMauderer @wdanilo
+/build/ @MichaelMauderer @wdanilo
+/app/gui/ @MichaelMauderer @wdanilo @farmaazon @mwu-tow
+/app/gui/view/ @MichaelMauderer @wdanilo @farmaazon
+/app/ide-desktop/ @MichaelMauderer @wdanilo
 
 # Engine (old)
 # This section should be removed once the engine moves to /app/engine
 /build.sbt @4e6
-/distribution/* @4e6
-/engine/* @4e6
-/project/* @4e6
-/test/* @4e6
-/tools/* @4e6
+/distribution/ @4e6
+/engine/ @4e6
+/project/ @4e6
+/test/ @4e6
+/tools/ @4e6
 
 # Enso Libraries
 # This section should be amended once the engine moves to /app/engine
-/distribution/lib/* @4e6 @jdunkerley @radeusgd
-/std-bits/* @4e6 @jdunkerley @radeusgd
+/distribution/lib/ @4e6 @jdunkerley @radeusgd
+/std-bits/ @4e6 @jdunkerley @radeusgd
 
 # Engine
-/app/engine/* @4e6
+/app/engine/ @4e6


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

The old codeowners file does not work properly, as can be seen in https://github.com/enso-org/enso/pull/3159/files : the only edited file is owned by all TLs, and should be only by GUI team.

I discovered, that the mindlessly-rewritten asterisks causes the problem (see example in https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- ~~[ ] The documentation has been updated if necessary.~~
- ~~[ ] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.~~
- ~~[ ] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/develop/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/develop/docs/style-guide/yaml.md) style guides.~~
- ~~[ ] All code has been tested where possible.~~
