### PR TITLE
Fix a few typos in code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1614,7 +1614,7 @@ lazy val `std-google-api` = project
   .settings(
     autoScalaLibrary := false,
     Compile / packageBin / artifactPath :=
-      `google-api-polyglot-root` / "std-image.jar",
+      `google-api-polyglot-root` / "std-google-api.jar",
     libraryDependencies ++= Seq(
       "com.google.api-client" % "google-api-client"          % "1.32.1",
       "com.google.apis"       % "google-api-services-sheets" % "v4-rev612-1.25.0"

--- a/engine/runtime/src/main/resources/Builtins.enso
+++ b/engine/runtime/src/main/resources/Builtins.enso
@@ -341,7 +341,7 @@ type Panic
        program control flow.
 
        Panics "bubble up" through the program until they reach either an
-       invocation of Panic.catch or the program's main method. An unhandled
+       invocation of Panic.recover or the program's main method. An unhandled
        panic in main will terminate the program.
 
        ? Dataflow Errors or Panics
@@ -365,7 +365,7 @@ type Panic
     ## Executes the provided action and converts any panic thrown by it into
        an Error.
 
-       If action executes successfully, the result of Panic.catch is the
+       If action executes successfully, the result of Panic.recover is the
        result of that action. Otherwise, it is the panic that was thrown after
        conversion to a dataflow error.
 
@@ -377,7 +377,7 @@ type Panic
 
              Panic.recover (Panic.throw "Oh no!")
     recover : Any -> Any
-    recover ~action = @Builtin_Method "Panic.catch"
+    recover ~action = @Builtin_Method "Panic.recover"
 
 # Function types.
 type Function


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

Fixes two typos.

1. The `Builtins.enso` file included references to a `Panic.catch` method which does not exist. It should be `Panic.recover`.
2. `build.sbt` had a wrong name for a library artifact which caused it to be regenerated on each rebuild.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/develop/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/develop/docs/style-guide/yaml.md) style guides.
- [ ] All code has been tested where possible.
