### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,9 @@
 # Catch All
 * @4e6 @MichaelMauderer @PabloBuchu @jdunkerley
 
+# Change log
+CHANGELOG.md
+
 # Rust Libraries
 Cargo.lock @MichaelMauderer @4e6 @mwu-tow @farmaazon
 Cargo.toml @MichaelMauderer @4e6 @mwu-tow @farmaazon
@@ -13,7 +16,7 @@ Cargo.toml @MichaelMauderer @4e6 @mwu-tow @farmaazon
 # GUI
 /run @MichaelMauderer @wdanilo
 /build/ @MichaelMauderer @wdanilo
-/app/gui/ @MichaelMauderer @wdanilo @farmaazon @mwu-tow @jdunkerley
+/app/gui/ @MichaelMauderer @wdanilo @farmaazon @mwu-tow
 /app/gui/view/ @MichaelMauderer @wdanilo @farmaazon
 /app/ide-desktop/ @MichaelMauderer @wdanilo
 
@@ -23,7 +26,7 @@ Cargo.toml @MichaelMauderer @4e6 @mwu-tow @farmaazon
 /distribution/ @4e6
 /engine/ @4e6
 /project/ @4e6
-/test/ @4e6
+/test/ @4e6 @jdunkerley @radeusgd
 /tools/ @4e6
 
 # Enso Libraries

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@ Cargo.toml @MichaelMauderer @4e6 @mwu-tow @farmaazon
 # GUI
 /run @MichaelMauderer @wdanilo
 /build/ @MichaelMauderer @wdanilo
-/app/gui/ @MichaelMauderer @wdanilo @farmaazon @mwu-tow
+/app/gui/ @MichaelMauderer @wdanilo @farmaazon @mwu-tow @jdunkerley
 /app/gui/view/ @MichaelMauderer @wdanilo @farmaazon
 /app/ide-desktop/ @MichaelMauderer @wdanilo
 


### PR DESCRIPTION
Adding myself to GUI codeowners so can approve `CHANGELOG.md` changes by library team.

Happy to be removed once CHANGELOG in a new common location.

### Pull Request Description

No real changes just expanded code owners list for the `app/gui`.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/develop/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/develop/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
