### PR TITLE
introduce a micro stdlib for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,7 @@
 - [Added a full-blown DSL for builtins][3471]
 - [Lazy evaluation of RHS argument for || and &&][3492]
 - [Drop Core implementation of IR][3512]
+- [Introduce a smaller version of the standard library, just for testing][3531]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -273,6 +274,7 @@
 [3493]: https://github.com/enso-org/enso/pull/3493
 [3505]: https://github.com/enso-org/enso/pull/3505
 [3512]: https://github.com/enso-org/enso/pull/3512
+[3531]: https://github.com/enso-org/enso/pull/3531
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
@@ -66,6 +66,11 @@ public class RuntimeOptions {
   private static final OptionDescriptor LANGUAGE_HOME_OVERRIDE_DESCRIPTOR =
       OptionDescriptor.newBuilder(LANGUAGE_HOME_OVERRIDE_KEY, LANGUAGE_HOME_OVERRIDE).build();
 
+  public static final String EDITION_OVERRIDE = optionName("editionOverride");
+  public static final OptionKey<String> EDITION_OVERRIDE_KEY = new OptionKey<>("");
+  private static final OptionDescriptor EDITION_OVERRIDE_DESCRIPTOR =
+      OptionDescriptor.newBuilder(EDITION_OVERRIDE_KEY, EDITION_OVERRIDE).build();
+
   public static final String DISABLE_IR_CACHES = optionName("disableIrCaches");
   public static final OptionKey<Boolean> DISABLE_IR_CACHES_KEY = new OptionKey<>(false);
   private static final OptionDescriptor DISABLE_IR_CACHES_DESCRIPTOR =
@@ -98,6 +103,7 @@ public class RuntimeOptions {
               ENABLE_GLOBAL_SUGGESTIONS_DESCRIPTOR,
               INTERACTIVE_MODE_DESCRIPTOR,
               LANGUAGE_HOME_OVERRIDE_DESCRIPTOR,
+              EDITION_OVERRIDE_DESCRIPTOR,
               INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION_DESCRIPTOR,
               DISABLE_IR_CACHES_DESCRIPTOR,
               WAIT_FOR_PENDING_SERIALIZATION_JOBS_DESCRIPTOR,

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
@@ -69,7 +69,7 @@ class RuntimeErrorsTest
         .option(RuntimeOptions.INTERACTIVE_MODE, "true")
         .option(
           RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-          Paths.get("../../distribution/component").toFile.getAbsolutePath
+          Paths.get("../../test/micro-distribution/component").toFile.getAbsolutePath
         )
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
@@ -74,6 +74,7 @@ class RuntimeErrorsTest
             .toFile
             .getAbsolutePath
         )
+        .options(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
@@ -74,7 +74,7 @@ class RuntimeErrorsTest
             .toFile
             .getAbsolutePath
         )
-        .options(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
+        .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
@@ -69,7 +69,10 @@ class RuntimeErrorsTest
         .option(RuntimeOptions.INTERACTIVE_MODE, "true")
         .option(
           RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-          Paths.get("../../test/micro-distribution/component").toFile.getAbsolutePath
+          Paths
+            .get("../../test/micro-distribution/component")
+            .toFile
+            .getAbsolutePath
         )
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
@@ -67,6 +67,7 @@ class RuntimeInstrumentTest
             .toFile
             .getAbsolutePath
         )
+        .options(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
@@ -62,7 +62,10 @@ class RuntimeInstrumentTest
         .option(RuntimeOptions.INTERACTIVE_MODE, "true")
         .option(
           RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-          Paths.get("../../test/micro-distribution/component").toFile.getAbsolutePath
+          Paths
+            .get("../../test/micro-distribution/component")
+            .toFile
+            .getAbsolutePath
         )
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
@@ -67,7 +67,7 @@ class RuntimeInstrumentTest
             .toFile
             .getAbsolutePath
         )
-        .options(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
+        .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
@@ -62,7 +62,7 @@ class RuntimeInstrumentTest
         .option(RuntimeOptions.INTERACTIVE_MODE, "true")
         .option(
           RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-          Paths.get("../../distribution/component").toFile.getAbsolutePath
+          Paths.get("../../test/micro-distribution/component").toFile.getAbsolutePath
         )
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeProjectContextTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeProjectContextTest.scala
@@ -22,7 +22,10 @@ class RuntimeProjectContextTest extends AnyWordSpec with Matchers {
           )
           .option(
             RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-            Paths.get("../../test/micro-distribution/component").toFile.getAbsolutePath
+            Paths
+              .get("../../test/micro-distribution/component")
+              .toFile
+              .getAbsolutePath
           )
           .option(RuntimeOptions.LOG_LEVEL, "WARNING")
           .build()

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeProjectContextTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeProjectContextTest.scala
@@ -22,7 +22,7 @@ class RuntimeProjectContextTest extends AnyWordSpec with Matchers {
           )
           .option(
             RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-            Paths.get("../../distribution/component").toFile.getAbsolutePath
+            Paths.get("../../test/micro-distribution/component").toFile.getAbsolutePath
           )
           .option(RuntimeOptions.LOG_LEVEL, "WARNING")
           .build()

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeProjectContextTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeProjectContextTest.scala
@@ -27,7 +27,7 @@ class RuntimeProjectContextTest extends AnyWordSpec with Matchers {
               .toFile
               .getAbsolutePath
           )
-          .options(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
+          .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
           .option(RuntimeOptions.LOG_LEVEL, "WARNING")
           .build()
         context.initialize(LanguageInfo.ID)

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeProjectContextTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeProjectContextTest.scala
@@ -27,6 +27,7 @@ class RuntimeProjectContextTest extends AnyWordSpec with Matchers {
               .toFile
               .getAbsolutePath
           )
+          .options(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
           .option(RuntimeOptions.LOG_LEVEL, "WARNING")
           .build()
         context.initialize(LanguageInfo.ID)

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -72,6 +72,7 @@ class RuntimeServerTest
             .toFile
             .getAbsolutePath
         )
+        .options(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
         .logHandler(logOut)
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -72,7 +72,7 @@ class RuntimeServerTest
             .toFile
             .getAbsolutePath
         )
-        .options(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
+        .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
         .logHandler(logOut)
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -67,7 +67,7 @@ class RuntimeServerTest
         .option(RuntimeOptions.INTERACTIVE_MODE, "true")
         .option(
           RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-          Paths.get("../../distribution/component").toFile.getAbsolutePath
+          Paths.get("../../test/micro-distribution/component").toFile.getAbsolutePath
         )
         .logHandler(logOut)
         .out(out)

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -67,7 +67,10 @@ class RuntimeServerTest
         .option(RuntimeOptions.INTERACTIVE_MODE, "true")
         .option(
           RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-          Paths.get("../../test/micro-distribution/component").toFile.getAbsolutePath
+          Paths
+            .get("../../test/micro-distribution/component")
+            .toFile
+            .getAbsolutePath
         )
         .logHandler(logOut)
         .out(out)

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
@@ -55,7 +55,10 @@ class RuntimeSuggestionUpdatesTest
         .option(RuntimeOptions.INTERACTIVE_MODE, "true")
         .option(
           RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-          Paths.get("../../test/micro-distribution/component").toFile.getAbsolutePath
+          Paths
+            .get("../../test/micro-distribution/component")
+            .toFile
+            .getAbsolutePath
         )
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
@@ -55,7 +55,7 @@ class RuntimeSuggestionUpdatesTest
         .option(RuntimeOptions.INTERACTIVE_MODE, "true")
         .option(
           RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-          Paths.get("../../distribution/component").toFile.getAbsolutePath
+          Paths.get("../../test/micro-distribution/component").toFile.getAbsolutePath
         )
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
@@ -60,7 +60,7 @@ class RuntimeSuggestionUpdatesTest
             .toFile
             .getAbsolutePath
         )
-        .options(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
+        .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
@@ -60,6 +60,7 @@ class RuntimeSuggestionUpdatesTest
             .toFile
             .getAbsolutePath
         )
+        .options(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()

--- a/engine/runtime/src/main/java/org/enso/interpreter/OptionsHelper.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/OptionsHelper.java
@@ -34,4 +34,12 @@ public class OptionsHelper {
       return Optional.of(option);
     }
   }
+  public static Optional<String> getEditionOverride(TruffleLanguage.Env env) {
+    String option = env.getOptions().get(RuntimeOptions.EDITION_OVERRIDE_KEY);
+    if (option.equals("")) {
+      return Optional.empty();
+    } else {
+      return Optional.of(option);
+    }
+  }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/OptionsHelper.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/OptionsHelper.java
@@ -34,6 +34,7 @@ public class OptionsHelper {
       return Optional.of(option);
     }
   }
+
   public static Optional<String> getEditionOverride(TruffleLanguage.Env env) {
     String option = env.getOptions().get(RuntimeOptions.EDITION_OVERRIDE_KEY);
     if (option.equals("")) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Context.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Context.java
@@ -128,12 +128,14 @@ public class Context {
 
     Optional<String> languageHome =
         OptionsHelper.getLanguageHomeOverride(environment).or(() -> Optional.ofNullable(home));
+    var editionOverride = OptionsHelper.getEditionOverride(environment);
     var resourceManager = new org.enso.distribution.locking.ResourceManager(lockManager);
 
     packageRepository =
         PackageRepository.initializeRepository(
             OptionConverters.toScala(projectPackage),
             OptionConverters.toScala(languageHome),
+            OptionConverters.toScala(editionOverride),
             distributionManager,
             resourceManager,
             this,

--- a/engine/runtime/src/main/scala/org/enso/compiler/PackageRepository.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/PackageRepository.scala
@@ -5,7 +5,7 @@ import com.typesafe.scalalogging.Logger
 import org.enso.distribution.locking.ResourceManager
 import org.enso.distribution.{DistributionManager, LanguageHome}
 import org.enso.editions.updater.EditionManager
-import org.enso.editions.{DefaultEdition, LibraryName, LibraryVersion}
+import org.enso.editions.{DefaultEdition, Editions, LibraryName, LibraryVersion}
 import org.enso.interpreter.instrument.NotificationHandler
 import org.enso.interpreter.runtime.builtin.Builtins
 import org.enso.interpreter.runtime.util.TruffleFileSystem
@@ -27,7 +27,6 @@ import org.enso.pkg.{
 }
 
 import java.nio.file.Path
-
 import scala.collection.immutable.ListSet
 import scala.util.Try
 
@@ -537,14 +536,19 @@ object PackageRepository {
   def initializeRepository(
     projectPackage: Option[Package[TruffleFile]],
     languageHome: Option[String],
+    editionOverride: Option[String],
     distributionManager: DistributionManager,
     resourceManager: ResourceManager,
     context: Context,
     builtins: Builtins,
     notificationHandler: NotificationHandler
   ): PackageRepository = {
-    val rawEdition = projectPackage
-      .flatMap(_.config.edition)
+    val rawEdition = editionOverride
+      .map(v => Editions.Raw.Edition(parent = Some(v)))
+      .orElse(
+        projectPackage
+          .flatMap(_.config.edition)
+      )
       .getOrElse(DefaultEdition.getDefaultEdition)
 
     val homeManager    = languageHome.map { home => LanguageHome(Path.of(home)) }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/InterpreterTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/InterpreterTest.scala
@@ -114,6 +114,7 @@ class InterpreterContext(
           .toFile
           .getAbsolutePath
       )
+      .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
       .serverTransport { (uri, peer) =>
         if (uri.toString == DebugServerInfo.URI) {
           new DebuggerSessionManagerEndpoint(sessionManager, peer)

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/InterpreterTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/InterpreterTest.scala
@@ -109,7 +109,7 @@ class InterpreterContext(
       .in(in)
       .option(
         RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-        Paths.get("../../distribution/component").toFile.getAbsolutePath
+        Paths.get("../../test/micro-distribution/component").toFile.getAbsolutePath
       )
       .serverTransport { (uri, peer) =>
         if (uri.toString == DebugServerInfo.URI) {

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/InterpreterTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/InterpreterTest.scala
@@ -109,7 +109,10 @@ class InterpreterContext(
       .in(in)
       .option(
         RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-        Paths.get("../../test/micro-distribution/component").toFile.getAbsolutePath
+        Paths
+          .get("../../test/micro-distribution/component")
+          .toFile
+          .getAbsolutePath
       )
       .serverTransport { (uri, peer) =>
         if (uri.toString == DebugServerInfo.URI) {

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/PackageTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/PackageTest.scala
@@ -25,7 +25,7 @@ trait PackageTest extends AnyFlatSpec with Matchers with ValueEquality {
       .option(RuntimeOptions.PROJECT_ROOT, pkgPath.getAbsolutePath)
       .option(
         RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-        Paths.get("../../distribution/component").toFile.getAbsolutePath
+        Paths.get("../../test/micro-distribution/component").toFile.getAbsolutePath
       )
       .option(RuntimeOptions.STRICT_ERRORS, "true")
       .option(RuntimeOptions.DISABLE_IR_CACHES, "true")

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/PackageTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/PackageTest.scala
@@ -30,6 +30,7 @@ trait PackageTest extends AnyFlatSpec with Matchers with ValueEquality {
           .toFile
           .getAbsolutePath
       )
+      .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
       .option(RuntimeOptions.STRICT_ERRORS, "true")
       .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
       .out(output)

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/PackageTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/PackageTest.scala
@@ -25,7 +25,10 @@ trait PackageTest extends AnyFlatSpec with Matchers with ValueEquality {
       .option(RuntimeOptions.PROJECT_ROOT, pkgPath.getAbsolutePath)
       .option(
         RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-        Paths.get("../../test/micro-distribution/component").toFile.getAbsolutePath
+        Paths
+          .get("../../test/micro-distribution/component")
+          .toFile
+          .getAbsolutePath
       )
       .option(RuntimeOptions.STRICT_ERRORS, "true")
       .option(RuntimeOptions.DISABLE_IR_CACHES, "true")

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/TextTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/TextTest.scala
@@ -105,16 +105,15 @@ class TextTest extends InterpreterTest {
     "support converting values to display texts" in {
       val code =
         """
-          |from Standard.Base.Data.List import Cons
+          |from Standard.Base.Data.List import Cons, Nil
           |from Standard.Base.Error.Common import all
-          |import Standard.Base.Data.Text
           |import Standard.Base.IO
           |import Standard.Base.Nothing
           |
           |main =
           |    IO.println (Cons Nothing Nothing).to_display_text
           |    IO.println (Syntax_Error "foo").to_display_text
-          |    IO.println (Type_Error Nothing Text "myvar").to_display_text
+          |    IO.println (Type_Error Nothing Nil "myvar").to_display_text
           |    IO.println (Compile_Error "error :(").to_display_text
           |    IO.println (Inexhaustive_Pattern_Match_Error 32).to_display_text
           |    IO.println (Arithmetic_Error "cannot frobnicate quaternions").to_display_text
@@ -126,7 +125,7 @@ class TextTest extends InterpreterTest {
       consumeOut shouldEqual List(
         "Cons",
         "Syntax error: foo",
-        "Type error: expected `myvar` to be Nothing, but got Text.",
+        "Type error: expected `myvar` to be Nothing, but got Nil.",
         "Compile error: error :(",
         "Inexhaustive pattern match: no branch matches 32 (Integer).",
         "Arithmetic error: cannot frobnicate quaternions",

--- a/test/micro-distribution/editions/0.0.0-dev.yaml
+++ b/test/micro-distribution/editions/0.0.0-dev.yaml
@@ -1,0 +1,8 @@
+engine-version: 0.0.0-dev
+repositories:
+  - name: main
+    url: https://libraries.release.enso.org/libraries
+libraries:
+  - name: Standard.Base
+    repository: main
+    version: 0.0.0-dev

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/manifest.yaml
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/manifest.yaml
@@ -1,0 +1,3 @@
+archives:
+- main.tgz
+dependencies: []

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/manifest.yaml
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/manifest.yaml
@@ -1,3 +1,3 @@
 archives:
-- main.tgz
+  - main.tgz
 dependencies: []

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/package.yaml
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/package.yaml
@@ -1,0 +1,10 @@
+name: Base
+namespace: Standard
+version: 0.0.0-dev
+license: APLv2
+authors:
+  - name: Enso Team
+    email: contact@enso.org
+maintainers:
+  - name: Enso Team
+    email: contact@enso.org

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Any.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Any.enso
@@ -1,0 +1,3 @@
+type Any
+    @Builtin_Type
+    type Any

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
@@ -1,0 +1,7 @@
+type Array
+    @Builtin_Type
+    type Array
+
+new_1 item_1 = @Builtin_Method "Array.new_1"
+new_2 item_1 item_2 = @Builtin_Method "Array.new_2"
+empty = @Builtin_Method "Array.empty"

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Boolean.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Boolean.enso
@@ -1,0 +1,11 @@
+type Boolean
+    @Builtin_Type
+    type Boolean
+
+    if_then_else ~on_true ~on_false = @Builtin_Method "Boolean.if_then_else"
+
+@Builtin_Type
+type True
+
+@Builtin_Type
+type False

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/List.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/List.enso
@@ -1,0 +1,3 @@
+type List
+    type Nil
+    type Cons x xs

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
@@ -1,0 +1,7 @@
+type Number
+    @Builtin_Type
+    type Number
+
+type Integer
+    @Builtin_Type
+    type Integer

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text.enso
@@ -1,0 +1,3 @@
+type Text
+    @Builtin_Type
+    type Text

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
@@ -1,0 +1,11 @@
+polyglot java import java.time.LocalDate
+polyglot java import java.time.format.DateTimeFormatter
+
+new year (month = 1) (day = 1) = LocalDate.of year month day
+
+type Date
+    type Date internal_local_date
+    year = this . internal_local_date . getYear
+    month = this . internal_local_date . getMonthValue
+    day = this . internal_local_date . getDayOfMonth
+    to_text = DateTimeFormatter.ISO_LOCAL_DATE.format this.internal_local_date

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Error/Common.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Error/Common.enso
@@ -1,0 +1,27 @@
+type Panic
+    @Builtin_Type
+    type Panic
+    throw payload = @Builtin_Method "Panic.throw"
+    catch_primitive ~action handler = @Builtin_Method "Panic.catch_primitive"
+
+@Builtin_Type
+type Syntax_Error message
+@Builtin_Type
+type Polyglot_Error cause
+@Builtin_Type
+type Arithmetic_Error message
+@Builtin_Type
+type Type_Error expected actual name
+@Builtin_Type
+type Compile_Error message
+@Builtin_Type
+type Inexhaustive_Pattern_Match_Error scrutinee
+@Builtin_Type
+type Arity_Error expected_min expected_max actual
+
+type Error
+    @Builtin_Type
+    type Error
+    throw payload = @Builtin_Method "Error.throw"
+    catch_primitive handler = @Builtin_Method "Error.catch_primitive"
+    catch (handler = x->x) = this.catch_primitive handler

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/IO.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/IO.enso
@@ -1,0 +1,3 @@
+print_err message = @Builtin_Method "IO.print_err"
+println message = @Builtin_Method "IO.println"
+readln = @Builtin_Method "IO.readln"

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Main.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Main.enso
@@ -1,0 +1,20 @@
+import project.IO
+export project.IO
+
+import project.Data.List
+from project.Data.List export Nil, Cons, List
+
+import project.Polyglot
+from project.Polyglot export all
+
+export project.Polyglot.Java
+import project.Polyglot.Java
+
+import project.Data.Array
+from project.Data.Array export Array
+
+import project.Error.Common
+from project.Error.Common export all
+
+import project.Data.Numbers
+from project.Data.Numbers export Number

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Nothing.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Nothing.enso
@@ -1,0 +1,3 @@
+type Nothing
+    @Builtin_Type
+    type Nothing

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Polyglot.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Polyglot.enso
@@ -1,0 +1,13 @@
+type Polyglot
+    @Builtin_Type
+    type Polyglot
+get_array_size array = @Builtin_Method "Polyglot.get_array_size"
+execute callable arguments = @Builtin_Method "Polyglot.execute"
+get_member object member_name = @Builtin_Method "Polyglot.get_member"
+get_members object = @Builtin_Method "Polyglot.get_members"
+new constructor arguments = @Builtin_Method "Polyglot.new"
+invoke target name arguments = @Builtin_Method "Polyglot.invoke"
+has_source_location value = @Builtin_Method "Polyglot.has_source_location"
+get_source_location value = @Builtin_Method "Polyglot.get_source_location"
+is_language_installed language_name = @Builtin_Method "Polyglot.is_language_installed"
+get_executable_name = @Builtin_Method "Polyglot.get_executable_name"

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Polyglot/Java.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Polyglot/Java.enso
@@ -1,0 +1,1 @@
+lookup_class name = @Builtin_Method "Java.lookup_class"

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/Debug.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/Debug.enso
@@ -1,0 +1,2 @@
+eval expression = @Builtin_Method "Debug.eval"
+breakpoint = @Builtin_Method "Debug.breakpoint"

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/Resource.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/Resource.enso
@@ -1,0 +1,10 @@
+bracket : Any -> (Any -> Nothing) -> (Any -> Any) -> Any
+bracket ~constructor ~destructor ~action = @Builtin_Method "Resource.bracket"
+
+type Managed_Resource
+    @Builtin_Type
+    type Managed_Resource
+    register resource function = @Builtin_Method "Managed_Resource.register"
+    finalize = @Builtin_Method "Managed_Resource.finalize"
+    with ~action = @Builtin_Method "Managed_Resource.with"
+    take = @Builtin_Method "Managed_Resource.take"

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/State.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/State.enso
@@ -1,0 +1,3 @@
+run key local_state ~computation = @Builtin_Method "State.run"
+get key = @Builtin_Method "State.get"
+put key new_state = @Builtin_Method "State.put"

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/Thread.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/Thread.enso
@@ -1,0 +1,1 @@
+with_interrupt_handler ~action ~interrupt_handler = @Builtin_Method "Thread.with_interrupt_handler"

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/System.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/System.enso
@@ -1,0 +1,4 @@
+create_process command arguments input redirect_in redirect_out redirect_err = @Builtin_Method "System.create_process"
+
+@Builtin_Type
+type System_Process_Result exit_code stdout stderr


### PR DESCRIPTION
### Pull Request Description
This introduces a tiny alternative to our stdlib, that can be used for testing the interpreter. There are 2 main advantages of such a solution:
1. Performance: on my machine, `runtime-with-intstruments/test` drops from 146s to 65s, while `runtime/test` drops from 165s to 51s. >6 mins total becoming <2 mins total is awesome. This alone means I'll drink less coffee in these breaks and will be healthier.
2. Better separation of concepts – currently working on a feature that breaks _all_ enso code. The dependency of interpreter tests on the stdlib means I have no means of incremental testing – ALL of stdlib must compile. This is horrible, rendered my work impossible, and resulted in this PR.

### Important Notes

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide dist` and `./run ide watch`.
