### PR TITLE
Fix enso-formatter unit test

### DIFF
--- a/build/enso-formatter/src/main.rs
+++ b/build/enso-formatter/src/main.rs
@@ -567,7 +567,6 @@ fn main() {
 // =============
 
 #[test]
-#[ignore]
 fn test_formatting() {
     let input = r#"//! Module-level documentation
 //! written in two lines.
@@ -595,6 +594,10 @@ pub struct Struct1 {}
 
 // === Features ===
 #![allow(incomplete_features)]
+
+// === Standard Linter Configuration ===
+#![deny(non_ascii_idents)]
+#![warn(unsafe_code)]
 
 // === Non-Standard Linter Configuration ===
 #![warn(missing_copy_implementations)]


### PR DESCRIPTION
### Pull Request Description

Unit test in enso-formatter is fixed and re-enabled.

[ci no changelog needed]

The fix by @wdanilo 

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.
