### PR TITLE
Register Views before creating them

### DIFF
--- a/app/gui/CHANGELOG.md
+++ b/app/gui/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - [Fixed histograms coloring and added a color legend.][3153]
 - [Fixed broken node whose expression contains non-ASCII characters.][3166]
-- [Fixed developer console warnings about views being created but not registered.][3181]
+- [Fixed developer console warnings about views being created but not
+  registered.][3181]
 
 [3153]: https://github.com/enso-org/enso/pull/3153
 [3166]: https://github.com/enso-org/enso/pull/3166

--- a/app/gui/CHANGELOG.md
+++ b/app/gui/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 - [Fixed histograms coloring and added a color legend.][3153]
 - [Fixed broken node whose expression contains non-ASCII characters.][3166]
+- [Fixed developer console warnings about views being created but not registered.][3181]
 
 [3153]: https://github.com/enso-org/enso/pull/3153
 [3166]: https://github.com/enso-org/enso/pull/3166
+[3181]: https://github.com/enso-org/enso/pull/3181
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/app/gui/src/ide/initializer.rs
+++ b/app/gui/src/ide/initializer.rs
@@ -107,6 +107,10 @@ impl Initializer {
 
     fn register_views(app: &Application) {
         app.views.register::<ide_view::root::View>();
+        app.views.register::<ide_view::graph_editor::GraphEditor>();
+        app.views.register::<ide_view::code_editor::View>();
+        app.views.register::<ide_view::project::View>();
+        app.views.register::<ide_view::searcher::View>();
     }
 
     /// Initialize and return a new Ide Controller.

--- a/app/gui/src/ide/initializer.rs
+++ b/app/gui/src/ide/initializer.rs
@@ -65,6 +65,7 @@ impl Initializer {
             info!(self.logger, "Starting IDE with the following config: {self.config:?}");
 
             let application = Application::new(&web::get_html_element_by_id("root").unwrap());
+            Initializer::register_views(&application);
             let view = application.new_view::<ide_view::root::View>();
 
             // If `rust_welcome_screen` feature-flag is not used, switch to project view
@@ -102,6 +103,10 @@ impl Initializer {
                 .ok();
         });
         std::mem::forget(executor);
+    }
+
+    fn register_views(app: &Application) {
+        app.views.register::<ide_view::root::View>();
     }
 
     /// Initialize and return a new Ide Controller.

--- a/app/gui/src/ide/initializer.rs
+++ b/app/gui/src/ide/initializer.rs
@@ -114,6 +114,9 @@ impl Initializer {
         app.views.register::<ide_view::searcher::View>();
         app.views.register::<ide_view::welcome_screen::View>();
         app.views.register::<ensogl_component::text::Area>();
+        // FIXME: decimal_aligned is a private module:
+        // app.views.register::<ensogl_component::selector::decimal_aligned::FloatLabel>();
+        app.views.register::<ensogl_component::selector::NumberPicker>();
 
         // As long as .label() of a View is the same, shortcuts and commands are currently also
         // expected to be the same, so it should not be important which concrete type parameter of

--- a/app/gui/src/ide/initializer.rs
+++ b/app/gui/src/ide/initializer.rs
@@ -117,6 +117,7 @@ impl Initializer {
         // FIXME: decimal_aligned is a private module:
         // app.views.register::<ensogl_component::selector::decimal_aligned::FloatLabel>();
         app.views.register::<ensogl_component::selector::NumberPicker>();
+        app.views.register::<ensogl_component::selector::NumberRangePicker>();
 
         // As long as .label() of a View is the same, shortcuts and commands are currently also
         // expected to be the same, so it should not be important which concrete type parameter of

--- a/app/gui/src/ide/initializer.rs
+++ b/app/gui/src/ide/initializer.rs
@@ -114,8 +114,6 @@ impl Initializer {
         app.views.register::<ide_view::searcher::View>();
         app.views.register::<ide_view::welcome_screen::View>();
         app.views.register::<ensogl_component::text::Area>();
-        // FIXME: decimal_aligned is a private module:
-        // app.views.register::<ensogl_component::selector::decimal_aligned::FloatLabel>();
         app.views.register::<ensogl_component::selector::NumberPicker>();
         app.views.register::<ensogl_component::selector::NumberRangePicker>();
 
@@ -127,7 +125,6 @@ impl Initializer {
 
         if enso_config::ARGS.is_in_cloud.unwrap_or(false) {
             app.views.register::<ide_view::window_control_buttons::View>();
-            // TODO: CloseButton
         }
     }
 

--- a/app/gui/src/ide/initializer.rs
+++ b/app/gui/src/ide/initializer.rs
@@ -114,6 +114,11 @@ impl Initializer {
         app.views.register::<ide_view::searcher::View>();
         app.views.register::<ide_view::welcome_screen::View>();
         app.views.register::<ensogl_component::text::Area>();
+
+        // As long as .label() of a View is the same, shortcuts and commands are currently also
+        // expected to be the same, so it should not be important which concrete type parameter of
+        // ListView we use below.
+        app.views.register::<ensogl_component::list_view::ListView<ensogl_component::list_view::entry::Label>>();
     }
 
     /// Initialize and return a new Ide Controller.

--- a/app/gui/src/ide/initializer.rs
+++ b/app/gui/src/ide/initializer.rs
@@ -113,6 +113,7 @@ impl Initializer {
         app.views.register::<ide_view::project::View>();
         app.views.register::<ide_view::searcher::View>();
         app.views.register::<ide_view::welcome_screen::View>();
+        app.views.register::<ensogl_component::text::Area>();
     }
 
     /// Initialize and return a new Ide Controller.

--- a/app/gui/src/ide/initializer.rs
+++ b/app/gui/src/ide/initializer.rs
@@ -108,9 +108,11 @@ impl Initializer {
     fn register_views(app: &Application) {
         app.views.register::<ide_view::root::View>();
         app.views.register::<ide_view::graph_editor::GraphEditor>();
+        app.views.register::<ide_view::graph_editor::component::breadcrumbs::ProjectName>();
         app.views.register::<ide_view::code_editor::View>();
         app.views.register::<ide_view::project::View>();
         app.views.register::<ide_view::searcher::View>();
+        app.views.register::<ide_view::welcome_screen::View>();
     }
 
     /// Initialize and return a new Ide Controller.

--- a/app/gui/src/ide/initializer.rs
+++ b/app/gui/src/ide/initializer.rs
@@ -125,7 +125,7 @@ impl Initializer {
         // ListView we use below.
         app.views.register::<ensogl_component::list_view::ListView<ensogl_component::list_view::entry::Label>>();
 
-        if enso_config::ARGS.is_in_cloud == Some(true) {
+        if enso_config::ARGS.is_in_cloud.unwrap_or(false) {
             app.views.register::<ide_view::window_control_buttons::View>();
             // TODO: CloseButton
         }

--- a/app/gui/src/ide/initializer.rs
+++ b/app/gui/src/ide/initializer.rs
@@ -119,11 +119,11 @@ impl Initializer {
         app.views.register::<ensogl_component::selector::NumberPicker>();
         app.views.register::<ensogl_component::selector::NumberRangePicker>();
 
-        // TODO(akavel): add warning in ListView.label()'s docs
         // As long as .label() of a View is the same, shortcuts and commands are currently also
         // expected to be the same, so it should not be important which concrete type parameter of
         // ListView we use below.
-        app.views.register::<ensogl_component::list_view::ListView<ensogl_component::list_view::entry::Label>>();
+        type PlaceholderEntryType = ensogl_component::list_view::entry::Label;
+        app.views.register::<ensogl_component::list_view::ListView<PlaceholderEntryType>>();
 
         if enso_config::ARGS.is_in_cloud.unwrap_or(false) {
             app.views.register::<ide_view::window_control_buttons::View>();

--- a/app/gui/src/ide/initializer.rs
+++ b/app/gui/src/ide/initializer.rs
@@ -119,6 +119,7 @@ impl Initializer {
         app.views.register::<ensogl_component::selector::NumberPicker>();
         app.views.register::<ensogl_component::selector::NumberRangePicker>();
 
+        // TODO(akavel): add warning in ListView.label()'s docs
         // As long as .label() of a View is the same, shortcuts and commands are currently also
         // expected to be the same, so it should not be important which concrete type parameter of
         // ListView we use below.
@@ -126,6 +127,7 @@ impl Initializer {
 
         if enso_config::ARGS.is_in_cloud == Some(true) {
             app.views.register::<ide_view::window_control_buttons::View>();
+            // TODO: CloseButton
         }
     }
 

--- a/app/gui/src/ide/initializer.rs
+++ b/app/gui/src/ide/initializer.rs
@@ -123,6 +123,10 @@ impl Initializer {
         // expected to be the same, so it should not be important which concrete type parameter of
         // ListView we use below.
         app.views.register::<ensogl_component::list_view::ListView<ensogl_component::list_view::entry::Label>>();
+
+        if enso_config::ARGS.is_in_cloud == Some(true) {
+            app.views.register::<ide_view::window_control_buttons::View>();
+        }
     }
 
     /// Initialize and return a new Ide Controller.

--- a/app/gui/view/src/window_control_buttons/common.rs
+++ b/app/gui/view/src/window_control_buttons/common.rs
@@ -332,14 +332,3 @@ impl<Shape> application::command::FrpNetworkProvider for View<Shape> {
     }
 }
 
-impl<Shape: ButtonShape> application::View for View<Shape> {
-    fn label() -> &'static str {
-        "CloseButton"
-    }
-    fn new(app: &Application) -> Self {
-        View::new(app)
-    }
-    fn app(&self) -> &Application {
-        &self.model.app
-    }
-}

--- a/app/gui/view/src/window_control_buttons/common.rs
+++ b/app/gui/view/src/window_control_buttons/common.rs
@@ -331,4 +331,3 @@ impl<Shape> application::command::FrpNetworkProvider for View<Shape> {
         &self.frp.network
     }
 }
-

--- a/lib/rust/ensogl/component/list-view/src/lib.rs
+++ b/lib/rust/ensogl/component/list-view/src/lib.rs
@@ -467,8 +467,6 @@ impl<E: Entry> application::command::FrpNetworkProvider for ListView<E> {
 }
 
 impl<E: Entry> application::View for ListView<E> {
-    // NOTE: if implementing a different specialization of ListView, make sure to change the label
-    // appropriately so that 'register' would properly differentiate shortcuts etc.
     fn label() -> &'static str {
         "ListView"
     }

--- a/lib/rust/ensogl/component/list-view/src/lib.rs
+++ b/lib/rust/ensogl/component/list-view/src/lib.rs
@@ -467,6 +467,8 @@ impl<E: Entry> application::command::FrpNetworkProvider for ListView<E> {
 }
 
 impl<E: Entry> application::View for ListView<E> {
+    // NOTE: if implementing a different specialization of ListView, make sure to change the label
+    // appropriately so that 'register' would properly differentiate shortcuts etc.
     fn label() -> &'static str {
         "ListView"
     }

--- a/lib/rust/ensogl/component/selector/src/decimal_aligned.rs
+++ b/lib/rust/ensogl/component/selector/src/decimal_aligned.rs
@@ -136,14 +136,3 @@ impl application::command::FrpNetworkProvider for FloatLabel {
     }
 }
 
-impl application::View for FloatLabel {
-    fn label() -> &'static str {
-        "FloatLabel"
-    }
-    fn new(app: &Application) -> Self {
-        FloatLabel::new(app)
-    }
-    fn app(&self) -> &Application {
-        &self.app
-    }
-}

--- a/lib/rust/ensogl/component/selector/src/decimal_aligned.rs
+++ b/lib/rust/ensogl/component/selector/src/decimal_aligned.rs
@@ -135,4 +135,3 @@ impl application::command::FrpNetworkProvider for FloatLabel {
         self.frp.network()
     }
 }
-

--- a/lib/rust/ensogl/component/selector/src/model.rs
+++ b/lib/rust/ensogl/component/selector/src/model.rs
@@ -79,7 +79,7 @@ impl Model {
     pub fn new(app: &Application) -> Self {
         let logger = Logger::new("selector::common::Model");
         let root = display::object::Instance::new(&logger);
-        let label = app.new_view::<FloatLabel>();
+        let label = FloatLabel::new(app);
         let label_left = app.new_view::<text::Area>();
         let label_right = app.new_view::<text::Area>();
         let caption_center = app.new_view::<text::Area>();

--- a/lib/rust/ensogl/core/src/application/view.rs
+++ b/lib/rust/ensogl/core/src/application/view.rs
@@ -44,6 +44,10 @@ impl Registry {
     }
 
     /// View registration.
+    /// Registers any keyboard shortcuts provided by the View, and registers the View for use with
+    /// commands. Should be called for every View that might potentially be instantiated at any
+    /// point in the future, so that the keyboard shortcuts overview has full information from the
+    /// outset.
     pub fn register<V: View>(&self) {
         let label = V::label().into();
         for shortcut in V::default_shortcuts() {

--- a/lib/rust/ensogl/core/src/application/view.rs
+++ b/lib/rust/ensogl/core/src/application/view.rs
@@ -44,10 +44,11 @@ impl Registry {
     }
 
     /// View registration.
-    /// Registers any keyboard shortcuts provided by the View, and registers the View for use with
-    /// commands. Should be called for every View that might potentially be instantiated at any
-    /// point in the future, so that the keyboard shortcuts overview has full information from the
-    /// outset.
+    ///
+    /// Registers any keyboard shortcuts provided by the [View], and registers the View for use
+    /// with commands. Should be called for every View that might potentially be instantiated at
+    /// any point in the future, so that the keyboard shortcuts overview has full information from
+    /// the outset.
     pub fn register<V: View>(&self) {
         let label = V::label().into();
         for shortcut in V::default_shortcuts() {


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Make sure components implementing the `View` trait are registered in `view::Registry`, so that their keyboard shortcuts can be displayed to the user in a help window immediately after the IDE is started.

Fixes #3093.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

 - components that did not emit warnings, but still implement the `View` trait, were also tracked and case-by-case decisions taken to make sure appropriate registering behavior is performed; in particular:
     - FloatLabel was modified to not implement View, as it's a private widget and not expected to need keyboard shortcuts
     - NumberPicker & NumberRangePicker were registered
     - Scrollbar was skipped for now as it's understood to not be complete & ready to use yet
     - TopButtons was registered (tested with `?is_in_cloud=true`)
     - CloseButton was modified to not implement View (the widget seems also internal: its creation was actually not even via `new_view`; it was used in 2 separate specializations & places as "close button" and "fullscreen button"; it had no keyboard shortcuts; a decision as of now was made to de-View it, with a possibility to reconsider in future if the understanding of its situation changes/develops)

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/develop/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/develop/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
