### PR TITLE
Update JS deps on CI

### DIFF
--- a/app/gui/docs/CONTRIBUTING.md
+++ b/app/gui/docs/CONTRIBUTING.md
@@ -202,9 +202,9 @@ build tool). The most common options are presented below:
 JS parts of the project are using [`lerna`](https://lerna.js.org/) to manage JS
 dependencies. When you add a new JS dependency or update an old one to the new
 version, `lerna` must be re-run to trigger `npm install` for all projects. The
-easiest way to do so is to remove `dist/init` file before the next build. You
-can also manually call `npm run install` in `app/ide-desktop/` directory with a
-similar result. Our CI does that for every build at the moment.
+easiest way to do so is to run `./run clean --no-rust` command. You can also
+manually call `npm run install` in `app/ide-desktop/` directory with a similar
+result. Our CI does that for every build at the moment.
 
 ### Testing IDE with a specific version of a backend
 

--- a/app/gui/docs/CONTRIBUTING.md
+++ b/app/gui/docs/CONTRIBUTING.md
@@ -197,6 +197,15 @@ build tool). The most common options are presented below:
   the `entry_point_ide` function, so you have to compile it to test your code in
   the Enso IDE.
 
+### Updating JS dependencies
+
+JS parts of the project are using [`lerna`](https://lerna.js.org/) to manage JS
+dependencies. When you add a new JS dependency or update an old one to the new
+version, `lerna` must be re-run to trigger `npm install` for all projects. The
+easiest way to do so is to remove `dist/init` file before the next build. You
+can also manually call `npm run install` in `app/ide-desktop/` directory with a
+similar result. Our CI does that for every build at the moment.
+
 ### Testing IDE with a specific version of a backend
 
 Sometimes changes to the IDE must be tested against the unreleased Enso Engine


### PR DESCRIPTION
### Pull Request Description

[ci no changelog needed]

While working on other tasks, I noticed that adding a new JS dependency breaks our CI builds, because runners are not doing clean builds every time, but rather make incremental builds preserving the old `node_modules`. We discussed the problem with @mwu-tow and decided to run `npm run install` on our CI in order to avoid such problems. It would probably make CI builds slower by 20-60 seconds (yes, `npm` is that slow). We will implement better heuristics in the future.

Also, I noticed that our developer documentation doesn't mention the need for clean builds in case of updating or adding a new JS dependency. I added a section to the CONTRIBUTING guide.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/develop/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/develop/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
