### PR TITLE
Convert LazyBodyNode to real ones before performing (deep)Copy

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/ClosureRootNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/ClosureRootNode.java
@@ -73,4 +73,8 @@ public class ClosureRootNode extends EnsoRootNode {
     state = FrameUtil.getObjectSafe(frame, this.getStateFrameSlot());
     return new Stateful(state, result);
   }
+
+  final ExpressionNode getBody() {
+    return body;
+  }
 }


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description
Patch provided by Jaroslav, appears to fix local issues with inifite loop
introduced in https://github.com/enso-org/enso/pull/3429.
Fairly urgent since this issue currently blocks people.

### Important Notes

This renders https://github.com/enso-org/enso/pull/3439 obsolete. Related to https://www.pivotaltracker.com/n/projects/2539304/stories/182024911

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.
