### PR TITLE
Moving distinct to Map

### DIFF
--- a/app/gui/CHANGELOG.md
+++ b/app/gui/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 - [Implemented `Vector.distinct` allowing to remove duplicate elements from a
   Vector][3224]
+- [Implemented `Duration.time_execution` allowing timing of the execution of an
+- expression within the UI][3229]
 
 [3153]: https://github.com/enso-org/enso/pull/3153
 [3166]: https://github.com/enso-org/enso/pull/3166
@@ -25,6 +27,7 @@
 [3193]: https://github.com/enso-org/enso/pull/3193
 [3208]: https://github.com/enso-org/enso/pull/3208
 [3224]: https://github.com/enso-org/enso/pull/3224
+[3229]: https://github.com/enso-org/enso/pull/3229
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Time/Duration.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Time/Duration.enso
@@ -28,15 +28,16 @@ between start_inclusive end_exclusive =
     Duration period duration
 
 
-## Time the evaluation of a function, return a Pair of Duration and Result
+## ADVANCED
+
+   Time the evaluation of a function, return a Pair of Duration and Result
 
    Arguments:
-   - input: Value to pass to callback.
-   - callback: Function to execute.
-time_execution : Any -> (Any -> Any) -> Pair Duration Any
-time_execution input callback =
+   - function: Function to execute.
+time_execution : Any -> Pair Duration Any
+time_execution ~function =
     start = Java_System.nanoTime
-    result = callback input
+    result = Runtime.no_inline function
     end = Java_System.nanoTime
     duration = Duration (Java_Period.ofDays 0) (Java_Duration.ofNanos (end - start))
     Pair duration result

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Time/Duration.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Time/Duration.enso
@@ -4,12 +4,13 @@ import Standard.Base.Data.Time
 
 polyglot java import java.time.Duration as Java_Duration
 polyglot java import java.time.Period as Java_Period
+polyglot java import java.lang.System as Java_System
 
 ## Create an interval representing the duration between two points in time.
 
    Arguments:
    - start_inclusive: The start time of the duration.
-   - end_inclusife: The end time of the duration.
+   - end_inclusive: The end time of the duration.
 
    > Example
      An hour interval between two points in time.
@@ -25,6 +26,21 @@ between start_inclusive end_exclusive =
     end = end_exclusive.internal_zoned_date_time
     duration = Java_Duration.between start end
     Duration period duration
+
+
+## Time the evaluation of a function, return a Pair of Duration and Result
+
+   Arguments:
+   - input: Value to pass to callback.
+   - callback: Function to execute.
+time_execution : Any -> (Any -> Any) -> Pair Duration Any
+time_execution input callback =
+    start = Java_System.nanoTime
+    result = callback input
+    end = Java_System.nanoTime
+    duration = Duration (Java_Period.ofDays 0) (Java_Duration.ofNanos (end - start))
+    Pair duration result
+
 
 type Duration
 

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Time/Duration.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Time/Duration.enso
@@ -4,7 +4,6 @@ import Standard.Base.Data.Time
 
 polyglot java import java.time.Duration as Java_Duration
 polyglot java import java.time.Period as Java_Period
-polyglot java import java.lang.System as Java_System
 
 ## Create an interval representing the duration between two points in time.
 
@@ -36,9 +35,9 @@ between start_inclusive end_exclusive =
    - function: Function to execute.
 time_execution : Any -> Pair Duration Any
 time_execution ~function =
-    start = Java_System.nanoTime
+    start = System.nano_time
     result = Runtime.no_inline function
-    end = Java_System.nanoTime
+    end = System.nano_time
     duration = Duration (Java_Period.ofDays 0) (Java_Duration.ofNanos (end - start))
     Pair duration result
 

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 from Standard.Builtins import Array
+from Standard.Builtins import Unsupported_Argument_Types
 
 ## Creates a new vector of the given length, initializing elements using
    the provided constructor function.
@@ -752,7 +753,7 @@ type Vector
          Keeping only pairs whose first elements are unique.
 
              [Pair 1 "a", Pair 2 "b", Pair 1 "c"] . distinct (on = _.first) == [Pair 1 "a", Pair 2 "b"]
-    distinct : (Any -> Any) -> -> Vector Any
+    distinct : (Any -> Any) -> Vector Any
     distinct (on = x->x) =
         recover = Panic.recover
             builder = here.new_builder
@@ -764,19 +765,11 @@ type Vector
                         existing.insert key True
             builder.to_vector
 
-        recover.catch error->
-            IO.println error
-            builder = here.new_builder
-            key_builder = here.new_builder
-            this.fold 0 count->
-                item->
-                    key = on item
-                    if (key_builder.exists k->(k == key)) then count else
-                        builder.append item
-                        key_builder.append key
-                        (count + 1)
-            builder.to_vector
-
+        recover.map_error e-> case e of
+            No_Such_Method_Error _ _ -> Incomparable_Values_Error
+            Unsupported_Argument_Types _ -> Incomparable_Values_Error
+            Type_Error _ _ -> Incomparable_Values_Error
+            _ -> Panic.throw e
 
 
     ## UNSTABLE
@@ -936,3 +929,10 @@ type Singleton_Error vec
 Singleton_Error.to_display_text : Text
 Singleton_Error.to_display_text =
     "The vector " + this.vec.to_text  + " has only one element."
+
+
+## UNSTABLE
+
+   An error when vector contains incomparable types
+
+type Incomparable_Values_Error

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
@@ -1,8 +1,6 @@
 from Standard.Base import all
 from Standard.Builtins import Array
 
-polyglot java import java.util.HashSet
-
 ## Creates a new vector of the given length, initializing elements using
    the provided constructor function.
 
@@ -747,13 +745,12 @@ type Vector
     distinct : (Any -> Any) -> Vector Any
     distinct (on = x->x) =
         builder = here.new_builder
-        existing_elements = HashSet.new
-
-        this.each elem->
-            proj = on elem
-            if existing_elements.contains proj then Nothing else
-                existing_elements.add proj
-                builder.append elem
+        this.fold Map.empty state->
+            item->
+                key = on item
+                if (state.get_or_else key False) then state else
+                    builder.append item
+                    state.insert key True
 
         builder.to_vector
 

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
@@ -755,7 +755,7 @@ type Vector
              [Pair 1 "a", Pair 2 "b", Pair 1 "c"] . distinct (on = _.first) == [Pair 1 "a", Pair 2 "b"]
     distinct : (Any -> Any) -> Vector Any
     distinct (on = x->x) =
-        recover = Panic.recover
+        recovered = Panic.recover
             builder = here.new_builder
             this.fold Map.empty existing->
                 item->
@@ -765,7 +765,7 @@ type Vector
                         existing.insert key True
             builder.to_vector
 
-        recover.map_error e-> case e of
+        recovered.map_error e-> case e of
             No_Such_Method_Error _ _ -> Incomparable_Values_Error
             Unsupported_Argument_Types _ -> Incomparable_Values_Error
             Type_Error _ _ -> Incomparable_Values_Error
@@ -933,6 +933,6 @@ Singleton_Error.to_display_text =
 
 ## UNSTABLE
 
-   An error when vector contains incomparable types
+   An error indicating that the vector contains incomparable types.
 
 type Incomparable_Values_Error

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
@@ -747,7 +747,7 @@ type Vector
         builder = here.new_builder
         this.fold Map.empty state->
             item->
-                key = on item
+                key = Mixed_Types_Map_Key (on item)
                 if (state.get_or_else key False) then state else
                     builder.append item
                     state.insert key True
@@ -900,3 +900,21 @@ Singleton_Error.to_display_text : Text
 Singleton_Error.to_display_text =
     "The vector " + this.vec.to_text  + " has only one element."
 
+
+type Mixed_Types_Map_Key
+    type Mixed_Types_Map_Key value
+
+    == : Mixed_Types_Map_Key -> Boolean
+    == that = this.value == that.value
+
+    compare_to : Mixed_Types_Map_Key -> Ordering
+    compare_to that =
+        # Naive Compare
+        r = Panic.recover (this.value.compare_to that.value)
+        r.catch err->
+            bool_check = this.value.is_a Boolean && that.value.is_a Boolean
+            if bool_check then if this.value then Ordering.Greater else Ordering.Less) else
+                this_type = Meta.get_qualified_type_name this.value
+                that_type = Meta.get_qualified_type_name that.value
+                if this_type != that_type then (this_type.compare_to that_type) else
+                    Panic.throw err

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
@@ -748,9 +748,9 @@ type Vector
         this.fold Map.empty state->
             item->
                 key = Mixed_Types_Map_Key (on item)
-                if (state.get_or_else key False) then state else
+                if (state.get_or_else key False) then existing else
                     builder.append item
-                    state.insert key True
+                    existing.insert key True
 
         builder.to_vector
 

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
@@ -726,6 +726,16 @@ type Vector
        Arguments:
        - on: A projection from the element type to the value of that element
              which determines the uniqueness criteria.
+       - on_problems: Specifies the behavior when a problem occurs during the
+         function.
+         By default, a warning is issued, but the operation proceeds.
+         If set to `Report_Error`, the operation fails with a dataflow error.
+         If set to `Ignore`, the operation proceeds without errors or warnings.
+       - warnings: A Warning_System instance specifying how to handle warnings.
+         This is a temporary workaround to allow for testing the warning
+         mechanism. Once the proper warning system is implemented, this
+         argument will become obsolete and will be removed. No user code should
+         use this argument, as it will be removed in the future.
 
        The returned unique elements are kept in the same order as they appeared
        in the input.
@@ -742,17 +752,31 @@ type Vector
          Keeping only pairs whose first elements are unique.
 
              [Pair 1 "a", Pair 2 "b", Pair 1 "c"] . distinct (on = _.first) == [Pair 1 "a", Pair 2 "b"]
-    distinct : (Any -> Any) -> Vector Any
+    distinct : (Any -> Any) -> -> Vector Any
     distinct (on = x->x) =
-        builder = here.new_builder
-        this.fold Map.empty state->
-            item->
-                key = Mixed_Types_Map_Key (on item)
-                if (state.get_or_else key False) then existing else
-                    builder.append item
-                    existing.insert key True
+        recover = Panic.recover
+            builder = here.new_builder
+            this.fold Map.empty existing->
+                item->
+                    key = on item
+                    if (existing.get_or_else key False) then existing else
+                        builder.append item
+                        existing.insert key True
+            builder.to_vector
 
-        builder.to_vector
+        recover.catch error->
+            IO.println error
+            builder = here.new_builder
+            key_builder = here.new_builder
+            this.fold 0 count->
+                item->
+                    key = on item
+                    if (key_builder.exists k->(k == key)) then count else
+                        builder.append item
+                        key_builder.append key
+                        (count + 1)
+            builder.to_vector
+
 
 
     ## UNSTABLE
@@ -838,6 +862,19 @@ type Builder
             this.append item
             Nothing
 
+    ## Checks whether a predicate holds for at least one element of this builder.
+
+       Arguments:
+       - predicate: A function that takes a list element and returns a boolean
+         that says whether that value satisfies the conditions of the function.
+
+    exists : (Any -> Boolean) -> Boolean
+    exists predicate =
+        len = this.length
+        go idx found = if found || (idx >= len) then found else
+            @Tail_Call go idx+1 (predicate (this.to_array.at idx))
+        go 0 False
+
     ## Converts this builder to a vector containing all the appended elements.
 
        > Example
@@ -899,22 +936,3 @@ type Singleton_Error vec
 Singleton_Error.to_display_text : Text
 Singleton_Error.to_display_text =
     "The vector " + this.vec.to_text  + " has only one element."
-
-
-type Mixed_Types_Map_Key
-    type Mixed_Types_Map_Key value
-
-    == : Mixed_Types_Map_Key -> Boolean
-    == that = this.value == that.value
-
-    compare_to : Mixed_Types_Map_Key -> Ordering
-    compare_to that =
-        # Naive Compare
-        r = Panic.recover (this.value.compare_to that.value)
-        r.catch err->
-            bool_check = this.value.is_a Boolean && that.value.is_a Boolean
-            if bool_check then if (this.value then Ordering.Greater else Ordering.Less) else
-                this_type = Meta.get_qualified_type_name this.value
-                that_type = Meta.get_qualified_type_name that.value
-                if this_type != that_type then (this_type.compare_to that_type) else
-                    Panic.throw err

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
@@ -913,7 +913,7 @@ type Mixed_Types_Map_Key
         r = Panic.recover (this.value.compare_to that.value)
         r.catch err->
             bool_check = this.value.is_a Boolean && that.value.is_a Boolean
-            if bool_check then if this.value then Ordering.Greater else Ordering.Less) else
+            if bool_check then if (this.value then Ordering.Greater else Ordering.Less) else
                 this_type = Meta.get_qualified_type_name this.value
                 that_type = Meta.get_qualified_type_name that.value
                 if this_type != that_type then (this_type.compare_to that_type) else

--- a/engine/runtime/src/main/resources/Builtins.enso
+++ b/engine/runtime/src/main/resources/Builtins.enso
@@ -334,6 +334,21 @@ type Invalid_Array_Index_Error array index
 @Builtin_Type
 type Not_Invokable_Error target
 
+## An error that occurs when arguments used in a function call are invalid
+   types for the function.
+
+   Arguments:
+     - arguments: The passed arguments.
+@Builtin_Type
+type Unsupported_Argument_Types arguments
+
+## An error that occurs when the specified module cannot be found.
+
+   Arguments:
+     - name: The module searched for.
+@Builtin_Type
+type Module_Does_Not_Exist name
+
 ## Panics.
 type Panic
 

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -256,14 +256,15 @@ spec = Test.group "Vectors" <|
     Test.specify "should return a vector containing only unique elements" <|
         [1, 3, 1, 2, 2, 1].distinct . should_equal [1, 3, 2]
         ["a", "a", "a"].distinct . should_equal ["a"]
+        [1, 1.0, 2, 2.0].distinct . should_equal [1, 2]
         [].distinct . should_equal []
 
-    Test.specify "should return a vector containing only unique mixed type elements" <|
-        [1, 1.0, 2, 2.0].distinct . should_equal [1, 2]
-        ["a", 2].distinct . should_equal ["a", 2]
-        [2, "a", Integer, "a", 2].distinct . should_equal [2, "a", Integer]
+    Test.specify "should throw a clean error for incomparable types" <|
+        ["a", 2].distinct . should_fail_with Vector.Incomparable_Values_Error
+        [2, "a", Integer, "a", 2].distinct . should_fail_with Vector.Incomparable_Values_Error
+        [Pair 1 2, Pair 3 4].distinct . should_fail_with Vector.Incomparable_Values_Error
 
-    Test.specify "should correctly handle distinct with custom types like Atoms" <|
+    Test.specify "should correctly handle distinct with custom types like Atoms that implement compare_to" <|
         [T 1 2, T 3 3, T 1 2].distinct . should_equal [T 1 2, T 3 3]
 
     Test.specify "should return a vector containing only unique elements up to some criteria" <|

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -257,9 +257,9 @@ spec = Test.group "Vectors" <|
         [1, 3, 1, 2, 2, 1].distinct . should_equal [1, 3, 2]
         ["a", "a", "a"].distinct . should_equal ["a"]
         [].distinct . should_equal []
-        [1, 1.0, 2, 2.0].distinct . should_equal [1, 2]
 
     Test.specify "should return a vector containing only unique mixed type elements" <|
+        [1, 1.0, 2, 2.0].distinct . should_equal [1, 2]
         ["a", 2].distinct . should_equal ["a", 2]
         [2, "a", Integer, "a", 2].distinct . should_equal [2, "a", Integer]
 

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -259,7 +259,6 @@ spec = Test.group "Vectors" <|
         [].distinct . should_equal []
         [1, 1.0, 2, 2.0].distinct . should_equal [1, 2]
 
-    structural_eq_reason="Disabled until map can support mixed types."
     Test.specify "should return a vector containing only unique mixed type elements" <|
         ["a", 2].distinct . should_equal ["a", 2]
         [2, "a", Integer, "a", 2].distinct . should_equal [2, "a", Integer]

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -263,8 +263,7 @@ spec = Test.group "Vectors" <|
         ["a", 2].distinct . should_equal ["a", 2]
         [2, "a", Integer, "a", 2].distinct . should_equal [2, "a", Integer]
 
-    structural_eq_reason="Disabled until structural equality of Atoms is properly exposed through Polyglot."
-    Test.specify "should correctly handle distinct with custom types like Atoms" pending=structural_eq_reason <|
+    Test.specify "should correctly handle distinct with custom types like Atoms" <|
         [T 1 2, T 3 3, T 1 2].distinct . should_equal [T 1 2, T 3 3]
 
     Test.specify "should return a vector containing only unique elements up to some criteria" <|

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -257,7 +257,10 @@ spec = Test.group "Vectors" <|
         [1, 3, 1, 2, 2, 1].distinct . should_equal [1, 3, 2]
         ["a", "a", "a"].distinct . should_equal ["a"]
         [].distinct . should_equal []
+        [1, 1.0, 2, 2.0].distinct . should_equal [1, 2]
 
+    structural_eq_reason="Disabled until map can support mixed types."
+    Test.specify "should return a vector containing only unique mixed type elements" <|
         ["a", 2].distinct . should_equal ["a", 2]
         [2, "a", Integer, "a", 2].distinct . should_equal [2, "a", Integer]
 


### PR DESCRIPTION
### Pull Request Description

Changing the implementation of `Vector.distinct` to be based off the Enso map class.

Initial QA process of the previous implementation highlighted differences in equality comparison in Enso and polyglot functions (HashMap in this case). By moving to a `Map` based implementation the Enso based equality is used.

It also allows for use of bespoke types which have comparison operators.

### Important Notes

- No change to the public API of `distinct`

### Checklist

Please include the following checklist in your PR:

- [X] The documentation has been updated if necessary.
- [X] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- [X] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/develop/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/develop/docs/style-guide/yaml.md) style guides.
- [X] All code has been tested where possible.
