### PR TITLE
Proper implementation of --no-backend flag for ./run script

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -606,6 +606,16 @@ manager process yourself. You can either get a project manager from one of the
 latest releases on [GitHub](https://github.com/enso-org/enso/releases), or build
 one using SBT `buildProjectManagerDistribution` command.
 
+Running development version of the IDE is possible via the `./run` script in the
+root of the repository:
+
+```bash
+$ ./run start --dev --no-backend
+```
+
+One can also add `--no-rust` to speed the start up when no changes to IDE
+sources were made.
+
 ##### Bash
 
 ```bash


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

Documentation of the `./run` script, as printed on console, doesn't advice how to disable the `--backend` & co. arguments. It is not entirely clear how to do that. Debugging reveals that one can disable `--rust` option by specifying `--no-rust`. On a the same note, disabling backend shall work with `--no-backend`. It didn't - the aim of this PR is to fix that. I can now:

```bash
$ ./run start --dev --no-rust --no-backend
```

and the IDE starts relatively fast (10-20s) and connects to my pre-launched backend. 

### Checklist

Please include the following checklist in your PR:

- [ x ] The documentation has been updated if necessary.
- [ x ] All code conforms to the JavaScript without `;` guidelines
