### PR TITLE
Documenting how to build the IDE

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -203,6 +203,18 @@ defined by [rust-toolchain](../rust-toolchain.toml) override file. The `rustup`
 will automatically download the appropriate compiler version along with the
 necessary components.
 
+Please consult the [GUI Contribution Guide](../app/gui/docs/CONTRIBUTING.md) to
+learn details on setting your system up. Quick summary:
+
+```bash
+enso$ rustup toolchain install stable                  # Stable toolchain required for the following tools.
+enso$ cargo +stable install wasm-pack --version 0.10.2 # Install the wasm-pack toolkit.
+enso$ cargo +stable install cargo-watch                # To enable ./run watch utility
+```
+
+The previous three steps shall be enough to build the IDE via
+`./run build --dev`.
+
 ### Getting Set Up (JVM)
 
 In order to properly build the `runtime` component, the JVM running SBT needs to

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -661,7 +661,7 @@ directory of the distribution folder. Distribution paths are printed when you
 run project manager with `-v` verbose logging.
 
 ```bash
-$ ./built-distribution/enso-project-manager-0.2.32-SNAPSHOT-linux-amd64/enso/bin/project-manager -v
+$ ./built-distribution/enso-project-manager-0.0.0-dev-linux-amd64/enso/bin/project-manager --no-log-masking -v
 [info] [2021-06-16T11:49:33.639Z] [org.enso.projectmanager.boot.ProjectManager$] Starting Project Manager...
 [debug] [2021-06-16T11:49:33.639Z] [org.enso.runtimeversionmanager.distribution.DistributionManager] Detected paths: DistributionPaths(
   dataRoot = /home/dbv/.local/share/enso,

--- a/run
+++ b/run
@@ -14,7 +14,7 @@ let args = process.argv.slice(2)
 let skip_validation = '--skip-version-validation'
 async function init () {
     let skipValidationIndex = args.indexOf(skip_validation)
-    if (skip_validation === -1) {
+    if (skipValidationIndex === -1) {
         cmd.section('Version Validation')
         console.log("Use the `" + skip_validation + "` flag to skip it.")
         console.log("Querying npm for the latest LTS versions.")


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

The first change 5c0f82c5ee1e4b6073f8a13528095cec3e9704e3 provides _falsification_ to #3386 - if the `--skip-version-validation` argument is missing - the validation is really performed.

<!-- Dropping the nodejs 14.x changes:
I am building the IDE on nodejs 14.x - e.g. not the latest version for two reasons:
- version 14 is installed on my Ubuntu 20.04 - easy with `apt install` - installing anything else is harder
- GraalVM 21.3 provides compatible implementation of nodejs@14 by itself - e.g. one doesn't need to install node at all and can just rely on the one provided by the same GraalVM that is used to build the engine

Building on nodejs@14 seems to work fine - except missing `fs.cp` (new in version 17 and still experimental). Commit 2f0363b0435826f7b4c16358684239b466093ed0 addresses that.
-->

It took me a while to realize what Rust tools to install. @4e6 hinted me via chat, but it is probably better to mention that in the documentation: 8100ec954e0a5bf50c81d68cff922a68dd73dd1c - @MichaelMauderer suggested to link to IDE guide: a4b817bd361a29d66a52f46b26fd4d23f9251d83 and last but not least, I added an argument to avoid log masking when running `project-manager`: 3811a31f88c98a8e5c099c2ce7d7cea31884db82

### Checklist

Please include the following checklist in your PR:

- [ x ] The documentation has been updated if necessary.
- All code has been tested:
  - [ x ] Without `--skip-version-validation` argument the build really fails on my systems

Please accept my apology  for not checking the behavior without the option in #3386 
