### PR TITLE
Make REPL display results using `to_text`

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/ReplDebuggerInstrument.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/ReplDebuggerInstrument.java
@@ -181,9 +181,7 @@ public class ReplDebuggerInstrument extends TruffleInstrument {
         }
 
         return new Right<>(o.toString());
-      } catch (UnsupportedMessageException
-          | ArityException
-          | UnsupportedTypeException e) {
+      } catch (UnsupportedMessageException | ArityException | UnsupportedTypeException e) {
         return new Right<>(o.toString());
       } catch (Exception e) {
         return new Left<>(e);

--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/ReplDebuggerInstrument.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/ReplDebuggerInstrument.java
@@ -16,7 +16,6 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import org.enso.interpreter.node.expression.builtin.text.AnyToTextNode;
 import org.enso.interpreter.node.expression.builtin.text.util.ToJavaStringNode;
 import org.enso.interpreter.node.expression.debug.CaptureResultScopeNode;
 import org.enso.interpreter.node.expression.debug.EvalNode;
@@ -89,7 +88,6 @@ public class ReplDebuggerInstrument extends TruffleInstrument {
   public static class ReplExecutionEventNode extends ExecutionEventNode {
     private @Child EvalNode evalNode = EvalNode.buildWithResultScopeCapture();
     private @Child ToJavaStringNode toJavaStringNode = ToJavaStringNode.build();
-    private @Child AnyToTextNode toTextNode = AnyToTextNode.build();
 
     private ReplExecutionEventNodeState nodeState;
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/ReplDebuggerInstrument.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/ReplDebuggerInstrument.java
@@ -10,12 +10,7 @@ import com.oracle.truffle.api.instrumentation.ExecutionEventNode;
 import com.oracle.truffle.api.instrumentation.Instrumenter;
 import com.oracle.truffle.api.instrumentation.SourceSectionFilter;
 import com.oracle.truffle.api.instrumentation.TruffleInstrument;
-import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.InteropLibrary;
-import com.oracle.truffle.api.interop.UnknownIdentifierException;
-import com.oracle.truffle.api.interop.UnsupportedMessageException;
-import com.oracle.truffle.api.interop.UnsupportedTypeException;
-import com.oracle.truffle.api.nodes.UnexpectedResultException;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
@@ -32,7 +27,6 @@ import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.scope.FramePointer;
 import org.enso.interpreter.runtime.state.Stateful;
-import org.enso.interpreter.runtime.type.TypesGen;
 import org.enso.polyglot.debugger.DebugServerInfo;
 import org.graalvm.options.OptionDescriptor;
 import org.graalvm.options.OptionDescriptors;
@@ -169,20 +163,8 @@ public class ReplDebuggerInstrument extends TruffleInstrument {
      */
     public Either<Exception, String> showObject(Object o) {
       try {
-        InteropLibrary atoms = InteropLibrary.getUncached();
-        String toTextIdentifier = "to_text";
-        if (atoms.isMemberInvocable(o, toTextIdentifier)) {
-          Object repr = atoms.invokeMember(o, toTextIdentifier);
-          if (repr instanceof Text) {
-            return new Right<>(toJavaStringNode.execute((Text) repr));
-          } else if (repr instanceof String) {
-            return new Right<>((String) repr);
-          }
-        }
-
-        return new Right<>(o.toString());
-      } catch (UnsupportedMessageException | ArityException | UnsupportedTypeException e) {
-        return new Right<>(o.toString());
+        InteropLibrary interop = InteropLibrary.getUncached();
+        return new Right<>(interop.asString(interop.toDisplayString(o)));
       } catch (Exception e) {
         return new Left<>(e);
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyToTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyToTextNode.java
@@ -18,11 +18,11 @@ public abstract class AnyToTextNode extends Node {
   private @Child InteropLibrary strings =
       InteropLibrary.getFactory().createDispatched(DISPATCH_CACHE);
 
-  static AnyToTextNode build() {
+  public static AnyToTextNode build() {
     return AnyToTextNodeGen.create();
   }
 
-  abstract Text execute(Object _this);
+  public abstract Text execute(Object _this);
 
   @Specialization
   Text doAtom(Atom at) {

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/DebuggerMessageHandler.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/DebuggerMessageHandler.scala
@@ -1,8 +1,8 @@
 package org.enso.interpreter.instrument
 
 import java.nio.ByteBuffer
-
 import com.oracle.truffle.api.TruffleStackTrace
+import com.typesafe.scalalogging.Logger
 import org.enso.interpreter.instrument.ReplDebuggerInstrument.ReplExecutionEventNode
 import org.enso.polyglot.debugger._
 import org.graalvm.polyglot.io.MessageEndpoint
@@ -91,7 +91,15 @@ class DebuggerMessageHandler extends MessageEndpoint {
                   Debugger.createEvaluationFailure(exceptionWithTraces)
                 )
               case Right(value) =>
-                sendToClient(Debugger.createEvaluationSuccess(value))
+                node.showObject(value) match {
+                  case Left(error) =>
+                    Logger[this.type].error(
+                      s"Failed to call `to_text` on computation result (${error.getMessage}), falling back to Java representation."
+                    )
+                    sendToClient(Debugger.createEvaluationSuccess(value))
+                  case Right(repr: String) =>
+                    sendToClient(Debugger.createEvaluationSuccess(repr))
+                }
             }
           case ListBindingsRequest =>
             val bindings = node.listBindings()

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/DebuggerMessageHandler.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/DebuggerMessageHandler.scala
@@ -93,7 +93,7 @@ class DebuggerMessageHandler extends MessageEndpoint {
               case Right(value) =>
                 node.showObject(value) match {
                   case Left(error) =>
-                    Logger[this.type].error(
+                    Logger[this.type].warn(
                       s"Failed to call `to_text` on computation result (${error.getMessage}), falling back to Java representation."
                     )
                     sendToClient(Debugger.createEvaluationSuccess(value))

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ReplTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ReplTest.scala
@@ -73,19 +73,44 @@ class ReplTest
       val code =
         """
           |from Standard.Builtins import all
+          |polyglot java import java.util.regex.Pattern
           |
           |type Foo a b
           |
           |Foo.to_text = "{" + this.a.to_text + ": " + this.b + "}"
+          |
+          |type Bar x
+          |
+          |Bar.to_text = 42
+          |
+          |type Baz x
+          |
+          |Baz.to_text a b c = a+b+c
           |
           |main =
           |    x = Debug.breakpoint
           |    x.a
           |""".stripMargin
       setSessionManager { executor =>
-        val result = executor.evaluate("Foo 2 'a'")
-        inside(result) { case Right(value) =>
-          value.toString shouldEqual "{2: a}"
+        inside(executor.evaluate("2")) { case Right(result) =>
+          result.toString shouldEqual "2"
+        }
+        inside(executor.evaluate("Bar 1")) { case Right(result) =>
+          result.toString shouldEqual "Bar 1"
+        }
+        inside(executor.evaluate("Baz 1")) { case Right(result) =>
+          result.toString shouldEqual "Baz 1"
+        }
+        inside(executor.evaluate("Pattern.compile 'foo'")) {
+          case Right(result) =>
+            result.toString shouldEqual "JavaObject[foo (java.util.regex.Pattern)]"
+        }
+        inside(executor.evaluate("Array.new_2 1 (Array.new 0)")) {
+          case Right(result) =>
+            result.toString shouldEqual "[1, []]"
+        }
+        inside(executor.evaluate("Foo 2 'a'")) { case Right(result) =>
+          result.toString shouldEqual "{2: a}"
         }
         executor.exit()
       }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ReplTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ReplTest.scala
@@ -72,20 +72,24 @@ class ReplTest
     "allow to access Text representations of the returned values" in {
       val code =
         """
-          |from Standard.Base import all
+          |from Standard.Builtins import all
+          |
+          |type Foo a b
+          |
+          |Foo.to_text = "{" + this.a.to_text + ": " + this.b + "}"
           |
           |main =
-          |    c = Debug.breakpoint
-          |    c.at 0
+          |    x = Debug.breakpoint
+          |    x.a
           |""".stripMargin
       setSessionManager { executor =>
-        val result = executor.evaluate("'a,b,c'.split ','")
+        val result = executor.evaluate("Foo 2 'a'")
         inside(result) { case Right(value) =>
-          value.toString shouldEqual "['a', 'b', 'c']"
+          value.toString shouldEqual "{2: a}"
         }
         executor.exit()
       }
-      eval(code) shouldEqual "a"
+      eval(code) shouldEqual 2
     }
 
     "be able to define its local variables" in {

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ReplTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ReplTest.scala
@@ -3,9 +3,13 @@ package org.enso.interpreter.test.instrument
 import org.enso.interpreter.test.{InterpreterContext, InterpreterTest}
 import org.enso.polyglot.debugger.{DebugServerInfo, ObjectRepresentation}
 import org.graalvm.polyglot.Context
-import org.scalatest.{BeforeAndAfter, EitherValues}
+import org.scalatest.{BeforeAndAfter, EitherValues, Inside}
 
-class ReplTest extends InterpreterTest with BeforeAndAfter with EitherValues {
+class ReplTest
+    extends InterpreterTest
+    with BeforeAndAfter
+    with EitherValues
+    with Inside {
 
   override def subject: String = "Repl"
 
@@ -63,6 +67,25 @@ class ReplTest extends InterpreterTest with BeforeAndAfter with EitherValues {
         executor.exit()
       }
       eval(code) shouldEqual 55
+    }
+
+    "allow to access Text representations of the returned values" in {
+      val code =
+        """
+          |from Standard.Base import all
+          |
+          |main =
+          |    c = Debug.breakpoint
+          |    c.at 0
+          |""".stripMargin
+      setSessionManager { executor =>
+        val result = executor.evaluate("'a,b,c'.split ','")
+        inside(result) { case Right(value) =>
+          value.toString shouldEqual "['a', 'b', 'c']"
+        }
+        executor.exit()
+      }
+      eval(code) shouldEqual "a"
     }
 
     "be able to define its local variables" in {

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ReplTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/ReplTest.scala
@@ -103,11 +103,7 @@ class ReplTest
         }
         inside(executor.evaluate("Pattern.compile 'foo'")) {
           case Right(result) =>
-            result.toString shouldEqual "JavaObject[foo (java.util.regex.Pattern)]"
-        }
-        inside(executor.evaluate("Array.new_2 1 (Array.new 0)")) {
-          case Right(result) =>
-            result.toString shouldEqual "[1, []]"
+            result.toString shouldEqual "foo"
         }
         inside(executor.evaluate("Foo 2 'a'")) { case Right(result) =>
           result.toString shouldEqual "{2: a}"


### PR DESCRIPTION
### Pull Request Description

[ci no changelog needed]

### Important Notes

The REPL used to use some builtin Java text representation leading to outputs like this:
```
> [1,2,3]
>>> Vector [1, 2, 3]
> 'a,b,c'.split ','
>>> Vector JavaObject[[Ljava.lang.String;@131c0b6f (java.lang.String[])]
```

This PR makes it use `to_text` (if available, otherwise falling back to regular `toString`). This way we get outputs like this:

```
> [1,2,3]
>>> [1, 2, 3]
> 'a,b,c'.split ','
>>> ['a', 'b', 'c']
```

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.
