### PR TITLE
Disable MultiTier compilation in benchmarks

### DIFF
--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/BenchmarksRunner.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/BenchmarksRunner.java
@@ -32,8 +32,10 @@ public class BenchmarksRunner {
    * @return a {@link BenchmarkItem} containing current run result and historical results.
    */
   public BenchmarkItem run(String label) throws RunnerException, JAXBException {
-    Options benchmarkOptions =
-        new OptionsBuilder().jvmArgsAppend("-Xss16M").include("^" + label + "$").build();
+    Options benchmarkOptions = new OptionsBuilder()
+      .jvmArgsAppend("-Xss16M", "-Dpolyglot.engine.MultiTier=false")
+      .include("^" + label + "$")
+      .build();
     RunResult benchmarksResult = new Runner(benchmarkOptions).runSingle();
 
     Report report;


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

Truffle is using [MultiTier compilation](https://github.com/oracle/graal/commit/190e0b2bb79ed5acc073752c352c4c7fd192e3df) by default since 21.1.0. That mean every `RootNode` is compiled twice. However benchmarks only care about peak performance. Let's return back the previous behavior and compile only once after profiling in interpreter.

 
### Important Notes

This change does not influence the peak performance. Just the amount of IGV graphs produced from benchmarks when running:
```
enso$ sbt  "project runtime" "withDebug --dumpGraphs benchOnly -- AtomBenchmark"
``` 
is cut to half.

### Checklist

Please include the following checklist in your PR:

- [ x ] [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md) style guides.
- All code has been tested:
  - [ x ] By running benchmarks in both configurations
