### PR TITLE
Increase WASM tests timeout

### DIFF
--- a/build/run.js
+++ b/build/run.js
@@ -253,6 +253,7 @@ commands.test.rust = async function (argv) {
             '--headless',
             '--chrome',
         ]
+        process.env.WASM_BINDGEN_TEST_TIMEOUT = 60
         await run_cargo('cargo', args)
     }
 }


### PR DESCRIPTION
[ci no changelog needed] 

### Pull Request Description

There's a hypothesis that the randomly occurring WASM test failures are due to quite short default timeout. In this PR it's  increased to 60 seconds. 

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- ~~[ ] The documentation has been updated if necessary.~~
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
~~  - [ ] Unit tests have been written where possible.~~
~~  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.~~
