### PR TITLE
Fix multiline code docparser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,7 @@
 [3361]: https://github.com/enso-org/enso/pull/3361
 [3364]: https://github.com/enso-org/enso/pull/3364
 [3366]: https://github.com/enso-org/enso/pull/3366
+[3379]: https://github.com/enso-org/enso/pull/3379
 
 #### Enso Compiler
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/search/DocSectionsBuilderTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/search/DocSectionsBuilderTest.scala
@@ -192,6 +192,55 @@ class DocSectionsBuilderTest extends AnyWordSpec with Matchers {
 
       build(comment) shouldEqual expected
     }
+
+    "build example 6" in {
+      val comment =
+        """ UNSTABLE
+          |
+          | Creates a new table from a vector of column names and a vector of vectors
+          | specifying row contents.
+          |
+          | Arguments:
+          | - header: A list of texts specifying the column names
+          | - rows: A vector of vectors, specifying the contents of each table row. The
+          |   length of each element of `rows` must be equal in length to `header`.
+          |
+          | > Example
+          |   Create a table with 3 columns, named `foo`, `bar`, and `baz`, containing
+          |   `[1, 2, 3]`, `[True, False, True]`, and `['a', 'b', 'c']`, respectively.
+          |
+          |       import Standard.Table
+          |
+          |       example_from_rows =
+          |           header = [ 'foo' , 'bar' , 'baz' ]
+          |           row_1 =  [ 1     , True  , 'a'   ]
+          |           row_2 =  [ 2     , False , 'b'   ]
+          |           row_3 =  [ 3     , True  , 'c'   ]
+          |           Table.from_rows header [row_1, row_2, row_3]
+          |
+          | Icon: table-from-rows
+          | Aliases: foo, bar baz, redshift®
+          |""".stripMargin.linesIterator.mkString("\n")
+      val expected = Seq(
+        DocSection.Tag("UNSTABLE", ""),
+        DocSection.Paragraph(
+          "Creates a new table from a vector of column names and a vector of vectors specifying row contents. "
+        ),
+        DocSection.Keyed(
+          "Arguments",
+          " <ul><li>header: A list of texts specifying the column names</li><li>rows: A vector of vectors, specifying the contents of each table row. The    length of each element of <code>rows</code> must be equal in length to <code>header</code>.</li></ul> "
+        ),
+        DocSection.Marked(
+          DocSection.Mark.Example(),
+          Some("Example"),
+          " Create a table with 3 columns, named <code>foo</code>, <code>bar</code>, and <code>baz</code>, containing <code>[1, 2, 3]</code>, <code>[True, False, True]</code>, and <code>['a', 'b', 'c']</code>, respectively. <pre><code>import Standard.Table</code><br /><code>example_from_rows =</code><br /><code>    header = [ 'foo' , 'bar' , 'baz' ]</code><br /><code>    row_1 =  [ 1     , True  , 'a'   ]</code><br /><code>    row_2 =  [ 2     , False , 'b'   ]</code><br /><code>    row_3 =  [ 3     , True  , 'c'   ]</code><br /><code>    Table.from_rows header [row_1, row_2, row_3]</code><br /></pre>"
+        ),
+        DocSection.Keyed("Icon", "table-from-rows"),
+        DocSection.Keyed("Aliases", "foo, bar baz, redshift®")
+      )
+
+      build(comment) shouldEqual expected
+    }
   }
 }
 object DocSectionsBuilderTest {

--- a/lib/scala/docs-generator/src/test/scala/org/enso/docs/sections/ParsedSectionsBuilderTest.scala
+++ b/lib/scala/docs-generator/src/test/scala/org/enso/docs/sections/ParsedSectionsBuilderTest.scala
@@ -171,6 +171,45 @@ class ParsedSectionsBuilderTest extends AnyWordSpec with Matchers {
       parseSections(comment) shouldEqual expected
     }
 
+    "generate multiple keyed" in {
+      val comment =
+        """ Description
+          |
+          | Icon: my-icon
+          | icon
+          | Aliases: foo, bar baz, redshift®
+          | and other
+          |
+          | Paragraph
+          |""".stripMargin.linesIterator.mkString("\n")
+      val expected = List(
+        Section.Paragraph(
+          List(Doc.Elem.Text("Description"), Doc.Elem.Newline)
+        ),
+        Section.Keyed(
+          "Icon",
+          List(
+            Doc.Elem.Text("my-icon"),
+            Doc.Elem.Newline,
+            Doc.Elem.Text("icon")
+          )
+        ),
+        Section.Keyed(
+          "Aliases",
+          List(
+            Doc.Elem.Text("foo, bar baz, redshift"),
+            Doc.Elem.Text("®"),
+            Doc.Elem.Newline,
+            Doc.Elem.Text("and other"),
+            Doc.Elem.Newline
+          )
+        ),
+        Section.Paragraph(List(Doc.Elem.Text("Paragraph")))
+      )
+
+      parseSections(comment) shouldEqual expected
+    }
+
     "generate marked example" in {
       val comment =
         """ Description

--- a/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/spec/DocParserDef.scala
+++ b/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/spec/DocParserDef.scala
@@ -946,18 +946,16 @@ case class DocParserDef() extends Parser[Doc] {
           current.indent > currentIndent &&
           current.isInstanceOf[Section.Raw]
         ) {
-          var stackOfCodeSections: List[Section] = List[Section]()
+          val codeIndent                         = current.indent
+          var stackOfCodeSections: List[Section] = List(current)
           while (
-            section.stack.nonEmpty && current.indent > currentIndent && current
-              .isInstanceOf[Section.Raw] && section.stack.head
-              .isInstanceOf[Section.Raw]
+            section.stack.nonEmpty &&
+            section.stack.head.indent >= codeIndent &&
+            section.stack.head.isInstanceOf[Section.Raw]
           ) {
-            stackOfCodeSections = stackOfCodeSections :+ current
-            if (section.stack.head.isInstanceOf[Section.Raw]) {
-              current = section.pop().get
-            }
+            current = section.pop().get
+            stackOfCodeSections :+= current
           }
-          stackOfCodeSections = stackOfCodeSections :+ current
           val codeLines = stackOfCodeSections.flatMap {
             _.repr
               .build()

--- a/lib/scala/syntax/specialization/shared/src/test/scala/org/enso/syntax/text/DocParserTests.scala
+++ b/lib/scala/syntax/specialization/shared/src/test/scala/org/enso/syntax/text/DocParserTests.scala
@@ -378,6 +378,61 @@ class DocParserTests extends AnyFlatSpec with Matchers {
       Section.Raw(2, "And this is not")
     )
   )
+  """ Synopsis
+    |
+    | !Important
+    |    This is a code
+    |
+    | Other: And this is a section""".stripMargin.replaceAll(
+    System.lineSeparator(),
+    "\n"
+  ) ?= Doc(
+    Synopsis(
+      Section.Raw(1, "Synopsis", Doc.Elem.Newline)
+    ),
+    Body(
+      Section.Marked(
+        1,
+        0,
+        Section.Marked.Important,
+        Section.Header("Important"),
+        Doc.Elem.Newline,
+        CodeBlock(CodeBlock.Line(4, "This is a code")),
+        Doc.Elem.Newline
+      ),
+      Section.Raw(1, "Other: And this is a section")
+    )
+  )
+  """ Synopsis
+    |
+    | ! Important
+    |
+    |    This is a multiline code
+    |
+    | ? Info""".stripMargin.replaceAll(
+    System.lineSeparator(),
+    "\n"
+  ) ?== Doc(
+    Synopsis(
+      Section.Raw(1, "Synopsis", Doc.Elem.Newline)
+    ),
+    Body(
+      Section.Marked(
+        1,
+        1,
+        Section.Marked.Important,
+        Section.Header("Important"),
+        Doc.Elem.Newline,
+        CodeBlock(CodeBlock.Line(4, "This is a multiline code"))
+      ),
+      Section.Marked(
+        1,
+        1,
+        Section.Marked.Info,
+        Section.Header("Info")
+      )
+    )
+  )
   """Synopsis
     |
     |! Important
@@ -400,6 +455,36 @@ class DocParserTests extends AnyFlatSpec with Matchers {
         "This is important",
         Doc.Elem.Newline,
         CodeBlock(CodeBlock.Line(4, "And this is a code"))
+      )
+    )
+  )
+  """ Synopsis
+    |
+    | ! Important
+    |
+    |    This is a multiline code
+    |
+    | Other: And this *is* a section""".stripMargin.replaceAll(
+    System.lineSeparator(),
+    "\n"
+  ) ?== Doc(
+    Synopsis(
+      Section.Raw(1, "Synopsis", Doc.Elem.Newline)
+    ),
+    Body(
+      Section.Marked(
+        1,
+        1,
+        Section.Marked.Important,
+        Section.Header("Important"),
+        Doc.Elem.Newline,
+        CodeBlock(CodeBlock.Line(4, "This is a multiline code"))
+      ),
+      Section.Raw(
+        1,
+        "Other: And this ",
+        Formatter(Formatter.Bold, "is"),
+        " a section"
       )
     )
   )
@@ -1498,6 +1583,105 @@ class DocParserTests extends AnyFlatSpec with Matchers {
           CodeBlock.Line(14, "Examples.csv_path"),
           CodeBlock.Line(10, "File.new path")
         )
+      )
+    )
+  )
+
+  """ UNSTABLE
+    |
+    | Creates a new table from a vector of column names and a vector of vectors
+    | specifying row contents.
+    |
+    | Arguments:
+    | - header: A list of texts specifying the column names
+    | - rows: A vector of vectors, specifying the contents of each table row. The
+    |   length of each element of `rows` must be equal in length to `header`.
+    |
+    | > Example
+    |   Create a table with 3 columns, named `foo`, `bar`, and `baz`, containing
+    |   `[1, 2, 3]`, `[True, False, True]`, and `['a', 'b', 'c']`, respectively.
+    |
+    |       import Standard.Table
+    |
+    |       example_from_rows =
+    |           header = [ 'foo' , 'bar' , 'baz' ]
+    |           row_1 =  [ 1     , True  , 'a'   ]
+    |           row_2 =  [ 2     , False , 'b'   ]
+    |           row_3 =  [ 3     , True  , 'c'   ]
+    |           Table.from_rows header [row_1, row_2, row_3]
+    |
+    | Icon: table-from-rows
+    | Aliases: foo, bar baz, redshift®
+    |""".stripMargin.replaceAll(System.lineSeparator(), "\n") ?== Doc(
+    Tags(Tag(1, Tags.Tag.Type.Unstable, None)),
+    Synopsis(Section.Raw(1, Newline)),
+    Body(
+      Section.Raw(
+        1,
+        "Creates a new table from a vector of column names and a vector of vectors",
+        Newline,
+        "specifying row contents.",
+        Newline
+      ),
+      Section.Raw(
+        1,
+        "Arguments:",
+        Newline,
+        List(
+          1,
+          List.Unordered,
+          ListItem("header: A list of texts specifying the column names"),
+          ListItem(
+            "rows: A vector of vectors, specifying the contents of each table row. The",
+            Newline,
+            "   ",
+            "length of each element of ",
+            CodeBlock.Inline("rows"),
+            " must be equal in length to ",
+            CodeBlock.Inline("header"),
+            "."
+          )
+        ),
+        Newline
+      ),
+      Section.Marked(
+        1,
+        1,
+        Section.Marked.Example,
+        Section.Header("Example"),
+        Newline,
+        "Create a table with 3 columns, named ",
+        CodeBlock.Inline("foo"),
+        ", ",
+        CodeBlock.Inline("bar"),
+        ", and ",
+        CodeBlock.Inline("baz"),
+        ", containing",
+        Newline,
+        CodeBlock.Inline("[1, 2, 3]"),
+        Text(", "),
+        CodeBlock.Inline("[True, False, True]"),
+        ", and ",
+        CodeBlock.Inline("['a', 'b', 'c']"),
+        ", respectively.",
+        Newline,
+        CodeBlock(
+          CodeBlock.Line(7, "import Standard.Table"),
+          CodeBlock.Line(7, "example_from_rows ="),
+          CodeBlock.Line(11, "header = [ 'foo' , 'bar' , 'baz' ]"),
+          CodeBlock.Line(11, "row_1 =  [ 1     , True  , 'a'   ]"),
+          CodeBlock.Line(11, "row_2 =  [ 2     , False , 'b'   ]"),
+          CodeBlock.Line(11, "row_3 =  [ 3     , True  , 'c'   ]"),
+          CodeBlock.Line(11, "Table.from_rows header [row_1, row_2, row_3]")
+        )
+      ),
+      Section.Raw(
+        1,
+        "Icon: table-from-rows",
+        Newline,
+        "Aliases: foo, bar baz, redshift",
+        "®",
+        Newline
       )
     )
   )


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Changelog:
- fix: docparser handles multiline code sections correctly
- feat: split paragraphs into keyed sections

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] ~If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.~
