### PR TITLE
Generate type definition for complex atoms

### DIFF
--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Any/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Any/Extensions.enso
@@ -34,8 +34,8 @@ from Standard.Base import all
              a == 147
 Any.== : Any -> Boolean
 Any.== that = if Meta.is_same_object this that then True else
-    this_meta = Meta.meta this
-    that_meta = Meta.meta that
+    this_meta = Meta.repr this
+    that_meta = Meta.repr that
     case Cons this_meta that_meta of
         Cons (Meta.Atom _) (Meta.Atom _) ->
             c_1 = this_meta.constructor

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Json.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Json.enso
@@ -1,4 +1,4 @@
-from Standard.Base import all
+from Standard.Base import all hiding Array, Number, Boolean
 
 import Standard.Base.Data.Json.Internal
 
@@ -135,12 +135,12 @@ type Json
              example_unwrap = Json.Number 3 . unwrap
     unwrap : Any
     unwrap = case this of
-        Json.Array its -> its.map .unwrap
-        Json.Boolean b -> b
-        Json.Number n -> n
-        Json.String t -> t
-        Json.Null -> Nothing
-        Json.Object f -> f.map .unwrap
+        Array its -> its.map .unwrap
+        Boolean b -> b
+        Number n -> n
+        String t -> t
+        Null -> Nothing
+        Object f -> f.map .unwrap
 
 ## UNSTABLE
 
@@ -243,7 +243,7 @@ type Marshalling_Error
      Convert a vector to JSON.
          [1, 2, 3, 4].to_json
 Any.to_json =
-    m = Meta.meta this
+    m = Meta.repr this
     case m of
         Meta.Atom _ ->
             cons = Meta.Constructor m.constructor
@@ -284,4 +284,3 @@ Base.Boolean.to_json = Boolean this
          Nothing.to_json
 Nothing.to_json : Null
 Nothing.to_json = Null
-

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Json/Internal.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Json/Internal.enso
@@ -298,7 +298,7 @@ into_helper fmt json = case fmt of
         String v -> v
         _ -> Panic.throw (Type_Mismatch_Error json fmt)
     _ ->
-        m = Meta.meta fmt
+        m = Meta.repr fmt
         case m of
             Meta.Atom _ -> case json of
                 Object json_fields ->

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Map.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Map.enso
@@ -7,7 +7,7 @@ import Standard.Base.Data.Map.Internal
    > Example
      Create an empty map.
 
-         import Standard.Base.Data.Map.Internal
+         import Standard.Base.Data.Map
 
          example_empty = Map.empty
 empty : Map
@@ -22,7 +22,7 @@ empty = Tip
    > Example
      Create a single element map storing the key 1 and the value 2.
 
-         import Standard.Base.Data.Map.Internal
+         import Standard.Base.Data.Map
 
          example_singleton = Map.singleton 1 2
 singleton : Any -> Any -> Map
@@ -36,11 +36,11 @@ singleton key value = Bin 1 key value Tip Tip
    > Example
      Building a map containing two key-value pairs.
 
-         import Standard.Base.Data.Map.Internal
+         import Standard.Base.Data.Map
 
          example_from_vector = Map.from_vector [[1, 2], [3, 4]]
 from_vector : Vector.Vector Any -> Map
-from_vector vec = vec.fold Map.empty (m -> el -> m.insert (el.at 0) (el.at 1))
+from_vector vec = vec.fold here.empty (m -> el -> m.insert (el.at 0) (el.at 1))
 
 ## A key-value store. This type assumes all keys are pairwise comparable,
    using the `<`, `>` and `==` operators.
@@ -454,4 +454,3 @@ type No_Value_For_Key_Error key
 No_Value_For_Key_Error.to_display_text : Text
 No_Value_For_Key_Error.to_display_text =
     "The map contained no value for the key " + this.key.to_text + "."
-

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Error/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Error/Extensions.enso
@@ -15,7 +15,7 @@ from Standard.Base import all
              error.method_name
 No_Such_Method_Error.method_name : Text
 No_Such_Method_Error.method_name =
-    Meta.meta this.symbol . name
+    Meta.repr this.symbol . name
 
 ## UNSTABLE
 

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Meta.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Meta.enso
@@ -9,8 +9,8 @@ import Standard.Builtins
 
    Arguments:
    - value: The runtime entity to get the meta representation of.
-meta : Any -> Meta
-meta value = if Builtins.Meta.is_atom value then Atom value else
+repr : Any -> Meta
+repr value = if Builtins.Meta.is_atom value then Atom value else
     if Builtins.Meta.is_constructor value then Constructor value else
         if Builtins.Meta.is_polyglot value then Polyglot value else
             if Builtins.Meta.is_unresolved_symbol value then Unresolved_Symbol value else
@@ -88,12 +88,12 @@ is_a value typ = if typ == Any then True else
                 Decimal -> typ == Decimal
             Base.Polyglot -> typ == Base.Polyglot
             _ ->
-                meta_val = here.meta value
+                meta_val = here.repr value
                 case meta_val of
                     Atom _ -> if Builtins.meta.is_atom typ then typ == value else
                         meta_val.constructor == typ
                     Constructor _ ->
-                        meta_typ = here.meta typ
+                        meta_typ = here.repr typ
                         case meta_typ of
                             Atom _ -> meta_val.constructor == meta_typ.constructor
                             Constructor _ -> meta_val.constructor == meta_typ

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/System/Platform.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/System/Platform.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 from Standard.Builtins import System
 
 ## A representation of the various operating systems on which Enso can run.
-type Os
+type Platform
 
     ## The Linux operating system.
     type Linux
@@ -25,13 +25,13 @@ type Os
          import Standard.Base.System.Platform
 
          example_os = Platform.os
-os : Os
+os : Platform
 os = here.from_text System.os
 
 ## PRIVATE
 
    Create an Os object from text.
-from_text: Text -> Os
+from_text: Text -> Platform
 from_text os =
     if os == "linux" then Linux else
         if os == "macos" then MacOS else

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
@@ -112,6 +112,7 @@ public class Builtins {
     text = new Text(language, scope);
     special = new Special(language);
 
+    AtomConstructor list = new AtomConstructor("List", scope).initializeFields();
     AtomConstructor nil = new AtomConstructor("Nil", scope).initializeFields();
     AtomConstructor cons =
         new AtomConstructor("Cons", scope)
@@ -131,6 +132,7 @@ public class Builtins {
     scope.registerConstructor(any);
     scope.registerConstructor(function);
 
+    scope.registerConstructor(list);
     scope.registerConstructor(cons);
     scope.registerConstructor(nil);
     scope.registerConstructor(io);

--- a/engine/runtime/src/main/resources/Builtins.enso
+++ b/engine/runtime/src/main/resources/Builtins.enso
@@ -482,6 +482,7 @@ type Polyglot
 type Java
 
     ## A type for operations specific to Java polyglot objects.
+    @Builtin_Type
     type Java
 
     ## Adds the provided entry to the host class path.
@@ -520,6 +521,7 @@ type Prim_Io
     ## PRIVATE
 
        A type for primitive IO operations.
+    @Builtin_Type
     type Prim_Io
 
     ## PRIVATE
@@ -548,6 +550,7 @@ type Prim_Io
 type IO
 
     ## A type containing basic operations for performing input and output.
+    @Builtin_Type
     type IO
 
     ## Prints the provided message to standard error.
@@ -1998,6 +2001,7 @@ type Project_Description
 type Nothing
 
 ## Cons lists.
+@Builtin_Type
 type List
 
     ## The type that indicates the end of a cons list.
@@ -2013,13 +2017,10 @@ type List
     type Cons head tail
 
 ## A representation of the relative ordering between two values.
+
+   These values must be able to be ordered with respect to each other.
+@Builtin_Type
 type Ordering
-
-    ## A representation of the relative ordering between two values.
-
-       These values must be able to be ordered with respect to each other.
-    @Builtin_Type
-    type Ordering
 
     ## A representation that the first value orders as less than the second.
     @Builtin_Type

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
@@ -713,7 +713,7 @@ class SuggestionBuilderTest extends CompilerTest {
       )
     }
 
-    "build conersion method for complex type" in {
+    "build conversion method for complex type" in {
       pending
       implicit val moduleContext: ModuleContext = freshModuleContext
       val code =
@@ -734,6 +734,18 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) shouldEqual Tree.Root(
         Vector(
           ModuleNode,
+          Tree.Node(
+            Suggestion.Atom(
+              externalId        = None,
+              module            = "Unnamed.Test",
+              name              = "MyMaybe",
+              arguments         = Seq(),
+              returnType        = "Unnamed.Test.MyMaybe",
+              documentation     = None,
+              documentationHtml = None
+            ),
+            Vector()
+          ),
           Tree.Node(
             Suggestion.Atom(
               externalId = None,
@@ -1413,6 +1425,18 @@ class SuggestionBuilderTest extends CompilerTest {
             Suggestion.Atom(
               externalId        = None,
               module            = "Unnamed.Test",
+              name              = "Maybe",
+              arguments         = Seq(),
+              returnType        = "Unnamed.Test.Maybe",
+              documentation     = None,
+              documentationHtml = None
+            ),
+            Vector()
+          ),
+          Tree.Node(
+            Suggestion.Atom(
+              externalId        = None,
+              module            = "Unnamed.Test",
               name              = "Nothing",
               arguments         = Seq(),
               returnType        = "Unnamed.Test.Nothing",
@@ -1473,6 +1497,19 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) shouldEqual Tree.Root(
         Vector(
           DoccedModuleNode,
+          Tree.Node(
+            Suggestion.Atom(
+              externalId    = None,
+              module        = "Unnamed.Test",
+              name          = "Maybe",
+              arguments     = Seq(),
+              returnType    = "Unnamed.Test.Maybe",
+              documentation = Some(" When in doubt"),
+              documentationHtml =
+                Some(DocParserWrapper.runOnPureDoc(" When in doubt", "Maybe"))
+            ),
+            Vector()
+          ),
           Tree.Node(
             Suggestion.Atom(
               externalId    = None,
@@ -1544,6 +1581,18 @@ class SuggestionBuilderTest extends CompilerTest {
           ModuleNode,
           Tree.Node(
             Suggestion.Atom(
+              externalId        = None,
+              module            = "Unnamed.Test",
+              name              = "List",
+              arguments         = Seq(),
+              returnType        = "Unnamed.Test.List",
+              documentation     = None,
+              documentationHtml = None
+            ),
+            Vector()
+          ),
+          Tree.Node(
+            Suggestion.Atom(
               externalId    = None,
               module        = "Unnamed.Test",
               name          = "Cons",
@@ -1578,7 +1627,7 @@ class SuggestionBuilderTest extends CompilerTest {
                   .Argument("this", "Unnamed.Test.Cons", false, false, None)
               ),
               selfType      = "Unnamed.Test.Cons",
-              returnType    = "List",
+              returnType    = "Unnamed.Test.List",
               documentation = Some(" a method"),
               documentationHtml =
                 Some(DocParserWrapper.runOnPureDoc(" a method", "empty"))
@@ -1595,7 +1644,7 @@ class SuggestionBuilderTest extends CompilerTest {
                   .Argument("this", "Unnamed.Test.Nil", false, false, None)
               ),
               selfType      = "Unnamed.Test.Nil",
-              returnType    = "List",
+              returnType    = "Unnamed.Test.List",
               documentation = Some(" a method"),
               documentationHtml =
                 Some(DocParserWrapper.runOnPureDoc(" a method", "empty"))
@@ -1621,6 +1670,18 @@ class SuggestionBuilderTest extends CompilerTest {
       build(code, module) shouldEqual Tree.Root(
         Vector(
           ModuleNode,
+          Tree.Node(
+            Suggestion.Atom(
+              externalId        = None,
+              module            = "Unnamed.Test",
+              name              = "Maybe",
+              arguments         = Seq(),
+              returnType        = "Unnamed.Test.Maybe",
+              documentation     = None,
+              documentationHtml = None
+            ),
+            Vector()
+          ),
           Tree.Node(
             Suggestion.Atom(
               externalId        = None,

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/ComplexTypeTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/ComplexTypeTest.scala
@@ -80,9 +80,13 @@ class ComplexTypeTest extends CompilerTest {
           |    type Bar
           |""".stripMargin.preprocessModule.desugar
 
-      exactly(2, ir.bindings) shouldBe a[Definition.Atom]
-      ir.bindings.head.asInstanceOf[Definition.Atom].name.name shouldEqual "Foo"
-      ir.bindings(1).asInstanceOf[Definition.Atom].name.name shouldEqual "Bar"
+      exactly(3, ir.bindings) shouldBe a[Definition.Atom]
+      ir.bindings(0)
+        .asInstanceOf[Definition.Atom]
+        .name
+        .name shouldEqual "MyType"
+      ir.bindings(1).asInstanceOf[Definition.Atom].name.name shouldEqual "Foo"
+      ir.bindings(2).asInstanceOf[Definition.Atom].name.name shouldEqual "Bar"
     }
 
     "have annotations on the type desugared to annotations on the defined" in {
@@ -93,52 +97,58 @@ class ComplexTypeTest extends CompilerTest {
           |    type Bar
           |""".stripMargin.preprocessModule.desugar
 
-      exactly(1, ir.bindings) shouldBe a[Definition.Atom]
-      ir.bindings.head
+      exactly(2, ir.bindings) shouldBe a[Definition.Atom]
+      ir.bindings(0)
         .asInstanceOf[Definition.Atom]
-        .unsafeGetMetadata(ModuleAnnotations, "")
+        .unsafeGetMetadata(ModuleAnnotations, ComplexTypeTest.EmptyMetadata)
+        .annotations
+        .head
+        .name shouldEqual "@Builtin_Type"
+      ir.bindings(1)
+        .asInstanceOf[Definition.Atom]
+        .unsafeGetMetadata(ModuleAnnotations, ComplexTypeTest.EmptyMetadata)
         .annotations
         .head
         .name shouldEqual "@Builtin_Type"
     }
 
     "have their methods desugared to methods on included atoms" in {
-      ir.bindings(3) shouldBe an[Definition.Method.Binding]
-      val justIsJust = ir.bindings(3).asInstanceOf[Definition.Method.Binding]
+      ir.bindings(4) shouldBe an[Definition.Method.Binding]
+      val justIsJust = ir.bindings(4).asInstanceOf[Definition.Method.Binding]
       justIsJust.methodName.name shouldEqual "is_just"
       justIsJust.typeName.name shouldEqual "Nothing"
 
-      ir.bindings(7) shouldBe an[Definition.Method.Binding]
-      val justF = ir.bindings(7).asInstanceOf[Definition.Method.Binding]
+      ir.bindings(8) shouldBe an[Definition.Method.Binding]
+      val justF = ir.bindings(8).asInstanceOf[Definition.Method.Binding]
       justF.methodName.name shouldEqual "f"
       justF.typeName.name shouldEqual "Nothing"
     }
 
     "have their methods desugared to methods on the defined atoms" in {
-      ir.bindings(5) shouldBe an[Definition.Method.Binding]
-      val justIsJust = ir.bindings(5).asInstanceOf[Definition.Method.Binding]
+      ir.bindings(6) shouldBe an[Definition.Method.Binding]
+      val justIsJust = ir.bindings(6).asInstanceOf[Definition.Method.Binding]
       justIsJust.methodName.name shouldEqual "is_just"
       justIsJust.typeName.name shouldEqual "Just"
 
-      ir.bindings(9) shouldBe an[Definition.Method.Binding]
-      val justF = ir.bindings(9).asInstanceOf[Definition.Method.Binding]
+      ir.bindings(10) shouldBe an[Definition.Method.Binding]
+      val justF = ir.bindings(10).asInstanceOf[Definition.Method.Binding]
       justF.methodName.name shouldEqual "f"
       justF.typeName.name shouldEqual "Just"
     }
 
     "have type signatures copied to above each method" in {
-      ir.bindings(2) shouldBe an[IR.Type.Ascription]
-      ir.bindings(6) shouldBe an[IR.Type.Ascription]
-      ir.bindings(4) shouldBe an[IR.Type.Ascription]
-      ir.bindings(8) shouldBe an[IR.Type.Ascription]
+      ir.bindings(3) shouldBe an[IR.Type.Ascription]
+      ir.bindings(7) shouldBe an[IR.Type.Ascription]
+      ir.bindings(5) shouldBe an[IR.Type.Ascription]
+      ir.bindings(9) shouldBe an[IR.Type.Ascription]
 
       val nothingIsJustSigName = ir
-        .bindings(2)
+        .bindings(3)
         .asInstanceOf[IR.Type.Ascription]
         .typed
         .asInstanceOf[IR.Name.MethodReference]
       val nothingIsJustMethodName = ir
-        .bindings(3)
+        .bindings(4)
         .asInstanceOf[Definition.Method.Binding]
         .methodReference
 
@@ -148,12 +158,12 @@ class ComplexTypeTest extends CompilerTest {
       )
 
       val nothingFSigName = ir
-        .bindings(6)
+        .bindings(7)
         .asInstanceOf[IR.Type.Ascription]
         .typed
         .asInstanceOf[IR.Name.MethodReference]
       val nothingFMethodName = ir
-        .bindings(7)
+        .bindings(8)
         .asInstanceOf[Definition.Method.Binding]
         .methodReference
 
@@ -163,12 +173,12 @@ class ComplexTypeTest extends CompilerTest {
       )
 
       val justIsJustSigName = ir
-        .bindings(4)
+        .bindings(5)
         .asInstanceOf[IR.Type.Ascription]
         .typed
         .asInstanceOf[IR.Name.MethodReference]
       val justIsJustMethodName = ir
-        .bindings(5)
+        .bindings(6)
         .asInstanceOf[Definition.Method.Binding]
         .methodReference
 
@@ -178,12 +188,12 @@ class ComplexTypeTest extends CompilerTest {
       )
 
       val justFSigName = ir
-        .bindings(8)
+        .bindings(9)
         .asInstanceOf[IR.Type.Ascription]
         .typed
         .asInstanceOf[IR.Name.MethodReference]
       val justFMethodName = ir
-        .bindings(9)
+        .bindings(10)
         .asInstanceOf[Definition.Method.Binding]
         .methodReference
 
@@ -194,15 +204,15 @@ class ComplexTypeTest extends CompilerTest {
     }
 
     "leave un-associated signatures intact" in {
-      ir.bindings(1) shouldBe an[IR.Type.Ascription]
-      ir.bindings(1)
+      ir.bindings(2) shouldBe an[IR.Type.Ascription]
+      ir.bindings(2)
         .asInstanceOf[IR.Type.Ascription]
         .typed
         .asInstanceOf[IR.Name.Literal]
         .name shouldEqual "invalid_sig"
 
-      ir.bindings(10) shouldBe an[IR.Type.Ascription]
-      ir.bindings(10)
+      ir.bindings(11) shouldBe an[IR.Type.Ascription]
+      ir.bindings(11)
         .asInstanceOf[IR.Type.Ascription]
         .typed
         .asInstanceOf[IR.Name.Literal]
@@ -225,8 +235,11 @@ class ComplexTypeTest extends CompilerTest {
         |""".stripMargin.preprocessModule.desugar
 
     "have their types translated untouched" in {
-      ir.bindings.head shouldBe a[Definition.Atom]
-      val atom = ir.bindings.head.asInstanceOf[Definition.Atom]
+      ir.bindings(0) shouldBe a[Definition.Atom]
+      val typeFoo = ir.bindings(0).asInstanceOf[Definition.Atom]
+      typeFoo.name.name shouldEqual "Foo"
+      ir.bindings(1) shouldBe a[Definition.Atom]
+      val atom = ir.bindings(1).asInstanceOf[Definition.Atom]
       atom.name.name shouldEqual "Baz"
     }
 
@@ -237,14 +250,19 @@ class ComplexTypeTest extends CompilerTest {
     }
 
     "have their valid methods desugared" in {
-      ir.bindings(1) shouldBe a[Definition.Method.Binding]
       ir.bindings(2) shouldBe a[Definition.Method.Binding]
-      val methodOnBar = ir.bindings(1).asInstanceOf[Definition.Method.Binding]
-      val methodOnBaz = ir.bindings(2).asInstanceOf[Definition.Method.Binding]
+      ir.bindings(3) shouldBe a[Definition.Method.Binding]
+      val methodOnBar = ir.bindings(2).asInstanceOf[Definition.Method.Binding]
+      val methodOnBaz = ir.bindings(3).asInstanceOf[Definition.Method.Binding]
       methodOnBar.typeName.name shouldEqual "Bar"
       methodOnBar.methodName.name shouldEqual "g"
       methodOnBaz.typeName.name shouldEqual "Baz"
       methodOnBaz.methodName.name shouldEqual "g"
     }
   }
+}
+
+object ComplexTypeTest {
+
+  private val EmptyMetadata = "Metadata is empty!"
 }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/resolve/DocumentationCommentsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/resolve/DocumentationCommentsTest.scala
@@ -224,8 +224,7 @@ class DocumentationCommentsTest extends CompilerTest with Inside {
           |    ## Do another thing
           |    z = x * y
           |""".stripMargin.preprocessModule.resolve
-      val body = ir
-        .bindings.head
+      val body = ir.bindings.head
         .asInstanceOf[IR.Module.Scope.Definition.Method.Binding]
         .body
         .asInstanceOf[IR.Expression.Block]
@@ -247,8 +246,7 @@ class DocumentationCommentsTest extends CompilerTest with Inside {
           |    ## Return thing
           |    f 1
           |""".stripMargin.preprocessModule.resolve
-      val body = ir
-        .bindings.head
+      val body = ir.bindings.head
         .asInstanceOf[IR.Module.Scope.Definition.Method.Binding]
         .body
         .asInstanceOf[IR.Expression.Block]
@@ -342,9 +340,11 @@ class DocumentationCommentsTest extends CompilerTest with Inside {
           |        _ -> 50
           |""".stripMargin.preprocessModule
 
-      val t1 = ir.bindings.head
-      getDoc(t1) shouldEqual " the constructor Bar"
-      inside(ir.bindings(1)) {
+      val tFoo = ir.bindings.head
+      getDoc(tFoo) shouldEqual " the type Foo"
+      val tBar = ir.bindings(1)
+      getDoc(tBar) shouldEqual " the constructor Bar"
+      inside(ir.bindings(2)) {
         case method: IR.Module.Scope.Definition.Method.Explicit =>
           getDoc(method) shouldEqual " a method"
           inside(method.body) { case lambda: IR.Function.Lambda =>
@@ -355,7 +355,7 @@ class DocumentationCommentsTest extends CompilerTest with Inside {
           }
       }
 
-      inside(ir.bindings(2)) {
+      inside(ir.bindings(3)) {
         case method: IR.Module.Scope.Definition.Method.Explicit =>
           inside(method.body) { case lambda: IR.Function.Lambda =>
             inside(lambda.body) { case block: IR.Expression.Block =>

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/resolve/TypeSignaturesTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/resolve/TypeSignaturesTest.scala
@@ -161,12 +161,13 @@ class TypeSignaturesTest extends CompilerTest {
           |    error_signature : Int
           |""".stripMargin.preprocessModule.resolve
 
-      ir.bindings.length shouldEqual 3
+      ir.bindings.length shouldEqual 4
       ir.bindings.head shouldBe an[IR.Module.Scope.Definition.Atom]
-      ir.bindings(1) shouldBe an[IR.Module.Scope.Definition.Method]
-      ir.bindings(1).getMetadata(TypeSignatures) shouldBe defined
-      ir.bindings(1).getMetadata(DocumentationComments) shouldBe defined
-      ir.bindings(2) shouldBe an[IR.Error.Unexpected.TypeSignature]
+      ir.bindings(1) shouldBe an[IR.Module.Scope.Definition.Atom]
+      ir.bindings(2) shouldBe an[IR.Module.Scope.Definition.Method]
+      ir.bindings(2).getMetadata(TypeSignatures) shouldBe defined
+      ir.bindings(2).getMetadata(DocumentationComments) shouldBe defined
+      ir.bindings(3) shouldBe an[IR.Error.Unexpected.TypeSignature]
     }
 
     "recurse into bodies" in {

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
@@ -978,6 +978,21 @@ class RuntimeSuggestionUpdatesTest
                   Suggestion.Atom(
                     None,
                     "Enso_Test.Test.A",
+                    "MyType",
+                    List(),
+                    "Enso_Test.Test.A.MyType",
+                    None,
+                    None
+                  ),
+                  Api.SuggestionAction.Add()
+                ),
+                Vector()
+              ),
+              Tree.Node(
+                Api.SuggestionUpdate(
+                  Suggestion.Atom(
+                    None,
+                    "Enso_Test.Test.A",
                     "MkA",
                     List(
                       Suggestion
@@ -1078,6 +1093,7 @@ class RuntimeSuggestionUpdatesTest
               ModuleExports(
                 "Enso_Test.Test.Main",
                 Set(
+                  ExportedSymbol.Atom("Enso_Test.Test.A", "MyType"),
                   ExportedSymbol.Atom("Enso_Test.Test.A", "MkA"),
                   ExportedSymbol.Method("Enso_Test.Test.A", "hello")
                 )
@@ -1204,7 +1220,10 @@ class RuntimeSuggestionUpdatesTest
             Api.ExportsUpdate(
               ModuleExports(
                 "Enso_Test.Test.Main",
-                Set(ExportedSymbol.Atom("Enso_Test.Test.A", "MkA"))
+                Set(
+                  ExportedSymbol.Atom("Enso_Test.Test.A", "MyType"),
+                  ExportedSymbol.Atom("Enso_Test.Test.A", "MkA")
+                )
               ),
               Api.ExportsAction.Remove()
             )

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/MethodsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/MethodsTest.scala
@@ -165,5 +165,35 @@ class MethodsTest extends InterpreterTest {
 
       eval(code) shouldEqual 6
     }
+
+    "be defined on a base type" in {
+      val code =
+        """type List
+          |    type Cons h t
+          |    type Nil
+          |
+          |List.empty = Nil
+          |
+          |main = case List.empty of
+          |    Cons _ _ -> 0
+          |    Nil -> 1
+          |""".stripMargin
+
+      eval(code) shouldEqual 1
+    }
+
+    "be defined on an imported base type" in {
+      val code =
+        """from Standard.Builtins import all
+          |
+          |List.empty = Nil
+          |
+          |main = case List.empty of
+          |    Cons _ _ -> 0
+          |    Nil -> 1
+          |""".stripMargin
+
+      eval(code) shouldEqual 1
+    }
   }
 }

--- a/test/Tests/src/Semantic/Meta_Spec.enso
+++ b/test/Tests/src/Semantic/Meta_Spec.enso
@@ -14,23 +14,23 @@ type Test_Type x
 spec = Test.group "Meta-Value Manipulation" <|
     Test.specify "should allow manipulating unresolved symbols" <|
         sym = .does_not_exist
-        meta_sym = Meta.meta sym
+        meta_sym = Meta.repr sym
         meta_sym.name.should_equal "does_not_exist"
         new_sym = meta_sym . rename "my_method"
         object = My_Type 1 2 3
         new_sym object . should_equal 6
     Test.specify "should allow manipulating atoms" <|
         atom = My_Type 1 "foo" Nothing
-        meta_atom = Meta.meta atom
+        meta_atom = Meta.repr atom
         meta_atom.constructor.should_equal My_Type
         meta_atom.fields.should_equal [1, "foo", Nothing]
-        Meta.meta (meta_atom.constructor) . new [1, "foo", Nothing] . should_equal atom
+        Meta.repr (meta_atom.constructor) . new [1, "foo", Nothing] . should_equal atom
     Test.specify "should correctly return representations of different classes of objects" <|
-        Meta.meta 1 . should_equal (Meta.Primitive 1)
-        Meta.meta "foo" . should_equal (Meta.Primitive "foo")
+        Meta.repr 1 . should_equal (Meta.Primitive 1)
+        Meta.repr "foo" . should_equal (Meta.Primitive "foo")
     Test.specify "should allow manipulation of error values" <|
         err = Error.throw "My Error"
-        meta_err = Meta.meta err
+        meta_err = Meta.repr err
         meta_err.is_a Meta.Error . should_be_true
         meta_err.value . should_equal "My Error"
     Test.specify "should allow checking if a value is of a certain type" <|


### PR DESCRIPTION
[no ci changelog needed]

### Pull Request Description

PR adds generation of atoms for complex atom definitions, i.e.

```py
type Maybe
    type Some a
    type Nothing
```

The atom Maybe is also generated, so it can be used in conversions, i.e

```py
x.to Maybe
```
or
```py
y.to Json
```

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

Stdlib changes:
- Rename method `Meta.meta` to `Meta.repr` to avoid clashing with the `type Meta` atom definition.
- Rename atom `type Os` to `type Platform` to avoid clashing with the `Platform.os` method definition.

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/develop/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/develop/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
