### PR TITLE
Fix CHANGELOG after merge conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@
 [3305]: https://github.com/enso-org/enso/pull/3305
 [3309]: https://github.com/enso-org/enso/pull/3309
 [3310]: https://github.com/enso-org/enso/pull/3310
+[3236]: https://github.com/enso-org/enso/pull/3236
+[3311]: https://github.com/enso-org/enso/pull/3311
 
 #### Enso Compiler
 


### PR DESCRIPTION
### Pull Request Description

Noticed that merge conflict and then mergify in https://github.com/enso-org/enso/pull/3311 led to missing PR link. 
This just updates  CHANGELOG to reflect the correct state, no code changes.

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.
