### PR TITLE
Fail `bin/enso --run` when there is an error in the script

### DIFF
--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -752,9 +752,9 @@ object Main {
     rootPkgPath: Option[File],
     mainMethodName: String = "main"
   ): Unit = {
-    val mainCons = mainModule.getAssociatedConstructor
-    val mainFun  = mainModule.getMethod(mainCons, mainMethodName)
     try {
+      val mainCons = mainModule.getAssociatedConstructor
+      val mainFun  = mainModule.getMethod(mainCons, mainMethodName)
       mainFun match {
         case Some(main) => main.execute(mainCons.newInstance())
         case None =>


### PR DESCRIPTION
[ci no changelog needed]

Let Main launcher catch exception from compiler and fail the execution with exitcode 1

### Pull Request Description

I was modifying `Date_Spec.enso` today and made a mistake. When executing with I could see the error, but the process got stuck...
```
enso/test/Tests/src/Data/Time$ ../../../../built-distribution/enso-engine-0.0.0-dev-linux-amd64/enso-0.0.0-dev/bin/enso --run Date_Spec.enso In module Date_Spec:
Compiler encountered warnings:
Date_Spec.enso[14:29-14:37]: Unused function argument parseDate.
Compiler encountered errors:
Date_Spec.enso[18:13-18:20]: Variable `debugger` is not defined.
Exception in thread "main" Compilation aborted due to errors.
        at org.graalvm.sdk/org.graalvm.polyglot.Value.invokeMember(Value.java:932)
        at org.enso.polyglot.Module.getAssociatedConstructor(Module.scala:19)
        at org.enso.runner.Main$.runMain(Main.scala:755)
        at org.enso.runner.Main$.runSingleFile(Main.scala:695)
        at org.enso.runner.Main$.run(Main.scala:582)
        at org.enso.runner.Main$.main(Main.scala:1031)
        at org.enso.runner.Main.main(Main.scala)
^C
```
...had to kill it with Ctrl-C. This PR fixes the problem by moving `getAssociatedConstructor` call into `try` block, catching the exception and exiting properly.

### Checklist

Please include the following checklist in your PR:

- [ x ] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md) style guides.
- All code has been tested:
  - Not really. Suggestions to properly test this welcomed!

