### PR TITLE
Make `Resource.bracket` not run the action if initializer failed with a dataflow error

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/CatchErrorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/CatchErrorNode.java
@@ -9,7 +9,6 @@ import org.enso.interpreter.node.callable.InvokeCallableNode;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
 import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.state.Stateful;
-import org.enso.interpreter.runtime.type.TypesGen;
 
 @BuiltinMethod(
     type = "Error",
@@ -30,7 +29,6 @@ public class CatchErrorNode extends Node {
 
   Stateful execute(
       VirtualFrame frame, @MonadicState Object state, DataflowError _this, Object handler) {
-    return invokeCallableNode.execute(
-        handler, frame, state, new Object[] {TypesGen.asDataflowError(_this).getPayload()});
+    return invokeCallableNode.execute(handler, frame, state, new Object[] {_this.getPayload()});
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/resource/BracketNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/resource/BracketNode.java
@@ -1,8 +1,10 @@
 package org.enso.interpreter.node.expression.builtin.resource;
 
+import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.profiles.BranchProfile;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.dsl.MonadicState;
 import org.enso.interpreter.dsl.Suspend;
@@ -10,8 +12,8 @@ import org.enso.interpreter.node.BaseNode;
 import org.enso.interpreter.node.callable.InvokeCallableNode;
 import org.enso.interpreter.node.callable.thunk.ThunkExecutorNode;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
-import org.enso.interpreter.runtime.callable.argument.Thunk;
 import org.enso.interpreter.runtime.state.Stateful;
+import org.enso.interpreter.runtime.type.TypesGen;
 
 /**
  * The basic bracket construct for resource management.
@@ -62,10 +64,15 @@ public abstract class BracketNode extends Node {
       Object _this,
       Object constructor,
       Object destructor,
-      Object action) {
+      Object action,
+      @Cached BranchProfile initializationFailedWithDataflowErrorProfile) {
     Stateful resourceStateful =
         invokeConstructorNode.executeThunk(constructor, state, BaseNode.TailStatus.NOT_TAIL);
     Object resource = resourceStateful.getValue();
+    if (TypesGen.isDataflowError(resource)) {
+      initializationFailedWithDataflowErrorProfile.enter();
+      return resourceStateful;
+    }
     state = resourceStateful.getState();
     try {
       Stateful result = invokeActionNode.execute(action, frame, state, new Object[] {resource});

--- a/test/Tests/src/Main.enso
+++ b/test/Tests/src/Main.enso
@@ -44,6 +44,8 @@ import project.Network.Http.Request_Spec as Http_Request_Spec
 import project.Network.Http_Spec
 import project.Network.Uri_Spec
 
+import project.Resource.Bracket_Spec
+
 import project.Runtime.Stack_Traces_Spec
 
 import project.System.File_Spec
@@ -87,6 +89,7 @@ main = Test.Suite.run_main <|
     Matching_Spec.spec
     Runtime_Spec.spec
     Span_Spec.spec
+    Bracket_Spec.spec
     Stack_Traces_Spec.spec
     Utils_Spec.spec
     Text_Spec.spec

--- a/test/Tests/src/Resource/Bracket_Spec.enso
+++ b/test/Tests/src/Resource/Bracket_Spec.enso
@@ -1,0 +1,55 @@
+from Standard.Base import all
+import Standard.Test
+
+spec = Test.group "Resource.bracket" <|
+    Test.specify "should call the destructor even if the action fails" <|
+        log_1 = Vector.new_builder
+        r_1 = Resource.bracket 42 log_1.append x->
+            log_1.append x+1
+            x
+        r_1 . should_equal 42
+        log_1.to_vector . should_equal [43, 42]
+
+        log_2 = Vector.new_builder
+        r_2 = Panic.recover Any <| Resource.bracket 42 log_2.append x->
+            log_2.append x+1
+            Panic.throw (Illegal_State_Error "foo")
+            log_2.append x+2
+        r_2.catch . should_equal (Illegal_State_Error "foo")
+        log_2.to_vector . should_equal [43, 42]
+
+        log_3 = Vector.new_builder
+        r_3 = Resource.bracket 42 log_3.append x->
+            log_3.append x+1
+            r = Error.throw (Illegal_State_Error "foo")
+            log_3.append x+2
+            r
+        r_3.catch . should_equal (Illegal_State_Error "foo")
+        log_3.to_vector . should_equal [43, 44, 42]
+
+    Test.specify "should not proceed further if initialization fails" <|
+        log_1 = Vector.new_builder
+        r_1 = Panic.recover Any <| Resource.bracket (Panic.throw (Illegal_State_Error "foo")) (_ -> log_1.append "destructor") _->
+            log_1.append "action"
+            42
+        r_1.catch . should_equal (Illegal_State_Error "foo")
+        log_1.to_vector . should_equal []
+
+        log_2 = Vector.new_builder
+        r_2 = Resource.bracket (Error.throw (Illegal_State_Error "foo")) (_ -> log_2.append "destructor") _->
+            log_2.append "action"
+            42
+        r_2.catch . should_equal (Illegal_State_Error "foo")
+        log_2.to_vector . should_equal []
+
+    Test.specify "should forward panics thrown in initializer and destructor" <|
+        r_1 = Panic.recover Any <| Resource.bracket (Panic.throw "init") (_-> Panic.throw "destruct") (_-> Panic.throw "action")
+        r_1.catch . should_equal "init"
+
+        r_2 = Panic.recover Any <| Resource.bracket 42 (_-> Panic.throw "destruct") (_-> Panic.throw "action")
+        r_2.catch . should_equal "destruct"
+
+        r_3 = Panic.recover Any <| Resource.bracket 42 (_-> Nothing) (_-> Panic.throw "action")
+        r_3.catch . should_equal "action"
+
+main = Test.Suite.run_main here.spec


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.
