### PR TITLE
Revert "Restrict maximum zoom in Graph Editor (#3273)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 #### Visual Environment
 
-- [Maximum zoom factor is limited to 1.0x if IDE is not in Debug Mode.][3273]
 - [Debug Mode for Graph Editor can be activated/deactivated using a
   shortcut.][3264] It allows access to a set of restricted features. See
   [debug-shortcuts].
@@ -68,7 +67,6 @@
 [3269]: https://github.com/enso-org/enso/pull/3269
 [3271]: https://github.com/enso-org/enso/pull/3271
 [3259]: https://github.com/enso-org/enso/pull/3259
-[3273]: https://github.com/enso-org/enso/pull/3273
 [3276]: https://github.com/enso-org/enso/pull/3276
 [3283]: https://github.com/enso-org/enso/pull/3283
 [3282]: https://github.com/enso-org/enso/pull/3282

--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -92,7 +92,6 @@ const MACOS_TRAFFIC_LIGHTS_CONTENT_HEIGHT: f32 = 12.0;
 const MACOS_TRAFFIC_LIGHTS_SIDE_OFFSET: f32 = 13.0;
 const MACOS_TRAFFIC_LIGHTS_VERTICAL_CENTER: f32 =
     -MACOS_TRAFFIC_LIGHTS_SIDE_OFFSET - MACOS_TRAFFIC_LIGHTS_CONTENT_HEIGHT / 2.0;
-const MAX_ZOOM: f32 = 1.0;
 
 fn traffic_lights_gap_width() -> f32 {
     let is_macos = ARGS.platform.map(|p| p.is_macos()) == Some(true);
@@ -3388,16 +3387,10 @@ fn new_graph_editor(app: &Application) -> GraphEditor {
 
     frp::extend! { network
         out.source.debug_mode <+ frp.set_debug_mode;
-
-        limit_max_zoom <- frp.set_debug_mode.on_false();
-        unlimit_max_zoom <- frp.set_debug_mode.on_true();
-        eval_ limit_max_zoom (model.navigator.set_max_zoom(Some(MAX_ZOOM)));
-        eval_ unlimit_max_zoom (model.navigator.set_max_zoom(None));
     }
 
     // Init defaults
     frp.edit_mode_off.emit(());
-    frp.set_debug_mode.emit(false);
 
     GraphEditor { model, frp }
 }

--- a/lib/rust/ensogl/core/src/display/navigation/navigator.rs
+++ b/lib/rust/ensogl/core/src/display/navigation/navigator.rs
@@ -14,18 +14,6 @@ use events::ZoomEvent;
 
 
 
-// =================
-// === Constants ===
-// =================
-
-/// Default maximum zoom factor (100x). This value can be changed by
-/// [`NavigatorModel::set_max_zoom`].
-const DEFAULT_MAX_ZOOM: f32 = 100.0;
-/// Default minimum zoom factor (0.15x).
-const MIN_ZOOM: f32 = 0.001;
-
-
-
 // ======================
 // === NavigatorModel ===
 // ======================
@@ -41,32 +29,25 @@ pub struct NavigatorModel {
     /// Indicates whether events handled the navigator should be stopped from propagating further
     /// after being handled by the Navigator.
     disable_events:  Rc<Cell<bool>>,
-    max_zoom:        Rc<Cell<Option<f32>>>,
 }
 
 impl NavigatorModel {
     pub fn new(scene: &Scene, camera: &Camera2d) -> Self {
         let zoom_speed = Rc::new(Cell::new(Switch::On(10.0 / 1000.0)));
         let pan_speed = Rc::new(Cell::new(Switch::On(1.0)));
+        let min_zoom = 10.0;
+        let max_zoom = 10000.0;
         let disable_events = Rc::new(Cell::new(true));
-        let max_zoom: Rc<Cell<_>> = default();
         let (simulator, resize_callback, _events) = Self::start_navigator_events(
             scene,
             camera,
-            zoom_speed.clone_ref(),
-            pan_speed.clone_ref(),
-            disable_events.clone_ref(),
-            max_zoom.clone_ref(),
-        );
-        Self {
-            _events,
-            simulator,
-            resize_callback,
-            zoom_speed,
-            pan_speed,
-            disable_events,
+            min_zoom,
             max_zoom,
-        }
+            Rc::clone(&zoom_speed),
+            Rc::clone(&pan_speed),
+            Rc::clone(&disable_events),
+        );
+        Self { _events, simulator, resize_callback, zoom_speed, pan_speed, disable_events }
     }
 
     fn create_simulator(camera: &Camera2d) -> physics::inertia::DynSimulator<Vector3> {
@@ -83,23 +64,20 @@ impl NavigatorModel {
     fn start_navigator_events(
         scene: &Scene,
         camera: &Camera2d,
+        min_zoom: f32,
+        max_zoom: f32,
         zoom_speed: SharedSwitch<f32>,
         pan_speed: SharedSwitch<f32>,
         disable_events: Rc<Cell<bool>>,
-        max_zoom: Rc<Cell<Option<f32>>>,
     ) -> (physics::inertia::DynSimulator<Vector3>, callback::Handle, NavigatorEvents) {
-        let distance_to_zoom_factor_of_1 = |scene: &Scene, camera: &Camera2d| {
-            let fovy_slope = camera.half_fovy_slope();
-            scene.shape().value().height / 2.0 / fovy_slope
-        };
-
         let simulator = Self::create_simulator(camera);
-        let panning_callback = f!([scene,camera,simulator,pan_speed] (pan: PanEvent) {
-            let distance = camera.position().z;
-            let distance_to_zoom_factor_of_1 = distance_to_zoom_factor_of_1(&scene, &camera);
-            let pan_speed = pan_speed.get().into_on().unwrap_or(0.0);
-            let movement_scale_for_distance = distance / distance_to_zoom_factor_of_1;
-            let diff = pan_speed * Vector3::new(pan.movement.x, pan.movement.y, 0.0) * movement_scale_for_distance;
+        let panning_callback = enclose!((scene,camera,mut simulator,pan_speed) move |pan: PanEvent| {
+            let fovy_slope                  = camera.half_fovy_slope();
+            let distance                    = camera.position().z;
+            let distance_to_show_full_ui    = scene.shape().value().height / 2.0 / fovy_slope;
+            let pan_speed                   = pan_speed.get().into_on().unwrap_or(0.0);
+            let movement_scale_for_distance = distance / distance_to_show_full_ui;
+            let diff = pan_speed * Vector3::new(pan.movement.x,pan.movement.y,0.0)*movement_scale_for_distance;
             simulator.update_target_value(|p| p - diff);
         });
 
@@ -112,41 +90,29 @@ impl NavigatorModel {
             }),
         );
 
-        let zoom_callback = f!([scene,camera,simulator,max_zoom] (zoom:ZoomEvent) {
-            let point = zoom.focus;
-            let normalized = normalize_point2(point,scene.shape().value().into());
-            let normalized = normalized_to_range2(normalized, -1.0, 1.0);
+        let zoom_callback = enclose!((scene,camera,simulator) move |zoom:ZoomEvent| {
+            let point       = zoom.focus;
+            let normalized  = normalize_point2(point,scene.shape().value().into());
+            let normalized  = normalized_to_range2(normalized, -1.0, 1.0);
             let half_height = 1.0;
 
             // Scale X and Y to compensate aspect and fov.
-            let x = -normalized.x * camera.screen().aspect();
-            let y = -normalized.y;
-            let z = half_height / camera.half_fovy_slope();
-            let direction = Vector3(x, y, z).normalize();
-            let mut position = simulator.target_value();
-            let zoom_amount = zoom.amount * position.z;
-            let translation = direction * zoom_amount;
-
-            let distance_to_zoom_factor_of_1 = distance_to_zoom_factor_of_1(&scene, &camera);
-            let max_zoom = max_zoom.get().unwrap_or(DEFAULT_MAX_ZOOM);
-            // Usage of min/max prefixes might be confusing here. Remember that the max zoom means
-            // the maximum visible size, thus the minimal distance from the camera and vice versa.
-            let min_distance = distance_to_zoom_factor_of_1 / max_zoom + camera.clipping().near;
-            let max_distance = (distance_to_zoom_factor_of_1 / MIN_ZOOM).min(camera.clipping().far);
-
-            // Smothly limit camera movements along z-axis near min/max distance.
-            let positive_z_translation_limit = max_distance - position.z;
-            let negative_z_translation_limit = min_distance - position.z;
-            let too_far = translation.z > positive_z_translation_limit;
-            let too_close = translation.z < negative_z_translation_limit;
-            let z_axis_movement_limiting_factor = if too_far {
-                positive_z_translation_limit / translation.z
-            } else if too_close {
-                negative_z_translation_limit / translation.z
-            } else {
-                1.0
-            };
-            position += translation * z_axis_movement_limiting_factor;
+            let x              = -normalized.x * camera.screen().aspect();
+            let y              = -normalized.y;
+            let z              = half_height / camera.half_fovy_slope();
+            let direction      = Vector3(x,y,z).normalize();
+            let mut position   = simulator.target_value();
+            let min_zoom       = camera.clipping().near + min_zoom;
+            let zoom_amount    = zoom.amount * position.z;
+            let direction      = direction   * zoom_amount;
+            let max_zoom_limit = max_zoom - position.z;
+            let min_zoom_limit = min_zoom - position.z;
+            let too_far        = direction.z > max_zoom_limit;
+            let too_close      = direction.z < min_zoom_limit;
+            let zoom_factor    = if too_far   { max_zoom_limit / direction.z }
+                            else if too_close { min_zoom_limit / direction.z }
+                            else              { 1.0 };
+            position          += direction * zoom_factor;
             simulator.set_target_value(position);
         });
         (
@@ -173,12 +139,6 @@ impl NavigatorModel {
         self.pan_speed.update(|switch| switch.switched(false));
         self.zoom_speed.update(|switch| switch.switched(false));
         self.disable_events.set(false);
-    }
-
-    /// Enable or disable the restriction of maximum zoom factor. Enabling it does change camera
-    /// zoom immediately, but the restriction will be applied on the next zoom event.
-    pub fn set_max_zoom(&self, value: Option<f32>) {
-        self.max_zoom.set(value);
     }
 }
 


### PR DESCRIPTION
This reverts commit [dbcc2548dfa0069051df174911e5fe72f271b37c](https://github.com/enso-org/enso/commit/dbcc2548dfa0069051df174911e5fe72f271b37c).

### Pull Request Description

A new regression was introduced:
1. If you open a project
2. And you didn't do zooming (this is important)
3. If you select GeoMap visualization and zoom out
4. All non-DOM components (including nodes) disappear

This happens because of a number of accidents:
1. Default camera position is ever so slightly behind the max-zoom limit (by about 14 units). So on first ZoomEvent `too_close` boolean condition will return `true`. For non-default camera positions (for example, if you've already done some zooming) - the bug won't appear.
2. It seems like GeoMap visualization captures zoom events in a weird way - so we receive ZoomEvents with `amount = 0`.
3. Our code divides by zero in `z_axis_movement_limiting_factor` equation, which causes `NaN` value for camera position.

### Important Notes

### Checklist

Please include the following checklist in your PR:

- ~~The documentation has been updated if necessary.~~
- ~~All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.~~
- All code has been tested:
  - ~~Unit tests have been written where possible.~~
  - ~~If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.~~
