### PR TITLE
Add support for the component groups syntax

### DIFF
--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -520,7 +520,7 @@ object Main {
           val mainModuleName = pkg.moduleNameForFile(pkg.mainFile).toString
           runPackage(context, mainModuleName, file)
         case scala.util.Failure(ex) =>
-          Console.err.println(ex.getMessage)
+          println(ex.getMessage)
           exitFail()
       }
     } else {

--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -509,16 +509,20 @@ object Main {
       enableAutoParallelism = enableAutoParallelism
     )
     if (projectMode) {
-      val pkg  = PackageManager.Default.fromDirectory(file)
-      val main = pkg.map(_.mainFile)
-      if (!main.exists(_.exists())) {
-        println("Main file does not exist.")
-        context.context.close()
-        exitFail()
+      PackageManager.Default.loadPackage(file) match {
+        case scala.util.Success(pkg) =>
+          val main = pkg.mainFile
+          if (!main.exists()) {
+            println("Main file does not exist.")
+            context.context.close()
+            exitFail()
+          }
+          val mainModuleName = pkg.moduleNameForFile(pkg.mainFile).toString
+          runPackage(context, mainModuleName, file)
+        case scala.util.Failure(ex) =>
+          Console.err.println(ex.getMessage)
+          exitFail()
       }
-      val mainFile       = main.get
-      val mainModuleName = pkg.get.moduleNameForFile(mainFile).toString
-      runPackage(context, mainModuleName, file)
     } else {
       runSingleFile(context, file)
     }

--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -14,13 +14,13 @@ import org.enso.pkg.{Contact, PackageManager, Template}
 import org.enso.polyglot.{LanguageInfo, Module, PolyglotContext}
 import org.enso.version.VersionDescription
 import org.graalvm.polyglot.PolyglotException
-
 import java.io.File
 import java.nio.file.Path
 import java.util.UUID
+
 import scala.Console.err
 import scala.jdk.CollectionConverters._
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
 /** The main CLI entry point class. */
@@ -510,7 +510,7 @@ object Main {
     )
     if (projectMode) {
       PackageManager.Default.loadPackage(file) match {
-        case scala.util.Success(pkg) =>
+        case Success(pkg) =>
           val main = pkg.mainFile
           if (!main.exists()) {
             println("Main file does not exist.")
@@ -519,7 +519,7 @@ object Main {
           }
           val mainModuleName = pkg.moduleNameForFile(pkg.mainFile).toString
           runPackage(context, mainModuleName, file)
-        case scala.util.Failure(ex) =>
+        case Failure(ex) =>
           println(ex.getMessage)
           exitFail()
       }

--- a/lib/scala/editions/src/main/scala/org/enso/editions/LibraryName.scala
+++ b/lib/scala/editions/src/main/scala/org/enso/editions/LibraryName.scala
@@ -14,7 +14,7 @@ case class LibraryName(namespace: String, name: String) {
   /** The qualified name of the library consists of its prefix and name
     * separated with a dot.
     */
-  def qualifiedName: String = s"$namespace.$name"
+  def qualifiedName: String = s"$namespace${LibraryName.separator}$name"
 
   /** @inheritdoc */
   override def toString: String = qualifiedName
@@ -36,7 +36,7 @@ object LibraryName {
     libraryName.toString.asJson
   }
 
-  private val separator = '.'
+  val separator = '.'
 
   /** Creates a [[LibraryName]] from its string representation.
     *

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/ComponentGroup.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/ComponentGroup.scala
@@ -150,7 +150,7 @@ object ExtendedComponentGroup {
       )
   }
 
-  /** [[Decoder]] instance for the [[ComponentGroup]]. */
+  /** [[Decoder]] instance for the [[ExtendedComponentGroup]]. */
   implicit val decoder: Decoder[ExtendedComponentGroup] = { json =>
     for {
       reference <- ConfigCodecs
@@ -225,6 +225,11 @@ object Shortcut {
   }
 }
 
+/** The reference to a module.
+  *
+  * @param libraryName the qualified name of a library where the module is defined
+  * @param moduleName the module name
+  */
 case class ModuleReference(
   libraryName: LibraryName,
   moduleName: Option[ModuleName]

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/ComponentGroup.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/ComponentGroup.scala
@@ -2,6 +2,7 @@ package org.enso.pkg
 
 import io.circe._
 import io.circe.syntax._
+import org.enso.editions.LibraryName
 
 /** The description of component groups provided by the package.
   *
@@ -14,7 +15,7 @@ case class ComponentGroups(
 )
 object ComponentGroups {
 
-  /** An empty component groups. */
+  /** Empty component groups. */
   val empty: ComponentGroups =
     ComponentGroups(List(), List())
 
@@ -236,13 +237,11 @@ case class ModuleReference(
 )
 object ModuleReference {
 
-  private val ModuleSeparator: Char = '.'
-
   private def toModuleString(moduleReference: ModuleReference): String = {
     val libraryName =
-      s"${moduleReference.libraryName.namespace}$ModuleSeparator${moduleReference.libraryName.name}"
+      s"${moduleReference.libraryName.namespace}${LibraryName.separator}${moduleReference.libraryName.name}"
     moduleReference.moduleName.fold(libraryName) { moduleName =>
-      s"$libraryName$ModuleSeparator${moduleName.name}"
+      s"$libraryName${LibraryName.separator}${moduleName.name}"
     }
   }
 
@@ -254,7 +253,7 @@ object ModuleReference {
   /** [[Decoder]] instance for the [[ModuleReference]]. */
   implicit val decoder: Decoder[ModuleReference] = { json =>
     json.as[String].flatMap { moduleString =>
-      moduleString.split(ModuleSeparator).toList match {
+      moduleString.split(LibraryName.separator).toList match {
         case namespace :: name :: module =>
           Right(
             ModuleReference(
@@ -307,10 +306,3 @@ object ModuleName {
     }
   }
 }
-
-/** The qualified library name.
-  *
-  * @param namespace the library namespace
-  * @param name the library name
-  */
-case class LibraryName(namespace: String, name: String)

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/ComponentGroup.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/ComponentGroup.scala
@@ -1,0 +1,168 @@
+package org.enso.pkg
+
+import io.circe._
+import io.circe.syntax._
+
+/** The description of component groups provided by the package.
+  *
+  * @param `new` the list of component groups provided by the package
+  * @param `extends` the list of component groups that this package extends
+  */
+case class ComponentGroups(
+  `new`: List[ComponentGroup],
+  `extends`: List[ComponentGroup]
+)
+object ComponentGroups {
+
+  /** An empty component groups. */
+  val empty: ComponentGroups =
+    ComponentGroups(List(), List())
+
+  /** Fields for use when serializing the [[ComponentGroups]]. */
+  private object Fields {
+    val New     = "new"
+    val Extends = "extends"
+  }
+
+  /** Does the provided JSON object have unknown fields. */
+  private def hasUnknownKeys(cursor: HCursor): Boolean =
+    (ConfigCodecs.objectKeys(cursor) - Fields.New - Fields.Extends).nonEmpty
+
+  /** [[Encoder]] instance for the [[ComponentGroups]]. */
+  implicit val encoder: Encoder[ComponentGroups] = { componentGroups =>
+    val newGroups = Option.unless(componentGroups.`new`.isEmpty)(
+      Fields.New -> componentGroups.`new`.asJson
+    )
+    val extendsGroups = Option.unless(componentGroups.`extends`.isEmpty)(
+      Fields.Extends -> componentGroups.`extends`.asJson
+    )
+    Json.obj(newGroups.toSeq ++ extendsGroups.toSeq: _*)
+  }
+
+  /** [[Decoder]] instance for the [[ComponentGroups]]. */
+  implicit val decoder: Decoder[ComponentGroups] = { json =>
+    def decodeComponentGroups: Either[DecodingFailure, ComponentGroups] = for {
+      newGroups <- json.getOrElse[List[ComponentGroup]](Fields.New)(List())
+      extendsGroups <- json.getOrElse[List[ComponentGroup]](Fields.Extends)(
+        List()
+      )
+    } yield ComponentGroups(newGroups, extendsGroups)
+
+    if (hasUnknownKeys(json)) {
+      Left(
+        DecodingFailure(
+          "Invalid component groups. Valid keys are 'new' or 'extends'.",
+          json.history
+        )
+      )
+    } else {
+      decodeComponentGroups
+    }
+  }
+}
+
+/** The definition of a single component group.
+  *
+  * @param module the module name
+  * @param color the component group color
+  * @param icon the component group icon
+  * @param exports the list of components provided by this component group
+  */
+case class ComponentGroup(
+  module: String,
+  color: Option[String],
+  icon: Option[String],
+  exports: Seq[Component]
+)
+object ComponentGroup {
+
+  /** Fields for use when serializing the [[ComponentGroup]]. */
+  private object Fields {
+    val Module  = "module"
+    val Color   = "color"
+    val Icon    = "icon"
+    val Exports = "exports"
+  }
+
+  /** [[Encoder]] instance for the [[ComponentGroup]]. */
+  implicit val encoder: Encoder[ComponentGroup] = { componentGroup =>
+    val color = componentGroup.color.map(Fields.Color -> _.asJson)
+    val icon  = componentGroup.icon.map(Fields.Icon -> _.asJson)
+    val exports = Option.unless(componentGroup.exports.isEmpty)(
+      Fields.Exports -> componentGroup.exports.asJson
+    )
+    Json.obj(
+      (Fields.Module -> componentGroup.module.asJson) +:
+      (color.toSeq ++ icon.toSeq ++ exports.toSeq): _*
+    )
+  }
+
+  /** [[Decoder]] instance for the [[ComponentGroup]]. */
+  implicit val decoder: Decoder[ComponentGroup] = { json =>
+    for {
+      name    <- ConfigCodecs.getName("component group")(json)
+      color   <- json.get[Option[String]](Fields.Color)
+      icon    <- json.get[Option[String]](Fields.Icon)
+      exports <- json.getOrElse[List[Component]](Fields.Exports)(List())
+    } yield ComponentGroup(name, color, icon, exports)
+  }
+
+}
+
+/** A component of a component group.
+  *
+  * @param name the component name
+  * @param shortcut the component shortcut
+  */
+case class Component(name: String, shortcut: Option[Shortcut])
+object Component {
+
+  object Fields {
+    val Name     = "name"
+    val Shortcut = "shortcut"
+  }
+
+  /** [[Encoder]] instance for the [[Component]]. */
+  implicit val encoder: Encoder[Component] = { component =>
+    component.shortcut match {
+      case Some(shortcut) =>
+        Json.obj(
+          Fields.Name     -> component.name.asJson,
+          Fields.Shortcut -> shortcut.asJson
+        )
+      case None =>
+        component.name.asJson
+    }
+  }
+
+  /** [[Decoder]] instance for the [[Component]]. */
+  implicit val decoder: Decoder[Component] = { json =>
+    json.as[String] match {
+      case Right(name) =>
+        Right(Component(name, None))
+      case Left(_) =>
+        for {
+          name     <- ConfigCodecs.getName("component")(json)
+          shortcut <- json.getOrElse[Option[Shortcut]](Fields.Shortcut)(None)
+        } yield Component(name, shortcut)
+    }
+  }
+}
+
+/** The shortcut reference to the component.
+  *
+  * @param key the shortcut key combination
+  */
+case class Shortcut(key: String)
+object Shortcut {
+
+  /** [[Encoder]] instance for the [[Shortcut]]. */
+  implicit val encoder: Encoder[Shortcut] = { shortcut =>
+    shortcut.key.asJson
+  }
+
+  /** [[Decoder]] instance for the [[Shortcut]]. */
+  implicit val decoder: Decoder[Shortcut] = { json =>
+    ConfigCodecs.getScalar("shortcut")(json).map(Shortcut(_))
+  }
+}

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/ComponentGroup.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/ComponentGroup.scala
@@ -5,12 +5,12 @@ import io.circe.syntax._
 
 /** The description of component groups provided by the package.
   *
-  * @param `new` the list of component groups provided by the package
-  * @param `extends` the list of component groups that this package extends
+  * @param newGroups the list of component groups provided by the package
+  * @param extendedGroups the list of component groups that this package extends
   */
 case class ComponentGroups(
-  `new`: List[ComponentGroup],
-  `extends`: List[ComponentGroup]
+  newGroups: List[ComponentGroup],
+  extendedGroups: List[ExtendedComponentGroup]
 )
 object ComponentGroups {
 
@@ -30,11 +30,11 @@ object ComponentGroups {
 
   /** [[Encoder]] instance for the [[ComponentGroups]]. */
   implicit val encoder: Encoder[ComponentGroups] = { componentGroups =>
-    val newGroups = Option.unless(componentGroups.`new`.isEmpty)(
-      Fields.New -> componentGroups.`new`.asJson
+    val newGroups = Option.unless(componentGroups.newGroups.isEmpty)(
+      Fields.New -> componentGroups.newGroups.asJson
     )
-    val extendsGroups = Option.unless(componentGroups.`extends`.isEmpty)(
-      Fields.Extends -> componentGroups.`extends`.asJson
+    val extendsGroups = Option.unless(componentGroups.extendedGroups.isEmpty)(
+      Fields.Extends -> componentGroups.extendedGroups.asJson
     )
     Json.obj(newGroups.toSeq ++ extendsGroups.toSeq: _*)
   }
@@ -43,9 +43,8 @@ object ComponentGroups {
   implicit val decoder: Decoder[ComponentGroups] = { json =>
     def decodeComponentGroups: Either[DecodingFailure, ComponentGroups] = for {
       newGroups <- json.getOrElse[List[ComponentGroup]](Fields.New)(List())
-      extendsGroups <- json.getOrElse[List[ComponentGroup]](Fields.Extends)(
-        List()
-      )
+      extendsGroups <-
+        json.getOrElse[List[ExtendedComponentGroup]](Fields.Extends)(List())
     } yield ComponentGroups(newGroups, extendsGroups)
 
     if (hasUnknownKeys(json)) {
@@ -69,7 +68,7 @@ object ComponentGroups {
   * @param exports the list of components provided by this component group
   */
 case class ComponentGroup(
-  module: String,
+  module: ModuleName,
   color: Option[String],
   icon: Option[String],
   exports: Seq[Component]
@@ -100,13 +99,71 @@ object ComponentGroup {
   /** [[Decoder]] instance for the [[ComponentGroup]]. */
   implicit val decoder: Decoder[ComponentGroup] = { json =>
     for {
-      name    <- ConfigCodecs.getName("component group")(json)
+      name <- ConfigCodecs
+        .getFromObject[ModuleName](
+          "component group name",
+          Fields.Module,
+          json
+        )
       color   <- json.get[Option[String]](Fields.Color)
       icon    <- json.get[Option[String]](Fields.Icon)
       exports <- json.getOrElse[List[Component]](Fields.Exports)(List())
     } yield ComponentGroup(name, color, icon, exports)
   }
 
+}
+
+/** The definition of a single component group.
+  *
+  * @param module the reference to the extended component group
+  * @param color the component group color
+  * @param icon the component group icon
+  * @param exports the list of components provided by this component group
+  */
+case class ExtendedComponentGroup(
+  module: ModuleReference,
+  color: Option[String],
+  icon: Option[String],
+  exports: Seq[Component]
+)
+object ExtendedComponentGroup {
+
+  /** Fields for use when serializing the [[ExtendedComponentGroup]]. */
+  private object Fields {
+    val Module  = "module"
+    val Color   = "color"
+    val Icon    = "icon"
+    val Exports = "exports"
+  }
+
+  /** [[Encoder]] instance for the [[ExtendedComponentGroup]]. */
+  implicit val encoder: Encoder[ExtendedComponentGroup] = {
+    extendedComponentGroup =>
+      val color = extendedComponentGroup.color.map(Fields.Color -> _.asJson)
+      val icon  = extendedComponentGroup.icon.map(Fields.Icon -> _.asJson)
+      val exports = Option.unless(extendedComponentGroup.exports.isEmpty)(
+        Fields.Exports -> extendedComponentGroup.exports.asJson
+      )
+      Json.obj(
+        (Fields.Module -> extendedComponentGroup.module.asJson) +:
+        (color.toSeq ++ icon.toSeq ++ exports.toSeq): _*
+      )
+  }
+
+  /** [[Decoder]] instance for the [[ComponentGroup]]. */
+  implicit val decoder: Decoder[ExtendedComponentGroup] = { json =>
+    for {
+      reference <- ConfigCodecs
+        .getFromObject[ModuleReference](
+          "extended component group reference",
+          Fields.Module,
+          json
+        )
+      color   <- json.get[Option[String]](Fields.Color)
+      icon    <- json.get[Option[String]](Fields.Icon)
+      exports <- json.getOrElse[List[Component]](Fields.Exports)(List())
+    } yield ExtendedComponentGroup(reference, color, icon, exports)
+  }
 }
 
 /** A component of a component group.
@@ -142,7 +199,8 @@ object Component {
         Right(Component(name, None))
       case Left(_) =>
         for {
-          name     <- ConfigCodecs.getName("component")(json)
+          name <- ConfigCodecs
+            .getFromObject[String]("component name", Fields.Name, json)
           shortcut <- json.getOrElse[Option[Shortcut]](Fields.Shortcut)(None)
         } yield Component(name, shortcut)
     }
@@ -163,6 +221,91 @@ object Shortcut {
 
   /** [[Decoder]] instance for the [[Shortcut]]. */
   implicit val decoder: Decoder[Shortcut] = { json =>
-    ConfigCodecs.getScalar("shortcut")(json).map(Shortcut(_))
+    ConfigCodecs.getScalar("shortcut", json).map(Shortcut(_))
   }
 }
+
+case class ModuleReference(
+  libraryName: LibraryName,
+  moduleName: Option[ModuleName]
+)
+object ModuleReference {
+
+  private val ModuleSeparator: Char = '.'
+
+  private def toModuleString(moduleReference: ModuleReference): String = {
+    val libraryName =
+      s"${moduleReference.libraryName.prefix}$ModuleSeparator${moduleReference.libraryName.name}"
+    moduleReference.moduleName.fold(libraryName) { moduleName =>
+      s"$libraryName$ModuleSeparator${moduleName.name}"
+    }
+  }
+
+  /** [[Encoder]] instance for the [[ModuleReference]]. */
+  implicit val encoder: Encoder[ModuleReference] = { moduleReference =>
+    toModuleString(moduleReference).asJson
+  }
+
+  /** [[Decoder]] instance for the [[ModuleReference]]. */
+  implicit val decoder: Decoder[ModuleReference] = { json =>
+    json.as[String].flatMap { moduleString =>
+      moduleString.split(ModuleSeparator).toList match {
+        case prefix :: name :: module =>
+          Right(
+            ModuleReference(
+              LibraryName(prefix, name),
+              ModuleName.fromComponents(module)
+            )
+          )
+        case _ =>
+          Left(
+            DecodingFailure(
+              s"Failed to decode '$moduleString' as module reference. " +
+              s"Module reference should consist of prefix (author), library name " +
+              s"and a module name (e.g. Standard.Base.Data).",
+              json.history
+            )
+          )
+      }
+    }
+  }
+
+}
+
+/** The module name.
+  *
+  * @param name the module name
+  */
+case class ModuleName(name: String)
+object ModuleName {
+
+  def fromComponents(items: List[String]): Option[ModuleName] =
+    Option.unless(items.isEmpty)(ModuleName(items.mkString(".")))
+
+  /** [[Encoder]] instance for the [[ModuleName]]. */
+  implicit val encoder: Encoder[ModuleName] = { moduleName =>
+    moduleName.name.asJson
+  }
+
+  /** [[Decoder]] instance for the [[ModuleName]]. */
+  implicit val decoder: Decoder[ModuleName] = { json =>
+    json.as[String] match {
+      case Left(_) =>
+        Left(
+          DecodingFailure(
+            "Failed to decode component group name.",
+            json.history
+          )
+        )
+      case Right(name) =>
+        Right(ModuleName(name))
+    }
+  }
+}
+
+/** The qualified library name.
+  *
+  * @param prefix the library prefix
+  * @param name the library name
+  */
+case class LibraryName(prefix: String, name: String)

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/ComponentGroup.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/ComponentGroup.scala
@@ -113,7 +113,7 @@ object ComponentGroup {
 
 }
 
-/** The definition of a single component group.
+/** The definition of a component group that extends an existing one.
   *
   * @param module the reference to the extended component group
   * @param color the component group color
@@ -166,7 +166,7 @@ object ExtendedComponentGroup {
   }
 }
 
-/** A component of a component group.
+/** A single component of a component group.
   *
   * @param name the component name
   * @param shortcut the component shortcut
@@ -240,7 +240,7 @@ object ModuleReference {
 
   private def toModuleString(moduleReference: ModuleReference): String = {
     val libraryName =
-      s"${moduleReference.libraryName.prefix}$ModuleSeparator${moduleReference.libraryName.name}"
+      s"${moduleReference.libraryName.namespace}$ModuleSeparator${moduleReference.libraryName.name}"
     moduleReference.moduleName.fold(libraryName) { moduleName =>
       s"$libraryName$ModuleSeparator${moduleName.name}"
     }
@@ -255,10 +255,10 @@ object ModuleReference {
   implicit val decoder: Decoder[ModuleReference] = { json =>
     json.as[String].flatMap { moduleString =>
       moduleString.split(ModuleSeparator).toList match {
-        case prefix :: name :: module =>
+        case namespace :: name :: module =>
           Right(
             ModuleReference(
-              LibraryName(prefix, name),
+              LibraryName(namespace, name),
               ModuleName.fromComponents(module)
             )
           )
@@ -266,8 +266,8 @@ object ModuleReference {
           Left(
             DecodingFailure(
               s"Failed to decode '$moduleString' as module reference. " +
-              s"Module reference should consist of prefix (author), library name " +
-              s"and a module name (e.g. Standard.Base.Data).",
+              s"Module reference should consist of a namespace (author), " +
+              s"library name and a module name (e.g. Standard.Base.Data).",
               json.history
             )
           )
@@ -310,7 +310,7 @@ object ModuleName {
 
 /** The qualified library name.
   *
-  * @param prefix the library prefix
+  * @param namespace the library namespace
   * @param name the library name
   */
-case class LibraryName(prefix: String, name: String)
+case class LibraryName(namespace: String, name: String)

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/ComponentGroup.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/ComponentGroup.scala
@@ -25,10 +25,6 @@ object ComponentGroups {
     val Extends = "extends"
   }
 
-  /** Does the provided JSON object have unknown fields. */
-  private def hasUnknownKeys(cursor: HCursor): Boolean =
-    (ConfigCodecs.objectKeys(cursor) - Fields.New - Fields.Extends).nonEmpty
-
   /** [[Encoder]] instance for the [[ComponentGroups]]. */
   implicit val encoder: Encoder[ComponentGroups] = { componentGroups =>
     val newGroups = Option.unless(componentGroups.newGroups.isEmpty)(
@@ -42,22 +38,11 @@ object ComponentGroups {
 
   /** [[Decoder]] instance for the [[ComponentGroups]]. */
   implicit val decoder: Decoder[ComponentGroups] = { json =>
-    def decodeComponentGroups: Either[DecodingFailure, ComponentGroups] = for {
+    for {
       newGroups <- json.getOrElse[List[ComponentGroup]](Fields.New)(List())
       extendsGroups <-
         json.getOrElse[List[ExtendedComponentGroup]](Fields.Extends)(List())
     } yield ComponentGroups(newGroups, extendsGroups)
-
-    if (hasUnknownKeys(json)) {
-      Left(
-        DecodingFailure(
-          "Invalid component groups. Valid keys are 'new' or 'extends'.",
-          json.history
-        )
-      )
-    } else {
-      decodeComponentGroups
-    }
   }
 }
 

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/Config.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/Config.scala
@@ -99,6 +99,8 @@ object Contact {
   * @param preferLocalLibraries specifies if library resolution should prefer
   *                             local libraries over what is defined in the
   *                             edition
+  * @param componentGroups the description of component groups provided by this
+  *                        package
   * @param originalJson a Json object holding the original values that this
   *                     Config was created from, used to preserve configuration
   *                     keys that are not known

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/Config.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/Config.scala
@@ -195,11 +195,13 @@ object Config {
       }
       .map(JsonFields.edition -> _)
 
-    val componentGroups = Option.unless(
-      config.componentGroups.`new`.isEmpty && config.componentGroups.`extends`.isEmpty
-    )(
-      JsonFields.componentGroups -> config.componentGroups.asJson
-    )
+    val componentGroups =
+      Option.unless(
+        config.componentGroups.newGroups.isEmpty &&
+        config.componentGroups.extendedGroups.isEmpty
+      )(
+        JsonFields.componentGroups -> config.componentGroups.asJson
+      )
 
     val overrides = Seq(
       JsonFields.name       -> config.name.asJson,

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/ConfigCodecs.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/ConfigCodecs.scala
@@ -1,0 +1,94 @@
+package org.enso.pkg
+
+import io.circe._
+
+/** A collection of utility codecs used in the [[Config]]. */
+object ConfigCodecs {
+
+  object Fields {
+    val Name = "name"
+  }
+
+  /** The common decoding failure.
+    *
+    * @param entity the name of decoded entity
+    * @param history the list of JSON cursor operations
+    */
+  private def decodingFailure(
+    entity: String,
+    history: List[CursorOp]
+  ): DecodingFailure =
+    DecodingFailure(s"Failed to decode $entity", history)
+
+  /** Get the name of decoded entity in case when the decoded entity is a JSON
+    * object.
+    *
+    * @param entity the name of decoded entity
+    * @param cursor the current focus in the JSON document
+    */
+  private def getNameKey(
+    entity: String,
+    cursor: HCursor
+  ): Decoder.Result[String] =
+    cursor.keys match {
+      case Some(keys) if keys.nonEmpty =>
+        cursor.get[Option[String]](keys.head).flatMap {
+          case Some(_) =>
+            Left(decodingFailure(s"$entity name", cursor.history))
+          case None =>
+            Right(keys.head)
+        }
+      case _ =>
+        Left(decodingFailure(s"$entity name", cursor.history))
+    }
+
+  /** Get the name of decoded entity in case when the decoded entity is a JSON
+    * string.
+    *
+    * @param entity the decoded entity
+    * @param cursor the current focus in the JSON document
+    */
+  private def getNameString(
+    entity: String,
+    cursor: HCursor
+  ): Decoder.Result[String] =
+    cursor
+      .as[String]
+      .left
+      .map(f => decodingFailure(s"$entity name", f.history))
+
+  private def getNameField(cursor: HCursor): Decoder.Result[String] =
+    cursor.get[String](Fields.Name)
+
+  /** Get the name of decoded entity.
+    *
+    * @param entity the decoded entity
+    * @param cursor the current focus in the JSON document
+    */
+  def getName(entity: String)(cursor: HCursor): Decoder.Result[String] =
+    getNameField(cursor)
+      .orElse(getNameKey(entity, cursor))
+      .orElse(getNameString(entity, cursor))
+
+  /** Get the scalar value of the provided JSON element.
+    *
+    * @param entity the name of decoded entity
+    * @param cursor the current focus in the JSON document
+    */
+  def getScalar(entity: String)(cursor: HCursor): Decoder.Result[String] =
+    cursor.value.fold(
+      jsonNull    = Left(decodingFailure(entity, cursor.history)),
+      jsonBoolean = value => Right(value.toString),
+      jsonNumber  = value => Right(value.toString),
+      jsonString  = value => Right(value),
+      jsonArray   = _ => Left(decodingFailure(entity, cursor.history)),
+      jsonObject  = _ => Left(decodingFailure(entity, cursor.history))
+    )
+
+  /** Get the set of JSON object keys.
+    *
+    * @param cursor the current focus in the JSON document
+    */
+  def objectKeys(cursor: HCursor): Set[String] =
+    cursor.keys.getOrElse(Seq()).toSet
+}

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/Package.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/Package.scala
@@ -224,7 +224,8 @@ class PackageManager[F](implicit val fileSystem: FileSystem[F]) {
     edition: Option[Editions.RawEdition] = None,
     authors: List[Contact]               = List(),
     maintainers: List[Contact]           = List(),
-    license: String                      = ""
+    license: String                      = "",
+    componentGroups: ComponentGroups     = ComponentGroups.empty
   ): Package[F] = {
     val config = Config(
       name                 = NameValidation.normalizeName(name),
@@ -234,7 +235,8 @@ class PackageManager[F](implicit val fileSystem: FileSystem[F]) {
       authors              = authors,
       edition              = edition,
       preferLocalLibraries = true,
-      maintainers          = maintainers
+      maintainers          = maintainers,
+      componentGroups      = componentGroups
     )
     create(root, config, template)
   }

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/Package.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/Package.scala
@@ -236,7 +236,7 @@ class PackageManager[F](implicit val fileSystem: FileSystem[F]) {
       edition              = edition,
       preferLocalLibraries = true,
       maintainers          = maintainers,
-      componentGroups      = componentGroups
+      componentGroups      = Right(componentGroups)
     )
     create(root, config, template)
   }

--- a/lib/scala/pkg/src/test/scala/org/enso/pkg/ConfigSpec.scala
+++ b/lib/scala/pkg/src/test/scala/org/enso/pkg/ConfigSpec.scala
@@ -143,19 +143,21 @@ class ConfigSpec
       parsed.componentGroups shouldEqual Right(expectedComponentGroups)
 
       val serialized = parsed.toYaml
-      serialized should include("""component-groups:
-                                  |  new:
-                                  |  - module: Group 1
-                                  |    color: '#C047AB'
-                                  |    icon: icon-name
-                                  |    exports:
-                                  |    - name: foo
-                                  |      shortcut: f
-                                  |    - bar
-                                  |  extends:
-                                  |  - module: Standard.Base.Group 2
-                                  |    exports:
-                                  |    - bax""".stripMargin)
+      serialized should include(
+        """component-groups:
+          |  new:
+          |  - module: Group 1
+          |    color: '#C047AB'
+          |    icon: icon-name
+          |    exports:
+          |    - name: foo
+          |      shortcut: f
+          |    - bar
+          |  extends:
+          |  - module: Standard.Base.Group 2
+          |    exports:
+          |    - bax""".stripMargin.linesIterator.mkString("\n")
+      )
     }
 
     "correctly de-serialize empty components" in {

--- a/lib/scala/pkg/src/test/scala/org/enso/pkg/ConfigSpec.scala
+++ b/lib/scala/pkg/src/test/scala/org/enso/pkg/ConfigSpec.scala
@@ -3,6 +3,7 @@ package org.enso.pkg
 import cats.Show
 import io.circe.{DecodingFailure, Json, JsonObject}
 import nl.gn0s1s.bump.SemVer
+import org.enso.editions.LibraryName
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.{Inside, OptionValues}
@@ -224,6 +225,7 @@ class ConfigSpec
           |      shortcut: 0
           |    - quux:
           |      shortcut:
+          |    - hmmm:
           |""".stripMargin
       val parsed = Config.fromYaml(config).get
 
@@ -237,7 +239,8 @@ class ConfigSpec
               Component("foo", Some(Shortcut("f"))),
               Component("bar", Some(Shortcut("fgh"))),
               Component("baz", Some(Shortcut("0"))),
-              Component("quux", None)
+              Component("quux", None),
+              Component("hmmm", None)
             )
           )
         ),
@@ -245,7 +248,7 @@ class ConfigSpec
       )
     }
 
-    "fail ot de-serialize invalid shortcuts" in {
+    "fail to de-serialize invalid shortcuts" in {
       val config =
         """name: FooBar
           |component-groups:

--- a/lib/scala/pkg/src/test/scala/org/enso/pkg/ConfigSpec.scala
+++ b/lib/scala/pkg/src/test/scala/org/enso/pkg/ConfigSpec.scala
@@ -1,16 +1,20 @@
 package org.enso.pkg
 
-import io.circe.{Json, JsonObject}
+import cats.Show
+import io.circe.{DecodingFailure, Json, JsonObject}
 import nl.gn0s1s.bump.SemVer
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.{Inside, OptionValues}
+
+import scala.util.Failure
 
 class ConfigSpec
     extends AnyWordSpec
     with Matchers
     with Inside
     with OptionValues {
+
   "Config" should {
     "preserve unknown keys when deserialized and serialized again" in {
       val original = Json.obj(
@@ -42,7 +46,8 @@ class ConfigSpec
           Contact(Some("B"), None),
           Contact(None, Some("c@example.com"))
         ),
-        preferLocalLibraries = true
+        preferLocalLibraries = true,
+        componentGroups      = ComponentGroups.empty
       )
       val deserialized = Config.fromYaml(config.toYaml).get
       val withoutJson  = deserialized.copy(originalJson = JsonObject())
@@ -90,4 +95,191 @@ class ConfigSpec
       serialized should include("edition: '2020.1'")
     }
   }
+
+  "Component groups" should {
+
+    "correctly de-serialize and serialize back the components syntax" in {
+      val config =
+        """name: FooBar
+          |component-groups:
+          |  new:
+          |  - Group 1:
+          |    color: '#C047AB'
+          |    icon: icon-name
+          |    exports:
+          |      - foo:
+          |        shortcut: f
+          |      - bar
+          |  extends:
+          |  - Base.Group 2:
+          |    exports:
+          |      - bax
+          |""".stripMargin
+      val parsed = Config.fromYaml(config).get
+
+      val expectedComponentGroups = ComponentGroups(
+        `new` = List(
+          ComponentGroup(
+            module = "Group 1",
+            color  = Some("#C047AB"),
+            icon   = Some("icon-name"),
+            exports = List(
+              Component("foo", Some(Shortcut("f"))),
+              Component("bar", None)
+            )
+          )
+        ),
+        `extends` = List(
+          ComponentGroup(
+            module  = "Base.Group 2",
+            color   = None,
+            icon    = None,
+            exports = List(Component("bax", None))
+          )
+        )
+      )
+      parsed.componentGroups shouldEqual expectedComponentGroups
+
+      val serialized = parsed.toYaml
+      serialized should include("""component-groups:
+                                  |  new:
+                                  |  - module: Group 1
+                                  |    color: '#C047AB'
+                                  |    icon: icon-name
+                                  |    exports:
+                                  |    - name: foo
+                                  |      shortcut: f
+                                  |    - bar
+                                  |  extends:
+                                  |  - module: Base.Group 2
+                                  |    exports:
+                                  |    - bax""".stripMargin)
+    }
+
+    "correctly de-serialize empty components" in {
+      val config =
+        """name: FooBar
+          |component-groups:
+          |""".stripMargin
+      val parsed = Config.fromYaml(config).get
+
+      parsed.componentGroups shouldEqual ComponentGroups.empty
+    }
+
+    "fail to de-serialize unknown keys in component groups" in {
+      val config =
+        """name: FooBar
+          |component-groups:
+          |  foo:
+          |  - Group 1:
+          |    exports:
+          |    - bax
+          |""".stripMargin
+
+      Config.fromYaml(config) match {
+        case Failure(f: DecodingFailure) =>
+          Show[DecodingFailure].show(f) should include(
+            "Invalid component group"
+          )
+        case unexpected =>
+          fail(s"Unexpected result: $unexpected")
+      }
+    }
+
+    "correctly de-serialize shortcuts" in {
+      val config =
+        """name: FooBar
+          |component-groups:
+          |  new:
+          |  - Group 1:
+          |    exports:
+          |    - foo:
+          |      shortcut: f
+          |    - bar:
+          |      shortcut: fgh
+          |    - baz:
+          |      shortcut: 0
+          |    - quux:
+          |      shortcut:
+          |""".stripMargin
+      val parsed = Config.fromYaml(config).get
+
+      parsed.componentGroups shouldEqual ComponentGroups(
+        `new` = List(
+          ComponentGroup(
+            module = "Group 1",
+            color  = None,
+            icon   = None,
+            exports = List(
+              Component("foo", Some(Shortcut("f"))),
+              Component("bar", Some(Shortcut("fgh"))),
+              Component("baz", Some(Shortcut("0"))),
+              Component("quux", None)
+            )
+          )
+        ),
+        `extends` = List()
+      )
+    }
+
+    "fail ot de-serialize invalid shortcuts" in {
+      val config =
+        """name: FooBar
+          |component-groups:
+          |  new:
+          |  - Group 1:
+          |    exports:
+          |    - foo:
+          |      shortcut: []
+          |""".stripMargin
+      Config.fromYaml(config) match {
+        case Failure(f: DecodingFailure) =>
+          Show[DecodingFailure].show(f) should include(
+            "Failed to decode shortcut"
+          )
+        case unexpected =>
+          fail(s"Unexpected result: $unexpected")
+      }
+    }
+
+    "fail to de-serialize invalid component groups" in {
+      val config =
+        """name: FooBar
+          |component-groups:
+          |  new:
+          |  - exports:
+          |    - name: foo
+          |""".stripMargin
+
+      Config.fromYaml(config) match {
+        case Failure(f: DecodingFailure) =>
+          Show[DecodingFailure].show(f) should include(
+            "Failed to decode component group name"
+          )
+        case unexpected =>
+          fail(s"Unexpected result: $unexpected")
+      }
+    }
+
+    "fail to de-serialize invalid components" in {
+      val config =
+        """name: FooBar
+          |component-groups:
+          |  new:
+          |  - Group 1:
+          |    exports:
+          |    - one: two
+          |""".stripMargin
+
+      Config.fromYaml(config) match {
+        case Failure(f: DecodingFailure) =>
+          Show[DecodingFailure].show(f) should include(
+            "Failed to decode component name"
+          )
+        case unexpected =>
+          fail(s"Unexpected result: $unexpected")
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Add support for a new metadata syntax describing the component groups:

```yaml
component-groups:        
  new:                   
  - Group 1:             
    color: '#C047AB'     
    icon: icon-name      
    exports:             
      - foo:             
        shortcut: f      
      - bar              
  extends:               
  - Standard.Base.Group 2:
    exports:             
      - bax
```

Changelog:
- feat: Extend the package config description with the new component groups
- feat: Implement the JSON codecs
- fix: Enso runner shows the original failure message when loading the package

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/develop/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/develop/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
