### PR TITLE
Implement creating nodes by dropping a connection

### DIFF
--- a/app/gui/CHANGELOG.md
+++ b/app/gui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - [New nodes can be created by dragging and dropping a connection on the
   scene.][3231]
-- [Node connections can be dropped by pressing the Enter key while dragging
+- [Node connections can be dropped by pressing the Esc key while dragging
   them.][3231]
 - [Added support of source maps for JS-based visualizations.][3208]
 - [Fixed histograms coloring and added a color legend.][3153]

--- a/app/gui/CHANGELOG.md
+++ b/app/gui/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Visual Environment
 
+- [New nodes can be created by dragging and dropping a connection on the scene.][3231]
 - [Added support of source maps for JS-based visualizations.][3208]
 - [Fixed histograms coloring and added a color legend.][3153]
 - [Fixed broken node whose expression contains non-ASCII characters.][3166]
@@ -25,6 +26,7 @@
 [3193]: https://github.com/enso-org/enso/pull/3193
 [3208]: https://github.com/enso-org/enso/pull/3208
 [3224]: https://github.com/enso-org/enso/pull/3224
+[3231]: https://github.com/enso-org/enso/pull/3231
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/app/gui/CHANGELOG.md
+++ b/app/gui/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - [New nodes can be created by dragging and dropping a connection on the
   scene.][3231]
+- [Node connections can be dropped by pressing the Enter key while dragging
+  them.][3231]
 - [Added support of source maps for JS-based visualizations.][3208]
 - [Fixed histograms coloring and added a color legend.][3153]
 - [Fixed broken node whose expression contains non-ASCII characters.][3166]

--- a/app/gui/CHANGELOG.md
+++ b/app/gui/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 #### Visual Environment
 
-- [New nodes can be created by dragging and dropping a connection on the scene.][3231]
+- [New nodes can be created by dragging and dropping a connection on the
+  scene.][3231]
 - [Added support of source maps for JS-based visualizations.][3208]
 - [Fixed histograms coloring and added a color legend.][3153]
 - [Fixed broken node whose expression contains non-ASCII characters.][3166]

--- a/app/gui/docs/product/shortcuts.md
+++ b/app/gui/docs/product/shortcuts.md
@@ -47,6 +47,7 @@ broken and require further investigation.
 | <kbd>alt</kbd>+<kbd>F4</kbd>                                | Close the application (MacOS, Windows, Linux)                                                                                                                                                                                                        |
 | <kbd>ctrl</kbd>+<kbd>w</kbd>                                | Close the application (Windows, Linux)                                                                                                                                                                                                               |
 | :warning: <kbd>ctrl</kbd>+<kbd>p</kbd>                      | Toggle profiling mode                                                                                                                                                                                                                                |
+| <kbd>escape</kbd>                                           | Cancel current action. For example, drop currently dragged connection.                                                                                                                                                                               |
 
 #### Navigation
 

--- a/app/gui/src/controller/searcher.rs
+++ b/app/gui/src/controller/searcher.rs
@@ -304,9 +304,11 @@ impl Display for ParsedInput {
 
 /// Information about a node that is used as a `this` argument.
 ///
-/// When searcher is brought up with a node selected, the node will be used as "this". This affects
-/// suggestions for the first completion (to include methods of the node's returned value) and the
-/// code inserted when the input is committed.
+/// "This" node is either:
+/// 1. A node that was selected when the searcher was brought up.
+/// 2. A source node of the connection that was dropped on the scene to create a new node.
+/// This affects suggestions for the first completion (to include methods of the node's returned
+/// value) and the code inserted when the input is committed.
 #[derive(Clone, Debug)]
 pub struct ThisNode {
     /// Identifier of the node that will be connected if the initial suggestion is picked.
@@ -318,7 +320,7 @@ pub struct ThisNode {
 }
 
 impl ThisNode {
-    /// Retrieve information about the `self` node. The first selected node will be used for this.
+    /// Retrieve information about the `self` node.
     ///
     /// Returns `None` if the given node's information cannot be retrieved or if the node does not
     /// introduce a variable.

--- a/app/gui/src/controller/searcher.rs
+++ b/app/gui/src/controller/searcher.rs
@@ -360,8 +360,8 @@ impl ThisNode {
 #[derive(Copy, Clone, Debug)]
 #[allow(missing_docs)]
 pub enum Mode {
-    /// Searcher should add a new node at given position. `source_node` is a selected node or a
-    /// node from which the connection was dragged out before being dropped at the scene.
+    /// Searcher should add a new node at a given position. `source_node` is either a selected node
+    /// or a node from which the connection was dragged out before being dropped at the scene.
     NewNode { position: Option<Position>, source_node: Option<ast::Id> },
     /// Searcher should edit existing node's expression.
     EditNode { node_id: ast::Id },
@@ -1252,7 +1252,7 @@ pub mod test {
             let code_range = enso_text::Location::default()..=end_of_code;
             let graph = data.graph.controller();
             let node = &graph.graph().nodes().unwrap()[0];
-            let this = ThisNode::new(vec![node.info.id()], &graph.graph());
+            let this = ThisNode::new(node.info.id(), &graph.graph());
             let this = data.selected_node.and_option(this);
             let logger = Logger::new("Searcher"); // new_empty
             let database = Rc::new(SuggestionDatabase::new_empty(&logger));
@@ -1278,7 +1278,7 @@ pub mod test {
                 ide: Rc::new(ide),
                 data: default(),
                 notifier: default(),
-                mode: Immutable(Mode::NewNode { position: default(), origin: None }),
+                mode: Immutable(Mode::NewNode { position: default(), source_node: None }),
                 language_server: language_server::Connection::new_mock_rc(client),
                 this_arg: Rc::new(this),
                 position_in_code: Immutable(end_of_code),
@@ -1849,7 +1849,7 @@ pub mod test {
             });
 
             // Add new node.
-            searcher.mode = Immutable(Mode::NewNode { position: None, origin: None });
+            searcher.mode = Immutable(Mode::NewNode { position: None, source_node: None });
             searcher.commit_node().unwrap();
 
             let module_info = module.info();
@@ -1887,7 +1887,7 @@ pub mod test {
 
         // Add new node.
         let position = Some(Position::new(4.0, 5.0));
-        searcher.mode = Immutable(Mode::NewNode { position, origin: None });
+        searcher.mode = Immutable(Mode::NewNode { position, source_node: None });
         searcher.commit_node().unwrap();
 
         let expected_code =

--- a/app/gui/src/presenter/graph.rs
+++ b/app/gui/src/presenter/graph.rs
@@ -499,7 +499,7 @@ impl Graph {
 
             view.add_node <+ update_data.map(|update| update.count_nodes_to_add()).repeat();
             added_node_update <- view.node_added.filter_map(f!((view_id)
-                model.state.assign_node_view(view_id.id())
+                model.state.assign_node_view(*view_id)
             ));
             init_node_expression <- added_node_update.filter_map(|update| Some((update.view_id?, update.expression.clone())));
             view.set_node_expression <+ init_node_expression;

--- a/app/gui/src/presenter/graph.rs
+++ b/app/gui/src/presenter/graph.rs
@@ -499,7 +499,7 @@ impl Graph {
 
             view.add_node <+ update_data.map(|update| update.count_nodes_to_add()).repeat();
             added_node_update <- view.node_added.filter_map(f!((view_id)
-                model.state.assign_node_view(*view_id)
+                model.state.assign_node_view(view_id.id())
             ));
             init_node_expression <- added_node_update.filter_map(|update| Some((update.view_id?, update.expression.clone())));
             view.set_node_expression <+ init_node_expression;

--- a/app/gui/src/presenter/project.rs
+++ b/app/gui/src/presenter/project.rs
@@ -3,13 +3,13 @@
 
 use crate::prelude::*;
 
-use crate::presenter;
-
 use crate::executor::global::spawn_stream_handler;
+use crate::presenter;
 use crate::presenter::graph::ViewNodeId;
+
 use enso_frp as frp;
 use ide_view as view;
-use view::project::WayOfOpeningSearcher;
+use ide_view::project::WayOfOpeningSearcher;
 
 
 // =============

--- a/app/gui/src/presenter/project.rs
+++ b/app/gui/src/presenter/project.rs
@@ -185,8 +185,8 @@ impl Project {
         let graph_view = &model.view.graph().frp;
 
         frp::extend! { network
-            eval view.searcher_opened ((node_created) {
-                model.setup_searcher_presenter(*node_created)
+            eval view.searcher_opened ((searcher_input) {
+                model.setup_searcher_presenter(*searcher_input)
             });
 
             graph_view.remove_node <+ view.editing_committed.filter_map(f!([model]((node_view, entry)) {

--- a/app/gui/src/presenter/project.rs
+++ b/app/gui/src/presenter/project.rs
@@ -9,7 +9,7 @@ use crate::executor::global::spawn_stream_handler;
 use crate::presenter::graph::ViewNodeId;
 use enso_frp as frp;
 use ide_view as view;
-use view::graph_editor::NodeCreated;
+use view::project::SearcherInput;
 
 
 // =============
@@ -65,8 +65,7 @@ impl Model {
         }
     }
 
-    fn setup_searcher_presenter(&self, node_created: NodeCreated) {
-        error!(self.logger, "Setting up searcher presenter for node {node_created:?}");
+    fn setup_searcher_presenter(&self, searcher_input: SearcherInput) {
         let new_presenter = presenter::Searcher::setup_controller(
             &self.logger,
             self.ide_controller.clone_ref(),
@@ -74,7 +73,7 @@ impl Model {
             self.graph_controller.clone_ref(),
             &self.graph,
             self.view.clone_ref(),
-            node_created,
+            searcher_input,
         );
         match new_presenter {
             Ok(searcher) => {

--- a/app/gui/src/presenter/project.rs
+++ b/app/gui/src/presenter/project.rs
@@ -9,7 +9,7 @@ use crate::presenter::graph::ViewNodeId;
 
 use enso_frp as frp;
 use ide_view as view;
-use ide_view::project::WayOfOpeningSearcher;
+use ide_view::project::ComponentBrowserOpenReason;
 
 
 // =============
@@ -65,7 +65,7 @@ impl Model {
         }
     }
 
-    fn setup_searcher_presenter(&self, way_of_opening_searcher: WayOfOpeningSearcher) {
+    fn setup_searcher_presenter(&self, way_of_opening_searcher: ComponentBrowserOpenReason) {
         let new_presenter = presenter::Searcher::setup_controller(
             &self.logger,
             self.ide_controller.clone_ref(),

--- a/app/gui/src/presenter/project.rs
+++ b/app/gui/src/presenter/project.rs
@@ -9,6 +9,7 @@ use crate::executor::global::spawn_stream_handler;
 use crate::presenter::graph::ViewNodeId;
 use enso_frp as frp;
 use ide_view as view;
+use view::graph_editor::NodeCreated;
 
 
 // =============
@@ -64,7 +65,8 @@ impl Model {
         }
     }
 
-    fn setup_searcher_presenter(&self, node_view: ViewNodeId) {
+    fn setup_searcher_presenter(&self, node_created: NodeCreated) {
+        error!(self.logger, "Setting up searcher presenter for node {node_created:?}");
         let new_presenter = presenter::Searcher::setup_controller(
             &self.logger,
             self.ide_controller.clone_ref(),
@@ -72,7 +74,7 @@ impl Model {
             self.graph_controller.clone_ref(),
             &self.graph,
             self.view.clone_ref(),
-            node_view,
+            node_created,
         );
         match new_presenter {
             Ok(searcher) => {
@@ -185,8 +187,8 @@ impl Project {
 
         frp::extend! { network
             searcher_input <- view.searcher_input.filter_map(|view| *view);
-            eval searcher_input ((node_view) {
-                model.setup_searcher_presenter(*node_view)
+            eval view.searcher_opened ((node_created) {
+                model.setup_searcher_presenter(*node_created)
             });
 
             graph_view.remove_node <+ view.editing_committed.filter_map(f!([model]((node_view, entry)) {

--- a/app/gui/src/presenter/project.rs
+++ b/app/gui/src/presenter/project.rs
@@ -9,7 +9,7 @@ use crate::executor::global::spawn_stream_handler;
 use crate::presenter::graph::ViewNodeId;
 use enso_frp as frp;
 use ide_view as view;
-use view::project::SearcherInput;
+use view::project::WayOfOpeningSearcher;
 
 
 // =============
@@ -65,7 +65,7 @@ impl Model {
         }
     }
 
-    fn setup_searcher_presenter(&self, searcher_input: SearcherInput) {
+    fn setup_searcher_presenter(&self, way_of_opening_searcher: WayOfOpeningSearcher) {
         let new_presenter = presenter::Searcher::setup_controller(
             &self.logger,
             self.ide_controller.clone_ref(),
@@ -73,7 +73,7 @@ impl Model {
             self.graph_controller.clone_ref(),
             &self.graph,
             self.view.clone_ref(),
-            searcher_input,
+            way_of_opening_searcher,
         );
         match new_presenter {
             Ok(searcher) => {
@@ -185,8 +185,8 @@ impl Project {
         let graph_view = &model.view.graph().frp;
 
         frp::extend! { network
-            eval view.searcher_opened ((searcher_input) {
-                model.setup_searcher_presenter(*searcher_input)
+            eval view.searcher_opened ((way_of_opening_searcher) {
+                model.setup_searcher_presenter(*way_of_opening_searcher)
             });
 
             graph_view.remove_node <+ view.editing_committed.filter_map(f!([model]((node_view, entry)) {

--- a/app/gui/src/presenter/project.rs
+++ b/app/gui/src/presenter/project.rs
@@ -186,7 +186,6 @@ impl Project {
         let graph_view = &model.view.graph().frp;
 
         frp::extend! { network
-            searcher_input <- view.searcher_input.filter_map(|view| *view);
             eval view.searcher_opened ((node_created) {
                 model.setup_searcher_presenter(*node_created)
             });

--- a/app/gui/src/presenter/searcher.rs
+++ b/app/gui/src/presenter/searcher.rs
@@ -11,10 +11,11 @@ use crate::executor::global::spawn_stream_handler;
 use crate::presenter;
 use crate::presenter::graph::AstNodeId;
 use crate::presenter::graph::ViewNodeId;
+
 use enso_frp as frp;
 use ide_view as view;
 use ide_view::graph_editor::component::node as node_view;
-use view::project::WayOfOpeningSearcher;
+use ide_view::project::WayOfOpeningSearcher;
 
 
 

--- a/app/gui/src/presenter/searcher.rs
+++ b/app/gui/src/presenter/searcher.rs
@@ -64,7 +64,6 @@ impl Model {
     }
 
     fn commit_editing(&self, entry_id: Option<view::searcher::entry::Id>) -> Option<AstNodeId> {
-        error!(self.logger, "Commiting editing {entry_id:?}");
         let result = match entry_id {
             Some(id) => self.controller.execute_action_by_index(id),
             None => self.controller.commit_node().map(Some),

--- a/app/gui/src/presenter/searcher.rs
+++ b/app/gui/src/presenter/searcher.rs
@@ -163,7 +163,7 @@ impl Searcher {
                 let view_data = view.graph().model.nodes.get_cloned_ref(&id);
                 let position = view_data.map(|node| node.position().xy());
                 let position = position.map(|vector| model::module::Position { vector });
-                let source_node = Self::source_node(&view, &graph_presenter, &searcher_input);
+                let source_node = Self::source_node(&view, graph_presenter, &searcher_input);
                 controller::searcher::Mode::NewNode { position, source_node }
             }
         };
@@ -203,9 +203,13 @@ impl Searcher {
     }
 
     /// Select source node for node creation. It would be either:
-    /// 1. The source node of the dragged connection, dropping which lead to the node creation.
+    /// 1. The source node of the dragged connection, dropping which leads to the node creation.
     /// 2. The first of the selected nodes on the scene.
-    fn source_node(view: &view::project::View, graph_presenter: &presenter::Graph, searcher_input: &SearcherInput) -> Option<Uuid> {
+    fn source_node(
+        view: &view::project::View,
+        graph_presenter: &presenter::Graph,
+        searcher_input: &SearcherInput,
+    ) -> Option<Uuid> {
         if let Some(edge_id) = searcher_input.edge() {
             let edge = view.graph().model.edges.get_cloned_ref(&edge_id);
             let edge_source = edge.map(|edge| edge.source()).flatten();
@@ -213,8 +217,7 @@ impl Searcher {
             id.map(|id| graph_presenter.ast_node_of_view(id)).flatten()
         } else {
             let selected_views = view.graph().model.nodes.all_selected();
-            selected_views.iter().filter_map(|view| graph_presenter.ast_node_of_view(*view)).next()
+            selected_views.iter().find_map(|view| graph_presenter.ast_node_of_view(*view))
         }
-
     }
 }

--- a/app/gui/src/presenter/searcher.rs
+++ b/app/gui/src/presenter/searcher.rs
@@ -14,7 +14,7 @@ use crate::presenter::graph::ViewNodeId;
 use enso_frp as frp;
 use ide_view as view;
 use ide_view::graph_editor::component::node as node_view;
-use view::project::SearcherInput;
+use view::project::WayOfOpeningSearcher;
 
 
 
@@ -152,9 +152,9 @@ impl Searcher {
         graph_controller: controller::ExecutedGraph,
         graph_presenter: &presenter::Graph,
         view: view::project::View,
-        searcher_input: SearcherInput,
+        way_of_opening_searcher: WayOfOpeningSearcher,
     ) -> FallibleResult<Self> {
-        let id = searcher_input.node();
+        let id = way_of_opening_searcher.node();
         let ast_node = graph_presenter.ast_node_of_view(id);
         let mode = match ast_node {
             Some(node_id) => controller::searcher::Mode::EditNode { node_id },
@@ -162,7 +162,8 @@ impl Searcher {
                 let view_data = view.graph().model.nodes.get_cloned_ref(&id);
                 let position = view_data.map(|node| node.position().xy());
                 let position = position.map(|vector| model::module::Position { vector });
-                let source_node = Self::source_node(&view, graph_presenter, &searcher_input);
+                let source_node =
+                    Self::source_node(&view, graph_presenter, &way_of_opening_searcher);
                 controller::searcher::Mode::NewNode { position, source_node }
             }
         };
@@ -207,9 +208,9 @@ impl Searcher {
     fn source_node(
         view: &view::project::View,
         graph_presenter: &presenter::Graph,
-        searcher_input: &SearcherInput,
+        way_of_opening_searcher: &WayOfOpeningSearcher,
     ) -> Option<Uuid> {
-        if let Some(edge_id) = searcher_input.edge() {
+        if let Some(edge_id) = way_of_opening_searcher.edge() {
             let edge = view.graph().model.edges.get_cloned_ref(&edge_id);
             let edge_source = edge.map(|edge| edge.source()).flatten();
             let id = edge_source.map(|source| source.node_id);

--- a/app/gui/src/test.rs
+++ b/app/gui/src/test.rs
@@ -297,7 +297,7 @@ pub mod mock {
             let executor = TestWithLocalPoolExecutor::set_up();
             let data = self.clone();
             let selected_nodes = Vec::new();
-            let searcher_mode = controller::searcher::Mode::NewNode { position: None };
+            let searcher_mode = controller::searcher::Mode::NewNode { position: None, origin: None };
             let searcher = controller::Searcher::new_from_graph_controller(
                 &logger,
                 ide.clone_ref(),

--- a/app/gui/src/test.rs
+++ b/app/gui/src/test.rs
@@ -296,15 +296,14 @@ pub mod mock {
             );
             let executor = TestWithLocalPoolExecutor::set_up();
             let data = self.clone();
-            let selected_nodes = Vec::new();
-            let searcher_mode = controller::searcher::Mode::NewNode { position: None, origin: None };
+            let searcher_mode =
+                controller::searcher::Mode::NewNode { position: None, source_node: None };
             let searcher = controller::Searcher::new_from_graph_controller(
                 &logger,
                 ide.clone_ref(),
                 &project,
                 executed_graph.clone_ref(),
                 searcher_mode,
-                selected_nodes,
             )
             .unwrap();
             Fixture {

--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -2460,9 +2460,9 @@ fn new_graph_editor(app: &Application) -> GraphEditor {
     frp::extend! { network
         // Clicking on background either drops dragged edge or aborts node editing.
         let background_selected = touch.background.selected.clone_ref();
-        edge_being_dragged  <- has_detached_edge.sample(&background_selected);
-        click_to_drop_edge  <- edge_being_dragged.on_true();
-        click_to_abort_edit <- edge_being_dragged.on_false();
+        was_edge_dragged_when_background_selected  <- has_detached_edge.sample(&background_selected);
+        click_to_drop_edge  <- was_edge_dragged_when_background_selected.on_true();
+        click_to_abort_edit <- was_edge_dragged_when_background_selected.on_false();
 
         node_in_edit_mode     <- out.node_being_edited.map(|n| n.is_some());
         edit_mode             <- bool(&inputs.edit_mode_off,&inputs.edit_mode_on);

--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -534,9 +534,9 @@ ensogl::define_endpoints! {
 
         // === Edge ===
 
-        create_node_by_edge_drop (EdgeId),
         on_edge_add                            (EdgeId),
         on_edge_drop                           (EdgeId),
+        on_edge_drop_without_target            (EdgeId),
         on_edge_source_set                     ((EdgeId,EdgeEndpoint)),
         on_edge_source_set_with_target_not_set ((EdgeId,EdgeEndpoint)),
         on_edge_target_set_with_source_not_set ((EdgeId,EdgeEndpoint)),
@@ -2706,7 +2706,8 @@ fn new_graph_editor(app: &Application) -> GraphEditor {
     drop_edges     <- any (drop_on_bg_up,click_to_drop_edge);
     edge_to_drop_without_targets <= drop_edges.map(f_!(model.take_edges_with_detached_targets()));
     edge_to_drop_without_sources <= drop_edges.map(f_!(model.take_edges_with_detached_sources()));
-    out.source.create_node_by_edge_drop <+ edge_to_drop_without_targets;
+    out.source.on_edge_drop_without_target <+ edge_to_drop_without_targets;
+
     edge_to_drop <- any(edge_to_drop_without_targets,edge_to_drop_without_sources);
     eval edge_to_drop ((id) model.remove_edge(id));
 

--- a/app/gui/view/src/project.rs
+++ b/app/gui/view/src/project.rs
@@ -471,6 +471,7 @@ impl View {
             open_searcher <- frp.open_searcher.constant(true);
             frp.source.adding_new_node <+ any(edge_dropped, open_searcher);
 
+            frp.source.searcher_opened <+ graph.output.node_being_edited.on_change().filter_map(|node| *node).map(|id| NodeCreated::Simple(*id));
             frp.source.searcher_opened <+ graph.output.create_node_by_edge_drop.map(f!((edge) model.add_node_by_dragged_edge_drop(*edge)));
             frp.source.searcher_opened <+ frp.open_searcher.map(f_!(model.add_node_and_edit()));
 

--- a/app/gui/view/src/project.rs
+++ b/app/gui/view/src/project.rs
@@ -506,7 +506,7 @@ impl View {
 
             // === Adding Node ===
 
-            let adding_by_dropping_edge = graph.output.on_edge_drop_without_target.clone_ref();
+            let adding_by_dropping_edge = graph.output.on_edge_drop_to_create_node.clone_ref();
             let adding_by_opening_searcher = frp.open_searcher.clone_ref();
             adding_by_dropping_edge_bool <- adding_by_dropping_edge.constant(true);
             adding_by_opening_searcher_bool <- adding_by_opening_searcher.constant(true);

--- a/app/gui/view/src/project.rs
+++ b/app/gui/view/src/project.rs
@@ -27,40 +27,40 @@ use ensogl_hardcoded_theme::Theme;
 
 
 
-// ============================
-// === WayOfOpeningSearcher ===
-// ============================
+// ==================================
+// === ComponentBrowserOpenReason ===
+// ==================================
 
-/// An enum describing how the searcher was opened.
+/// An enum describing how the component browser was opened.
 #[derive(Clone, CloneRef, Copy, Debug, PartialEq)]
-pub enum WayOfOpeningSearcher {
-    /// New node was created by opening the searcher or the node is being edited.
-    NodeEdited(NodeId),
+pub enum ComponentBrowserOpenReason {
+    /// New node was created by opening the component browser or the node is being edited.
+    NodeEditing(NodeId),
     /// New node was created by dropping a dragged connection on the scene.
     EdgeDropped(NodeId, EdgeId),
 }
 
-impl WayOfOpeningSearcher {
-    /// NodeId of the created/edited node.
+impl ComponentBrowserOpenReason {
+    /// [`NodeId`] of the created/edited node.
     pub fn node(&self) -> NodeId {
         match self {
-            Self::NodeEdited(id) => *id,
+            Self::NodeEditing(id) => *id,
             Self::EdgeDropped(id, _) => *id,
         }
     }
 
-    /// EdgeId of the edge that was dropped to create a node.
+    /// [`EdgeId`] of the edge that was dropped to create a node.
     pub fn edge(&self) -> Option<EdgeId> {
         match self {
-            Self::NodeEdited(_) => None,
+            Self::NodeEditing(_) => None,
             Self::EdgeDropped(_, id) => Some(*id),
         }
     }
 }
 
-impl Default for WayOfOpeningSearcher {
+impl Default for ComponentBrowserOpenReason {
     fn default() -> Self {
-        Self::NodeEdited(default())
+        Self::NodeEditing(default())
     }
 }
 
@@ -95,7 +95,7 @@ ensogl::define_endpoints! {
     }
 
     Output {
-        searcher_opened                     (WayOfOpeningSearcher),
+        searcher_opened                     (ComponentBrowserOpenReason),
         adding_new_node                     (bool),
         is_searcher_opened                  (bool),
         old_expression_of_edited_node       (Expression),
@@ -274,15 +274,15 @@ impl Model {
         node_id
     }
 
-    fn add_node_by_opening_searcher(&self) -> WayOfOpeningSearcher {
+    fn add_node_by_opening_searcher(&self) -> ComponentBrowserOpenReason {
         let node_above = self.graph_editor.model.nodes.selected.first_cloned();
         let node_id = self.add_node_and_edit(node_above);
-        WayOfOpeningSearcher::NodeEdited(node_id)
+        ComponentBrowserOpenReason::NodeEditing(node_id)
     }
 
-    fn add_node_by_dropping_edge(&self, edge: EdgeId) -> WayOfOpeningSearcher {
+    fn add_node_by_dropping_edge(&self, edge: EdgeId) -> ComponentBrowserOpenReason {
         let node_id = self.add_node_and_edit(None);
-        WayOfOpeningSearcher::EdgeDropped(node_id, edge)
+        ComponentBrowserOpenReason::EdgeDropped(node_id, edge)
     }
 
     fn show_fullscreen_visualization(&self, node_id: NodeId) {
@@ -514,7 +514,7 @@ impl View {
 
             node_being_edited <- graph.output.node_being_edited.on_change().filter_map(|n| *n);
 
-            frp.source.searcher_opened <+ node_being_edited.map(|id| WayOfOpeningSearcher::NodeEdited(*id));
+            frp.source.searcher_opened <+ node_being_edited.map(|id| ComponentBrowserOpenReason::NodeEditing(*id));
             frp.source.searcher_opened <+ adding_by_dropping_edge.map(f!((e) model.add_node_by_dropping_edge(*e)));
             frp.source.searcher_opened <+ adding_by_opening_searcher.map(f_!(model.add_node_by_opening_searcher()));
 

--- a/app/gui/view/src/project.rs
+++ b/app/gui/view/src/project.rs
@@ -501,6 +501,8 @@ impl View {
             frp.source.editing_aborted   <+ editing_finished.gate(&editing_aborted);
             editing_aborted              <+ graph.output.node_editing_finished.constant(false);
 
+            frp.source.is_searcher_opened <+ graph.output.node_being_edited.map(|n| n.is_some());
+
 
             // === Adding Node ===
 
@@ -588,7 +590,7 @@ impl View {
             let prompt_size            = styles.get_number(prompt_size_path);
             prompt_size                <- all(&prompt_size,&init)._0();
 
-            disable_after_opening_searcher <- searcher.is_visible.filter(|v| *v).constant(());
+            disable_after_opening_searcher <- frp.is_searcher_opened.filter(|v| *v).constant(());
             disable                        <- any(frp.disable_prompt,disable_after_opening_searcher);
             disabled                       <- disable.constant(true);
             show_prompt                    <- frp.show_prompt.gate_not(&disabled);

--- a/app/gui/view/src/project.rs
+++ b/app/gui/view/src/project.rs
@@ -6,9 +6,9 @@ use crate::code_editor;
 use crate::graph_editor::component::node;
 use crate::graph_editor::component::node::Expression;
 use crate::graph_editor::component::visualization;
+use crate::graph_editor::EdgeId;
 use crate::graph_editor::GraphEditor;
 use crate::graph_editor::NodeId;
-use crate::graph_editor::EdgeId;
 use crate::open_dialog::OpenDialog;
 use crate::searcher;
 
@@ -34,11 +34,14 @@ use ensogl_hardcoded_theme::Theme;
 /// The information needed to setup Searcher Controller.
 #[derive(Clone, CloneRef, Copy, Debug, PartialEq)]
 pub enum SearcherInput {
+    /// New node was created by opening the searcher or the node is being edited.
     Node(NodeId),
+    /// New node was created by dropping dragged connection on the scene.
     NodeAndEdge(NodeId, EdgeId),
 }
 
-impl SearcherInput  {
+impl SearcherInput {
+    /// NodeId of the created/edited node.
     pub fn node(&self) -> NodeId {
         match self {
             Self::Node(id) => *id,
@@ -46,6 +49,7 @@ impl SearcherInput  {
         }
     }
 
+    /// EdgeId of the edge that was dropped to create a node.
     pub fn edge(&self) -> Option<EdgeId> {
         match self {
             Self::Node(_) => None,
@@ -54,7 +58,7 @@ impl SearcherInput  {
     }
 }
 
-impl Default for SearcherInput  {
+impl Default for SearcherInput {
     fn default() -> Self {
         Self::Node(default())
     }
@@ -255,8 +259,8 @@ impl Model {
         }
     }
 
-    /// Add a new node and start editing it. Place it below `node_above` if provided, otherwise place
-    /// under the cursor.
+    /// Add a new node and start editing it. Place it below `node_above` if provided, otherwise
+    /// place it under the cursor.
     fn add_node_and_edit(&self, node_above: Option<NodeId>) -> NodeId {
         let graph_editor_inputs = &self.graph_editor.frp.input;
         let node_id = if let Some(node_above) = node_above {

--- a/app/gui/view/src/project.rs
+++ b/app/gui/view/src/project.rs
@@ -59,7 +59,6 @@ ensogl::define_endpoints! {
     Output {
         searcher_opened                     (NodeCreated),
         adding_new_node                     (bool),
-        searcher_input                      (Option<NodeCreated>),
         is_searcher_opened                  (bool),
         old_expression_of_edited_node       (Expression),
         editing_aborted                     (NodeId),
@@ -461,9 +460,6 @@ impl View {
             frp.source.editing_aborted   <+ editing_finished.gate(&editing_aborted);
             editing_aborted              <+ graph.output.node_editing_finished.constant(false);
 
-            frp.source.searcher_input     <+ graph.output.node_being_edited.map(|node| node.map(|id| NodeCreated::Simple(id)));
-            frp.source.is_searcher_opened <+ frp.searcher_input.map(|n| n.is_some());
-
 
             // === Adding Node ===
 
@@ -547,7 +543,7 @@ impl View {
             let prompt_size            = styles.get_number(prompt_size_path);
             prompt_size                <- all(&prompt_size,&init)._0();
 
-            disable_after_opening_searcher <- frp.is_searcher_opened.filter(|v| *v).constant(());
+            disable_after_opening_searcher <- searcher.is_visible.filter(|v| *v).constant(());
             disable                        <- any(frp.disable_prompt,disable_after_opening_searcher);
             disabled                       <- disable.constant(true);
             show_prompt                    <- frp.show_prompt.gate_not(&disabled);


### PR DESCRIPTION
### Pull Request Description

Creating nodes by pressing Tab works as before, without changes.

Creating nodes by dragging edges and dropping them on the scene:

https://user-images.githubusercontent.com/6566674/150524868-c6eaa71b-9a95-40c2-a133-cbc47d8bf396.mp4

It doesn't matter if you drag the connection by pressing LMB then releasing it or if you continuously hold LMB while dragging.
Searcher filters suggestions based on the type of node from which the connection was dragged.

Disconnecting existing connections works depending on which endpoint you drag (which half of the connection you start to drag): dropping the target endpoint creates a new node, dropping the source endpoint does not.


https://user-images.githubusercontent.com/6566674/150758664-89a3b36f-dd31-44c2-b9bb-d339614f2e3b.mov


This PR does not cover nodes alignment after creation - they are created always directly below the cursor (you can't really mess up with other nodes though, as dropping connection on top of other node won't work or will just connect these nodes).

Changes in this PR:
1. `controller::searcher::Mode::NewNode` node holds an optional node id of the "source node". The source node is either the node selected while creating a new node or the node from which the connection was dragged out.
2. `controller::searcher::ThisNode` constructor changed so now it accepts a single node id argument instead of a list of nodes. Previously it accepted a list of selected nodes, but it doesn't make sense now, as we should make a decision on what node to use as a "source node" earlier.
3. `WayOfOpeningSearcher` enum added.
4. `searcher_input` output of the Project View is removed, its usages replaced with `searcher_opened` output (it now contains WayOfOpeningSearcher rather than NodeId.
5. GraphEditor FRP refactored so clicking on the background to abort node editing doesn't conflict with dropping connection.
6. Pressing the Enter key while dragging the connection now causes a connection drop. It is useful to drop connections without opening the searcher.

### Important Notes

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/develop/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/develop/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
