### PR TITLE
Add formatting checks for Scala and Java

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,11 +1,6 @@
 name: Code Formatting Check
 
 on:
-  workflow_run:
-    workflows: [ "Engine CI (legacy)", "Engine CI (new)" ]
-    branches: [ main ]
-    types:
-      - completed
   push:
     branches: [develop, "release/*"]
   pull_request:
@@ -18,66 +13,22 @@ env:
   javaVersion: 11
   # Please ensure that this is in sync with project/build.properties
   sbtVersion: 1.5.2
-  # Please ensure that this is in sync with rustVersion in build.sbt
-  rustToolchain: nightly-2021-11-29
-  # Some moderately recent version of Node.JS is needed to run the library download tests.
-  nodeVersion: 14.17.2
 
 jobs:
   test_formatting:
     name: Build and Test Formatting
     runs-on: "ubuntu-18.04"
     timeout-minutes: 120
-    # Only run if basic build succeeded, might be too restrictive depending on the stability of CI
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:
       # No need to run it on multiple distros, result should be the same
       fail-fast: false
     steps:
-      - name: Disable TCP/UDP Offloading (Linux)
-        shell: bash
-        run: sudo ethtool -K eth0 tx off rx off
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: ${{ env.rustToolchain }}
-          override: true
-      - name: Setup conda
-        uses: s-weigand/setup-conda@v1.0.5
-        with:
-          update-conda: false
-          conda-channels: anaconda, conda-forge
-      - name: Install FlatBuffers Compiler
-        run: conda install --freeze-installed flatbuffers=1.12.0
       - name: Setup GraalVM Environment
         uses: ayltai/setup-graalvm@v1
         with:
           graalvm-version: ${{ env.graalVersion }}
           java-version: ${{ env.javaVersion }}
           native-image: true
-      - name: Install Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ env.nodeVersion }}
-      - name: Install Dependencies of the Simple Library Server
-        shell: bash
-        working-directory: tools/simple-library-server
-        run: |
-          npm install
-      - name: Install Dependencies of the Simple Library Server
-        shell: bash
-        working-directory: tools/simple-library-server
-        run: |
-          npm install
-      - name: Download Project Template Files
-        shell: bash
-        run: |
-          curl --retry 4 --retry-connrefused -fsSL -o lib/scala/pkg/src/main/resources/orders/data/store_data.xlsx https://github.com/enso-org/project-templates/raw/main/Orders/data/store_data.xlsx
-          curl --retry 4 --retry-connrefused -fsSL -o lib/scala/pkg/src/main/resources/orders/src/Main.enso https://github.com/enso-org/project-templates/raw/main/Orders/src/Main.enso
-          curl --retry 4 --retry-connrefused -fsSL -o lib/scala/pkg/src/main/resources/restaurants/data/la_districts.csv https://github.com/enso-org/project-templates/raw/main/Restaurants/data/la_districts.csv
-          curl --retry 4 --retry-connrefused -fsSL -o lib/scala/pkg/src/main/resources/restaurants/data/restaurants.csv https://github.com/enso-org/project-templates/raw/main/Restaurants/data/restaurants.csv
-          curl --retry 4 --retry-connrefused -fsSL -o lib/scala/pkg/src/main/resources/restaurants/src/Main.enso https://github.com/enso-org/project-templates/raw/main/Restaurants/src/Main.enso
-          curl --retry 4 --retry-connrefused -fsSL -o lib/scala/pkg/src/main/resources/stargazers/src/Main.enso https://github.com/enso-org/project-templates/raw/main/Stargazers/src/Main.enso
       - name: Set Up SBT
         shell: bash
         run: |
@@ -85,34 +36,8 @@ jobs:
           tar -xzf sbt.tgz
           echo $GITHUB_WORKSPACE/sbt/bin/ >> $GITHUB_PATH
 
-      # Caches
-      - name: Cache SBT
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.cache
-          key: Linux-sbt-${{ hashFiles('**build.sbt') }}
-          restore-keys: Linux-sbt-
-
-      - name: Bootstrap Enso project
-        run: |
-          sleep 1
-          sbt --no-colors bootstrap
-
-      # Compile
-      - name: Build Enso
-        run: |
-          sleep 1
-          sbt --no-colors compile
-
       # The actual check
       - name: Check Scala formatting
         run: |
-          sleep 1
-          sbt --no-colors scalafmtCheckAll
-      - name: Check Java formatting
-        run: |
-          sleep 1
-          sbt --no-colors javafmtCheckAll
+          sbt --no-colors "scalafmtCheckAll; javafmtCheckAll"
+

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,0 +1,118 @@
+name: Code Formatting Check
+
+on:
+  workflow_run:
+    workflows: [ "Engine CI (legacy)", "Engine CI (new)" ]
+    branches: [ main ]
+    types:
+      - completed
+  push:
+    branches: [develop, "release/*"]
+  pull_request:
+    branches: ["*"]
+
+env:
+  # Please ensure that this is in sync with graalVersion in build.sbt
+  graalVersion: 21.3.0
+  # Please ensure that this is in sync with javaVersion in build.sbt
+  javaVersion: 11
+  # Please ensure that this is in sync with project/build.properties
+  sbtVersion: 1.5.2
+  # Please ensure that this is in sync with rustVersion in build.sbt
+  rustToolchain: nightly-2021-11-29
+  # Some moderately recent version of Node.JS is needed to run the library download tests.
+  nodeVersion: 14.17.2
+
+jobs:
+  test_formatting:
+    name: Build and Test Formatting
+    runs-on: "ubuntu-18.04"
+    timeout-minutes: 120
+    # Only run if basic build succeeded, might be too restrictive depending on the stability of CI
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    strategy:
+      # No need to run it on multiple distros, result should be the same
+      fail-fast: false
+    steps:
+      - name: Disable TCP/UDP Offloading (Linux)
+        shell: bash
+        run: sudo ethtool -K eth0 tx off rx off
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: ${{ env.rustToolchain }}
+          override: true
+      - name: Setup conda
+        uses: s-weigand/setup-conda@v1.0.5
+        with:
+          update-conda: false
+          conda-channels: anaconda, conda-forge
+      - name: Install FlatBuffers Compiler
+        run: conda install --freeze-installed flatbuffers=1.12.0
+      - name: Setup GraalVM Environment
+        uses: ayltai/setup-graalvm@v1
+        with:
+          graalvm-version: ${{ env.graalVersion }}
+          java-version: ${{ env.javaVersion }}
+          native-image: true
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.nodeVersion }}
+      - name: Install Dependencies of the Simple Library Server
+        shell: bash
+        working-directory: tools/simple-library-server
+        run: |
+          npm install
+      - name: Install Dependencies of the Simple Library Server
+        shell: bash
+        working-directory: tools/simple-library-server
+        run: |
+          npm install
+      - name: Download Project Template Files
+        shell: bash
+        run: |
+          curl --retry 4 --retry-connrefused -fsSL -o lib/scala/pkg/src/main/resources/orders/data/store_data.xlsx https://github.com/enso-org/project-templates/raw/main/Orders/data/store_data.xlsx
+          curl --retry 4 --retry-connrefused -fsSL -o lib/scala/pkg/src/main/resources/orders/src/Main.enso https://github.com/enso-org/project-templates/raw/main/Orders/src/Main.enso
+          curl --retry 4 --retry-connrefused -fsSL -o lib/scala/pkg/src/main/resources/restaurants/data/la_districts.csv https://github.com/enso-org/project-templates/raw/main/Restaurants/data/la_districts.csv
+          curl --retry 4 --retry-connrefused -fsSL -o lib/scala/pkg/src/main/resources/restaurants/data/restaurants.csv https://github.com/enso-org/project-templates/raw/main/Restaurants/data/restaurants.csv
+          curl --retry 4 --retry-connrefused -fsSL -o lib/scala/pkg/src/main/resources/restaurants/src/Main.enso https://github.com/enso-org/project-templates/raw/main/Restaurants/src/Main.enso
+          curl --retry 4 --retry-connrefused -fsSL -o lib/scala/pkg/src/main/resources/stargazers/src/Main.enso https://github.com/enso-org/project-templates/raw/main/Stargazers/src/Main.enso
+      - name: Set Up SBT
+        shell: bash
+        run: |
+          curl --retry 4 --retry-connrefused -fsSL -o sbt.tgz https://github.com/sbt/sbt/releases/download/v${{env.sbtVersion}}/sbt-${{env.sbtVersion}}.tgz
+          tar -xzf sbt.tgz
+          echo $GITHUB_WORKSPACE/sbt/bin/ >> $GITHUB_PATH
+
+      # Caches
+      - name: Cache SBT
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.cache
+          key: Linux-sbt-${{ hashFiles('**build.sbt') }}
+          restore-keys: Linux-sbt-
+
+      - name: Bootstrap Enso project
+        run: |
+          sleep 1
+          sbt --no-colors bootstrap
+
+      # Compile
+      - name: Build Enso
+        run: |
+          sleep 1
+          sbt --no-colors compile
+
+      # The actual check
+      - name: Check Scala formatting
+        run: |
+          sleep 1
+          sbt --no-colors scalafmtCheckAll
+      - name: Check Java formatting
+        run: |
+          sleep 1
+          sbt --no-colors javafmtCheckAll

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -39,4 +39,3 @@ jobs:
       - name: Check Code Formatting
         run: |
           sbt "scalafmtCheckAll; javafmtCheckAll"
-

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -16,13 +16,14 @@ env:
 
 jobs:
   test_formatting:
-    name: Build and Test Formatting
-    runs-on: "ubuntu-18.04"
+    name: Test Formatting
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
       # No need to run it on multiple distros, result should be the same
       fail-fast: false
     steps:
+      - uses: actions/checkout@v2
       - name: Setup GraalVM Environment
         uses: ayltai/setup-graalvm@v1
         with:
@@ -35,9 +36,7 @@ jobs:
           curl --retry 4 --retry-connrefused -fsSL -o sbt.tgz https://github.com/sbt/sbt/releases/download/v${{env.sbtVersion}}/sbt-${{env.sbtVersion}}.tgz
           tar -xzf sbt.tgz
           echo $GITHUB_WORKSPACE/sbt/bin/ >> $GITHUB_PATH
-
-      # The actual check
-      - name: Check Scala formatting
+      - name: Check Code Formatting
         run: |
-          sbt --no-colors "scalafmtCheckAll; javafmtCheckAll"
+          sbt "scalafmtCheckAll; javafmtCheckAll"
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeMethodNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeMethodNode.java
@@ -245,8 +245,7 @@ public abstract class InvokeMethodNode extends BaseNode {
       Object[] arguments,
       @CachedLibrary(limit = "10") MethodDispatchLibrary methods,
       @CachedLibrary(limit = "1") MethodDispatchLibrary dateDispatch,
-      @CachedLibrary(limit = "10") InteropLibrary interop
-  ) {
+      @CachedLibrary(limit = "10") InteropLibrary interop) {
     try {
       var dateConstructor = Context.get(this).getDateConstructor();
       Object date = dateConstructor.isPresent() ? dateConstructor.get().newInstance(_this) : _this;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/resolver/HostMethodCallNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/resolver/HostMethodCallNode.java
@@ -52,12 +52,11 @@ public abstract class HostMethodCallNode extends Node {
     NOT_SUPPORTED;
 
     /**
-     * Directly use {@link InteropLibrary}, or not. Types that return false are
-     * either {@link #NOT_SUPPORTED unsupported} or require
-     * additional conversions like {@link #CONVERT_TO_TEXT} and {@link #CONVERT_TO_DATE}.
+     * Directly use {@link InteropLibrary}, or not. Types that return false are either {@link
+     * #NOT_SUPPORTED unsupported} or require additional conversions like {@link #CONVERT_TO_TEXT}
+     * and {@link #CONVERT_TO_DATE}.
      *
-     * @return true if one can directly pass this object to
-     * {@link InteropLibrary}
+     * @return true if one can directly pass this object to {@link InteropLibrary}
      */
     public boolean isInteropLibrary() {
       return this != NOT_SUPPORTED && this != CONVERT_TO_TEXT && this != CONVERT_TO_DATE;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Context.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Context.java
@@ -65,8 +65,7 @@ public class Context {
   private final DistributionManager distributionManager;
   private final LockManager lockManager;
   private final AtomicLong clock = new AtomicLong();
-  @CompilerDirectives.CompilationFinal
-  private Optional<AtomConstructor> date;
+  @CompilerDirectives.CompilationFinal private Optional<AtomConstructor> date;
 
   /**
    * Creates a new Enso context.
@@ -468,7 +467,8 @@ public class Context {
     return clock.getAndIncrement();
   }
 
-  /** Return the {@code Standard.Base.Data.Time.Date} constructor.
+  /**
+   * Return the {@code Standard.Base.Data.Time.Date} constructor.
    *
    * @return optional with {@link AtomConstructor} for the date, if it can be found
    */
@@ -480,7 +480,9 @@ public class Context {
       ensureModuleIsLoaded(stdDateModuleName);
       Optional<Module> dateModule = findModule(stdDateModuleName);
       if (dateModule.isPresent()) {
-        date = Optional.ofNullable(dateModule.get().getScope().getConstructors().get(stdDateConstructorName));
+        date =
+            Optional.ofNullable(
+                dateModule.get().getScope().getConstructors().get(stdDateConstructorName));
       } else {
         date = Optional.empty();
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/Atom.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/Atom.java
@@ -216,7 +216,8 @@ public class Atom implements TruffleObject {
   }
 
   @ExportMessage
-  LocalDate asDate(@CachedLibrary(limit = "3") InteropLibrary iop) throws UnsupportedMessageException {
+  LocalDate asDate(@CachedLibrary(limit = "3") InteropLibrary iop)
+      throws UnsupportedMessageException {
     return iop.asDate(fields[0]);
   }
 


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

Contribution notes mention that formatting should be run prior to PR merges
but that is clearly not the case (see `Important Notes` section). 
Added a new workflow that runs after regular builds finish (and
succeed). Mostly c&p from scala workflow + `javafmtCheckAll` and
`scalafmtCheckAll` sbt commands. Translation to new CI workflow can be done independently.

### Important Notes
To illustrate the problem:
```
sbt:enso> javafmtCheck
...
[error] 66 files must be formatted
[error] 1 file must be formatted
[error] (runtime / Compile / javafmtCheck) 66 files must be formatted
[error] (logging-utils / Compile / javafmtCheck) 1 file must be formatted
[error] Total time: 2 s, completed Apr 12, 2022, 3:31:30 PM
```
and 
```
sbt:enso> scalafmtCheckAll
[warn] scalafmt: /home/hubert/work/repos/enso/enso/lib/scala/text-buffer: 1 files aren't formatted properly:
...
[warn] scalafmt: /home/hubert/work/repos/enso/enso/lib/scala/pkg: 1 files aren't formatted properly:
...
[warn] scalafmt: /home/hubert/work/repos/enso/enso/lib/scala/syntax/definition/.jvm: 1 files aren't formatted properly:
...
[warn] scalafmt: /home/hubert/work/repos/enso/enso/engine/polyglot-api: 1 files aren't formatted properly:
...
[warn] scalafmt: /home/hubert/work/repos/enso/enso/engine/runtime: 6 files aren't formatted properly:
...
[warn] scalafmt: /home/hubert/work/repos/enso/enso/engine/language-server: 2 files aren't formatted properly:
...
[warn] scalafmt: /home/hubert/work/repos/enso/enso/lib/scala/project-manager: 1 files aren't formatted properly:
...
[warn] scalafmt: /home/hubert/work/repos/enso/enso/engine/language-server: 8 files aren't formatted properly:
...
[info] scalafmt: Checking 127 Scala sources (/home/hubert/work/repos/enso/enso/engine/runtime)...
[warn] scalafmt: /home/hubert/work/repos/enso/enso/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstView.scala isn't formatted properly!
[warn] scalafmt: /home/hubert/work/repos/enso/enso/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala isn't formatted properly!
[error] stack trace is suppressed; run last runtime / Compile / scalafmtCheck for the full output
[error] scalafmt: 6 files must be formatted (/home/hubert/work/repos/enso/enso/engine/runtime)
[error] scalafmt: 1 files must be formatted (/home/hubert/work/repos/enso/enso/lib/scala/project-manager)
[error] scalafmt: 1 files must be formatted (/home/hubert/work/repos/enso/enso/lib/scala/syntax/definition/.jvm)
[error] scalafmt: 8 files must be formatted (/home/hubert/work/repos/enso/enso/engine/language-server)
[error] scalafmt: 2 files must be formatted (/home/hubert/work/repos/enso/enso/engine/language-server)
[error] scalafmt: 1 files must be formatted (/home/hubert/work/repos/enso/enso/lib/scala/text-buffer)
[error] scalafmt: 1 files must be formatted (/home/hubert/work/repos/enso/enso/engine/polyglot-api)
[error] scalafmt: 1 files must be formatted (/home/hubert/work/repos/enso/enso/lib/scala/pkg)
[error] (runtime / Compile / scalafmtCheck) org.scalafmt.sbt.ScalafmtSbtReporter$ScalafmtSbtError: scalafmt: /home/hubert/work/repos/enso/enso/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala:2052: error: ; expected but string constant found
[error]       override def showCode(indent: Int): String = s"\"$text\""
[error]                                                              ^ [/home/hubert/work/repos/enso/enso/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala]
[error] (runtime / Test / scalafmtCheck) scalafmt: 6 files must be formatted (/home/hubert/work/repos/enso/enso/engine/runtime)
[error] (project-manager / Compile / scalafmtCheck) scalafmt: 1 files must be formatted (/home/hubert/work/repos/enso/enso/lib/scala/project-manager)
[error] (syntax-definition / Compile / scalafmtCheck) scalafmt: 1 files must be formatted (/home/hubert/work/repos/enso/enso/lib/scala/syntax/definition/.jvm)
[error] (language-server / Compile / scalafmtCheck) scalafmt: 8 files must be formatted (/home/hubert/work/repos/enso/enso/engine/language-server)
[error] (language-server / Test / scalafmtCheck) scalafmt: 2 files must be formatted (/home/hubert/work/repos/enso/enso/engine/language-server)
[error] (text-buffer / Compile / scalafmtCheck) scalafmt: 1 files must be formatted (/home/hubert/work/repos/enso/enso/lib/scala/text-buffer)
[error] (polyglot-api / Test / scalafmtCheck) scalafmt: 1 files must be formatted (/home/hubert/work/repos/enso/enso/engine/polyglot-api)
[error] (pkg / Compile / scalafmtCheck) scalafmt: 1 files must be formatted (/home/hubert/work/repos/enso/enso/lib/scala/pkg)
```

This is not the problem with individual contributions. Those things will slip through no matter how much one tries to do due diligence with the checklist below. Only automatic check will ensure the consistency.

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.
