### PR TITLE
Fix codec spec

### DIFF
--- a/test/Image_Tests/src/Codecs_Spec.enso
+++ b/test/Image_Tests/src/Codecs_Spec.enso
@@ -10,10 +10,7 @@ import Standard.Test
 polyglot java import java.lang.System as Java_System
 
 fetch addr file =
-    wget = case Platform.os of
-        Platform.Windows -> "wget.exe"
-        _ -> "wget"
-    Process.run wget ["--quiet", "--output-document", file.path, addr]
+    Process.run "curl" [addr, "--silent", "--output", file.path]
 
 spec =
     is_ci = Java_System.getenv "CI" == "true"

--- a/test/Image_Tests/src/Codecs_Spec.enso
+++ b/test/Image_Tests/src/Codecs_Spec.enso
@@ -9,7 +9,7 @@ import Standard.Test
 polyglot java import java.lang.System as Java_System
 
 fetch addr file =
-    Process.run "curl" [addr, "--silent", "--remote-name", file.path]
+    Process.run "wget" ["--quiet", "--output-document", file.path, addr]
 
 spec =
     is_ci = Java_System.getenv "CI" == "true"

--- a/test/Image_Tests/src/Codecs_Spec.enso
+++ b/test/Image_Tests/src/Codecs_Spec.enso
@@ -11,7 +11,7 @@ polyglot java import java.lang.System as Java_System
 
 fetch addr file =
     wget = case Platform.os of
-        Platform.Windows -> "wget.ext"
+        Platform.Windows -> "wget.exe"
         _ -> "wget"
     Process.run wget ["--quiet", "--output-document", file.path, addr]
 

--- a/test/Image_Tests/src/Codecs_Spec.enso
+++ b/test/Image_Tests/src/Codecs_Spec.enso
@@ -9,7 +9,7 @@ import Standard.Test
 polyglot java import java.lang.System as Java_System
 
 fetch addr file =
-    Process.run "curl" [addr, "--silent", "--output", file.path]
+    Process.run "curl" [addr, "--silent", "--remote-name", file.path]
 
 spec =
     is_ci = Java_System.getenv "CI" == "true"

--- a/test/Image_Tests/src/Codecs_Spec.enso
+++ b/test/Image_Tests/src/Codecs_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 import Standard.Base.System.File
+import Standard.Base.System.Platform
 import Standard.Base.System.Process
 import Standard.Base.System.Process.Exit_Code
 import Standard.Image.Codecs
@@ -9,7 +10,10 @@ import Standard.Test
 polyglot java import java.lang.System as Java_System
 
 fetch addr file =
-    Process.run "wget" ["--quiet", "--output-document", file.path, addr]
+    wget = case Platform.os of
+        Platform.Windows -> "wget.ext"
+        _ -> "wget"
+    Process.run wget ["--quiet", "--output-document", file.path, addr]
 
 spec =
     is_ci = Java_System.getenv "CI" == "true"

--- a/test/Tests/src/Data/Locale_Spec.enso
+++ b/test/Tests/src/Data/Locale_Spec.enso
@@ -11,6 +11,7 @@ with_locale locale ~test =
     result = Panic.recover test . catch_primitive e->
         JavaLocale.setDefault default_locale
         Panic.throw e
+    JavaLocale.setDefault default_locale
     result
 
 spec = Test.group "Locale" <|


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

CodecsSpec on the new CI infrastructure. Windows runner downloads artifact with an error. It happens because curl downloads artifacts in text mode.

PR switches curs to binary mode when downloading the artifact

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/develop/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/develop/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
