### PR TITLE
Developers should find the ide-gui controller codebase logical and easy to work with. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2059,6 +2059,7 @@ dependencies = [
  "ensogl-text-msdf-sys",
  "ide-view-graph-editor",
  "js-sys",
+ "multi-map",
  "nalgebra 0.26.2",
  "ordered-float 2.8.0",
  "parser",
@@ -2523,6 +2524,12 @@ dependencies = [
  "quote 1.0.10",
  "syn",
 ]
+
+[[package]]
+name = "multi-map"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bba551d6d795f74a01767577ea8339560bf0a65354e0417b7e915ed608443d46"
 
 [[package]]
 name = "nalgebra"

--- a/app/gui/config/src/lib.rs
+++ b/app/gui/config/src/lib.rs
@@ -56,5 +56,6 @@ ensogl::read_args! {
         authentication_enabled : bool,
         email                  : String,
         application_config_url : String,
+        rust_new_presentation_layer : bool,
     }
 }

--- a/app/gui/src/controller/graph.rs
+++ b/app/gui/src/controller/graph.rs
@@ -93,6 +93,10 @@ pub struct Node {
 }
 
 impl Node {
+    pub fn id(&self) -> double_representation::node::Id {
+        self.main_line.id()
+    }
+
     /// Get the node's position.
     pub fn position(&self) -> Option<model::module::Position> {
         self.metadata.as_ref().and_then(|m| m.position)

--- a/app/gui/src/controller/graph.rs
+++ b/app/gui/src/controller/graph.rs
@@ -93,6 +93,7 @@ pub struct Node {
 }
 
 impl Node {
+    /// Get the node's id.
     pub fn id(&self) -> double_representation::node::Id {
         self.main_line.id()
     }

--- a/app/gui/src/ide.rs
+++ b/app/gui/src/ide.rs
@@ -33,6 +33,11 @@ const ALIVE_LOG_INTERVAL_SEC: u64 = 60;
 // === Ide ===
 // ===========
 
+/// One of the integration implementations.
+///
+/// The new, refactored integration is called "Presenter", but it is not yet fully implemented.
+/// To test it, run IDE with `--rust-new-presentation-layer` option. By default, the old integration
+/// is used.
 #[derive(Debug)]
 enum Integration {
     Old(integration::Integration),

--- a/app/gui/src/lib.rs
+++ b/app/gui/src/lib.rs
@@ -16,6 +16,7 @@
 #![feature(map_try_insert)]
 #![feature(assert_matches)]
 #![feature(cell_filter_map)]
+#![feature(hash_drain_filter)]
 #![recursion_limit = "512"]
 #![warn(missing_docs)]
 #![warn(trivial_casts)]
@@ -33,6 +34,7 @@ pub mod executor;
 pub mod ide;
 pub mod model;
 pub mod notification;
+pub mod presenter;
 pub mod sync;
 pub mod test;
 pub mod transport;

--- a/app/gui/src/presenter.rs
+++ b/app/gui/src/presenter.rs
@@ -1,0 +1,1 @@
+pub mod graph;

--- a/app/gui/src/presenter.rs
+++ b/app/gui/src/presenter.rs
@@ -1,3 +1,10 @@
+//! The Presenter is a layer between logical part of the IDE (controllers, engine models) and the
+//! views (the P letter in MVP pattern). The presenter reacts to changes in the controllers.
+//!
+//! **The presenters are not fully implemented**. Therefore, the old integration defined in
+//! [`crate::integration`] is used by default. The presenters may be tested by passing
+//! --rust-new-presentation-layer commandline argument.
+
 pub mod graph;
 pub mod project;
 
@@ -13,16 +20,22 @@ use crate::presenter;
 use ide_view as view;
 use ide_view::graph_editor::SharedHashMap;
 
+
+
+// =============
+// === Model ===
+// =============
+
 #[derive(Debug)]
 struct Model {
     logger:          Logger,
-    current_project: RefCell<Option<presenter::Project>>,
+    current_project: RefCell<Option<Project>>,
     controller:      controller::Ide,
     view:            view::root::View,
 }
 
 impl Model {
-    /// Create a new project integration
+    /// Instantiate a new project presenter, which will display current project in the view.
     fn setup_and_display_new_project(self: Rc<Self>) {
         // Remove the old integration first. We want to be sure the old and new integrations will
         // not race for the view.
@@ -55,12 +68,25 @@ impl Model {
     }
 }
 
+
+
+// =================
+// === Presenter ===
+// =================
+
+/// The root presenter, handling the synchronization between IDE controller and root view.
+///
+/// See [`crate::presenter`] docs for information about presenters in general.
 #[derive(Clone, CloneRef, Debug)]
 pub struct Presenter {
     model: Rc<Model>,
 }
 
 impl Presenter {
+    /// Create new root presenter.
+    ///
+    /// The returned presenter is working and does not require any initialization. The current
+    /// project will be displayed (if any).
     pub fn new(controller: controller::Ide, view: ide_view::root::View) -> Self {
         let logger = Logger::new("Presenter");
         let current_project = default();

--- a/app/gui/src/presenter.rs
+++ b/app/gui/src/presenter.rs
@@ -1,9 +1,10 @@
 //! The Presenter is a layer between logical part of the IDE (controllers, engine models) and the
-//! views (the P letter in MVP pattern). The presenter reacts to changes in the controllers.
+//! views (the P letter in MVP pattern). The presenter reacts to changes in the controllers, and
+//! actively updates the view. It also passes all user interactions from view to controllers.
 //!
 //! **The presenters are not fully implemented**. Therefore, the old integration defined in
 //! [`crate::integration`] is used by default. The presenters may be tested by passing
-//! --rust-new-presentation-layer commandline argument.
+//! `--rust-new-presentation-layer` commandline argument.
 
 pub mod graph;
 pub mod project;
@@ -108,9 +109,9 @@ impl Presenter {
         let logger = self.model.logger.clone_ref();
         let process_map = SharedHashMap::<ControllerHandle, ViewHandle>::new();
         let status_bar = self.model.view.status_bar().clone_ref();
-        let status_notif_sub = self.model.controller.status_notifications().subscribe();
+        let status_notifications = self.model.controller.status_notifications().subscribe();
         let weak = Rc::downgrade(&self.model);
-        spawn_stream_handler(weak, status_notif_sub, move |notification, _| {
+        spawn_stream_handler(weak, status_notifications, move |notification, _| {
             match notification {
                 StatusNotification::Event { label } => {
                     status_bar.add_event(ide_view::status_bar::event::Label::new(label));

--- a/app/gui/src/presenter.rs
+++ b/app/gui/src/presenter.rs
@@ -1,1 +1,119 @@
 pub mod graph;
+
+pub use graph::Graph;
+
+use crate::prelude::*;
+
+use crate::controller::ide::StatusNotification;
+use crate::executor::global::spawn_stream_handler;
+use ide_view as view;
+use ide_view::graph_editor::SharedHashMap;
+
+#[derive(Debug)]
+struct Model {
+    logger:          Logger,
+    current_project: RefCell<Option<Graph>>,
+    controller:      controller::Ide,
+    view:            view::root::View,
+}
+
+impl Model {
+    /// Create a new project integration
+    fn setup_and_display_new_project(self: Rc<Self>) {
+        // Remove the old integration first. We want to be sure the old and new integrations will
+        // not race for the view.
+        *self.current_project.borrow_mut() = None;
+
+        if let Some(project_model) = self.controller.current_project() {
+            // We know the name of new project before it loads. We set it right now to avoid
+            // displaying placeholder on the scene during loading.
+            let project_view = self.view.project();
+            let breadcrumbs = &project_view.graph().model.breadcrumbs;
+            breadcrumbs.project_name(project_model.name().to_string());
+
+            let status_notifications = self.controller.status_notifications().clone_ref();
+            let project = controller::Project::new(project_model, status_notifications.clone_ref());
+
+            executor::global::spawn(async move {
+                match project.initialize().await {
+                    Ok(result) => {
+                        let graph_controller = result.main_graph;
+                        let graph_view = project_view.graph().clone_ref();
+                        let project = Graph::new(graph_controller, graph_view);
+                        *self.current_project.borrow_mut() = Some(project);
+                    }
+                    Err(err) => {
+                        let err_msg = format!("Failed to initialize project: {}", err);
+                        error!(self.logger, "{err_msg}");
+                        status_notifications.publish_event(err_msg)
+                    }
+                }
+            });
+        }
+    }
+}
+
+#[derive(Clone, CloneRef, Debug)]
+pub struct Presenter {
+    model: Rc<Model>,
+}
+
+impl Presenter {
+    pub fn new(controller: controller::Ide, view: ide_view::root::View) -> Self {
+        let logger = Logger::new("Presenter");
+        let current_project = default();
+        let model = Rc::new(Model { logger, controller, view, current_project });
+        Self { model }.init()
+    }
+
+    fn init(self) -> Self {
+        self.setup_status_bar_notification_handler();
+        self.setup_controller_notification_handler();
+        self.model.clone_ref().setup_and_display_new_project();
+        self
+    }
+
+    fn setup_status_bar_notification_handler(&self) {
+        use controller::ide::BackgroundTaskHandle as ControllerHandle;
+        use ide_view::status_bar::process::Id as ViewHandle;
+
+        let logger = self.model.logger.clone_ref();
+        let process_map = SharedHashMap::<ControllerHandle, ViewHandle>::new();
+        let status_bar = self.model.view.status_bar().clone_ref();
+        let status_notif_sub = self.model.controller.status_notifications().subscribe();
+        let weak = Rc::downgrade(&self.model);
+        spawn_stream_handler(weak, status_notif_sub, move |notification, _| {
+            match notification {
+                StatusNotification::Event { label } => {
+                    status_bar.add_event(ide_view::status_bar::event::Label::new(label));
+                }
+                StatusNotification::BackgroundTaskStarted { label, handle } => {
+                    status_bar.add_process(ide_view::status_bar::process::Label::new(label));
+                    let view_handle = status_bar.last_process.value();
+                    process_map.insert(handle, view_handle);
+                }
+                StatusNotification::BackgroundTaskFinished { handle } => {
+                    if let Some(view_handle) = process_map.remove(&handle) {
+                        status_bar.finish_process(view_handle);
+                    } else {
+                        warning!(logger, "Controllers finished process not displayed in view");
+                    }
+                }
+            }
+            futures::future::ready(())
+        });
+    }
+
+    fn setup_controller_notification_handler(&self) {
+        let stream = self.model.controller.subscribe();
+        let weak = Rc::downgrade(&self.model);
+        spawn_stream_handler(weak, stream, move |notification, model| {
+            match notification {
+                controller::ide::Notification::NewProjectCreated
+                | controller::ide::Notification::ProjectOpened =>
+                    model.setup_and_display_new_project(),
+            }
+            futures::future::ready(())
+        });
+    }
+}

--- a/app/gui/src/presenter/graph.rs
+++ b/app/gui/src/presenter/graph.rs
@@ -1,14 +1,16 @@
+mod state;
+
 use crate::prelude::*;
 
 use crate::executor::global::spawn_stream_handler;
 
-use bimap::BiMap;
-use bimap::Overwritten;
 use enso_frp as frp;
 use ide_view as view;
 use ide_view::graph_editor::component::node as node_view;
 use ide_view::graph_editor::EdgeEndpoint;
 
+
+type Logger = enso_logger::DefaultTraceLogger;
 
 
 // ===============
@@ -22,342 +24,16 @@ type AstConnection = controller::graph::Connection;
 
 
 
-// ======================
-// === DisplayedState ===
-// ======================
-
-// === DisplayedNodes ===
-
-#[derive(Clone, Debug, Default)]
-struct DisplayedNode {
-    view_id:    Option<ViewNodeId>,
-    position:   Vector2,
-    expression: node_view::Expression,
-}
-
-#[derive(Clone, Debug, Default)]
-struct DisplayedNodes {
-    displayed_nodes:     HashMap<AstNodeId, DisplayedNode>,
-    nodes_without_view:  Vec<AstNodeId>,
-    ast_node_by_view_id: HashMap<ViewNodeId, AstNodeId>,
-}
-
-impl DisplayedNodes {
-    fn get(&self, id: AstNodeId) -> Option<&DisplayedNode> {
-        self.displayed_nodes.get(&id)
-    }
-
-    fn get_mut(&mut self, id: AstNodeId) -> Option<&mut DisplayedNode> {
-        self.displayed_nodes.get_mut(&id)
-    }
-
-    fn get_mut_or_create(&mut self, id: AstNodeId) -> &mut DisplayedNode {
-        let nodes_without_view = &mut self.nodes_without_view;
-        self.displayed_nodes.entry(id).or_insert_with(|| {
-            nodes_without_view.push(id);
-            default()
-        })
-    }
-
-    fn ast_id_of_view(&self, view_id: ViewNodeId) -> Option<AstNodeId> {
-        self.ast_node_by_view_id.get(&view_id).copied()
-    }
-
-    fn assign_newly_created_node(&mut self, view_id: ViewNodeId) -> Option<&mut DisplayedNode> {
-        let ast_node = self.nodes_without_view.pop()?;
-        let mut opt_displayed = self.displayed_nodes.get_mut(&ast_node);
-        if let Some(displayed) = &mut opt_displayed {
-            displayed.view_id = Some(view_id);
-            self.ast_node_by_view_id.insert(view_id, ast_node);
-        }
-        opt_displayed
-    }
-
-    fn retain_nodes(&mut self, nodes: &HashSet<AstNodeId>) -> Vec<ViewNodeId> {
-        self.nodes_without_view.drain_filter(|id| !nodes.contains(id));
-        let removed = self.displayed_nodes.drain_filter(|id, _| !nodes.contains(id));
-        let removed_views = removed.filter_map(|(_, data)| data.view_id).collect();
-        for view_id in &removed_views {
-            self.ast_node_by_view_id.remove(view_id);
-        }
-        removed_views
-    }
-
-    fn remove_node(&mut self, node: ViewNodeId) -> Option<AstNodeId> {
-        let ast_id = self.ast_node_by_view_id.remove(&node)?;
-        self.displayed_nodes.remove(&ast_id);
-        Some(ast_id)
-    }
-}
-
-
-// === Displayed Connections ===
-
-#[derive(Clone, Debug, Default)]
-struct DisplayedConnections {
-    connections:              BiMap<AstConnection, ViewConnection>,
-    connections_without_view: HashSet<AstConnection>,
-}
-
-impl DisplayedConnections {
-    fn view_of_ast_connection(&self, connection: &AstConnection) -> Option<ViewConnection> {
-        self.connections.get_by_left(connection).copied()
-    }
-
-    fn retain_connections(&mut self, connections: &HashSet<AstConnection>) -> Vec<ViewConnection> {
-        self.connections_without_view.retain(|x| connections.contains(x));
-        let to_remove = self.connections.iter().filter(|(con, _)| !connections.contains(con));
-        let to_remove_vec = to_remove.map(|(_, edge_id)| *edge_id).collect_vec();
-        self.connections.retain(|con, _| connections.contains(con));
-        to_remove_vec
-    }
-
-    /// Returns true if the controller needs refreshing.
-    fn assign_connection_view(&mut self, connection: AstConnection, view: ViewConnection) -> bool {
-        let exited_without_view = self.connections_without_view.remove(&connection);
-        match self.connections.insert(connection, view) {
-            Overwritten::Neither => !exited_without_view,
-            Overwritten::Left(_, _) => false,
-            Overwritten::Right(previous, _) => {
-                self.connections_without_view.insert(previous);
-                !exited_without_view
-            }
-            Overwritten::Pair(_, _) => false,
-            Overwritten::Both(_, (previous, _)) => {
-                self.connections_without_view.insert(previous);
-                false
-            }
-        }
-    }
-
-    fn remove_connection(&mut self, connection: ViewConnection) -> Option<AstConnection> {
-        let (ast_connection, _) = self.connections.remove_by_right(&connection)?;
-        Some(ast_connection)
-    }
-}
-
-
-// === DisplayedExpressionss ===
-
-#[derive(Clone, Debug, Default)]
-struct DisplayedExpression {
-    node:            AstNodeId,
-    expression_type: Option<view::graph_editor::Type>,
-    method_pointer:  Option<view::graph_editor::MethodPointer>,
-}
-
-#[derive(Clone, Debug, Default)]
-struct DisplayedExpressions {
-    expressions:         HashMap<ast::Id, DisplayedExpression>,
-    expressions_of_node: HashMap<AstNodeId, Vec<ast::Id>>,
-}
-
-impl DisplayedExpressions {
-    fn retain_expression_of_nodes(&mut self, nodes: &HashSet<AstNodeId>) {
-        let nodes_to_remove =
-            self.expressions_of_node.drain_filter(|node_id, _| !nodes.contains(node_id));
-        let expr_to_remove = nodes_to_remove.map(|(_, exprs)| exprs).flatten();
-        for expression_id in expr_to_remove {
-            self.expressions.remove(&expression_id);
-        }
-    }
-
-    fn node_expression_changed(&mut self, node: AstNodeId, expressions: Vec<ast::Id>) {
-        let new_set: HashSet<ast::Id> = expressions.iter().copied().collect();
-        let old_set = self.expressions_of_node.insert(node, expressions).unwrap_or_default();
-        for old_expression in old_set {
-            if !new_set.contains(&old_expression) {
-                self.expressions.remove(&old_expression);
-            }
-        }
-    }
-
-    fn get_mut(&mut self, id: ast::Id) -> Option<&mut DisplayedExpression> {
-        self.expressions.get_mut(&id)
-    }
-
-    fn subexpressions_of_node(&self, id: ast::Id) -> &[ast::Id] {
-        self.expressions_of_node.get(&id).map_or(&[], |v| v.as_slice())
-    }
-}
-
-
-// === DisplayedState ===
-
-#[derive(Clone, Debug, Default)]
-struct DisplayedState {
-    nodes:       RefCell<DisplayedNodes>,
-    connections: RefCell<DisplayedConnections>,
-    expressions: RefCell<DisplayedExpressions>,
-}
-
-impl DisplayedState {
-    fn assign_newly_created_node(&self, view_id: ViewNodeId) -> Option<DisplayedNode> {
-        self.nodes.borrow_mut().assign_newly_created_node(view_id).cloned()
-    }
-
-    fn assign_connection_view(
-        &self,
-        connection: view::graph_editor::Edge,
-    ) -> Option<AstConnection> {
-        let view_source = connection.source()?;
-        let view_target = connection.target()?;
-        let ast_connection =
-            self.ast_connection_from_view_edge_targets(view_source, view_target)?;
-        let mut connections = self.connections.borrow_mut();
-        let should_update_controllers =
-            connections.assign_connection_view(ast_connection.clone(), connection.id());
-        should_update_controllers.then_some(ast_connection)
-    }
-
-    fn view_id_of_ast_node(&self, node: AstNodeId) -> Option<ViewNodeId> {
-        self.nodes.borrow().get(node).and_then(|n| n.view_id)
-    }
-
-    fn ast_id_of_view_node(&self, node: ViewNodeId) -> Option<AstNodeId> {
-        self.nodes.borrow().ast_id_of_view(node)
-    }
-
-    fn view_of_ast_connection(&self, connection: &AstConnection) -> Option<ViewConnection> {
-        self.connections.borrow().view_of_ast_connection(connection)
-    }
-
-    fn view_edge_targets_of_ast_connection(
-        &self,
-        connection: AstConnection,
-    ) -> Option<(EdgeEndpoint, EdgeEndpoint)> {
-        let nodes = self.nodes.borrow();
-        let src_node = nodes.get(connection.source.node)?.view_id?;
-        let dst_node = nodes.get(connection.destination.node)?.view_id?;
-        let src = EdgeEndpoint::new(src_node, connection.source.port);
-        let data = EdgeEndpoint::new(dst_node, connection.destination.port);
-        Some((src, data))
-    }
-
-    fn ast_connection_from_view_edge_targets(
-        &self,
-        source: EdgeEndpoint,
-        target: EdgeEndpoint,
-    ) -> Option<controller::graph::Connection> {
-        let nodes = self.nodes.borrow();
-        let src_node = nodes.ast_id_of_view(source.node_id)?;
-        let dst_node = nodes.ast_id_of_view(target.node_id)?;
-        Some(controller::graph::Connection {
-            source:      controller::graph::Endpoint::new(src_node, source.port),
-            destination: controller::graph::Endpoint::new(dst_node, target.port),
-        })
-    }
-
-    fn subexpressions_of_node(&self, node: ViewNodeId) -> Vec<ast::Id> {
-        let ast_node = self.nodes.borrow().ast_id_of_view(node);
-        ast_node
-            .map_or_default(|id| self.expressions.borrow().subexpressions_of_node(id).to_owned())
-    }
-
-    fn retain_nodes(&self, nodes: &HashSet<AstNodeId>) -> Vec<ViewNodeId> {
-        self.expressions.borrow_mut().retain_expression_of_nodes(nodes);
-        self.nodes.borrow_mut().retain_nodes(nodes)
-    }
-
-    fn retain_connections(&self, connections: &HashSet<AstConnection>) -> Vec<ViewConnection> {
-        self.connections.borrow_mut().retain_connections(connections)
-    }
-
-    fn refresh_node_position(&self, node: AstNodeId, position: Vector2) -> Option<ViewNodeId> {
-        let mut nodes = self.nodes.borrow_mut();
-        let mut displayed = nodes.get_mut_or_create(node);
-        if displayed.position != position {
-            displayed.position = position;
-            displayed.view_id
-        } else {
-            None
-        }
-    }
-
-    fn refresh_node_expression(
-        &self,
-        node: &controller::graph::Node,
-        trees: controller::graph::NodeTrees,
-    ) -> Option<(ViewNodeId, node_view::Expression)> {
-        let ast_id = node.main_line.id();
-        let new_displayed_expr = node_view::Expression {
-            pattern:             node.info.pattern().map(|t| t.repr()),
-            code:                node.info.expression().repr(),
-            whole_expression_id: node.info.expression().id,
-            input_span_tree:     trees.inputs,
-            output_span_tree:    trees.outputs.unwrap_or_else(default),
-        };
-        let mut nodes = self.nodes.borrow_mut();
-        let displayed = nodes.get_mut_or_create(ast_id);
-        if &displayed.expression != &new_displayed_expr {
-            displayed.expression = new_displayed_expr.clone();
-            let new_expressions =
-                node.info.ast().iter_recursive().filter_map(|ast| ast.id).collect();
-            self.expressions.borrow_mut().node_expression_changed(ast_id, new_expressions);
-            Some((displayed.view_id?, new_displayed_expr))
-        } else {
-            None
-        }
-    }
-
-    fn refresh_expression_type(
-        &self,
-        id: ast::Id,
-        new_type: Option<view::graph_editor::Type>,
-    ) -> Option<ViewNodeId> {
-        let mut expressions = self.expressions.borrow_mut();
-        let to_update = expressions.get_mut(id).filter(|d| d.expression_type != new_type);
-        if let Some(displayed) = to_update {
-            displayed.expression_type = new_type;
-            self.nodes.borrow().get(displayed.node).and_then(|node| node.view_id)
-        } else {
-            None
-        }
-    }
-
-    fn refresh_expression_method_pointer(
-        &self,
-        id: ast::Id,
-        method_ptr: Option<view::graph_editor::MethodPointer>,
-    ) -> Option<ViewNodeId> {
-        let mut expressions = self.expressions.borrow_mut();
-        let to_update = expressions.get_mut(id).filter(|d| d.method_pointer != method_ptr);
-        if let Some(displayed) = to_update {
-            displayed.method_pointer = method_ptr;
-            self.nodes.borrow().get(displayed.node).and_then(|node| node.view_id)
-        } else {
-            None
-        }
-    }
-
-    fn node_position_changed(&self, id: ViewNodeId, new_position: Vector2) -> Option<AstNodeId> {
-        let mut nodes = self.nodes.borrow_mut();
-        let ast_id = nodes.ast_id_of_view(id)?;
-        let displayed = nodes.get_mut(ast_id)?;
-        if displayed.position != new_position {
-            displayed.position = new_position;
-            Some(ast_id)
-        } else {
-            None
-        }
-    }
-
-    fn connection_removed(&self, id: ViewConnection) -> Option<AstConnection> {
-        self.connections.borrow_mut().remove_connection(id)
-    }
-
-    fn node_removed(&self, id: ViewNodeId) -> Option<AstNodeId> {
-        self.nodes.borrow_mut().remove_node(id)
-    }
-}
-
+// =============
+// === Model ===
+// =============
 
 #[derive(Clone, Debug)]
 struct Model {
     logger:     Logger,
     controller: controller::ExecutedGraph,
     view:       view::graph_editor::GraphEditor,
-    displayed:  Rc<DisplayedState>,
+    state:      Rc<state::State>,
 }
 
 impl Model {
@@ -366,14 +42,14 @@ impl Model {
         view: view::graph_editor::GraphEditor,
     ) -> Self {
         let logger = Logger::new("presenter::Graph");
-        let displayed = default();
-        Self { logger, controller, view, displayed }
+        let state = default();
+        Self { logger, controller, view, state }
     }
 
     fn node_position_changed(&self, id: ViewNodeId, position: Vector2) {
         self.update_ast(
             || {
-                let ast_id = self.displayed.node_position_changed(id, position)?;
+                let ast_id = self.state.node_position_changed(id, position)?;
                 Some(self.controller.graph().set_node_position(ast_id, position))
             },
             "update node position",
@@ -383,7 +59,7 @@ impl Model {
     fn node_removed(&self, id: ViewNodeId) {
         self.update_ast(
             || {
-                let ast_id = self.displayed.node_removed(id)?;
+                let ast_id = self.state.node_removed(id)?;
                 Some(self.controller.graph().remove_node(ast_id))
             },
             "remove node",
@@ -394,7 +70,7 @@ impl Model {
         self.update_ast(
             || {
                 let connection = self.view.model.edges.get_cloned_ref(&id)?;
-                let ast_to_create = self.displayed.assign_connection_view(connection)?;
+                let ast_to_create = self.state.assign_connection_view(connection)?;
                 Some(self.controller.connect(&ast_to_create))
             },
             "create connection",
@@ -404,7 +80,7 @@ impl Model {
     fn connection_removed(&self, id: ViewConnection) {
         self.update_ast(
             || {
-                let ast_to_remove = self.displayed.connection_removed(id)?;
+                let ast_to_remove = self.state.connection_removed(id)?;
                 Some(self.controller.disconnect(&ast_to_remove))
             },
             "delete connection",
@@ -422,12 +98,12 @@ impl Model {
         &self,
         node: ViewNodeId,
     ) -> Vec<(ViewNodeId, ast::Id, Option<view::graph_editor::Type>)> {
-        let subexpressions = self.displayed.subexpressions_of_node(node);
+        let subexpressions = self.state.subexpressions_of_node(node);
         subexpressions
             .iter()
             .map(|id| {
                 let a_type = self.expression_type(*id);
-                self.displayed.refresh_expression_type(*id, a_type.clone());
+                self.state.refresh_expression_type(*id, a_type.clone());
                 (node, *id, a_type)
             })
             .collect()
@@ -437,7 +113,7 @@ impl Model {
         &self,
         node: ViewNodeId,
     ) -> Vec<(ast::Id, Option<view::graph_editor::MethodPointer>)> {
-        let subexpressions = self.displayed.subexpressions_of_node(node);
+        let subexpressions = self.state.subexpressions_of_node(node);
         subexpressions.iter().filter_map(|id| self.refresh_expression_method_pointer(*id)).collect()
     }
 
@@ -446,7 +122,7 @@ impl Model {
         id: ast::Id,
     ) -> Option<(ViewNodeId, ast::Id, Option<view::graph_editor::Type>)> {
         let a_type = self.expression_type(id);
-        let node_view = self.displayed.refresh_expression_type(id, a_type.clone())?;
+        let node_view = self.state.refresh_expression_type(id, a_type.clone())?;
         Some((node_view, id, a_type))
     }
 
@@ -455,7 +131,7 @@ impl Model {
         id: ast::Id,
     ) -> Option<(ast::Id, Option<view::graph_editor::MethodPointer>)> {
         let method_pointer = self.expression_method(id);
-        self.displayed.refresh_expression_method_pointer(id, method_pointer.clone())?;
+        self.state.refresh_expression_method_pointer(id, method_pointer.clone())?;
         Some((id, method_pointer))
     }
 
@@ -477,7 +153,7 @@ impl Model {
 
 #[derive(Clone, Debug, Default)]
 struct ViewUpdate {
-    displayed:   Rc<DisplayedState>,
+    state:       Rc<state::State>,
     nodes:       Vec<controller::graph::Node>,
     trees:       HashMap<AstNodeId, controller::graph::NodeTrees>,
     connections: HashSet<AstConnection>,
@@ -485,20 +161,20 @@ struct ViewUpdate {
 
 impl ViewUpdate {
     fn new(model: &Model) -> FallibleResult<Self> {
-        let displayed = model.displayed.clone_ref();
+        let displayed = model.state.clone_ref();
         let nodes = model.controller.graph().nodes()?;
         let connections_and_trees = model.controller.connections()?;
         let connections = connections_and_trees.connections.into_iter().collect();
         let trees = connections_and_trees.trees;
-        Ok(Self { displayed, nodes, trees, connections })
+        Ok(Self { state: displayed, nodes, trees, connections })
     }
 
     fn nodes_to_remove(&self) -> Vec<ViewNodeId> {
-        self.displayed.retain_nodes(&self.node_ids().collect())
+        self.state.retain_nodes(&self.node_ids().collect())
     }
 
     fn nodes_to_add(&self) -> usize {
-        self.node_ids().filter(|n| self.displayed.view_id_of_ast_node(*n).is_none()).count()
+        self.node_ids().filter(|n| self.state.view_id_of_ast_node(*n).is_none()).count()
     }
 
     fn expressions_to_set(&self) -> Vec<(ViewNodeId, node_view::Expression)> {
@@ -507,7 +183,7 @@ impl ViewUpdate {
             .filter_map(|node| {
                 let id = node.main_line.id();
                 let trees = self.trees.get(&id).cloned().unwrap_or_default();
-                self.displayed.refresh_node_expression(node, trees)
+                self.state.refresh_node_expression(node, trees)
             })
             .collect()
     }
@@ -518,24 +194,21 @@ impl ViewUpdate {
             .filter_map(|node| {
                 let id = node.main_line.id();
                 let position = node.position()?.vector;
-                let view_id = self.displayed.refresh_node_position(id, position)?;
+                let view_id = self.state.refresh_node_position(id, position)?;
                 Some((view_id, position))
             })
             .collect()
     }
 
     fn connections_to_remove(&self) -> Vec<ViewConnection> {
-        self.displayed.retain_connections(&self.connections)
+        self.state.retain_connections(&self.connections)
     }
 
     fn connections_to_add(&self) -> Vec<(EdgeEndpoint, EdgeEndpoint)> {
+        DEBUG!("connections_to_add: {self.connections:?}");
         let ast_conns = self.connections.iter();
-        let ast_conns_to_add = ast_conns
-            .filter(|connection| self.displayed.view_of_ast_connection(connection).is_none());
-        ast_conns_to_add
-            .filter_map(|connection| {
-                self.displayed.view_edge_targets_of_ast_connection(connection.clone())
-            })
+        ast_conns
+            .filter_map(|connection| self.state.refresh_connection(connection.clone()))
             .collect()
     }
 
@@ -577,24 +250,34 @@ impl Graph {
                 })
             );
 
+
+            // === Refreshing Nodes ===
+
             remove_node <= update_data.map(|update| update.nodes_to_remove());
             update_node_expression <= update_data.map(|update| update.expressions_to_set());
             set_node_position <= update_data.map(|update| update.positions_to_set());
-            remove_connection <= update_data.map(|update| update.connections_to_remove());
-            add_connection <= update_data.map(|update| update.connections_to_add());
             view.remove_node <+ remove_node;
             view.set_node_expression <+ update_node_expression;
             view.set_node_position <+ set_node_position;
-            view.remove_edge <+ remove_connection;
-            view.connect_nodes <+ add_connection;
 
             view.add_node <+ update_data.map(|update| update.nodes_to_add()).repeat();
             added_node_update <- view.node_added.filter_map(f!((view_id)
-                model.displayed.assign_newly_created_node(*view_id)
+                model.state.assign_newly_created_node(*view_id)
             ));
             init_node_expression <- added_node_update.filter_map(|update| Some((update.view_id?, update.expression.clone())));
             view.set_node_expression <+ init_node_expression;
             view.set_node_position <+ added_node_update.filter_map(|update| Some((update.view_id?, update.position)));
+
+
+            // === Refreshing Connections ===
+
+            remove_connection <= update_data.map(|update| update.connections_to_remove());
+            add_connection <= update_data.map(|update| update.connections_to_add());
+            view.remove_edge <+ remove_connection;
+            view.connect_nodes <+ add_connection;
+
+
+            // === Refreshing Expressions ===
 
             reset_node_types <- any(update_node_expression, init_node_expression)._0();
             set_expression_type <= reset_node_types.map(f!((view_id) model.all_types_of_node(*view_id)));
@@ -602,17 +285,21 @@ impl Graph {
             view.set_expression_usage_type <+ set_expression_type;
             view.set_method_pointer <+ set_method_pointer;
 
-            eval view.node_position_set_batched(((node_id, position)) model.node_position_changed(*node_id, *position));
-            eval view.node_removed((node_id) model.node_removed(*node_id));
-            eval view.on_edge_endpoints_set((edge_id) model.new_connection_created(*edge_id));
-            eval view.on_edge_endpoint_unset(((edge_id,_)) model.connection_removed(*edge_id));
-
             update_expressions <- source::<Vec<ast::Id>>();
             update_expression <= update_expressions;
             view.set_expression_usage_type <+ update_expression.filter_map(f!((id) model.refresh_expression_type(*id)));
             view.set_method_pointer <+ update_expression.filter_map(f!((id) model.refresh_expression_method_pointer(*id)));
+
+
+            // === Changes from the View ===
+
+            eval view.node_position_set_batched(((node_id, position)) model.node_position_changed(*node_id, *position));
+            eval view.node_removed((node_id) model.node_removed(*node_id));
+            eval view.on_edge_endpoints_set((edge_id) model.new_connection_created(*edge_id));
+            eval view.on_edge_endpoint_unset(((edge_id,_)) model.connection_removed(*edge_id));
         }
 
+        update_view.emit(());
         self.setup_controller_notification_handlers(update_view, update_expressions);
 
         self
@@ -626,7 +313,8 @@ impl Graph {
         use crate::controller::graph::executed;
         use crate::controller::graph::Notification;
         let graph_notifications = self.model.controller.subscribe();
-        self.spawn_sync_stream_handler(graph_notifications, move |notification, _model| {
+        self.spawn_sync_stream_handler(graph_notifications, move |notification, model| {
+            info!(model.logger, "Received controller notification {notification:?}");
             match notification {
                 executed::Notification::Graph(graph) => match graph {
                     Notification::Invalidate => update_view.emit(()),

--- a/app/gui/src/presenter/graph.rs
+++ b/app/gui/src/presenter/graph.rs
@@ -1,9 +1,24 @@
 use crate::prelude::*;
-use bimap::BiMap;
 
+use crate::executor::global::spawn_stream_handler;
+
+use bimap::BiMap;
+use bimap::Overwritten;
 use enso_frp as frp;
 use ide_view as view;
 use ide_view::graph_editor::component::node as node_view;
+use ide_view::graph_editor::EdgeEndpoint;
+
+
+
+// ===============
+// === Aliases ===
+// ===============
+
+type ViewNodeId = view::graph_editor::NodeId;
+type AstNodeId = ast::Id;
+type ViewConnection = view::graph_editor::EdgeId;
+type AstConnection = controller::graph::Connection;
 
 
 
@@ -13,22 +28,11 @@ use ide_view::graph_editor::component::node as node_view;
 
 // === DisplayedNodes ===
 
-type ViewNodeId = view::graph_editor::NodeId;
-type AstNodeId = ast::Id;
-type ViewConnection = view::graph_editor::EdgeId;
-type AstConnection = controller::graph::Connection;
-
 #[derive(Clone, Debug, Default)]
 struct DisplayedNode {
     view_id:    Option<ViewNodeId>,
     position:   Vector2,
     expression: node_view::Expression,
-}
-
-impl DisplayedNode {
-    fn new(view_id: ViewNodeId) -> Self {
-        DisplayedNode { view_id: Some(view_id), position: default(), expression: default() }
-    }
 }
 
 #[derive(Clone, Debug, Default)]
@@ -39,6 +43,10 @@ struct DisplayedNodes {
 }
 
 impl DisplayedNodes {
+    fn get(&self, id: AstNodeId) -> Option<&DisplayedNode> {
+        self.displayed_nodes.get(&id)
+    }
+
     fn get_mut(&mut self, id: AstNodeId) -> Option<&mut DisplayedNode> {
         self.displayed_nodes.get_mut(&id)
     }
@@ -55,14 +63,14 @@ impl DisplayedNodes {
         self.ast_node_by_view_id.get(&view_id).copied()
     }
 
-    fn assign_newly_created_node(&mut self, view_id: ViewNodeId) -> Option<DisplayedNode> {
+    fn assign_newly_created_node(&mut self, view_id: ViewNodeId) -> Option<&mut DisplayedNode> {
         let ast_node = self.nodes_without_view.pop()?;
         let mut opt_displayed = self.displayed_nodes.get_mut(&ast_node);
         if let Some(displayed) = &mut opt_displayed {
             displayed.view_id = Some(view_id);
             self.ast_node_by_view_id.insert(view_id, ast_node);
         }
-        opt_displayed.cloned()
+        opt_displayed
     }
 
     fn retain_nodes(&mut self, nodes: &HashSet<AstNodeId>) -> Vec<ViewNodeId> {
@@ -74,12 +82,68 @@ impl DisplayedNodes {
         }
         removed_views
     }
+
+    fn remove_node(&mut self, node: ViewNodeId) -> Option<AstNodeId> {
+        let ast_id = self.ast_node_by_view_id.remove(&node)?;
+        self.displayed_nodes.remove(&ast_id);
+        Some(ast_id)
+    }
 }
+
+
+// === Displayed Connections ===
+
+#[derive(Clone, Debug, Default)]
+struct DisplayedConnections {
+    connections:              BiMap<AstConnection, ViewConnection>,
+    connections_without_view: HashSet<AstConnection>,
+}
+
+impl DisplayedConnections {
+    fn view_of_ast_connection(&self, connection: &AstConnection) -> Option<ViewConnection> {
+        self.connections.get_by_left(connection).copied()
+    }
+
+    fn retain_connections(&mut self, connections: &HashSet<AstConnection>) -> Vec<ViewConnection> {
+        self.connections_without_view.retain(|x| connections.contains(x));
+        let to_remove = self.connections.iter().filter(|(con, _)| !connections.contains(con));
+        let to_remove_vec = to_remove.map(|(_, edge_id)| *edge_id).collect_vec();
+        self.connections.retain(|con, _| connections.contains(con));
+        to_remove_vec
+    }
+
+    /// Returns true if the controller needs refreshing.
+    fn assign_connection_view(&mut self, connection: AstConnection, view: ViewConnection) -> bool {
+        let exited_without_view = self.connections_without_view.remove(&connection);
+        match self.connections.insert(connection, view) {
+            Overwritten::Neither => !exited_without_view,
+            Overwritten::Left(_, _) => false,
+            Overwritten::Right(previous, _) => {
+                self.connections_without_view.insert(previous);
+                !exited_without_view
+            }
+            Overwritten::Pair(_, _) => false,
+            Overwritten::Both(_, (previous, _)) => {
+                self.connections_without_view.insert(previous);
+                false
+            }
+        }
+    }
+
+    fn remove_connection(&mut self, connection: ViewConnection) -> Option<AstConnection> {
+        let (ast_connection, _) = self.connections.remove_by_right(&connection)?;
+        Some(ast_connection)
+    }
+}
+
+
+// === Displayed Expression ===
 
 #[derive(Clone, Debug, Default)]
 struct DisplayedExpression {
     node:            ViewNodeId,
     expression_type: Option<view::graph_editor::Type>,
+    method_pointer:  Option<view::graph_editor::MethodPointer>,
 }
 
 
@@ -88,21 +152,69 @@ struct DisplayedExpression {
 #[derive(Clone, Debug, Default)]
 struct DisplayedState {
     nodes:       RefCell<DisplayedNodes>,
-    connections: RefCell<BiMap<AstConnection, ViewConnection>>,
+    connections: RefCell<DisplayedConnections>,
     expressions: RefCell<HashMap<ast::Id, DisplayedExpression>>,
 }
 
 impl DisplayedState {
     fn assign_newly_created_node(&self, view_id: ViewNodeId) -> Option<DisplayedNode> {
-        self.nodes.borrow_mut().assign_newly_created_node(view_id)
+        self.nodes.borrow_mut().assign_newly_created_node(view_id).cloned()
+    }
+
+    fn assign_connection_view(
+        &self,
+        connection: view::graph_editor::Edge,
+    ) -> Option<AstConnection> {
+        let view_source = connection.source()?;
+        let view_target = connection.target()?;
+        let ast_connection =
+            self.ast_connection_from_view_edge_targets(view_source, view_target)?;
+        let mut connections = self.connections.borrow_mut();
+        let should_update_controllers =
+            connections.assign_connection_view(ast_connection.clone(), connection.id());
+        should_update_controllers.then_some(ast_connection)
     }
 
     fn view_id_of_ast_node(&self, node: AstNodeId) -> Option<ViewNodeId> {
         self.nodes.borrow().displayed_nodes.get(&node).and_then(|node| node.view_id)
     }
 
+    fn view_of_ast_connection(&self, connection: &AstConnection) -> Option<ViewConnection> {
+        self.connections.borrow().view_of_ast_connection(connection)
+    }
+
+    fn view_edge_targets_of_ast_connection(
+        &self,
+        connection: AstConnection,
+    ) -> Option<(EdgeEndpoint, EdgeEndpoint)> {
+        let nodes = self.nodes.borrow();
+        let src_node = nodes.get(connection.source.node)?.view_id?;
+        let dst_node = nodes.get(connection.destination.node)?.view_id?;
+        let src = EdgeEndpoint::new(src_node, connection.source.port);
+        let data = EdgeEndpoint::new(dst_node, connection.destination.port);
+        Some((src, data))
+    }
+
+    fn ast_connection_from_view_edge_targets(
+        &self,
+        source: EdgeEndpoint,
+        target: EdgeEndpoint,
+    ) -> Option<controller::graph::Connection> {
+        let nodes = self.nodes.borrow();
+        let src_node = nodes.ast_id_of_view(source.node_id)?;
+        let dst_node = nodes.ast_id_of_view(target.node_id)?;
+        Some(controller::graph::Connection {
+            source:      controller::graph::Endpoint::new(src_node, source.port),
+            destination: controller::graph::Endpoint::new(dst_node, target.port),
+        })
+    }
+
     fn retain_nodes(&self, nodes: &HashSet<AstNodeId>) -> Vec<ViewNodeId> {
         self.nodes.borrow_mut().retain_nodes(nodes)
+    }
+
+    fn retain_connections(&self, connections: &HashSet<AstConnection>) -> Vec<ViewConnection> {
+        self.connections.borrow_mut().retain_connections(connections)
     }
 
     fn refresh_node_position(&self, node: AstNodeId, position: Vector2) -> Option<ViewNodeId> {
@@ -150,6 +262,14 @@ impl DisplayedState {
             None
         }
     }
+
+    fn connection_removed(&self, id: ViewConnection) -> Option<AstConnection> {
+        self.connections.borrow_mut().remove_connection(id)
+    }
+
+    fn node_removed(&self, id: ViewNodeId) -> Option<AstNodeId> {
+        self.nodes.borrow_mut().remove_node(id)
+    }
 }
 
 
@@ -158,7 +278,7 @@ struct Model {
     logger:     Logger,
     controller: controller::ExecutedGraph,
     view:       view::graph_editor::GraphEditor,
-    displayed:  DisplayedState,
+    displayed:  Rc<DisplayedState>,
 }
 
 impl Model {
@@ -167,15 +287,55 @@ impl Model {
         view: view::graph_editor::GraphEditor,
     ) -> Self {
         let logger = Logger::new("presenter::Graph");
-        let mappings = default();
-        Self { logger, controller, view, displayed: mappings }
+        let displayed = default();
+        Self { logger, controller, view, displayed }
     }
 
     fn node_position_changed(&self, id: ViewNodeId, position: Vector2) {
-        if let Some(ast_id) = self.displayed.node_position_changed(id, position) {
-            if let Err(err) = self.controller.graph().set_node_position(ast_id, position) {
-                error!(self.logger, "Failed to set node position in AST: {err}");
-            }
+        self.update_ast(
+            || {
+                let ast_id = self.displayed.node_position_changed(id, position)?;
+                Some(self.controller.graph().set_node_position(ast_id, position))
+            },
+            "update node position",
+        );
+    }
+
+    fn node_removed(&self, id: ViewNodeId) {
+        self.update_ast(
+            || {
+                let ast_id = self.displayed.node_removed(id)?;
+                Some(self.controller.graph().remove_node(ast_id))
+            },
+            "remove node",
+        )
+    }
+
+    fn new_connection_created(&self, id: ViewConnection) {
+        self.update_ast(
+            || {
+                let connection = self.view.model.edges.get_cloned_ref(&id)?;
+                let ast_to_create = self.displayed.assign_connection_view(connection)?;
+                Some(self.controller.connect(&ast_to_create))
+            },
+            "create connetion",
+        );
+    }
+
+    fn connection_removed(&self, id: ViewConnection) {
+        self.update_ast(
+            || {
+                let ast_to_remove = self.displayed.connection_removed(id)?;
+                Some(self.controller.disconnect(&ast_to_remove))
+            },
+            "delete connection",
+        );
+    }
+
+    fn update_ast<F>(&self, f: F, action: &str)
+    where F: FnOnce() -> Option<FallibleResult> {
+        if let Some(Err(err)) = f() {
+            error!(self.logger, "Failed to {action} in AST: {err}");
         }
     }
 }
@@ -183,40 +343,70 @@ impl Model {
 
 #[derive(Clone, Debug, Default)]
 struct ViewUpdate {
-    nodes_to_remove:    Vec<ViewNodeId>,
-    nodes_to_add:       usize,
-    expressions_to_set: Vec<(ViewNodeId, node_view::Expression)>,
-    positions_to_set:   Vec<(ViewNodeId, Vector2)>,
+    displayed:   Rc<DisplayedState>,
+    nodes:       Vec<controller::graph::Node>,
+    trees:       HashMap<AstNodeId, controller::graph::NodeTrees>,
+    connections: HashSet<AstConnection>,
 }
 
 impl ViewUpdate {
-    fn new(model: Rc<Model>) -> FallibleResult<Self> {
+    fn new(model: &Model) -> FallibleResult<Self> {
+        let displayed = model.displayed.clone_ref();
         let nodes = model.controller.graph().nodes()?;
-        let connections = model.controller.connections()?;
-        let mut trees = connections.trees;
-        let connections = connections.connections;
-        let id_of_node = |n: &controller::graph::Node| n.info.main_line.id();
-        let node_ids = nodes.iter().map(id_of_node);
-        let nodes_to_remove = model.displayed.retain_nodes(&node_ids.clone().collect());
-        let nodes_to_add =
-            node_ids.filter(|node| model.displayed.view_id_of_ast_node(*node).is_none());
-        let expressions_to_set = nodes.iter().filter_map(|node| {
-            let id = node.main_line.id();
-            let trees = trees.remove(&id).unwrap_or_default();
-            model.displayed.refresh_node_expression(node, trees)
-        });
-        let positions_to_set = nodes.iter().filter_map(|node| {
-            let id = node.main_line.id();
-            let position = node.position()?.vector;
-            let view_id = model.displayed.refresh_node_position(id, position)?;
-            Some((view_id, position))
-        });
-        Ok(Self {
-            nodes_to_remove,
-            expressions_to_set: expressions_to_set.collect(),
-            positions_to_set: positions_to_set.collect(),
-            nodes_to_add: nodes_to_add.count(),
-        })
+        let connections_and_trees = model.controller.connections()?;
+        let connections = connections_and_trees.connections.into_iter().collect();
+        let trees = connections_and_trees.trees;
+        Ok(Self { displayed, nodes, trees, connections })
+    }
+
+    fn nodes_to_remove(&self) -> Vec<ViewNodeId> {
+        self.displayed.retain_nodes(&self.node_ids().collect())
+    }
+
+    fn nodes_to_add(&self) -> usize {
+        self.node_ids().filter(|n| self.displayed.view_id_of_ast_node(*n).is_none()).count()
+    }
+
+    fn expressions_to_set(&self) -> Vec<(ViewNodeId, node_view::Expression)> {
+        self.nodes
+            .iter()
+            .filter_map(|node| {
+                let id = node.main_line.id();
+                let trees = self.trees.get(&id).cloned().unwrap_or_default();
+                self.displayed.refresh_node_expression(node, trees)
+            })
+            .collect()
+    }
+
+    fn positions_to_set(&self) -> Vec<(ViewNodeId, Vector2)> {
+        self.nodes
+            .iter()
+            .filter_map(|node| {
+                let id = node.main_line.id();
+                let position = node.position()?.vector;
+                let view_id = self.displayed.refresh_node_position(id, position)?;
+                Some((view_id, position))
+            })
+            .collect()
+    }
+
+    fn connections_to_remove(&self) -> Vec<ViewConnection> {
+        self.displayed.retain_connections(&self.connections)
+    }
+
+    fn connections_to_add(&self) -> Vec<(EdgeEndpoint, EdgeEndpoint)> {
+        let ast_conns = self.connections.iter();
+        let ast_conns_to_add = ast_conns
+            .filter(|connection| self.displayed.view_of_ast_connection(connection).is_none());
+        ast_conns_to_add
+            .filter_map(|connection| {
+                self.displayed.view_edge_targets_of_ast_connection(connection.clone())
+            })
+            .collect()
+    }
+
+    fn node_ids<'a>(&'a self) -> impl Iterator<Item = AstNodeId> + 'a {
+        self.nodes.iter().map(controller::graph::Node::id)
     }
 }
 
@@ -240,11 +430,13 @@ impl Graph {
         let logger = &self.model.logger;
         let network = &self.network;
         let model = &self.model;
+        let displayed = &model.displayed;
+        let controller = &model.controller;
         let view = &self.model.view.frp;
         frp::extend! { network
             update_view <- source::<()>();
             update_data <- update_view.map(
-                f_!([logger,model] match ViewUpdate::new(model.clone_ref()) {
+                f_!([logger,model] match ViewUpdate::new(&*model) {
                     Ok(update) => Rc::new(update),
                     Err(err) => {
                         error!(logger,"Failed to update view: {err:?}");
@@ -253,20 +445,60 @@ impl Graph {
                 })
             );
 
-            remove_node <= update_data.map(|update| update.nodes_to_remove.clone());
-            set_node_expression <= update_data.map(|update| update.expressions_to_set.clone());
-            set_node_position <= update_data.map(|update| update.positions_to_set.clone());
+            remove_node <= update_data.map(|update| update.nodes_to_remove());
+            set_node_expression <= update_data.map(|update| update.expressions_to_set());
+            set_node_position <= update_data.map(|update| update.positions_to_set());
+            remove_connection <= update_data.map(|update| update.connections_to_remove());
+            add_connection <= update_data.map(|update| update.connections_to_add());
             view.remove_node <+ remove_node;
             view.set_node_expression <+ set_node_expression;
             view.set_node_position <+ set_node_position;
+            view.remove_edge <+ remove_connection;
+            view.connect_nodes <+ add_connection;
 
-            view.add_node <+ update_data.map(|update| update.nodes_to_add).repeat();
+            view.add_node <+ update_data.map(|update| update.nodes_to_add()).repeat();
             added_node_update <- view.node_added.filter_map(f!((view_id)
                 model.displayed.assign_newly_created_node(*view_id)
             ));
             view.set_node_expression <+ added_node_update.filter_map(|update| Some((update.view_id?, update.expression.clone())));
             view.set_node_position <+ added_node_update.filter_map(|update| Some((update.view_id?, update.position)));
+
+            eval view.node_position_set_batched(((node_id, position)) model.node_position_changed(*node_id, *position));
+            eval view.node_removed((node_id) model.node_removed(*node_id));
+            eval view.on_edge_endpoints_set((edge_id) model.new_connection_created(*edge_id));
+            eval view.on_edge_endpoint_unset(((edge_id,_)) model.connection_removed(*edge_id));
         }
+
+        self.setup_controller_notification_handlers(update_view.clone_ref());
+
         self
+    }
+
+    fn setup_controller_notification_handlers(&self, update_view: frp::Source<()>) {
+        use crate::controller::graph::executed;
+        use crate::controller::graph::Notification;
+        let graph_notifications = self.model.controller.subscribe();
+        self.spawn_sync_stream_handler(graph_notifications, move |notification, model| {
+            match notification {
+                executed::Notification::Graph(graph) => match graph {
+                    Notification::Invalidate => update_view.emit(()),
+                    Notification::PortsUpdate => {}
+                },
+                executed::Notification::ComputedValueInfo(_) => {}
+                executed::Notification::EnteredNode(_) => {}
+                executed::Notification::SteppedOutOfNode(_) => {}
+            }
+        })
+    }
+
+    fn spawn_sync_stream_handler<Stream, Function>(&self, stream: Stream, handler: Function)
+    where
+        Stream: StreamExt + Unpin + 'static,
+        Function: Fn(Stream::Item, Rc<Model>) + 'static, {
+        let model = Rc::downgrade(&self.model);
+        spawn_stream_handler(model, stream, move |item, model| {
+            handler(item, model);
+            futures::future::ready(())
+        })
     }
 }

--- a/app/gui/src/presenter/graph.rs
+++ b/app/gui/src/presenter/graph.rs
@@ -564,8 +564,6 @@ impl Graph {
         let logger = &self.model.logger;
         let network = &self.network;
         let model = &self.model;
-        let displayed = &model.displayed;
-        let controller = &model.controller;
         let view = &self.model.view.frp;
         frp::extend! { network
             update_view <- source::<()>();
@@ -628,7 +626,7 @@ impl Graph {
         use crate::controller::graph::executed;
         use crate::controller::graph::Notification;
         let graph_notifications = self.model.controller.subscribe();
-        self.spawn_sync_stream_handler(graph_notifications, move |notification, model| {
+        self.spawn_sync_stream_handler(graph_notifications, move |notification, _model| {
             match notification {
                 executed::Notification::Graph(graph) => match graph {
                     Notification::Invalidate => update_view.emit(()),

--- a/app/gui/src/presenter/graph.rs
+++ b/app/gui/src/presenter/graph.rs
@@ -1,3 +1,5 @@
+//! The [`Graph`] presenter module.
+
 mod state;
 
 use crate::prelude::*;
@@ -9,8 +11,6 @@ use ide_view as view;
 use ide_view::graph_editor::component::node as node_view;
 use ide_view::graph_editor::EdgeEndpoint;
 
-
-type Logger = enso_logger::DefaultTraceLogger;
 
 
 // ===============
@@ -46,41 +46,45 @@ impl Model {
         Self { logger, controller, view, state }
     }
 
+    /// Node position was changed in view.
     fn node_position_changed(&self, id: ViewNodeId, position: Vector2) {
         self.update_ast(
             || {
-                let ast_id = self.state.node_position_changed(id, position)?;
+                let ast_id = self.state.update_from_view().set_node_position(id, position)?;
                 Some(self.controller.graph().set_node_position(ast_id, position))
             },
             "update node position",
         );
     }
 
+    /// Node was removed in view.
     fn node_removed(&self, id: ViewNodeId) {
         self.update_ast(
             || {
-                let ast_id = self.state.node_removed(id)?;
+                let ast_id = self.state.update_from_view().remove_node(id)?;
                 Some(self.controller.graph().remove_node(ast_id))
             },
             "remove node",
         )
     }
 
+    /// Connection was created in view.
     fn new_connection_created(&self, id: ViewConnection) {
         self.update_ast(
             || {
                 let connection = self.view.model.edges.get_cloned_ref(&id)?;
-                let ast_to_create = self.state.assign_connection_view(connection)?;
+                let ast_to_create = self.state.update_from_view().create_connection(connection)?;
                 Some(self.controller.connect(&ast_to_create))
             },
             "create connection",
         );
     }
 
+    /// Connection was removed in view.
     fn connection_removed(&self, id: ViewConnection) {
         self.update_ast(
             || {
-                let ast_to_remove = self.state.connection_removed(id)?;
+                let ast_to_remove = self.state.update_from_view().remove_connection(id)?;
                 Some(self.controller.disconnect(&ast_to_remove))
             },
             "delete connection",
@@ -94,53 +98,71 @@ impl Model {
         }
     }
 
+    /// Extract all types for subexpressions in node expressions, update the state,
+    /// and return the events for graph editor FRP input setting all of those types.
+    ///
+    /// The result includes the types not changed according to the state. That's because this
+    /// function is used after node expression change, and we need to reset all the types in view.
     fn all_types_of_node(
         &self,
         node: ViewNodeId,
     ) -> Vec<(ViewNodeId, ast::Id, Option<view::graph_editor::Type>)> {
-        let subexpressions = self.state.subexpressions_of_node(node);
+        let subexpressions = self.state.expressions_of_node(node);
         subexpressions
             .iter()
             .map(|id| {
                 let a_type = self.expression_type(*id);
-                self.state.refresh_expression_type(*id, a_type.clone());
+                self.state.update_from_controller().set_expression_type(*id, a_type.clone());
                 (node, *id, a_type)
             })
             .collect()
     }
 
+    /// Extract all method pointers for subexpressions, update the state, and return events updating
+    /// view for expressions where method pointer actually changed.
     fn all_method_pointers_of_node(
         &self,
         node: ViewNodeId,
     ) -> Vec<(ast::Id, Option<view::graph_editor::MethodPointer>)> {
-        let subexpressions = self.state.subexpressions_of_node(node);
+        let subexpressions = self.state.expressions_of_node(node);
         subexpressions.iter().filter_map(|id| self.refresh_expression_method_pointer(*id)).collect()
     }
 
+    /// Refresh type of the given expression.
+    ///
+    /// If the view update is required, the GraphEditor's FRP input event is returned.
     fn refresh_expression_type(
         &self,
         id: ast::Id,
     ) -> Option<(ViewNodeId, ast::Id, Option<view::graph_editor::Type>)> {
         let a_type = self.expression_type(id);
-        let node_view = self.state.refresh_expression_type(id, a_type.clone())?;
+        let node_view =
+            self.state.update_from_controller().set_expression_type(id, a_type.clone())?;
         Some((node_view, id, a_type))
     }
 
+    /// Refresh method pointer of the given expression.
+    ///
+    /// If the view update is required, the GraphEditor's FRP input event is returned.
     fn refresh_expression_method_pointer(
         &self,
         id: ast::Id,
     ) -> Option<(ast::Id, Option<view::graph_editor::MethodPointer>)> {
         let method_pointer = self.expression_method(id);
-        self.state.refresh_expression_method_pointer(id, method_pointer.clone())?;
+        self.state
+            .update_from_controller()
+            .set_expression_method_pointer(id, method_pointer.clone())?;
         Some((id, method_pointer))
     }
 
+    /// Extract the expression's current type from controllers.
     fn expression_type(&self, id: ast::Id) -> Option<view::graph_editor::Type> {
         let registry = self.controller.computed_value_info_registry();
         let info = registry.get(&id)?;
         Some(view::graph_editor::Type(info.typename.as_ref()?.clone_ref()))
     }
 
+    /// Extract the expression's current method pointer from controllers.
     fn expression_method(&self, id: ast::Id) -> Option<view::graph_editor::MethodPointer> {
         let registry = self.controller.computed_value_info_registry();
         let method_id = registry.get(&id)?.method_call?;
@@ -151,6 +173,15 @@ impl Model {
 }
 
 
+
+// ==================
+// === ViewUpdate ===
+// ==================
+
+/// Structure handling view update after graph invalidation.
+///
+/// Because updating various graph elements (nodes, connections, types) bases on the same data
+/// extracted from controllers, the data are cached in this structure.
 #[derive(Clone, Debug, Default)]
 struct ViewUpdate {
     state:       Rc<state::State>,
@@ -160,6 +191,7 @@ struct ViewUpdate {
 }
 
 impl ViewUpdate {
+    /// Create ViewUpdate information from Graph Presenter's model.
     fn new(model: &Model) -> FallibleResult<Self> {
         let displayed = model.state.clone_ref();
         let nodes = model.controller.graph().nodes()?;
@@ -169,54 +201,79 @@ impl ViewUpdate {
         Ok(Self { state: displayed, nodes, trees, connections })
     }
 
-    fn nodes_to_remove(&self) -> Vec<ViewNodeId> {
-        self.state.retain_nodes(&self.node_ids().collect())
+    /// Remove nodes from the state and return node views to be removed.
+    fn remove_nodes(&self) -> Vec<ViewNodeId> {
+        self.state.update_from_controller().retain_nodes(&self.node_ids().collect())
     }
 
-    fn nodes_to_add(&self) -> usize {
+    /// Returns number of nodes view should create.
+    fn add_nodes(&self) -> usize {
         self.node_ids().filter(|n| self.state.view_id_of_ast_node(*n).is_none()).count()
     }
 
-    fn expressions_to_set(&self) -> Vec<(ViewNodeId, node_view::Expression)> {
+    /// Set the nodes expressions in state, and return the events to be passed to Graph Editor FRP
+    /// input for nodes where expression changed.
+    ///
+    /// The nodes not having views are also updated in the state.
+    fn set_node_expressions(&self) -> Vec<(ViewNodeId, node_view::Expression)> {
         self.nodes
             .iter()
             .filter_map(|node| {
                 let id = node.main_line.id();
                 let trees = self.trees.get(&id).cloned().unwrap_or_default();
-                self.state.refresh_node_expression(node, trees)
+                self.state.update_from_controller().set_node_expression(node, trees)
             })
             .collect()
     }
 
-    fn positions_to_set(&self) -> Vec<(ViewNodeId, Vector2)> {
+    /// Set the nodes position in state, and return the events to be passed to GraphEditor FRP
+    /// input for nodes where position changed.
+    ///
+    /// The nodes not having views are also updated in the state.
+    fn set_node_positions(&self) -> Vec<(ViewNodeId, Vector2)> {
         self.nodes
             .iter()
             .filter_map(|node| {
                 let id = node.main_line.id();
                 let position = node.position()?.vector;
-                let view_id = self.state.refresh_node_position(id, position)?;
+                let view_id =
+                    self.state.update_from_controller().set_node_position(id, position)?;
                 Some((view_id, position))
             })
             .collect()
     }
 
-    fn connections_to_remove(&self) -> Vec<ViewConnection> {
-        self.state.retain_connections(&self.connections)
+    /// Remove connections from the state and return views to be removed.
+    fn remove_connections(&self) -> Vec<ViewConnection> {
+        self.state.update_from_controller().retain_connections(&self.connections)
     }
 
-    fn connections_to_add(&self) -> Vec<(EdgeEndpoint, EdgeEndpoint)> {
-        DEBUG!("connections_to_add: {self.connections:?}");
+    /// Add connections to the state and return endpoints of connections to be created in views.
+    fn add_connections(&self) -> Vec<(EdgeEndpoint, EdgeEndpoint)> {
         let ast_conns = self.connections.iter();
         ast_conns
-            .filter_map(|connection| self.state.refresh_connection(connection.clone()))
+            .filter_map(|connection| {
+                self.state.update_from_controller().set_connection(connection.clone())
+            })
             .collect()
     }
 
-    fn node_ids<'a>(&'a self) -> impl Iterator<Item = AstNodeId> + 'a {
+    fn node_ids(&self) -> impl Iterator<Item = AstNodeId> + '_ {
         self.nodes.iter().map(controller::graph::Node::id)
     }
 }
 
+
+
+// =============
+// === Graph ===
+// =============
+
+/// The Graph Presenter, synchronizing graph state between graph controller and view.
+///
+/// This presenter focuses on the graph structure: nodes, their expressions and types, and
+/// connections between them. It does not integrate Searcher nor Breadcrumbs - integration of
+/// these is still to-be-delivered.
 #[derive(Debug)]
 pub struct Graph {
     network: frp::Network,
@@ -224,6 +281,8 @@ pub struct Graph {
 }
 
 impl Graph {
+    /// Create graph presenter. The returned structure is working and does not require any
+    /// initialization.
     pub fn new(
         controller: controller::ExecutedGraph,
         view: view::graph_editor::GraphEditor,
@@ -233,7 +292,7 @@ impl Graph {
         Self { network, model }.init()
     }
 
-    pub fn init(self) -> Self {
+    fn init(self) -> Self {
         let logger = &self.model.logger;
         let network = &self.network;
         let model = &self.model;
@@ -253,16 +312,16 @@ impl Graph {
 
             // === Refreshing Nodes ===
 
-            remove_node <= update_data.map(|update| update.nodes_to_remove());
-            update_node_expression <= update_data.map(|update| update.expressions_to_set());
-            set_node_position <= update_data.map(|update| update.positions_to_set());
+            remove_node <= update_data.map(|update| update.remove_nodes());
+            update_node_expression <= update_data.map(|update| update.set_node_expressions());
+            set_node_position <= update_data.map(|update| update.set_node_positions());
             view.remove_node <+ remove_node;
             view.set_node_expression <+ update_node_expression;
             view.set_node_position <+ set_node_position;
 
-            view.add_node <+ update_data.map(|update| update.nodes_to_add()).repeat();
+            view.add_node <+ update_data.map(|update| update.add_nodes()).repeat();
             added_node_update <- view.node_added.filter_map(f!((view_id)
-                model.state.assign_newly_created_node(*view_id)
+                model.state.assign_node_view(*view_id)
             ));
             init_node_expression <- added_node_update.filter_map(|update| Some((update.view_id?, update.expression.clone())));
             view.set_node_expression <+ init_node_expression;
@@ -271,8 +330,8 @@ impl Graph {
 
             // === Refreshing Connections ===
 
-            remove_connection <= update_data.map(|update| update.connections_to_remove());
-            add_connection <= update_data.map(|update| update.connections_to_add());
+            remove_connection <= update_data.map(|update| update.remove_connections());
+            add_connection <= update_data.map(|update| update.add_connections());
             view.remove_edge <+ remove_connection;
             view.connect_nodes <+ add_connection;
 

--- a/app/gui/src/presenter/graph.rs
+++ b/app/gui/src/presenter/graph.rs
@@ -1,0 +1,272 @@
+use crate::prelude::*;
+use bimap::BiMap;
+
+use enso_frp as frp;
+use ide_view as view;
+use ide_view::graph_editor::component::node as node_view;
+
+
+
+// ======================
+// === DisplayedState ===
+// ======================
+
+// === DisplayedNodes ===
+
+type ViewNodeId = view::graph_editor::NodeId;
+type AstNodeId = ast::Id;
+type ViewConnection = view::graph_editor::EdgeId;
+type AstConnection = controller::graph::Connection;
+
+#[derive(Clone, Debug, Default)]
+struct DisplayedNode {
+    view_id:    Option<ViewNodeId>,
+    position:   Vector2,
+    expression: node_view::Expression,
+}
+
+impl DisplayedNode {
+    fn new(view_id: ViewNodeId) -> Self {
+        DisplayedNode { view_id: Some(view_id), position: default(), expression: default() }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct DisplayedNodes {
+    displayed_nodes:     HashMap<AstNodeId, DisplayedNode>,
+    nodes_without_view:  Vec<AstNodeId>,
+    ast_node_by_view_id: HashMap<ViewNodeId, AstNodeId>,
+}
+
+impl DisplayedNodes {
+    fn get_mut(&mut self, id: AstNodeId) -> Option<&mut DisplayedNode> {
+        self.displayed_nodes.get_mut(&id)
+    }
+
+    fn get_mut_or_create(&mut self, id: AstNodeId) -> &mut DisplayedNode {
+        let nodes_without_view = &mut self.nodes_without_view;
+        self.displayed_nodes.entry(id).or_insert_with(|| {
+            nodes_without_view.push(id);
+            default()
+        })
+    }
+
+    fn ast_id_of_view(&self, view_id: ViewNodeId) -> Option<AstNodeId> {
+        self.ast_node_by_view_id.get(&view_id).copied()
+    }
+
+    fn assign_newly_created_node(&mut self, view_id: ViewNodeId) -> Option<DisplayedNode> {
+        let ast_node = self.nodes_without_view.pop()?;
+        let mut opt_displayed = self.displayed_nodes.get_mut(&ast_node);
+        if let Some(displayed) = &mut opt_displayed {
+            displayed.view_id = Some(view_id);
+            self.ast_node_by_view_id.insert(view_id, ast_node);
+        }
+        opt_displayed.cloned()
+    }
+
+    fn retain_nodes(&mut self, nodes: &HashSet<AstNodeId>) -> Vec<ViewNodeId> {
+        self.nodes_without_view.drain_filter(|id| !nodes.contains(id));
+        let removed = self.displayed_nodes.drain_filter(|id, _| !nodes.contains(id));
+        let removed_views = removed.filter_map(|(_, data)| data.view_id).collect();
+        for view_id in &removed_views {
+            self.ast_node_by_view_id.remove(view_id);
+        }
+        removed_views
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct DisplayedExpression {
+    node:            ViewNodeId,
+    expression_type: Option<view::graph_editor::Type>,
+}
+
+
+// === DisplayedState ===
+
+#[derive(Clone, Debug, Default)]
+struct DisplayedState {
+    nodes:       RefCell<DisplayedNodes>,
+    connections: RefCell<BiMap<AstConnection, ViewConnection>>,
+    expressions: RefCell<HashMap<ast::Id, DisplayedExpression>>,
+}
+
+impl DisplayedState {
+    fn assign_newly_created_node(&self, view_id: ViewNodeId) -> Option<DisplayedNode> {
+        self.nodes.borrow_mut().assign_newly_created_node(view_id)
+    }
+
+    fn view_id_of_ast_node(&self, node: AstNodeId) -> Option<ViewNodeId> {
+        self.nodes.borrow().displayed_nodes.get(&node).and_then(|node| node.view_id)
+    }
+
+    fn retain_nodes(&self, nodes: &HashSet<AstNodeId>) -> Vec<ViewNodeId> {
+        self.nodes.borrow_mut().retain_nodes(nodes)
+    }
+
+    fn refresh_node_position(&self, node: AstNodeId, position: Vector2) -> Option<ViewNodeId> {
+        let mut nodes = self.nodes.borrow_mut();
+        let mut displayed = nodes.get_mut_or_create(node);
+        if displayed.position != position {
+            displayed.position = position;
+            displayed.view_id
+        } else {
+            None
+        }
+    }
+
+    fn refresh_node_expression(
+        &self,
+        node: &controller::graph::Node,
+        trees: controller::graph::NodeTrees,
+    ) -> Option<(ViewNodeId, node_view::Expression)> {
+        let ast_id = node.main_line.id();
+        let new_displayed_expr = node_view::Expression {
+            pattern:             node.info.pattern().map(|t| t.repr()),
+            code:                node.info.expression().repr(),
+            whole_expression_id: node.info.expression().id,
+            input_span_tree:     trees.inputs,
+            output_span_tree:    trees.outputs.unwrap_or_else(default),
+        };
+        let mut nodes = self.nodes.borrow_mut();
+        let displayed = nodes.get_mut_or_create(ast_id);
+        if &displayed.expression != &new_displayed_expr {
+            displayed.expression = new_displayed_expr.clone();
+            Some((displayed.view_id?, new_displayed_expr))
+        } else {
+            None
+        }
+    }
+
+    fn node_position_changed(&self, id: ViewNodeId, new_position: Vector2) -> Option<AstNodeId> {
+        let mut nodes = self.nodes.borrow_mut();
+        let ast_id = nodes.ast_id_of_view(id)?;
+        let displayed = nodes.get_mut(ast_id)?;
+        if displayed.position != new_position {
+            displayed.position = new_position;
+            Some(ast_id)
+        } else {
+            None
+        }
+    }
+}
+
+
+#[derive(Clone, Debug)]
+struct Model {
+    logger:     Logger,
+    controller: controller::ExecutedGraph,
+    view:       view::graph_editor::GraphEditor,
+    displayed:  DisplayedState,
+}
+
+impl Model {
+    pub fn new(
+        controller: controller::ExecutedGraph,
+        view: view::graph_editor::GraphEditor,
+    ) -> Self {
+        let logger = Logger::new("presenter::Graph");
+        let mappings = default();
+        Self { logger, controller, view, displayed: mappings }
+    }
+
+    fn node_position_changed(&self, id: ViewNodeId, position: Vector2) {
+        if let Some(ast_id) = self.displayed.node_position_changed(id, position) {
+            if let Err(err) = self.controller.graph().set_node_position(ast_id, position) {
+                error!(self.logger, "Failed to set node position in AST: {err}");
+            }
+        }
+    }
+}
+
+
+#[derive(Clone, Debug, Default)]
+struct ViewUpdate {
+    nodes_to_remove:    Vec<ViewNodeId>,
+    nodes_to_add:       usize,
+    expressions_to_set: Vec<(ViewNodeId, node_view::Expression)>,
+    positions_to_set:   Vec<(ViewNodeId, Vector2)>,
+}
+
+impl ViewUpdate {
+    fn new(model: Rc<Model>) -> FallibleResult<Self> {
+        let nodes = model.controller.graph().nodes()?;
+        let connections = model.controller.connections()?;
+        let mut trees = connections.trees;
+        let connections = connections.connections;
+        let id_of_node = |n: &controller::graph::Node| n.info.main_line.id();
+        let node_ids = nodes.iter().map(id_of_node);
+        let nodes_to_remove = model.displayed.retain_nodes(&node_ids.clone().collect());
+        let nodes_to_add =
+            node_ids.filter(|node| model.displayed.view_id_of_ast_node(*node).is_none());
+        let expressions_to_set = nodes.iter().filter_map(|node| {
+            let id = node.main_line.id();
+            let trees = trees.remove(&id).unwrap_or_default();
+            model.displayed.refresh_node_expression(node, trees)
+        });
+        let positions_to_set = nodes.iter().filter_map(|node| {
+            let id = node.main_line.id();
+            let position = node.position()?.vector;
+            let view_id = model.displayed.refresh_node_position(id, position)?;
+            Some((view_id, position))
+        });
+        Ok(Self {
+            nodes_to_remove,
+            expressions_to_set: expressions_to_set.collect(),
+            positions_to_set: positions_to_set.collect(),
+            nodes_to_add: nodes_to_add.count(),
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct Graph {
+    network: frp::Network,
+    model:   Rc<Model>,
+}
+
+impl Graph {
+    pub fn new(
+        controller: controller::ExecutedGraph,
+        view: view::graph_editor::GraphEditor,
+    ) -> Self {
+        let network = frp::Network::new("presenter::Graph");
+        let model = Rc::new(Model::new(controller, view));
+        Self { network, model }.init()
+    }
+
+    pub fn init(self) -> Self {
+        let logger = &self.model.logger;
+        let network = &self.network;
+        let model = &self.model;
+        let view = &self.model.view.frp;
+        frp::extend! { network
+            update_view <- source::<()>();
+            update_data <- update_view.map(
+                f_!([logger,model] match ViewUpdate::new(model.clone_ref()) {
+                    Ok(update) => Rc::new(update),
+                    Err(err) => {
+                        error!(logger,"Failed to update view: {err:?}");
+                        Rc::new(default())
+                    }
+                })
+            );
+
+            remove_node <= update_data.map(|update| update.nodes_to_remove.clone());
+            set_node_expression <= update_data.map(|update| update.expressions_to_set.clone());
+            set_node_position <= update_data.map(|update| update.positions_to_set.clone());
+            view.remove_node <+ remove_node;
+            view.set_node_expression <+ set_node_expression;
+            view.set_node_position <+ set_node_position;
+
+            view.add_node <+ update_data.map(|update| update.nodes_to_add).repeat();
+            added_node_update <- view.node_added.filter_map(f!((view_id)
+                model.displayed.assign_newly_created_node(*view_id)
+            ));
+            view.set_node_expression <+ added_node_update.filter_map(|update| Some((update.view_id?, update.expression.clone())));
+            view.set_node_position <+ added_node_update.filter_map(|update| Some((update.view_id?, update.position)));
+        }
+        self
+    }
+}

--- a/app/gui/src/presenter/graph.rs
+++ b/app/gui/src/presenter/graph.rs
@@ -1,4 +1,5 @@
-//! The [`Graph`] presenter module.
+//! The module with the [`Graph`] presenter. See [`crate::presenter`] documentation to know more
+//! about presenters in general.
 
 mod state;
 
@@ -207,7 +208,7 @@ impl ViewUpdate {
     }
 
     /// Returns number of nodes view should create.
-    fn add_nodes(&self) -> usize {
+    fn count_nodes_to_add(&self) -> usize {
         self.node_ids().filter(|n| self.state.view_id_of_ast_node(*n).is_none()).count()
     }
 
@@ -319,7 +320,7 @@ impl Graph {
             view.set_node_expression <+ update_node_expression;
             view.set_node_position <+ set_node_position;
 
-            view.add_node <+ update_data.map(|update| update.add_nodes()).repeat();
+            view.add_node <+ update_data.map(|update| update.count_nodes_to_add()).repeat();
             added_node_update <- view.node_added.filter_map(f!((view_id)
                 model.state.assign_node_view(*view_id)
             ));

--- a/app/gui/src/presenter/graph/state.rs
+++ b/app/gui/src/presenter/graph/state.rs
@@ -1,0 +1,668 @@
+use crate::prelude::*;
+
+use crate::presenter::graph::AstConnection;
+use crate::presenter::graph::AstNodeId;
+use crate::presenter::graph::ViewConnection;
+use crate::presenter::graph::ViewNodeId;
+
+use bimap::BiMap;
+use bimap::Overwritten;
+use ide_view as view;
+use ide_view::graph_editor::component::node as node_view;
+use ide_view::graph_editor::EdgeEndpoint;
+
+
+
+// =============
+// === Nodes ===
+// =============
+
+#[derive(Clone, Debug, Default)]
+pub struct Node {
+    pub view_id:    Option<ViewNodeId>,
+    pub position:   Vector2,
+    pub expression: node_view::Expression,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Nodes {
+    displayed_nodes:     HashMap<AstNodeId, Node>,
+    nodes_without_view:  Vec<AstNodeId>,
+    ast_node_by_view_id: HashMap<ViewNodeId, AstNodeId>,
+}
+
+impl Nodes {
+    pub fn get(&self, id: AstNodeId) -> Option<&Node> {
+        self.displayed_nodes.get(&id)
+    }
+
+    pub fn get_mut(&mut self, id: AstNodeId) -> Option<&mut Node> {
+        self.displayed_nodes.get_mut(&id)
+    }
+
+    pub fn get_mut_or_create(&mut self, id: AstNodeId) -> &mut Node {
+        let nodes_without_view = &mut self.nodes_without_view;
+        self.displayed_nodes.entry(id).or_insert_with(|| {
+            nodes_without_view.push(id);
+            default()
+        })
+    }
+
+    pub fn ast_id_of_view(&self, view_id: ViewNodeId) -> Option<AstNodeId> {
+        self.ast_node_by_view_id.get(&view_id).copied()
+    }
+
+    pub fn assign_newly_created_node(&mut self, view_id: ViewNodeId) -> Option<&mut Node> {
+        let ast_node = self.nodes_without_view.pop()?;
+        let mut opt_displayed = self.displayed_nodes.get_mut(&ast_node);
+        if let Some(displayed) = &mut opt_displayed {
+            displayed.view_id = Some(view_id);
+            self.ast_node_by_view_id.insert(view_id, ast_node);
+        }
+        opt_displayed
+    }
+
+    pub fn retain_nodes(&mut self, nodes: &HashSet<AstNodeId>) -> Vec<ViewNodeId> {
+        self.nodes_without_view.drain_filter(|id| !nodes.contains(id));
+        let removed = self.displayed_nodes.drain_filter(|id, _| !nodes.contains(id));
+        let removed_views = removed.filter_map(|(_, data)| data.view_id).collect();
+        for view_id in &removed_views {
+            self.ast_node_by_view_id.remove(view_id);
+        }
+        removed_views
+    }
+
+    pub fn remove_node(&mut self, node: ViewNodeId) -> Option<AstNodeId> {
+        let ast_id = self.ast_node_by_view_id.remove(&node)?;
+        self.displayed_nodes.remove(&ast_id);
+        Some(ast_id)
+    }
+}
+
+
+
+// ===================
+// === Connections ===
+// ===================
+
+#[derive(Clone, Debug, Default)]
+pub struct Connections {
+    connections:              BiMap<AstConnection, ViewConnection>,
+    connections_without_view: HashSet<AstConnection>,
+}
+
+impl Connections {
+    pub fn view_of_ast_connection(&self, connection: &AstConnection) -> Option<ViewConnection> {
+        self.connections.get_by_left(connection).copied()
+    }
+
+    pub fn retain_connections(
+        &mut self,
+        connections: &HashSet<AstConnection>,
+    ) -> Vec<ViewConnection> {
+        self.connections_without_view.retain(|x| connections.contains(x));
+        let to_remove = self.connections.iter().filter(|(con, _)| !connections.contains(con));
+        let to_remove_vec = to_remove.map(|(_, edge_id)| *edge_id).collect_vec();
+        self.connections.retain(|con, _| connections.contains(con));
+        to_remove_vec
+    }
+
+    pub fn add_ast_connection(&mut self, connection: AstConnection) -> bool {
+        if !self.connections.contains_left(&connection) {
+            self.connections_without_view.insert(connection)
+        } else {
+            false
+        }
+    }
+
+    /// Returns true if the controller needs refreshing.
+    pub fn assign_connection_view(
+        &mut self,
+        connection: AstConnection,
+        view: ViewConnection,
+    ) -> bool {
+        let existed_without_view = self.connections_without_view.remove(&connection);
+        match self.connections.insert(connection, view) {
+            Overwritten::Neither => !existed_without_view,
+            Overwritten::Left(_, _) => false,
+            Overwritten::Right(previous, _) => {
+                self.connections_without_view.insert(previous);
+                !existed_without_view
+            }
+            Overwritten::Pair(_, _) => false,
+            Overwritten::Both(_, (previous, _)) => {
+                self.connections_without_view.insert(previous);
+                false
+            }
+        }
+    }
+
+    pub fn remove_connection(&mut self, connection: ViewConnection) -> Option<AstConnection> {
+        let (ast_connection, _) = self.connections.remove_by_right(&connection)?;
+        Some(ast_connection)
+    }
+}
+
+
+
+// ===================
+// === Expressions ===
+// ===================
+
+#[derive(Clone, Debug, Default)]
+pub struct Expression {
+    pub node:            AstNodeId,
+    pub expression_type: Option<view::graph_editor::Type>,
+    pub method_pointer:  Option<view::graph_editor::MethodPointer>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Expressions {
+    expressions:         HashMap<ast::Id, Expression>,
+    expressions_of_node: HashMap<AstNodeId, Vec<ast::Id>>,
+}
+
+impl Expressions {
+    pub fn retain_expression_of_nodes(&mut self, nodes: &HashSet<AstNodeId>) {
+        let nodes_to_remove =
+            self.expressions_of_node.drain_filter(|node_id, _| !nodes.contains(node_id));
+        let expr_to_remove = nodes_to_remove.map(|(_, exprs)| exprs).flatten();
+        for expression_id in expr_to_remove {
+            self.expressions.remove(&expression_id);
+        }
+    }
+
+    pub fn node_expression_changed(&mut self, node: AstNodeId, expressions: Vec<ast::Id>) {
+        let new_set: HashSet<ast::Id> = expressions.iter().copied().collect();
+        let old_set = self.expressions_of_node.insert(node, expressions).unwrap_or_default();
+        for old_expression in &old_set {
+            if !new_set.contains(old_expression) {
+                self.expressions.remove(old_expression);
+            }
+        }
+        for new_expression in new_set {
+            if !old_set.contains(&new_expression) {
+                self.expressions.insert(new_expression, Expression { node, ..default() });
+            }
+        }
+    }
+
+    pub fn get_mut(&mut self, id: ast::Id) -> Option<&mut Expression> {
+        self.expressions.get_mut(&id)
+    }
+
+    pub fn subexpressions_of_node(&self, id: ast::Id) -> &[ast::Id] {
+        self.expressions_of_node.get(&id).map_or(&[], |v| v.as_slice())
+    }
+}
+
+
+
+// =============
+// === State ===
+// =============
+
+#[derive(Clone, Debug, Default)]
+pub struct State {
+    nodes:       RefCell<Nodes>,
+    connections: RefCell<Connections>,
+    expressions: RefCell<Expressions>,
+}
+
+
+// === Getters ===
+
+impl State {
+    pub fn view_id_of_ast_node(&self, node: AstNodeId) -> Option<ViewNodeId> {
+        self.nodes.borrow().get(node).and_then(|n| n.view_id)
+    }
+
+    pub fn ast_id_of_view_node(&self, node: ViewNodeId) -> Option<AstNodeId> {
+        self.nodes.borrow().ast_id_of_view(node)
+    }
+
+    pub fn view_of_ast_connection(&self, connection: &AstConnection) -> Option<ViewConnection> {
+        self.connections.borrow().view_of_ast_connection(connection)
+    }
+
+    pub fn view_edge_targets_of_ast_connection(
+        &self,
+        connection: AstConnection,
+    ) -> Option<(EdgeEndpoint, EdgeEndpoint)> {
+        let nodes = self.nodes.borrow();
+        let src_node = nodes.get(connection.source.node)?.view_id?;
+        let dst_node = nodes.get(connection.destination.node)?.view_id?;
+        let src = EdgeEndpoint::new(src_node, connection.source.port);
+        let data = EdgeEndpoint::new(dst_node, connection.destination.port);
+        Some((src, data))
+    }
+
+    pub fn ast_connection_from_view_edge_targets(
+        &self,
+        source: EdgeEndpoint,
+        target: EdgeEndpoint,
+    ) -> Option<controller::graph::Connection> {
+        let nodes = self.nodes.borrow();
+        let src_node = nodes.ast_id_of_view(source.node_id)?;
+        let dst_node = nodes.ast_id_of_view(target.node_id)?;
+        Some(controller::graph::Connection {
+            source:      controller::graph::Endpoint::new(src_node, source.port),
+            destination: controller::graph::Endpoint::new(dst_node, target.port),
+        })
+    }
+
+    pub fn subexpressions_of_node(&self, node: ViewNodeId) -> Vec<ast::Id> {
+        let ast_node = self.nodes.borrow().ast_id_of_view(node);
+        ast_node
+            .map_or_default(|id| self.expressions.borrow().subexpressions_of_node(id).to_owned())
+    }
+}
+
+
+// === Nodes Refreshing and Changes ===
+
+impl State {
+    pub fn assign_newly_created_node(&self, view_id: ViewNodeId) -> Option<Node> {
+        self.nodes.borrow_mut().assign_newly_created_node(view_id).cloned()
+    }
+
+    pub fn retain_nodes(&self, nodes: &HashSet<AstNodeId>) -> Vec<ViewNodeId> {
+        self.expressions.borrow_mut().retain_expression_of_nodes(nodes);
+        self.nodes.borrow_mut().retain_nodes(nodes)
+    }
+
+    pub fn refresh_node_position(&self, node: AstNodeId, position: Vector2) -> Option<ViewNodeId> {
+        let mut nodes = self.nodes.borrow_mut();
+        let mut displayed = nodes.get_mut_or_create(node);
+        if displayed.position != position {
+            displayed.position = position;
+            displayed.view_id
+        } else {
+            None
+        }
+    }
+
+    pub fn refresh_node_expression(
+        &self,
+        node: &controller::graph::Node,
+        trees: controller::graph::NodeTrees,
+    ) -> Option<(ViewNodeId, node_view::Expression)> {
+        let ast_id = node.main_line.id();
+        let new_displayed_expr = node_view::Expression {
+            pattern:             node.info.pattern().map(|t| t.repr()),
+            code:                node.info.expression().repr(),
+            whole_expression_id: node.info.expression().id,
+            input_span_tree:     trees.inputs,
+            output_span_tree:    trees.outputs.unwrap_or_else(default),
+        };
+        let mut nodes = self.nodes.borrow_mut();
+        let displayed = nodes.get_mut_or_create(ast_id);
+        if &displayed.expression != &new_displayed_expr {
+            displayed.expression = new_displayed_expr.clone();
+            let new_expressions =
+                node.info.ast().iter_recursive().filter_map(|ast| ast.id).collect();
+            self.expressions.borrow_mut().node_expression_changed(ast_id, new_expressions);
+            Some((displayed.view_id?, new_displayed_expr))
+        } else {
+            None
+        }
+    }
+
+    pub fn node_position_changed(
+        &self,
+        id: ViewNodeId,
+        new_position: Vector2,
+    ) -> Option<AstNodeId> {
+        let mut nodes = self.nodes.borrow_mut();
+        let ast_id = nodes.ast_id_of_view(id)?;
+        let displayed = nodes.get_mut(ast_id)?;
+        if displayed.position != new_position {
+            displayed.position = new_position;
+            Some(ast_id)
+        } else {
+            None
+        }
+    }
+
+    pub fn node_removed(&self, id: ViewNodeId) -> Option<AstNodeId> {
+        self.nodes.borrow_mut().remove_node(id)
+    }
+}
+
+
+// === Connections Refreshing and Changes ===
+
+impl State {
+    pub fn assign_connection_view(
+        &self,
+        connection: view::graph_editor::Edge,
+    ) -> Option<AstConnection> {
+        let source = connection.source()?;
+        let target = connection.target()?;
+        self.assign_connection_view_endpoints(connection.id(), source, target)
+    }
+
+    pub fn refresh_connection(
+        &self,
+        connection: AstConnection,
+    ) -> Option<(EdgeEndpoint, EdgeEndpoint)> {
+        self.connections
+            .borrow_mut()
+            .add_ast_connection(connection.clone())
+            .and_option_from(move || self.view_edge_targets_of_ast_connection(connection))
+    }
+
+    pub fn assign_connection_view_endpoints(
+        &self,
+        connection: ViewConnection,
+        source: EdgeEndpoint,
+        target: EdgeEndpoint,
+    ) -> Option<AstConnection> {
+        let ast_connection = self.ast_connection_from_view_edge_targets(source, target)?;
+        let mut connections = self.connections.borrow_mut();
+        let should_update_controllers =
+            connections.assign_connection_view(ast_connection.clone(), connection);
+        should_update_controllers.then_some(ast_connection)
+    }
+
+    pub fn retain_connections(&self, connections: &HashSet<AstConnection>) -> Vec<ViewConnection> {
+        self.connections.borrow_mut().retain_connections(connections)
+    }
+
+    pub fn connection_removed(&self, id: ViewConnection) -> Option<AstConnection> {
+        self.connections.borrow_mut().remove_connection(id)
+    }
+}
+
+
+// === Expression Refreshing ===
+
+impl State {
+    pub fn refresh_expression_type(
+        &self,
+        id: ast::Id,
+        new_type: Option<view::graph_editor::Type>,
+    ) -> Option<ViewNodeId> {
+        let mut expressions = self.expressions.borrow_mut();
+        let to_update = expressions.get_mut(id).filter(|d| d.expression_type != new_type);
+        if let Some(displayed) = to_update {
+            displayed.expression_type = new_type;
+            self.nodes.borrow().get(displayed.node).and_then(|node| node.view_id)
+        } else {
+            None
+        }
+    }
+
+    pub fn refresh_expression_method_pointer(
+        &self,
+        id: ast::Id,
+        method_ptr: Option<view::graph_editor::MethodPointer>,
+    ) -> Option<ViewNodeId> {
+        let mut expressions = self.expressions.borrow_mut();
+        let to_update = expressions.get_mut(id).filter(|d| d.method_pointer != method_ptr);
+        if let Some(displayed) = to_update {
+            displayed.method_pointer = method_ptr;
+            self.nodes.borrow().get(displayed.node).and_then(|node| node.view_id)
+        } else {
+            None
+        }
+    }
+}
+
+
+
+// =============
+// === Tests ===
+// =============
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use engine_protocol::language_server::MethodPointer;
+    use parser::Parser;
+
+    fn create_test_node(expression: &str) -> controller::graph::Node {
+        let parser = Parser::new_or_panic();
+        let ast = parser.parse_line_ast(expression).unwrap();
+        controller::graph::Node {
+            info:     double_representation::node::NodeInfo {
+                documentation: None,
+                main_line:     double_representation::node::MainLine::from_ast(&ast).unwrap(),
+            },
+            metadata: None,
+        }
+    }
+
+    fn node_trees_of(node: &controller::graph::Node) -> controller::graph::NodeTrees {
+        controller::graph::NodeTrees::new(&node.info, &span_tree::generate::context::Empty).unwrap()
+    }
+
+    struct TestNode {
+        node: controller::graph::Node,
+        view: ViewNodeId,
+    }
+
+    struct Fixture {
+        state: State,
+        nodes: Vec<TestNode>,
+    }
+
+    impl Fixture {
+        fn setup_nodes(expressions: impl IntoIterator<Item: AsRef<str>>) -> Self {
+            let nodes = expressions.into_iter().map(|expr| create_test_node(expr.as_ref()));
+            let state = State::default();
+            let displayed_nodes = nodes
+                .enumerate()
+                .map(|(i, node)| {
+                    let view = ensogl::display::object::Id::from(i).into();
+                    state.refresh_node_expression(&node, node_trees_of(&node));
+                    state.assign_newly_created_node(view);
+                    TestNode { node, view }
+                })
+                .collect();
+            Fixture { state, nodes: displayed_nodes }
+        }
+    }
+
+    #[test]
+    fn adding_and_removing_nodes() {
+        let state = State::default();
+        let node1 = create_test_node("node1 = 2 + 2");
+        let node2 = create_test_node("node2 = node1 + 2");
+        let node_view_1 = ensogl::display::object::Id::from(1).into();
+        let node_view_2 = ensogl::display::object::Id::from(2).into();
+
+        assert_eq!(state.refresh_node_expression(&node1, node_trees_of(&node1)), None);
+        assert_eq!(state.refresh_node_expression(&node2, node_trees_of(&node2)), None);
+
+        assert_eq!(state.view_id_of_ast_node(node1.id()), None);
+        assert_eq!(state.view_id_of_ast_node(node2.id()), None);
+
+        let assigned = state.assign_newly_created_node(node_view_2);
+        assert_eq!(assigned.map(|node| node.expression.code), Some("node1 + 2".to_owned()));
+        let assigned = state.assign_newly_created_node(node_view_1);
+        assert_eq!(assigned.map(|node| node.expression.code), Some("2 + 2".to_owned()));
+
+        assert_eq!(state.view_id_of_ast_node(node1.id()), Some(node_view_1));
+        assert_eq!(state.view_id_of_ast_node(node2.id()), Some(node_view_2));
+
+        let node1_exprs =
+            node1.info.main_line.ast().iter_recursive().filter_map(|a| a.id).collect_vec();
+        assert_eq!(state.subexpressions_of_node(node_view_1), node1_exprs);
+        let node2_exprs =
+            node2.info.main_line.ast().iter_recursive().filter_map(|a| a.id).collect_vec();
+        assert_eq!(state.subexpressions_of_node(node_view_2), node2_exprs);
+
+        let views_to_remove = state.retain_nodes(&[node1.id()].iter().copied().collect());
+        assert_eq!(views_to_remove, vec![node_view_2]);
+
+        assert_eq!(state.view_id_of_ast_node(node1.id()), Some(node_view_1));
+        assert_eq!(state.view_id_of_ast_node(node2.id()), None);
+
+        assert_eq!(state.node_removed(node_view_1), Some(node1.id()));
+        assert_eq!(state.view_id_of_ast_node(node1.id()), None)
+    }
+
+    #[test]
+    fn adding_and_removing_connections() {
+        use controller::graph::Endpoint;
+        let Fixture { state, nodes } = Fixture::setup_nodes(&["node1 = 2", "node1 + node1"]);
+        let source = Endpoint {
+            node:       nodes[0].node.id(),
+            port:       default(),
+            var_crumbs: default(),
+        };
+        let destination1 = Endpoint {
+            node:       nodes[1].node.id(),
+            port:       span_tree::Crumbs::new(vec![0]),
+            var_crumbs: default(),
+        };
+        let destination2 = Endpoint {
+            node:       nodes[1].node.id(),
+            port:       span_tree::Crumbs::new(vec![2]),
+            var_crumbs: default(),
+        };
+        let ast_connection1 =
+            AstConnection { source: source.clone(), destination: destination1.clone() };
+        let ast_connection2 =
+            AstConnection { source: source.clone(), destination: destination2.clone() };
+        let view_connection1 = ensogl::display::object::Id::from(1).into();
+        let view_connection2 = ensogl::display::object::Id::from(2).into();
+        let view_source = EdgeEndpoint { node_id: nodes[0].view, port: source.port.clone() };
+        let view_target1 =
+            EdgeEndpoint { node_id: nodes[1].view, port: destination1.port.clone() };
+        let view_target2 =
+            EdgeEndpoint { node_id: nodes[1].view, port: destination2.port.clone() };
+        let view_endpoints1 = (view_source.clone(), view_target1.clone());
+        let view_endpoints2 = (view_source.clone(), view_target2.clone());
+
+        assert_eq!(state.view_of_ast_connection(&ast_connection1), None);
+        assert_eq!(state.view_of_ast_connection(&ast_connection2), None);
+
+        assert_eq!(
+            state.refresh_connection(ast_connection1.clone()),
+            Some(view_endpoints1.clone())
+        );
+
+        assert_eq!(state.view_of_ast_connection(&ast_connection1), None);
+        assert_eq!(state.view_of_ast_connection(&ast_connection2), None);
+
+        assert_eq!(
+            state.assign_connection_view_endpoints(
+                view_connection1,
+                view_source.clone(),
+                view_target1
+            ),
+            None
+        );
+        assert_eq!(
+            state.assign_connection_view_endpoints(
+                view_connection2,
+                view_source.clone(),
+                view_target2
+            ),
+            Some(ast_connection2.clone())
+        );
+
+        assert_eq!(state.view_of_ast_connection(&ast_connection1), Some(view_connection1));
+        assert_eq!(state.view_of_ast_connection(&ast_connection2), Some(view_connection2));
+
+        assert_eq!(
+            state.retain_connections(
+                &[ast_connection1.clone(), ast_connection2.clone()].into_iter().collect()
+            ),
+            vec![]
+        );
+        assert_eq!(
+            state.retain_connections(&[ast_connection2.clone()].into_iter().collect()),
+            vec![view_connection1]
+        );
+
+        assert_eq!(state.view_of_ast_connection(&ast_connection1), None);
+        assert_eq!(state.view_of_ast_connection(&ast_connection2), Some(view_connection2.clone()));
+
+        assert_eq!(state.connection_removed(view_connection2), Some(ast_connection2.clone()));
+        assert_eq!(state.view_of_ast_connection(&ast_connection2), None);
+    }
+
+    #[test]
+    fn refreshing_node_expression() {
+        let Fixture { state, nodes } = Fixture::setup_nodes(&["foo bar"]);
+        let node_id = nodes[0].node.id();
+        let new_ast = Parser::new_or_panic().parse_line_ast("foo baz").unwrap().with_id(node_id);
+        let new_node = controller::graph::Node {
+            info:     double_representation::node::NodeInfo {
+                documentation: None,
+                main_line:     double_representation::node::MainLine::from_ast(&new_ast).unwrap(),
+            },
+            metadata: None,
+        };
+        let new_subexpressions = new_ast.iter_recursive().filter_map(|ast| ast.id).collect_vec();
+        let new_trees = node_trees_of(&new_node);
+        let view = nodes[0].view;
+        let expected_new_expression = view::graph_editor::component::node::Expression {
+            pattern:             None,
+            code:                "foo baz".to_string(),
+            whole_expression_id: Some(node_id),
+            input_span_tree:     new_trees.inputs.clone(),
+            output_span_tree:    default(),
+        };
+        assert_eq!(
+            state.refresh_node_expression(&new_node, new_trees.clone()),
+            Some((view, expected_new_expression))
+        );
+        assert_eq!(state.refresh_node_expression(&new_node, new_trees), None);
+        assert_eq!(state.subexpressions_of_node(view), new_subexpressions);
+    }
+
+    #[test]
+    fn updating_node_position() {
+        let Fixture { state, nodes } = Fixture::setup_nodes(&["foo"]);
+        let node_id = nodes[0].node.id();
+        let view_id = nodes[0].view;
+        let position_from_ast = Vector2(1.0, 2.0);
+        let position_from_view = Vector2(3.0, 4.0);
+
+        assert_eq!(state.refresh_node_position(node_id, position_from_ast), Some(view_id));
+        assert_eq!(state.node_position_changed(view_id, position_from_ast), None);
+        assert_eq!(state.node_position_changed(view_id, position_from_view), Some(node_id));
+        assert_eq!(state.refresh_node_position(node_id, position_from_view), None);
+    }
+
+    #[test]
+    fn refreshing_expression_types() {
+        use ast::crumbs::InfixCrumb;
+        let Fixture { state, nodes } = Fixture::setup_nodes(&["2 + 3"]);
+        let view = nodes[0].view;
+        let node_ast = nodes[0].node.main_line.expression();
+        let left_operand = node_ast.get(&InfixCrumb::LeftOperand.into()).unwrap().id.unwrap();
+        let right_operand = node_ast.get(&InfixCrumb::RightOperand.into()).unwrap().id.unwrap();
+
+        let number_type = Some(view::graph_editor::Type::from("Number".to_owned()));
+        assert_eq!(state.refresh_expression_type(left_operand, number_type.clone()), Some(view));
+        assert_eq!(state.refresh_expression_type(right_operand, number_type.clone()), Some(view));
+
+        assert_eq!(state.refresh_expression_type(left_operand, number_type.clone()), None);
+        assert_eq!(state.refresh_expression_type(right_operand, number_type), None);
+
+        assert_eq!(state.refresh_expression_type(left_operand, None), Some(view));
+        assert_eq!(state.refresh_expression_type(right_operand, None), Some(view));
+    }
+
+    #[test]
+    fn refreshing_expression_method_pointers() {
+        let Fixture { state, nodes } = Fixture::setup_nodes(&["foo bar"]);
+        let view = nodes[0].view;
+        let expr = nodes[0].node.id();
+
+        let method_ptr = MethodPointer {
+            module:          "Foo".to_string(),
+            defined_on_type: "Foo".to_string(),
+            name:            "foo".to_string(),
+        };
+        let method_ptr = Some(view::graph_editor::MethodPointer::from(method_ptr));
+        assert_eq!(state.refresh_expression_method_pointer(expr, method_ptr.clone()), Some(view));
+        assert_eq!(state.refresh_expression_method_pointer(expr, method_ptr), None);
+        assert_eq!(state.refresh_expression_method_pointer(expr, None), Some(view));
+    }
+}

--- a/app/gui/src/presenter/project.rs
+++ b/app/gui/src/presenter/project.rs
@@ -1,9 +1,19 @@
+//! The module with the [`Project`] presenter.
+
 use crate::prelude::*;
 
 use crate::presenter;
 
 use ide_view as view;
 
+
+
+// =============
+// === Model ===
+// =============
+
+// Those fields will be probably used when Searcher and Breadcrumbs integration will be implemented.
+#[allow(unused)]
 #[derive(Debug)]
 struct Model {
     controller: controller::Project,
@@ -12,12 +22,21 @@ struct Model {
 }
 
 
+
+// ===============
+// === Project ===
+// ===============
+
+/// The Project Presenter, synchronizing state between project controller and project view.
 #[derive(Clone, CloneRef, Debug)]
 pub struct Project {
     model: Rc<Model>,
 }
 
 impl Project {
+    /// Construct new project presenter, basing of the project initialization result.
+    ///
+    /// The returned presenter will be already working: it will display the initial main graph,
     pub fn new(
         controller: controller::Project,
         init_result: controller::project::InitializationResult,
@@ -29,6 +48,10 @@ impl Project {
         Self { model: Rc::new(model) }
     }
 
+    /// Initialize project and return working presenter.
+    ///
+    /// This calls the [`controller::Project::initialize`] method and use the initialization result
+    /// to construct working presenter.
     pub async fn initialize(
         controller: controller::Project,
         view: view::project::View,

--- a/app/gui/src/presenter/project.rs
+++ b/app/gui/src/presenter/project.rs
@@ -1,0 +1,39 @@
+use crate::prelude::*;
+
+use crate::presenter;
+
+use ide_view as view;
+
+#[derive(Debug)]
+struct Model {
+    controller: controller::Project,
+    view:       view::project::View,
+    graph:      presenter::Graph,
+}
+
+
+#[derive(Clone, CloneRef, Debug)]
+pub struct Project {
+    model: Rc<Model>,
+}
+
+impl Project {
+    pub fn new(
+        controller: controller::Project,
+        init_result: controller::project::InitializationResult,
+        view: view::project::View,
+    ) -> Self {
+        let graph_controller = init_result.main_graph;
+        let graph = presenter::Graph::new(graph_controller, view.graph().clone_ref());
+        let model = Model { controller, view, graph };
+        Self { model: Rc::new(model) }
+    }
+
+    pub async fn initialize(
+        controller: controller::Project,
+        view: view::project::View,
+    ) -> FallibleResult<Self> {
+        let init_result = controller.initialize().await?;
+        Ok(Self::new(controller, init_result, view))
+    }
+}

--- a/app/gui/src/presenter/project.rs
+++ b/app/gui/src/presenter/project.rs
@@ -1,4 +1,5 @@
-//! The module with the [`Project`] presenter.
+//! The module with the [`Project`] presenter. See [`crate::presenter`] documentation to know more
+//! about presenters in general.
 
 use crate::prelude::*;
 
@@ -36,7 +37,8 @@ pub struct Project {
 impl Project {
     /// Construct new project presenter, basing of the project initialization result.
     ///
-    /// The returned presenter will be already working: it will display the initial main graph,
+    /// The returned presenter will be already working: it will display the initial main graph, and
+    /// react to all notifications.
     pub fn new(
         controller: controller::Project,
         init_result: controller::project::InitializationResult,

--- a/app/gui/view/Cargo.toml
+++ b/app/gui/view/Cargo.toml
@@ -24,6 +24,7 @@ ide-view-graph-editor = { path = "graph-editor" }
 parser = { path = "../language/parser" }
 span-tree = { path = "../language/span-tree" }
 js-sys = { version = "0.3.28" }
+multi-map = { version = "1.3.0" }
 nalgebra = { version = "0.26.1", features = ["serde-serialize"] }
 ordered-float = { version = "2.7.0" }
 serde_json = { version = "1.0" }

--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -857,7 +857,7 @@ pub struct LocalCall {
 // === EdgeEndpoint ===
 // ==================
 
-#[derive(Clone, CloneRef, Debug, Default)]
+#[derive(Clone, CloneRef, Debug, Default, Eq, PartialEq)]
 pub struct EdgeEndpoint {
     pub node_id: NodeId,
     pub port:    span_tree::Crumbs,

--- a/app/ide-desktop/lib/content/src/index.ts
+++ b/app/ide-desktop/lib/content/src/index.ts
@@ -816,6 +816,7 @@ class Config {
     public authentication_enabled: boolean
     public email: string
     public application_config_url: string
+    public rust_new_presentation_layer: boolean
 
     static default() {
         let config = new Config()
@@ -878,6 +879,9 @@ class Config {
         this.application_config_url = ok(other.application_config_url)
             ? tryAsString(other.application_config_url)
             : this.application_config_url
+        this.rust_welcome_screen = ok(other.rust_welcome_screen)
+            ? tryAsBoolean(other.rust_welcome_screen)
+            : this.rust_welcome_screen
     }
 }
 

--- a/app/ide-desktop/lib/content/src/index.ts
+++ b/app/ide-desktop/lib/content/src/index.ts
@@ -879,9 +879,9 @@ class Config {
         this.application_config_url = ok(other.application_config_url)
             ? tryAsString(other.application_config_url)
             : this.application_config_url
-        this.rust_welcome_screen = ok(other.rust_welcome_screen)
-            ? tryAsBoolean(other.rust_welcome_screen)
-            : this.rust_welcome_screen
+        this.rust_new_presentation_layer = ok(other.rust_new_presentation_layer)
+            ? tryAsBoolean(other.rust_new_presentation_layer)
+            : this.rust_new_presentation_layer
     }
 }
 


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

This PR introduces the first step of refactoring integration layer.

After some thinking, I discovered, that the design pattern we are closest to is Model-View-Presenter. Therefore, I rewrote the old integration module under the new name: presentation.

So far, the basic graph is integrated: refreshing nodes and connections, updating their position, connecting/reconnecting, and expressions' types and method pointers. This is not a complete integration: therefore it is not used by default, but you can test it by adding option --rust-new-presentation-layer.

### Important Notes

I resigned from the old "fenced action" approach. I have used it before to ensure there will be no cycles in view-controllers synchronization. Instead, I keep the intermediate model of "desired state", and I use it mainly to suppress spurious updates. See State documentation for details.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/develop/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/develop/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
