### PR TITLE
Fix teardown for engine's testcases

### DIFF
--- a/engine/language-server/src/test/scala/org/enso/languageserver/filemanager/ContentRootManagerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/filemanager/ContentRootManagerSpec.scala
@@ -8,17 +8,16 @@ import org.enso.languageserver.filemanager.ContentRootManagerProtocol.{
   ContentRootsAddedNotification,
   SubscribeToNotifications
 }
-import org.apache.commons.io.FileUtils
 import org.enso.polyglot.runtime.Runtime.Api
-import org.enso.testkit.EitherValue
+import org.enso.testkit.{EitherValue, WithTemporaryDirectory}
 import org.scalatest.concurrent.Futures
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import org.scalatest.{BeforeAndAfterEach, Inside, OptionValues}
+import org.scalatest.{Inside, OptionValues}
 
 import java.io.File
-import java.nio.file.{Files, Path => JPath}
+import java.nio.file.{Path => JPath}
 import java.util.UUID
 import scala.concurrent.duration.DurationInt
 
@@ -30,19 +29,17 @@ class ContentRootManagerSpec
     with Inside
     with EitherValue
     with OptionValues
-    with BeforeAndAfterEach {
+    with WithTemporaryDirectory {
 
   var rootManager: ContentRootManagerWrapper = _
   var rootActor: ActorRef                    = _
-  var rootProjectDirectory: File             = _
 
   override def beforeEach(): Unit = {
-    rootProjectDirectory =
-      Files.createTempDirectory("root-manager-spec").toFile()
+    super.beforeEach()
 
     val root = ContentRootWithFile(
       ContentRoot.Project(UUID.randomUUID()),
-      rootProjectDirectory.getCanonicalFile
+      getTestDirectory.toFile.getCanonicalFile
     )
     val config = Config(
       root,
@@ -53,10 +50,6 @@ class ContentRootManagerSpec
     )
     rootActor   = system.actorOf(ContentRootManagerActor.props(config))
     rootManager = new ContentRootManagerWrapper(config, rootActor)
-  }
-
-  override def afterEach(): Unit = {
-    FileUtils.deleteDirectory(rootProjectDirectory)
   }
 
   "ContentRootManager" should {

--- a/engine/language-server/src/test/scala/org/enso/languageserver/filemanager/ContentRootManagerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/filemanager/ContentRootManagerSpec.scala
@@ -8,6 +8,7 @@ import org.enso.languageserver.filemanager.ContentRootManagerProtocol.{
   ContentRootsAddedNotification,
   SubscribeToNotifications
 }
+import org.apache.commons.io.FileUtils
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.testkit.EitherValue
 import org.scalatest.concurrent.Futures
@@ -18,7 +19,7 @@ import org.scalatest.{BeforeAndAfterEach, Inside, OptionValues}
 
 import java.io.File
 import java.nio.file.{Files, Path => JPath}
-import java.util.{Comparator, UUID}
+import java.util.UUID
 import scala.concurrent.duration.DurationInt
 
 class ContentRootManagerSpec
@@ -33,14 +34,15 @@ class ContentRootManagerSpec
 
   var rootManager: ContentRootManagerWrapper = _
   var rootActor: ActorRef                    = _
-  var rootProjectDirectory: JPath            = _
+  var rootProjectDirectory: File             = _
 
   override def beforeEach(): Unit = {
-    rootProjectDirectory = Files.createTempDirectory("root-manager-spec")
+    rootProjectDirectory =
+      Files.createTempDirectory("root-manager-spec").toFile()
 
     val root = ContentRootWithFile(
       ContentRoot.Project(UUID.randomUUID()),
-      rootProjectDirectory.toFile.getCanonicalFile
+      rootProjectDirectory.getCanonicalFile
     )
     val config = Config(
       root,
@@ -54,11 +56,7 @@ class ContentRootManagerSpec
   }
 
   override def afterEach(): Unit = {
-    Files
-      .walk(rootProjectDirectory)
-      .sorted(Comparator.reverseOrder())
-      .map(_.toFile)
-      .forEach(_.delete())
+    FileUtils.deleteDirectory(rootProjectDirectory)
   }
 
   "ContentRootManager" should {

--- a/engine/polyglot-api/src/test/scala/org/enso/polyglot/ModuleManagementTest.scala
+++ b/engine/polyglot-api/src/test/scala/org/enso/polyglot/ModuleManagementTest.scala
@@ -2,7 +2,7 @@ package org.enso.polyglot
 
 import java.io.File
 import java.nio.file.{Files, Paths}
-import java.util.Comparator
+import org.apache.commons.io.FileUtils
 import org.enso.pkg.{Package, PackageManager}
 import org.graalvm.polyglot.{Context, PolyglotException}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -38,11 +38,7 @@ class ModuleManagementTest extends AnyFlatSpec with Matchers {
     }
 
     def teardown(): Unit = {
-      Files
-        .walk(tmpDir.toPath())
-        .sorted(Comparator.reverseOrder())
-        .map(_.toFile)
-        .forEach(_.delete())
+      FileUtils.deleteDirectory(tmpDir)
     }
   }
 


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

This change intends to cleanup some directories that are being left
behind after running `sbt test`:
- a random `foobar` directory was being created in the `engine` project
directory
- every run of a test suite would add more temporary directories in `/tmp`

The change does not make use of `deleteOnExit` which can be pretty
unreliable. Instead we recursively delete files in directories and
directories to make sure nothing is left behind.
Run scalafmt on changed files to follow the guidelines.

### Important Notes

No architecture changes, just fixing test setup

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.
