### PR TITLE
Fix many of the deprecated warnings in the engine build

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/ReplDebuggerInstrument.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/ReplDebuggerInstrument.java
@@ -16,10 +16,10 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.node.expression.builtin.text.util.ToJavaStringNode;
 import org.enso.interpreter.node.expression.debug.CaptureResultScopeNode;
 import org.enso.interpreter.node.expression.debug.EvalNode;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.CallerInfo;
 import org.enso.interpreter.runtime.callable.function.Function;
@@ -184,7 +184,7 @@ public class ReplDebuggerInstrument extends TruffleInstrument {
     @Override
     protected void onEnter(VirtualFrame frame) {
       CallerInfo lastScope = Function.ArgumentsHelper.getCallerInfo(frame.getArguments());
-      Object lastReturn = lookupContextReference(Language.class).get().getNothing().newInstance();
+      Object lastReturn = Context.get(this).getNothing().newInstance();
       // Note [Safe Access to State in the Debugger Instrument]
       Object lastState = Function.ArgumentsHelper.getState(frame.getArguments());
       nodeState = new ReplExecutionEventNodeState(lastReturn, lastState, lastScope);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/EnsoRootNode.java
@@ -1,7 +1,5 @@
 package org.enso.interpreter.node;
 
-import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.nodes.NodeInfo;
@@ -11,7 +9,6 @@ import org.enso.interpreter.Language;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.scope.LocalScope;
 import org.enso.interpreter.runtime.scope.ModuleScope;
-import org.enso.pkg.QualifiedName;
 
 /** A common base class for all kinds of root node in Enso. */
 @NodeInfo(shortName = "Root", description = "A root node for Enso computations")
@@ -20,8 +17,6 @@ public abstract class EnsoRootNode extends RootNode {
   private final SourceSection sourceSection;
   private final LocalScope localScope;
   private final ModuleScope moduleScope;
-  private @CompilerDirectives.CompilationFinal TruffleLanguage.ContextReference<Context>
-      contextReference;
   private final FrameSlot stateFrameSlot;
 
   /**
@@ -54,12 +49,7 @@ public abstract class EnsoRootNode extends RootNode {
    * @return a reference to the language context
    */
   public Context getContext() {
-    if (contextReference == null) {
-      CompilerDirectives.transferToInterpreterAndInvalidate();
-      contextReference = lookupContextReference(Language.class);
-    }
-
-    return contextReference.get();
+    return Context.get(this);
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/ProgramRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/ProgramRootNode.java
@@ -54,7 +54,7 @@ public class ProgramRootNode extends RootNode {
     if (module == null) {
       CompilerDirectives.transferToInterpreterAndInvalidate();
       QualifiedName name = QualifiedName.simpleName(canonicalizeName(sourceCode.getName()));
-      Context ctx = lookupContextReference(Language.class).get();
+      Context ctx = Context.get(this);
       if (sourceCode.getPath() != null) {
         TruffleFile src = ctx.getTruffleFile(new File(sourceCode.getPath()));
         Package<TruffleFile> pkg = ctx.getPackageOf(src).orElse(null);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/ExecuteCallNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/ExecuteCallNode.java
@@ -2,15 +2,12 @@ package org.enso.interpreter.node.callable;
 
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.GenerateUncached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeInfo;
-import org.enso.interpreter.Language;
-import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.CallerInfo;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.state.Stateful;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeCallableNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeCallableNode.java
@@ -6,7 +6,6 @@ import com.oracle.truffle.api.dsl.GenerateUncached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.node.BaseNode;
 import org.enso.interpreter.node.callable.dispatch.IndirectInvokeFunctionNode;
 import org.enso.interpreter.node.callable.thunk.ThunkExecutorNode;
@@ -173,8 +172,7 @@ public abstract class IndirectInvokeCallableNode extends Node {
       InvokeCallableNode.DefaultsExecutionMode defaultsExecutionMode,
       InvokeCallableNode.ArgumentsExecutionMode argumentsExecutionMode,
       BaseNode.TailStatus isTail) {
-    Context ctx = lookupContextReference(Language.class).get();
-    Atom error = ctx.getBuiltins().error().makeNotInvokableError(callable);
+    Atom error = Context.get(this).getBuiltins().error().makeNotInvokableError(callable);
     throw new PanicException(error, this);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeConversionNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeConversionNode.java
@@ -1,26 +1,18 @@
 package org.enso.interpreter.node.callable;
 
-import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.dsl.*;
 import com.oracle.truffle.api.frame.MaterializedFrame;
-import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
-import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.BranchProfile;
 import com.oracle.truffle.api.profiles.ConditionProfile;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.node.BaseNode;
 import org.enso.interpreter.node.callable.dispatch.IndirectInvokeFunctionNode;
-import org.enso.interpreter.node.callable.resolver.AnyResolverNode;
-import org.enso.interpreter.node.callable.resolver.DataflowErrorResolverNode;
 import org.enso.interpreter.node.callable.resolver.HostMethodCallNode;
-import org.enso.interpreter.node.callable.thunk.ThunkExecutorNode;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.UnresolvedConversion;
-import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.data.ArrayRope;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeMethodNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeMethodNode.java
@@ -1,21 +1,17 @@
 package org.enso.interpreter.node.callable;
 
-import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateUncached;
 import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.dsl.*;
 import com.oracle.truffle.api.frame.MaterializedFrame;
-import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.ConditionProfile;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.node.BaseNode;
 import org.enso.interpreter.node.callable.dispatch.IndirectInvokeFunctionNode;
 import org.enso.interpreter.node.callable.resolver.*;
@@ -23,15 +19,12 @@ import org.enso.interpreter.node.callable.thunk.ThunkExecutorNode;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
-import org.enso.interpreter.runtime.callable.atom.Atom;
-import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.data.Array;
 import org.enso.interpreter.runtime.data.ArrayRope;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.error.*;
 import org.enso.interpreter.runtime.library.dispatch.MethodDispatchLibrary;
-import org.enso.interpreter.runtime.number.EnsoBigInteger;
 import org.enso.interpreter.runtime.state.Stateful;
 
 @GenerateUncached

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InteropApplicationNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InteropApplicationNode.java
@@ -2,11 +2,9 @@ package org.enso.interpreter.node.callable;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.*;
-import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import org.enso.interpreter.Constants;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.node.BaseNode;
 import org.enso.interpreter.node.callable.dispatch.IndirectInvokeFunctionNode;
 import org.enso.interpreter.node.callable.dispatch.InvokeFunctionNode;
@@ -59,14 +57,17 @@ public abstract class InteropApplicationNode extends Node {
         InvokeCallableNode.ArgumentsExecutionMode.PRE_EXECUTED);
   }
 
+  Context getContext() {
+    return Context.get(this);
+  }
+
   @Specialization(
-      guards = {"!context.isInlineCachingDisabled()", "arguments.length == cachedArgsLength"},
+      guards = {"!getContext().isInlineCachingDisabled()", "arguments.length == cachedArgsLength"},
       limit = Constants.CacheSizes.FUNCTION_INTEROP_LIBRARY)
   Object callCached(
       Function function,
       Object state,
       Object[] arguments,
-      @CachedContext(Language.class) Context context,
       @Cached("arguments.length") int cachedArgsLength,
       @Cached("buildSorter(cachedArgsLength)") InvokeFunctionNode sorterNode,
       @Cached("build()") HostValueToEnsoNode hostValueToEnsoNode) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InteropConversionCallNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InteropConversionCallNode.java
@@ -2,7 +2,6 @@ package org.enso.interpreter.node.callable;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.GenerateUncached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.ArityException;
@@ -10,15 +9,12 @@ import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import org.enso.interpreter.Constants;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.node.BaseNode.TailStatus;
 import org.enso.interpreter.node.callable.InvokeCallableNode.ArgumentsExecutionMode;
 import org.enso.interpreter.node.callable.InvokeCallableNode.DefaultsExecutionMode;
-import org.enso.interpreter.node.callable.InvokeConversionNode;
 import org.enso.interpreter.node.expression.builtin.interop.syntax.HostValueToEnsoNode;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.UnresolvedConversion;
-import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
 
 /** A helper node to handle conversion application for the interop library. */
@@ -49,6 +45,10 @@ public abstract class InteropConversionCallNode extends Node {
         args, DefaultsExecutionMode.EXECUTE, ArgumentsExecutionMode.PRE_EXECUTED, 1);
   }
 
+  Context getContext() {
+    return Context.get(this);
+  }
+  
   Context getContext() {
     return Context.get(this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InteropConversionCallNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InteropConversionCallNode.java
@@ -44,10 +44,6 @@ public abstract class InteropConversionCallNode extends Node {
     return InvokeConversionNode.build(
         args, DefaultsExecutionMode.EXECUTE, ArgumentsExecutionMode.PRE_EXECUTED, 1);
   }
-
-  Context getContext() {
-    return Context.get(this);
-  }
   
   Context getContext() {
     return Context.get(this);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InteropMethodCallNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InteropMethodCallNode.java
@@ -79,7 +79,7 @@ public abstract class InteropMethodCallNode extends Node {
     for (int i = 0; i < cachedArgsLength; i++) {
       args[i] = hostValueToEnsoNode.execute(arguments[i]);
     }
-    if (arguments.length == 0) throw ArityException.create(1, 1, 0);
+    if (arguments.length == 0) throw ArityException.create(1, -1, 0);
     return sorterNode.execute(null, state, method, args[0], args).getValue();
   }
 
@@ -95,7 +95,7 @@ public abstract class InteropMethodCallNode extends Node {
     for (int i = 0; i < arguments.length; i++) {
       args[i] = hostValueToEnsoNode.execute(arguments[i]);
     }
-    if (arguments.length == 0) throw ArityException.create(1, 1, 0);
+    if (arguments.length == 0) throw ArityException.create(1, -1, 0);
     return indirectInvokeMethodNode
         .execute(
             null,

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InteropMethodCallNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InteropMethodCallNode.java
@@ -2,20 +2,15 @@ package org.enso.interpreter.node.callable;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.GenerateUncached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeInfo;
-import org.bouncycastle.asn1.tsp.ArchiveTimeStamp;
 import org.enso.interpreter.Constants;
-import org.enso.interpreter.Language;
-import org.enso.interpreter.node.BaseNode;
 import org.enso.interpreter.node.BaseNode.TailStatus;
 import org.enso.interpreter.node.callable.InvokeCallableNode.ArgumentsExecutionMode;
 import org.enso.interpreter.node.callable.InvokeCallableNode.DefaultsExecutionMode;
-import org.enso.interpreter.node.callable.dispatch.IndirectInvokeFunctionNode;
 import org.enso.interpreter.node.expression.builtin.interop.syntax.HostValueToEnsoNode;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
@@ -65,14 +60,17 @@ public abstract class InteropMethodCallNode extends Node {
         0);
   }
 
+  Context getContext() {
+    return Context.get(this);
+  }
+
   @Specialization(
-      guards = {"!context.isInlineCachingDisabled()", "arguments.length == cachedArgsLength"},
+      guards = {"!getContext().isInlineCachingDisabled()", "arguments.length == cachedArgsLength"},
       limit = Constants.CacheSizes.FUNCTION_INTEROP_LIBRARY)
   Object callCached(
       UnresolvedSymbol method,
       Object state,
       Object[] arguments,
-      @CachedContext(Language.class) Context context,
       @Cached("arguments.length") int cachedArgsLength,
       @Cached("buildSorter(cachedArgsLength)") InvokeMethodNode sorterNode,
       @Cached("build()") HostValueToEnsoNode hostValueToEnsoNode)
@@ -81,7 +79,7 @@ public abstract class InteropMethodCallNode extends Node {
     for (int i = 0; i < cachedArgsLength; i++) {
       args[i] = hostValueToEnsoNode.execute(arguments[i]);
     }
-    if (arguments.length == 0) throw ArityException.create(1, 0);
+    if (arguments.length == 0) throw ArityException.create(1, 1, 0);
     return sorterNode.execute(null, state, method, args[0], args).getValue();
   }
 
@@ -97,7 +95,7 @@ public abstract class InteropMethodCallNode extends Node {
     for (int i = 0; i < arguments.length; i++) {
       args[i] = hostValueToEnsoNode.execute(arguments[i]);
     }
-    if (arguments.length == 0) throw ArityException.create(1, 0);
+    if (arguments.length == 0) throw ArityException.create(1, 1, 0);
     return indirectInvokeMethodNode
         .execute(
             null,

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
@@ -10,7 +10,6 @@ import com.oracle.truffle.api.source.SourceSection;
 import java.util.UUID;
 import java.util.concurrent.locks.Lock;
 import org.enso.interpreter.Constants;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.node.BaseNode;
 import org.enso.interpreter.node.callable.dispatch.InvokeFunctionNode;
 import org.enso.interpreter.node.callable.thunk.ThunkExecutorNode;
@@ -86,7 +85,6 @@ public abstract class InvokeCallableNode extends BaseNode {
   @Child private InvokeConversionNode invokeConversionNode;
   @Child private ThunkExecutorNode thisExecutor;
   @Child private ThunkExecutorNode thatExecutor;
-  private final ConditionProfile functionErrorProfile = ConditionProfile.createCountingProfile();
 
   private final boolean canApplyThis;
   private final boolean canApplyThat;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeConversionNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeConversionNode.java
@@ -11,10 +11,8 @@ import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.BranchProfile;
 import com.oracle.truffle.api.profiles.ConditionProfile;
 import com.oracle.truffle.api.source.SourceSection;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.node.BaseNode;
 import org.enso.interpreter.node.callable.dispatch.InvokeFunctionNode;
-import org.enso.interpreter.node.callable.resolver.AnyResolverNode;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.UnresolvedConversion;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
@@ -196,7 +194,6 @@ public abstract class InvokeConversionNode extends BaseNode {
       Object _this,
       Object that,
       Object[] arguments,
-      @CachedLibrary(limit = "10") MethodDispatchLibrary methods,
       @CachedLibrary(limit = "1") MethodDispatchLibrary textDispatch,
       @CachedLibrary(limit = "10") InteropLibrary interop) {
     try {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/dispatch/InvokeFunctionNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/dispatch/InvokeFunctionNode.java
@@ -62,15 +62,18 @@ public abstract class InvokeFunctionNode extends BaseNode {
     return InvokeFunctionNodeGen.create(schema, defaultsExecutionMode, argumentsExecutionMode);
   }
 
+  Context getContext() {
+    return Context.get(this);
+  }
+
   @Specialization(
-      guards = {"!context.isInlineCachingDisabled()", "function.getSchema() == cachedSchema"},
+      guards = {"!getContext().isInlineCachingDisabled()", "function.getSchema() == cachedSchema"},
       limit = Constants.CacheSizes.ARGUMENT_SORTER_NODE)
   Stateful invokeCached(
       Function function,
       VirtualFrame callerFrame,
       Object state,
       Object[] arguments,
-      @CachedContext(Language.class) Context context,
       @Cached("function.getSchema()") FunctionSchema cachedSchema,
       @Cached("generate(cachedSchema, getSchema())")
           CallArgumentInfo.ArgumentMapping argumentMapping,

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/resolver/AnyResolverNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/resolver/AnyResolverNode.java
@@ -1,11 +1,8 @@
 package org.enso.interpreter.node.callable.resolver;
 
 import com.oracle.truffle.api.dsl.*;
-import org.enso.interpreter.Language;
-import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.function.Function;
-import org.enso.interpreter.runtime.error.DataflowError;
 
 @GenerateUncached
 @ReportPolymorphism
@@ -14,20 +11,19 @@ public abstract class AnyResolverNode extends BaseResolverNode {
   public abstract Function execute(UnresolvedSymbol symbol, Object _this);
 
   @Specialization(
-      guards = {"!context.isInlineCachingDisabled()", "cachedSymbol == symbol", "function != null"},
+      guards = {"!getContext().isInlineCachingDisabled()", "cachedSymbol == symbol", "function != null"},
       limit = "CACHE_SIZE")
   Function resolveCached(
       UnresolvedSymbol symbol,
       Object _this,
-      @CachedContext(Language.class) Context context,
       @Cached("symbol") UnresolvedSymbol cachedSymbol,
-      @Cached("resolveMethodOnAny(context, cachedSymbol)") Function function) {
+      @Cached("resolveMethodOnAny(cachedSymbol)") Function function) {
     return function;
   }
 
   @Specialization(replaces = "resolveCached")
   Function resolve(
-      UnresolvedSymbol symbol, Object _this, @CachedContext(Language.class) Context context) {
-    return throwIfNull(context, resolveMethodOnAny(context, symbol), _this, symbol);
+      UnresolvedSymbol symbol, Object _this) {
+    return throwIfNull(resolveMethodOnAny(symbol), _this, symbol);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/resolver/BaseResolverNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/resolver/BaseResolverNode.java
@@ -3,33 +3,33 @@ package org.enso.interpreter.node.callable.resolver;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.runtime.Context;
-import org.enso.interpreter.runtime.builtin.Bool;
-import org.enso.interpreter.runtime.builtin.Number;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
-import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.error.PanicException;
 
 public class BaseResolverNode extends Node {
   protected static final int CACHE_SIZE = 10;
 
-  protected Function throwIfNull(
-      Context context, Function function, Object _this, UnresolvedSymbol sym) {
+  protected Context getContext() {
+    return Context.get(this);
+  }
+
+  protected Function throwIfNull(Function function, Object _this, UnresolvedSymbol sym) {
     if (function == null) {
       CompilerDirectives.transferToInterpreter();
       throw new PanicException(
-          context.getBuiltins().error().makeNoSuchMethodError(_this, sym), this);
+          getContext().getBuiltins().error().makeNoSuchMethodError(_this, sym), this);
     }
     return function;
   }
 
   @CompilerDirectives.TruffleBoundary
-  Function resolveMethodOnError(Context context, UnresolvedSymbol symbol) {
-    return symbol.resolveFor(context.getBuiltins().dataflowError().constructor());
+  Function resolveMethodOnError(UnresolvedSymbol symbol) {
+    return symbol.resolveFor(getContext().getBuiltins().dataflowError().constructor());
   }
 
   @CompilerDirectives.TruffleBoundary
-  Function resolveMethodOnAny(Context context, UnresolvedSymbol symbol) {
-    return symbol.resolveFor(context.getBuiltins().any());
+  Function resolveMethodOnAny(UnresolvedSymbol symbol) {
+    return symbol.resolveFor(getContext().getBuiltins().any());
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/resolver/DataflowErrorResolverNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/resolver/DataflowErrorResolverNode.java
@@ -1,12 +1,9 @@
 package org.enso.interpreter.node.callable.resolver;
 
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.GenerateUncached;
 import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
-import org.enso.interpreter.Language;
-import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.error.DataflowError;
@@ -18,22 +15,20 @@ public abstract class DataflowErrorResolverNode extends BaseResolverNode {
   public abstract Function execute(UnresolvedSymbol symbol, DataflowError _this);
 
   @Specialization(
-      guards = {"!context.isInlineCachingDisabled()", "cachedSymbol == symbol"},
+      guards = {"!getContext().isInlineCachingDisabled()", "cachedSymbol == symbol"},
       limit = "CACHE_SIZE")
   Function resolveCached(
       UnresolvedSymbol symbol,
       DataflowError _this,
-      @CachedContext(Language.class) Context context,
       @Cached("symbol") UnresolvedSymbol cachedSymbol,
-      @Cached("resolveMethodOnError(context, cachedSymbol)") Function function) {
+      @Cached("resolveMethodOnError(cachedSymbol)") Function function) {
     return function;
   }
 
   @Specialization(replaces = "resolveCached")
   Function resolve(
       UnresolvedSymbol symbol,
-      DataflowError _this,
-      @CachedContext(Language.class) Context context) {
-    return resolveMethodOnError(context, symbol);
+      DataflowError _this) {
+    return resolveMethodOnError(symbol);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/resolver/HostMethodCallNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/resolver/HostMethodCallNode.java
@@ -5,7 +5,6 @@ import com.oracle.truffle.api.interop.*;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.BranchProfile;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.node.expression.builtin.interop.syntax.HostValueToEnsoNode;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -101,7 +100,6 @@ public abstract class HostMethodCallNode extends Node {
       Object _this,
       Object[] args,
       @CachedLibrary(limit = "LIB_LIMIT") InteropLibrary members,
-      @CachedContext(Language.class) Context context,
       @Cached HostValueToEnsoNode hostValueToEnsoNode) {
     try {
       return hostValueToEnsoNode.execute(members.invokeMember(_this, symbol, args));
@@ -110,11 +108,11 @@ public abstract class HostMethodCallNode extends Node {
           "Impossible to reach here. The member is checked to be invocable.");
     } catch (ArityException e) {
       throw new PanicException(
-          context.getBuiltins().error().makeArityError(e.getExpectedArity(), e.getActualArity()),
+          Context.get(this).getBuiltins().error().makeArityError(e.getExpectedArity(), e.getActualArity()),
           this);
     } catch (UnsupportedTypeException e) {
       throw new PanicException(
-          context.getBuiltins().error().makeUnsupportedArgumentsError(e.getSuppliedValues()), this);
+          Context.get(this).getBuiltins().error().makeUnsupportedArgumentsError(e.getSuppliedValues()), this);
     }
   }
 
@@ -125,12 +123,11 @@ public abstract class HostMethodCallNode extends Node {
       Object _this,
       Object[] args,
       @CachedLibrary(limit = "LIB_LIMIT") InteropLibrary members,
-      @CachedContext(Language.class) Context context,
       @Cached HostValueToEnsoNode hostValueToEnsoNode,
       @Cached BranchProfile errorProfile) {
     if (args.length != 0) {
       errorProfile.enter();
-      throw new PanicException(context.getBuiltins().error().makeArityError(0, args.length), this);
+      throw new PanicException(Context.get(this).getBuiltins().error().makeArityError(0, args.length), this);
     }
     try {
       return hostValueToEnsoNode.execute(members.readMember(_this, symbol));
@@ -147,7 +144,6 @@ public abstract class HostMethodCallNode extends Node {
       Object _this,
       Object[] args,
       @CachedLibrary(limit = "LIB_LIMIT") InteropLibrary instances,
-      @CachedContext(Language.class) Context context,
       @Cached HostValueToEnsoNode hostValueToEnsoNode) {
     try {
       return hostValueToEnsoNode.execute(instances.instantiate(_this, args));
@@ -156,11 +152,11 @@ public abstract class HostMethodCallNode extends Node {
           "Impossible to reach here. The member is checked to be instantiable.");
     } catch (ArityException e) {
       throw new PanicException(
-          context.getBuiltins().error().makeArityError(e.getExpectedArity(), e.getActualArity()),
+          Context.get(this).getBuiltins().error().makeArityError(e.getExpectedArity(), e.getActualArity()),
           this);
     } catch (UnsupportedTypeException e) {
       throw new PanicException(
-          context.getBuiltins().error().makeUnsupportedArgumentsError(e.getSuppliedValues()), this);
+          Context.get(this).getBuiltins().error().makeUnsupportedArgumentsError(e.getSuppliedValues()), this);
     }
   }
 
@@ -171,12 +167,11 @@ public abstract class HostMethodCallNode extends Node {
       Object _this,
       Object[] args,
       @CachedLibrary(limit = "LIB_LIMIT") InteropLibrary arrays,
-      @CachedContext(Language.class) Context ctx,
       @Cached BranchProfile errorProfile,
       @Cached HostValueToEnsoNode hostValueToEnsoNode) {
     if (args.length != 0) {
       errorProfile.enter();
-      throw new PanicException(ctx.getBuiltins().error().makeArityError(0, args.length), this);
+      throw new PanicException(Context.get(this).getBuiltins().error().makeArityError(0, args.length), this);
     }
     try {
       return hostValueToEnsoNode.execute(arrays.getArraySize(_this));
@@ -194,16 +189,15 @@ public abstract class HostMethodCallNode extends Node {
       @CachedLibrary(limit = "LIB_LIMIT") InteropLibrary arrays,
       @Cached BranchProfile arityErrorProfile,
       @Cached BranchProfile typeErrorProfile,
-      @CachedContext(Language.class) Context ctx,
       @Cached HostValueToEnsoNode hostValueToEnsoNode) {
     if (args.length != 1) {
       arityErrorProfile.enter();
-      throw new PanicException(ctx.getBuiltins().error().makeArityError(1, args.length), this);
+      throw new PanicException(Context.get(this).getBuiltins().error().makeArityError(1, args.length), this);
     }
     if (!(args[0] instanceof Long)) {
       typeErrorProfile.enter();
       throw new PanicException(
-          ctx.getBuiltins().error().makeInvalidArrayIndexError(_this, args[0]), this);
+          Context.get(this).getBuiltins().error().makeInvalidArrayIndexError(_this, args[0]), this);
     }
     long idx = (Long) args[0];
     try {
@@ -212,7 +206,7 @@ public abstract class HostMethodCallNode extends Node {
       throw new IllegalStateException("Impossible to reach here, _this is checked to be an array");
     } catch (InvalidArrayIndexException e) {
       throw new PanicException(
-          ctx.getBuiltins().error().makeInvalidArrayIndexError(_this, idx), this);
+          Context.get(this).getBuiltins().error().makeInvalidArrayIndexError(_this, idx), this);
     }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/resolver/HostMethodCallNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/resolver/HostMethodCallNode.java
@@ -108,7 +108,7 @@ public abstract class HostMethodCallNode extends Node {
           "Impossible to reach here. The member is checked to be invocable.");
     } catch (ArityException e) {
       throw new PanicException(
-          Context.get(this).getBuiltins().error().makeArityError(e.getExpectedArity(), e.getActualArity()),
+          Context.get(this).getBuiltins().error().makeArityError(e.getExpectedMinArity(), e.getExpectedMaxArity(), e.getActualArity()),
           this);
     } catch (UnsupportedTypeException e) {
       throw new PanicException(
@@ -127,7 +127,7 @@ public abstract class HostMethodCallNode extends Node {
       @Cached BranchProfile errorProfile) {
     if (args.length != 0) {
       errorProfile.enter();
-      throw new PanicException(Context.get(this).getBuiltins().error().makeArityError(0, args.length), this);
+      throw new PanicException(Context.get(this).getBuiltins().error().makeArityError(0, 0, args.length), this);
     }
     try {
       return hostValueToEnsoNode.execute(members.readMember(_this, symbol));
@@ -152,7 +152,7 @@ public abstract class HostMethodCallNode extends Node {
           "Impossible to reach here. The member is checked to be instantiable.");
     } catch (ArityException e) {
       throw new PanicException(
-          Context.get(this).getBuiltins().error().makeArityError(e.getExpectedArity(), e.getActualArity()),
+          Context.get(this).getBuiltins().error().makeArityError(e.getExpectedMinArity(), e.getExpectedMaxArity(), e.getActualArity()),
           this);
     } catch (UnsupportedTypeException e) {
       throw new PanicException(
@@ -171,7 +171,7 @@ public abstract class HostMethodCallNode extends Node {
       @Cached HostValueToEnsoNode hostValueToEnsoNode) {
     if (args.length != 0) {
       errorProfile.enter();
-      throw new PanicException(Context.get(this).getBuiltins().error().makeArityError(0, args.length), this);
+      throw new PanicException(Context.get(this).getBuiltins().error().makeArityError(0, 0, args.length), this);
     }
     try {
       return hostValueToEnsoNode.execute(arrays.getArraySize(_this));
@@ -192,7 +192,7 @@ public abstract class HostMethodCallNode extends Node {
       @Cached HostValueToEnsoNode hostValueToEnsoNode) {
     if (args.length != 1) {
       arityErrorProfile.enter();
-      throw new PanicException(Context.get(this).getBuiltins().error().makeArityError(1, args.length), this);
+      throw new PanicException(Context.get(this).getBuiltins().error().makeArityError(1, 1, args.length), this);
     }
     if (!(args[0] instanceof Long)) {
       typeErrorProfile.enter();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CaseNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CaseNode.java
@@ -1,15 +1,12 @@
 package org.enso.interpreter.node.controlflow.caseexpr;
 
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.TruffleLanguage;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.FrameUtil;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.NodeInfo;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.data.ArrayRope;
@@ -83,7 +80,6 @@ public abstract class CaseNode extends ExpressionNode {
    *
    * @param frame the stack frame in which to execute
    * @param object the object being matched against
-   * @param ctx the language context reference
    * @return the result of executing the case expression on {@code object}
    */
   @Specialization(

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/PolyglotBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/PolyglotBranchNode.java
@@ -1,13 +1,11 @@
 package org.enso.interpreter.node.controlflow.caseexpr;
 
 import com.oracle.truffle.api.RootCallTarget;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import com.oracle.truffle.api.profiles.ConditionProfile;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
@@ -41,13 +39,12 @@ public abstract class PolyglotBranchNode extends BranchNode {
     }
   }
 
-  @Specialization(guards = "isPolyglotObject(context,obj)")
+  @Specialization(guards = "isPolyglotObject(obj)")
   void doLiteral(
       VirtualFrame frame,
       Object state,
-      Object obj,
-      @CachedContext(Language.class) Context context) {
-    if (polyglotProfile.profile(isPolyglotObject(context, obj))) {
+      Object obj) {
+    if (polyglotProfile.profile(isPolyglotObject(obj))) {
       accept(frame, state, new Object[0]);
     }
   }
@@ -55,7 +52,7 @@ public abstract class PolyglotBranchNode extends BranchNode {
   @Fallback
   void doFallback(VirtualFrame frame, Object state, Object target) {}
 
-  boolean isPolyglotObject(Context context, Object o) {
-    return context.getEnvironment().isHostObject(o);
+  boolean isPolyglotObject(Object o) {
+    return Context.get(this).getEnvironment().isHostObject(o);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/EqualsNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/EqualsNode.java
@@ -1,12 +1,9 @@
 package org.enso.interpreter.node.expression.builtin.bool;
 
-import com.oracle.truffle.api.TruffleLanguage.ContextReference;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.atom.Atom;
@@ -29,8 +26,7 @@ public abstract class EqualsNode extends Node {
   boolean doAtom(
       Atom _this,
       Atom that,
-      @CachedContext(Language.class) ContextReference<Context> ctxRef,
-      @Cached("getBooleanConstructor(ctxRef)") AtomConstructor boolCons
+      @Cached("getBooleanConstructor()") AtomConstructor boolCons
   ) {
     var thisCons = _this.getConstructor();
     var thatCons = that.getConstructor();
@@ -42,7 +38,7 @@ public abstract class EqualsNode extends Node {
     return false;
   }
 
-  AtomConstructor getBooleanConstructor(ContextReference<Context> ctxRef) {
-    return ctxRef.get().getBuiltins().bool().getBool();
+  AtomConstructor getBooleanConstructor() {
+    return Context.get(this).getBuiltins().bool().getBool();
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/IfThenNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/bool/IfThenNode.java
@@ -1,10 +1,8 @@
 package org.enso.interpreter.node.expression.builtin.bool;
 
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.ConditionProfile;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.dsl.MonadicState;
 import org.enso.interpreter.dsl.Suspend;
@@ -29,11 +27,11 @@ public abstract class IfThenNode extends Node {
 
   @Specialization
   Stateful doExecute(
-      Object state, boolean _this, Object if_true, @CachedContext(Language.class) Context context) {
+      Object state, boolean _this, Object if_true) {
     if (condProfile.profile(_this)) {
       return leftThunkExecutorNode.executeThunk(if_true, state, BaseNode.TailStatus.TAIL_DIRECT);
     } else {
-      return new Stateful(state, context.getNothing().newInstance());
+      return new Stateful(state, Context.get(this).getNothing().newInstance());
     }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/debug/DebugBreakpointNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/debug/DebugBreakpointNode.java
@@ -1,7 +1,6 @@
 package org.enso.interpreter.node.expression.builtin.debug;
 
 import com.oracle.truffle.api.debug.DebuggerTags;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.GenerateWrapper;
@@ -9,7 +8,6 @@ import com.oracle.truffle.api.instrumentation.InstrumentableNode;
 import com.oracle.truffle.api.instrumentation.ProbeNode;
 import com.oracle.truffle.api.instrumentation.Tag;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.dsl.MonadicState;
 import org.enso.interpreter.runtime.Context;
@@ -46,9 +44,8 @@ public abstract class DebugBreakpointNode extends Node implements Instrumentable
       VirtualFrame frame,
       CallerInfo callerInfo,
       Object state,
-      Object _this,
-      @CachedContext(Language.class) Context context) {
-    return new Stateful(state, context.getNothing().newInstance());
+      Object _this) {
+    return new Stateful(state, Context.get(this).getNothing().newInstance());
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/RecoverPanicNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/RecoverPanicNode.java
@@ -1,14 +1,11 @@
 package org.enso.interpreter.node.expression.builtin.error;
 
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.exception.AbstractTruffleException;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.BranchProfile;
-import com.oracle.truffle.api.profiles.ConditionProfile;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.dsl.MonadicState;
 import org.enso.interpreter.dsl.Suspend;
@@ -38,8 +35,7 @@ public abstract class RecoverPanicNode extends Node {
       @MonadicState Object state,
       Object _this,
       Object action,
-      @CachedLibrary(limit = "5") InteropLibrary exceptions,
-      @CachedContext(Language.class) Context ctx) {
+      @CachedLibrary(limit = "5") InteropLibrary exceptions) {
     try {
       return thunkExecutorNode.executeThunk(action, state, BaseNode.TailStatus.NOT_TAIL);
     } catch (PanicException e) {
@@ -49,7 +45,7 @@ public abstract class RecoverPanicNode extends Node {
         return new Stateful(
             state,
             DataflowError.withTrace(
-                ctx.getBuiltins().error().makePolyglotError(e), (AbstractTruffleException) e));
+                Context.get(this).getBuiltins().error().makePolyglotError(e), (AbstractTruffleException) e));
       }
       unknownExceptionProfile.enter();
       throw e;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ArityErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ArityErrorToDisplayTextNode.java
@@ -17,10 +17,21 @@ public abstract class ArityErrorToDisplayTextNode extends Node {
 
   @Specialization
   Text doAtom(Atom _this) {
+    Object[] fields = _this.getFields();
+
+    Text expected;
+    if (fields[0].equals(fields[1])) {
+        expected = Text.create(String.valueOf(fields[0]));
+    } else {
+        expected = Text.create(String.valueOf(fields[0]))
+            .add("-")
+            .add(String.valueOf(fields[1]));
+    }
+
     return Text.create("Wrong number of arguments. Expected ")
-        .add(String.valueOf(_this.getFields()[0]))
+        .add(expected)
         .add(", but got ")
-        .add(String.valueOf(_this.getFields()[1]))
+        .add(String.valueOf(fields[2]))
         .add(".");
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ArityErrorToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ArityErrorToDisplayTextNode.java
@@ -19,13 +19,12 @@ public abstract class ArityErrorToDisplayTextNode extends Node {
   Text doAtom(Atom _this) {
     Object[] fields = _this.getFields();
 
-    Text expected;
-    if (fields[0].equals(fields[1])) {
-        expected = Text.create(String.valueOf(fields[0]));
-    } else {
-        expected = Text.create(String.valueOf(fields[0]))
-            .add("-")
-            .add(String.valueOf(fields[1]));
+    Text expected = Text.create(String.valueOf(fields[0]));
+    if (!fields[0].equals(fields[1])) {
+        expected = expected.add("-");
+        if (!fields[1].equals(-1)) {
+          expected = expected.add(String.valueOf(fields[1]));
+        }
     }
 
     return Text.create("Wrong number of arguments. Expected ")

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/GetArraySizeNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/GetArraySizeNode.java
@@ -5,8 +5,8 @@ import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.BranchProfile;
 import org.enso.interpreter.Constants;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.error.PanicException;
 
@@ -24,7 +24,7 @@ public class GetArraySizeNode extends Node {
       return library.getArraySize(array);
     } catch (UnsupportedMessageException e) {
       err.enter();
-      Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+      Builtins builtins = Context.get(this).getBuiltins();
       throw new PanicException(
           builtins.error().makeTypeError(builtins.mutable().array(), array, "array"), this);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/IsLanguageInstalledNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/IsLanguageInstalledNode.java
@@ -1,12 +1,9 @@
 package org.enso.interpreter.node.expression.builtin.interop.generic;
 
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
-import org.enso.interpreter.node.expression.builtin.interop.java.AddToClassPathNodeGen;
 import org.enso.interpreter.node.expression.builtin.text.util.ExpectStringNode;
 import org.enso.interpreter.runtime.Context;
 
@@ -26,10 +23,9 @@ public abstract class IsLanguageInstalledNode extends Node {
   boolean doExecute(
       Object _this,
       Object language_name,
-      @CachedContext(Language.class) Context context,
       @Cached ExpectStringNode expectStringNode) {
     String name = expectStringNode.execute(language_name);
-    return context.getEnvironment().getPublicLanguages().get(name) != null;
+    return Context.get(this).getEnvironment().getPublicLanguages().get(name) != null;
   }
 
   abstract boolean execute(Object _this, Object language_name);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/java/AddToClassPathNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/java/AddToClassPathNode.java
@@ -1,10 +1,8 @@
 package org.enso.interpreter.node.expression.builtin.interop.java;
 
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.text.util.ExpectStringNode;
 import org.enso.interpreter.runtime.Context;
@@ -25,8 +23,8 @@ public abstract class AddToClassPathNode extends Node {
   Object doExecute(
       Object _this,
       Object path,
-      @CachedContext(Language.class) Context context,
       @Cached ExpectStringNode expectStringNode) {
+    Context context = Context.get(this);
     context
         .getEnvironment()
         .addToHostClassPath(context.getTruffleFile(new File(expectStringNode.execute(path))));

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/java/LookupClassNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/java/LookupClassNode.java
@@ -1,10 +1,8 @@
 package org.enso.interpreter.node.expression.builtin.interop.java;
 
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.text.util.ExpectStringNode;
 import org.enso.interpreter.runtime.Context;
@@ -19,9 +17,8 @@ public abstract class LookupClassNode extends Node {
   Object doExecute(
       Object _this,
       Object name,
-      @CachedContext(Language.class) Context ctx,
       @Cached("build()") ExpectStringNode expectStringNode) {
-    return ctx.getEnvironment().lookupHostSymbol(expectStringNode.execute(name));
+    return Context.get(this).getEnvironment().lookupHostSymbol(expectStringNode.execute(name));
   }
 
   abstract Object execute(Object _this, Object name);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/syntax/HostValueToEnsoNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/syntax/HostValueToEnsoNode.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.dsl.*;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.data.text.Text;
@@ -61,9 +60,8 @@ public abstract class HostValueToEnsoNode extends Node {
   @Specialization(guards = {"o != null", "nulls.isNull(o)"})
   Atom doNull(
       Object o,
-      @CachedLibrary(limit = "3") InteropLibrary nulls,
-      @CachedContext(Language.class) Context ctx) {
-    return ctx.getBuiltins().nothing().newInstance();
+      @CachedLibrary(limit = "3") InteropLibrary nulls) {
+    return Context.get(this).getBuiltins().nothing().newInstance();
   }
 
   @Fallback

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/GetCwdNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/GetCwdNode.java
@@ -1,16 +1,11 @@
 package org.enso.interpreter.node.expression.builtin.io;
 
 import com.oracle.truffle.api.TruffleFile;
-import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
-import org.enso.interpreter.node.expression.builtin.text.util.ToJavaStringNode;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.data.EnsoFile;
-import org.enso.interpreter.runtime.data.text.Text;
 
 @BuiltinMethod(
     type = "Prim_Io",
@@ -24,9 +19,10 @@ public abstract class GetCwdNode extends Node {
   abstract Object execute(Object _this);
 
   @Specialization
-  Object doExecute(Object _this, @CachedContext(Language.class) Context ctx) {
-    TruffleFile file = ctx.getEnvironment().getCurrentWorkingDirectory();
+  Object doExecute(Object _this) {
+    var env= Context.get(this).getEnvironment();
+    TruffleFile file = env.getCurrentWorkingDirectory();
     EnsoFile ensoFile = new EnsoFile(file);
-    return ctx.getEnvironment().asGuestValue(ensoFile);
+    return env.asGuestValue(ensoFile);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/GetCwdNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/GetCwdNode.java
@@ -20,9 +20,9 @@ public abstract class GetCwdNode extends Node {
 
   @Specialization
   Object doExecute(Object _this) {
-    var env= Context.get(this).getEnvironment();
-    TruffleFile file = env.getCurrentWorkingDirectory();
+    Context context = Context.get(this);
+    TruffleFile file = context.getEnvironment().getCurrentWorkingDirectory();
     EnsoFile ensoFile = new EnsoFile(file);
-    return env.asGuestValue(ensoFile);
+    return context.getEnvironment().asGuestValue(ensoFile);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/GetFileNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/GetFileNode.java
@@ -27,9 +27,9 @@ public abstract class GetFileNode extends Node {
       Object path,
       @Cached("build()") ExpectStringNode expectStringNode) {
     String pathStr = expectStringNode.execute(path);
-    var env= Context.get(this).getEnvironment();
-    TruffleFile file = env.getPublicTruffleFile(pathStr);
+    var context= Context.get(this);
+    TruffleFile file = context.getEnvironment().getPublicTruffleFile(pathStr);
     EnsoFile ensoFile = new EnsoFile(file);
-    return env.asGuestValue(ensoFile);
+    return context.getEnvironment().asGuestValue(ensoFile);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/GetFileNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/GetFileNode.java
@@ -2,15 +2,12 @@ package org.enso.interpreter.node.expression.builtin.io;
 
 import com.oracle.truffle.api.TruffleFile;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.text.util.ExpectStringNode;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.data.EnsoFile;
-import org.enso.interpreter.runtime.data.text.Text;
 
 @BuiltinMethod(
     type = "Prim_Io",
@@ -28,11 +25,11 @@ public abstract class GetFileNode extends Node {
   Object doGetFile(
       Object _this,
       Object path,
-      @CachedContext(Language.class) Context ctx,
       @Cached("build()") ExpectStringNode expectStringNode) {
     String pathStr = expectStringNode.execute(path);
-    TruffleFile file = ctx.getEnvironment().getPublicTruffleFile(pathStr);
+    var env= Context.get(this).getEnvironment();
+    TruffleFile file = env.getPublicTruffleFile(pathStr);
     EnsoFile ensoFile = new EnsoFile(file);
-    return ctx.getEnvironment().asGuestValue(ensoFile);
+    return env.asGuestValue(ensoFile);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintErrNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintErrNode.java
@@ -2,7 +2,6 @@ package org.enso.interpreter.node.expression.builtin.io;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.InteropLibrary;
@@ -10,7 +9,6 @@ import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
 import java.io.PrintStream;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.dsl.MonadicState;
@@ -40,8 +38,8 @@ public abstract class PrintErrNode extends Node {
       Object state,
       Object self,
       Object message,
-      @CachedContext(Language.class) Context ctx,
       @CachedLibrary(limit = "10") InteropLibrary strings) {
+    Context ctx = Context.get(this);
     try {
       print(ctx.getErr(), strings.asString(message));
     } catch (UnsupportedMessageException e) {
@@ -56,12 +54,12 @@ public abstract class PrintErrNode extends Node {
       Object state,
       Object self,
       Object message,
-      @CachedContext(Language.class) Context ctx,
       @CachedLibrary(limit = "10") InteropLibrary strings,
-      @Cached("buildSymbol(ctx)") UnresolvedSymbol symbol,
+      @Cached("buildSymbol()") UnresolvedSymbol symbol,
       @Cached("buildInvokeCallableNode()") InvokeCallableNode invokeCallableNode,
       @Cached ExpectStringNode expectStringNode) {
     Stateful str = invokeCallableNode.execute(symbol, frame, state, new Object[] {message});
+    Context ctx = Context.get(this);
     print(ctx.getErr(), expectStringNode.execute(str.getValue()));
     return new Stateful(str.getState(), ctx.getNothing().newInstance());
   }
@@ -82,7 +80,7 @@ public abstract class PrintErrNode extends Node {
         InvokeCallableNode.ArgumentsExecutionMode.PRE_EXECUTED);
   }
 
-  UnresolvedSymbol buildSymbol(Context ctx) {
-    return UnresolvedSymbol.build("to_text", ctx.getBuiltins().getScope());
+  UnresolvedSymbol buildSymbol() {
+    return UnresolvedSymbol.build("to_text", Context.get(this).getBuiltins().getScope());
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/ReadlnNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/ReadlnNode.java
@@ -1,12 +1,10 @@
 package org.enso.interpreter.node.expression.builtin.io;
 
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
 
 import java.io.IOException;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.data.text.Text;
@@ -22,9 +20,9 @@ public abstract class ReadlnNode extends Node {
 
   @Specialization
   @TruffleBoundary
-  Text doRead(Object _this, @CachedContext(Language.class) Context ctx) {
+  Text doRead(Object _this) {
     try {
-      return Text.create(ctx.getInReader().readLine());
+      return Text.create(Context.get(this).getInReader().readLine());
     } catch (IOException e) {
       throw new PanicException("Empty input stream", this);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/GetPolyglotLanguageNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/GetPolyglotLanguageNode.java
@@ -1,9 +1,7 @@
 package org.enso.interpreter.node.expression.builtin.meta;
 
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.data.text.Text;
@@ -23,8 +21,8 @@ public abstract class GetPolyglotLanguageNode extends Node {
   abstract Text execute(Object _this, Object value);
 
   @Specialization
-  Text doExecute(Object _this, Object value, @CachedContext(Language.class) Context context) {
-    if (context.getEnvironment().isHostObject(value)) {
+  Text doExecute(Object _this, Object value) {
+    if (Context.get(this).getEnvironment().isHostObject(value)) {
       return java;
     } else {
       return unknown;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/GetUnresolvedSymbolNameNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/GetUnresolvedSymbolNameNode.java
@@ -1,17 +1,14 @@
 package org.enso.interpreter.node.expression.builtin.meta;
 
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.Constants;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.UnresolvedConversion;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
-import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.error.PanicException;
 
@@ -40,7 +37,7 @@ public abstract class GetUnresolvedSymbolNameNode extends Node {
 
   @Fallback
   Text doFallback(Object _this, Object symbol) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     throw new PanicException(
         builtins.error().makeTypeError("Unresolved_Symbol", symbol, "symbol"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/GetUnresolvedSymbolScopeNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/GetUnresolvedSymbolScopeNode.java
@@ -3,12 +3,11 @@ package org.enso.interpreter.node.expression.builtin.meta;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.UnresolvedConversion;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
-import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.scope.ModuleScope;
 
@@ -35,7 +34,7 @@ public abstract class GetUnresolvedSymbolScopeNode extends Node {
 
   @Fallback
   ModuleScope doFallback(Object _this, Object symbol) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     throw new PanicException(
         builtins.error().makeTypeError("Unresolved_Symbol", symbol, "symbol"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsPolyglotNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsPolyglotNode.java
@@ -1,9 +1,7 @@
 package org.enso.interpreter.node.expression.builtin.meta;
 
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.Context;
@@ -20,7 +18,7 @@ public abstract class IsPolyglotNode extends Node {
   abstract boolean execute(Object _this, @AcceptsError Object value);
 
   @Specialization
-  boolean doExecute(Object _this, Object value, @CachedContext(Language.class) Context context) {
-    return context.getEnvironment().isHostObject(value);
+  boolean doExecute(Object _this, Object value) {
+    return Context.get(this).getEnvironment().isHostObject(value);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/GetAtNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/GetAtNode.java
@@ -1,8 +1,8 @@
 package org.enso.interpreter.node.expression.builtin.mutable;
 
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.data.Array;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -17,7 +17,7 @@ public class GetAtNode extends Node {
     try {
       return _this.getItems()[(int) index];
     } catch (IndexOutOfBoundsException exception) {
-      Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+      Builtins builtins = Context.get(this).getBuiltins();
       throw new PanicException(builtins.error().makeInvalidArrayIndexError(_this, index), this);
     }
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/SetAtNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/SetAtNode.java
@@ -1,9 +1,9 @@
 package org.enso.interpreter.node.expression.builtin.mutable;
 
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.data.Array;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -19,7 +19,7 @@ public class SetAtNode extends Node {
       _this.getItems()[(int) index] = value;
       return _this;
     } catch (IndexOutOfBoundsException exception) {
-      Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+      Builtins builtins = Context.get(this).getBuiltins();
       throw new PanicException(builtins.error().makeInvalidArrayIndexError(_this, index), this);
     }
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/AddNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/AddNode.java
@@ -3,10 +3,10 @@ package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -39,7 +39,7 @@ public abstract class AddNode extends Node {
 
   @Fallback
   Object doOther(EnsoBigInteger _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/BitAndNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/BitAndNode.java
@@ -1,10 +1,8 @@
 package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
@@ -35,15 +33,15 @@ public abstract class BitAndNode extends Node {
   }
 
   @Specialization
-  Object doAtomThis(Atom _this, Object that, @CachedContext(Language.class) Context ctx) {
-    Builtins builtins = ctx.getBuiltins();
+  Object doAtomThis(Atom _this, Object that) {
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, _this, "this"), this);
   }
 
   @Fallback
   Object doOther(Object _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/BitNotNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/BitNotNode.java
@@ -3,8 +3,8 @@ package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -25,7 +25,7 @@ public abstract class BitNotNode extends Node {
 
   @Fallback
   Object doOther(Object _this) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, _this, "this"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/BitOrNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/BitOrNode.java
@@ -1,10 +1,8 @@
 package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
@@ -35,15 +33,15 @@ public abstract class BitOrNode extends Node {
   }
 
   @Specialization
-  Object doAtomThis(Atom _this, Object that, @CachedContext(Language.class) Context ctx) {
-    Builtins builtins = ctx.getBuiltins();
+  Object doAtomThis(Atom _this, Object that) {
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, _this, "this"), this);
   }
 
   @Fallback
   Object doOther(Object _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/BitShiftRightNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/BitShiftRightNode.java
@@ -1,11 +1,9 @@
 package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.runtime.Context;
@@ -37,15 +35,15 @@ public abstract class BitShiftRightNode extends Node {
   }
 
   @Specialization
-  Object doAtomThis(Atom _this, Object that, @CachedContext(Language.class)Context ctx) {
-    Builtins builtins = ctx.getBuiltins();
+  Object doAtomThis(Atom _this, Object that) {
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, _this, "this"), this);
   }
 
   @Fallback
   Object doOther(Object _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/BitXorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/BitXorNode.java
@@ -1,10 +1,8 @@
 package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
@@ -35,15 +33,15 @@ public abstract class BitXorNode extends Node {
   }
 
   @Specialization
-  Object doAtomThis(Atom _this, Object that, @CachedContext(Language.class) Context ctx) {
-    Builtins builtins = ctx.getBuiltins();
+  Object doAtomThis(Atom _this, Object that) {
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, _this, "this"), this);
   }
 
   @Fallback
   Object doOther(Object _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/CompareToNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/CompareToNode.java
@@ -1,12 +1,9 @@
 package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.TruffleLanguage.ContextReference;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.runtime.Context;
@@ -31,8 +28,7 @@ public abstract class CompareToNode extends Node {
   Atom doLong(
       EnsoBigInteger _this,
       long that,
-      @CachedContext(Language.class) ContextReference<Context> ctxRef,
-      @Cached("getOrdering(ctxRef)") Ordering ordering) {
+      @Cached("getOrdering()") Ordering ordering) {
     return ordering.fromJava(BigIntegerOps.compareTo(_this.getValue(), that));
   }
 
@@ -40,8 +36,7 @@ public abstract class CompareToNode extends Node {
   Atom doBigInt(
       EnsoBigInteger _this,
       EnsoBigInteger that,
-      @CachedContext(Language.class) ContextReference<Context> ctxRef,
-      @Cached("getOrdering(ctxRef)") Ordering ordering) {
+      @Cached("getOrdering()") Ordering ordering) {
     return ordering.fromJava(BigIntegerOps.compareTo(_this.getValue(), that.getValue()));
   }
 
@@ -49,23 +44,21 @@ public abstract class CompareToNode extends Node {
   Atom doDecimal(
       EnsoBigInteger _this,
       double that,
-      @CachedContext(Language.class) ContextReference<Context> ctxRef,
-      @Cached("getOrdering(ctxRef)") Ordering ordering) {
+      @Cached("getOrdering()") Ordering ordering) {
     return ordering.fromJava(BigIntegerOps.compareTo(_this.getValue(), that));
   }
 
   @Specialization
   Atom doOther(
       EnsoBigInteger _this,
-      Object that,
-      @CachedContext(Language.class) ContextReference<Context> ctxRef) {
+      Object that) {
     CompilerDirectives.transferToInterpreter();
-    var number = ctxRef.get().getBuiltins().number().getNumber().newInstance();
-    var typeError = ctxRef.get().getBuiltins().error().makeTypeError(that, number, "that");
+    var number = Context.get(this).getBuiltins().number().getNumber().newInstance();
+    var typeError = Context.get(this).getBuiltins().error().makeTypeError(that, number, "that");
     throw new PanicException(typeError, this);
   }
 
-  Ordering getOrdering(ContextReference<Context> ctxRef) {
-    return ctxRef.get().getBuiltins().ordering();
+  Ordering getOrdering() {
+    return Context.get(this).getBuiltins().ordering();
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/DivNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/DivNode.java
@@ -1,11 +1,8 @@
 package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 
-import com.oracle.truffle.api.TruffleLanguage.ContextReference;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
@@ -29,13 +26,12 @@ public abstract class DivNode extends Node {
   @Specialization
   Object doLong(
       EnsoBigInteger _this,
-      long that,
-      @CachedContext(Language.class) ContextReference<Context> ctxRef) {
+      long that) {
     try {
       return toEnsoNumberNode.execute(BigIntegerOps.divide(_this.getValue(), that));
     } catch (ArithmeticException e) {
       return DataflowError.withoutTrace(
-          ctxRef.get().getBuiltins().error().getDivideByZeroError(), this);
+          Context.get(this).getBuiltins().error().getDivideByZeroError(), this);
     }
   }
 
@@ -47,7 +43,7 @@ public abstract class DivNode extends Node {
 
   @Fallback
   Object doOther(EnsoBigInteger _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/DivideNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/DivideNode.java
@@ -3,9 +3,9 @@ package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -36,7 +36,7 @@ public abstract class DivideNode extends Node {
 
   @Fallback
   double doOther(EnsoBigInteger _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/EqualsNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/EqualsNode.java
@@ -1,12 +1,9 @@
 package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 
-import com.oracle.truffle.api.TruffleLanguage.ContextReference;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.runtime.Context;
@@ -37,8 +34,7 @@ public abstract class EqualsNode extends Node {
   boolean doAtom(
       Atom _this,
       Atom that,
-      @CachedContext(Language.class) ContextReference<Context> ctxRef,
-      @Cached("getBigIntegerConstructor(ctxRef)") AtomConstructor bigIntCons) {
+      @Cached("getBigIntegerConstructor()") AtomConstructor bigIntCons) {
     var thisCons = _this.getConstructor();
     var thatCons = that.getConstructor();
     return (thatCons == bigIntCons) && (thisCons == thatCons);
@@ -49,7 +45,7 @@ public abstract class EqualsNode extends Node {
     return false;
   }
 
-  AtomConstructor getBigIntegerConstructor(ContextReference<Context> ctxRef) {
-    return ctxRef.get().getBuiltins().number().getBigInteger();
+  AtomConstructor getBigIntegerConstructor() {
+    return Context.get(this).getBuiltins().number().getBigInteger();
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/GreaterNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/GreaterNode.java
@@ -3,9 +3,9 @@ package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -37,7 +37,7 @@ public abstract class GreaterNode extends Node {
 
   @Fallback
   boolean doOther(EnsoBigInteger _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/GreaterOrEqualNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/GreaterOrEqualNode.java
@@ -3,9 +3,9 @@ package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -37,7 +37,7 @@ public abstract class GreaterOrEqualNode extends Node {
 
   @Fallback
   boolean doOther(EnsoBigInteger _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/LessNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/LessNode.java
@@ -3,9 +3,9 @@ package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -37,7 +37,7 @@ public abstract class LessNode extends Node {
 
   @Fallback
   boolean doOther(EnsoBigInteger _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/LessOrEqualNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/LessOrEqualNode.java
@@ -3,9 +3,9 @@ package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -37,7 +37,7 @@ public abstract class LessOrEqualNode extends Node {
 
   @Fallback
   boolean doOther(EnsoBigInteger _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/ModNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/ModNode.java
@@ -1,11 +1,8 @@
 package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 
-import com.oracle.truffle.api.TruffleLanguage.ContextReference;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
@@ -29,13 +26,12 @@ public abstract class ModNode extends Node {
   @Specialization
   Object doLong(
       EnsoBigInteger _this,
-      long that,
-      @CachedContext(Language.class) ContextReference<Context> ctxRef) {
+      long that) {
     try {
       return toEnsoNumberNode.execute(BigIntegerOps.modulo(_this.getValue(), that));
     } catch (ArithmeticException e) {
       return DataflowError.withoutTrace(
-          ctxRef.get().getBuiltins().error().getDivideByZeroError(), this);
+          Context.get(this).getBuiltins().error().getDivideByZeroError(), this);
     }
   }
 
@@ -47,7 +43,7 @@ public abstract class ModNode extends Node {
 
   @Fallback
   Object doOther(EnsoBigInteger _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/MultiplyNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/MultiplyNode.java
@@ -3,10 +3,10 @@ package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -39,7 +39,7 @@ public abstract class MultiplyNode extends Node {
 
   @Fallback
   Object doOther(EnsoBigInteger _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/PowNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/PowNode.java
@@ -3,10 +3,10 @@ package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -52,7 +52,7 @@ public abstract class PowNode extends Node {
 
   @Fallback
   Object doOther(EnsoBigInteger _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/SubtractNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/bigInteger/SubtractNode.java
@@ -3,10 +3,10 @@ package org.enso.interpreter.node.expression.builtin.number.bigInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -39,7 +39,7 @@ public abstract class SubtractNode extends Node {
 
   @Fallback
   Object doOther(EnsoBigInteger _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/AddNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/AddNode.java
@@ -3,9 +3,9 @@ package org.enso.interpreter.node.expression.builtin.number.decimal;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -36,7 +36,7 @@ public abstract class AddNode extends Node {
 
   @Fallback
   double doOther(double _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/CompareToNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/CompareToNode.java
@@ -1,12 +1,9 @@
 package org.enso.interpreter.node.expression.builtin.number.decimal;
 
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.TruffleLanguage.ContextReference;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.runtime.Context;
@@ -28,8 +25,7 @@ public abstract class CompareToNode extends Node {
   Atom doLong(
       double _this,
       long that,
-      @CachedContext(Language.class) ContextReference<Context> ctxRef,
-      @Cached("getOrdering(ctxRef)") Ordering ordering) {
+      @Cached("getOrdering()") Ordering ordering) {
     if (_this == that) {
       return ordering.newEqual();
     } else if (_this > that) {
@@ -43,8 +39,7 @@ public abstract class CompareToNode extends Node {
   Atom doBigInt(
       double _this,
       EnsoBigInteger that,
-      @CachedContext(Language.class) ContextReference<Context> ctxRef,
-      @Cached("getOrdering(ctxRef)") Ordering ordering) {
+      @Cached("getOrdering()") Ordering ordering) {
     return ordering.fromJava(BigIntegerOps.compareTo(_this, that.getValue()));
   }
 
@@ -52,8 +47,7 @@ public abstract class CompareToNode extends Node {
   Atom doDecimal(
       double _this,
       double that,
-      @CachedContext(Language.class) ContextReference<Context> ctxRef,
-      @Cached("getOrdering(ctxRef)") Ordering ordering) {
+      @Cached("getOrdering()") Ordering ordering) {
     if (_this == that) {
       return ordering.newEqual();
     } else if (_this > that) {
@@ -65,14 +59,14 @@ public abstract class CompareToNode extends Node {
 
   @Specialization
   Atom doOther(
-      double _this, Object that, @CachedContext(Language.class) ContextReference<Context> ctxRef) {
+      double _this, Object that) {
     CompilerDirectives.transferToInterpreter();
-    var number = ctxRef.get().getBuiltins().number().getNumber().newInstance();
-    var typeError = ctxRef.get().getBuiltins().error().makeTypeError(that, number, "that");
+    var number = Context.get(this).getBuiltins().number().getNumber().newInstance();
+    var typeError = Context.get(this).getBuiltins().error().makeTypeError(that, number, "that");
     throw new PanicException(typeError, this);
   }
 
-  Ordering getOrdering(ContextReference<Context> ctxRef) {
-    return ctxRef.get().getBuiltins().ordering();
+  Ordering getOrdering() {
+    return Context.get(this).getBuiltins().ordering();
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/DivideNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/DivideNode.java
@@ -3,9 +3,9 @@ package org.enso.interpreter.node.expression.builtin.number.decimal;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -36,7 +36,7 @@ public abstract class DivideNode extends Node {
 
   @Fallback
   double doOther(double _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/EqualsNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/EqualsNode.java
@@ -1,12 +1,9 @@
 package org.enso.interpreter.node.expression.builtin.number.decimal;
 
-import com.oracle.truffle.api.TruffleLanguage.ContextReference;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.runtime.Context;
@@ -41,8 +38,7 @@ public abstract class EqualsNode extends Node {
   boolean doAtom(
       Atom _this,
       Atom that,
-      @CachedContext(Language.class) ContextReference<Context> ctxRef,
-      @Cached("getDecimalConstructor(ctxRef)") AtomConstructor decimalCons) {
+      @Cached("getDecimalConstructor()") AtomConstructor decimalCons) {
     var thatCons = that.getConstructor();
     var thisCons = _this.getConstructor();
     return (thatCons == decimalCons) && (thisCons == thatCons);
@@ -53,7 +49,7 @@ public abstract class EqualsNode extends Node {
     return false;
   }
 
-  AtomConstructor getDecimalConstructor(ContextReference<Context> ctxRef) {
-    return ctxRef.get().getBuiltins().number().getDecimal();
+  AtomConstructor getDecimalConstructor() {
+    return Context.get(this).getBuiltins().number().getDecimal();
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/GreaterNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/GreaterNode.java
@@ -3,9 +3,9 @@ package org.enso.interpreter.node.expression.builtin.number.decimal;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -37,7 +37,7 @@ public abstract class GreaterNode extends Node {
 
   @Fallback
   boolean doOther(double _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/GreaterOrEqualNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/GreaterOrEqualNode.java
@@ -3,9 +3,9 @@ package org.enso.interpreter.node.expression.builtin.number.decimal;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -37,7 +37,7 @@ public abstract class GreaterOrEqualNode extends Node {
 
   @Fallback
   boolean doOther(double _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/LessNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/LessNode.java
@@ -3,9 +3,9 @@ package org.enso.interpreter.node.expression.builtin.number.decimal;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -37,7 +37,7 @@ public abstract class LessNode extends Node {
 
   @Fallback
   boolean doOther(double _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/LessOrEqualNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/LessOrEqualNode.java
@@ -3,9 +3,9 @@ package org.enso.interpreter.node.expression.builtin.number.decimal;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -37,7 +37,7 @@ public abstract class LessOrEqualNode extends Node {
 
   @Fallback
   boolean doOther(double _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/MultiplyNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/MultiplyNode.java
@@ -3,9 +3,9 @@ package org.enso.interpreter.node.expression.builtin.number.decimal;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -36,7 +36,7 @@ public abstract class MultiplyNode extends Node {
 
   @Fallback
   double doOther(double _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/PowNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/PowNode.java
@@ -3,9 +3,9 @@ package org.enso.interpreter.node.expression.builtin.number.decimal;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -36,7 +36,7 @@ public abstract class PowNode extends Node {
 
   @Fallback
   double doOther(double _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/SubtractNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/decimal/SubtractNode.java
@@ -3,9 +3,9 @@ package org.enso.interpreter.node.expression.builtin.number.decimal;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -36,7 +36,7 @@ public abstract class SubtractNode extends Node {
 
   @Fallback
   double doOther(double _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/AddNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/AddNode.java
@@ -3,10 +3,10 @@ package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -44,7 +44,7 @@ public abstract class AddNode extends Node {
 
   @Fallback
   Object doOther(long _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/BitAndNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/BitAndNode.java
@@ -1,10 +1,8 @@
 package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
@@ -35,15 +33,15 @@ public abstract class BitAndNode extends Node {
   }
 
   @Specialization
-  Object doAtomThis(Atom _this, Object that, @CachedContext(Language.class) Context ctx) {
-    Builtins builtins = ctx.getBuiltins();
+  Object doAtomThis(Atom _this, Object that) {
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, _this, "this"), this);
   }
 
   @Fallback
   Object doOther(Object _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/BitNotNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/BitNotNode.java
@@ -3,8 +3,8 @@ package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -24,7 +24,7 @@ public abstract class BitNotNode extends Node {
 
   @Fallback
   Object doOther(Object _this) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, _this, "this"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/BitOrNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/BitOrNode.java
@@ -1,10 +1,8 @@
 package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
@@ -35,15 +33,15 @@ public abstract class BitOrNode extends Node {
   }
 
   @Specialization
-  Object doAtomThis(Atom _this, Object that, @CachedContext(Language.class) Context ctx) {
-    Builtins builtins = ctx.getBuiltins();
+  Object doAtomThis(Atom _this, Object that) {
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, _this, "this"), this);
   }
 
   @Fallback
   Object doOther(Object _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/BitShiftRightNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/BitShiftRightNode.java
@@ -1,11 +1,9 @@
 package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.runtime.Context;
@@ -34,15 +32,15 @@ public abstract class BitShiftRightNode extends Node {
   }
 
   @Specialization
-  Object doAtomThis(Atom _this, Object that, @CachedContext(Language.class) Context ctx) {
-    Builtins builtins = ctx.getBuiltins();
+  Object doAtomThis(Atom _this, Object that) {
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, _this, "this"), this);
   }
 
   @Fallback
   Object doOther(Object _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/BitXorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/BitXorNode.java
@@ -1,10 +1,8 @@
 package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
@@ -35,15 +33,15 @@ public abstract class BitXorNode extends Node {
   }
 
   @Specialization
-  Object doAtomThis(Atom _this, Object that, @CachedContext(Language.class) Context ctx) {
-    Builtins builtins = ctx.getBuiltins();
+  Object doAtomThis(Atom _this, Object that) {
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, _this, "this"), this);
   }
 
   @Fallback
   Object doOther(Object _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/CompareToNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/CompareToNode.java
@@ -1,12 +1,9 @@
 package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.TruffleLanguage.ContextReference;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.runtime.Context;
@@ -31,8 +28,7 @@ public abstract class CompareToNode extends Node {
   Atom doLong(
       long _this,
       long that,
-      @CachedContext(Language.class) ContextReference<Context> ctxRef,
-      @Cached("getOrdering(ctxRef)") Ordering ordering) {
+      @Cached("getOrdering()") Ordering ordering) {
     if (_this == that) {
       return ordering.newEqual();
     } else if (_this > that) {
@@ -46,8 +42,7 @@ public abstract class CompareToNode extends Node {
   Atom doBigInt(
       long _this,
       EnsoBigInteger that,
-      @CachedContext(Language.class) ContextReference<Context> ctxRef,
-      @Cached("getOrdering(ctxRef)") Ordering ordering) {
+      @Cached("getOrdering()") Ordering ordering) {
     return ordering.fromJava(BigIntegerOps.compareTo(_this, that.getValue()));
   }
 
@@ -55,8 +50,7 @@ public abstract class CompareToNode extends Node {
   Atom doDecimal(
       long _this,
       double that,
-      @CachedContext(Language.class) ContextReference<Context> ctxRef,
-      @Cached("getOrdering(ctxRef)") Ordering ordering) {
+      @Cached("getOrdering()") Ordering ordering) {
     if (_this == that) {
       return ordering.newEqual();
     } else if (_this > that) {
@@ -68,14 +62,14 @@ public abstract class CompareToNode extends Node {
 
   @Specialization
   Atom doOther(
-      long _this, Object that, @CachedContext(Language.class) ContextReference<Context> ctxRef) {
+      long _this, Object that) {
     CompilerDirectives.transferToInterpreter();
-    var number = ctxRef.get().getBuiltins().number().getNumber().newInstance();
-    var typeError = ctxRef.get().getBuiltins().error().makeTypeError(that, number, "that");
+    var number = Context.get(this).getBuiltins().number().getNumber().newInstance();
+    var typeError = Context.get(this).getBuiltins().error().makeTypeError(that, number, "that");
     throw new PanicException(typeError, this);
   }
 
-  Ordering getOrdering(ContextReference<Context> ctxRef) {
-    return ctxRef.get().getBuiltins().ordering();
+  Ordering getOrdering() {
+    return Context.get(this).getBuiltins().ordering();
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/DivNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/DivNode.java
@@ -1,11 +1,8 @@
 package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 
-import com.oracle.truffle.api.TruffleLanguage.ContextReference;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
@@ -23,13 +20,12 @@ public abstract class DivNode extends Node {
   }
 
   @Specialization
-  Object doLong(
-      long _this, long that, @CachedContext(Language.class) ContextReference<Context> ctxRef) {
+  Object doLong(long _this, long that) {
     try {
       return _this / that;
     } catch (ArithmeticException e) {
       return DataflowError.withoutTrace(
-          ctxRef.get().getBuiltins().error().getDivideByZeroError(), this);
+          Context.get(this).getBuiltins().error().getDivideByZeroError(), this);
     }
   }
 
@@ -41,7 +37,7 @@ public abstract class DivNode extends Node {
 
   @Fallback
   Object doOther(long _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/DivideNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/DivideNode.java
@@ -3,9 +3,9 @@ package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -36,7 +36,7 @@ public abstract class DivideNode extends Node {
 
   @Fallback
   double doOther(long _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/EqualsNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/EqualsNode.java
@@ -1,12 +1,9 @@
 package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 
-import com.oracle.truffle.api.TruffleLanguage.ContextReference;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.atom.Atom;
@@ -35,8 +32,7 @@ public abstract class EqualsNode extends Node {
   boolean doAtom(
       Atom _this,
       Atom that,
-      @CachedContext(Language.class) ContextReference<Context> ctxRef,
-      @Cached("getSmallIntegerConstructor(ctxRef)") AtomConstructor smallIntCons) {
+      @Cached("getSmallIntegerConstructor()") AtomConstructor smallIntCons) {
     var thisCons = _this.getConstructor();
     var thatCons = that.getConstructor();
     return (thatCons == smallIntCons) && (thisCons == thatCons);
@@ -47,7 +43,7 @@ public abstract class EqualsNode extends Node {
     return false;
   }
 
-  AtomConstructor getSmallIntegerConstructor(ContextReference<Context> ctxRef) {
-    return ctxRef.get().getBuiltins().number().getBigInteger();
+  AtomConstructor getSmallIntegerConstructor() {
+    return Context.get(this).getBuiltins().number().getBigInteger();
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/GreaterNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/GreaterNode.java
@@ -3,8 +3,8 @@ package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -36,7 +36,7 @@ public abstract class GreaterNode extends Node {
 
   @Fallback
   boolean doOther(long _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/GreaterOrEqualNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/GreaterOrEqualNode.java
@@ -3,8 +3,8 @@ package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -36,7 +36,7 @@ public abstract class GreaterOrEqualNode extends Node {
 
   @Fallback
   boolean doOther(long _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/LessNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/LessNode.java
@@ -3,8 +3,8 @@ package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -36,7 +36,7 @@ public abstract class LessNode extends Node {
 
   @Fallback
   boolean doOther(long _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/LessOrEqualNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/LessOrEqualNode.java
@@ -3,8 +3,8 @@ package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -36,7 +36,7 @@ public abstract class LessOrEqualNode extends Node {
 
   @Fallback
   boolean doOther(long _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/ModNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/ModNode.java
@@ -1,7 +1,5 @@
 package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 
-import com.oracle.truffle.api.TruffleLanguage.ContextReference;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/ModNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/ModNode.java
@@ -5,7 +5,6 @@ import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
@@ -23,13 +22,12 @@ public abstract class ModNode extends Node {
   }
 
   @Specialization
-  Object doLong(
-      long _this, long that, @CachedContext(Language.class) ContextReference<Context> ctxRef) {
+  Object doLong(long _this, long that) {
     try {
       return _this % that;
     } catch (ArithmeticException e) {
       return DataflowError.withoutTrace(
-          ctxRef.get().getBuiltins().error().getDivideByZeroError(), this);
+          Context.get(this).getBuiltins().error().getDivideByZeroError(), this);
     }
   }
 
@@ -41,7 +39,7 @@ public abstract class ModNode extends Node {
 
   @Fallback
   Object doOther(long _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom integer = builtins.number().getInteger().newInstance();
     throw new PanicException(builtins.error().makeTypeError(integer, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/MultiplyNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/MultiplyNode.java
@@ -3,10 +3,10 @@ package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -44,7 +44,7 @@ public abstract class MultiplyNode extends Node {
 
   @Fallback
   Object doOther(long _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/PowNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/PowNode.java
@@ -4,15 +4,15 @@ import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
 import java.math.BigInteger;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.number.EnsoBigInteger;
 
-@BuiltinMethod(type = "Small_Integer", name = "^", description = "Exponentation of numbers.")
+@BuiltinMethod(type = "Small_Integer", name = "^", description = "Exponentiation of numbers.")
 public abstract class PowNode extends Node {
   private @Child ToEnsoNumberNode toEnsoNumberNode = ToEnsoNumberNode.build();
   private @Child org.enso.interpreter.node.expression.builtin.number.smallInteger.MultiplyNode
@@ -73,7 +73,7 @@ public abstract class PowNode extends Node {
 
   @Fallback
   Object doOther(long _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/SubtractNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/smallInteger/SubtractNode.java
@@ -3,10 +3,10 @@ package org.enso.interpreter.node.expression.builtin.number.smallInteger;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.number.utils.BigIntegerOps;
 import org.enso.interpreter.node.expression.builtin.number.utils.ToEnsoNumberNode;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -44,7 +44,7 @@ public abstract class SubtractNode extends Node {
 
   @Fallback
   Object doOther(long _this, Object that) {
-    Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+    Builtins builtins = Context.get(this).getBuiltins();
     Atom number = builtins.number().getNumber().newInstance();
     throw new PanicException(builtins.error().makeTypeError(number, that, "that"), this);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/resource/FinalizeNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/resource/FinalizeNode.java
@@ -1,9 +1,7 @@
 package org.enso.interpreter.node.expression.builtin.resource;
 
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.data.ManagedResource;
@@ -21,8 +19,8 @@ public abstract class FinalizeNode extends Node {
   abstract Object execute(Object _this, ManagedResource resource);
 
   @Specialization
-  Object doClose(
-      Object _this, ManagedResource resource, @CachedContext(Language.class) Context context) {
+  Object doClose(Object _this, ManagedResource resource) {
+    Context context = Context.get(this);
     context.getResourceManager().close(resource);
     return context.getBuiltins().nothing().newInstance();
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/resource/RegisterNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/resource/RegisterNode.java
@@ -1,10 +1,8 @@
 package org.enso.interpreter.node.expression.builtin.resource;
 
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.function.Function;
@@ -27,8 +25,7 @@ public abstract class RegisterNode extends Node {
   ManagedResource doRegister(
       Object _this,
       Object resource,
-      Function function,
-      @CachedContext(Language.class) Context context) {
-    return context.getResourceManager().register(resource, function);
+      Function function) {
+    return Context.get(this).getResourceManager().register(resource, function);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/resource/TakeNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/resource/TakeNode.java
@@ -1,9 +1,7 @@
 package org.enso.interpreter.node.expression.builtin.resource;
 
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.data.ManagedResource;
@@ -24,8 +22,8 @@ public abstract class TakeNode extends Node {
 
   @Specialization
   Object doTake(
-      Object _this, ManagedResource resource, @CachedContext(Language.class) Context context) {
-    context.getResourceManager().take(resource);
+      Object _this, ManagedResource resource) {
+    Context.get(this).getResourceManager().take(resource);
     return resource.getResource();
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/resource/WithNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/resource/WithNode.java
@@ -1,14 +1,13 @@
 package org.enso.interpreter.node.expression.builtin.resource;
 
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.dsl.MonadicState;
 import org.enso.interpreter.node.callable.InvokeCallableNode;
 import org.enso.interpreter.runtime.Context;
+import org.enso.interpreter.runtime.ResourceManager;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
 import org.enso.interpreter.runtime.data.ManagedResource;
 import org.enso.interpreter.runtime.state.Stateful;
@@ -43,14 +42,14 @@ public abstract class WithNode extends Node {
       VirtualFrame frame,
       Object _this,
       ManagedResource resource,
-      Object action,
-      @CachedContext(Language.class) Context context) {
-    context.getResourceManager().park(resource);
+      Object action) {
+    ResourceManager resourceManager = Context.get(this).getResourceManager();
+    resourceManager.park(resource);
     try {
       return invokeCallableNode.execute(
           action, frame, state, new Object[] {resource.getResource()});
     } finally {
-      context.getResourceManager().unpark(resource);
+      resourceManager.unpark(resource);
     }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/runtime/GCNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/runtime/GCNode.java
@@ -1,14 +1,10 @@
 package org.enso.interpreter.node.expression.builtin.runtime;
 
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.Context;
-import org.enso.interpreter.runtime.callable.atom.Atom;
 
 @BuiltinMethod(type = "Runtime", name = "gc", description = "Forces garbage collection")
 public abstract class GCNode extends Node {
@@ -21,9 +17,9 @@ public abstract class GCNode extends Node {
   }
 
   @Specialization
-  Object doGc(Object _this, @CachedContext(Language.class) Context context) {
+  Object doGc(Object _this) {
     runGC();
-    return context.getBuiltins().nothing().newInstance();
+    return Context.get(this).getBuiltins().nothing().newInstance();
   }
 
   @CompilerDirectives.TruffleBoundary

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/special/RunThreadNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/special/RunThreadNode.java
@@ -1,10 +1,8 @@
 package org.enso.interpreter.node.expression.builtin.special;
 
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.dsl.MonadicState;
 import org.enso.interpreter.dsl.Suspend;
@@ -22,7 +20,8 @@ public abstract class RunThreadNode extends Node {
 
   @CompilerDirectives.TruffleBoundary
   @Specialization
-  Thread doExecute(Object state, Object th, @CachedContext(Language.class) Context ctx) {
+  Thread doExecute(Object state, Object th) {
+    Context ctx = Context.get(this);
     Thread thread =
         ctx.getEnvironment()
             .createThread(

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/state/GetStateNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/state/GetStateNode.java
@@ -1,13 +1,10 @@
 package org.enso.interpreter.node.expression.builtin.state;
 
-import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.dsl.MonadicState;
 import org.enso.interpreter.runtime.Context;
@@ -50,12 +47,11 @@ public abstract class GetStateNode extends Node {
   Object doMultiUncached(
       SmallMap state,
       Object _this,
-      Object key,
-      @CachedContext(Language.class) TruffleLanguage.ContextReference<Context> ctxRef) {
+      Object key) {
     int idx = state.indexOf(key);
     if (idx == SmallMap.NOT_FOUND) {
       return DataflowError.withoutTrace(
-          ctxRef.get().getBuiltins().error().uninitializedState().newInstance(key), this);
+          Context.get(this).getBuiltins().error().uninitializedState().newInstance(key), this);
     } else {
       return state.getValues()[idx];
     }
@@ -63,15 +59,15 @@ public abstract class GetStateNode extends Node {
 
   @Specialization
   Object doEmpty(
-      EmptyMap state, Object _this, Object key, @CachedContext(Language.class) Context ctx) {
+      EmptyMap state, Object _this, Object key) {
     return DataflowError.withoutTrace(
-        ctx.getBuiltins().error().uninitializedState().newInstance(key), this);
+        Context.get(this).getBuiltins().error().uninitializedState().newInstance(key), this);
   }
 
   @Specialization
   Object doSingletonError(
-      SingletonMap state, Object _this, Object key, @CachedContext(Language.class) Context ctx) {
+      SingletonMap state, Object _this, Object key) {
     return DataflowError.withoutTrace(
-        ctx.getBuiltins().error().uninitializedState().newInstance(key), this);
+        Context.get(this).getBuiltins().error().uninitializedState().newInstance(key), this);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/state/PutStateNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/state/PutStateNode.java
@@ -1,8 +1,6 @@
 package org.enso.interpreter.node.expression.builtin.state;
 
-import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -55,14 +53,13 @@ public abstract class PutStateNode extends Node {
       SmallMap state,
       Object _this,
       Object key,
-      Object new_state,
-      @CachedContext(Language.class) TruffleLanguage.ContextReference<Context> ctxRef) {
+      Object new_state) {
     int index = state.indexOf(key);
     if (index == SmallMap.NOT_FOUND) {
       return new Stateful(
           state,
           DataflowError.withoutTrace(
-              ctxRef.get().getBuiltins().error().uninitializedState().newInstance(key), this));
+              Context.get(this).getBuiltins().error().uninitializedState().newInstance(key), this));
     } else {
       return doExistingMultiCached(state, _this, key, new_state, key, state.getKeys(), index);
     }
@@ -73,11 +70,10 @@ public abstract class PutStateNode extends Node {
       Object state,
       Object _this,
       Object key,
-      Object new_state,
-      @CachedContext(Language.class) Context ctx) {
+      Object new_state) {
     return new Stateful(
         state,
         DataflowError.withoutTrace(
-            ctx.getBuiltins().error().uninitializedState().newInstance(key), this));
+            Context.get(this).getBuiltins().error().uninitializedState().newInstance(key), this));
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/system/CreateProcessNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/system/CreateProcessNode.java
@@ -2,14 +2,11 @@ package org.enso.interpreter.node.expression.builtin.system;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.io.TruffleProcessBuilder;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.text.util.ExpectStringNode;
-import org.enso.interpreter.node.expression.builtin.text.util.ToJavaStringNode;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.data.Array;
 import org.enso.interpreter.runtime.data.text.Text;
@@ -46,8 +43,8 @@ public abstract class CreateProcessNode extends Node {
       boolean redirectIn,
       boolean redirectOut,
       boolean redirectErr,
-      @CachedContext(Language.class) Context ctx,
       @Cached ExpectStringNode expectStringNode) {
+    Context ctx = Context.get(this);
     String[] cmd = new String[arguments.getItems().length + 1];
     cmd[0] = expectStringNode.execute(command);
     for (int i = 1; i <= arguments.getItems().length; i++) {
@@ -114,8 +111,8 @@ public abstract class CreateProcessNode extends Node {
       }
 
       long exitCode = p.exitValue();
-      Text returnOut = Text.create(new String(out.toByteArray()));
-      Text returnErr = Text.create(new String(err.toByteArray()));
+      Text returnOut = Text.create(out.toString());
+      Text returnErr = Text.create(err.toString());
 
       return ctx.getBuiltins()
           .system()

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/util/ExpectStringNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/util/ExpectStringNode.java
@@ -6,7 +6,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.data.text.Text;
@@ -36,7 +36,7 @@ public abstract class ExpectStringNode extends Node {
     try {
       return library.asString(str);
     } catch (UnsupportedMessageException e) {
-      Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+      Builtins builtins = Context.get(this).getBuiltins();
       Atom err = builtins.error().makeTypeError(builtins.text().getText(), str, "str");
       throw new PanicException(err, this);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/util/ExpectTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/util/ExpectTextNode.java
@@ -6,7 +6,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
+import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.data.text.Text;
@@ -37,7 +37,7 @@ public abstract class ExpectTextNode extends Node {
     try {
       return Text.create(library.asString(str));
     } catch (UnsupportedMessageException e) {
-      Builtins builtins = lookupContextReference(Language.class).get().getBuiltins();
+      Builtins builtins = Context.get(this).getBuiltins();
       Atom err = builtins.error().makeTypeError(builtins.text().getText(), str, "str");
       throw new PanicException(err, this);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/constant/ConstructorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/constant/ConstructorNode.java
@@ -1,10 +1,8 @@
 package org.enso.interpreter.node.expression.constant;
 
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
@@ -35,11 +33,12 @@ public abstract class ConstructorNode extends ExpressionNode {
    * @return the constructor of the type defined
    */
   @Specialization
-  Object doExecute(VirtualFrame frame, @CachedContext(Language.class) Context ctx) {
-    if (constructor == ctx.getBuiltins().bool().getTrue()) {
+  Object doExecute(VirtualFrame frame) {
+    var bool = Context.get(this).getBuiltins().bool();
+    if (constructor == bool.getTrue()) {
       return true;
     }
-    if (constructor == ctx.getBuiltins().bool().getFalse()) {
+    if (constructor == bool.getFalse()) {
       return false;
     }
     if (constructor.getArity() == 0) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/EvalNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/EvalNode.java
@@ -61,7 +61,7 @@ public abstract class EvalNode extends BaseNode {
   public abstract Stateful execute(CallerInfo callerInfo, Object state, Text expression);
 
   RootCallTarget parseExpression(LocalScope scope, ModuleScope moduleScope, String expression) {
-    Context context = lookupContextReference(Language.class).get();
+    Context context = Context.get(this);
     LocalScope localScope = scope.createChild();
     InlineContext inlineContext =
         InlineContext.fromJava(

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/EvalNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/EvalNode.java
@@ -8,7 +8,6 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import org.enso.compiler.context.InlineContext;
 import org.enso.interpreter.Constants;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.node.BaseNode;
 import org.enso.interpreter.node.ClosureRootNode;
 import org.enso.interpreter.node.ExpressionNode;
@@ -77,7 +76,7 @@ public abstract class EvalNode extends BaseNode {
     }
     ClosureRootNode framedNode =
         ClosureRootNode.build(
-            lookupLanguageReference(Language.class).get(),
+            context.getLanguage(),
             localScope,
             moduleScope,
             expr,

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/scope/AssignmentNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/scope/AssignmentNode.java
@@ -1,6 +1,5 @@
 package org.enso.interpreter.node.scope;
 
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -8,7 +7,6 @@ import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.Context;
 
@@ -35,16 +33,14 @@ public abstract class AssignmentNode extends ExpressionNode {
    *
    * @param frame the frame to write to
    * @param value the value to write
-   * @param ctx language context for global values access
    * @return the unit type
    */
   @Specialization(guards = "isLongOrIllegal(frame)")
-  protected Object writeLong(
-      VirtualFrame frame, long value, @CachedContext(Language.class) Context ctx) {
+  protected Object writeLong(VirtualFrame frame, long value) {
     frame.getFrameDescriptor().setFrameSlotKind(getFrameSlot(), FrameSlotKind.Long);
     frame.setLong(getFrameSlot(), value);
 
-    return ctx.getNothing().newInstance();
+    return Context.get(this).getNothing().newInstance();
   }
 
   /**
@@ -52,16 +48,14 @@ public abstract class AssignmentNode extends ExpressionNode {
    *
    * @param frame the frame to write to
    * @param value the value to write
-   * @param ctx language context for global values access
    * @return the unit type
    */
   @Specialization
-  protected Object writeObject(
-      VirtualFrame frame, Object value, @CachedContext(Language.class) Context ctx) {
+  protected Object writeObject(VirtualFrame frame, Object value) {
     frame.getFrameDescriptor().setFrameSlotKind(getFrameSlot(), FrameSlotKind.Object);
     frame.setObject(getFrameSlot(), value);
 
-    return ctx.getNothing().newInstance();
+    return Context.get(this).getNothing().newInstance();
   }
 
   boolean isLongOrIllegal(VirtualFrame frame) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -3,7 +3,6 @@ package org.enso.interpreter.runtime;
 import com.oracle.truffle.api.TruffleFile;
 import com.oracle.truffle.api.TruffleLogger;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.InteropLibrary;
@@ -19,7 +18,6 @@ import java.util.logging.Level;
 import org.enso.compiler.ModuleCache;
 import org.enso.compiler.core.IR;
 import org.enso.compiler.phase.StubIrBuilder;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.node.callable.dispatch.CallOptimiserNode;
 import org.enso.interpreter.node.callable.dispatch.LoopingCallOptimiserNode;
 import org.enso.interpreter.runtime.builtin.Builtins;
@@ -498,9 +496,9 @@ public class Module implements TruffleObject {
         Module module,
         String member,
         Object[] arguments,
-        @CachedContext(Language.class) Context context,
         @Cached LoopingCallOptimiserNode callOptimiserNode)
         throws UnknownIdentifierException, ArityException, UnsupportedTypeException {
+      Context context = Context.get(null);
       ModuleScope scope;
       switch (member) {
         case MethodNames.Module.GET_NAME:

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Error.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Error.java
@@ -103,8 +103,9 @@ public class Error {
     arityError =
         new AtomConstructor("Arity_Error", scope)
             .initializeFields(
-                new ArgumentDefinition(0, "expected", ArgumentDefinition.ExecutionMode.EXECUTE),
-                new ArgumentDefinition(1, "actual", ArgumentDefinition.ExecutionMode.EXECUTE));
+                new ArgumentDefinition(0, "expected_min", ArgumentDefinition.ExecutionMode.EXECUTE),
+                new ArgumentDefinition(1, "expected_max", ArgumentDefinition.ExecutionMode.EXECUTE),
+                new ArgumentDefinition(2, "actual", ArgumentDefinition.ExecutionMode.EXECUTE));
 
     unsupportedArgumentsError =
         new AtomConstructor("Unsupported_Argument_Types", scope)
@@ -293,12 +294,13 @@ public class Error {
   }
 
   /**
-   * @param expected the expected arity
+   * @param expected_min the minimum expected arity
+   * @param expected_max the maximum expected arity
    * @param actual the actual arity
    * @return an error informing about the arity being mismatched
    */
-  public Atom makeArityError(long expected, long actual) {
-    return arityError.newInstance(expected, actual);
+  public Atom makeArityError(long expected_min, long expected_max, long actual) {
+    return arityError.newInstance(expected_min, expected_max, actual);
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/Atom.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/Atom.java
@@ -209,12 +209,16 @@ public class Atom implements TruffleObject {
 
     @CompilerDirectives.TruffleBoundary
     static Function doResolve(AtomConstructor cons, UnresolvedSymbol symbol) {
-      return symbol.resolveFor(cons, Context.get(null).getBuiltins().any());
+      return symbol.resolveFor(cons, getContext().getBuiltins().any());
+    }
+
+    static Context getContext() {
+      return Context.get(null);
     }
 
     @Specialization(
         guards = {
-          "!Context.get(null).isInlineCachingDisabled()",
+          "!getContext().isInlineCachingDisabled()",
           "cachedSymbol == symbol",
           "_this.constructor == cachedConstructor",
           "function != null"
@@ -256,12 +260,16 @@ public class Atom implements TruffleObject {
         AtomConstructor cons,
         AtomConstructor target,
         UnresolvedConversion conversion) {
-      return conversion.resolveFor(target, cons, Context.get(null).getBuiltins().any());
+      return conversion.resolveFor(target, cons, getContext().getBuiltins().any());
+    }
+
+    static Context getContext() {
+      return Context.get(null);
     }
 
     @Specialization(
         guards = {
-          "!Context.get(null).isInlineCachingDisabled()",
+          "!getContext().isInlineCachingDisabled()",
           "cachedConversion == conversion",
           "cachedTarget == target",
           "_this.constructor == cachedConstructor",

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/Atom.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/Atom.java
@@ -2,7 +2,6 @@ package org.enso.interpreter.runtime.callable.atom;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.*;
 import com.oracle.truffle.api.library.CachedLibrary;
@@ -10,7 +9,6 @@ import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.UnresolvedConversion;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
@@ -196,8 +194,8 @@ public class Atom implements TruffleObject {
   }
 
   @ExportMessage
-  boolean isNull(@CachedContext(Language.class) Context ctx) {
-    return this.getConstructor() == ctx.getBuiltins().nothing();
+  boolean isNull() {
+    return this.getConstructor() == Context.get(null).getBuiltins().nothing();
   }
 
   @ExportMessage
@@ -210,13 +208,13 @@ public class Atom implements TruffleObject {
     static final int CACHE_SIZE = 10;
 
     @CompilerDirectives.TruffleBoundary
-    static Function doResolve(Context context, AtomConstructor cons, UnresolvedSymbol symbol) {
-      return symbol.resolveFor(cons, context.getBuiltins().any());
+    static Function doResolve(AtomConstructor cons, UnresolvedSymbol symbol) {
+      return symbol.resolveFor(cons, Context.get(null).getBuiltins().any());
     }
 
     @Specialization(
         guards = {
-          "!context.isInlineCachingDisabled()",
+          "!Context.get(null).isInlineCachingDisabled()",
           "cachedSymbol == symbol",
           "_this.constructor == cachedConstructor",
           "function != null"
@@ -225,18 +223,17 @@ public class Atom implements TruffleObject {
     static Function resolveCached(
         Atom _this,
         UnresolvedSymbol symbol,
-        @CachedContext(Language.class) Context context,
         @Cached("symbol") UnresolvedSymbol cachedSymbol,
         @Cached("_this.constructor") AtomConstructor cachedConstructor,
-        @Cached("doResolve(context, cachedConstructor, cachedSymbol)") Function function) {
+        @Cached("doResolve(cachedConstructor, cachedSymbol)") Function function) {
       return function;
     }
 
     @Specialization(replaces = "resolveCached")
     static Function resolve(
-        Atom _this, UnresolvedSymbol symbol, @CachedContext(Language.class) Context context)
+        Atom _this, UnresolvedSymbol symbol)
         throws MethodDispatchLibrary.NoSuchMethodException {
-      Function function = doResolve(context, _this.constructor, symbol);
+      Function function = doResolve(_this.constructor, symbol);
       if (function == null) {
         throw new MethodDispatchLibrary.NoSuchMethodException();
       }
@@ -256,16 +253,15 @@ public class Atom implements TruffleObject {
 
     @CompilerDirectives.TruffleBoundary
     static Function doResolve(
-        Context context,
         AtomConstructor cons,
         AtomConstructor target,
         UnresolvedConversion conversion) {
-      return conversion.resolveFor(target, cons, context.getBuiltins().any());
+      return conversion.resolveFor(target, cons, Context.get(null).getBuiltins().any());
     }
 
     @Specialization(
         guards = {
-          "!context.isInlineCachingDisabled()",
+          "!Context.get(null).isInlineCachingDisabled()",
           "cachedConversion == conversion",
           "cachedTarget == target",
           "_this.constructor == cachedConstructor",
@@ -276,11 +272,10 @@ public class Atom implements TruffleObject {
         Atom _this,
         AtomConstructor target,
         UnresolvedConversion conversion,
-        @CachedContext(Language.class) Context context,
         @Cached("conversion") UnresolvedConversion cachedConversion,
         @Cached("_this.constructor") AtomConstructor cachedConstructor,
         @Cached("target") AtomConstructor cachedTarget,
-        @Cached("doResolve(context, cachedConstructor, cachedTarget, cachedConversion)")
+        @Cached("doResolve(cachedConstructor, cachedTarget, cachedConversion)")
             Function function) {
       return function;
     }
@@ -289,10 +284,9 @@ public class Atom implements TruffleObject {
     static Function resolve(
         Atom _this,
         AtomConstructor target,
-        UnresolvedConversion conversion,
-        @CachedContext(Language.class) Context context)
+        UnresolvedConversion conversion)
         throws MethodDispatchLibrary.NoSuchConversionException {
-      Function function = doResolve(context, _this.constructor, target, conversion);
+      Function function = doResolve(_this.constructor, target, conversion);
       if (function == null) {
         throw new MethodDispatchLibrary.NoSuchConversionException();
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/AtomConstructor.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/AtomConstructor.java
@@ -4,7 +4,6 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.InteropLibrary;
@@ -12,7 +11,6 @@ import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.RootNode;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.node.callable.argument.ReadArgumentNode;
 import org.enso.interpreter.node.expression.atom.GetFieldNode;
@@ -235,12 +233,16 @@ public final class AtomConstructor implements TruffleObject {
 
     @CompilerDirectives.TruffleBoundary
     static Function doResolve(AtomConstructor cons, UnresolvedSymbol symbol) {
-      return symbol.resolveFor(cons, Context.get(null).getBuiltins().any());
+      return symbol.resolveFor(cons, getContext().getBuiltins().any());
+    }
+
+    static Context getContext() {
+      return Context.get(null);
     }
 
     @Specialization(
         guards = {
-          "!context.isInlineCachingDisabled()",
+          "!getContext().isInlineCachingDisabled()",
           "cachedSymbol == symbol",
           "_this == cachedConstructor",
           "function != null"
@@ -282,12 +284,16 @@ public final class AtomConstructor implements TruffleObject {
         AtomConstructor cons,
         AtomConstructor target,
         UnresolvedConversion conversion) {
-      return conversion.resolveFor(target, cons, Context.get(null).getBuiltins().any());
+      return conversion.resolveFor(target, cons, getContext().getBuiltins().any());
+    }
+
+    static Context getContext() {
+      return Context.get(null);
     }
 
     @Specialization(
         guards = {
-          "!context.isInlineCachingDisabled()",
+          "!getContext().isInlineCachingDisabled()",
           "cachedConversion == conversion",
           "cachedTarget == target",
           "_this == cachedConstructor",

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/AtomConstructor.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/AtomConstructor.java
@@ -194,8 +194,9 @@ public final class AtomConstructor implements TruffleObject {
    */
   @ExportMessage
   Atom instantiate(Object... arguments) throws ArityException {
-    if (arguments.length != getArity()) {
-      throw ArityException.create(getArity(), arguments.length);
+    int expected_arity = getArity();
+    if (arguments.length != expected_arity) {
+      throw ArityException.create(expected_arity, expected_arity, arguments.length);
     }
     if (cachedInstance != null) {
       return cachedInstance;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/AtomConstructor.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/AtomConstructor.java
@@ -234,8 +234,8 @@ public final class AtomConstructor implements TruffleObject {
     static final int CACHE_SIZE = 10;
 
     @CompilerDirectives.TruffleBoundary
-    static Function doResolve(Context context, AtomConstructor cons, UnresolvedSymbol symbol) {
-      return symbol.resolveFor(cons, context.getBuiltins().any());
+    static Function doResolve(AtomConstructor cons, UnresolvedSymbol symbol) {
+      return symbol.resolveFor(cons, Context.get(null).getBuiltins().any());
     }
 
     @Specialization(
@@ -249,20 +249,18 @@ public final class AtomConstructor implements TruffleObject {
     static Function resolveCached(
         AtomConstructor _this,
         UnresolvedSymbol symbol,
-        @CachedContext(Language.class) Context context,
         @Cached("symbol") UnresolvedSymbol cachedSymbol,
         @Cached("_this") AtomConstructor cachedConstructor,
-        @Cached("doResolve(context, cachedConstructor, cachedSymbol)") Function function) {
+        @Cached("doResolve(cachedConstructor, cachedSymbol)") Function function) {
       return function;
     }
 
     @Specialization(replaces = "resolveCached")
     static Function resolve(
         AtomConstructor _this,
-        UnresolvedSymbol symbol,
-        @CachedContext(Language.class) Context context)
+        UnresolvedSymbol symbol)
         throws MethodDispatchLibrary.NoSuchMethodException {
-      Function function = doResolve(context, _this, symbol);
+      Function function = doResolve(_this, symbol);
       if (function == null) {
         throw new MethodDispatchLibrary.NoSuchMethodException();
       }
@@ -281,11 +279,10 @@ public final class AtomConstructor implements TruffleObject {
 
     @CompilerDirectives.TruffleBoundary
     static Function doResolve(
-        Context context,
         AtomConstructor cons,
         AtomConstructor target,
         UnresolvedConversion conversion) {
-      return conversion.resolveFor(target, cons, context.getBuiltins().any());
+      return conversion.resolveFor(target, cons, Context.get(null).getBuiltins().any());
     }
 
     @Specialization(
@@ -301,12 +298,10 @@ public final class AtomConstructor implements TruffleObject {
         AtomConstructor _this,
         AtomConstructor target,
         UnresolvedConversion conversion,
-        @CachedContext(Language.class) Context context,
         @Cached("conversion") UnresolvedConversion cachedConversion,
         @Cached("target") AtomConstructor cachedTarget,
         @Cached("_this") AtomConstructor cachedConstructor,
-        @Cached("doResolve(context, cachedConstructor, cachedTarget, cachedConversion)")
-            Function function) {
+        @Cached("doResolve(cachedConstructor, cachedTarget, cachedConversion)") Function function) {
       return function;
     }
 
@@ -314,10 +309,9 @@ public final class AtomConstructor implements TruffleObject {
     static Function resolve(
         AtomConstructor _this,
         AtomConstructor target,
-        UnresolvedConversion conversion,
-        @CachedContext(Language.class) Context context)
+        UnresolvedConversion conversion)
         throws MethodDispatchLibrary.NoSuchConversionException {
-      Function function = doResolve(context, _this, target, conversion);
+      Function function = doResolve(_this, target, conversion);
       if (function == null) {
         throw new MethodDispatchLibrary.NoSuchConversionException();
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
@@ -2,14 +2,12 @@ package org.enso.interpreter.runtime.data;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.InvalidArrayIndexException;
 import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.UnresolvedConversion;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
@@ -130,14 +128,19 @@ public class Array implements TruffleObject {
     static final int CACHE_SIZE = 10;
 
     @CompilerDirectives.TruffleBoundary
-    static Function doResolve(Context context, UnresolvedSymbol symbol) {
+    static Function doResolve(UnresolvedSymbol symbol) {
+      Context context = getContext();
       return symbol.resolveFor(
           context.getBuiltins().mutable().array(), context.getBuiltins().any());
     }
 
+    static Context getContext() {
+      return Context.get(null);
+    }
+
     @Specialization(
         guards = {
-          "!context.isInlineCachingDisabled()",
+          "!getContext().isInlineCachingDisabled()",
           "cachedSymbol == symbol",
           "function != null"
         },
@@ -145,17 +148,16 @@ public class Array implements TruffleObject {
     static Function resolveCached(
         Array _this,
         UnresolvedSymbol symbol,
-        @CachedContext(Language.class) Context context,
         @Cached("symbol") UnresolvedSymbol cachedSymbol,
-        @Cached("doResolve(context, cachedSymbol)") Function function) {
+        @Cached("doResolve(cachedSymbol)") Function function) {
       return function;
     }
 
     @Specialization(replaces = "resolveCached")
     static Function resolve(
-        Array _this, UnresolvedSymbol symbol, @CachedContext(Language.class) Context context)
+        Array _this, UnresolvedSymbol symbol)
         throws MethodDispatchLibrary.NoSuchMethodException {
-      Function function = doResolve(context, symbol);
+      Function function = doResolve(symbol);
       if (function == null) {
         throw new MethodDispatchLibrary.NoSuchMethodException();
       }
@@ -173,15 +175,19 @@ public class Array implements TruffleObject {
     static final int CACHE_SIZE = 10;
 
     @CompilerDirectives.TruffleBoundary
-    static Function doResolve(
-        Context context, AtomConstructor target, UnresolvedConversion conversion) {
+    static Function doResolve(AtomConstructor target, UnresolvedConversion conversion) {
+      Context context = getContext();
       return conversion.resolveFor(
           target, context.getBuiltins().mutable().array(), context.getBuiltins().any());
     }
 
+    static Context getContext() {
+      return Context.get(null);
+    }
+
     @Specialization(
         guards = {
-          "!context.isInlineCachingDisabled()",
+          "!getContext().isInlineCachingDisabled()",
           "cachedConversion == conversion",
           "cachedTarget == target",
           "function != null"
@@ -191,10 +197,9 @@ public class Array implements TruffleObject {
         Array _this,
         AtomConstructor target,
         UnresolvedConversion conversion,
-        @CachedContext(Language.class) Context context,
         @Cached("conversion") UnresolvedConversion cachedConversion,
         @Cached("target") AtomConstructor cachedTarget,
-        @Cached("doResolve(context, cachedTarget, cachedConversion)") Function function) {
+        @Cached("doResolve(cachedTarget, cachedConversion)") Function function) {
       return function;
     }
 
@@ -202,10 +207,9 @@ public class Array implements TruffleObject {
     static Function resolve(
         Array _this,
         AtomConstructor target,
-        UnresolvedConversion conversion,
-        @CachedContext(Language.class) Context context)
+        UnresolvedConversion conversion)
         throws MethodDispatchLibrary.NoSuchConversionException {
-      Function function = doResolve(context, target, conversion);
+      Function function = doResolve(target, conversion);
       if (function == null) {
         throw new MethodDispatchLibrary.NoSuchConversionException();
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/text/Text.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/text/Text.java
@@ -2,16 +2,13 @@ package org.enso.interpreter.runtime.data.text;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.node.expression.builtin.text.util.ToJavaStringNode;
 import org.enso.interpreter.runtime.Context;
-import org.enso.interpreter.runtime.builtin.Number;
 import org.enso.interpreter.runtime.callable.UnresolvedConversion;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
@@ -191,13 +188,18 @@ public class Text implements TruffleObject {
     static final int CACHE_SIZE = 10;
 
     @CompilerDirectives.TruffleBoundary
-    static Function doResolve(Context context, UnresolvedSymbol symbol) {
+    static Function doResolve(UnresolvedSymbol symbol) {
+      Context context = getContext();
       return symbol.resolveFor(context.getBuiltins().text().getText(), context.getBuiltins().any());
+    }
+
+    static Context getContext() {
+      return Context.get(null);
     }
 
     @Specialization(
         guards = {
-          "!context.isInlineCachingDisabled()",
+          "!getContext().isInlineCachingDisabled()",
           "cachedSymbol == symbol",
           "function != null"
         },
@@ -205,17 +207,16 @@ public class Text implements TruffleObject {
     static Function resolveCached(
         Text _this,
         UnresolvedSymbol symbol,
-        @CachedContext(Language.class) Context context,
         @Cached("symbol") UnresolvedSymbol cachedSymbol,
-        @Cached("doResolve(context, cachedSymbol)") Function function) {
+        @Cached("doResolve(cachedSymbol)") Function function) {
       return function;
     }
 
     @Specialization(replaces = "resolveCached")
     static Function resolve(
-        Text _this, UnresolvedSymbol symbol, @CachedContext(Language.class) Context context)
+        Text _this, UnresolvedSymbol symbol)
         throws MethodDispatchLibrary.NoSuchMethodException {
-      Function function = doResolve(context, symbol);
+      Function function = doResolve(symbol);
       if (function == null) {
         throw new MethodDispatchLibrary.NoSuchMethodException();
       }
@@ -239,15 +240,19 @@ public class Text implements TruffleObject {
     static final int CACHE_SIZE = 10;
 
     @CompilerDirectives.TruffleBoundary
-    static Function doResolve(
-        Context context, AtomConstructor target, UnresolvedConversion conversion) {
+    static Function doResolve(AtomConstructor target, UnresolvedConversion conversion) {
+      Context context = getContext();
       return conversion.resolveFor(
           target, context.getBuiltins().text().getText(), context.getBuiltins().any());
     }
 
+    static Context getContext() {
+      return Context.get(null);
+    }
+
     @Specialization(
         guards = {
-          "!context.isInlineCachingDisabled()",
+          "!getContext().isInlineCachingDisabled()",
           "cachedTarget == target",
           "cachedConversion == conversion",
           "function != null"
@@ -257,10 +262,9 @@ public class Text implements TruffleObject {
         Text _this,
         AtomConstructor target,
         UnresolvedConversion conversion,
-        @CachedContext(Language.class) Context context,
         @Cached("target") AtomConstructor cachedTarget,
         @Cached("conversion") UnresolvedConversion cachedConversion,
-        @Cached("doResolve(context, cachedTarget, cachedConversion)") Function function) {
+        @Cached("doResolve(cachedTarget, cachedConversion)") Function function) {
       return function;
     }
 
@@ -268,10 +272,9 @@ public class Text implements TruffleObject {
     static Function resolve(
         Text _this,
         AtomConstructor target,
-        UnresolvedConversion conversion,
-        @CachedContext(Language.class) Context context)
+        UnresolvedConversion conversion)
         throws MethodDispatchLibrary.NoSuchConversionException {
-      Function function = doResolve(context, target, conversion);
+      Function function = doResolve(target, conversion);
       if (function == null) {
         throw new MethodDispatchLibrary.NoSuchConversionException();
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/DataflowError.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/DataflowError.java
@@ -1,9 +1,7 @@
 package org.enso.interpreter.runtime.error;
 
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.TruffleStackTrace;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.exception.AbstractTruffleException;
 import com.oracle.truffle.api.interop.InteropLibrary;
@@ -11,9 +9,7 @@ import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
-import com.oracle.truffle.api.library.GenerateLibrary;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.UnresolvedConversion;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
@@ -115,13 +111,18 @@ public class DataflowError extends AbstractTruffleException {
     static final int CACHE_SIZE = 10;
 
     @CompilerDirectives.TruffleBoundary
-    static Function doResolve(Context context, AtomConstructor target, UnresolvedConversion conversion) {
+    static Function doResolve(AtomConstructor target, UnresolvedConversion conversion) {
+      Context context = getContext();
       return conversion.resolveFor(target, context.getBuiltins().dataflowError().constructor());
+    }
+
+    static Context getContext() {
+      return Context.get(null);
     }
 
     @Specialization(
             guards = {
-                    "!context.isInlineCachingDisabled()",
+                    "!getContext().isInlineCachingDisabled()",
                     "cachedTarget == target",
                     "cachedConversion == conversion",
                     "function != null"
@@ -131,10 +132,9 @@ public class DataflowError extends AbstractTruffleException {
             DataflowError _this,
             AtomConstructor target,
             UnresolvedConversion conversion,
-            @CachedContext(Language.class) Context context,
             @Cached("conversion") UnresolvedConversion cachedConversion,
             @Cached("target") AtomConstructor cachedTarget,
-            @Cached("doResolve(context, cachedTarget, cachedConversion)") Function function) {
+            @Cached("doResolve(cachedTarget, cachedConversion)") Function function) {
       return function;
     }
 
@@ -142,10 +142,9 @@ public class DataflowError extends AbstractTruffleException {
     static Function resolve(
             DataflowError _this,
             AtomConstructor target,
-            UnresolvedConversion conversion,
-            @CachedContext(Language.class) Context context)
+            UnresolvedConversion conversion)
             throws MethodDispatchLibrary.NoSuchConversionException {
-      Function function = doResolve(context, target, conversion);
+      Function function = doResolve(target, conversion);
       if (function == null) {
         throw new MethodDispatchLibrary.NoSuchConversionException();
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/library/dispatch/DefaultDoubleExports.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/library/dispatch/DefaultDoubleExports.java
@@ -2,12 +2,9 @@ package org.enso.interpreter.runtime.library.dispatch;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
-import com.oracle.truffle.api.library.GenerateLibrary;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Number;
 import org.enso.interpreter.runtime.callable.UnresolvedConversion;
@@ -25,17 +22,22 @@ public class DefaultDoubleExports {
   @ExportMessage
   static class GetFunctionalDispatch {
     @CompilerDirectives.TruffleBoundary
-    static Function doResolve(Context context, UnresolvedSymbol symbol) {
+    static Function doResolve(UnresolvedSymbol symbol) {
+      Context context = getContext();
       Number number = context.getBuiltins().number();
       return symbol.resolveFor(
           number.getDecimal(), number.getNumber(), context.getBuiltins().any());
+    }
+
+    static Context getContext() {
+      return Context.get(null);
     }
 
     static final int CACHE_SIZE = 10;
 
     @Specialization(
         guards = {
-          "!context.isInlineCachingDisabled()",
+          "!getContext().isInlineCachingDisabled()",
           "cachedSymbol == symbol",
           "function != null"
         },
@@ -43,17 +45,16 @@ public class DefaultDoubleExports {
     static Function resolveCached(
         Double _this,
         UnresolvedSymbol symbol,
-        @CachedContext(Language.class) Context context,
         @Cached("symbol") UnresolvedSymbol cachedSymbol,
-        @Cached("doResolve(context, cachedSymbol)") Function function) {
+        @Cached("doResolve(cachedSymbol)") Function function) {
       return function;
     }
 
     @Specialization(replaces = "resolveCached")
     static Function resolve(
-        Double _this, UnresolvedSymbol symbol, @CachedContext(Language.class) Context context)
+        Double _this, UnresolvedSymbol symbol)
         throws MethodDispatchLibrary.NoSuchMethodException {
-      Function function = doResolve(context, symbol);
+      Function function = doResolve(symbol);
       if (function == null) {
         throw new MethodDispatchLibrary.NoSuchMethodException();
       }
@@ -74,18 +75,22 @@ public class DefaultDoubleExports {
   @ExportMessage
   static class GetConversionFunction {
     @CompilerDirectives.TruffleBoundary
-    static Function doResolve(
-        Context context, AtomConstructor target, UnresolvedConversion conversion) {
+    static Function doResolve(AtomConstructor target, UnresolvedConversion conversion) {
+      Context context = getContext();
       Number number = context.getBuiltins().number();
       return conversion.resolveFor(
           target, number.getDecimal(), number.getNumber(), context.getBuiltins().any());
+    }
+
+    static Context getContext() {
+      return Context.get(null);
     }
 
     static final int CACHE_SIZE = 10;
 
     @Specialization(
         guards = {
-          "!context.isInlineCachingDisabled()",
+          "!getContext().isInlineCachingDisabled()",
           "cachedConversion == conversion",
           "cachedTarget == target",
           "function != null"
@@ -95,10 +100,9 @@ public class DefaultDoubleExports {
         Double _this,
         AtomConstructor target,
         UnresolvedConversion conversion,
-        @CachedContext(Language.class) Context context,
         @Cached("conversion") UnresolvedConversion cachedConversion,
         @Cached("target") AtomConstructor cachedTarget,
-        @Cached("doResolve(context, cachedTarget, cachedConversion)") Function function) {
+        @Cached("doResolve(cachedTarget, cachedConversion)") Function function) {
       return function;
     }
 
@@ -106,10 +110,9 @@ public class DefaultDoubleExports {
     static Function resolve(
         Double _this,
         AtomConstructor target,
-        UnresolvedConversion conversion,
-        @CachedContext(Language.class) Context context)
+        UnresolvedConversion conversion)
         throws MethodDispatchLibrary.NoSuchConversionException {
-      Function function = doResolve(context, target, conversion);
+      Function function = doResolve(target, conversion);
       if (function == null) {
         throw new MethodDispatchLibrary.NoSuchConversionException();
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/library/dispatch/DefaultLongExports.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/library/dispatch/DefaultLongExports.java
@@ -2,11 +2,9 @@ package org.enso.interpreter.runtime.library.dispatch;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Number;
 import org.enso.interpreter.runtime.callable.UnresolvedConversion;
@@ -24,7 +22,8 @@ public class DefaultLongExports {
   @ExportMessage
   static class GetFunctionalDispatch {
     @CompilerDirectives.TruffleBoundary
-    static Function doResolve(Context context, UnresolvedSymbol symbol) {
+    static Function doResolve(UnresolvedSymbol symbol) {
+      Context context = getContext();
       Number number = context.getBuiltins().number();
       return symbol.resolveFor(
           number.getSmallInteger(),
@@ -33,11 +32,15 @@ public class DefaultLongExports {
           context.getBuiltins().any());
     }
 
+    static Context getContext() {
+      return Context.get(null);
+    }
+
     static final int CACHE_SIZE = 10;
 
     @Specialization(
         guards = {
-          "!context.isInlineCachingDisabled()",
+          "!getContext().isInlineCachingDisabled()",
           "cachedSymbol == symbol",
           "function != null"
         },
@@ -45,17 +48,16 @@ public class DefaultLongExports {
     static Function resolveCached(
         Long _this,
         UnresolvedSymbol symbol,
-        @CachedContext(Language.class) Context context,
         @Cached("symbol") UnresolvedSymbol cachedSymbol,
-        @Cached("doResolve(context, cachedSymbol)") Function function) {
+        @Cached("doResolve(cachedSymbol)") Function function) {
       return function;
     }
 
     @Specialization(replaces = "resolveCached")
     static Function resolve(
-        Long _this, UnresolvedSymbol symbol, @CachedContext(Language.class) Context context)
+        Long _this, UnresolvedSymbol symbol)
         throws MethodDispatchLibrary.NoSuchMethodException {
-      Function function = doResolve(context, symbol);
+      Function function = doResolve(symbol);
       if (function == null) {
         throw new MethodDispatchLibrary.NoSuchMethodException();
       }
@@ -76,8 +78,8 @@ public class DefaultLongExports {
   @ExportMessage
   static class GetConversionFunction {
     @CompilerDirectives.TruffleBoundary
-    static Function doResolve(
-            Context context, AtomConstructor target, UnresolvedConversion conversion) {
+    static Function doResolve(AtomConstructor target, UnresolvedConversion conversion) {
+      Context context = getContext();
       Number number = context.getBuiltins().number();
       return conversion.resolveFor(target,
               number.getSmallInteger(),
@@ -86,11 +88,15 @@ public class DefaultLongExports {
               context.getBuiltins().any());
     }
 
+    static Context getContext() {
+      return Context.get(null);
+    }
+
     static final int CACHE_SIZE = 10;
 
     @Specialization(
             guards = {
-                    "!context.isInlineCachingDisabled()",
+                    "!getContext().isInlineCachingDisabled()",
                     "cachedConversion == conversion",
                     "cachedTarget == target",
                     "function != null"
@@ -100,10 +106,9 @@ public class DefaultLongExports {
             Long _this,
             AtomConstructor target,
             UnresolvedConversion conversion,
-            @CachedContext(Language.class) Context context,
             @Cached("conversion") UnresolvedConversion cachedConversion,
             @Cached("target") AtomConstructor cachedTarget,
-            @Cached("doResolve(context, cachedTarget, cachedConversion)") Function function) {
+            @Cached("doResolve(cachedTarget, cachedConversion)") Function function) {
       return function;
     }
 
@@ -111,10 +116,9 @@ public class DefaultLongExports {
     static Function resolve(
             Long _this,
             AtomConstructor target,
-            UnresolvedConversion conversion,
-            @CachedContext(Language.class) Context context)
+            UnresolvedConversion conversion)
             throws MethodDispatchLibrary.NoSuchConversionException {
-      Function function = doResolve(context, target, conversion);
+      Function function = doResolve(target, conversion);
       if (function == null) {
         throw new MethodDispatchLibrary.NoSuchConversionException();
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/number/EnsoBigInteger.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/number/EnsoBigInteger.java
@@ -2,14 +2,11 @@ package org.enso.interpreter.runtime.number;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.TruffleObject;
-
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
-import org.enso.interpreter.Language;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.builtin.Number;
 import org.enso.interpreter.runtime.callable.UnresolvedConversion;
@@ -62,7 +59,8 @@ public class EnsoBigInteger implements TruffleObject {
     static final int CACHE_SIZE = 10;
 
     @CompilerDirectives.TruffleBoundary
-    static Function doResolve(Context context, UnresolvedSymbol symbol) {
+    static Function doResolve(UnresolvedSymbol symbol) {
+      Context context = getContext();
       Number number = context.getBuiltins().number();
       return symbol.resolveFor(
           number.getBigInteger(),
@@ -71,9 +69,13 @@ public class EnsoBigInteger implements TruffleObject {
           context.getBuiltins().any());
     }
 
+    static Context getContext() {
+      return Context.get(null);
+    }
+
     @Specialization(
         guards = {
-          "!context.isInlineCachingDisabled()",
+          "!getContext().isInlineCachingDisabled()",
           "cachedSymbol == symbol",
           "function != null"
         },
@@ -81,19 +83,17 @@ public class EnsoBigInteger implements TruffleObject {
     static Function resolveCached(
         EnsoBigInteger _this,
         UnresolvedSymbol symbol,
-        @CachedContext(Language.class) Context context,
         @Cached("symbol") UnresolvedSymbol cachedSymbol,
-        @Cached("doResolve(context, cachedSymbol)") Function function) {
+        @Cached("doResolve(cachedSymbol)") Function function) {
       return function;
     }
 
     @Specialization(replaces = "resolveCached")
     static Function resolve(
         EnsoBigInteger _this,
-        UnresolvedSymbol symbol,
-        @CachedContext(Language.class) Context context)
+        UnresolvedSymbol symbol)
         throws MethodDispatchLibrary.NoSuchMethodException {
-      Function function = doResolve(context, symbol);
+      Function function = doResolve(symbol);
       if (function == null) {
         throw new MethodDispatchLibrary.NoSuchMethodException();
       }
@@ -112,8 +112,8 @@ public class EnsoBigInteger implements TruffleObject {
     static final int CACHE_SIZE = 10;
 
     @CompilerDirectives.TruffleBoundary
-    static Function doResolve(
-        Context context, AtomConstructor target, UnresolvedConversion conversion) {
+    static Function doResolve(AtomConstructor target, UnresolvedConversion conversion) {
+      Context context = getContext();
       Number number = context.getBuiltins().number();
       return conversion.resolveFor(
           target,
@@ -123,9 +123,13 @@ public class EnsoBigInteger implements TruffleObject {
           context.getBuiltins().any());
     }
 
+    static Context getContext() {
+      return Context.get(null);
+    }
+
     @Specialization(
         guards = {
-          "!context.isInlineCachingDisabled()",
+          "!getContext().isInlineCachingDisabled()",
           "cachedTarget == target",
           "cachedConversion == conversion",
           "function != null"
@@ -135,10 +139,9 @@ public class EnsoBigInteger implements TruffleObject {
         EnsoBigInteger _this,
         AtomConstructor target,
         UnresolvedConversion conversion,
-        @CachedContext(Language.class) Context context,
         @Cached("conversion") UnresolvedConversion cachedConversion,
         @Cached("target") AtomConstructor cachedTarget,
-        @Cached("doResolve(context, cachedTarget, cachedConversion)") Function function) {
+        @Cached("doResolve(cachedTarget, cachedConversion)") Function function) {
       return function;
     }
 
@@ -146,10 +149,9 @@ public class EnsoBigInteger implements TruffleObject {
     static Function resolve(
         EnsoBigInteger _this,
         AtomConstructor target,
-        UnresolvedConversion conversion,
-        @CachedContext(Language.class) Context context)
+        UnresolvedConversion conversion)
         throws MethodDispatchLibrary.NoSuchConversionException {
-      Function function = doResolve(context, target, conversion);
+      Function function = doResolve(target, conversion);
       if (function == null) {
         throw new MethodDispatchLibrary.NoSuchConversionException();
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
@@ -1,8 +1,6 @@
 package org.enso.interpreter.runtime.scope;
 
 import com.oracle.truffle.api.TruffleFile;
-import com.oracle.truffle.api.TruffleLanguage;
-import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.InteropLibrary;
@@ -114,8 +112,7 @@ public class TopLevelScope implements TruffleObject {
   abstract static class InvokeMember {
     private static Module getModule(
         TopLevelScope scope,
-        Object[] arguments,
-        TruffleLanguage.ContextReference<Context> contextReference)
+        Object[] arguments)
         throws ArityException, UnsupportedTypeException, UnknownIdentifierException {
       String moduleName = Types.extractArguments(arguments, String.class);
 
@@ -167,22 +164,21 @@ public class TopLevelScope implements TruffleObject {
     static Object doInvoke(
         TopLevelScope scope,
         String member,
-        Object[] arguments,
-        @CachedContext(Language.class) TruffleLanguage.ContextReference<Context> contextRef)
+        Object[] arguments)
         throws UnknownIdentifierException, ArityException, UnsupportedTypeException {
       switch (member) {
         case MethodNames.TopScope.GET_MODULE:
-          return getModule(scope, arguments, contextRef);
+          return getModule(scope, arguments);
         case MethodNames.TopScope.CREATE_MODULE:
-          return createModule(scope, arguments, contextRef.get());
+          return createModule(scope, arguments, Context.get(null));
         case MethodNames.TopScope.REGISTER_MODULE:
-          return registerModule(scope, arguments, contextRef.get());
+          return registerModule(scope, arguments, Context.get(null));
         case MethodNames.TopScope.UNREGISTER_MODULE:
-          return unregisterModule(scope, arguments, contextRef.get());
+          return unregisterModule(scope, arguments, Context.get(null));
         case MethodNames.TopScope.LEAK_CONTEXT:
-          return leakContext(contextRef.get());
+          return leakContext(Context.get(null));
         case MethodNames.TopScope.COMPILE:
-          return compile(arguments, contextRef.get());
+          return compile(arguments, Context.get(null));
         default:
           throw UnknownIdentifierException.create(member);
       }
@@ -232,7 +228,7 @@ public class TopLevelScope implements TruffleObject {
    */
   @ExportMessage
   Object getScopeParent() throws UnsupportedMessageException {
-    return UnsupportedMessageException.create();
+    throw UnsupportedMessageException.create();
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/type/Types.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/type/Types.java
@@ -99,7 +99,7 @@ public class Types {
    */
   public static void extractArguments(Object[] arguments) throws ArityException {
     if (arguments.length != 0) {
-      throw ArityException.create(0, arguments.length);
+      throw ArityException.create(0, 0, arguments.length);
     }
   }
 
@@ -166,7 +166,7 @@ public class Types {
   public static <A> A extractArguments(Object[] arguments, Class<A> cls)
       throws ArityException, UnsupportedTypeException {
     if (arguments.length != 1) {
-      throw ArityException.create(1, arguments.length);
+      throw ArityException.create(1, 1, arguments.length);
     }
 
     if (!(cls.isInstance(arguments[0]))) {
@@ -192,7 +192,7 @@ public class Types {
   public static <A, B> Pair<A, B> extractArguments(Object[] arguments, Class<A> cls1, Class<B> cls2)
       throws ArityException, UnsupportedTypeException {
     if (arguments.length != 2) {
-      throw ArityException.create(2, arguments.length);
+      throw ArityException.create(2, 2, arguments.length);
     }
     if (!(cls1.isInstance(arguments[0]))) {
       throw UnsupportedTypeException.create(

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/TextTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/TextTest.scala
@@ -116,7 +116,7 @@ class TextTest extends InterpreterTest {
           |    IO.println (Arithmetic_Error "cannot frobnicate quaternions").to_display_text
           |    IO.println ((Panic.recover (1 + "foo")).catch_primitive .to_display_text)
           |    IO.println ((Panic.recover (7 1)).catch_primitive .to_display_text)
-          |    IO.println (Arity_Error 10 20).to_display_text
+          |    IO.println (Arity_Error 10 10 20).to_display_text
           |""".stripMargin
       eval(code)
       consumeOut shouldEqual List(


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

Cleaning up the deprecated access to Context and Language

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.
