### PR TITLE
Revert #3429

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,7 +191,6 @@
 - [Converting Enso Date to java.time.LocalDate and back][3374]
 - [Functions with all-defaulted arguments now execute automatically][3414]
 - [Provide `tagValues` for function arguments in the language server][3422]
-- [Delay construction of Truffle nodes to speed initialization][3429]
 - [Frgaal compiler integration to allow for latest Java constructs][3421]
 - [Move Builtin Types and Methods definitions to stdlib][3363]
 
@@ -207,7 +206,6 @@
 [3414]: https://github.com/enso-org/enso/pull/3414
 [3417]: https://github.com/enso-org/enso/pull/3417
 [3422]: https://github.com/enso-org/enso/pull/3422
-[3429]: https://github.com/enso-org/enso/pull/3429
 [3421]: https://github.com/enso-org/enso/pull/3421
 [3363]: https://github.com/enso-org/enso/pull/3363
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/MethodRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/MethodRootNode.java
@@ -1,10 +1,8 @@
 package org.enso.interpreter.node;
 
 import com.oracle.truffle.api.dsl.ReportPolymorphism;
-import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import com.oracle.truffle.api.source.SourceSection;
-import java.util.function.Supplier;
 import org.enso.interpreter.Language;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.scope.LocalScope;
@@ -46,30 +44,12 @@ public class MethodRootNode extends ClosureRootNode {
    * @param language the language identifier
    * @param localScope a description of the local scope
    * @param moduleScope a description of the module scope
-   * @param body the program provider to be executed
-   * @param section a mapping from {@code provider} to the program source
+   * @param body the program body to be executed
+   * @param section a mapping from {@code body} to the program source
    * @param atomConstructor the constructor this method is defined for
    * @param methodName the name of this method
    * @return a node representing the specified closure
    */
-  public static MethodRootNode build(
-      Language language,
-      LocalScope localScope,
-      ModuleScope moduleScope,
-      Supplier<ExpressionNode> body,
-      SourceSection section,
-      AtomConstructor atomConstructor,
-      String methodName) {
-    return build(
-        language,
-        localScope,
-        moduleScope,
-        new LazyBodyNode(body),
-        section,
-        atomConstructor,
-        methodName);
-  }
-
   public static MethodRootNode build(
       Language language,
       LocalScope localScope,
@@ -106,20 +86,5 @@ public class MethodRootNode extends ClosureRootNode {
   /** @return the method name */
   public String getMethodName() {
     return methodName;
-  }
-
-  private static class LazyBodyNode extends ExpressionNode {
-    private final Supplier<ExpressionNode> provider;
-
-    LazyBodyNode(Supplier<ExpressionNode> body) {
-      this.provider = body;
-    }
-
-    @Override
-    public Object executeGeneric(VirtualFrame frame) {
-      ExpressionNode newNode = replace(provider.get());
-      notifyInserted(newNode);
-      return newNode.executeGeneric(frame);
-    }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/function/BlockNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/function/BlockNode.java
@@ -30,10 +30,6 @@ public class BlockNode extends ExpressionNode {
     return new BlockNode(expressions, returnExpr);
   }
 
-  public static BlockNode buildSilent(ExpressionNode[] expressions, ExpressionNode returnExpr) {
-    return new BlockNode(expressions, returnExpr);
-  }
-
   /**
    * Executes the body of the function.
    *

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/AtomConstructor.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/AtomConstructor.java
@@ -154,7 +154,7 @@ public final class AtomConstructor implements TruffleObject {
       ArgumentDefinition[] args) {
 
     ExpressionNode instantiateNode = InstantiateNode.build(this, varReads);
-    BlockNode instantiateBlock = BlockNode.buildSilent(assignments, instantiateNode);
+    BlockNode instantiateBlock = BlockNode.build(assignments, instantiateNode);
     RootNode rootNode =
         ClosureRootNode.build(
             null,


### PR DESCRIPTION
### Pull Request Description
"Delay conversion of Truffle function body nodes until the function is invoked (#3429)"
This reverts commit 3ab2c8f8a0d258bde7f41b90c9e7e158e94c47cb.

It looks like many of us are getting into infinite loop locally because of this one while CI is happy and marry. 

### Important Notes

- [ ] investigate why infinite loop appears in the first place
- [ ] investigate why CI is still happy

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.
