### PR TITLE
Fixed rate animation loop fixes

### DIFF
--- a/lib/rust/ensogl/core/src/animation/loops.rs
+++ b/lib/rust/ensogl/core/src/animation/loops.rs
@@ -225,8 +225,9 @@ impl<Callback: FnMut<(TimeInfo,)>> FnMut<(TimeInfo,)> for FixedFrameRateSampler<
     extern "rust-call" fn call_mut(&mut self, args: (TimeInfo,)) -> Self::Output {
         let mut time = args.0;
         self.time_buffer += time.since_animation_loop_started - self.local_time;
-
-        while self.time_buffer > self.frame_time * 1.5 {
+        
+        let sub_frame_interpolation_threshold = 1.5;
+        while self.time_buffer > self.frame_time * sub_frame_interpolation_threshold {
             self.local_time += self.frame_time;
             self.time_buffer -= self.frame_time;
 

--- a/lib/rust/ensogl/core/src/animation/loops.rs
+++ b/lib/rust/ensogl/core/src/animation/loops.rs
@@ -291,12 +291,12 @@ mod tests {
             since_animation_loop_started: 0.ms(),
         };
 
-        let mut step = |frame_time: Duration, ts: &[Duration], offset: Duration| {
+        let mut step = |frame_time: Duration, sub_frames: &[Duration], offset: Duration| {
             let time2 = time.new_frame(frame_time);
             lp(time2);
-            for t in ts {
+            for sub_frame in sub_frames {
                 count_check += 1;
-                time = time.new_frame(*t);
+                time = time.new_frame(*sub_frame);
                 assert_eq!(frame_times.borrow_mut().pop_front(), Some(time));
             }
             count_check += 1;

--- a/lib/rust/ensogl/core/src/animation/loops.rs
+++ b/lib/rust/ensogl/core/src/animation/loops.rs
@@ -224,7 +224,6 @@ impl<Callback: FnOnce<(TimeInfo,)>> FnOnce<(TimeInfo,)> for FixedFrameRateSample
 impl<Callback: FnMut<(TimeInfo,)>> FnMut<(TimeInfo,)> for FixedFrameRateSampler<Callback> {
     extern "rust-call" fn call_mut(&mut self, args: (TimeInfo,)) -> Self::Output {
         let mut time = args.0;
-
         self.time_buffer += time.since_animation_loop_started - self.local_time;
 
         while self.time_buffer > self.frame_time * 1.5 {

--- a/lib/rust/ensogl/core/src/animation/loops.rs
+++ b/lib/rust/ensogl/core/src/animation/loops.rs
@@ -196,6 +196,7 @@ where
 /// callback will be used instead.
 #[derive(Derivative)]
 #[derivative(Debug(bound = ""))]
+#[allow(missing_docs)]
 pub struct FixedFrameRateSampler<Callback, OnTooManyFramesSkipped> {
     pub max_skipped_frames:     usize,
     frame_time:                 Duration,

--- a/lib/rust/ensogl/core/src/animation/loops.rs
+++ b/lib/rust/ensogl/core/src/animation/loops.rs
@@ -39,6 +39,8 @@ impl TimeInfo {
         self.animation_loop_start != 0.ms()
     }
 
+    /// Creates a new [`TimeInfo`] for the next frame with the provided time. The frame time will
+    /// be computed based on the current and the new frame time.
     pub fn new_frame(mut self, since_animation_loop_started: Duration) -> Self {
         self.previous_frame = since_animation_loop_started - self.since_animation_loop_started;
         self.since_animation_loop_started = since_animation_loop_started;
@@ -278,8 +280,8 @@ mod tests {
     #[test]
     fn fixed_frame_rate_sampler_test() {
         let mut count_check = 0;
-        let mut count = Rc::new(Cell::new(0));
-        let mut frame_times = Rc::new(RefCell::new(VecDeque::new()));
+        let count = Rc::new(Cell::new(0));
+        let frame_times = Rc::new(RefCell::new(VecDeque::new()));
         let mut lp = FixedFrameRateSampler::new(10.0, |t| {
             frame_times.borrow_mut().push_back(t);
             count.set(count.get() + 1);

--- a/lib/rust/ensogl/core/src/animation/loops.rs
+++ b/lib/rust/ensogl/core/src/animation/loops.rs
@@ -135,6 +135,7 @@ impl<Callback> Drop for RawLoopData<Callback> {
 // === Types ===
 
 pub trait LoopCallback = FnMut(TimeInfo) + 'static;
+pub trait OnTooManyFramesSkippedCallback = FnMut() + 'static;
 
 
 // === Definition ===
@@ -191,60 +192,90 @@ where
 // =============================
 
 /// A callback `FnMut(TimeInfo) -> FnMut(TimeInfo)` transformer. Calls the inner callback with a
-/// constant frame rate.
+/// constant frame rate. If too many frames were skipped, the [`on_too_many_frames_skipped`]
+/// callback will be used instead.
 #[derive(Derivative)]
 #[derivative(Debug(bound = ""))]
-pub struct FixedFrameRateSampler<Callback> {
-    frame_time:  Duration,
-    local_time:  Duration,
-    time_buffer: Duration,
+pub struct FixedFrameRateSampler<Callback, OnTooManyFramesSkipped> {
+    pub max_skipped_frames:     usize,
+    frame_time:                 Duration,
+    local_time:                 Duration,
+    time_buffer:                Duration,
     #[derivative(Debug = "ignore")]
-    callback:    Callback,
+    callback:                   Callback,
+    #[derivative(Debug = "ignore")]
+    on_too_many_frames_skipped: OnTooManyFramesSkipped,
 }
 
-impl<Callback> FixedFrameRateSampler<Callback> {
+impl<Callback, OnTooManyFramesSkipped> FixedFrameRateSampler<Callback, OnTooManyFramesSkipped> {
     /// Constructor.
-    pub fn new(frame_rate: f32, callback: Callback) -> Self {
+    pub fn new(
+        frame_rate: f32,
+        callback: Callback,
+        on_too_many_frames_skipped: OnTooManyFramesSkipped,
+    ) -> Self {
+        let max_skipped_frames = 2;
         let frame_time = (1000.0 / frame_rate).ms();
         let local_time = default();
         // The first call to this sampler will be with frame time 0, which would drop this
         // `time_buffer` to 0.
         let time_buffer = frame_time;
-        Self { frame_time, local_time, time_buffer, callback }
+        Self {
+            max_skipped_frames,
+            frame_time,
+            local_time,
+            time_buffer,
+            callback,
+            on_too_many_frames_skipped,
+        }
     }
 }
 
-impl<Callback: FnOnce<(TimeInfo,)>> FnOnce<(TimeInfo,)> for FixedFrameRateSampler<Callback> {
+impl<Callback: FnOnce<(TimeInfo,)>, OnTooManyFramesSkipped> FnOnce<(TimeInfo,)>
+    for FixedFrameRateSampler<Callback, OnTooManyFramesSkipped>
+{
     type Output = ();
     extern "rust-call" fn call_once(self, args: (TimeInfo,)) -> Self::Output {
         self.callback.call_once(args);
     }
 }
 
-impl<Callback: FnMut<(TimeInfo,)>> FnMut<(TimeInfo,)> for FixedFrameRateSampler<Callback> {
+impl<Callback, OnTooManyFramesSkipped> FnMut<(TimeInfo,)>
+    for FixedFrameRateSampler<Callback, OnTooManyFramesSkipped>
+where
+    Callback: FnMut(TimeInfo),
+    OnTooManyFramesSkipped: FnMut(),
+{
     extern "rust-call" fn call_mut(&mut self, args: (TimeInfo,)) -> Self::Output {
         let mut time = args.0;
         self.time_buffer += time.since_animation_loop_started - self.local_time;
-        
-        let sub_frame_interpolation_threshold = 1.5;
-        while self.time_buffer > self.frame_time * sub_frame_interpolation_threshold {
-            self.local_time += self.frame_time;
-            self.time_buffer -= self.frame_time;
 
-            let animation_loop_start = time.animation_loop_start;
-            let previous_frame = self.frame_time;
-            let since_animation_loop_started = self.local_time;
-            let time2 =
-                TimeInfo { animation_loop_start, previous_frame, since_animation_loop_started };
-            self.callback.call_mut((time2,));
+        let frame_time_2 = self.frame_time * 0.5;
+        let skipped_frames = ((self.time_buffer - frame_time_2) / self.frame_time) as usize;
+        let too_many_frames_skipped = skipped_frames > self.max_skipped_frames;
+        if !too_many_frames_skipped {
+            for _ in 0..skipped_frames {
+                self.local_time += self.frame_time;
+                self.time_buffer -= self.frame_time;
+                let animation_loop_start = time.animation_loop_start;
+                let previous_frame = self.frame_time;
+                let since_animation_loop_started = self.local_time;
+                let time2 =
+                    TimeInfo { animation_loop_start, previous_frame, since_animation_loop_started };
+                self.callback.call_mut((time2,));
+            }
+            let not_too_fast_refresh_rate = self.time_buffer >= -frame_time_2;
+            if not_too_fast_refresh_rate {
+                self.time_buffer -= self.frame_time;
+            }
+            time.previous_frame = time.since_animation_loop_started - self.local_time;
+            self.local_time = time.since_animation_loop_started;
+            (self.callback)(time);
+        } else {
+            self.local_time = time.since_animation_loop_started;
+            self.time_buffer = 0.ms();
+            (self.on_too_many_frames_skipped)();
         }
-
-        if self.time_buffer >= 0.ms() {
-            self.time_buffer -= self.frame_time;
-        }
-        time.previous_frame = time.since_animation_loop_started - self.local_time;
-        self.local_time = time.since_animation_loop_started;
-        self.callback.call_mut((time,));
     }
 }
 
@@ -255,14 +286,21 @@ impl<Callback: FnMut<(TimeInfo,)>> FnMut<(TimeInfo,)> for FixedFrameRateSampler<
 // ==========================
 
 /// Loop with a `FixedFrameRateSampler` attached.
-pub type FixedFrameRateLoop<Callback> = Loop<FixedFrameRateSampler<Callback>>;
+pub type FixedFrameRateLoop<Callback, OnTooManyFramesSkipped> =
+    Loop<FixedFrameRateSampler<Callback, OnTooManyFramesSkipped>>;
 
-impl<Callback> FixedFrameRateLoop<Callback>
-where Callback: LoopCallback
+impl<Callback, OnTooManyFramesSkipped> FixedFrameRateLoop<Callback, OnTooManyFramesSkipped>
+where
+    Callback: LoopCallback,
+    OnTooManyFramesSkipped: OnTooManyFramesSkippedCallback,
 {
     /// Constructor.
-    pub fn new_with_fixed_frame_rate(frame_rate: f32, callback: Callback) -> Self {
-        Self::new(FixedFrameRateSampler::new(frame_rate, callback))
+    pub fn new_with_fixed_frame_rate(
+        frame_rate: f32,
+        callback: Callback,
+        on_too_many_frames_skipped: OnTooManyFramesSkipped,
+    ) -> Self {
+        Self::new(FixedFrameRateSampler::new(frame_rate, callback, on_too_many_frames_skipped))
     }
 }
 
@@ -281,18 +319,28 @@ mod tests {
     fn fixed_frame_rate_sampler_test() {
         let mut count_check = 0;
         let count = Rc::new(Cell::new(0));
+        let too_many_frames_skipped_count = Rc::new(Cell::new(0));
         let frame_times = Rc::new(RefCell::new(VecDeque::new()));
-        let mut lp = FixedFrameRateSampler::new(10.0, |t| {
-            frame_times.borrow_mut().push_back(t);
-            count.set(count.get() + 1);
-        });
+        let mut lp = FixedFrameRateSampler::new(
+            10.0,
+            |t| {
+                frame_times.borrow_mut().push_back(t);
+                count.set(count.get() + 1);
+            },
+            || {
+                too_many_frames_skipped_count.set(too_many_frames_skipped_count.get() + 1);
+            },
+        );
         let mut time = TimeInfo {
             animation_loop_start:         0.ms(),
             previous_frame:               0.ms(),
             since_animation_loop_started: 0.ms(),
         };
 
-        let mut step = |frame_time: Duration, sub_frames: &[Duration], offset: Duration| {
+        let mut step = |frame_time: Duration,
+                        sub_frames: &[Duration],
+                        offset: Duration,
+                        skipped_count: Option<usize>| {
             let time2 = time.new_frame(frame_time);
             lp(time2);
             for sub_frame in sub_frames {
@@ -300,43 +348,51 @@ mod tests {
                 time = time.new_frame(*sub_frame);
                 assert_eq!(frame_times.borrow_mut().pop_front(), Some(time));
             }
-            count_check += 1;
             time = time.new_frame(time2.since_animation_loop_started);
-            assert_eq!(frame_times.borrow_mut().pop_front(), Some(time));
+            if skipped_count.is_none() {
+                count_check += 1;
+                assert_eq!(frame_times.borrow_mut().pop_front(), Some(time));
+            }
             assert_eq!(frame_times.borrow_mut().pop_front(), None);
             assert_eq!(count.get(), count_check);
             assert_eq!(lp.time_buffer, offset);
+            if let Some(skipped_count) = skipped_count {
+                assert_eq!(too_many_frames_skipped_count.get(), skipped_count);
+            }
         };
 
         // Start frame.
-        step(0.ms(), &[], 0.ms());
+        step(0.ms(), &[], 0.ms(), None);
 
         // Perfectly timed next frame.
-        step(100.ms(), &[], 0.ms());
+        step(100.ms(), &[], 0.ms(), None);
 
         // Skipping 2 frames.
-        step(400.ms(), &[200.ms(), 300.ms()], 0.ms());
+        step(400.ms(), &[200.ms(), 300.ms()], 0.ms(), None);
 
         // Perfectly timed next frame.
-        step(500.ms(), &[], 0.ms());
+        step(500.ms(), &[], 0.ms(), None);
 
         // Next frame too slow.
-        step(650.ms(), &[], 50.ms());
+        step(640.ms(), &[], 40.ms(), None);
 
         // Next frame too slow.
-        step(800.ms(), &[750.ms()], 0.ms());
+        step(800.ms(), &[740.ms()], 0.ms(), None);
 
         // Not-perfectly timed next frames.
-        step(870.ms(), &[], -30.ms());
-        step(1010.ms(), &[], 10.ms());
-        step(1090.ms(), &[], -10.ms());
-        step(1200.ms(), &[], 0.ms());
+        step(870.ms(), &[], -30.ms(), None);
+        step(1010.ms(), &[], 10.ms(), None);
+        step(1090.ms(), &[], -10.ms(), None);
+        step(1200.ms(), &[], 0.ms(), None);
 
         // Next frames way too fast.
-        step(1210.ms(), &[], -90.ms());
+        step(1210.ms(), &[], -90.ms(), None);
         // Time compression – we don't want to accumulate too much of negative time buffer for
         // monitors with bigger refresh-rate than assumed. The total accumulated time buffer would
         // be -180 here, so we add a frame time to it (100).
-        step(1220.ms(), &[], -80.ms());
+        step(1220.ms(), &[], -80.ms(), None);
+
+        // Too many frames skipped.
+        step(2000.ms(), &[], 0.ms(), Some(1));
     }
 }

--- a/lib/rust/ensogl/core/src/animation/loops.rs
+++ b/lib/rust/ensogl/core/src/animation/loops.rs
@@ -334,7 +334,8 @@ mod tests {
         // Next frames way too fast.
         step(1210.ms(), &[], -90.ms());
         // Time compression – we don't want to accumulate too much of negative time buffer for
-        // monitors with bigger refresh-rate than assumed.
+        // monitors with bigger refresh-rate than assumed. The total accumulated time buffer would
+        // be -180 here, so we add a frame time to it (100).
         step(1220.ms(), &[], -80.ms());
     }
 }

--- a/lib/rust/ensogl/core/src/animation/loops.rs
+++ b/lib/rust/ensogl/core/src/animation/loops.rs
@@ -19,7 +19,7 @@ use web::Closure;
 /// differ across browsers and browser versions. We have even observed that `performance.now()` can
 /// sometimes provide a bigger value than time provided to `requestAnimationFrame` callback later,
 /// which resulted in a negative frame time.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 #[allow(missing_docs)]
 pub struct TimeInfo {
     pub animation_loop_start:         Duration,

--- a/lib/rust/ensogl/core/src/lib.rs
+++ b/lib/rust/ensogl/core/src/lib.rs
@@ -25,6 +25,7 @@
 #![warn(unsafe_code)]
 // === Non-Standard Linter Configuration ===
 #![allow(clippy::option_map_unit_fn)]
+#![allow(clippy::precedence)]
 #![allow(dead_code)]
 #![deny(unconditional_recursion)]
 #![warn(missing_copy_implementations)]

--- a/lib/rust/types/src/unit2.rs
+++ b/lib/rust/types/src/unit2.rs
@@ -152,7 +152,6 @@ impl<V, R> AsRef<UnitData<V, R>> for UnitData<V, R> {
 // === Eq ===
 // ==========
 
-impl<V, R: PartialEq> Eq for UnitData<V, R> {}
 impl<V, R: PartialEq> PartialEq for UnitData<V, R> {
     fn eq(&self, other: &Self) -> bool {
         self.repr.eq(&other.repr)
@@ -164,12 +163,6 @@ impl<V, R: PartialEq> PartialEq for UnitData<V, R> {
 // ===========
 // === Ord ===
 // ===========
-
-impl<V, R: Ord> Ord for UnitData<V, R> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.repr.cmp(&other.repr)
-    }
-}
 
 impl<V, R: PartialOrd> PartialOrd for UnitData<V, R> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {

--- a/lib/rust/types/src/unit2.rs
+++ b/lib/rust/types/src/unit2.rs
@@ -354,8 +354,6 @@ macro_rules! gen_ops_mut {
     };
 }
 
-
-
 gen_ops!(RevAdd, Add, add);
 gen_ops!(RevSub, Sub, sub);
 gen_ops!(RevMul, Mul, mul);
@@ -367,6 +365,15 @@ gen_ops_mut!(RevAdd, Add, AddAssign, add_assign);
 gen_ops_mut!(RevSub, Sub, SubAssign, sub_assign);
 gen_ops_mut!(RevMul, Mul, MulAssign, mul_assign);
 gen_ops_mut!(RevDiv, Div, DivAssign, div_assign);
+
+impl<V, R: ops::Neg<Output = R>> ops::Neg for UnitData<V, R> {
+    type Output = UnitData<V, R>;
+
+    fn neg(mut self) -> Self::Output {
+        self.repr = self.repr.neg();
+        self
+    }
+}
 
 
 
@@ -615,6 +622,16 @@ impl const DurationNumberOps for f32 {
 
     fn s(self) -> Duration {
         Duration::s(self)
+    }
+}
+
+impl const DurationNumberOps for i64 {
+    fn ms(self) -> Duration {
+        (self as f32).ms()
+    }
+
+    fn s(self) -> Duration {
+        (self as f32).s()
     }
 }
 


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

When implementing my another task I noticed that our fixed rate animation loop is broken. When the `requestAnimationFrame` was not being called at the exact time, some frames could be delayed to be refreshed to the next frame. This PR fixes that and adds tests to make sure it works properly.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.
