### PR TITLE
Remove --skip-version-validation option before passing the args on

### DIFF
--- a/run
+++ b/run
@@ -13,7 +13,8 @@ let args = process.argv.slice(2)
 
 let skip_validation = '--skip-version-validation'
 async function init () {
-    if(!args.includes(skip_validation)) {
+    let skipValidationIndex = args.indexOf(skip_validation)
+    if (skip_validation === -1) {
         cmd.section('Version Validation')
         console.log("Use the `" + skip_validation + "` flag to skip it.")
         console.log("Querying npm for the latest LTS versions.")
@@ -24,6 +25,8 @@ async function init () {
         await cmd.check_version('rustc','1.61.0-nightly',{
             preprocess:(v)=>v.substring(6,20)
         })
+    } else {
+        args.splice(skipValidationIndex, 1)
     }
 
     let initialized = fss.existsSync(paths.dist.buildInit)


### PR DESCRIPTION
### Pull Request Description

I am trying to build and run the IDE. When I use following command, help gets printed and then an error:
```bash
$ ./run --skip-version-validation build --dev
...
Not enough non-option arguments: got 0, need at least 1
```
I believe this is caused by `--skip-version-validation` being propagated where it shouldn't.
### Checklist

Please include the following checklist in your PR:

> All code conforms to the ... style guidelines.

A JavaScript guideline would suggest use of `;` at the end of line. However I am adding lines without `;` to be consistent with current style used in the file.