### PR TITLE
Add benchmark for `Text.reverse` with strings of varying length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@
 - [Added warning handling to `Table.aggregate`][3349]
 - [Improved performance of `Table.aggregate` and full warnings implementation]
   [3364]
-- [Implemented `Text.reverse`][3377, 3381]
+- [Implemented `Text.reverse`][3377]
 
 [debug-shortcuts]:
   https://github.com/enso-org/enso/blob/develop/app/gui/docs/product/shortcuts.md#debug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@
 - [Added warning handling to `Table.aggregate`][3349]
 - [Improved performance of `Table.aggregate` and full warnings implementation]
   [3364]
-- [Implemented `Text.reverse`][3377]
+- [Implemented `Text.reverse`][3377, 3381]
 
 [debug-shortcuts]:
   https://github.com/enso-org/enso/blob/develop/app/gui/docs/product/shortcuts.md#debug
@@ -147,6 +147,7 @@
 [3364]: https://github.com/enso-org/enso/pull/3364
 [3377]: https://github.com/enso-org/enso/pull/3377
 [3366]: https://github.com/enso-org/enso/pull/3366
+[3381]: https://github.com/enso-org/enso/pull/3381
 
 #### Enso Compiler
 

--- a/test/Benchmarks/src/Text/Reverse.enso
+++ b/test/Benchmarks/src/Text/Reverse.enso
@@ -1,0 +1,28 @@
+from Standard.Base import all
+
+import Standard.Test.Bench
+import Standard.Test.Faker
+
+# Benchmarks ##################################################################
+
+main =
+    ## The `Text.reverse` benchmarks check both scenarios where the Texts are
+       short and very long. This is to show any overheads related to string
+       building.
+    bench_reverse suite_prefix character_template =
+        faker = Faker.new
+        ## Warning: this relies on the fact that Faker will treat the accent
+           codepoint `\u{301}` as a separate code unit. We rely on this to add
+           accents randomly to neighboring characters. If the implementation of
+           Faker is changed, this must be modified accordingly.
+        make_alpha_template length = Vector.new length _-> character_template
+
+        very_short_template = make_alpha_template 4
+        very_short_random = faker.string_value very_short_template
+        big_template = make_alpha_template 100000
+        big_random = faker.string_value big_template
+
+        Bench.measure (very_short_random.reverse) suite_prefix+" 4" 10 10
+        Bench.measure (big_random.reverse) suite_prefix+" 100000" 10 10
+
+    bench_reverse "Text.reverse" (Faker.upper_case_letters + Faker.lower_case_letters + 'ąę\u{301}\u{302}\u{303}\u{321}'.utf_16)


### PR DESCRIPTION
### Pull Request Description

This pull request adds a benchmark for the `Text.reverse` function added in #3377 as part of https://www.pivotaltracker.com/n/projects/2539304/stories/181265419.

Per discussion with @jdunkerley on Discord it is useful to have this benchmark as this is a low-level item we want to track.

### Important Notes

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [ ] ~~Unit tests have been written where possible.~~
  - [ ] ~~If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.~~
