### PR TITLE
Allow trailing slash in `ENSO_HTTP_TEST_HTTPBIN_URL`.

### DIFF
--- a/test/Tests/README.md
+++ b/test/Tests/README.md
@@ -3,4 +3,4 @@ This is a set of tests for the `Base` library for Enso.
 The run test suite for the HTTP component requires an active `httbin` server on
 the localhost. If it is present, the port it listens to should be provided by
 setting the `ENSO_HTTP_TEST_HTTPBIN_URL` environment variable to a value like
-`http://localhost:8080`. The URL should not contain a trailing slash.
+`http://localhost:8080`. The URL may contain a trailing slash.

--- a/test/Tests/src/Network/Http_Spec.enso
+++ b/test/Tests/src/Network/Http_Spec.enso
@@ -23,8 +23,12 @@ spec =
         The HTTP tests only run when the `ENSO_HTTP_TEST_HTTPBIN_URL` environment variable is set to URL of the httpbin server
 
     Test.group "Http" pending=pending <|
-        url_get = base_url + "/get"
-        url_post = base_url + "/post"
+        # httpbin is picky about slashes in URL path. We need exactly one at the
+        # beginning of path. Otherwise, POST request with double slash would
+        # fail with error 405. 
+        base_url_with_slash = if base_url.ends_with "/" then base_url else base_url + "/"
+        url_get = base_url_with_slash + "get"
+        url_post = base_url_with_slash + "post"
         Test.specify "should create HTTP client with timeout setting" <|
             http = Http.new (timeout = 30.seconds)
             http.timeout.should_equal 30.seconds


### PR DESCRIPTION
### Pull Request Description
When trying to bump the build script used for Engine builds, I noticed a failure in our standard library test. New build script passes `ENSO_HTTP_TEST_HTTPBIN_URL` with a trailing slash, like `http://localhost:45436/`. Since the tests just append `/post` to the URL, we end up with double slash and tests fail.

This PR adds a check, so both formats are supported now.

[ci no changelog needed]

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run.sh ide dist` and `./run.sh ide watch`.
