### PR TITLE
Log `set_context` in profile data

### DIFF
--- a/lib/rust/ensogl/core/src/display/scene.rs
+++ b/lib/rust/ensogl/core/src/display/scene.rs
@@ -960,6 +960,7 @@ impl SceneData {
     }
 
     pub fn set_context(&self, context: Option<&Context>) {
+        let _profiler = profiler::start_objective!(profiler::APP_LIFETIME, "@set_context");
         self.symbols.set_context(context);
         *self.context.borrow_mut() = context.cloned();
         self.dirty.shape.set();

--- a/lib/rust/profiler/data/src/lib.rs
+++ b/lib/rust/profiler/data/src/lib.rs
@@ -287,6 +287,8 @@ impl Measurement {
 pub enum Class {
     /// Profiler that is active during the execution of anything else, after early startup.
     OnFrame,
+    /// Profiler that is run when a WebGL context is acquired or lost.
+    SetContext,
     /// Any profiler that doesn't need special treatment.
     Normal,
 }
@@ -423,6 +425,7 @@ impl Label {
     fn classify(&self) -> Class {
         match self.name.as_str() {
             "@on_frame" => Class::OnFrame,
+            "@set_context" => Class::SetContext,
             // Data producer is probably newer than consumer. Forward compatibility isn't necessary.
             name if name.starts_with('@') => panic!("Unrecognized special profiler: {:?}", name),
             _ => Class::Normal,


### PR DESCRIPTION
### Pull Request Description

Include `set_context` in the profiler data, as any occurrence after the first time indicates a context loss.

Any context loss may be relevant to performance. Also, having the event in the log may help debugging any context-loss-related issues we might encounter.

### Important Notes

- The profiler for `set_context` uses the low-level syntax to create a special profiler that can be identified by a unique name. This will allow our tools to interpret this event specially without having to identify the event by the function name or file path, which are not-necessarily-unique and prone-to-change, respectively. (This is the same pattern I used for `@on_frame`).

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.

[ci no changelog needed] not user-visible