### PR TITLE
Fix broken AtomBenchmarks

### DIFF
--- a/engine/runtime/src/bench/scala/org/enso/interpreter/bench/fixtures/semantic/AtomFixtures.scala
+++ b/engine/runtime/src/bench/scala/org/enso/interpreter/bench/fixtures/semantic/AtomFixtures.scala
@@ -7,10 +7,10 @@ class AtomFixtures extends DefaultInterpreterRunner {
 
   val millionElementList = eval(
     s"""|from Standard.Base.Data.List import Cons,Nil
-        |from Standard.Base.Data.Range import all
         |
         |main =
-        |    res = (1.up_to $million).fold Nil (acc -> x -> Cons x acc)
+        |    generator fn acc i end = if i == end then acc else @Tail_Call generator fn (fn acc i) i+1 end
+        |    res = generator (acc -> x -> Cons x acc) Nil 1 $million
         |    res
         """.stripMargin)
 


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

`AtomBenchmarks` are broken since the introduction of [micro distribution](https://github.com/enso-org/enso/pull/3531). The micro distribution doesn't contain `Range` and as such one cannot use `1.up_to` method.

### Important Notes

I have rewritten enso code to manual `generator`. The results of the benchmark seem comparable. Executed as:
```
sbt:runtime> benchOnly AtomBenchmarks
```

### Checklist

Please include the following checklist in your PR:

- All code has been tested:
  - [ x ] Benchmark can be executed
