### PR TITLE
Quick-fix for Error.to_text CCE

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/ErrorToTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/ErrorToTextNode.java
@@ -1,25 +1,40 @@
 package org.enso.interpreter.node.expression.builtin.error;
 
+import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.error.DataflowError;
 
 @BuiltinMethod(type = "Error", name = "to_text", description = "Convert an error to text.")
-public class ErrorToTextNode extends Node {
+public abstract class ErrorToTextNode extends Node {
   private static final int DISPATCH_CACHE = 3;
   private @Child InteropLibrary displays =
       InteropLibrary.getFactory().createDispatched(DISPATCH_CACHE);
   private @Child InteropLibrary strings =
       InteropLibrary.getFactory().createDispatched(DISPATCH_CACHE);
 
-  public Text execute(DataflowError _this) {
+  static ErrorToTextNode build() {
+    return ErrorToTextNodeGen.create();
+  }
+
+  public abstract Text execute(@AcceptsError Object _this);
+
+  @Specialization
+  public Text doDataflowError(DataflowError _this) {
     try {
       return Text.create(strings.asString(displays.toDisplayString(_this)));
     } catch (UnsupportedMessageException ignored) {
       throw new IllegalStateException("Unreachable");
     }
+  }
+
+  @Specialization
+  public Text doAtom(Atom _this) {
+    return Text.create("Error");
   }
 }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualisationsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualisationsTest.scala
@@ -102,12 +102,12 @@ class RuntimeVisualisationsTest
     }
 
     def receive: Option[Api.Response] =
-      receiveTimeout(10)
+      receiveTimeout(20)
 
     def receiveTimeout(timeoutSeconds: Int): Option[Api.Response] =
       Option(messageQueue.poll(timeoutSeconds.toLong, TimeUnit.SECONDS))
 
-    def receive(n: Int, timeoutSeconds: Int = 10): List[Api.Response] =
+    def receive(n: Int, timeoutSeconds: Int = 20): List[Api.Response] =
       Iterator
         .continually(receiveTimeout(timeoutSeconds))
         .take(n)
@@ -1902,7 +1902,7 @@ class RuntimeVisualisationsTest
       Api.Request(requestId, Api.PushContextRequest(contextId, item1))
     )
     val pushContextResponses =
-      context.receive(n = 4, timeoutSeconds = 60)
+      context.receive(n = 4, timeoutSeconds = 90)
     pushContextResponses should contain allOf (
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       TestMessages.error(

--- a/test/Tests/src/Semantic/Error_Spec.enso
+++ b/test/Tests/src/Semantic/Error_Spec.enso
@@ -54,6 +54,10 @@ spec =
         Test.specify "should implement to_display_text" <|
             Error.throw Nothing . to_display_text . should_equal "Error: Nothing"
 
+        Test.specify "should implement to_text" <|
+            Error.throw Nothing . to_text . should_equal "(Error: Nothing)"
+            Error.to_text . should_equal "Error"
+
         Test.specify "should be able to be mapped" <|
             error = Error.throw 42
             regular = 10


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

This is just a quick fix addressing an issue which was making debugging problematic.

The proper solution to the broader issue described at https://github.com/enso-org/enso/issues/1538#issuecomment-789645573 still needs to be done.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.
