### PR TITLE
Fix blink when adding node

### DIFF
--- a/app/gui/view/graph-editor/src/component/breadcrumbs.rs
+++ b/app/gui/view/graph-editor/src/component/breadcrumbs.rs
@@ -189,6 +189,7 @@ impl BreadcrumbsModel {
     /// Constructor.
     /// The `gap_width` describes an empty space on the left of all the content. This space will be
     /// covered by the background and is intended to make room for windows control buttons.
+    #[profile(Detail)]
     pub fn new(app: Application, frp: &Frp) -> Self {
         let scene = &app.display.default_scene;
         let project_name = app.new_view();

--- a/app/gui/view/graph-editor/src/component/breadcrumbs/breadcrumb.rs
+++ b/app/gui/view/graph-editor/src/component/breadcrumbs/breadcrumb.rs
@@ -273,6 +273,7 @@ pub struct BreadcrumbModel {
 
 impl BreadcrumbModel {
     /// Constructor.
+    #[profile(Detail)]
     pub fn new(
         app: &Application,
         frp: &Frp,

--- a/app/gui/view/graph-editor/src/component/breadcrumbs/breadcrumb.rs
+++ b/app/gui/view/graph-editor/src/component/breadcrumbs/breadcrumb.rs
@@ -73,6 +73,7 @@ mod icon {
     use super::*;
 
     ensogl::define_shape_system! {
+        pointer_events = [false];
         (red:f32,green:f32,blue:f32,alpha:f32) {
             let outer_circle  = Circle((ICON_RADIUS).px());
             let inner_circle  = Circle((ICON_RADIUS - ICON_RING_WIDTH).px());
@@ -98,6 +99,7 @@ mod separator {
     use super::*;
 
     ensogl::define_shape_system! {
+        pointer_events = [false];
         (red:f32,green:f32,blue:f32,alpha:f32) {
             let size     = SEPARATOR_SIZE;
             let angle    = PI/2.0;
@@ -303,28 +305,16 @@ impl BreadcrumbModel {
         }
 
         scene.layers.panel.add_exclusive(&view);
-        let shape_system = scene
+        let background = &scene
             .layers
             .panel
             .shape_system_registry
-            .shape_system(scene, PhantomData::<background::DynamicShape>);
-        scene.layers.panel.add_exclusive(&shape_system.shape_system.symbol);
-
+            .shape_system(scene, PhantomData::<background::DynamicShape>)
+            .shape_system
+            .symbol;
+        scene.layers.panel.add_exclusive(&background);
         scene.layers.panel.add_exclusive(&icon);
-        let shape_system = scene
-            .layers
-            .panel
-            .shape_system_registry
-            .shape_system(scene, PhantomData::<icon::DynamicShape>);
-        shape_system.shape_system.set_pointer_events(false);
-
         scene.layers.panel.add_exclusive(&separator);
-        let shape_system = scene
-            .layers
-            .panel
-            .shape_system_registry
-            .shape_system(scene, PhantomData::<separator::DynamicShape>);
-        shape_system.shape_system.set_pointer_events(false);
 
         label.remove_from_scene_layer(&scene.layers.main);
         label.add_to_scene_layer(&scene.layers.panel_text);

--- a/app/gui/view/graph-editor/src/component/breadcrumbs/breadcrumb.rs
+++ b/app/gui/view/graph-editor/src/component/breadcrumbs/breadcrumb.rs
@@ -73,7 +73,7 @@ mod icon {
     use super::*;
 
     ensogl::define_shape_system! {
-        pointer_events = [false];
+        pointer_events = false;
         (red:f32,green:f32,blue:f32,alpha:f32) {
             let outer_circle  = Circle((ICON_RADIUS).px());
             let inner_circle  = Circle((ICON_RADIUS - ICON_RING_WIDTH).px());
@@ -99,7 +99,7 @@ mod separator {
     use super::*;
 
     ensogl::define_shape_system! {
-        pointer_events = [false];
+        pointer_events = false;
         (red:f32,green:f32,blue:f32,alpha:f32) {
             let size     = SEPARATOR_SIZE;
             let angle    = PI/2.0;

--- a/app/gui/view/graph-editor/src/component/edge.rs
+++ b/app/gui/view/graph-editor/src/component/edge.rs
@@ -287,6 +287,7 @@ pub mod joint {
     use super::*;
 
     ensogl::define_shape_system! {
+        pointer_events = [false];
         (color_rgba:Vector4<f32>) {
             let radius        = Var::<Pixels>::from("input_size.y");
             let joint         = Circle((radius-PADDING.px())/2.0);
@@ -1286,13 +1287,6 @@ impl EdgeModelData {
         let front = Front::new(Logger::new_sub(&logger, "front"));
         let back = Back::new(Logger::new_sub(&logger, "back"));
         let joint = joint::View::new(Logger::new_sub(&logger, "joint"));
-
-        let shape_system = scene
-            .layers
-            .main
-            .shape_system_registry
-            .shape_system(scene, PhantomData::<joint::DynamicShape>);
-        shape_system.shape_system.set_pointer_events(false);
 
         display_object.add_child(&front);
         display_object.add_child(&back);

--- a/app/gui/view/graph-editor/src/component/edge.rs
+++ b/app/gui/view/graph-editor/src/component/edge.rs
@@ -1075,6 +1075,7 @@ pub struct Frp {
 
 impl Frp {
     /// Constructor.
+    #[profile(Debug)]
     pub fn new(network: &frp::Network) -> Self {
         frp::extend! { network
             def source_width    = source();
@@ -1166,6 +1167,7 @@ impl display::Object for EdgeModelData {
 
 impl Edge {
     /// Constructor.
+    #[profile(Detail)]
     pub fn new(app: &Application) -> Self {
         let network = frp::Network::new("node_edge");
         let data = Rc::new(EdgeModelData::new(&app.display.default_scene, &network));
@@ -1277,6 +1279,7 @@ pub struct EdgeModelData {
 
 impl EdgeModelData {
     /// Constructor.
+    #[profile(Debug)]
     pub fn new(scene: &Scene, network: &frp::Network) -> Self {
         let logger = Logger::new("edge");
         let display_object = display::object::Instance::new(&logger);

--- a/app/gui/view/graph-editor/src/component/edge.rs
+++ b/app/gui/view/graph-editor/src/component/edge.rs
@@ -287,7 +287,7 @@ pub mod joint {
     use super::*;
 
     ensogl::define_shape_system! {
-        pointer_events = [false];
+        pointer_events = false;
         (color_rgba:Vector4<f32>) {
             let radius        = Var::<Pixels>::from("input_size.y");
             let joint         = Circle((radius-PADDING.px())/2.0);

--- a/app/gui/view/graph-editor/src/component/node.rs
+++ b/app/gui/view/graph-editor/src/component/node.rs
@@ -127,6 +127,8 @@ pub mod backdrop {
     use super::*;
 
     ensogl::define_shape_system! {
+        // Disable to allow interaction with the output port.
+        pointer_events = [false];
         (style:Style, selection:f32) {
 
             let width  = Var::<Pixels>::from("input_size.x");
@@ -482,14 +484,6 @@ impl NodeModel {
         display_object.add_child(&backdrop);
         display_object.add_child(&background);
         display_object.add_child(&vcs_indicator);
-
-        // Disable shadows to allow interaction with the output port.
-        let shape_system = scene
-            .layers
-            .main
-            .shape_system_registry
-            .shape_system(scene, PhantomData::<backdrop::DynamicShape>);
-        shape_system.shape_system.set_pointer_events(false);
 
         let input = input::Area::new(&logger, app);
         let visualization = visualization::Container::new(&logger, app, registry);

--- a/app/gui/view/graph-editor/src/component/node.rs
+++ b/app/gui/view/graph-editor/src/component/node.rs
@@ -128,7 +128,7 @@ pub mod backdrop {
 
     ensogl::define_shape_system! {
         // Disable to allow interaction with the output port.
-        pointer_events = [false];
+        pointer_events = false;
         (style:Style, selection:f32) {
 
             let width  = Var::<Pixels>::from("input_size.x");

--- a/app/gui/view/graph-editor/src/component/node/growth_animation.rs
+++ b/app/gui/view/graph-editor/src/component/node/growth_animation.rs
@@ -78,10 +78,10 @@ pub fn initialize_edited_node_animator(
         });
 
         // We want to:
-        // 1. Smothly animate edited node camera from `main_cam` position to `searcher_cam` position when we
+        // 1. Smoothly animate edited node camera from `main_cam` position to `searcher_cam` position when we
         // start/finish node editing so that the edited node "grows" or "shrinks" to reach the correct
         // visible size. This is `growth_animation`.
-        // 2. Keep `searcher_cam` and `edited_node_cam` at the same position everywhen else so that the
+        // 2. Keep `searcher_cam` and `edited_node_cam` at the same position everywhere else so that the
         // searcher and the edited node are at the same visible position at all times. This is
         // `edited_node_cam_target`.
         //
@@ -114,6 +114,7 @@ pub fn initialize_edited_node_animator(
 
 impl GraphEditorModelWithNetwork {
     /// Move node to the `edited_node` scene layer, so that it is rendered by the separate camera.
+    #[profile(Debug)]
     fn move_node_to_edited_node_layer(&self, node_id: NodeId) {
         if let Some(node) = self.nodes.get_cloned(&node_id) {
             node.model().move_to_edited_node_layer();
@@ -121,6 +122,7 @@ impl GraphEditorModelWithNetwork {
     }
 
     /// Move node to the `main` scene layer, so that it is rendered by the main camera.
+    #[profile(Debug)]
     fn move_node_to_main_layer(&self, node_id: NodeId) {
         if let Some(node) = self.nodes.get_cloned(&node_id) {
             node.model().move_to_main_layer();

--- a/app/gui/view/graph-editor/src/component/node/input/area.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/area.rs
@@ -21,7 +21,6 @@ use enso_text::text::Text;
 use ensogl::application::Application;
 use ensogl::data::color;
 use ensogl::display;
-use ensogl::display::scene::Scene;
 use ensogl::gui::cursor;
 use ensogl::Animation;
 use ensogl_component::text;
@@ -300,10 +299,6 @@ impl Model {
 
     fn set_label_layer(&self, layer: &display::scene::Layer) {
         self.label.add_to_scene_layer(layer);
-    }
-
-    fn scene(&self) -> &Scene {
-        &self.app.display.default_scene
     }
 
     /// Run the provided function on the target port if exists.
@@ -622,8 +617,7 @@ impl Area {
                 let padded_size = Vector2(width_padded, height);
                 let size = Vector2(width, height);
                 let logger = &self.model.logger;
-                let scene = self.model.scene();
-                let port_shape = port.payload_mut().init_shape(logger, scene, size, node::HEIGHT);
+                let port_shape = port.payload_mut().init_shape(logger, size, node::HEIGHT);
 
                 port_shape.mod_position(|t| t.x = unit * i32::from(index) as f32);
                 if DEBUG {

--- a/app/gui/view/graph-editor/src/component/node/input/port.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/port.rs
@@ -9,7 +9,6 @@ use crate::Type;
 
 use ensogl::data::color;
 use ensogl::display;
-use ensogl::display::scene::Scene;
 
 
 
@@ -58,6 +57,7 @@ pub mod viz {
     use super::*;
     ensogl::define_shape_system! {
         above = [hover];
+        pointer_events = [false];
         (style:Style, color:Vector4) {
             let width  : Var<Pixels> = "input_size.x".into();
             let height : Var<Pixels> = "input_size.y".into();
@@ -96,7 +96,7 @@ pub struct Shape {
 impl Shape {
     /// Constructor.
     #[profile(Debug)]
-    pub fn new(logger: &Logger, scene: &Scene, size: Vector2, hover_height: f32) -> Self {
+    pub fn new(logger: &Logger, size: Vector2, hover_height: f32) -> Self {
         let root = display::object::Instance::new(logger);
         let hover = hover::View::new(logger);
         let viz = viz::View::new(logger);
@@ -110,12 +110,6 @@ impl Shape {
 
         root.add_child(&hover);
         root.add_child(&viz);
-        let viz_shape_system = scene
-            .layers
-            .main
-            .shape_system_registry
-            .shape_system(scene, PhantomData::<viz::DynamicShape>);
-        viz_shape_system.shape_system.set_pointer_events(false);
 
         Self { root, hover, viz }
     }
@@ -185,13 +179,12 @@ impl Model {
     pub fn init_shape(
         &mut self,
         logger: impl AnyLogger,
-        scene: &Scene,
         size: Vector2,
         hover_height: f32,
     ) -> Shape {
         let logger_name = format!("port({},{})", self.index, self.length);
         let logger = Logger::new_sub(logger, logger_name);
-        let shape = Shape::new(&logger, scene, size, hover_height);
+        let shape = Shape::new(&logger, size, hover_height);
         self.shape = Some(shape);
         self.shape.as_ref().unwrap().clone_ref()
     }

--- a/app/gui/view/graph-editor/src/component/node/input/port.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/port.rs
@@ -97,7 +97,6 @@ impl Shape {
     /// Constructor.
     #[profile(Debug)]
     pub fn new(logger: &Logger, size: Vector2, hover_height: f32) -> Self {
-
         let root = display::object::Instance::new(logger);
         let hover = hover::View::new(logger);
         let viz = viz::View::new(logger);

--- a/app/gui/view/graph-editor/src/component/node/input/port.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/port.rs
@@ -57,7 +57,7 @@ pub mod viz {
     use super::*;
     ensogl::define_shape_system! {
         above = [hover];
-        pointer_events = [false];
+        pointer_events = false;
         (style:Style, color:Vector4) {
             let width  : Var<Pixels> = "input_size.x".into();
             let height : Var<Pixels> = "input_size.y".into();

--- a/app/gui/view/graph-editor/src/component/node/output/port.rs
+++ b/app/gui/view/graph-editor/src/component/node/output/port.rs
@@ -80,6 +80,7 @@ struct AllPortsShape {
 }
 
 impl AllPortsShape {
+    #[profile(Debug)]
     fn new(
         canvas_width: &Var<Pixels>,
         canvas_height: &Var<Pixels>,
@@ -381,6 +382,7 @@ macro_rules! fn_multi_only {
 }
 
 impl PortShapeView {
+    #[profile(Debug)]
     fn new(number_of_ports: usize, logger: &Logger) -> Self {
         if number_of_ports <= 1 {
             Self::Single(SinglePortView::new(&logger))

--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -2861,7 +2861,7 @@ fn new_graph_editor(app: &Application) -> GraphEditor {
         out.node_editing_finished <+ node_being_edited.sample(&edit_switch);
         out.node_editing_started  <+ edit_node;
 
-        out.node_being_edited <+ out.node_editing_started.map(|n| Some(*n));;
+        out.node_being_edited <+ out.node_editing_started.map(|n| Some(*n));
         out.node_being_edited <+ out.node_editing_finished.constant(None);
         out.node_editing      <+ out.node_being_edited.map(|t|t.is_some());
 
@@ -2869,11 +2869,13 @@ fn new_graph_editor(app: &Application) -> GraphEditor {
         out.nodes_labels_visible <+ out.node_edit_mode || node_in_edit_mode;
 
         eval out.node_editing_started ([model] (id) {
+            let _profiler = profiler::start_debug!(profiler::APP_LIFETIME, "node_editing_started");
             if let Some(node) = model.nodes.get_cloned_ref(id) {
                 node.model().input.frp.set_edit_mode(true);
             }
         });
         eval out.node_editing_finished ([model](id) {
+            let _profiler = profiler::start_debug!(profiler::APP_LIFETIME, "node_editing_finished");
             if let Some(node) = model.nodes.get_cloned_ref(id) {
                 node.model().input.set_edit_mode(false);
             }

--- a/app/gui/view/graph-editor/src/selection.rs
+++ b/app/gui/view/graph-editor/src/selection.rs
@@ -1,4 +1,4 @@
-//! Module that contains the logic sor selecting nodes. This includes selecting single nodes
+//! Module that contains the logic for selecting nodes. This includes selecting single nodes
 //! by clicking on them separately, as well as click+drag for selecting with a selection area.
 
 

--- a/lib/rust/ensogl/component/scroll-area/src/lib.rs
+++ b/lib/rust/ensogl/component/scroll-area/src/lib.rs
@@ -137,6 +137,7 @@ impl display::Object for ScrollArea {
 
 impl ScrollArea {
     /// Create a new scroll area for use in the given application.
+    #[profile(Detail)]
     pub fn new(app: &Application) -> ScrollArea {
         let scene = &app.display.default_scene;
         let logger = Logger::new("ScrollArea");

--- a/lib/rust/ensogl/component/selector/src/number.rs
+++ b/lib/rust/ensogl/component/selector/src/number.rs
@@ -1,6 +1,5 @@
 ///! Frp of the number selector.
 use crate::prelude::*;
-use crate::shape::*;
 use ensogl_core::display::shape::*;
 
 use crate::bounds::absolute_value;
@@ -51,9 +50,6 @@ impl Frp {
         model.show_background(true);
 
         let base_frp = super::Frp::new(model, style, network, frp.resize.clone().into(), mouse);
-
-        let track_shape_system = scene.shapes.shape_system(PhantomData::<track::Shape>);
-        track_shape_system.shape_system.set_pointer_events(false);
 
         let background_click = relative_shape_down_position(network, scene, &model.background);
         let track_click = relative_shape_down_position(network, scene, &model.track);

--- a/lib/rust/ensogl/component/selector/src/shape.rs
+++ b/lib/rust/ensogl/component/selector/src/shape.rs
@@ -100,6 +100,7 @@ pub mod track {
     use super::*;
 
     ensogl_core::define_shape_system! {
+        pointer_events = [false];
         (style:Style,left:f32,right:f32,corner_left:f32,corner_right:f32,corner_inner:f32,
          track_color:Vector4) {
             let background    = Background::new(&corner_left,&corner_right,style);

--- a/lib/rust/ensogl/component/selector/src/shape.rs
+++ b/lib/rust/ensogl/component/selector/src/shape.rs
@@ -100,7 +100,7 @@ pub mod track {
     use super::*;
 
     ensogl_core::define_shape_system! {
-        pointer_events = [false];
+        pointer_events = false;
         (style:Style,left:f32,right:f32,corner_left:f32,corner_right:f32,corner_inner:f32,
          track_color:Vector4) {
             let background    = Background::new(&corner_left,&corner_right,style);

--- a/lib/rust/ensogl/component/text/src/component/area.rs
+++ b/lib/rust/ensogl/component/text/src/component/area.rs
@@ -613,12 +613,8 @@ impl AreaModel {
         let single_line = default();
         let layer = Rc::new(CloneRefCell::new(scene.layers.main.clone_ref()));
 
-        // FIXME[WD]: These settings should be managed wiser. They should be set up during
-        // initialization of the shape system, not for every area creation. To be improved during
-        // refactoring of the architecture some day.
         let shape_system = scene.shapes.shape_system(PhantomData::<selection::shape::Shape>);
         let symbol = &shape_system.shape_system.sprite_system.symbol;
-        shape_system.shape_system.set_pointer_events(false);
 
         // FIXME[WD]: This is temporary sorting utility, which places the cursor in front of mouse
         // pointer and nodes. Should be refactored when proper sorting mechanisms are in place.

--- a/lib/rust/ensogl/component/text/src/component/selection.rs
+++ b/lib/rust/ensogl/component/text/src/component/selection.rs
@@ -57,6 +57,7 @@ pub mod shape {
     use super::*;
 
     ensogl_core::define_shape_system! {
+        pointer_events = [false];
         (style:Style, selection:f32, start_time:f32, letter_width:f32, color_rgb:Vector3<f32>) {
             let width_abs      = Var::<f32>::from("abs(input_size.x)");
             let height         = Var::<f32>::from("input_size.y");

--- a/lib/rust/ensogl/component/text/src/component/selection.rs
+++ b/lib/rust/ensogl/component/text/src/component/selection.rs
@@ -57,7 +57,7 @@ pub mod shape {
     use super::*;
 
     ensogl_core::define_shape_system! {
-        pointer_events = [false];
+        pointer_events = false;
         (style:Style, selection:f32, start_time:f32, letter_width:f32, color_rgb:Vector3<f32>) {
             let width_abs      = Var::<f32>::from("abs(input_size.x)");
             let height         = Var::<f32>::from("input_size.y");

--- a/lib/rust/ensogl/core/src/display/scene/layer.rs
+++ b/lib/rust/ensogl/core/src/display/scene/layer.rs
@@ -185,6 +185,7 @@ impl Layer {
     }
 
     /// Constructor.
+    #[profile(Detail)]
     pub fn new_with_cam(logger: Logger, camera: &Camera2d) -> Self {
         let this = Self::new(logger);
         this.set_camera(camera);
@@ -556,6 +557,7 @@ impl LayerModel {
     }
 
     /// Consume all dirty flags and update the ordering of elements if needed.
+    #[profile(Debug)]
     pub(crate) fn update_internal(
         &self,
         global_element_depth_order: Option<&DependencyGraph<LayerItem>>,

--- a/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
+++ b/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
@@ -48,19 +48,22 @@ pub struct ShapeSystem {
     pub sprite_system:  SpriteSystem,
     pub shape:          Rc<RefCell<def::AnyShape>>,
     pub material:       Rc<RefCell<Material>>,
-    pub pointer_events: Rc<Cell<bool>>,
+    /// Enables or disables pointer events on this shape system. All shapes of a shape system which
+    /// has pointer events disabled would be completely transparent for the mouse (they would pass
+    /// through all mouse events).
+    pub pointer_events: Immutable<bool>,
 }
 
 impl ShapeSystem {
     /// Constructor.
-    pub fn new<'t, S, Sh>(scene: S, shape: Sh) -> Self
+    pub fn new<'t, S, Sh>(scene: S, shape: Sh, pointer_events: bool) -> Self
     where
         S: Into<&'t Scene>,
         Sh: Into<def::AnyShape>, {
         let shape = shape.into();
         let sprite_system = SpriteSystem::new(scene);
         let material = Rc::new(RefCell::new(Self::surface_material()));
-        let pointer_events = Rc::new(Cell::new(true));
+        let pointer_events = Immutable(pointer_events);
         let shape = Rc::new(RefCell::new(shape));
         let this = Self { sprite_system, shape, material, pointer_events };
         this.reload_shape();
@@ -81,16 +84,6 @@ impl ShapeSystem {
         material
     }
 
-    /// Enables or disables pointer events on this shape system. All shapes of a shape system which
-    /// has pointer events disabled would be completely transparent for the mouse (they would pass
-    /// through all mouse events).
-    pub fn set_pointer_events(&self, val: bool) {
-        let old_val = self.pointer_events.replace(val);
-        if val != old_val {
-            self.reload_shape();
-        }
-    }
-
     /// Replaces the shape definition.
     pub fn set_shape<S: Into<def::AnyShape>>(&self, shape: S) {
         let shape = shape.into();
@@ -99,9 +92,9 @@ impl ShapeSystem {
     }
 
     /// Generates the shape again. It is used after some parameters are changed, like setting new
-    /// `pointer_events` value.
+    /// `shape`.
     fn reload_shape(&self) {
-        let code = shader::builder::Builder::run(&*self.shape.borrow(), self.pointer_events.get());
+        let code = shader::builder::Builder::run(&*self.shape.borrow(), *self.pointer_events);
         self.material.borrow_mut().set_code(code);
         self.reload_material();
     }
@@ -328,24 +321,24 @@ macro_rules! define_shape_system {
     (
         $(above = [$($always_above_1:tt $(::$always_above_2:tt)*),*];)?
         $(below = [$($always_below_1:tt $(::$always_below_2:tt)*),*];)?
+        $(pointer_events = [$pointer_events:tt];)?
         ($style:ident : Style $(,$gpu_param : ident : $gpu_param_type : ty)* $(,)?) {$($body:tt)*}
     ) => {
         $crate::_define_shape_system! {
             $(above = [$($always_above_1 $(::$always_above_2)*),*];)?
             $(below = [$($always_below_1 $(::$always_below_2)*),*];)?
+            $(pointer_events = [$pointer_events];)?
             [$style] ($($gpu_param : $gpu_param_type),*){$($body)*}
         }
     };
 
     (
-        $(above = [$($always_above_1:tt $(::$always_above_2:tt)*),*];)?
-        $(below = [$($always_below_1:tt $(::$always_below_2:tt)*),*];)?
+        $($arg:ident = [$($arg_val:tt)*];)*
         ($($gpu_param : ident : $gpu_param_type : ty),* $(,)?) {$($body:tt)*}
     ) => {
-        $crate::_define_shape_system! {
-            $(above = [$($always_above_1 $(::$always_above_2)*),*];)?
-            $(below = [$($always_below_1 $(::$always_below_2)*),*];)?
-            [style] ($($gpu_param : $gpu_param_type),*){$($body)*}
+        $crate::define_shape_system! {
+            $($arg = [$($arg_val)*];)*
+            (style : Style, $($gpu_param : $gpu_param_type),*){$($body)*}
         }
     }
 }
@@ -356,6 +349,7 @@ macro_rules! _define_shape_system {
     (
         $(above = [$($always_above_1:tt $(::$always_above_2:tt)*),*];)?
         $(below = [$($always_below_1:tt $(::$always_below_2:tt)*),*];)?
+        $(pointer_events = [$pointer_events:tt];)?
         [$style:ident]
         ($($gpu_param : ident : $gpu_param_type : ty),* $(,)?)
         {$($body:tt)*}
@@ -550,9 +544,11 @@ macro_rules! _define_shape_system {
 
                 #[profile(Debug)]
                 fn new(scene:&display::scene::Scene) -> Self {
-                    let style_watch  = display::shape::StyleWatch::new(&scene.style_sheet);
-                    let shape_def    = Self::shape_def(&style_watch);
-                    let shape_system = display::shape::ShapeSystem::new(scene,&shape_def);
+                    let style_watch   = display::shape::StyleWatch::new(&scene.style_sheet);
+                    let shape_def     = Self::shape_def(&style_watch);
+                    let _events       = true;
+                    $( let _events     = $pointer_events; )?
+                    let shape_system = display::shape::ShapeSystem::new(scene,&shape_def,_events);
                     $(
                         let name = stringify!($gpu_param);
                         let val  = gpu::data::default::gpu_default::<$gpu_param_type>();

--- a/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
+++ b/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
@@ -333,11 +333,11 @@ macro_rules! define_shape_system {
     };
 
     (
-        $($arg:ident = [$($arg_val:tt)*];)*
+        $($arg:ident = $arg_val:tt;)*
         ($($gpu_param : ident : $gpu_param_type : ty),* $(,)?) {$($body:tt)*}
     ) => {
         $crate::define_shape_system! {
-            $($arg = [$($arg_val)*];)*
+            $($arg = $arg_val;)*
             (style : Style, $($gpu_param : $gpu_param_type),*){$($body)*}
         }
     }

--- a/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
+++ b/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
@@ -85,8 +85,10 @@ impl ShapeSystem {
     /// has pointer events disabled would be completely transparent for the mouse (they would pass
     /// through all mouse events).
     pub fn set_pointer_events(&self, val: bool) {
-        self.pointer_events.set(val);
-        self.reload_shape();
+        let old_val = self.pointer_events.replace(val);
+        if val != old_val {
+            self.reload_shape();
+        }
     }
 
     /// Replaces the shape definition.

--- a/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
+++ b/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
@@ -321,13 +321,13 @@ macro_rules! define_shape_system {
     (
         $(above = [$($always_above_1:tt $(::$always_above_2:tt)*),*];)?
         $(below = [$($always_below_1:tt $(::$always_below_2:tt)*),*];)?
-        $(pointer_events = [$pointer_events:tt];)?
+        $(pointer_events = $pointer_events:tt;)?
         ($style:ident : Style $(,$gpu_param : ident : $gpu_param_type : ty)* $(,)?) {$($body:tt)*}
     ) => {
         $crate::_define_shape_system! {
             $(above = [$($always_above_1 $(::$always_above_2)*),*];)?
             $(below = [$($always_below_1 $(::$always_below_2)*),*];)?
-            $(pointer_events = [$pointer_events];)?
+            $(pointer_events = $pointer_events;)?
             [$style] ($($gpu_param : $gpu_param_type),*){$($body)*}
         }
     };
@@ -349,7 +349,7 @@ macro_rules! _define_shape_system {
     (
         $(above = [$($always_above_1:tt $(::$always_above_2:tt)*),*];)?
         $(below = [$($always_below_1:tt $(::$always_below_2:tt)*),*];)?
-        $(pointer_events = [$pointer_events:tt];)?
+        $(pointer_events = $pointer_events:tt;)?
         [$style:ident]
         ($($gpu_param : ident : $gpu_param_type : ty),* $(,)?)
         {$($body:tt)*}

--- a/lib/rust/ensogl/core/src/gui/component.rs
+++ b/lib/rust/ensogl/core/src/gui/component.rs
@@ -99,6 +99,7 @@ impl<S> Drop for ShapeViewModel<S> {
 }
 
 impl<S: DynamicShapeInternals> ShapeViewModel<S> {
+    #[profile(Debug)]
     fn on_scene_layers_changed(
         &self,
         scene: &Scene,

--- a/lib/rust/ensogl/core/src/gui/cursor.rs
+++ b/lib/rust/ensogl/core/src/gui/cursor.rs
@@ -137,7 +137,7 @@ impl Style {
 pub mod shape {
     use super::*;
     crate::define_shape_system! {
-        pointer_events = [false];
+        pointer_events = false;
         ( press  : f32
         , radius : f32
         , color  : Vector4

--- a/lib/rust/ensogl/core/src/gui/cursor.rs
+++ b/lib/rust/ensogl/core/src/gui/cursor.rs
@@ -137,6 +137,7 @@ impl Style {
 pub mod shape {
     use super::*;
     crate::define_shape_system! {
+        pointer_events = [false];
         ( press  : f32
         , radius : f32
         , color  : Vector4
@@ -210,12 +211,6 @@ impl CursorModel {
         let port_selection_layer = &scene.layers.port_selection;
         tgt_layer.add_exclusive(&view);
         port_selection_layer.add_exclusive(&port_selection);
-
-        for layer in &[tgt_layer, port_selection_layer] {
-            let registry = &layer.shape_system_registry;
-            let shape_sys = registry.shape_system(&scene, PhantomData::<shape::DynamicShape>);
-            shape_sys.shape_system.set_pointer_events(false);
-        }
 
         Self { logger, scene, display_object, view, port_selection, style }
     }

--- a/lib/rust/ensogl/example/shape-system/src/lib.rs
+++ b/lib/rust/ensogl/example/shape-system/src/lib.rs
@@ -61,7 +61,7 @@ pub fn main() {
     let scene = &world.default_scene;
     let camera = scene.camera().clone_ref();
     let navigator = Navigator::new(scene, &camera);
-    let sprite_system = ShapeSystem::new(&world, &shape());
+    let sprite_system = ShapeSystem::new(&world, &shape(), true);
     let sprite = sprite_system.new_instance();
 
     sprite.size.set(Vector2::new(300.0, 300.0));

--- a/lib/rust/frp/src/io/js.rs
+++ b/lib/rust/frp/src/io/js.rs
@@ -4,6 +4,7 @@ use enso_web::prelude::*;
 
 use crate as frp;
 
+use enso_profiler as profiler;
 use enso_web as web;
 
 
@@ -140,6 +141,7 @@ impl CurrentJsEvent {
     {
         let event_source = self.event_source.clone_ref();
         move |event| {
+            let _profiler = profiler::start_debug!(profiler::APP_LIFETIME, "event_handler");
             let js_event = event.as_ref().clone();
             event_source.emit(Some(js_event));
             processing_fn(event);

--- a/lib/rust/profiler/data/src/bin/measurements.rs
+++ b/lib/rust/profiler/data/src/bin/measurements.rs
@@ -46,14 +46,14 @@ fn print_measurement<Metadata>(
         indent.push_str("  ");
     }
     println!("{}{}", indent, measurement.label);
-    println!("{}  intervals:", indent);
+    print!("{}", indent);
     for active in &measurement.intervals {
         let interval = profile[*active].interval;
-        println!("{}    interval: {}", indent, fmt_interval(interval));
+        print!("  {}", fmt_interval(interval));
     }
-    println!("{}  children:", indent);
+    println!();
     for child in &measurement.children {
-        print_measurement(profile, *child, i + 2);
+        print_measurement(profile, *child, i + 1);
     }
 }
 


### PR DESCRIPTION
### Pull Request Description

Fix the blinking of nodes and their input areas that has been observable since parallel-shader-compile was introduced. Implements [#182132765](https://www.pivotaltracker.com/story/show/182132765).

The problem was `set_pointer_events`: It was unconditionally triggering shader recompilation, and we call it every time we create an instance of certain shapes.

### Important Notes

- This is a quick fix for the visual bug. I think the `set_pointer_events` API is wrong: It is a property of a whole shape system, that we are setting every time we create an instance. However simply making the function idempotent fixes the resulting performance problem.
- Also included in PR: The output of the `measurements` tool is now more compact.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.

[ci no changelog needed]