### PR TITLE
Build and memoize a GLSL prelude

### DIFF
--- a/lib/rust/ensogl/core/src/display/shape/primitive/shader/builder.rs
+++ b/lib/rust/ensogl/core/src/display/shape/primitive/shader/builder.rs
@@ -35,15 +35,15 @@ pub struct Builder {}
 impl Builder {
     /// Returns the final GLSL code. If `pointer_events_enabled` is set to false, the generated
     /// shape will be transparent for pointer events and will pass them trough.
+    #[profile(Detail)]
     pub fn run<S: canvas::Draw>(shape: &S, pointer_events_enabled: bool) -> CodeTemplate {
         let mut canvas = Canvas::default();
         let shape_ref = shape.draw(&mut canvas);
         let shape_header = header("Shape Definition");
         canvas.add_current_function_code_line(iformat!("return {shape_ref.getter()};"));
         canvas.submit_shape_constructor("run");
-        let defs = [&shape_header, canvas.to_glsl()].join("\n\n");
-        let defs = overload::allow_overloading(defs);
-        let code = [GLSL_PRELUDE.as_str(), &defs].join("\n\n\n\n");
+        let defs = overload::allow_overloading(&canvas.to_glsl());
+        let code = [GLSL_PRELUDE.as_str(), "", &shape_header, &defs].join("\n\n");
         let main = format!(
             "bool pointer_events_enabled = {};\n{}",
             pointer_events_enabled, FRAGMENT_RUNNER

--- a/lib/rust/ensogl/core/src/display/shape/primitive/shader/builder.rs
+++ b/lib/rust/ensogl/core/src/display/shape/primitive/shader/builder.rs
@@ -42,8 +42,8 @@ impl Builder {
         let shape_header = header("Shape Definition");
         canvas.add_current_function_code_line(iformat!("return {shape_ref.getter()};"));
         canvas.submit_shape_constructor("run");
-        let defs = overload::allow_overloading(&canvas.to_glsl());
-        let code = [GLSL_PRELUDE.as_str(), "", &shape_header, &defs].join("\n\n");
+        let shape_def = overload::allow_overloading(&canvas.to_glsl());
+        let code = [GLSL_PRELUDE.as_str(), "", &shape_header, &shape_def].join("\n\n");
         let main = format!(
             "bool pointer_events_enabled = {};\n{}",
             pointer_events_enabled, FRAGMENT_RUNNER
@@ -78,6 +78,6 @@ fn make_glsl_prelude() -> String {
     let debug = overload::allow_overloading(DEBUG);
     let shape = overload::allow_overloading(SHAPE);
     let defs_header = header("SDF Primitives");
-    let sdf_defs = primitive::all_shapes_glsl_definitions();
+    let sdf_defs = overload::allow_overloading(&primitive::all_shapes_glsl_definitions());
     [redirections, math, color, debug, shape, defs_header, sdf_defs].join("\n\n")
 }

--- a/lib/rust/ensogl/core/src/display/shape/primitive/shader/builder.rs
+++ b/lib/rust/ensogl/core/src/display/shape/primitive/shader/builder.rs
@@ -46,17 +46,8 @@ impl Builder {
         let defs =
             iformat!("{defs_header}\n\n{sdf_defs}\n\n\n\n{shape_header}\n\n{canvas.to_glsl()}");
 
-        let redirections = overload::builtin_redirections();
-        let math = overload::allow_overloading(MATH);
-        let color = overload::allow_overloading(COLOR);
-        let debug = overload::allow_overloading(DEBUG);
-        let shape = overload::allow_overloading(SHAPE);
-
         let defs = overload::allow_overloading(&defs);
-        let code = format!(
-            "{}\n\n{}\n\n{}\n\n{}\n\n{}\n\n{}",
-            redirections, math, color, debug, shape, defs
-        );
+        let code = [GLSL_PRELUDE.as_str(), &defs].join("\n\n");
         let main = format!(
             "bool pointer_events_enabled = {};\n{}",
             pointer_events_enabled, FRAGMENT_RUNNER
@@ -74,4 +65,20 @@ fn header(label: &str) -> String {
     let border_len = label.len() + 8;
     let border = "=".repeat(border_len);
     iformat!("// {border}\n// === {label} ===\n// {border}")
+}
+
+// == GLSL_PRELUDE ==
+
+lazy_static! {
+    /// A common preamble used to start every shader program.
+    static ref GLSL_PRELUDE: String = make_glsl_prelude();
+}
+
+fn make_glsl_prelude() -> String {
+    let redirections = overload::builtin_redirections();
+    let math = overload::allow_overloading(MATH);
+    let color = overload::allow_overloading(COLOR);
+    let debug = overload::allow_overloading(DEBUG);
+    let shape = overload::allow_overloading(SHAPE);
+    [redirections, math, color, debug, shape].join("\n\n")
 }


### PR DESCRIPTION
### Pull Request Description

Reduces time spent mangling symbols by 93%, reducing work done during startup by 375ms in my tests with text-areas completely disabled. (Since text areas presently build a lot of shaders, the improvement for the current `develop` would be higher.)


See: [#181681629](https://www.pivotaltracker.com/story/show/181681629)

Before:
```console
    self_duration total_duration count profiler
     528.6  528.6 1 parse_with_metadata (app/gui/language/parser/src/lib.rs:107)
     345.4  345.4 33 use_program (lib/rust/ensogl/core/src/display/symbol/gpu.rs:648)
     308.9  308.9 66 check (lib/rust/ensogl/core/src/system/gpu/shader.rs:96)
---> 243.7  243.7 265 build_and_mangle_glsl (lib/rust/ensogl/core/src/display/shape/primitive/shader/builder.rs:58)
     200.0  264.6 255 new (app/gui/src/controller/graph.rs:273)
     160.4 1841.0 134 EventLoopExecutor::runner (app/gui/src/executor/web.rs:67)
     151.4  151.4 1272 new (lib/rust/ensogl/core/src/animation/loops.rs:67)
      98.4  103.2 315 code_coloring (app/gui/view/graph-editor/src/component/node/input/area.rs:764)
      72.3   72.3 700 render_by_ids (lib/rust/ensogl/core/src/display/symbol/gpu/registry.rs:127)
      68.1  180.0 17 create_node (app/gui/view/graph-editor/src/lib.rs:1425)
      ...
--->  23.6  416.6 406 run (lib/rust/ensogl/core/src/display/shape/primitive/shader/builder.rs:38)
```

After (the `run` function below does the work of `build_and_mangle_glsl` and `run` above):
```console
     577.3  577.3 1 parse_with_metadata (app/gui/language/parser/src/lib.rs:107)
     368.1  368.1 33 use_program (lib/rust/ensogl/core/src/display/symbol/gpu.rs:648)
     326.9  326.9 66 check (lib/rust/ensogl/core/src/system/gpu/shader.rs:96)
     194.6  259.0 255 new (app/gui/src/controller/graph.rs:273)
     156.4  156.4 1259 new (lib/rust/ensogl/core/src/animation/loops.rs:67)
     151.3 1690.1 134 EventLoopExecutor::runner (app/gui/src/executor/web.rs:67)
     114.4  120.6 315 code_coloring (app/gui/view/graph-editor/src/component/node/input/area.rs:764)
      76.8   76.8 745 render_by_ids (lib/rust/ensogl/core/src/display/symbol/gpu/registry.rs:127)
      69.9  158.3 17 create_node (app/gui/view/graph-editor/src/lib.rs:1425)
      63.4   63.9 628 animation::physics::inertia::step (lib/rust/ensogl/core/src/animation/physics/inertia.rs:801)
      ...
--->  23.7   29.1 191 run (lib/rust/ensogl/core/src/display/shape/primitive/shader/builder.rs:38)
```

### Important Notes

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.
 
 [ci no changelog needed] I expect we'll be writing one CHANGELOG entry for all this release's performance improvements