### PR TITLE
Fix compiler crash when the module defines a function and an atom with the same name

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -464,7 +464,7 @@ class IrToTruffle(
       "No binding analysis at the point of codegen."
     )
     bindingsMap.exportedSymbols.foreach {
-      case (name, List(resolution)) =>
+      case (name, resolution :: _) =>
         if (resolution.module.unsafeAsModule() != moduleScope.getModule) {
           resolution match {
             case BindingsMap.ResolvedConstructor(definitionModule, cons) =>
@@ -1096,6 +1096,11 @@ class IrToTruffle(
             .compileError()
             .newInstance(Text.create(err.message))
         case err: Error.Redefined.Method =>
+          context.getBuiltins
+            .error()
+            .compileError()
+            .newInstance(Text.create(err.message))
+        case err: Error.Redefined.MethodClashWithAtom =>
           context.getBuiltins
             .error()
             .compileError()

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/OverloadsResolution.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/OverloadsResolution.scala
@@ -74,11 +74,21 @@ case object OverloadsResolution extends IRPass {
         IR.Error.Redefined
           .Method(method.typeName, method.methodName, method.location)
       } else {
-        val currentMethods = seenMethods(method.typeName.name)
-        seenMethods = seenMethods + (method.typeName.name ->
-        (currentMethods + method.methodName.name))
+        atoms.find(_.name.name.equalsIgnoreCase(method.methodName.name)) match {
+          case Some(clashedAtom)
+              if method.typeName.isInstanceOf[IR.Name.Here] =>
+            IR.Error.Redefined.MethodClashWithAtom(
+              clashedAtom.name,
+              method.methodName,
+              method.location
+            )
+          case _ =>
+            val currentMethods = seenMethods(method.typeName.name)
+            seenMethods = seenMethods + (method.typeName.name ->
+            (currentMethods + method.methodName.name))
 
-        method
+            method
+        }
       }
     })
 

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -2512,6 +2512,66 @@ class RuntimeServerTest
     )
   }
 
+  it should "return error when method name clashes with atom" in {
+    val contextId  = UUID.randomUUID()
+    val requestId  = UUID.randomUUID()
+    val moduleName = "Enso_Test.Test.Main"
+    val metadata   = new Metadata
+
+    val code =
+      """type Foo
+        |foo = 0
+        |main = 0
+        |""".stripMargin.linesIterator.mkString("\n")
+    val contents = metadata.appendToCode(code)
+    val mainFile = context.writeMain(contents)
+
+    // create context
+    context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
+    context.receive shouldEqual Some(
+      Api.Response(requestId, Api.CreateContextResponse(contextId))
+    )
+
+    // Open the new file
+    context.send(
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
+    )
+    context.receiveNone shouldEqual None
+
+    // push main
+    context.send(
+      Api.Request(
+        requestId,
+        Api.PushContextRequest(
+          contextId,
+          Api.StackItem.ExplicitCall(
+            Api.MethodPointer(moduleName, "Enso_Test.Test.Main", "main"),
+            None,
+            Vector()
+          )
+        )
+      )
+    )
+    context.receive(3) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PushContextResponse(contextId)),
+      Api.Response(
+        Api.ExecutionUpdate(
+          contextId,
+          Seq(
+            Api.ExecutionResult.Diagnostic.error(
+              "Method definitions with the same name as atoms are not supported. Method foo clashes with the atom Foo in this module.",
+              Some(mainFile),
+              Some(model.Range(model.Position(1, 0), model.Position(1, 7))),
+              None,
+              Vector()
+            )
+          )
+        )
+      ),
+      context.executionComplete(contextId)
+    )
+  }
+
   it should "return error with a stack trace" in {
     val contextId  = UUID.randomUUID()
     val requestId  = UUID.randomUUID()

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/MethodsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/MethodsTest.scala
@@ -160,7 +160,6 @@ class MethodsTest extends InterpreterTest {
           |main =
           |    myList = Cons 1 (Cons 2 (Cons 3 Nil))
           |    myList.sum
-          |
           |""".stripMargin
 
       eval(code) shouldEqual 6

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/OverloadsResolutionErrorTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/OverloadsResolutionErrorTest.scala
@@ -18,7 +18,7 @@ class OverloadsResolutionErrorTest extends InterpreterTest {
     interpreterContext: InterpreterContext
   ): Unit = {
 
-    "result in an error at runtime for methods" in {
+    "result in an error at runtime for method overloads" in {
       val code =
         """from Standard.Builtins import all
           |
@@ -38,7 +38,7 @@ class OverloadsResolutionErrorTest extends InterpreterTest {
       )
     }
 
-    "result in an error at runtime for atoms" in {
+    "result in an error at runtime for atom overloads" in {
       val code =
         """
           |type MyAtom
@@ -56,6 +56,25 @@ class OverloadsResolutionErrorTest extends InterpreterTest {
         "Test[3:1-3:11]: Redefining atoms is not supported: MyAtom is defined multiple times in this module."
       )
     }
-  }
 
+    "result in an error at runtime for methods overloading atoms" in {
+      val code =
+        """
+          |type Foo
+          |foo = 0
+          |""".stripMargin.linesIterator.mkString("\n")
+
+      the[InterpreterException] thrownBy eval(code) should have message
+      "Compilation aborted due to errors."
+
+      val diagnostics = consumeOut
+      diagnostics
+        .filterNot(_.contains("Compiler encountered"))
+        .filterNot(_.contains("In module"))
+        .toSet shouldEqual Set(
+        "Test[3:1-3:7]: Method definitions with the same name as atoms are not supported. Method foo clashes with the atom Foo in this module."
+      )
+    }
+
+  }
 }


### PR DESCRIPTION
### Pull Request Description

PR fixes the compiler crash when there is a definition of a method and an atom with the same name in the module, i.e.

```py
type Foo
foo = ""
```

and generates an appropriate compiler error.

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/develop/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/develop/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
