### PR TITLE
Fix runtime-with-instruments dependency on runtime

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1353,7 +1353,7 @@ lazy val `runtime-with-instruments`  = (project in file("engine/runtime-with-ins
       case _ => MergeStrategy.first
     }
   )
-  .dependsOn(runtime % "compile->compile;test->test")
+  .dependsOn(runtime % "compile->compile;test->test;runtime->runtime")
   .dependsOn(`runtime-instrument-id-execution`)
   .dependsOn(`runtime-instrument-repl-debugger`)
   .dependsOn(`runtime-instrument-runtime-server`)


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

This change makes sure that Runtime configuration of `runtime` is listed
as a dependency of `runtime-with-instruments`.
That way `buildEngineDistribution` which indirectly depends on
`runtime-with-instruments`/assembly triggers compilation for std-bits,
if necessary.

### Important Notes

Minor adjustments for a problem introduced in https://github.com/enso-org/enso/pull/3509

