### PR TITLE
Data analysts should be able to transform a Table using the rename_columns functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
   operations.][3240]
 - [Implemented the `Table.sort_columns` operation.][3250]
 - [Fixed `Vector.sort` to handle tail-recursive comparators][3256]
-- [Implemented `Range.find`, `Table.rename_columns` and 
+- [Implemented `Range.find`, `Table.rename_columns` and
   `Table.use_first_row_as_names` operations][3249]
 
 [3153]: https://github.com/enso-org/enso/pull/3153

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
   operations.][3240]
 - [Implemented the `Table.sort_columns` operation.][3250]
 - [Fixed `Vector.sort` to handle tail-recursive comparators][3256]
+- [Implemented `Range.find`, `Table.rename_columns` and 
+  `Table.use_first_row_as_names` operations][3249]
 
 [3153]: https://github.com/enso-org/enso/pull/3153
 [3166]: https://github.com/enso-org/enso/pull/3166
@@ -47,6 +49,7 @@
 [3240]: https://github.com/enso-org/enso/pull/3240
 [3250]: https://github.com/enso-org/enso/pull/3250
 [3256]: https://github.com/enso-org/enso/pull/3256
+[3249]: https://github.com/enso-org/enso/pull/3249
 
 #### Enso Compiler
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Range.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Range.enso
@@ -125,11 +125,7 @@ type Range
 
              1.up_to 100 . exists (> 10)
     exists : (Number -> Boolean) -> Boolean
-    exists predicate =
-        limit = this.end
-        go n found = if found || (n >= limit) then found else
-            @Tail_Call go n+1 (predicate n)
-        go this.start False
+    exists predicate = this.find predicate . is_nothing . not
 
     ## Checks whether `predicate` is satisfied for any number in this range.
 
@@ -145,6 +141,26 @@ type Range
     any : (Number -> Boolean) -> Boolean
     any predicate = this.exists predicate
 
+    ## Gets the first index when `predicate` is satisfied this range.
+       If no index satisfies the predicate, return Nothing
+
+       Arguments:
+       - predicate: A function that takes a list element and returns a boolean
+         value that says whether that value satisfies the conditions of the
+         function.
+
+       > Example
+         Get the first number in the range divisible by 2, 3 and 5.
+
+             1.up_to 100 . find i->(i%2==0 && i%3==0 && i%5==0)
+    find : (Integer -> Boolean) -> Integer | Nothing
+    find predicate =
+        limit = this.end
+        go n = if (n >= limit) then Nothing else
+          if (predicate n) then n else
+            @Tail_Call go n+1
+        go this.start
+
     ## Converts the range to a vector containing the numbers in the range.
 
        > Example
@@ -155,4 +171,3 @@ type Range
     to_vector =
         length = Math.max 0 (this.end - this.start)
         Vector.new length (i -> i + this.start)
-

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -279,6 +279,40 @@ type Table
         new_columns = Table_Helpers.sort_columns internal_columns=this.internal_columns sort_method
         this.updated_columns new_columns
 
+    ## Returns a new table with the columns renamed based on either a mapping
+       from the old name to the new or a positional list of new names.
+
+       Arguments:
+       - column_map: Mapping from old column names to new.
+       - on_problems: Specifies how to handle problems if they occur, reporting
+         them as warnings by default.
+
+         The following problems can occur:
+         - If a column in columns is not in the input table, a
+           `Missing_Input_Columns`.
+         - If duplicate columns, names or indices are provided, a
+           `Duplicate_Column_Selectors`.
+         - If a column index is out of range, a `Column_Indexes_Out_Of_Range`.
+         - If two distinct indices would refer to the same column, a
+           `Input_Indices_Already_Matched`, indicating that the additional
+           indices will not introduce additional columns.
+         - If any of the new names are invalid, an
+           `Invalid_Output_Column_Names`.
+         - If any of the new names clash either with existing names or each
+           other, a Duplicate_Output_Column_Names.
+       - warnings: A `Warning_System` instance specifying how to handle
+         warnings. This is a temporary workaround to allow for testing the
+         warning mechanism. Once the proper warning system is implemented, this
+         argument will become obsolete and will be removed. No user code should
+         use this argument, as it will be removed in the future.
+
+       > Example
+    rename_columns : Column_Mapping -> Problem_Behavior -> Warnings.Warning_System -> Table
+    rename_columns (column_map=(Column_Mapping.By_Position ["Column"])) (on_problems=Report_Warning) (warnings=Warnings.default) =
+        new_names = Table_Helpers.rename_columns internal_columns=this.internal_columns mapping=column_map on_problems=on_problems warnings=warnings
+        new_columns = this.internal_columns.map_with_index i->c->(c.rename (new_names.at i))
+        this.updated_columns new_columns
+
     ## PRIVATE
 
        Resolves the column name to a column within this table.
@@ -590,9 +624,9 @@ type Table
             right_new_columns_names = new_names.second
 
             # Rename columns to the newly allocated names
-            new_index = here.rename_columns left_new_meta_index left_new_meta_index_names
-            left_renamed_columns = here.rename_columns left_new_columns left_new_columns_names
-            right_renamed_columns = here.rename_columns right_new_columns right_new_columns_names
+            new_index = here.internal_rename_columns left_new_meta_index left_new_meta_index_names
+            left_renamed_columns = here.internal_rename_columns left_new_columns left_new_columns_names
+            right_renamed_columns = here.internal_rename_columns right_new_columns right_new_columns_names
             new_columns = left_renamed_columns + right_renamed_columns
 
             on_exprs = left_new_join_index.zip right_new_join_index l-> r->
@@ -993,8 +1027,8 @@ fresh_names used_names preferred_names =
    Arguments:
    - columns: A vector of columns to rename.
    - new_names: The new names for the columns.
-rename_columns : Vector Internal_Column -> Vector Text -> Vector Internal_Column
-rename_columns columns new_names =
+internal_rename_columns : Vector Internal_Column -> Vector Text -> Vector Internal_Column
+internal_rename_columns columns new_names =
     columns.zip new_names col-> name->
         col.rename name
 
@@ -1012,5 +1046,5 @@ rename_columns columns new_names =
 freshen_columns : Vector Text -> Vector Internal_Column -> Vector Internal_Column
 freshen_columns used_names columns =
     fresh_names = here.fresh_names used_names (columns.map .name)
-    here.rename_columns columns fresh_names
+    here.internal_rename_columns columns fresh_names
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -15,6 +15,7 @@ from Standard.Table.Data.Order_Rule as Order_Rule_Module import Order_Rule
 from Standard.Table.Data.Column_Selector as Column_Selector_Module import Column_Selector, By_Index
 from Standard.Table.Data.Sort_Method as Sort_Method_Module import Sort_Method
 from Standard.Base.Error.Problem_Behavior as Problem_Behavior_Module import Problem_Behavior, Report_Warning
+import Standard.Table.Data.Column_Mapping
 import Standard.Table.Data.Position
 import Standard.Base.Error.Warnings
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -311,8 +311,9 @@ type Table
     rename_columns : Column_Mapping -> Problem_Behavior -> Warnings.Warning_System -> Table
     rename_columns (column_map=(Column_Mapping.By_Position ["Column"])) (on_problems=Report_Warning) (warnings=Warnings.default) =
         new_names = Table_Helpers.rename_columns internal_columns=this.internal_columns mapping=column_map on_problems=on_problems warnings=warnings
-        new_columns = this.internal_columns.map_with_index i->c->(c.rename (new_names.at i))
-        this.updated_columns new_columns
+        if new_names.is_error then new_names else
+            new_columns = this.internal_columns.map_with_index i->c->(c.rename (new_names.at i))
+            this.updated_columns new_columns
 
     ## PRIVATE
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column_Mapping.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column_Mapping.enso
@@ -1,0 +1,38 @@
+from Standard.Base import all
+
+from Standard.Table.Data.Matching import Matching_Strategy, Exact
+
+## Specifies a selection of columns from the table and the new name for them to
+   become.
+type Column_Mapping
+
+    ## Selects columns based on their names.
+
+       The `matching_strategy` can be used to specify if the names should be
+       matched exactly or should be treated as regular expressions. It also
+       allows to specify if the matching should be case-sensitive.
+    type By_Name (names : Map Text Text) (matching_strategy : Matching_Strategy = Exact True)
+
+    ## Selects columns by their index.
+
+       The index of the first column in the table is 0. If the provided index is
+       negative, it counts from the end of the table (e.g. -1 refers to the last
+       column in the table).
+    type By_Index (indexes : Map Number Text)
+
+    ## Selects columns having exactly the same names as the columns provided in
+       the input.
+
+       The input columns do not necessarily have to come from the same table, so
+       this approach can be used to match columns with the same names as a set
+       of columns of some other table, for example, when preparing for a join.
+    type By_Column (columns : Map Column Text)
+
+    ## Selects columns by position starting at the first column until the
+       new_names is exhausted.
+    type By_Position (new_names : Vector Text)
+
+## UNSTABLE
+   A temporary workaround to allow the By_Name constructor to work with default arguments.
+By_Name.new : Map Text Text -> Matching_Strategy  -> By_Name
+By_Name.new names (matching_strategy = Exact.new) = By_Name names matching_strategy

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column_Mapping.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column_Mapping.enso
@@ -26,7 +26,9 @@ type Column_Mapping
        The input columns do not necessarily have to come from the same table, so
        this approach can be used to match columns with the same names as a set
        of columns of some other table, for example, when preparing for a join.
-    type By_Column (columns : Map Column Text)
+
+       The Vector should be of the form [[Column, Name], [Column1, Name1], ...]
+    type By_Column (columns : Vector)
 
     ## Selects columns by position starting at the first column until the
        new_names is exhausted.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Matching.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Matching.enso
@@ -7,17 +7,31 @@ from Standard.Base.Error.Warnings import Warning_System
 
 ## Strategy for matching names.
 type Matching_Strategy
-   ## UNSTABLE
-      Exact name matching.
+    ## UNSTABLE
+       Exact name matching.
 
-      A name is matched if its exact name is provided.
-   type Exact (case_sensitivity : (True | Case_Insensitive) = True)
+       A name is matched if its exact name is provided.
+    type Exact (case_sensitivity : (True | Case_Insensitive) = True)
 
-   ## UNSTABLE
-      Regex-based name matching.
+    ## UNSTABLE
+       Regex-based name matching.
 
-      A name is matched if its name matches the provided regular expression.
-   type Regex (case_sensitivity : (True | Case_Insensitive) = True)
+       A name is matched if its name matches the provided regular expression.
+    type Regex (case_sensitivity : (True | Case_Insensitive) = True)
+
+
+    ## ADVANCED
+       Compiles the regular expression following the Matching_Strategy rules.
+    compile : Text -> Regex_Module.Pattern
+    compile criterion =
+        case this of
+            Regex _ ->
+                insensitive = case this.case_sensitivity of
+                    True -> False
+                    Case_Insensitive -> True
+                Regex_Module.compile criterion case_insensitive=insensitive
+            _ -> Error.throw "Invalid Matching_Strategy to compile"
+
 
 ## UNSTABLE
    A temporary workaround to allow the `Exact` constructor to work with default
@@ -40,6 +54,7 @@ Exact.new (case_sensitivity = True) = Exact case_sensitivity
    Once that issue is fixed, it can be removed.
 Regex.new : (True | Case_Insensitive) -> Regex
 Regex.new (case_sensitivity = True) = Regex case_sensitivity
+
 
 ## UNSTABLE
    Specifies that the operation should ignore case.
@@ -168,13 +183,6 @@ match_criteria objects criteria reorder=False name_mapper=(x->x) matching_strate
 match_single_criterion : Text -> Text -> Matching_Strategy -> Boolean
 match_single_criterion name criterion matching_strategy = case matching_strategy of
     Exact case_sensitivity -> case case_sensitivity of
-        True ->
-            name == criterion
-        Case_Insensitive ->
-            name.equals_ignore_case criterion
-    Regex case_sensitivity ->
-        insensitive = case case_sensitivity of
-            True -> False
-            Case_Insensitive -> True
-        re = Regex_Module.compile criterion case_insensitive=insensitive
-        re.matches name
+        True -> name == criterion
+        Case_Insensitive -> name.equals_ignore_case criterion
+    Regex _ -> matching_strategy.compile . matches name

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Matching.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Matching.enso
@@ -19,7 +19,6 @@ type Matching_Strategy
        A name is matched if its name matches the provided regular expression.
     type Regex (case_sensitivity : (True | Case_Insensitive) = True)
 
-
     ## ADVANCED
        Compiles the regular expression following the Matching_Strategy rules.
     compile : Text -> Regex_Module.Pattern
@@ -29,8 +28,9 @@ type Matching_Strategy
                 insensitive = case this.case_sensitivity of
                     True -> False
                     Case_Insensitive -> True
-                Regex_Module.compile criterion case_insensitive=insensitive
-            _ -> Error.throw "Invalid Matching_Strategy to compile"
+                re = Regex_Module.compile criterion case_insensitive=insensitive
+                re
+            Exact _ -> Error.throw "Invalid Matching_Strategy to compile"
 
 
 ## UNSTABLE
@@ -43,6 +43,7 @@ type Matching_Strategy
    Once that issue is fixed, it can be removed.
 Exact.new : (True | Case_Insensitive) -> Exact
 Exact.new (case_sensitivity = True) = Exact case_sensitivity
+
 
 ## UNSTABLE
    A temporary workaround to allow the `Regex` constructor to work with default
@@ -182,7 +183,9 @@ match_criteria objects criteria reorder=False name_mapper=(x->x) matching_strate
          Matching.match_single_criterion "Foobar" "f.*" (Regex case_sensitivity=Case_Insensitive) == True
 match_single_criterion : Text -> Text -> Matching_Strategy -> Boolean
 match_single_criterion name criterion matching_strategy = case matching_strategy of
-    Exact case_sensitivity -> case case_sensitivity of
-        True -> name == criterion
-        Case_Insensitive -> name.equals_ignore_case criterion
-    Regex _ -> matching_strategy.compile . matches name
+    Exact case_sensitivity ->
+        case case_sensitivity of
+            True -> name == criterion
+            Case_Insensitive -> name.equals_ignore_case criterion
+    Regex _ ->
+        matching_strategy.compile criterion . matches name

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -13,6 +13,7 @@ from Standard.Table.Data.Order_Rule as Order_Rule_Module import Order_Rule
 from Standard.Table.Data.Column_Selector as Column_Selector_Module import Column_Selector, By_Index
 from Standard.Table.Data.Sort_Method as Sort_Method_Module import Sort_Method
 from Standard.Base.Error.Problem_Behavior as Problem_Behavior_Module import Problem_Behavior, Report_Warning
+import Standard.Table.Data.Column_Mapping
 import Standard.Table.Data.Position
 import Standard.Base.Error.Warnings
 
@@ -433,6 +434,40 @@ type Table
     sort_columns (sort_method = Sort_Method.new) =
         new_columns = Table_Helpers.sort_columns internal_columns=this.columns sort_method
         here.new new_columns
+
+    ## Returns a new table with the columns renamed based on either a mapping
+       from the old name to the new or a positional list of new names.
+
+       Arguments:
+       - column_map: Mapping from old column names to new.
+       - on_problems: Specifies how to handle problems if they occur, reporting
+         them as warnings by default.
+
+         The following problems can occur:
+         - If a column in columns is not in the input table, a
+           `Missing_Input_Columns`.
+         - If duplicate columns, names or indices are provided, a
+           `Duplicate_Column_Selectors`.
+         - If a column index is out of range, a `Column_Indexes_Out_Of_Range`.
+         - If two distinct indices would refer to the same column, a
+           `Input_Indices_Already_Matched`, indicating that the additional
+           indices will not introduce additional columns.
+         - If any of the new names are invalid, an
+           `Invalid_Output_Column_Names`.
+         - If any of the new names clash either with existing names or each
+           other, a Duplicate_Output_Column_Names.
+       - warnings: A `Warning_System` instance specifying how to handle
+         warnings. This is a temporary workaround to allow for testing the
+         warning mechanism. Once the proper warning system is implemented, this
+         argument will become obsolete and will be removed. No user code should
+         use this argument, as it will be removed in the future.
+
+       > Example
+    rename_columns : Column_Mapping -> Problem_Behavior -> Warnings.Warning_System -> Table
+    rename_columns (column_map=Column_Mapping.By_Position ["Column"]) (on_problems = Report_Warning) (warnings = Warnings.default) =
+        new_names = Table_Helpers.rename_columns internal_columns=this.columns mapping=column_map on_problems=on_problems warnings=warnings
+        new_columns = this.columns.map_with_index i->c->(c.rename (new_names.at i) . java_column)
+        Table new_columns
 
     ## ALIAS Filter Rows
        ALIAS Mask Columns

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -469,8 +469,9 @@ type Table
     rename_columns : Column_Mapping -> Problem_Behavior -> Warnings.Warning_System -> Table
     rename_columns (column_map=(Column_Mapping.By_Position ["Column"])) (on_problems=Report_Warning) (warnings=Warnings.default) =
         new_names = Table_Helpers.rename_columns internal_columns=this.columns mapping=column_map on_problems=on_problems warnings=warnings
-        new_columns = this.columns.map_with_index i->c->(c.rename (new_names.at i))
-        here.new new_columns
+        if new_names.is_error then new_names else
+            new_columns = this.columns.map_with_index i->c->(c.rename (new_names.at i))
+            here.new new_columns
 
     ## ALIAS Filter Rows
        ALIAS Mask Columns

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -473,6 +473,41 @@ type Table
             new_columns = this.columns.map_with_index i->c->(c.rename (new_names.at i))
             here.new new_columns
 
+    ## Returns a new table with the columns renamed based on entries in the
+       first row.
+
+       Arguments:
+       - on_problems: Specifies how to handle problems if they occur, reporting
+         them as warnings by default.
+
+         The following problems can occur:
+         - If a column in columns is not in the input table, a
+           `Missing_Input_Columns`.
+         - If duplicate columns, names or indices are provided, a
+           `Duplicate_Column_Selectors`.
+         - If a column index is out of range, a `Column_Indexes_Out_Of_Range`.
+         - If two distinct indices would refer to the same column, a
+           `Input_Indices_Already_Matched`, indicating that the additional
+           indices will not introduce additional columns.
+         - If any of the new names are invalid, an
+           `Invalid_Output_Column_Names`.
+         - If any of the new names clash either with existing names or each
+           other, a Duplicate_Output_Column_Names.
+       - warnings: A `Warning_System` instance specifying how to handle
+         warnings. This is a temporary workaround to allow for testing the
+         warning mechanism. Once the proper warning system is implemented, this
+         argument will become obsolete and will be removed. No user code should
+         use this argument, as it will be removed in the future.
+
+       > Example
+         Rename the column based on the first row
+
+              table.use_first_row_as_names
+    use_first_row_as_names : Problem_Behavior -> Warnings.Warning_System -> Table
+    use_first_row_as_names (on_problems=Report_Warning) (warnings=Warnings.default) =
+        new_names = this.columns.map col->(col.at 0).to_text
+        this.take_end (this.length - 1) . rename_columns (Column_Mapping.By_Position new_names) on_problems=on_problems warnings=warnings
+
     ## ALIAS Filter Rows
        ALIAS Mask Columns
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -463,6 +463,9 @@ type Table
          use this argument, as it will be removed in the future.
 
        > Example
+         Rename the first column to "FirstColumn"
+
+              table.rename_columns (Column_Mapping.By_Position ["FirstColumn"])
     rename_columns : Column_Mapping -> Problem_Behavior -> Warnings.Warning_System -> Table
     rename_columns (column_map=(Column_Mapping.By_Position ["Column"])) (on_problems=Report_Warning) (warnings=Warnings.default) =
         new_names = Table_Helpers.rename_columns internal_columns=this.columns mapping=column_map on_problems=on_problems warnings=warnings

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -464,10 +464,10 @@ type Table
 
        > Example
     rename_columns : Column_Mapping -> Problem_Behavior -> Warnings.Warning_System -> Table
-    rename_columns (column_map=Column_Mapping.By_Position ["Column"]) (on_problems = Report_Warning) (warnings = Warnings.default) =
+    rename_columns (column_map=(Column_Mapping.By_Position ["Column"])) (on_problems=Report_Warning) (warnings=Warnings.default) =
         new_names = Table_Helpers.rename_columns internal_columns=this.columns mapping=column_map on_problems=on_problems warnings=warnings
-        new_columns = this.columns.map_with_index i->c->(c.rename (new_names.at i) . java_column)
-        Table new_columns
+        new_columns = this.columns.map_with_index i->c->(c.rename (new_names.at i))
+        here.new new_columns
 
     ## ALIAS Filter Rows
        ALIAS Mask Columns

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -505,7 +505,13 @@ type Table
               table.use_first_row_as_names
     use_first_row_as_names : Problem_Behavior -> Warnings.Warning_System -> Table
     use_first_row_as_names (on_problems=Report_Warning) (warnings=Warnings.default) =
-        new_names = this.columns.map col->(col.at 0).to_text
+        mapper = col->
+            val = col.at 0
+            case val of
+                Text -> val
+                Nothing -> Nothing
+                _ -> val.to_text
+        new_names = this.columns.map mapper
         this.take_end (this.length - 1) . rename_columns (Column_Mapping.By_Position new_names) on_problems=on_problems warnings=warnings
 
     ## ALIAS Filter Rows

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Error.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Error.enso
@@ -24,8 +24,18 @@ type Too_Many_Column_Names_Provided (column_names : [Text])
 ## One or more column names were invalid during a rename operation.
 type Invalid_Output_Column_Names (column_names : [Text])
 
+Invalid_Output_Column_Names.to_display_text : Text
+Invalid_Output_Column_Names.to_display_text = case this.column_names.length == 1 of
+    True -> "The name " + (this.column_names.at 0).to_text + " is invalid."
+    False -> "The names "+this.column_names.short_display_text+" are invalid."
+
 ## One or more column names clashed during a rename operation.
 type Duplicate_Output_Column_Names (column_names : [Text])
+
+Duplicate_Output_Column_Names.to_display_text : Text
+Duplicate_Output_Column_Names.to_display_text = case this.column_names.length == 1 of
+    True -> "The name " + (this.column_names.at 0).to_text + " was repeated in the output, so was renamed."
+    False -> "The names "+this.column_names.short_display_text+" were repeated in the output, and were renamed."
 
 ## No columns in the output result.
 type No_Output_Columns

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Error.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Error.enso
@@ -21,6 +21,10 @@ Column_Indexes_Out_Of_Range.to_display_text = case this.indexes.length == 1 of
    Can occur when using By_Position.
 type Too_Many_Column_Names_Provided (column_names : [Text])
 
+Too_Many_Column_Names_Provided.to_display_text : Text
+Too_Many_Column_Names_Provided.to_display_text =
+    "Too many column names provided. " + (this.column_names.at 0).to_text + " unused."
+
 ## One or more column names were invalid during a rename operation.
 type Invalid_Output_Column_Names (column_names : [Text])
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -114,9 +114,31 @@ reorder_columns internal_columns selector position on_problems warnings =
         Position.After_Other_Columns -> other_columns + selection
     result
 
+## PRIVATE
+   A helper function encapsulating shared code for `rename_columns`
+   implementations of various Table variants. See the documentation for the
+   Table type for details.
+
+   It takes a list of columns and a mapping, and returns the complete new set
+   of column names which should be applied to the table. It is the
+   responsibility of each implementation to reconstruct a proper table from the
+   resulting list of names.
+
+   Arguments:
+   - internal_columns: A list of all columns in a table.
+   - mapping: A selector specifying which columns should be moved and the order
+     in which they should appear in the result.
+   - on_problems: Specifies the behavior when a problem occurs during the
+     operation. By default, a warning is issued, but the operation proceeds.
+     If set to `Report_Error`, the operation fails with a dataflow error.
+     If set to `Ignore`, the operation proceeds without errors or warnings.
+   - warnings: A Warning_System instance specifying how to handle warnings. This
+     is a temporary workaround to allow for testing the warning mechanism. Once
+     the proper warning system is implemented, this argument will become
+     obsolete and will be removed. No user code should use this argument, as it
+     will be removed in the future.
 rename_columns : Vector -> Column_Mapping -> Problem_Behavior -> Warnings.Warning_System -> Map
 rename_columns internal_columns mapping on_problems warnings =
-    # ToDo: Use .name on internal_columns
     # ToDo: RegEx Baby
     # ToDo: Invalid Name Errors ==> Column
 
@@ -131,18 +153,19 @@ rename_columns internal_columns mapping on_problems warnings =
     col_count = internal_columns.length
 
     mapped = case mapping of
-        Column_Mapping.By_Column map ->
-            output = here.rename_columns internal_columns (Column_Mapping.By_Name (map.transform k->v->[k.Name, v]) (Matching.Exact case_sensitivity=True)) on_problems warnings
+        Column_Mapping.By_Column vec ->
+            map = Map.from_vector (vec.map r-> [r.at 0 . name, r.at 1])
+            output = here.rename_columns internal_columns (Column_Mapping.By_Name map (Matching.Exact case_sensitivity=True)) on_problems warnings
             Validation_Result output []
         Column_Mapping.By_Name map ms ->
             keys = map.keys
             mapper = name->
-                index = keys.find k->(Matching.match_single_criterion name k ms)
+                index = 0.up_to col_count . find k->(Matching.match_single_criterion name k ms)
                 case index of
                     Nothing -> Nothing
                     _ -> make_unique (map.get (keys.at index))
 
-            new_names = 0.up_to col_count . map i->(mapper (internal_columns.at i))
+            new_names = 0.up_to col_count . map i->(mapper (internal_columns.at i).name)
             Validation_Result new_names []
         Column_Mapping.By_Index map ->
             validation = here.validate_indices col_count map.keys
@@ -161,11 +184,11 @@ rename_columns internal_columns mapping on_problems warnings =
                 False -> Validation_Result vec []
             good_names = validation.valid
 
-            new_names = 0.up_to col_count . map i->if i < good_names.length then good_names.at i else make_unique (internal_columns.at i)
+            new_names = 0.up_to col_count . map i->if i < good_names.length then good_names.at i else Nothing
             Validation_Result new_names validation.problems
 
     processed = mapped.valid.map_with_index i->n->
-        if n.is_nothing then (make_unique (internal_columns.at i)) else n
+        if n.is_nothing then (make_unique (internal_columns.at i).name) else n
 
     problems = mapped.problems + (if renames.length == 0 then [] else [Duplicate_Output_Column_Names renames.to_vector])
     on_problems.attach_problems_before problems warnings processed
@@ -273,13 +296,13 @@ select_indices_preserving_order vector indices =
    If the negative index is sufficiently large, a negative result can still be
    returned. This function does not ensure that the resulting indices are within
    bounds.
-resolve_index Integer->Integer->Integer
+resolve_index : Integer->Integer->Integer
 resolve_index length ix =
     if ix < 0 then length+ix else ix
 
 ## PRIVATE
    Checks if the given index is in the valid range for the provided vector.
-is_index_valid Integer->Integer->Boolean
+is_index_valid : Integer->Integer->Boolean
 is_index_valid length ix =
     actual_ix = here.resolve_index length ix
     actual_ix>=0 && actual_ix<length

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -6,7 +6,9 @@ from Standard.Table.Data.Column_Selector as Column_Selector_Module import Column
 from Standard.Table.Data.Sort_Method as Sort_Method_Module import Sort_Method
 from Standard.Base.Error.Problem_Behavior as Problem_Behavior_Module import Problem_Behavior, Report_Warning
 import Standard.Table.Data.Position
-from Standard.Table.Error as Error_Module import Missing_Input_Columns, Column_Indexes_Out_Of_Range, No_Output_Columns, Duplicate_Column_Selectors, Input_Indices_Already_Matched
+from Standard.Table.Error as Error_Module import Missing_Input_Columns, Column_Indexes_Out_Of_Range, No_Output_Columns, Duplicate_Column_Selectors, Input_Indices_Already_Matched, Too_Many_Column_Names_Provided, Duplicate_Output_Column_Names
+import Standard.Table.Data.Column_Mapping
+import Standard.Table.Internal.Unique_Name_Strategy
 import Standard.Base.Data.Ordering.Natural_Order
 
 ## PRIVATE
@@ -112,6 +114,64 @@ reorder_columns internal_columns selector position on_problems warnings =
         Position.After_Other_Columns -> other_columns + selection
     result
 
+rename_columns : Vector -> Column_Mapping -> Problem_Behavior -> Warnings.Warning_System -> Map
+rename_columns internal_columns mapping on_problems warnings =
+    # ToDo: Use .name on internal_columns
+    # ToDo: RegEx Baby
+    # ToDo: Invalid Name Errors ==> Column
+
+    unique = Unique_Name_Strategy.new
+    renames = Vector.new_builder
+
+    make_unique = target ->
+        new_target = unique.make_unique target
+        if target != new_target then renames.append target
+        new_target
+
+    col_count = internal_columns.length
+
+    mapped = case mapping of
+        Column_Mapping.By_Column map ->
+            output = here.rename_columns internal_columns (Column_Mapping.By_Name (map.transform k->v->[k.Name, v]) (Matching.Exact case_sensitivity=True)) on_problems warnings
+            Validation_Result output []
+        Column_Mapping.By_Name map ms ->
+            keys = map.keys
+            mapper = name->
+                index = keys.find k->(Matching.match_single_criterion name k ms)
+                case index of
+                    Nothing -> Nothing
+                    _ -> make_unique (map.get (keys.at index))
+
+            new_names = 0.up_to col_count . map i->(mapper (internal_columns.at i))
+            Validation_Result new_names []
+        Column_Mapping.By_Index map ->
+            validation = here.validate_indices col_count map.keys
+            good_indices = validation.valid
+
+            index_map = Map.from_vector <| good_indices.map i->[i, map.get_or_else i (map.get (i - col_count))]
+
+            new_names = 0.up_to col_count . map i->
+                target = index_map.get_or_else i Nothing
+                if target.is_nothing then target else make_unique target
+
+            Validation_Result new_names validation.problems
+        Column_Mapping.By_Position vec ->
+            validation = case vec.length > col_count of
+                True -> Validation_Result (vec.take_start col_count) [Too_Many_Column_Names_Provided vec.drop_start col_count]
+                False -> Validation_Result vec []
+            good_names = validation.valid
+
+            new_names = 0.up_to col_count . map i->if i < good_names.length then good_names.at i else make_unique (internal_columns.at i)
+            Validation_Result new_names validation.problems
+
+    processed = mapped.valid.map_with_index i->n->
+        if n.is_nothing then (make_unique (internal_columns.at i)) else n
+
+    problems = mapped.problems + (if renames.length == 0 then [] else [Duplicate_Output_Column_Names renames.to_vector])
+    on_problems.attach_problems_before problems warnings processed
+
+
+
 ## PRIVATE
    A helper function encapsulating shared code for `sort_columns`
    implementations of various Table variants. See the documentation for the
@@ -163,37 +223,15 @@ sort_columns internal_columns sort_method =
 select_columns_helper : Vector -> Column_Selector -> Boolean -> Problem_Behavior -> Warnings.Warning_System -> Vector
 select_columns_helper internal_columns selector reorder on_problems warnings = case selector of
     By_Name names matching_strategy ->
-        split_result = here.split_to_distinct_and_duplicates names
-        distinct_names = split_result.first
-        duplicate_names = split_result.second
-        problems = if duplicate_names.is_empty then [] else
-            [Duplicate_Column_Selectors duplicate_names]
-        on_problems.attach_problems_before problems warnings <|
+        validation = here.validate_unique names v->[Duplicate_Column_Selectors v]
+        on_problems.attach_problems_before validation.problems warnings <|
             Warnings.map_warnings_and_errors here.promote_no_matches_to_missing_columns warnings warnings->
-                Matching.match_criteria internal_columns distinct_names reorder=reorder name_mapper=(_.name) matching_strategy=matching_strategy on_problems=on_problems warnings=warnings
+                Matching.match_criteria internal_columns validation.valid reorder=reorder name_mapper=(_.name) matching_strategy=matching_strategy on_problems=on_problems warnings=warnings
     By_Index indices ->
-        partitioned_indices = indices.partition (here.is_index_valid internal_columns)
-        inbound_indices = partitioned_indices.first
-        oob_indices = partitioned_indices.second
+        validation  = here.validate_indices internal_columns.length indices
+        good_indices = validation.valid
 
-        split_result = here.split_to_distinct_and_duplicates inbound_indices
-        duplicate_indices = split_result.second
-        distinct_indices = split_result.first
-
-        resolved_indices = distinct_indices.map ix-> Pair ix (here.resolve_index internal_columns ix)
-        alias_split_result = here.split_to_distinct_and_duplicates resolved_indices .second
-        aliasing_indices = alias_split_result.second.map .first
-        good_indices = alias_split_result.first.map .second
-
-        oob_problems = if oob_indices.is_empty then [] else
-            [Column_Indexes_Out_Of_Range oob_indices]
-        duplicate_problems = if duplicate_indices.is_empty then [] else
-            [Duplicate_Column_Selectors duplicate_indices]
-        aliasing_problems = if aliasing_indices.is_empty then [] else
-            [Input_Indices_Already_Matched aliasing_indices]
-        problems = oob_problems + duplicate_problems + aliasing_problems
-
-        on_problems.attach_problems_before problems warnings <| case reorder of
+        on_problems.attach_problems_before validation.problems warnings <| case reorder of
             True ->
                 here.select_indices_reordering internal_columns good_indices
             False ->
@@ -208,8 +246,7 @@ select_columns_helper internal_columns selector reorder on_problems warnings = c
    `Missing_Input_Columns`. Any other errors are returned as-is.
 promote_no_matches_to_missing_columns error = case error of
     Matching.No_Matches_Found criteria -> Missing_Input_Columns criteria
-    _ ->
-        error
+    _ -> error
 
 ## PRIVATE
    Selects element from the vector based on the given indices.
@@ -236,27 +273,54 @@ select_indices_preserving_order vector indices =
    If the negative index is sufficiently large, a negative result can still be
    returned. This function does not ensure that the resulting indices are within
    bounds.
-resolve_index vector ix =
-    if ix < 0 then vector.length+ix else ix
+resolve_index Integer->Integer->Integer
+resolve_index length ix =
+    if ix < 0 then length+ix else ix
 
 ## PRIVATE
    Checks if the given index is in the valid range for the provided vector.
-is_index_valid vector ix =
-    actual_ix = here.resolve_index vector ix
-    actual_ix>=0 && actual_ix<vector.length
+is_index_valid Integer->Integer->Boolean
+is_index_valid length ix =
+    actual_ix = here.resolve_index length ix
+    actual_ix>=0 && actual_ix<length
 
-type Repeated_Acc distinct_builder duplicate_builder existing
+## PRIVATE
+   Validates a Vector of indices returning a pair of `good_indices` and `problems`
+validate_indices : Integer -> Vector -> Validation_Result Vector Vector
+validate_indices length indices =
+    partitioned_indices = indices.partition (here.is_index_valid length)
+    inbound_indices = partitioned_indices.first
+    oob_indices = partitioned_indices.second
+    oob_problems = if oob_indices.is_empty then [] else
+        [Column_Indexes_Out_Of_Range oob_indices]
+
+    uniques = here.validate_unique inbound_indices v->[Duplicate_Column_Selectors v]
+
+    resolver = ix->(here.resolve_index length ix)
+    alias_uniques = here.validate_unique uniques.valid v->[Input_Indices_Already_Matched v] resolver
+    good_indices = alias_uniques.valid.map resolver
+
+    problems = oob_problems + uniques.problems + alias_uniques.problems
+
+    Validation_Result good_indices problems
 
 ## PRIVATE
    Splits a vector into elements which are distinct and the duplicates.
-split_to_distinct_and_duplicates : (Any -> Any) -> Vector -> Pair Vector Vector
-split_to_distinct_and_duplicates vector (on = x->x) =
-    acc = vector.fold (Repeated_Acc Vector.new_builder Vector.new_builder Map.empty) acc-> item->
+   Duplicates are wrapped as an error
+validate_unique : Vector -> (Vector -> Vector) -> (Any -> Any) -> Validation_Result Vector Vector
+validate_unique vector problem_wrapper on=(x->x) =
+    acc = vector.fold [Map.empty, Vector.new_builder, Vector.new_builder] acc-> item->
+        existing = acc.at 0
         key = on item
-        already_present = acc.existing.get_or_else key False
+        already_present = existing.get_or_else key False
         case already_present of
-            True ->
-                Repeated_Acc acc.distinct_builder (acc.duplicate_builder.append item) acc.existing
-            False ->
-                Repeated_Acc (acc.distinct_builder.append item) acc.duplicate_builder (acc.existing.insert key True)
-    Pair acc.distinct_builder.to_vector acc.duplicate_builder.to_vector
+            True -> [existing, acc.at 1, acc.at 2 . append item]
+            False -> [existing.insert key True, acc.at 1 . append item, acc.at 2]
+
+    duplicates = acc.at 2
+    problems = if duplicates.length == 0 then [] else problem_wrapper duplicates.to_vector
+
+    Validation_Result (acc.at 1).to_vector problems
+
+## PRIVATE
+type Validation_Result valid problems

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -11,6 +11,8 @@ import Standard.Table.Data.Column_Mapping
 import Standard.Table.Internal.Unique_Name_Strategy
 import Standard.Base.Data.Ordering.Natural_Order
 
+polyglot java import java.util.HashSet
+
 ## PRIVATE
    A helper function encapsulating shared code for `select_columns`
    implementations of various Table variants. See the documentation for the
@@ -143,14 +145,16 @@ rename_columns internal_columns mapping on_problems warnings =
     col_count = internal_columns.length
 
     name_mapper vec ms =
-        validation = here.validate_unique vec v->[Duplicate_Column_Selectors v] x->(x.at 1)
+        validation = here.validate_unique vec v->[Duplicate_Column_Selectors (v.map c->(c.at 0))] x->(x.at 0)
         good_names = validation.valid
+        matched = HashSet.new
 
         mapper = name->
             index = 0.up_to good_names.length . find i->(Matching.match_single_criterion name ((good_names.at i).at 0) ms)
             case index of
                 Nothing -> Nothing
                 _ ->
+                    matched.add index
                     new_name = case ms of
                         Matching.Regex _ ->
                             pattern = ms.compile ((good_names.at index).at 0)
@@ -159,7 +163,9 @@ rename_columns internal_columns mapping on_problems warnings =
                     unique.make_unique new_name
 
         new_names = 0.up_to col_count . map i->(mapper (internal_columns.at i).name)
-        Validation_Result new_names validation.problems
+        unused = good_names.filter_with_index i->_->(matched.contains i).not . map e->(e.at 0)
+
+        Validation_Result new_names (validation.problems + if unused.is_empty then [] else [Missing_Input_Columns unused])
 
     mapped = case mapping of
         Column_Mapping.By_Column vec -> name_mapper (vec.map r-> [r.at 0 . name, r.at 1]) (Matching.Exact case_sensitivity=True)
@@ -168,7 +174,7 @@ rename_columns internal_columns mapping on_problems warnings =
             validation = here.validate_indices col_count map.keys
             good_indices = validation.valid
 
-            index_map = Map.from_vector <| good_indices.map i->[i, map.get_or_else i (map.get (i - col_count))]
+            index_map = Map.from_vector <| good_indices.map p->[p.at 0, map.get (p.at 1)]
 
             new_names = 0.up_to col_count . map i->
                 target = index_map.get_or_else i Nothing
@@ -177,7 +183,7 @@ rename_columns internal_columns mapping on_problems warnings =
             Validation_Result new_names validation.problems
         Column_Mapping.By_Position vec ->
             validation = case vec.length > col_count of
-                True -> Validation_Result (vec.take_start col_count) [Too_Many_Column_Names_Provided vec.drop_start col_count]
+                True -> Validation_Result (vec.take_start col_count) [Too_Many_Column_Names_Provided (vec.drop_start col_count)]
                 False -> Validation_Result vec []
             good_names = validation.valid
 
@@ -188,9 +194,9 @@ rename_columns internal_columns mapping on_problems warnings =
     processed = mapped.valid.map_with_index i->n->
         if n.is_nothing then (unique.make_unique (internal_columns.at i).name) else n
 
-    problems = mapped.problems +
-        (if unique.invalid_names.length == 0 then [] else [Invalid_Output_Column_Names unique.invalid_names.to_vector]) +
-        (if unique.renames.length == 0 then [] else [Duplicate_Output_Column_Names unique.renames.to_vector])
+    invalid_names = (if unique.invalid_names.length == 0 then [] else [Invalid_Output_Column_Names unique.invalid_names.to_vector])
+    duplicate_names = (if unique.renames.length == 0 then [] else [Duplicate_Output_Column_Names unique.renames.to_vector])
+    problems = mapped.problems + invalid_names + duplicate_names
 
     on_problems.attach_problems_before problems warnings processed
 
@@ -252,7 +258,7 @@ select_columns_helper internal_columns selector reorder on_problems warnings = c
                 Matching.match_criteria internal_columns validation.valid reorder=reorder name_mapper=(_.name) matching_strategy=matching_strategy on_problems=on_problems warnings=warnings
     By_Index indices ->
         validation  = here.validate_indices internal_columns.length indices
-        good_indices = validation.valid
+        good_indices = validation.valid.map p->(p.at 0)
 
         on_problems.attach_problems_before validation.problems warnings <| case reorder of
             True ->
@@ -321,7 +327,7 @@ validate_indices length indices =
 
     resolver = ix->(here.resolve_index length ix)
     alias_uniques = here.validate_unique uniques.valid v->[Input_Indices_Already_Matched v] resolver
-    good_indices = alias_uniques.valid.map resolver
+    good_indices = alias_uniques.valid.map i->[resolver i, i]
 
     problems = oob_problems + uniques.problems + alias_uniques.problems
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -6,7 +6,7 @@ from Standard.Table.Data.Column_Selector as Column_Selector_Module import Column
 from Standard.Table.Data.Sort_Method as Sort_Method_Module import Sort_Method
 from Standard.Base.Error.Problem_Behavior as Problem_Behavior_Module import Problem_Behavior, Report_Warning
 import Standard.Table.Data.Position
-from Standard.Table.Error as Error_Module import Missing_Input_Columns, Column_Indexes_Out_Of_Range, No_Output_Columns, Duplicate_Column_Selectors, Input_Indices_Already_Matched, Too_Many_Column_Names_Provided, Duplicate_Output_Column_Names
+from Standard.Table.Error as Error_Module import Missing_Input_Columns, Column_Indexes_Out_Of_Range, No_Output_Columns, Duplicate_Column_Selectors, Input_Indices_Already_Matched, Too_Many_Column_Names_Provided, Duplicate_Output_Column_Names, Invalid_Output_Column_Names
 import Standard.Table.Data.Column_Mapping
 import Standard.Table.Internal.Unique_Name_Strategy
 import Standard.Base.Data.Ordering.Natural_Order
@@ -139,34 +139,31 @@ reorder_columns internal_columns selector position on_problems warnings =
      will be removed in the future.
 rename_columns : Vector -> Column_Mapping -> Problem_Behavior -> Warnings.Warning_System -> Map
 rename_columns internal_columns mapping on_problems warnings =
-    # ToDo: RegEx Baby
-    # ToDo: Invalid Name Errors ==> Column
-
     unique = Unique_Name_Strategy.new
-    renames = Vector.new_builder
-
-    make_unique = target ->
-        new_target = unique.make_unique target
-        if target != new_target then renames.append target
-        new_target
-
     col_count = internal_columns.length
 
-    mapped = case mapping of
-        Column_Mapping.By_Column vec ->
-            map = Map.from_vector (vec.map r-> [r.at 0 . name, r.at 1])
-            output = here.rename_columns internal_columns (Column_Mapping.By_Name map (Matching.Exact case_sensitivity=True)) on_problems warnings
-            Validation_Result output []
-        Column_Mapping.By_Name map ms ->
-            keys = map.keys
-            mapper = name->
-                index = 0.up_to col_count . find k->(Matching.match_single_criterion name k ms)
-                case index of
-                    Nothing -> Nothing
-                    _ -> make_unique (map.get (keys.at index))
+    name_mapper vec ms =
+        validation = here.validate_unique vec v->[Duplicate_Column_Selectors v] x->(x.at 1)
+        good_names = validation.valid
 
-            new_names = 0.up_to col_count . map i->(mapper (internal_columns.at i).name)
-            Validation_Result new_names []
+        mapper = name->
+            index = 0.up_to good_names.length . find i->(Matching.match_single_criterion name ((good_names.at i).at 0) ms)
+            case index of
+                Nothing -> Nothing
+                _ ->
+                    new_name = case ms of
+                        Matching.Regex _ ->
+                            pattern = ms.compile ((good_names.at index).at 0)
+                            pattern.replace name (good_names.at index).at 1
+                        _ -> (good_names.at index).at 1
+                    unique.make_unique new_name
+
+        new_names = 0.up_to col_count . map i->(mapper (internal_columns.at i).name)
+        Validation_Result new_names validation.problems
+
+    mapped = case mapping of
+        Column_Mapping.By_Column vec -> name_mapper (vec.map r-> [r.at 0 . name, r.at 1]) (Matching.Exact case_sensitivity=True)
+        Column_Mapping.By_Name map ms -> name_mapper map.to_vector ms
         Column_Mapping.By_Index map ->
             validation = here.validate_indices col_count map.keys
             good_indices = validation.valid
@@ -175,7 +172,7 @@ rename_columns internal_columns mapping on_problems warnings =
 
             new_names = 0.up_to col_count . map i->
                 target = index_map.get_or_else i Nothing
-                if target.is_nothing then target else make_unique target
+                if target.is_nothing then target else unique.make_unique target
 
             Validation_Result new_names validation.problems
         Column_Mapping.By_Position vec ->
@@ -184,15 +181,18 @@ rename_columns internal_columns mapping on_problems warnings =
                 False -> Validation_Result vec []
             good_names = validation.valid
 
-            new_names = 0.up_to col_count . map i->if i < good_names.length then good_names.at i else Nothing
+            new_names = 0.up_to col_count . map i->if i>=good_names.length then Nothing else
+                unique.make_unique (good_names.at i)
             Validation_Result new_names validation.problems
 
     processed = mapped.valid.map_with_index i->n->
-        if n.is_nothing then (make_unique (internal_columns.at i).name) else n
+        if n.is_nothing then (unique.make_unique (internal_columns.at i).name) else n
 
-    problems = mapped.problems + (if renames.length == 0 then [] else [Duplicate_Output_Column_Names renames.to_vector])
+    problems = mapped.problems +
+        (if unique.invalid_names.length == 0 then [] else [Invalid_Output_Column_Names unique.invalid_names.to_vector]) +
+        (if unique.renames.length == 0 then [] else [Duplicate_Output_Column_Names unique.renames.to_vector])
+
     on_problems.attach_problems_before problems warnings processed
-
 
 
 ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -154,7 +154,7 @@ rename_columns internal_columns mapping on_problems warnings =
                     new_name = case ms of
                         Matching.Regex _ ->
                             pattern = ms.compile ((good_names.at index).at 0)
-                            pattern.replace name (good_names.at index).at 1
+                            pattern.replace name ((good_names.at index).at 1)
                         _ -> (good_names.at index).at 1
                     unique.make_unique new_name
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Unique_Name_Strategy.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Unique_Name_Strategy.enso
@@ -1,17 +1,82 @@
 from Standard.Base import all
 
+## Creates a new Unique_Name_Strategy instance.
+
+   This is a mutable data structure, that allows for creating a collection
+   of columns names and making them unique. It will track any duplicates or
+   invalid names thet are passed to it.
+
+   > Example
+     Construct a set of unique names from two duplicate lists
+
+         unique_name_strategy = Unique_Name_Strategy.new
+         unique_names = ["A","B","A",""] . map unique_name_strategy.make_unique
+         duplicates = unique_name_strategy.renames
+         invalid = unique_name_strategy.invalid_names
 new : Unique_Name_Strategy
 new = Unique_Name_Strategy.new
 
 type Unique_Name_Strategy
-    type Unique_Name_Strategy store
+    ## PRIVATE
+       Creates a Unique_Name_Strategy
 
+       Arguments:
+       - store: Backing store for used names (must support get_or_else and insert)
+       - renames: Vector builder for any duplicates renamed (must support append)
+       - invalid_names: Vector builder for any invalid names (must support append)
+    type Unique_Name_Strategy store renames invalid_names
+
+    ## Creates a new strategy object.
+
+       > Example
+         Make a new strategy
+
+             Unique_Name_Strategy.new
     new : Unique_Name_Strategy
-    new = Unique_Name_Strategy Map.empty
+    new = Unique_Name_Strategy Map.empty Vector.new_builder Vector.new_builder
 
+    ## Takes a value and converts to a valid (but not necessarily unique) name
+
+       Arguments:
+       - name: The column name to make valid.
+
+       > Example
+             strategy = Unique_Name_Strategy.new
+             strategy.make_valid_name "" # returns "Column"
+             strategy.make_valid_name 1 # returns "1"
+             strategy.make_valid_name "Hello" # returns "Hello"
+    make_valid_name : Any -> Text
+    make_valid_name input =
+        case input of
+            Text ->
+                if input.is_empty.not then input else
+                    this.invalid_names.append ""
+                    "Column"
+            Nothing -> this.make_valid_name ""
+            _ -> this.make_valid_name input.to_text
+
+    ## Takes a name and gets a unique version
+
+       Arguments:
+       - name: The column name to make unique.
+
+       > Example
+             strategy = Unique_Name_Strategy.new
+             strategy.make_unique "A" # returns "A"
+             strategy.make_unique "A" # returns "A_1"
     make_unique : Text -> Text
-    make_unique name = this.internal_unique name 0
+    make_unique name =
+        valid_name = this.make_valid_name name
+        unique = this.internal_unique valid_name 0
+        if valid_name != unique then (this.renames.append name)
+        unique
 
+    ## PRIVATE
+       Follows the strategy to find a valid unique name.
+
+       Arguments:
+       - name: The column name to make unique.
+       - shift: The current index added to the name.
     internal_unique : Text -> Integer -> Text
     internal_unique name shift =
         inner_name = if shift == 0 then name else (name + "_"+ shift.to_text)

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Unique_Name_Strategy.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Unique_Name_Strategy.enso
@@ -1,0 +1,24 @@
+from Standard.Base import all
+
+new : Unique_Name_Strategy
+new = Unique_Name_Strategy.new
+
+type Unique_Name_Strategy
+    type Unique_Name_Strategy store
+
+    new : Unique_Name_Strategy
+    new = Unique_Name_Strategy Map.empty
+
+    make_unique : Text -> Text
+    make_unique name = this.internal_unique name 0
+
+    internal_unique : Text -> Integer -> Text
+    internal_unique name shift =
+        inner_name = if shift == 0 then name else (name + "_"+ shift.to_text)
+        case this.store.get_or_else inner_name False of
+            False ->
+                new_store = this.store.insert inner_name True
+                Unsafe.set_atom_field this 0 new_store
+                inner_name
+            True ->
+                @Tail_Call this.internal_unique name (shift+1)

--- a/std-bits/base/src/main/java/org/enso/base/Regex_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/Regex_Utils.java
@@ -1,6 +1,7 @@
 package org.enso.base;
 
 import java.util.ArrayList;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class Regex_Utils {
@@ -51,5 +52,22 @@ public class Regex_Utils {
     }
 
     return names.toArray(new String[0]);
+  }
+
+  /**
+   * Looks for matches of the provided regular expression in the provided text.
+   *
+   * <p>This should behave exactly the same as `Regex.compile regex . find text` in Enso, it is here
+   * only as a temporary workaround, because the Enso function gives wrong results on examples like
+   * `Regex.compile "([0-9]+|[^0-9]+)" . find "1a2c"` where it returns `[1, a, 2]` instead of
+   * `[1, a, 2, c]`.
+   */
+  public static String[] find_all_matches(String regex, String text) {
+    var allMatches = new ArrayList<String>();
+    Matcher m = Pattern.compile(regex).matcher(text);
+    while (m.find()) {
+      allMatches.add(m.group());
+    }
+    return allMatches.toArray(new String[0]);
   }
 }

--- a/test/Table_Tests/src/Common_Table_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Spec.enso
@@ -403,3 +403,18 @@ spec prefix table_builder supports_case_sensitive_columns =
             map = Map.from_vector [[0, "FirstColumn"], [-2, "Another"]]
             expect_column_names ["FirstColumn", "beta", "Another", "delta"] <|
                 table.rename_columns (Column_Mapping.By_Index map)
+
+        Test.specify "should work by position" <|
+            vec = ["one", "two", "three"]
+            expect_column_names ["one", "two", "three", "delta"] <|
+                table.rename_columns (Column_Mapping.By_Position vec)
+
+        Test.specify "should work by name" <|
+            map = Map.from_vector [["alpha", "FirstColumn"], ["delta", "Another"]]
+            expect_column_names ["FirstColumn", "beta", "gamma", "Another"] <|
+                table.rename_columns (Column_Mapping.By_Name map (Matching.Exact True))
+
+        Test.specify "should work by name case insensitively" <|
+            map = Map.from_vector [["ALPHA", "FirstColumn"], ["DELTA", "Another"]]
+            expect_column_names ["FirstColumn", "beta", "gamma", "Another"] <|
+                table.rename_columns (Column_Mapping.By_Name map (Matching.Exact Matching.Case_Insensitive))

--- a/test/Table_Tests/src/Common_Table_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Spec.enso
@@ -359,6 +359,7 @@ spec prefix table_builder supports_case_sensitive_columns =
             problems = [Column_Indexes_Out_Of_Range [100], Duplicate_Column_Selectors [0], Input_Indices_Already_Matched [-7]]
             tester = expect_column_names ["bar", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123", "foo"]
             Problems.test_problem_handling action problems tester
+
     Test.group prefix+"Table.sort_columns" <|
         table =
             col1 = ["foo_21", Integer, [1,2,3]]
@@ -418,3 +419,75 @@ spec prefix table_builder supports_case_sensitive_columns =
             map = Map.from_vector [["ALPHA", "FirstColumn"], ["DELTA", "Another"]]
             expect_column_names ["FirstColumn", "beta", "gamma", "Another"] <|
                 table.rename_columns (Column_Mapping.By_Name map (Matching.Exact Matching.Case_Insensitive))
+
+        Test.specify "should work by name using regex" <|
+            map = Map.from_vector [["a.*", "FirstColumn"]]
+            expect_column_names ["FirstColumn", "beta", "gamma", "delta"] <|
+                table.rename_columns (Column_Mapping.By_Name map (Matching.Regex.new))
+
+        Test.specify "should work by name using regex substitution" <|
+            map = Map.from_vector [["a(.*)", "$1"]]
+            expect_column_names ["lpha", "beta", "gamma", "delta"] <|
+                table.rename_columns (Column_Mapping.By_Name map (Matching.Regex.new))
+
+        Test.specify "should work by column" <|
+            vec = [[table.at "alpha", "FirstColumn"], [table.at "delta", "Another"]]
+            expect_column_names ["FirstColumn", "beta", "gamma", "Another"] <|
+                table.rename_columns (Column_Mapping.By_Column vec)
+
+        Test.specify "should correctly handle problems: duplicate columns" <|
+            map = Column_Mapping.By_Column [[table.at "alpha", "FirstColumn"], [table.at "alpha", "Another"]]
+            action = table.rename_columns map warnings=_ on_problems=_
+            tester = expect_column_names ["FirstColumn", "beta", "gamma", "delta"]
+            problems = [Duplicate_Column_Selectors ["alpha"]]
+            Problems.test_problem_handling action problems tester
+
+        Test.specify "should correctly handle problems: unmatched names" <|
+            weird_name = '.*?-!@#!"'
+            map = Column_Mapping.By_Name.new (Map.from_vector [["alpha", "FirstColumn"], ["omicron", "Another"], [weird_name, "Fixed"]])
+            action = table.rename_columns map warnings=_ on_problems=_
+            tester = expect_column_names ["FirstColumn", "beta", "gamma", "delta"]
+            problems = [Missing_Input_Columns [weird_name, "omicron"]]
+            Problems.test_problem_handling action problems tester
+
+        Test.specify "should correctly handle problems: out of bounds indices" <|
+            map = Column_Mapping.By_Index (Map.from_vector [[0, "FirstColumn"], [-1, "Another"], [100, "Boo"], [-200, "Nothing"], [300, "Here"]])
+            action = table.rename_columns map warnings=_ on_problems=_
+            tester = expect_column_names ["FirstColumn", "beta", "gamma", "Another"]
+            problems = [Column_Indexes_Out_Of_Range [-200, 100, 300]]
+            Problems.test_problem_handling action problems tester
+
+        Test.specify "should correctly handle problems: aliased indices" <|
+            map = Column_Mapping.By_Index (Map.from_vector [[1, "FirstColumn"], [-3, "Another"]])
+            action = table.rename_columns map warnings=_ on_problems=_
+            tester = expect_column_names ["alpha", "Another", "gamma", "delta"]
+            problems = [Input_Indices_Already_Matched [1]]
+            Problems.test_problem_handling action problems tester
+
+        Test.specify "should correctly handle problems: invalid names ''" <|
+            map = Column_Mapping.By_Index (Map.from_vector [[1, ""]])
+            action = table.rename_columns map warnings=_ on_problems=_
+            tester = expect_column_names ["alpha", "Column", "gamma", "delta"]
+            problems = [Invalid_Output_Column_Names [""]]
+            Problems.test_problem_handling action problems tester
+
+        Test.specify "should correctly handle problems: invalid names Nothing" <|
+            map = Column_Mapping.By_Position ["alpha", Nothing]
+            action = table.rename_columns map warnings=_ on_problems=_
+            tester = expect_column_names ["alpha", "Column", "gamma", "delta"]
+            problems = [Invalid_Output_Column_Names [""]]
+            Problems.test_problem_handling action problems tester
+
+        Test.specify "should correctly handle problems: duplicate names" <|
+            map = Column_Mapping.By_Position ["Test", "Test", "Test", "Test"]
+            action = table.rename_columns map warnings=_ on_problems=_
+            tester = expect_column_names ["Test", "Test_1", "Test_2", "Test_3"]
+            problems = [Duplicate_Output_Column_Names ["Test", "Test", "Test"]]
+            Problems.test_problem_handling action problems tester
+
+        Test.specify "should correctly handle problems: too many input names" <|
+            map = Column_Mapping.By_Position ["A", "B", "C", "D", "E", "F"]
+            action = table.rename_columns map warnings=_ on_problems=_
+            tester = expect_column_names ["A", "B", "C", "D"]
+            problems = [Too_Many_Column_Names_Provided ["E", "F"]]
+            Problems.test_problem_handling action problems tester

--- a/test/Table_Tests/src/Common_Table_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Spec.enso
@@ -5,6 +5,7 @@ import Standard.Test.Problems
 import Standard.Base.Error.Problem_Behavior
 import Standard.Base.Error.Warnings
 import Standard.Table.Data.Matching
+import Standard.Table.Data.Column_Mapping
 from Standard.Table.Data.Matching import Case_Insensitive
 from Standard.Table.Error as Table_Errors import all
 from Standard.Table.Data.Column_Selector as Column_Selector_Module import all
@@ -385,3 +386,20 @@ spec prefix table_builder supports_case_sensitive_columns =
 
         Test.specify "should correctly handle various combinations of options" <|
             expect_column_names ["foo_100", "foo_21", "foo_3", "Foo_2", "foo_1", "foo_001", "bar"] <| table.sort_columns (Sort_Method natural_order=True case_sensitive=Case_Insensitive order=Sort_Order.Descending)
+
+    Test.group prefix+"Table.rename_columns" <|
+        table =
+            col1 = ["alpha", Integer, [1,2,3]]
+            col2 = ["beta", Integer, [4,5,6]]
+            col3 = ["gamma", Integer, [16,17,18]]
+            col4 = ["delta", Integer, [19,20,21]]
+            table_builder [col1, col2, col3, col4]
+
+        Test.specify "should work as shown in the doc examples" <|
+            expect_column_names ["FirstColumn", "beta", "gamma", "delta"] <|
+                table.rename_columns (Column_Mapping.By_Position ["FirstColumn"])
+
+        Test.specify "should work by index" <|
+            map = Map.from_vector [[0, "FirstColumn"], [-2, "Another"]]
+            expect_column_names ["FirstColumn", "beta", "Another", "delta"] <|
+                table.rename_columns (Column_Mapping.By_Index map)

--- a/test/Table_Tests/src/Table_Spec.enso
+++ b/test/Table_Tests/src/Table_Spec.enso
@@ -3,9 +3,12 @@ from Standard.Table import all
 
 from Standard.Table.Data.Table as Table_Internal import Empty_Error
 
+import Standard.Base.Data.Time.Date
 import Standard.Table.Data.Storage
 import Standard.Test
+import Standard.Test.Problems
 import Standard.Visualization
+from Standard.Table.Error as Table_Errors import Invalid_Output_Column_Names, Duplicate_Output_Column_Names
 
 import project.Common_Table_Spec
 
@@ -636,5 +639,48 @@ spec =
         Table.new <| columns.map description-> [description.at 0, description.at 2]
 
     Common_Table_Spec.spec "" table_builder supports_case_sensitive_columns=True
+
+    Test.group "Use First Row As Names" <|
+        expect_column_names names table =
+            table.columns . map .name . should_equal names frames_to_skip=2
+
+        Test.specify "should work happily with mixed types" <|
+            c_0 = ['A', ["H", "B", "C"]]
+            c_1 = ['B', [Date.new 1980, Date.new 1979, Date.new 2000]]
+            c_2 = ['x', [1, 2, 3]]
+            c_3 = ['Y', [5.3, 56.2, 6.3]]
+            c_4 = ['Z', [True, False, True]]
+            table = Table.new [c_0, c_1, c_2, c_3, c_4]
+            expect_column_names ["H", "1980-01-01", "1", "5.3", "True"] <| table.use_first_row_as_names
+
+        Test.specify "should correctly handle problems: invalid names ''" <|
+            c_0 = ['A', ["", "B", "C"]]
+            c_2 = ['x', [1, 2, 3]]
+            table = Table.new [c_0, c_2]
+            action = table.use_first_row_as_names warnings=_ on_problems=_
+            tester = expect_column_names ["Column", "1"]
+            problems = [Invalid_Output_Column_Names [""]]
+            Problems.test_problem_handling action problems tester
+
+        Test.specify "should correctly handle problems: invalid names Nothing" <|
+            c_0 = ['A', ["A", "B", "C"]]
+            c_2 = ['x', [Nothing, 2, 3]]
+            table = Table.new [c_0, c_2]
+            action = table.use_first_row_as_names warnings=_ on_problems=_
+            tester = expect_column_names ["A", "Column"]
+            problems = [Invalid_Output_Column_Names [""]]
+            Problems.test_problem_handling action problems tester
+
+        Test.specify "should correctly handle problems: duplicate names" <|
+            c_0 = ['A', ["A", "B", "C"]]
+            c_1 = ['B', ["A", "B", "C"]]
+            c_2 = ['x', ["A", "B", "C"]]
+            c_3 = ['C', ["A", "B", "C"]]
+            table = Table.new [c_0, c_1, c_2, c_3]
+            action = table.use_first_row_as_names warnings=_ on_problems=_
+            tester = expect_column_names ["A", "A_1", "A_2", "A_3"]
+            problems = [Duplicate_Output_Column_Names ["A", "A", "A"]]
+            Problems.test_problem_handling action problems tester
+
 
 main = Test.Suite.run_main here.spec

--- a/test/Table_Tests/src/Unique_Naming_Strategy_Spec.enso
+++ b/test/Table_Tests/src/Unique_Naming_Strategy_Spec.enso
@@ -1,0 +1,42 @@
+from Standard.Base import all
+
+import Standard.Table.Internal.Unique_Name_Strategy
+import Standard.Test
+
+spec = Test.group 'Unique_Name_Strategy Helper' <|
+    Test.specify 'should change an empty name to "Column"' <|
+        strategy = Unique_Name_Strategy.new
+        strategy.make_valid_name "" . should_equal "Column"
+        strategy.invalid_names.length . should_equal 1
+
+    Test.specify 'should change Nothing to "Column"' <|
+        strategy = Unique_Name_Strategy.new
+        strategy.make_valid_name Nothing . should_equal "Column"
+        strategy.invalid_names.length . should_equal 1
+
+    Test.specify 'should not rename unique names' <|
+        strategy = Unique_Name_Strategy.new
+        strategy.make_unique "A" . should_equal "A"
+        strategy.make_unique "B" . should_equal "B"
+        strategy.make_unique "C" . should_equal "C"
+        strategy.renames.length . should_equal 0
+        strategy.invalid_names.length . should_equal 0
+
+    Test.specify 'should rename duplicates names' <|
+        strategy = Unique_Name_Strategy.new
+        strategy.make_unique "A" . should_equal "A"
+        strategy.make_unique "A" . should_equal "A_1"
+        strategy.make_unique "A" . should_equal "A_2"
+        strategy.renames.length . should_equal 2
+        strategy.invalid_names.length . should_equal 0
+
+    Test.specify 'should preserve existing suffix' <|
+        strategy = Unique_Name_Strategy.new
+        strategy.make_unique "A" . should_equal "A"
+        strategy.make_unique "A_1" . should_equal "A_1"
+        strategy.make_unique "A" . should_equal "A_2"
+        strategy.make_unique "A_1" . should_equal "A_1_1"
+        strategy.renames.length . should_equal 2
+        strategy.invalid_names.length . should_equal 0
+
+main = Test.Suite.run_main here.spec

--- a/test/Tests/src/Data/Range_Spec.enso
+++ b/test/Tests/src/Data/Range_Spec.enso
@@ -40,5 +40,8 @@ spec = Test.group "Range" <|
     Test.specify "should check any" <|
         1.up_to 10 . any (> 5) . should_be_true
         1.up_to 10 . any (> 10) . should_be_false
+    Test.specify "should find elements" <|
+        1.up_to 10 . find (> 5) . should_equal 6
+        1.up_to 10 . find (> 10) . should_be_a Nothing
     Test.specify "should allow conversion to vector" <|
         1.up_to 6 . to_vector . should_equal [1, 2, 3, 4, 5]


### PR DESCRIPTION
### Pull Request Description

Adding the `rename_columns` function to the `System.Table.Data.Table` and `System.DataBase.Data.Table` types.
Adding the `use_first_row_as_names` function to the `System.Table.Data.Table` type.

Closes https://www.pivotaltracker.com/story/show/181034927
Closes https://www.pivotaltracker.com/story/show/181034968 

### Important Notes

Implemented a Range.Find utility function to help with this. 
Some minor issues added to [bugs to investigate](https://docs.google.com/document/d/1T0BsYC-pn_dINT4r9GTXdGWKDkgRd89IwPCe2Ny4f9U/edit?usp=sharing) list.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- [x] All documentation and configuration conforms to the [markdown](https://github.com/enso-org/enso/blob/develop/docs/style-guide/markdown.md) and [YAML](https://github.com/enso-org/enso/blob/develop/docs/style-guide/yaml.md) style guides.
- [x] All code has been tested where possible.
