### PR TITLE
Restrict annotation processors in interpreter-dsl

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -987,6 +987,10 @@ lazy val `interpreter-dsl` = (project in file("lib/scala/interpreter-dsl"))
   .settings(
     version := "0.1",
     frgaalJavaCompilerSetting,
+    Compile / javacOptions := ((Compile / javacOptions).value ++
+      // Only run ServiceProvider processor and ignore those defined in META-INF, thus
+      // fixing incremental compilation setup
+      Seq("-processor", "org.netbeans.modules.openide.util.ServiceProviderProcessor")),
     libraryDependencies ++= Seq(
       "org.apache.commons" % "commons-lang3"           % commonsLangVersion,
       "org.netbeans.api"   % "org-openide-util-lookup" % "RELEASE130"


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

`interpreter-dsl` should only attempt to run explicitly specified
processors. That way, even if the generated
`META-INF/services/javax.annotation.processing.Processor` is present,
it does not attempt to apply those processors on itself.

This change makes errors related to
```
[warn] Unexpected javac output: error: Bad service configuration file, or
exception thrown while constructing Processor object:
javax.annotation.processing.Processor: Provider org.enso.interpreter.dsl....
```
a thing of the past. This was supper annoying when switching branches and
required to either clean the project or remove the file by hand.

Related to https://www.pivotaltracker.com/story/show/182297597
