### PR TITLE
Drop down for Text.trim 'where' attribute

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/search/SearchProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/search/SearchProtocol.scala
@@ -172,7 +172,8 @@ object SearchProtocol {
       conversion.sourceType,
       false,
       false,
-      None
+      None,
+      Option.empty
     )
     Suggestion.Method(
       conversion.externalId,

--- a/engine/language-server/src/test/scala/org/enso/languageserver/search/Suggestions.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/search/Suggestions.scala
@@ -25,6 +25,16 @@ object Suggestions {
         |""".stripMargin.linesIterator.mkString("\n")
   }
 
+  private def suggestionArgument(
+    name: String,
+    reprType: String,
+    isSuspended: Boolean,
+    hasDefault: Boolean,
+    defaultValue: Option[String]
+  ): Suggestion.Argument = {
+    Suggestion.Argument(name, reprType, isSuspended, hasDefault, defaultValue, None)
+  }  
+
   val htmlDocsGenerator: DocsGenerator =
     DocsGenerator
   val docSectionsBuilder: DocSectionsBuilder =
@@ -42,7 +52,7 @@ object Suggestions {
     externalId    = None,
     module        = "Test.Main",
     name          = "MyType",
-    arguments     = Vector(Suggestion.Argument("a", "Any", false, false, None)),
+    arguments     = Vector(suggestionArgument("a", "Any", false, false, None)),
     returnType    = "MyAtom",
     documentation = Some(comment.atom),
     documentationHtml =
@@ -55,8 +65,8 @@ object Suggestions {
     module     = "Test.Main",
     name       = "foo",
     arguments = Vector(
-      Suggestion.Argument("this", "MyType", false, false, None),
-      Suggestion.Argument("foo", "Number", false, true, Some("42"))
+      suggestionArgument("this", "MyType", false, false, None),
+      suggestionArgument("foo", "Number", false, true, Some("42"))
     ),
     selfType              = "MyType",
     returnType            = "Number",
@@ -70,9 +80,9 @@ object Suggestions {
     module     = "Test.Main",
     name       = "print",
     arguments = Vector(
-      Suggestion.Argument("a", "Any", false, false, None),
-      Suggestion.Argument("b", "Any", true, false, None),
-      Suggestion.Argument("c", "Any", false, true, Some("C"))
+      suggestionArgument("a", "Any", false, false, None),
+      suggestionArgument("b", "Any", true, false, None),
+      suggestionArgument("c", "Any", false, true, Some("C"))
     ),
     returnType = "IO",
     scope =
@@ -93,8 +103,8 @@ object Suggestions {
     module     = "Standard.Base.Data.Any.Extensions",
     name       = "<<",
     arguments = Vector(
-      Suggestion.Argument("this", "Any", false, false, None),
-      Suggestion.Argument("that", "Any", false, false, None)
+      suggestionArgument("this", "Any", false, false, None),
+      suggestionArgument("that", "Any", false, false, None)
     ),
     selfType              = "Any",
     returnType            = "Any",
@@ -108,7 +118,7 @@ object Suggestions {
     module     = "Standard.Base.Data.Number.Extensions",
     name       = "asin",
     arguments = Vector(
-      Suggestion.Argument("this", "Number", false, false, None)
+      suggestionArgument("this", "Number", false, false, None)
     ),
     selfType              = "Number",
     returnType            = "Number",
@@ -122,7 +132,7 @@ object Suggestions {
     module     = "Builtins.Main",
     name       = "+",
     arguments = Vector(
-      Suggestion.Argument("that", "Number", false, false, None)
+      suggestionArgument("that", "Number", false, false, None)
     ),
     selfType              = "Integer",
     returnType            = "Number",

--- a/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
@@ -1232,8 +1232,8 @@ class SuggestionsHandlerSpec
         module     = "Test.Pair",
         name       = "Pair",
         arguments = Seq(
-          Suggestion.Argument("a", "Any", false, false, None),
-          Suggestion.Argument("b", "Any", false, false, None)
+          Suggestion.Argument("a", "Any", false, false, None, None),
+          Suggestion.Argument("b", "Any", false, false, None, None)
         ),
         returnType            = "Pair",
         documentation         = Some("Awesome"),

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/SuggestionsHandlerEventsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/SuggestionsHandlerEventsTest.scala
@@ -58,7 +58,8 @@ class SuggestionsHandlerEventsTest extends BaseServerTest with FlakySpec {
                       "reprType" : "Any",
                       "isSuspended" : false,
                       "hasDefault" : false,
-                      "defaultValue" : null
+                      "defaultValue" : null,
+                      "tagValues" : null
                     }
                   ],
                   "returnType" : "MyAtom",
@@ -141,14 +142,16 @@ class SuggestionsHandlerEventsTest extends BaseServerTest with FlakySpec {
                       "reprType" : "MyType",
                       "isSuspended" : false,
                       "hasDefault" : false,
-                      "defaultValue" : null
+                      "defaultValue" : null,
+                      "tagValues" : null
                     },
                     {
                       "name" : "foo",
                       "reprType" : "Number",
                       "isSuspended" : false,
                       "hasDefault" : true,
-                      "defaultValue" : "42"
+                      "defaultValue" : "42",
+                      "tagValues" : null
                     }
                   ],
                   "selfType" : "MyType",
@@ -224,21 +227,24 @@ class SuggestionsHandlerEventsTest extends BaseServerTest with FlakySpec {
                       "reprType" : "Any",
                       "isSuspended" : false,
                       "hasDefault" : false,
-                      "defaultValue" : null
+                      "defaultValue" : null,
+                      "tagValues" : null
                     },
                     {
                       "name" : "b",
                       "reprType" : "Any",
                       "isSuspended" : true,
                       "hasDefault" : false,
-                      "defaultValue" : null
+                      "defaultValue" : null,
+                      "tagValues" : null
                     },
                     {
                       "name" : "c",
                       "reprType" : "Any",
                       "isSuspended" : false,
                       "hasDefault" : true,
-                      "defaultValue" : "C"
+                      "defaultValue" : "C",
+                      "tagValues" : null
                     }
                   ],
                   "returnType" : "IO",
@@ -356,21 +362,24 @@ class SuggestionsHandlerEventsTest extends BaseServerTest with FlakySpec {
                       "reprType" : "Any",
                       "isSuspended" : false,
                       "hasDefault" : false,
-                      "defaultValue" : null
+                      "defaultValue" : null,
+                      "tagValues" : null
                     },
                     {
                       "name" : "b",
                       "reprType" : "Any",
                       "isSuspended" : true,
                       "hasDefault" : false,
-                      "defaultValue" : null
+                      "defaultValue" : null,
+                      "tagValues" : null
                     },
                     {
                       "name" : "c",
                       "reprType" : "Any",
                       "isSuspended" : false,
                       "hasDefault" : true,
-                      "defaultValue" : "C"
+                      "defaultValue" : "C",
+                      "tagValues" : null
                     }
                   ],
                   "returnType" : "IO",
@@ -419,14 +428,16 @@ class SuggestionsHandlerEventsTest extends BaseServerTest with FlakySpec {
                       "reprType" : "MyType",
                       "isSuspended" : false,
                       "hasDefault" : false,
-                      "defaultValue" : null
+                      "defaultValue" : null,
+                      "tagValues" : null
                     },
                     {
                       "name" : "foo",
                       "reprType" : "Number",
                       "isSuspended" : false,
                       "hasDefault" : true,
-                      "defaultValue" : "42"
+                      "defaultValue" : "42",
+                      "tagValues" : null
                     }
                   ],
                   "selfType" : "MyType",
@@ -453,7 +464,8 @@ class SuggestionsHandlerEventsTest extends BaseServerTest with FlakySpec {
                       "reprType" : "Any",
                       "isSuspended" : false,
                       "hasDefault" : false,
-                      "defaultValue" : null
+                      "defaultValue" : null,
+                      "tagValues" : null
                     }
                   ],
                   "returnType" : "MyAtom",
@@ -572,7 +584,8 @@ class SuggestionsHandlerEventsTest extends BaseServerTest with FlakySpec {
                       "reprType" : "Any",
                       "isSuspended" : true,
                       "hasDefault" : false,
-                      "defaultValue" : null
+                      "defaultValue" : null,
+                      "tagValues" : null
                     }
                   }
                 ]

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/Suggestion.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/Suggestion.scala
@@ -123,7 +123,8 @@ object Suggestion {
     reprType: String,
     isSuspended: Boolean,
     hasDefault: Boolean,
-    defaultValue: Option[String]
+    defaultValue: Option[String],
+    tagValues: Option[Seq[String]]
   ) extends ToLogString {
 
     /** @inheritdoc */

--- a/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
@@ -435,6 +435,13 @@ final class SuggestionBuilder[A: IndexedSource](val source: A) {
     methodName: String
   ): (Seq[Suggestion.Argument], Option[TypeArg]) = {
     var tagValues: Map[String, Seq[String]] = Map.empty;
+    if (selfType.toString().equals("Standard.Builtins.Main.Text")) {
+      if ("trim".equals(methodName)) {
+        tagValues = Map(
+          "where" -> Seq("Location.Both", "Location.Start", "Location.End")
+        )
+      }
+    }
     @scala.annotation.tailrec
     def go(
       vargs: Seq[IR.DefinitionArgument],

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
@@ -36,6 +36,16 @@ class SuggestionBuilderTest extends CompilerTest {
     Vector()
   )
 
+  private def suggestionArgument(
+    name: String,
+    reprType: String,
+    isSuspended: Boolean,
+    hasDefault: Boolean,
+    defaultValue: Option[String]
+  ): Suggestion.Argument = {
+    Suggestion.Argument(name, reprType, isSuspended, hasDefault, defaultValue, None)
+  }
+
   "SuggestionBuilder" should {
 
     "build method without explicit arguments" in {
@@ -53,7 +63,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "foo",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -84,7 +94,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "foo",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -116,7 +126,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "foo",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = "Number",
@@ -146,7 +156,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "foo",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = "Foo.Bar",
@@ -176,8 +186,8 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "foo",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None),
-                Suggestion.Argument("a", "Text", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None),
+                suggestionArgument("a", "Text", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = "Number",
@@ -207,8 +217,8 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "foo",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None),
-                Suggestion.Argument(
+                suggestionArgument("this", "Unnamed.Test", false, false, None),
+                suggestionArgument(
                   "a",
                   "Either (Vector Number) Text",
                   false,
@@ -245,7 +255,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "foo",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = "Foo.Bar Baz",
@@ -277,11 +287,9 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "foo",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None),
-                Suggestion
-                  .Argument("a", SuggestionBuilder.Any, false, false, None),
-                Suggestion
-                  .Argument("b", SuggestionBuilder.Any, false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None),
+                suggestionArgument("a", SuggestionBuilder.Any, false, false, None),
+                suggestionArgument("b", SuggestionBuilder.Any, false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -331,9 +339,8 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "foo",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None),
-                Suggestion
-                  .Argument("a", SuggestionBuilder.Any, false, true, Some("0"))
+                suggestionArgument("this", "Unnamed.Test", false, false, None),
+                suggestionArgument("a", SuggestionBuilder.Any, false, true, Some("0"))
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -375,12 +382,9 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "bar",
               arguments = Seq(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.MyType", false, false, None),
-                Suggestion
-                  .Argument("a", SuggestionBuilder.Any, false, false, None),
-                Suggestion
-                  .Argument("b", SuggestionBuilder.Any, false, false, None)
+                suggestionArgument("this", "Unnamed.Test.MyType", false, false, None),
+                suggestionArgument("a", SuggestionBuilder.Any, false, false, None),
+                suggestionArgument("b", SuggestionBuilder.Any, false, false, None)
               ),
               selfType      = "Unnamed.Test.MyType",
               returnType    = SuggestionBuilder.Any,
@@ -434,10 +438,9 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "bar",
               arguments = Seq(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.MyAtom", false, false, None),
-                Suggestion.Argument("a", "Number", false, false, None),
-                Suggestion.Argument("b", "Number", false, false, None)
+                suggestionArgument("this", "Unnamed.Test.MyAtom", false, false, None),
+                suggestionArgument("a", "Number", false, false, None),
+                suggestionArgument("b", "Number", false, false, None)
               ),
               selfType      = "Unnamed.Test.MyAtom",
               returnType    = "Number",
@@ -480,9 +483,8 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "apply",
               arguments = Seq(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.MyAtom", false, false, None),
-                Suggestion.Argument("f", "Number -> Number", false, false, None)
+                suggestionArgument("this", "Unnamed.Test.MyAtom", false, false, None),
+                suggestionArgument("f", "Number -> Number", false, false, None)
               ),
               selfType      = "Unnamed.Test.MyAtom",
               returnType    = "Number",
@@ -525,9 +527,8 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "apply",
               arguments = Seq(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.MyAtom", false, false, None),
-                Suggestion.Argument(
+                suggestionArgument("this", "Unnamed.Test.MyAtom", false, false, None),
+                suggestionArgument(
                   "f",
                   "Number | Text | Unnamed.Test.MyAtom",
                   false,
@@ -561,9 +562,8 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "foo",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None),
-                Suggestion
-                  .Argument("a", SuggestionBuilder.Any, true, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None),
+                suggestionArgument("a", SuggestionBuilder.Any, true, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -605,8 +605,8 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "foo",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None),
-                Suggestion.Argument("a", "Unnamed.Test.A", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None),
+                suggestionArgument("a", "Unnamed.Test.A", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = "Unnamed.Test.A",
@@ -640,8 +640,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "MyType",
               arguments = Seq(
-                Suggestion
-                  .Argument("a", SuggestionBuilder.Any, false, false, None)
+                suggestionArgument("a", SuggestionBuilder.Any, false, false, None)
               ),
               returnType    = "Unnamed.Test.MyType",
               documentation = None
@@ -654,8 +653,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "a",
               arguments = List(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.MyType", false, false, None)
+                suggestionArgument("this", "Unnamed.Test.MyType", false, false, None)
               ),
               selfType      = "Unnamed.Test.MyType",
               returnType    = SuggestionBuilder.Any,
@@ -668,7 +666,7 @@ class SuggestionBuilderTest extends CompilerTest {
               externalId = None,
               module     = "Unnamed.Test",
               arguments = Seq(
-                Suggestion.Argument("a", "Number", false, false, None)
+                suggestionArgument("a", "Number", false, false, None)
               ),
               returnType    = "Unnamed.Test.MyType",
               sourceType    = "Number",
@@ -707,8 +705,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "Some",
               arguments = Seq(
-                Suggestion
-                  .Argument("a", SuggestionBuilder.Any, false, false, None)
+                suggestionArgument("a", SuggestionBuilder.Any, false, false, None)
               ),
               returnType    = "Unnamed.Test.MyMaybe",
               documentation = None
@@ -721,8 +718,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "a",
               arguments = List(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.MyMaybe", false, false, None)
+                suggestionArgument("this", "Unnamed.Test.MyMaybe", false, false, None)
               ),
               selfType      = "Unnamed.Test.MyMaybe",
               returnType    = SuggestionBuilder.Any,
@@ -747,8 +743,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "Newtype",
               arguments = Seq(
-                Suggestion
-                  .Argument("x", SuggestionBuilder.Any, false, false, None)
+                suggestionArgument("x", SuggestionBuilder.Any, false, false, None)
               ),
               returnType    = "Unnamed.Test.Newtype",
               documentation = None
@@ -761,8 +756,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "x",
               arguments = List(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.Newtype", false, false, None)
+                suggestionArgument("this", "Unnamed.Test.Newtype", false, false, None)
               ),
               selfType      = "Unnamed.Test.NewType",
               returnType    = SuggestionBuilder.Any,
@@ -775,8 +769,7 @@ class SuggestionBuilderTest extends CompilerTest {
               externalId = None,
               module     = "Unnamed.Test",
               arguments = Seq(
-                Suggestion
-                  .Argument("opt", "Unnamed.Test.MyMaybe", false, false, None)
+                suggestionArgument("opt", "Unnamed.Test.MyMaybe", false, false, None)
               ),
               returnType    = "Unnamed.Test.MyType",
               sourceType    = "Unnamed.Test.MyMaybe",
@@ -806,7 +799,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "main",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -819,8 +812,7 @@ class SuggestionBuilderTest extends CompilerTest {
                   module     = "Unnamed.Test",
                   name       = "foo",
                   arguments = Seq(
-                    Suggestion
-                      .Argument("a", SuggestionBuilder.Any, false, false, None)
+                    suggestionArgument("a", SuggestionBuilder.Any, false, false, None)
                   ),
                   returnType = SuggestionBuilder.Any,
                   scope = Suggestion.Scope(
@@ -856,7 +848,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "main",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -869,8 +861,7 @@ class SuggestionBuilderTest extends CompilerTest {
                   module     = "Unnamed.Test",
                   name       = "foo",
                   arguments = Seq(
-                    Suggestion
-                      .Argument("a", SuggestionBuilder.Any, false, false, None)
+                    suggestionArgument("a", SuggestionBuilder.Any, false, false, None)
                   ),
                   returnType = SuggestionBuilder.Any,
                   scope = Suggestion.Scope(
@@ -919,7 +910,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "main",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -932,7 +923,7 @@ class SuggestionBuilderTest extends CompilerTest {
                   module     = "Unnamed.Test",
                   name       = "foo",
                   arguments = Seq(
-                    Suggestion.Argument("a", "Number", false, false, None)
+                    suggestionArgument("a", "Number", false, false, None)
                   ),
                   returnType = "Number",
                   scope = Suggestion.Scope(
@@ -980,7 +971,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "main",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -993,8 +984,7 @@ class SuggestionBuilderTest extends CompilerTest {
                   module     = "Unnamed.Test",
                   name       = "foo",
                   arguments = Seq(
-                    Suggestion
-                      .Argument("a", "Unnamed.Test.A", false, false, None)
+                    suggestionArgument("a", "Unnamed.Test.A", false, false, None)
                   ),
                   returnType = "Unnamed.Test.A",
                   scope = Suggestion.Scope(
@@ -1028,7 +1018,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "main",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -1074,7 +1064,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "main",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -1133,7 +1123,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "main",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -1191,7 +1181,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "main",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -1232,10 +1222,8 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "MyType",
               arguments = Seq(
-                Suggestion
-                  .Argument("a", SuggestionBuilder.Any, false, false, None),
-                Suggestion
-                  .Argument("b", SuggestionBuilder.Any, false, false, None)
+                suggestionArgument("a", SuggestionBuilder.Any, false, false, None),
+                suggestionArgument("b", SuggestionBuilder.Any, false, false, None)
               ),
               returnType    = "Unnamed.Test.MyType",
               documentation = None
@@ -1248,8 +1236,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "a",
               arguments = List(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.MyType", false, false, None)
+                suggestionArgument("this", "Unnamed.Test.MyType", false, false, None)
               ),
               selfType      = "Unnamed.Test.MyType",
               returnType    = SuggestionBuilder.Any,
@@ -1263,8 +1250,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "b",
               arguments = List(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.MyType", false, false, None)
+                suggestionArgument("this", "Unnamed.Test.MyType", false, false, None)
               ),
               selfType      = "Unnamed.Test.MyType",
               returnType    = SuggestionBuilder.Any,
@@ -1295,10 +1281,8 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "MyType",
               arguments = Seq(
-                Suggestion
-                  .Argument("a", SuggestionBuilder.Any, false, false, None),
-                Suggestion
-                  .Argument("b", SuggestionBuilder.Any, false, false, None)
+                suggestionArgument("a", SuggestionBuilder.Any, false, false, None),
+                suggestionArgument("b", SuggestionBuilder.Any, false, false, None)
               ),
               returnType    = "Unnamed.Test.MyType",
               documentation = Some(" My sweet type")
@@ -1311,8 +1295,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "a",
               arguments = List(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.MyType", false, false, None)
+                suggestionArgument("this", "Unnamed.Test.MyType", false, false, None)
               ),
               selfType      = "Unnamed.Test.MyType",
               returnType    = SuggestionBuilder.Any,
@@ -1326,8 +1309,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "b",
               arguments = List(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.MyType", false, false, None)
+                suggestionArgument("this", "Unnamed.Test.MyType", false, false, None)
               ),
               selfType      = "Unnamed.Test.MyType",
               returnType    = SuggestionBuilder.Any,
@@ -1368,8 +1350,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "Just",
               arguments = Seq(
-                Suggestion
-                  .Argument("a", SuggestionBuilder.Any, false, false, None)
+                suggestionArgument("a", SuggestionBuilder.Any, false, false, None)
               ),
               returnType    = "Unnamed.Test.Just",
               documentation = None
@@ -1382,8 +1363,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "a",
               arguments = List(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.Just", false, false, None)
+                suggestionArgument("this", "Unnamed.Test.Just", false, false, None)
               ),
               selfType      = "Unnamed.Test.Just",
               returnType    = SuggestionBuilder.Any,
@@ -1429,8 +1409,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "Just",
               arguments = Seq(
-                Suggestion
-                  .Argument("a", SuggestionBuilder.Any, false, false, None)
+                suggestionArgument("a", SuggestionBuilder.Any, false, false, None)
               ),
               returnType    = "Unnamed.Test.Just",
               documentation = Some(" Something there")
@@ -1443,8 +1422,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "a",
               arguments = List(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.Just", false, false, None)
+                suggestionArgument("this", "Unnamed.Test.Just", false, false, None)
               ),
               selfType      = "Unnamed.Test.Just",
               returnType    = SuggestionBuilder.Any,
@@ -1502,8 +1480,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "empty",
               arguments = Seq(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.Cons", false, false, None)
+                suggestionArgument("this", "Unnamed.Test.Cons", false, false, None)
               ),
               selfType      = "Unnamed.Test.Cons",
               returnType    = "List",
@@ -1517,8 +1494,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "empty",
               arguments = Seq(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.Nil", false, false, None)
+                suggestionArgument("this", "Unnamed.Test.Nil", false, false, None)
               ),
               selfType      = "Unnamed.Test.Nil",
               returnType    = "List",
@@ -1562,8 +1538,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "Just",
               arguments = Seq(
-                Suggestion
-                  .Argument("a", SuggestionBuilder.Any, false, false, None)
+                suggestionArgument("a", SuggestionBuilder.Any, false, false, None)
               ),
               returnType    = "Unnamed.Test.Just",
               documentation = None
@@ -1576,8 +1551,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "a",
               arguments = List(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.Just", false, false, None)
+                suggestionArgument("this", "Unnamed.Test.Just", false, false, None)
               ),
               selfType      = "Unnamed.Test.Just",
               returnType    = SuggestionBuilder.Any,
@@ -1591,10 +1565,8 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "map",
               arguments = Seq(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.Nothing", false, false, None),
-                Suggestion
-                  .Argument("f", SuggestionBuilder.Any, false, false, None)
+                suggestionArgument("this", "Unnamed.Test.Nothing", false, false, None),
+                suggestionArgument("f", SuggestionBuilder.Any, false, false, None)
               ),
               selfType      = "Unnamed.Test.Nothing",
               returnType    = SuggestionBuilder.Any,
@@ -1608,10 +1580,8 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "map",
               arguments = Seq(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.Just", false, false, None),
-                Suggestion
-                  .Argument("f", SuggestionBuilder.Any, false, false, None)
+                suggestionArgument("this", "Unnamed.Test.Just", false, false, None),
+                suggestionArgument("f", SuggestionBuilder.Any, false, false, None)
               ),
               selfType      = "Unnamed.Test.Just",
               returnType    = SuggestionBuilder.Any,
@@ -1640,10 +1610,8 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "MyType",
               arguments = Seq(
-                Suggestion
-                  .Argument("a", SuggestionBuilder.Any, false, false, None),
-                Suggestion
-                  .Argument("b", SuggestionBuilder.Any, false, false, None)
+                suggestionArgument("a", SuggestionBuilder.Any, false, false, None),
+                suggestionArgument("b", SuggestionBuilder.Any, false, false, None)
               ),
               returnType    = "Unnamed.Test.MyType",
               documentation = None
@@ -1656,8 +1624,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "a",
               arguments = List(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.MyType", false, false, None)
+                suggestionArgument("this", "Unnamed.Test.MyType", false, false, None)
               ),
               selfType      = "Unnamed.Test.MyType",
               returnType    = SuggestionBuilder.Any,
@@ -1671,8 +1638,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "b",
               arguments = List(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.MyType", false, false, None)
+                suggestionArgument("this", "Unnamed.Test.MyType", false, false, None)
               ),
               selfType      = "Unnamed.Test.MyType",
               returnType    = SuggestionBuilder.Any,
@@ -1686,7 +1652,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "main",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -1715,8 +1681,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "Test",
               arguments = Seq(
-                Suggestion
-                  .Argument("a", SuggestionBuilder.Any, false, false, None)
+                suggestionArgument("a", SuggestionBuilder.Any, false, false, None)
               ),
               returnType    = "Unnamed.Test.Test",
               documentation = None
@@ -1729,8 +1694,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "a",
               arguments = List(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test.Test",
               returnType    = SuggestionBuilder.Any,
@@ -1744,7 +1708,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "main",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -1793,9 +1757,8 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "quux",
               arguments = Vector(
-                Suggestion
-                  .Argument("this", "Unnamed.Test.A", false, false, None),
-                Suggestion.Argument("x", "Unnamed.Test.A", false, false, None)
+                suggestionArgument("this", "Unnamed.Test.A", false, false, None),
+                suggestionArgument("x", "Unnamed.Test.A", false, false, None)
               ),
               selfType      = "Unnamed.Test.A",
               returnType    = "Unnamed.Test.A",
@@ -1809,8 +1772,8 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "quux",
               arguments = Vector(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None),
-                Suggestion.Argument("x", "Unnamed.Test.A", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None),
+                suggestionArgument("x", "Unnamed.Test.A", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = "Unnamed.Test.A",
@@ -1824,7 +1787,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "main",
               arguments = List(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -1858,7 +1821,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module = "Unnamed.Test",
               name   = "main",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -1893,7 +1856,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "main",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -1908,8 +1871,7 @@ class SuggestionBuilderTest extends CompilerTest {
                   module = "Unnamed.Test",
                   name   = "id",
                   arguments = Seq(
-                    Suggestion
-                      .Argument("x", SuggestionBuilder.Any, false, false, None)
+                    suggestionArgument("x", SuggestionBuilder.Any, false, false, None)
                   ),
                   returnType = SuggestionBuilder.Any,
                   scope = Suggestion.Scope(
@@ -1948,7 +1910,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "main",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,
@@ -2001,7 +1963,7 @@ class SuggestionBuilderTest extends CompilerTest {
               module     = "Unnamed.Test",
               name       = "foo",
               arguments = Seq(
-                Suggestion.Argument("this", "Unnamed.Test", false, false, None)
+                suggestionArgument("this", "Unnamed.Test", false, false, None)
               ),
               selfType      = "Unnamed.Test",
               returnType    = SuggestionBuilder.Any,

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
@@ -101,6 +101,16 @@ class RuntimeSuggestionUpdatesTest
   def contentsVersion(content: String): ContentVersion =
     Sha3_224VersionCalculator.evalVersion(content)
 
+  def suggestionArgument(
+    name: String,
+    reprType: String,
+    isSuspended: Boolean,
+    hasDefault: Boolean,
+    defaultValue: Option[String]
+  ): Suggestion.Argument = {
+    Suggestion.Argument(name, reprType, isSuspended, hasDefault, defaultValue, None)
+  }
+
   override protected def beforeEach(): Unit = {
     context = new TestContext("Test")
     val Some(Api.Response(_, Api.InitializedNotification())) = context.receive
@@ -174,8 +184,7 @@ class RuntimeSuggestionUpdatesTest
                     moduleName,
                     "main",
                     List(
-                      Suggestion
-                        .Argument(
+                      suggestionArgument(
                           "this",
                           "Enso_Test.Test.Main",
                           false,
@@ -238,8 +247,7 @@ class RuntimeSuggestionUpdatesTest
                     moduleName,
                     "main",
                     List(
-                      Suggestion
-                        .Argument(
+                      suggestionArgument(
                           "this",
                           "Enso_Test.Test.Main",
                           false,
@@ -324,8 +332,7 @@ class RuntimeSuggestionUpdatesTest
                     moduleName,
                     "main",
                     List(
-                      Suggestion
-                        .Argument(
+                      suggestionArgument(
                           "this",
                           "Enso_Test.Test.Main",
                           false,
@@ -430,8 +437,7 @@ class RuntimeSuggestionUpdatesTest
                     moduleName,
                     "main",
                     List(
-                      Suggestion
-                        .Argument(
+                      suggestionArgument(
                           "this",
                           "Enso_Test.Test.Main",
                           false,
@@ -546,8 +552,7 @@ class RuntimeSuggestionUpdatesTest
                     moduleName,
                     "main",
                     List(
-                      Suggestion
-                        .Argument(
+                      suggestionArgument(
                           "this",
                           "Enso_Test.Test.Main",
                           false,
@@ -619,16 +624,14 @@ class RuntimeSuggestionUpdatesTest
                     moduleName,
                     "foo",
                     List(
-                      Suggestion
-                        .Argument(
+                      suggestionArgument(
                           "this",
                           "Enso_Test.Test.Main",
                           false,
                           false,
                           None
                         ),
-                      Suggestion
-                        .Argument("x", Constants.ANY, false, false, None)
+                      suggestionArgument("x", Constants.ANY, false, false, None)
                     ),
                     "Enso_Test.Test.Main",
                     Constants.ANY,
@@ -689,16 +692,14 @@ class RuntimeSuggestionUpdatesTest
                     moduleName,
                     "foo",
                     List(
-                      Suggestion
-                        .Argument(
+                      suggestionArgument(
                           "this",
                           "Enso_Test.Test.Main",
                           false,
                           false,
                           None
                         ),
-                      Suggestion
-                        .Argument("x", Constants.ANY, false, false, None)
+                      suggestionArgument("x", Constants.ANY, false, false, None)
                     ),
                     "Enso_Test.Test.Main",
                     Constants.ANY,
@@ -714,8 +715,7 @@ class RuntimeSuggestionUpdatesTest
                           .Modify(1, Some("a"), None, None, None, None),
                         Api.SuggestionArgumentAction.Add(
                           2,
-                          Suggestion
-                            .Argument("b", Constants.ANY, false, false, None)
+                          suggestionArgument("b", Constants.ANY, false, false, None)
                         )
                       )
                     ),
@@ -810,8 +810,7 @@ class RuntimeSuggestionUpdatesTest
                     moduleName,
                     "main",
                     Seq(
-                      Suggestion
-                        .Argument(
+                      suggestionArgument(
                           "this",
                           "Enso_Test.Test.Main",
                           false,
@@ -853,15 +852,14 @@ class RuntimeSuggestionUpdatesTest
                     moduleName,
                     "overloaded",
                     Seq(
-                      Suggestion.Argument(
+                      suggestionArgument(
                         "this",
                         Constants.TEXT,
                         false,
                         false,
                         None
                       ),
-                      Suggestion
-                        .Argument("arg", Constants.ANY, false, false, None)
+                      suggestionArgument("arg", Constants.ANY, false, false, None)
                     ),
                     Constants.TEXT,
                     Constants.ANY,
@@ -880,15 +878,14 @@ class RuntimeSuggestionUpdatesTest
                     moduleName,
                     "overloaded",
                     Seq(
-                      Suggestion.Argument(
+                      suggestionArgument(
                         "this",
                         Constants.NUMBER,
                         false,
                         false,
                         None
                       ),
-                      Suggestion
-                        .Argument("arg", Constants.ANY, false, false, None)
+                      suggestionArgument("arg", Constants.ANY, false, false, None)
                     ),
                     Constants.NUMBER,
                     Constants.ANY,
@@ -992,8 +989,7 @@ class RuntimeSuggestionUpdatesTest
                     "Enso_Test.Test.A",
                     "MkA",
                     List(
-                      Suggestion
-                        .Argument("a", Constants.ANY, false, false, None)
+                      suggestionArgument("a", Constants.ANY, false, false, None)
                     ),
                     "Enso_Test.Test.A.MkA",
                     None,
@@ -1011,8 +1007,7 @@ class RuntimeSuggestionUpdatesTest
                     "Enso_Test.Test.A",
                     "a",
                     List(
-                      Suggestion
-                        .Argument(
+                      suggestionArgument(
                           "this",
                           "Enso_Test.Test.A.MkA",
                           false,
@@ -1037,7 +1032,7 @@ class RuntimeSuggestionUpdatesTest
                     "Enso_Test.Test.A",
                     "fortytwo",
                     List(
-                      Suggestion.Argument(
+                      suggestionArgument(
                         "this",
                         Constants.INTEGER,
                         false,
@@ -1062,7 +1057,7 @@ class RuntimeSuggestionUpdatesTest
                     "Enso_Test.Test.A",
                     "hello",
                     List(
-                      Suggestion.Argument(
+                      suggestionArgument(
                         "this",
                         "Enso_Test.Test.A",
                         false,
@@ -1122,8 +1117,7 @@ class RuntimeSuggestionUpdatesTest
                     moduleName,
                     "main",
                     List(
-                      Suggestion
-                        .Argument(
+                      suggestionArgument(
                           "this",
                           "Enso_Test.Test.Main",
                           false,

--- a/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlSuggestionsRepo.scala
+++ b/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlSuggestionsRepo.scala
@@ -1069,7 +1069,8 @@ final class SqlSuggestionsRepo(val db: SqlDatabase)(implicit
           sourceType,
           false,
           false,
-          None
+          None,
+          Option.empty
         )
         val row = SuggestionRow(
           id               = None,
@@ -1259,7 +1260,8 @@ final class SqlSuggestionsRepo(val db: SqlDatabase)(implicit
       reprType     = row.tpe,
       isSuspended  = row.isSuspended,
       hasDefault   = row.hasDefault,
-      defaultValue = row.defaultValue
+      defaultValue = row.defaultValue,
+      tagValues = Option.empty
     )
 
   /** Convert bits to the UUID.

--- a/lib/scala/searcher/src/test/scala/org/enso/searcher/sql/SuggestionsRepoTest.scala
+++ b/lib/scala/searcher/src/test/scala/org/enso/searcher/sql/SuggestionsRepoTest.scala
@@ -29,6 +29,16 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
     tmp
   }
 
+  private def suggestionArgument(
+    name: String,
+    reprType: String,
+    isSuspended: Boolean,
+    hasDefault: Boolean,
+    defaultValue: Option[String]
+  ): Suggestion.Argument = {
+    Suggestion.Argument(name, reprType, isSuspended, hasDefault, defaultValue, None)
+  }
+
   def withRepo(test: SqlSuggestionsRepo => Any): Any = {
     val tmpdb = Files.createTempFile(tmpdir, "suggestions-repo", ".db")
     val repo  = new SqlSuggestionsRepo(SqlDatabase(tmpdb.toFile))
@@ -787,7 +797,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
       s shouldEqual Some(
         suggestion.atom.copy(arguments =
           suggestion.atom.arguments.init :+
-          Suggestion.Argument("c", "C", true, true, Some("C"))
+          suggestionArgument("c", "C", true, true, Some("C"))
         )
       )
     }
@@ -1026,8 +1036,8 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
 
         val method = suggestion.method.copy(arguments =
           Seq(
-            Suggestion.Argument("x", "Number", false, true, Some("0")),
-            Suggestion.Argument(
+            suggestionArgument("x", "Number", false, true, Some("0")),
+            suggestionArgument(
               "y",
               "Test.Main.Test.MyType",
               false,
@@ -1621,8 +1631,8 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
         module     = "Test.Main",
         name       = "Pair",
         arguments = Seq(
-          Suggestion.Argument("a", "Any", false, false, None),
-          Suggestion.Argument("b", "Any", false, false, None)
+          suggestionArgument("a", "Any", false, false, None),
+          suggestionArgument("b", "Any", false, false, None)
         ),
         returnType    = "Pair",
         documentation = Some("Awesome")
@@ -1655,7 +1665,7 @@ class SuggestionsRepoTest extends AnyWordSpec with Matchers with RetrySpec {
         module     = "Test.Main",
         name       = "bar",
         arguments = Seq(
-          Suggestion.Argument("x", "Number", false, true, Some("0"))
+          suggestionArgument("x", "Number", false, true, Some("0"))
         ),
         returnType = "Test.Main.MyType",
         scope =


### PR DESCRIPTION
### Pull Request Description

Based on [Dmitry's hints](https://docs.google.com/document/d/16B5DT7fkToJdUZVHNE6YhKy_TFYAEsRXym-mRPH2L_c/edit#heading=h.k35tiw5lnnk3):
- _Extend the [Suggestion](https://github.com/enso-org/enso/blob/e8dfc6d270ef084a1b5d9c6bd3bbadd8aff1d919/engine/polyglot-api/src/main/scala/org/enso/polyglot/Suggestion.scala) record so that it can hold information_
- _In the [SuggestionsBuilder](https://github.com/enso-org/enso/blob/e8dfc6d270ef084a1b5d9c6bd3bbadd8aff1d919/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala) populate suggestion records with new extended type data_

This PR expands the `Suggestion.Attribute` structure with optional `tagValues` hints. It hard-codes these data for the `Text.trim` method. If we managed to transfer these data to the IDE, display it and use it, we'd have a solid 1st prototype of trivial static drop downs.

### TODO

[Dmitry also noted](https://docs.google.com/document/d/16B5DT7fkToJdUZVHNE6YhKy_TFYAEsRXym-mRPH2L_c/edit#heading=h.k35tiw5lnnk3):
- Update JSON codecs of suggestion records in the [org.enso.languageserver.search.SearchProtocol](https://github.com/enso-org/enso/blob/e8dfc6d270ef084a1b5d9c6bd3bbadd8aff1d919/engine/language-server/src/main/scala/org/enso/languageserver/search/SearchProtocol.scala)

That might be necessary step before IDE can accept the newly transmitted `tagValues` and use them.

### Important Notes

It is not the goal of this PR to extract the information directly from the standard library. Enhancing the Enso language type system to provide enough information and extracting them for the `Text.trim` method is a task for another, orthogonal PR.

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.
