### PR TITLE
Wip/jd/slice idea

### DIFF
--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
@@ -537,6 +537,27 @@ type Vector
             if this.length == 1 then this.unsafe_at 0 else
                 (1.up_to this.length . fold (this.unsafe_at 0) acc-> i-> acc + separator + this.unsafe_at i)
 
+    ## Creates a new vector with the skipping elements until `start` and then
+       continuing for `length` elements.
+
+       Arguments:
+       - start: The number of elements to drop from the start of `this`.
+       - length: The number of elements for the sub-vector.
+
+       > Example
+         Remove the first 2 elements then take 5 from the vector.
+
+             [1, 2, 3, 4, 5, 6, 7, 8].slice 2 5
+    slice : Integer -> Integer -> Vector Any
+    slice start length =
+        if start > this.length then Vector (Array.new 0) else
+            slice_length = Math.min (this.length - start) length
+            if slice_length == 0 then Vector (Array.new 0) else
+                case this.store of
+                    Slice b o _ -> Vector (Slice b (o + start) slice_length)
+                    _ -> Vector (Slice this.store start length)
+
+
     ## Creates a new vector with the first `count` elements in `this` removed.
 
        Arguments:
@@ -547,8 +568,7 @@ type Vector
 
              [1, 2, 3, 4, 5].drop_start 1
     drop_start : Integer -> Vector Any
-    drop_start count = if count >= this.length then here.new 0 (x -> x) else
-        Vector (Slice this.store count (this.length - count))
+    drop_start count = this.slice count (this.length - count)
 
     ## Creates a new vector with the last `count` elements in `this` removed.
 
@@ -560,8 +580,7 @@ type Vector
 
              [1, 2, 3, 4, 5].drop_end 2
     drop_end : Integer -> Vector Any
-    drop_end count = if count >= this.length then here.new 0 (x -> x) else
-        Vector (Slice this.store 0 (this.length - count))
+    drop_end count = this.slice 0 (this.length - count)
 
     ## Creates a new vector, consisting of the first `count` elements on the
        left of `this`.
@@ -574,8 +593,7 @@ type Vector
 
              [1, 2, 3, 4, 5].take_start 2
     take_start : Integer -> Vector Any
-    take_start count = if count >= this.length then this else
-        Vector (Slice this.store 0 count)
+    take_start count = this.slice 0 count
 
     ## Creates a new vector, consisting of the last `count` elements on the
        right of `this`.
@@ -961,16 +979,54 @@ Singleton_Error.to_display_text =
     "The vector " + this.vec.to_text  + " has only one element."
 
 type Slice
-    type Slice backing offset length
+    ## PRIVATE
+
+       A slice type for Enso vectors.
+
+       Arguments:
+       - store: The backing array of the vector.
+       - offset: Starting index for the slice.
+       - length: The length of the slice.
+
+       A slice provides a window onto an underlying Array. It supports the
+       basic operations needed for it be used within a Vector.
+
+       > Example
+         In the following example we take a Array and get items 3 to 7.
+
+             example_slice =
+                 arr = Array.new 10
+                 0.up_to 10 . each (x->arr.set_at x x)
+                 Slice arr 3 5
+
+    type Slice store offset length
 
     at : Integer -> Any ! Index_Out_Of_Bounds_Error
     at index =
         if ((index < 0) || (index > this.length)) then Error.throw (Index_Out_Of_Bounds_Error index this.length) else
-            this.backing.at (index + this.offset)
+            this.store.at (index + this.offset)
 
     to_array : Array
     to_array :
-        arr = this.backing.to_array
         output = Array.new this.length
-        Array.copy arr this.offset output 0 this.length
+        Array.copy this.store this.offset output 0 this.length
         output
+
+
+    ## Slice to JSON conversion.
+
+       > Example
+         Convert a slice of numbers to JSON.
+
+             [1, 2, 3].to_json
+    to_json : Json.Array
+    to_json = Json.Array (0.up_to this.length this.at)
+
+
+    ## UNSTABLE
+
+       Transform the slice into text for displaying as part of its default
+       visualization.
+    to_default_visualization_data : Text
+    to_default_visualization_data =
+        (Json.Array (0.up_to (Math.Min 100 this.length) this.at)).to_text

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
@@ -118,9 +118,9 @@ type Vector
 
     ## Returns the underlying store as an Array
     to_array : Array
-    to_array = case store of
-        Slice _ _ _ -> store.to_array
-        _ -> _
+    to_array = case this.store of
+        Slice _ _ _ -> this.store.to_array
+        _ -> this.store
 
     ## Returns the number of elements stored in this vector.
 
@@ -492,6 +492,7 @@ type Vector
     + that =
         this_len = this.length
         arr = Array.new (this_len + that.length)
+
         Array.copy this.to_array 0 arr 0 this_len
         Array.copy that.to_array 0 arr this_len that.length
         Vector arr
@@ -547,7 +548,7 @@ type Vector
              [1, 2, 3, 4, 5].drop_start 1
     drop_start : Integer -> Vector Any
     drop_start count = if count >= this.length then here.new 0 (x -> x) else
-        Vector (Slice this.to_array count (this.length - count))
+        Vector (Slice this.store count (this.length - count))
 
     ## Creates a new vector with the last `count` elements in `this` removed.
 
@@ -560,7 +561,7 @@ type Vector
              [1, 2, 3, 4, 5].drop_end 2
     drop_end : Integer -> Vector Any
     drop_end count = if count >= this.length then here.new 0 (x -> x) else
-        Vector (Slice this.to_array 0 (this.length - count))
+        Vector (Slice this.store 0 (this.length - count))
 
     ## Creates a new vector, consisting of the first `count` elements on the
        left of `this`.
@@ -574,7 +575,7 @@ type Vector
              [1, 2, 3, 4, 5].take_start 2
     take_start : Integer -> Vector Any
     take_start count = if count >= this.length then this else
-        Vector (Slice this.to_array 0 count)
+        Vector (Slice this.store 0 count)
 
     ## Creates a new vector, consisting of the last `count` elements on the
        right of `this`.
@@ -767,7 +768,8 @@ type Vector
            not want to sort in place on the original vector, as `sort` is not
            intended to be mutable.
         new_vec_arr = Array.new this.length
-        Array.copy this.to_array 0 new_vec_arr 0 this.length
+        this_arr = this.to_array
+        Array.copy this_arr 0 new_vec_arr 0 this.length
 
         ## As we want to account for both custom projections and custom
            comparisons we need to construct a comparator for internal use that
@@ -963,12 +965,12 @@ type Slice
 
     at : Integer -> Any ! Index_Out_Of_Bounds_Error
     at index =
-        if (index < 0 || index > this.length) then Error.throw (Index_Out_Of_Bounds_Error index this.length) else
-            backing.at (index - this.offset)
+        if ((index < 0) || (index > this.length)) then Error.throw (Index_Out_Of_Bounds_Error index this.length) else
+            this.backing.at (index + this.offset)
 
     to_array : Array
     to_array :
-        arr = backing.to_array
+        arr = this.backing.to_array
         output = Array.new this.length
         Array.copy arr this.offset output 0 this.length
         output

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
@@ -140,7 +140,7 @@ type Vector
          Get the last element of a vector.
 
              [1, 2, 3].at -1 == 3
-    at : Number -> Any ! Index_Out_Of_Bounds_Error
+    at : Integer -> Any ! Index_Out_Of_Bounds_Error
     at index =
         actual_index = if index < 0 then this.length + index else index
         if actual_index>=0 && actual_index<this.length then this.to_array.at actual_index else
@@ -153,7 +153,7 @@ type Vector
        indices and will panic with a raw Java exception on out-of-bounds access.
        Thus it should only be used when the access is guaranteed to be within
        bounds or with additional error handling.
-    unsafe_at : Number -> Any
+    unsafe_at : Integer -> Any
     unsafe_at index =
         this.to_array.at index
 
@@ -325,9 +325,14 @@ type Vector
     filter : (Any -> Boolean) -> Vector Any
     filter predicate =
         builder = here.new_builder
-        this.each elem->
-            if predicate elem then builder.append elem
-        builder.to_vector
+        acc = this.fold Nothing acc-> elem->
+            ## The accumulator is threaded through to preserve dataflow
+               dependencies which are cut by using the stateful builder. This to
+               ensure correct dataflow error propagation.
+            case acc of
+                _ -> if predicate elem then builder.append elem
+        case acc of
+            _ -> builder.to_vector
 
     ## Applies a function to each element of the vector, returning the vector of
        results.
@@ -526,7 +531,7 @@ type Vector
          Join the elements of the vector together as a string.
 
              ["foo", "bar", "baz"].join ", "
-    join : String -> Text
+    join : Text -> Text
     join separator =
         if this.length == 0 then "" else
             if this.length == 1 then this.unsafe_at 0 else

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
@@ -443,8 +443,6 @@ type Vector
          vector contains more elements, the number of hidden elements is also
          displayed.
 
-       TODO: a better name may be chosen
-
        > Example
          Convert a large vector of numbers to a short text.
 

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
@@ -127,14 +127,35 @@ type Vector
     ## Gets an element from the vector at a specified index (0-based).
 
        Arguments:
-       - index: The location in the vector to get the element from.
+       - index: The location in the vector to get the element from. The index is
+         also allowed be negative, then the elements are indexed from the back
+         of the vector, i.e. -1 will correspond to the last element.
 
        > Example
          Get the second element of a vector.
 
-             [1, 2, 3].at 1
-    at : Number -> Any
-    at index = this.to_array.at index
+             [1, 2, 3].at 1 == 2
+
+       > Example
+         Get the last element of a vector.
+
+             [1, 2, 3].at -1 == 3
+    at : Number -> Any ! Index_Out_Of_Bounds_Error
+    at index =
+        actual_index = if index < 0 then this.length + index else index
+        if actual_index>=0 && actual_index<this.length then this.to_array.at actual_index else
+            Error.throw (Index_Out_Of_Bounds_Error index this.length)
+
+    ## ADVANCED
+       UNSTABLE
+
+       An unsafe variant of the `at` operation. It only allows non-negative
+       indices and will panic with a raw Java exception on out-of-bounds access.
+       Thus it should only be used when the access is guaranteed to be within
+       bounds or with additional error handling.
+    unsafe_at : Number -> Any
+    unsafe_at index =
+        this.to_array.at index
 
     ## Combines all the elements of the vector, by iteratively applying the
        passed function with next elements of the vector.
@@ -207,7 +228,7 @@ type Vector
     exists predicate =
         len = this.length
         go idx found = if found || (idx >= len) then found else
-            @Tail_Call go idx+1 (predicate (this.at idx))
+            @Tail_Call go idx+1 (predicate (this.unsafe_at idx))
         go 0 False
 
     ## Returns the first element of the vector that satisfies the predicate or
@@ -227,8 +248,8 @@ type Vector
         len = this.length
         go idx =
             if (idx >= len) then Error.throw Nothing else
-                elem = this.at idx
-                if (predicate elem) then elem else
+                elem = this.unsafe_at idx
+                if predicate elem then elem else
                     @Tail_Call go idx+1
         go 0
 
@@ -303,8 +324,10 @@ type Vector
              [1, 2, 3, 4, 5].filter (> 3)
     filter : (Any -> Boolean) -> Vector Any
     filter predicate =
-        check acc ix = if predicate ix then acc + [ix] else acc
-        this.fold [] check
+        builder = here.new_builder
+        this.each elem->
+            if predicate elem then builder.append elem
+        builder.to_vector
 
     ## Applies a function to each element of the vector, returning the vector of
        results.
@@ -319,7 +342,7 @@ type Vector
              [1, 2, 3] . map +1
     map : (Any -> Any) -> Vector Any
     map function =
-        here.new this.length i-> function (this.at i)
+        here.new this.length i-> function (this.unsafe_at i)
 
     ## Applies a function to each element of the vector, returning the vector
        that contains all results concatenated.
@@ -357,7 +380,7 @@ type Vector
 
              [1, 2, 3].map_with_index (+)
     map_with_index : (Integer -> Any -> Any) -> Vector Any
-    map_with_index function = here.new this.length i-> function i (this.at i)
+    map_with_index function = here.new this.length i-> function i (this.unsafe_at i)
 
     ## Applies a function to each element of the vector.
 
@@ -373,8 +396,8 @@ type Vector
              [1, 2, 3, 4, 5] . each IO.println
     each : (Any -> Any) -> Nothing
     each f =
-        this.map f
-        Nothing
+        0.up_to this.length . each ix->
+            f (this.unsafe_at ix)
 
     ## Reverses the vector, returning a vector with the same elements, but in
        the opposite order.
@@ -384,7 +407,7 @@ type Vector
 
              [1, 2].reverse
     reverse : Vector Any
-    reverse = here.new this.length (i -> this.at (this.length - (1 + i)))
+    reverse = here.new this.length (i -> this.unsafe_at (this.length - (1 + i)))
 
     ## Generates a human-readable text representation of the vector.
 
@@ -393,12 +416,44 @@ type Vector
 
              [1, 2, 3].to_text == "[1, 2, 3]"
     to_text : Text
-    to_text =
-        if this.length == 0 then "[]" else
-            if this.length == 1 then "[" + (this.at 0 . to_text) + "]" else
-                folder = str -> ix -> str + ", " + (this.at ix).to_text
-                tail_elems = 1.up_to this.length . fold "" folder
-                "[" + (this.at 0 . to_text) + tail_elems + "]"
+    to_text = this.generic_to_text "[" ", " "]"
+
+    ## PRIVATE
+       A generic utility which concatenates textual representations of the
+       vector elements, separated by the `separator` and appends the provided
+       `prefix` and `suffix`.
+    generic_to_text : Text -> Text -> Text -> Text
+    generic_to_text prefix separator suffix =
+        if this.length == 0 then prefix+suffix else
+            folder = str -> ix -> str + separator + (this.unsafe_at ix).to_text
+            tail_elems = 1.up_to this.length . fold "" folder
+            prefix + (this.unsafe_at 0 . to_text) + tail_elems + suffix
+
+    ## UNSTABLE
+       Generates a human-readable text representation of the vector, keeping its
+       length limited.
+
+       Arguments:
+       - max_entries: The maximum number of entries that are displayed. If the
+         vector contains more elements, the number of hidden elements is also
+         displayed.
+
+       TODO: a better name may be chosen
+
+       > Example
+         Convert a large vector of numbers to a short text.
+
+             (0.up_to 100).to_vector.short_display_text max_entries=2 == "[0, 1 and 98 more elements]"
+    short_display_text : Integer -> Text
+    short_display_text max_entries=10 =
+        # TODO should this be some specific error type? We may want a generic Illegal_Argument_Error for such situations
+        if max_entries < 1 then Error.throw "The `max_entries` parameter must be positive" else
+            prefix = this.take_start max_entries
+            if prefix.length == this.length then this.to_text else
+                remaining_count = this.length - prefix.length
+                remaining_text = if remaining_count == 1 then "and 1 more element" else
+                    "and " + remaining_count.to_text + " more elements"
+                prefix.generic_to_text "[" ", " " "+remaining_text+"]"
 
     ## Checks whether this vector is equal to `that`.
 
@@ -414,7 +469,7 @@ type Vector
              [1, 2, 3] == [2, 3, 4]
     == : Vector -> Boolean
     == that =
-        eq_at i = this.at i == that.at i
+        eq_at i = this.unsafe_at i == that.unsafe_at i
         if this.length == that.length then 0.up_to this.length . all eq_at else False
 
     ## Concatenates two vectors, resulting in a new vector, containing all the
@@ -432,9 +487,9 @@ type Vector
         this_len = this.length
         arr = Array.new (this_len + that.length)
         0.up_to this_len . each i->
-            arr.set_at i (this.at i)
+            arr.set_at i (this.unsafe_at i)
         this.length.up_to arr.length . each i->
-            arr.set_at i (that.at i-this_len)
+            arr.set_at i (that.unsafe_at i-this_len)
         Vector arr
 
     ## Add `element` to the beginning of `this` vector.
@@ -474,8 +529,8 @@ type Vector
     join : String -> Text
     join separator =
         if this.length == 0 then "" else
-            if this.length == 1 then this.at 0 else
-                this.at 0 + (1.up_to this.length . fold "" acc-> i-> acc + separator + this.at i)
+            if this.length == 1 then this.unsafe_at 0 else
+                this.unsafe_at 0 + (1.up_to this.length . fold "" acc-> i-> acc + separator + this.unsafe_at i)
 
     ## Creates a new vector with the first `count` elements in `this` removed.
 
@@ -488,7 +543,7 @@ type Vector
              [1, 2, 3, 4, 5].drop_start 1
     drop_start : Integer -> Vector Any
     drop_start count = if count >= this.length then here.new 0 (x -> x) else
-        here.new (this.length - count) (i -> this.at i+count)
+        here.new (this.length - count) (i -> this.unsafe_at i+count)
 
     ## Creates a new vector with the last `count` elements in `this` removed.
 
@@ -555,7 +610,7 @@ type Vector
     zip : Vector Any -> (Any -> Any -> Any) -> Vector Any
     zip that function=[_,_] =
         len = Math.min this.length that.length
-        here.new len i-> function (this.at i) (that.at i)
+        here.new len i-> function (this.unsafe_at i) (that.unsafe_at i)
 
     ## Extend `this` vector to the length of `n` appending elements `elem` to
        the end.
@@ -598,7 +653,7 @@ type Vector
 
              [1, 2, 3, 4].head
     head : Any ! Empty_Error
-    head = if this.length >= 1 then this.at 0 else Error.throw Empty_Error
+    head = if this.length >= 1 then this.unsafe_at 0 else Error.throw Empty_Error
 
     ## Get all elements in the vector except the first.
 
@@ -627,7 +682,7 @@ type Vector
 
              [1, 2, 3, 4].last
     last : Vector ! Empty_Error
-    last = if this.length >= 1 then (this.take_end 1).at 0 else
+    last = if this.length >= 1 then this.unsafe_at (this.length-1) else
         Error.throw Empty_Error
 
     ## Get the first element from the vector, or an `Empty_Error` if the vector
@@ -650,7 +705,7 @@ type Vector
 
              [1, 2, 3, 4].second
     second : Vector ! Singleton_Error
-    second = if this.length >= 2 then this.at 1 else
+    second = if this.length >= 2 then this.unsafe_at 1 else
         Error.throw (Singleton_Error this)
 
     ## Get all elements in the vector except the first.

--- a/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.2.32-SNAPSHOT/src/Data/Vector.enso
@@ -100,7 +100,7 @@ type Vector
        The basic, immutable, vector type.
 
        Arguments:
-       - to_array: The underlying array.
+       - store: The underlying data store.
 
        A vector allows to store an arbitrary number of elements, in linear memory.
        It is the recommended data structure for most applications.
@@ -113,7 +113,14 @@ type Vector
          A vector containing 50 elements, each being the number `42`, can be
          created by:
              Vector.fill length=50 item=42
-    type Vector to_array
+    type Vector store
+
+
+    ## Returns the underlying store as an Array
+    to_array : Array
+    to_array = case store of
+        Slice _ _ _ -> store.to_array
+        _ -> _
 
     ## Returns the number of elements stored in this vector.
 
@@ -122,7 +129,7 @@ type Vector
 
              [1, 2, 3, 4].length
     length : Number
-    length = Polyglot.get_array_size this.to_array
+    length = this.store.length
 
     ## Gets an element from the vector at a specified index (0-based).
 
@@ -143,7 +150,7 @@ type Vector
     at : Integer -> Any ! Index_Out_Of_Bounds_Error
     at index =
         actual_index = if index < 0 then this.length + index else index
-        if actual_index>=0 && actual_index<this.length then this.to_array.at actual_index else
+        if actual_index>=0 && actual_index<this.length then this.store.at actual_index else
             Error.throw (Index_Out_Of_Bounds_Error index this.length)
 
     ## ADVANCED
@@ -155,7 +162,7 @@ type Vector
        bounds or with additional error handling.
     unsafe_at : Integer -> Any
     unsafe_at index =
-        this.to_array.at index
+        this.store.at index
 
     ## Combines all the elements of the vector, by iteratively applying the
        passed function with next elements of the vector.
@@ -175,8 +182,7 @@ type Vector
              [0, 1, 2] . fold 0 (+)
     fold : Any -> (Any -> Any -> Any) -> Any
     fold init function =
-        arr = this.to_array
-        f = acc -> ix -> function acc (arr.at ix)
+        f = acc -> ix -> function acc (this.unsafe_at ix)
         0.up_to this.length . fold init f
 
     ## Combines all the elements of a non-empty vector using a binary operation.
@@ -226,10 +232,7 @@ type Vector
              [1, 2, 3, 4, 5].exists (> 3)
     exists : (Any -> Boolean) -> Boolean
     exists predicate =
-        len = this.length
-        go idx found = if found || (idx >= len) then found else
-            @Tail_Call go idx+1 (predicate (this.unsafe_at idx))
-        go 0 False
+        0.up_to this.length . exists (idx -> (predicate (this.unsafe_at idx)))
 
     ## Returns the first element of the vector that satisfies the predicate or
        if no elements of the vector satisfy the predicate, it throws nothing.
@@ -489,10 +492,8 @@ type Vector
     + that =
         this_len = this.length
         arr = Array.new (this_len + that.length)
-        0.up_to this_len . each i->
-            arr.set_at i (this.unsafe_at i)
-        this.length.up_to arr.length . each i->
-            arr.set_at i (that.unsafe_at i-this_len)
+        Array.copy this.to_array 0 arr 0 this_len
+        Array.copy that.to_array 0 arr this_len that.length
         Vector arr
 
     ## Add `element` to the beginning of `this` vector.
@@ -533,7 +534,7 @@ type Vector
     join separator =
         if this.length == 0 then "" else
             if this.length == 1 then this.unsafe_at 0 else
-                this.unsafe_at 0 + (1.up_to this.length . fold "" acc-> i-> acc + separator + this.unsafe_at i)
+                (1.up_to this.length . fold (this.unsafe_at 0) acc-> i-> acc + separator + this.unsafe_at i)
 
     ## Creates a new vector with the first `count` elements in `this` removed.
 
@@ -546,7 +547,7 @@ type Vector
              [1, 2, 3, 4, 5].drop_start 1
     drop_start : Integer -> Vector Any
     drop_start count = if count >= this.length then here.new 0 (x -> x) else
-        here.new (this.length - count) (i -> this.unsafe_at i+count)
+        Vector (Slice this.to_array count (this.length - count))
 
     ## Creates a new vector with the last `count` elements in `this` removed.
 
@@ -559,7 +560,7 @@ type Vector
              [1, 2, 3, 4, 5].drop_end 2
     drop_end : Integer -> Vector Any
     drop_end count = if count >= this.length then here.new 0 (x -> x) else
-        this.take_start (this.length - count)
+        Vector (Slice this.to_array 0 (this.length - count))
 
     ## Creates a new vector, consisting of the first `count` elements on the
        left of `this`.
@@ -573,7 +574,7 @@ type Vector
              [1, 2, 3, 4, 5].take_start 2
     take_start : Integer -> Vector Any
     take_start count = if count >= this.length then this else
-        here.new count this.at
+        Vector (Slice this.to_array 0 count)
 
     ## Creates a new vector, consisting of the last `count` elements on the
        right of `this`.
@@ -892,9 +893,7 @@ type Builder
         False ->
             old_array = this.to_array
             new_array = Array.new old_array.length*2
-            0.up_to this.length . each i->
-                new_array.set_at i (old_array.at i)
-                Nothing
+            Array.copy old_array 0 new_array 0 this.length
             Unsafe.set_atom_field this 0 new_array
             this.append item
             Nothing
@@ -914,9 +913,7 @@ type Builder
     to_vector =
         old_array = this.to_array
         new_array = Array.new this.length
-        0.up_to this.length . each i->
-            new_array.set_at i (old_array.at i)
-            Nothing
+        Array.copy old_array 0 new_array 0 this.length
         Vector new_array
 
 ## UNSTABLE
@@ -961,3 +958,17 @@ Singleton_Error.to_display_text : Text
 Singleton_Error.to_display_text =
     "The vector " + this.vec.to_text  + " has only one element."
 
+type Slice
+    type Slice backing offset length
+
+    at : Integer -> Any ! Index_Out_Of_Bounds_Error
+    at index =
+        if (index < 0 || index > this.length) then Error.throw (Index_Out_Of_Bounds_Error index this.length) else
+            backing.at (index - this.offset)
+
+    to_array : Array
+    to_array :
+        arr = backing.to_array
+        output = Array.new this.length
+        Array.copy arr this.offset output 0 this.length
+        output

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/GetAtNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/GetAtNode.java
@@ -1,8 +1,11 @@
 package org.enso.interpreter.node.expression.builtin.mutable;
 
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.data.Array;
+import org.enso.interpreter.runtime.error.PanicException;
 
 @BuiltinMethod(
     type = "Array",
@@ -11,6 +14,11 @@ import org.enso.interpreter.runtime.data.Array;
 public class GetAtNode extends Node {
 
   Object execute(Array _this, long index) {
-    return _this.getItems()[(int) index];
+    try {
+      return _this.getItems()[(int) index];
+    } catch (IndexOutOfBoundsException exception) {
+      Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+      throw new PanicException(builtins.error().makeInvalidArrayIndexError(_this, index), this);
+    }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/SetAtNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/SetAtNode.java
@@ -1,9 +1,12 @@
 package org.enso.interpreter.node.expression.builtin.mutable;
 
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.data.Array;
+import org.enso.interpreter.runtime.error.PanicException;
 
 @BuiltinMethod(
     type = "Array",
@@ -12,7 +15,12 @@ import org.enso.interpreter.runtime.data.Array;
 public class SetAtNode extends Node {
 
   Object execute(Array _this, long index, @AcceptsError Object value) {
-    _this.getItems()[(int) index] = value;
-    return _this;
+    try {
+      _this.getItems()[(int) index] = value;
+      return _this;
+    } catch (IndexOutOfBoundsException exception) {
+      Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+      throw new PanicException(builtins.error().makeInvalidArrayIndexError(_this, index), this);
+    }
   }
 }

--- a/engine/runtime/src/main/resources/Builtins.enso
+++ b/engine/runtime/src/main/resources/Builtins.enso
@@ -874,6 +874,10 @@ type Array
        Arguments:
        - index: The index to get the element from.
 
+       ? Safety
+         If index < 0 or index >= this.length, then this operation will result
+         in an Invalid_Array_Index_Error exception.
+
        > Example
          Get the element at index 1.
 
@@ -892,8 +896,8 @@ type Array
        programming style in Enso.
 
        ? Safety
-         If index >= this.length, then this operation will result in an
-         Invalid_Array_Index_Error exception.
+         If index < 0 or index >= this.length, then this operation will result
+         in an Invalid_Array_Index_Error exception.
     set_at : Integer -> Any -> Array
     set_at index value = @Builtin_Method "Array.set_at"
 

--- a/test/Benchmarks/src/Vector.enso
+++ b/test/Benchmarks/src/Vector.enso
@@ -21,7 +21,12 @@ make_random_vec n =
 
 main =
     random_vec = here.make_random_vec here.vector_size
+    random_vec_2 = here.make_random_vec 100000
 
+    Bench.measure (random_vec + [1]) "Append Single" here.iter_size here.num_iterations
+    Bench.measure (random_vec + random_vec_2) "Append Large" here.iter_size here.num_iterations
+    Bench.measure ((random_vec.drop_start 20).sum) "Drop First 20" here.iter_size here.num_iterations
+    Bench.measure ((random_vec.drop_end 20).sum) "Drop Last 20" here.iter_size here.num_iterations
     Bench.measure (random_vec.filter (x -> x % 3 == 1)) "Filter" here.iter_size here.num_iterations
 
     stateful_fun x =

--- a/test/Benchmarks/src/Vector.enso
+++ b/test/Benchmarks/src/Vector.enso
@@ -8,7 +8,7 @@ polyglot java import org.enso.base.Time_Utils
 
 ## Bench Utilities ============================================================
 
-vector_size = 
+vector_size =
 num_iterations = 10
 
 make_random_vec : Integer -> Base.Vector.Vector

--- a/test/Benchmarks/src/Vector.enso
+++ b/test/Benchmarks/src/Vector.enso
@@ -8,7 +8,8 @@ polyglot java import org.enso.base.Time_Utils
 
 ## Bench Utilities ============================================================
 
-vector_size =
+vector_size = 1000000
+iter_size = 100
 num_iterations = 10
 
 make_random_vec : Integer -> Base.Vector.Vector
@@ -19,13 +20,11 @@ make_random_vec n =
 # The Benchmarks ==============================================================
 
 main =
-    random_vec_1 = here.make_random_vec 50000
+    random_vec = here.make_random_vec here.vector_size
 
-    Bench.measure (random_vec_1.filter (x -> x % 3 == 1)) "Filter" 20 here.num_iterations
-
-    random_vec_2 = here.make_random_vec 1000000
+    Bench.measure (random_vec.filter (x -> x % 3 == 1)) "Filter" here.iter_size here.num_iterations
 
     stateful_fun x =
        s = State.get Number
        State.put s+x
-    Bench.measure (State.run Number 0 <| random_vec_2.each stateful_fun) "Each" 100 here.num_iterations
+    Bench.measure (State.run Number 0 <| random_vec.each stateful_fun) "Each" here.iter_size here.num_iterations

--- a/test/Benchmarks/src/Vector.enso
+++ b/test/Benchmarks/src/Vector.enso
@@ -6,68 +6,26 @@ polyglot java import java.util.Random
 polyglot java import org.enso.base.Time_Utils
 
 
-
 ## Bench Utilities ============================================================
 
-vector_size = 1000000
-iter_size = 100
+vector_size = 
 num_iterations = 10
-
-make_sorted_ascending_vec : Integer -> Base.Vector.Vector
-make_sorted_ascending_vec n = 0.up_to n+1 . to_vector
-
-make_partially_sorted_vec : Integer -> Base.Vector.Vector
-make_partially_sorted_vec n =
-    random_gen = Random.new n
-    direction = Ref.new Sort_Order.Ascending
-    last_num = Ref.new 0
-    run_length = Ref.new 0
-    Base.Vector.fill n <|
-        case (Ref.get run_length) == 0 of
-            True ->
-                new_direction = if random_gen.nextDouble > 0 then Sort_Order.Ascending else
-                    Sort_Order.Descending
-                Ref.put direction new_direction
-                Ref.put run_length ((random_gen.nextLong % (n / 10).floor) - 1)
-                num = random_gen.nextInt
-                Ref.put last_num num
-                num
-            False ->
-                change = random_gen.nextInt.abs % n
-                num = case Ref.get direction of
-                    Sort_Order.Ascending ->
-                        num = (Ref.get last_num) + change
-                        Ref.put last_num num
-                        num
-                    Sort_Order.Descending ->
-                        num = (Ref.get last_num) - change
-                        Ref.put last_num num
-                        num
-                Ref.put run_length ((Ref.get run_length) - 1)
-                num
 
 make_random_vec : Integer -> Base.Vector.Vector
 make_random_vec n =
     random_gen = Random.new n
     Base.Vector.fill n random_gen.nextLong
 
-
-
 # The Benchmarks ==============================================================
 
 main =
-    sorted_vec = here.make_sorted_ascending_vec here.vector_size
-    partially_sorted_vec = here.make_partially_sorted_vec here.vector_size
-    random_vec = here.make_random_vec here.vector_size
-    projection = x -> x % 10
-    comparator = l -> r -> r.compare_to l
+    random_vec_1 = here.make_random_vec 50000
 
-    Bench.measure (sorted_vec.sort) "Already Sorted" here.iter_size here.num_iterations
-    Bench.measure (sorted_vec.sort order=Sort_Order.Descending) "Sorted in Opposite Order" here.iter_size here.num_iterations
-    Bench.measure (partially_sorted_vec.sort) "Sorted Runs Ascending" here.iter_size here.num_iterations
-    Bench.measure (partially_sorted_vec.sort order=Sort_Order.Descending) "Sorted Runs Descending" here.iter_size here.num_iterations
-    Bench.measure (random_vec.sort) "Random Elements Ascending" here.iter_size here.num_iterations
-    Bench.measure (random_vec.sort order=Sort_Order.Descending) "Random Elements Descending" here.iter_size here.num_iterations
-    Bench.measure (random_vec.sort on=projection) "Sorting with a Custom Projection" here.iter_size here.num_iterations
-    Bench.measure (random_vec.sort by=comparator) "Sorting with a Custom Comparison" here.iter_size here.num_iterations
+    Bench.measure (random_vec_1.filter (x -> x % 3 == 1)) "Filter" 20 here.num_iterations
 
+    random_vec_2 = here.make_random_vec 1000000
+
+    stateful_fun x =
+       s = State.get Number
+       State.put s+x
+    Bench.measure (State.run Number 0 <| random_vec_2.each stateful_fun) "Each" 100 here.num_iterations

--- a/test/Benchmarks/src/Vector_Sort.enso
+++ b/test/Benchmarks/src/Vector_Sort.enso
@@ -1,0 +1,68 @@
+from Standard.Base import all
+
+import Standard.Test.Bench
+
+import project.Vector as Vector_Utils
+
+polyglot java import java.util.Random
+polyglot java import org.enso.base.Time_Utils
+
+
+
+## Bench Utilities ============================================================
+
+vector_size = 1000000
+iter_size = 100
+num_iterations = 10
+
+make_sorted_ascending_vec : Integer -> Base.Vector.Vector
+make_sorted_ascending_vec n = 0.up_to n+1 . to_vector
+
+make_partially_sorted_vec : Integer -> Base.Vector.Vector
+make_partially_sorted_vec n =
+    random_gen = Random.new n
+    direction = Ref.new Sort_Order.Ascending
+    last_num = Ref.new 0
+    run_length = Ref.new 0
+    Base.Vector.fill n <|
+        case (Ref.get run_length) == 0 of
+            True ->
+                new_direction = if random_gen.nextDouble > 0 then Sort_Order.Ascending else
+                    Sort_Order.Descending
+                Ref.put direction new_direction
+                Ref.put run_length ((random_gen.nextLong % (n / 10).floor) - 1)
+                num = random_gen.nextInt
+                Ref.put last_num num
+                num
+            False ->
+                change = random_gen.nextInt.abs % n
+                num = case Ref.get direction of
+                    Sort_Order.Ascending ->
+                        num = (Ref.get last_num) + change
+                        Ref.put last_num num
+                        num
+                    Sort_Order.Descending ->
+                        num = (Ref.get last_num) - change
+                        Ref.put last_num num
+                        num
+                Ref.put run_length ((Ref.get run_length) - 1)
+                num
+
+
+# The Benchmarks ==============================================================
+
+main =
+    sorted_vec = here.make_sorted_ascending_vec here.vector_size
+    partially_sorted_vec = here.make_partially_sorted_vec here.vector_size
+    random_vec = Vector_Utils.make_random_vec here.vector_size
+    projection = x -> x % 10
+    comparator = l -> r -> r.compare_to l
+
+    Bench.measure (sorted_vec.sort) "Already Sorted" here.iter_size here.num_iterations
+    Bench.measure (sorted_vec.sort order=Sort_Order.Descending) "Sorted in Opposite Order" here.iter_size here.num_iterations
+    Bench.measure (partially_sorted_vec.sort) "Sorted Runs Ascending" here.iter_size here.num_iterations
+    Bench.measure (partially_sorted_vec.sort order=Sort_Order.Descending) "Sorted Runs Descending" here.iter_size here.num_iterations
+    Bench.measure (random_vec.sort) "Random Elements Ascending" here.iter_size here.num_iterations
+    Bench.measure (random_vec.sort order=Sort_Order.Descending) "Random Elements Descending" here.iter_size here.num_iterations
+    Bench.measure (random_vec.sort on=projection) "Sorting with a Custom Projection" here.iter_size here.num_iterations
+    Bench.measure (random_vec.sort by=comparator) "Sorting with a Custom Comparison" here.iter_size here.num_iterations

--- a/test/Tests/src/Data/Array_Spec.enso
+++ b/test/Tests/src/Data/Array_Spec.enso
@@ -10,3 +10,19 @@ spec = Test.group "Arrays" <|
         as_vec = json.into (Vector.Vector Number)
         as_vec.should_equal <| Vector.fill 100 0
 
+    Test.specify "should allow accessing elements"
+        arr = [1, 2, 3] . to_array
+        arr.at 0 . should_equal 1
+        arr.at 2 . should_equal 3
+
+    Test.specify "should allow setting elements"
+        arr = [1, 2, 3] . to_array
+        arr.set_at 1 10
+        arr.at 1 . should_equal 10
+        Vector.from_array arr . should_equal [1, 10, 3]
+
+    Test.specify "should panic on out of bounds access"
+        arr = [1, 2, 3] . to_array
+        Test.expect_panic_with (arr.at -1) Invalid_Array_Index_Error
+        Test.expect_panic_with (arr.at 3) Invalid_Array_Index_Error
+        Test.expect_panic_with (arr.at 3 100) Invalid_Array_Index_Error

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -90,6 +90,7 @@ spec = Test.group "Vectors" <|
         vec.filter (ix -> ix > 3) . should_equal [4, 5]
         vec.filter (ix -> ix == 1) . should_equal [1]
         vec.filter (ix -> ix < 0) . should_equal []
+        vec.filter (ix -> if ix == 2 then Error.throw <| My_Error "foo" else True) . should_fail_with My_Error
 
     Test.specify "should allow mapping an operation, returning a new vector" <|
         vec = [1, 2, 3, 4]

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -26,7 +26,17 @@ spec = Test.group "Vectors" <|
         built . should_equal [1, 2, 3, 4, 5]
 
     Test.specify "should allow accessing elements" <|
+        [1,2,3].at 0 . should_equal 1
         [1,2,3].at 2 . should_equal 3
+
+    Test.specify "should allow accessing elements with negative indices" <|
+        [1,2,3].at -1 . should_equal 3
+        [1,2,3].at -2 . should_equal 2
+        [1,2,3].at -3 . should_equal 1
+
+    Test.specify "should return a dataflow error when accessing elements out of bounds" <|
+        [1,2,3].at -4 . should_fail_with Vector.Index_Out_Of_Bounds_Error
+        [1,2,3].at 3 . should_fail_with Vector.Index_Out_Of_Bounds_Error
 
     Test.specify "should have a well-defined length" <|
         [1,2,3].length . should_equal 3
@@ -105,6 +115,18 @@ spec = Test.group "Vectors" <|
         [].to_text.should_equal "[]"
         [1,2,3].to_text.should_equal "[1, 2, 3]"
         [Nothing].to_text.should_equal "[Nothing]"
+        ['a'].to_text . should_equal "['a']"
+
+    Test.specify "should allow to generate a short text representation for display" <|
+        [].short_display_text max_entries=3 . should_equal "[]"
+        [1].short_display_text max_entries=3 . should_equal "[1]"
+        [1, 2].short_display_text max_entries=3 . should_equal "[1, 2]"
+        [1, 2, 3].short_display_text max_entries=3 . should_equal "[1, 2, 3]"
+        [1, 2, 3, 4].short_display_text max_entries=3 . should_equal "[1, 2, 3 and 1 more element]"
+        [1, 2, 3, 4, 5, 6].short_display_text max_entries=3 . should_equal "[1, 2, 3 and 3 more elements]"
+        (0.up_to 100).to_vector.short_display_text max_entries=2 . should_equal "[0, 1 and 98 more elements]"
+
+        [].short_display_text max_entries=0 . catch . should_equal "The `max_entries` parameter must be positive"
 
     Test.specify "should define equality" <|
         [1,2,3]==[1,2] . should_be_false


### PR DESCRIPTION
### Pull Request Description

Experiment to use mem copy and slice structure for Vectore

### Important Notes

**length** now uses the property of Array (or another backing store) rather than `Polyglot.get_array_size`
  - thought should be ok as the Vector should have been normalised into Enso world at creation.
**to_array** needs to be a member to allow for slice

Benchmarks based on 1mm records with 10 iterations and iter size 100

| Test | Ref | New |
|---|---|---|
| Append Single | 15.6 | 2.3 |
| Append Large | 16.2 | 1.8 |
| Drop First 20 and Sum | 192.1 | 129.7 |
| Drop Last 20 and Sum | 229.9| 113.2 |
| Filter | 180.7 | 72.1 |
| Each | 73.6 | 62.5 |

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- [ ] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/develop/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/develop/docs/style-guide/yaml.md) style guides.
- [ ] All code has been tested where possible.
