### PR TITLE
Add type constructors

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/AtomConstructor.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/AtomConstructor.java
@@ -31,6 +31,7 @@ import org.enso.interpreter.runtime.scope.ModuleScope;
 import org.enso.pkg.QualifiedName;
 
 import java.util.Map;
+import scala.collection.immutable.List;
 
 /** A representation of an Atom constructor. */
 @ExportLibrary(InteropLibrary.class)
@@ -42,6 +43,9 @@ public final class AtomConstructor implements TruffleObject {
   private final boolean builtin;
   private @CompilerDirectives.CompilationFinal Atom cachedInstance;
   private @CompilerDirectives.CompilationFinal Function constructorFunction;
+
+  private @CompilerDirectives.CompilationFinal AtomConstructor parentType;
+  private @CompilerDirectives.CompilationFinal scala.collection.immutable.List<AtomConstructor> variants;
 
   /**
    * Creates a new Atom constructor for a given name. The constructor is not valid until {@link
@@ -247,6 +251,20 @@ public final class AtomConstructor implements TruffleObject {
   public String toString() {
     return name;
   }
+
+  /**
+   * Gets the atom constructor of the parent of this constructor, if this is a variant in a sum type
+   *
+   * @return the parent of this atom constructor if it is a variant in a sum type, null otherwise
+   */
+  public AtomConstructor getParentType() { return parentType; }
+
+  /**
+   * Gets the list of all variants of this constructor if this is a variant in a sum type.
+   *
+   * @return
+   */
+  public List<AtomConstructor> getVariants() { return variants; }
 
   /**
    * Gets the constructor function of this constructor.

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/AtomConstructor.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/AtomConstructor.java
@@ -45,7 +45,7 @@ public final class AtomConstructor implements TruffleObject {
   private @CompilerDirectives.CompilationFinal Function constructorFunction;
 
   private @CompilerDirectives.CompilationFinal AtomConstructor parentType;
-  private @CompilerDirectives.CompilationFinal scala.collection.immutable.List<AtomConstructor> variants;
+  private @CompilerDirectives.CompilationFinal(dimensions = 1) AtomConstructor[] variants;
 
   /**
    * Creates a new Atom constructor for a given name. The constructor is not valid until {@link
@@ -257,21 +257,34 @@ public final class AtomConstructor implements TruffleObject {
    *
    * @return the parent of this atom constructor if it is a variant in a sum type, null otherwise
    */
-  public AtomConstructor getParentType() { return parentType; }
+  public AtomConstructor getParentType() {
+    return parentType;
+  }
 
   public void setParentType(AtomConstructor parent) {
+    CompilerDirectives.transferToInterpreterAndInvalidate();
+    if (parentType != null) throw new IllegalStateException("parent type already initialized");
     parentType = parent;
   }
 
   /**
-   * Gets the list of all variants of this constructor if this is a variant in a sum type.
+   * Gets the array of all variants of this constructor if this is a variant in a sum type.
    *
-   * @return
+   * @return the array of variants
    */
-  public List<AtomConstructor> getVariants() { return variants; }
+  public AtomConstructor[] getVariants() {
+    if (variants == null) throw new IllegalStateException("variants not initialized");
+    return variants.clone();
+  }
 
-  public void setVariants(List<AtomConstructor> variantConstructors) {
-    variants = variantConstructors;
+  /**
+   * Sets the array of all variants of this constructor when used as a sum type.
+   */
+
+  public void setVariants(AtomConstructor[] variantConstructors) {
+    CompilerDirectives.transferToInterpreterAndInvalidate();
+    if (variants != null) throw new IllegalStateException("variants already initialized");
+    variants = variantConstructors.clone();
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/AtomConstructor.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/AtomConstructor.java
@@ -259,12 +259,20 @@ public final class AtomConstructor implements TruffleObject {
    */
   public AtomConstructor getParentType() { return parentType; }
 
+  public void setParentType(AtomConstructor parent) {
+    parentType = parent;
+  }
+
   /**
    * Gets the list of all variants of this constructor if this is a variant in a sum type.
    *
    * @return
    */
   public List<AtomConstructor> getVariants() { return variants; }
+
+  public void setVariants(List<AtomConstructor> variantConstructors) {
+    variants = variantConstructors;
+  }
 
   /**
    * Gets the constructor function of this constructor.

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/RedefinedConstructorException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/RedefinedConstructorException.java
@@ -1,0 +1,17 @@
+package org.enso.interpreter.runtime.error;
+
+import com.oracle.truffle.api.exception.AbstractTruffleException;
+import org.enso.interpreter.runtime.Module;
+
+/** An exception thrown when the program tries to redefine an already-defined constructor */
+public class RedefinedConstructorException extends AbstractTruffleException {
+
+  /**
+   * Creates a new error.
+   *
+   * @param atom the method of the atom on which {@code method} is being defined
+   */
+  public RedefinedConstructorException(String atom, Module scope) {
+    super("Constructors cannot be overloaded, but you have tried to overload " + atom + " in scope " + scope.getName());
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
@@ -8,6 +8,7 @@ import com.oracle.truffle.api.interop.TruffleObject;
 import org.enso.interpreter.runtime.Module;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.error.RedefinedConstructorException;
 import org.enso.interpreter.runtime.error.RedefinedMethodException;
 import org.enso.interpreter.runtime.error.RedefinedConversionException;
 
@@ -38,8 +39,16 @@ public class ModuleScope implements TruffleObject {
    * @param constructor the constructor to register
    */
   public void registerConstructor(AtomConstructor constructor) {
+    var name = constructor.getName();
+    if (constructors.containsKey(name))
+      throw new RedefinedConstructorException(name, module);
+    constructors.put(name, constructor);
+  }
+
+  public void forciblyRegisterConstructor(AtomConstructor constructor) {
     constructors.put(constructor.getName(), constructor);
   }
+
 
   /** @return the associated type of this module. */
   public AtomConstructor getAssociatedType() {

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/AstToIr.scala
@@ -137,7 +137,6 @@ object AstToIr {
         IR.Name.Annotation(annotation.name, getIdentifiedLocation(annotation))
       case AstView.Atom(consName, args) =>
         val newArgs = args.map(translateArgumentDefinition(_))
-
         if (newArgs.exists(_.suspended)) {
           val ast = newArgs
             .zip(args)
@@ -148,6 +147,7 @@ object AstToIr {
           Module.Scope.Definition.Atom(
             buildName(consName),
             newArgs,
+            List.empty[Name],
             getIdentifiedLocation(inputAst)
           )
         }

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/RuntimeStubsGenerator.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/RuntimeStubsGenerator.scala
@@ -42,7 +42,7 @@ class RuntimeStubsGenerator(builtins: Builtins) {
     // link parents to variants and vice versa
     constructors.foreach { case (tp,tcons) =>
       val variants = tp.variants.map(scope.getConstructor(_).get()).toList;
-      tcons.setVariants(variants);
+      tcons.setVariants(variants.toArray);
       variants.foreach(_.setParentType(tcons));
     }
   }

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/RuntimeStubsGenerator.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/RuntimeStubsGenerator.scala
@@ -23,13 +23,13 @@ class RuntimeStubsGenerator(builtins: Builtins) {
       BindingAnalysis,
       "Non-parsed module used in stubs generator"
     )
-    val constructors = localBindings.constructors.map { tp =>
+    val constructors = localBindings.constructors./*distinctBy(_.name). */map { tp =>
       if (tp.builtinType) {
         val builtinType = builtins.getBuiltinType(tp.name)
         if (builtinType == null) {
           throw new CompilerError("Unknown @BuiltinType " + tp.name)
         }
-        scope.registerConstructor(builtinType)
+        scope.forciblyRegisterConstructor(builtinType)
         builtinType.setShadowDefinitions(scope)
         (tp, builtinType)
       } else {

--- a/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
@@ -344,6 +344,13 @@ final class SuggestionBuilder[A: IndexedSource](val source: A) {
     }
   }
 
+  /** Resolve a name to either an explicit sum type or a simple TypeArg. Used to link
+   * suggestions to concrete types, so the editor can know a fully qualified
+   * type name if possible.
+   *
+   * @param resolvedName the name to resolve
+   * @return how to present it to the suggestion engine
+   */
   private def buildResolvedUnionTypeName(
     resolvedName: BindingsMap.ResolvedName
   ): Option[TypeArg] = resolvedName match {

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
@@ -939,7 +939,7 @@ object IR {
         ): Definition
       }
       object Definition {
-
+/*
         /** The definition of a union type and its members.
           *
           * NB: this should probably be removed once we propagate the union
@@ -1038,11 +1038,12 @@ object IR {
             s"type ${name.showCode(indent)} = $fields"
           }
         }
-
+*/
         /** The definition of an atom constructor and its associated arguments.
           *
           * @param name the name of the atom
           * @param arguments the arguments to the atom constructor
+          * @param variants the names of the variants of this type if a sum type
           * @param location the source location that the node corresponds to
           * @param passData the pass metadata associated with this node
           * @param diagnostics compiler diagnostics for this node
@@ -1050,6 +1051,7 @@ object IR {
         sealed case class Atom(
           name: IR.Name,
           arguments: List[DefinitionArgument],
+          variants: List[IR.Name],
           override val location: Option[IdentifiedLocation],
           override val passData: MetadataStorage      = MetadataStorage(),
           override val diagnostics: DiagnosticStorage = DiagnosticStorage()
@@ -1061,6 +1063,7 @@ object IR {
             *
             * @param name the name of the atom
             * @param arguments the arguments to the atom constructor
+            * @param variants the names of the variants of this type if a sum type
             * @param location the source location that the node corresponds to
             * @param passData the pass metadata associated with this node
             * @param diagnostics compiler diagnostics for this node
@@ -1070,12 +1073,13 @@ object IR {
           def copy(
             name: IR.Name                        = name,
             arguments: List[DefinitionArgument]  = arguments,
+            variants: List[IR.Name]              = variants,
             location: Option[IdentifiedLocation] = location,
             passData: MetadataStorage            = passData,
             diagnostics: DiagnosticStorage       = diagnostics,
             id: Identifier                       = id
           ): Atom = {
-            val res = Atom(name, arguments, location, passData, diagnostics)
+            val res = Atom(name, arguments, variants, location, passData, diagnostics)
             res.id = id
             res
           }
@@ -1128,6 +1132,7 @@ object IR {
             |IR.Module.Scope.Definition.Atom(
             |name = $name,
             |arguments = $arguments,
+            |variants = $variants,
             |location = $location,
             |passData = ${this.showPassData},
             |diagnostics = $diagnostics,
@@ -1141,8 +1146,12 @@ object IR {
           /** @inheritdoc */
           override def showCode(indent: Int): String = {
             val fields = arguments.map(_.showCode(indent)).mkString(" ")
-
-            s"type ${name.showCode(indent)} $fields"
+            if (variants.isEmpty) {
+              s"type ${name.showCode(indent)} $fields"
+            } else {
+              val alts = variants.map(_.showCode(indent)).mkString(" | ")
+              s"type ${name.showCode(indent)} $fields = $alts"
+            }
           }
         }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
@@ -227,7 +227,7 @@ case object AliasAnalysis extends IRPass {
         throw new CompilerError(
           "Method definition sugar should not occur during alias analysis."
         )
-      case a @ IR.Module.Scope.Definition.Atom(_, args, _, _, _) =>
+      case a @ IR.Module.Scope.Definition.Atom(_, args, variants@_, _, _, _) =>
         a.copy(
           arguments =
             analyseArgumentDefs(args, topLevelGraph, topLevelGraph.rootScope)
@@ -252,7 +252,6 @@ case object AliasAnalysis extends IRPass {
           "analysis."
         )
       case err: IR.Error                            => err
-      case ut: IR.Module.Scope.Definition.UnionType => ut
     }
   }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/BindingAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/BindingAnalysis.scala
@@ -50,11 +50,6 @@ case object BindingAnalysis extends IRPass {
     ir: IR.Module,
     moduleContext: ModuleContext
   ): IR.Module = {
-    val definedSumTypes = ir.bindings.collect {
-      case sumType: IR.Module.Scope.Definition.UnionType =>
-        BindingsMap.Type(sumType.name.name, sumType.members.map(_.name))
-    }
-
     val definedConstructors = ir.bindings.collect {
       case cons: IR.Module.Scope.Definition.Atom =>
         // FIXME: move to a different pass
@@ -65,7 +60,8 @@ case object BindingAnalysis extends IRPass {
           cons.name.name,
           cons.arguments.length,
           cons.arguments.forall(_.defaultValue.isDefined),
-          isBuiltinType
+          isBuiltinType,
+          cons.variants.map(_.name)
         )
     }
     val importedPolyglot = ir.imports.collect {
@@ -99,7 +95,6 @@ case object BindingAnalysis extends IRPass {
       ) :: moduleMethods
     ir.updateMetadata(
       this -->> BindingsMap(
-        definedSumTypes,
         definedConstructors,
         importedPolyglot,
         methodsWithAutogen,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/CachePreferenceAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/CachePreferenceAnalysis.scala
@@ -87,13 +87,12 @@ case object CachePreferenceAnalysis extends IRPass {
     weights: WeightInfo
   ): IR.Module.Scope.Definition =
     binding match {
-      case atom @ IR.Module.Scope.Definition.Atom(_, arguments, _, _, _) =>
+      case atom @ IR.Module.Scope.Definition.Atom(_, arguments, _, _, _, _) =>
         atom
           .copy(arguments =
             arguments.map(analyseDefinitionArgument(_, weights))
           )
           .updateMetadata(this -->> weights)
-      case _: IR.Module.Scope.Definition.UnionType => binding
       case method: Method.Conversion =>
         method
           .copy(body = analyseExpression(method.body, weights))

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
@@ -119,13 +119,14 @@ case object DataflowAnalysis extends IRPass {
     info: DependencyInfo
   ): IR.Module.Scope.Definition = {
     binding match {
-      case atom @ IR.Module.Scope.Definition.Atom(_, arguments, _, _, _) =>
+      case atom @ IR.Module.Scope.Definition.Atom(_, arguments, variants@_, _, _, _) =>
         arguments.foreach(arg => {
           val argDep  = asStatic(arg)
           val atomDep = asStatic(atom)
           info.dependents.updateAt(argDep, Set(atomDep))
           info.dependencies.updateAt(atomDep, Set(argDep))
         })
+        // do we need to incur a dependency on the parent for each variant?
 
         atom
           .copy(
@@ -154,7 +155,7 @@ case object DataflowAnalysis extends IRPass {
         method
           .copy(body = analyseExpression(body, info))
           .updateMetadata(this -->> info)
-      case _: IR.Module.Scope.Definition.UnionType => binding
+      // case _: IR.Module.Scope.Definition.UnionType => binding
       case _: IR.Module.Scope.Definition.Method.Binding =>
         throw new CompilerError(
           "Sugared method definitions should not occur during dataflow " +

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/TailCall.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/TailCall.scala
@@ -109,13 +109,12 @@ case object TailCall extends IRPass {
           "Sugared method definitions should not occur during tail call " +
           "analysis."
         )
-      case atom @ IR.Module.Scope.Definition.Atom(_, args, _, _, _) =>
+      case atom @ IR.Module.Scope.Definition.Atom(_, args, _, _, _, _) =>
         atom
           .copy(
             arguments = args.map(analyseDefArgument)
           )
           .updateMetadata(this -->> TailPosition.Tail)
-      case _: IR.Module.Scope.Definition.UnionType => definition
       case _: IR.Module.Scope.Definition.Type =>
         throw new CompilerError(
           "Complex type definitions should not be present during " +

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/ComplexType.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/ComplexType.scala
@@ -190,8 +190,10 @@ case object ComplexType extends IRPass {
     val allEntities = entityResults ::: lastSignature.toList
 
     val includedNames = atomDefs.map(_.name)
+
+    // build the union type
     val sumType = IR.Module.Scope.Definition
-      .UnionType(typ.name, includedNames, typ.location)
+      .Atom(typ.name, typ.arguments, includedNames, typ.location)
 
     sumType :: atomDefs ::: allEntities
   }

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
@@ -128,9 +128,8 @@ case object FunctionBinding extends IRPass {
     definition: IR.Module.Scope.Definition
   ): IR.Module.Scope.Definition = {
     definition match {
-      case a @ Definition.Atom(_, arguments, _, _, _) =>
+      case a @ Definition.Atom(_, arguments, variants@_, _, _, _) =>
         a.copy(arguments = arguments.map(_.mapExpressions(desugarExpression)))
-      case _: Definition.UnionType => definition
       case _: Method.Explicit =>
         throw new CompilerError(
           "Explicit method definitions should not exist during function " +

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/DocumentationComments.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/DocumentationComments.scala
@@ -148,10 +148,6 @@ case object DocumentationComments extends IRPass {
           "Conversion methods should not yet be present in the compiler " +
           "pipeline."
         )
-      case _: IR.Module.Scope.Definition.UnionType =>
-        throw new CompilerError(
-          "Union types should not yet be present in the compiler pipeline."
-        )
       case method: IR.Module.Scope.Definition.Method.Binding =>
         method.copy(body = resolveExpression(method.body))
       case method: IR.Module.Scope.Definition.Method.Explicit =>

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/SuspendedArguments.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/SuspendedArguments.scala
@@ -176,7 +176,6 @@ case object SuspendedArguments extends IRPass {
         }
       case _: Method.Binding       => throw new CompilerError("")
       case atom: Definition.Atom   => atom
-      case _: Definition.UnionType => binding
       case err: IR.Error           => err
       case _: Definition.Type =>
         throw new CompilerError(

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/TypeSignatures.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/TypeSignatures.scala
@@ -137,7 +137,6 @@ case object TypeSignatures extends IRPass {
         res
       case atom: IR.Module.Scope.Definition.Atom =>
         Some(atom.mapExpressions(resolveExpression))
-      case ut: IR.Module.Scope.Definition.UnionType => Some(ut)
       case err: IR.Error                            => Some(err)
       case _: IR.Module.Scope.Definition.Type =>
         throw new CompilerError(

--- a/engine/runtime/src/main/scala/org/enso/compiler/phase/StubIrBuilder.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/phase/StubIrBuilder.scala
@@ -3,10 +3,10 @@ package org.enso.compiler.phase
 import org.enso.compiler.core.IR
 import org.enso.compiler.core.ir.MetadataStorage._
 import org.enso.compiler.data.BindingsMap
-import org.enso.compiler.data.BindingsMap.{ModuleReference, ResolvedConstructor, ResolvedMethod}
 import org.enso.compiler.pass.analyse.BindingAnalysis
 import org.enso.interpreter.runtime.Module
 
+import scala.collection.immutable.ArraySeq
 import scala.jdk.CollectionConverters._
 
 /** Builds an IR stub. This is useful for source-less modules (such as
@@ -31,7 +31,7 @@ object StubIrBuilder {
           cons.getArity,
           allFieldsDefaulted = false,
           builtinType = false,
-          variants = cons.getVariants.map(_.getName)
+          variants = ArraySeq.unsafeWrapArray(cons.getVariants).map(_.getName)
         );
       }
     val moduleMethods = Option(scope.getMethods.get(scope.getAssociatedType))
@@ -47,16 +47,16 @@ object StubIrBuilder {
     val exportedBindings = definedConstructors.map(c =>
       (
         c.name.toLowerCase,
-        List(ResolvedConstructor(ModuleReference.Concrete(module), c))
+        List(BindingsMap.ResolvedConstructor(BindingsMap.ModuleReference.Concrete(module), c))
       )
     ) ++ moduleMethods.map(m =>
-      (m.name, List(ResolvedMethod(ModuleReference.Concrete(module), m)))
+      (m.name, List(BindingsMap.ResolvedMethod(BindingsMap.ModuleReference.Concrete(module), m)))
     )
     val meta = BindingsMap(
       definedConstructors,
       polyglot,
       moduleMethods,
-      ModuleReference.Concrete(module)
+      BindingsMap.ModuleReference.Concrete(module)
     )
     meta.exportedSymbols = exportedBindings.toMap
     ir.updateMetadata(BindingAnalysis -->> meta)

--- a/engine/runtime/src/main/scala/org/enso/compiler/phase/StubIrBuilder.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/phase/StubIrBuilder.scala
@@ -3,11 +3,7 @@ package org.enso.compiler.phase
 import org.enso.compiler.core.IR
 import org.enso.compiler.core.ir.MetadataStorage._
 import org.enso.compiler.data.BindingsMap
-import org.enso.compiler.data.BindingsMap.{
-  ModuleReference,
-  ResolvedConstructor,
-  ResolvedMethod
-}
+import org.enso.compiler.data.BindingsMap.{ModuleReference, ResolvedConstructor, ResolvedMethod}
 import org.enso.compiler.pass.analyse.BindingAnalysis
 import org.enso.interpreter.runtime.Module
 
@@ -30,7 +26,13 @@ object StubIrBuilder {
     val consNames = conses.keys.map(_.toLowerCase()).toSet
     val definedConstructors: List[BindingsMap.Cons] =
       conses.toList.map { case (name, cons) =>
-        BindingsMap.Cons(name, cons.getArity, allFieldsDefaulted = false)
+        BindingsMap.Cons(
+          name,
+          cons.getArity,
+          allFieldsDefaulted = false,
+          builtinType = false,
+          variants = cons.getVariants.map(_.getName)
+        );
       }
     val moduleMethods = Option(scope.getMethods.get(scope.getAssociatedType))
       .map(methods =>
@@ -51,7 +53,6 @@ object StubIrBuilder {
       (m.name, List(ResolvedMethod(ModuleReference.Concrete(module), m)))
     )
     val meta = BindingsMap(
-      List(),
       definedConstructors,
       polyglot,
       moduleMethods,

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/CompilerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/CompilerTest.scala
@@ -212,6 +212,7 @@ trait CompilerRunner {
               None
             )
         ),
+        List(),
         None
       )
     }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/GatherDiagnosticsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/GatherDiagnosticsTest.scala
@@ -92,6 +92,7 @@ class GatherDiagnosticsTest extends CompilerTest {
               IR.DefinitionArgument
                 .Specified(fooName, None, Some(error2), suspended = false, None)
             ),
+            List(),
             None
           ),
           IR.Module.Scope.Definition.Method

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/ComplexTypeTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/ComplexTypeTest.scala
@@ -82,7 +82,7 @@ class ComplexTypeTest extends CompilerTest {
 
       exactly(2, ir.bindings) shouldBe a[Definition.Atom]
       ir.bindings(0)
-        .asInstanceOf[Definition.UnionType]
+        .asInstanceOf[Definition.Type]
         .name
         .name shouldEqual "MyType"
       ir.bindings(1).asInstanceOf[Definition.Atom].name.name shouldEqual "Foo"

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Any.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Any.enso
@@ -1,3 +1,3 @@
-type Any
+type Any_Tp
     @Builtin_Type
     type Any

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
@@ -1,4 +1,4 @@
-type Array
+type Array_Tp
     @Builtin_Type
     type Array
 

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Boolean.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Boolean.enso
@@ -1,4 +1,4 @@
-type Boolean
+type Boolean_Tp
     @Builtin_Type
     type Boolean
 

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
@@ -1,7 +1,7 @@
-type Number
+type Number_Tp
     @Builtin_Type
     type Number
 
-type Integer
+type Integer_Tp
     @Builtin_Type
     type Integer

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text.enso
@@ -1,3 +1,3 @@
-type Text
+type Text_Tp
     @Builtin_Type
     type Text

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
@@ -3,7 +3,7 @@ polyglot java import java.time.format.DateTimeFormatter
 
 new year (month = 1) (day = 1) = LocalDate.of year month day
 
-type Date
+type Date_Tp
     type Date internal_local_date
     year = this . internal_local_date . getYear
     month = this . internal_local_date . getMonthValue

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Error/Common.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Error/Common.enso
@@ -1,4 +1,4 @@
-type Panic
+type Panic_Tp
     @Builtin_Type
     type Panic
     throw payload = @Builtin_Method "Panic.throw"
@@ -19,7 +19,7 @@ type Inexhaustive_Pattern_Match_Error scrutinee
 @Builtin_Type
 type Arity_Error expected_min expected_max actual
 
-type Error
+type Error_Tp
     @Builtin_Type
     type Error
     throw payload = @Builtin_Method "Error.throw"

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Nothing.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Nothing.enso
@@ -1,3 +1,3 @@
-type Nothing
+type Nothing_Tp
     @Builtin_Type
     type Nothing

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Polyglot.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Polyglot.enso
@@ -1,4 +1,4 @@
-type Polyglot
+type Polyglot_Tp
     @Builtin_Type
     type Polyglot
 get_array_size array = @Builtin_Method "Polyglot.get_array_size"

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/Resource.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/Resource.enso
@@ -1,7 +1,7 @@
 bracket : Any -> (Any -> Nothing) -> (Any -> Any) -> Any
 bracket ~constructor ~destructor ~action = @Builtin_Method "Resource.bracket"
 
-type Managed_Resource
+type Managed_Resource_Tp
     @Builtin_Type
     type Managed_Resource
     register resource function = @Builtin_Method "Managed_Resource.register"


### PR DESCRIPTION
### Pull Request Description

This is a work-in-progress draft PR of what we need to get type constructors to exist for real in the compiler.

### Important Notes

This removes ResolvedTypeName, and merges it with ResolvedName. It then expands AtomConstructor with `parentType` and `variants` information. `variants` being the name used internally for member types of the parent type.

Open issues:

Status: This now pulls the information from the right place, but doesn't yet populate all of that information.

We need to populate the parent side of the code I ported from Marcin's branch and the child portion of my code to make the two engines work together.

I've yet to fully fix the test suite, though I _started_ with a couple of errors due to resource exhaustion that don't appear to be caused by me.

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH `./run dist` and `./run watch`.
