### PR TITLE
Replace Rope with CharSequence when building suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,7 @@
 [3432]: https://github.com/enso-org/enso/pull/3432
 [3363]: https://github.com/enso-org/enso/pull/3363
 [3444]: https://github.com/enso-org/enso/pull/3444
+[3453]: https://github.com/enso-org/enso/pull/3453
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/lib/scala/text-buffer/src/main/scala/org/enso/text/ContentBasedVersioning.scala
+++ b/lib/scala/text-buffer/src/main/scala/org/enso/text/ContentBasedVersioning.scala
@@ -8,6 +8,5 @@ trait ContentBasedVersioning {
     * @param content a textual content
     * @return a content version
     */
-  def evalVersion(content: String): ContentVersion
-
+  def evalVersion(content: CharSequence): ContentVersion
 }

--- a/lib/scala/text-buffer/src/main/scala/org/enso/text/Sha3_224VersionCalculator.scala
+++ b/lib/scala/text-buffer/src/main/scala/org/enso/text/Sha3_224VersionCalculator.scala
@@ -8,9 +8,10 @@ import org.bouncycastle.jcajce.provider.digest.SHA3
 object Sha3_224VersionCalculator extends ContentBasedVersioning {
 
   /** @inheritdoc */
-  override def evalVersion(content: String): ContentVersion = {
+  override def evalVersion(content: CharSequence): ContentVersion = {
     val digestSHA3 = new SHA3.Digest224()
-    ContentVersion(digestSHA3.digest(content.getBytes(StandardCharsets.UTF_8)))
+    val digest =
+      digestSHA3.digest(content.toString.getBytes(StandardCharsets.UTF_8))
+    ContentVersion(digest)
   }
-
 }


### PR DESCRIPTION
### Pull Request Description

PR addresses an issue when during the initial compilation the `EnsureCompiledJob` depends too much time building the `LineView` of ropes.
Replacing the `Rope` with `CharSequence` in the compilation job reduces total time building the suggestions from ~600 ms to ~200 ms.

#### Before
![2022-05-13-160549_1310x120_scrot](https://user-images.githubusercontent.com/357683/168289736-fe8983ef-9bcc-4df0-bcd2-881bc2949773.png)
#### After
![2022-05-13-160609_1303x123_scrot](https://user-images.githubusercontent.com/357683/168289741-3326603d-8183-4925-b995-435655d6c8be.png)

[context-registry-npss.zip](https://github.com/enso-org/enso/files/8687294/context-registry-npss.zip)

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] ~If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.~
