### PR TITLE
Fix GitHub Releases Lookup

### DIFF
--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/releases/ReleaseProvider.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/releases/ReleaseProvider.scala
@@ -36,5 +36,8 @@ trait ReleaseProvider[ReleaseType] {
 }
 
 object ReleaseProvider {
+
+  val TagPrefix = "enso-"
+
   case class Version(version: SemVer, markedAsBroken: Boolean)
 }

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/releases/github/GithubRelease.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/releases/github/GithubRelease.scala
@@ -1,14 +1,12 @@
 package org.enso.runtimeversionmanager.releases.github
 
-import org.enso.runtimeversionmanager.releases.{Asset, Release}
+import org.enso.runtimeversionmanager.releases.{Asset, Release, ReleaseProvider}
 
 case class GithubRelease(release: GithubAPI.Release) extends Release {
 
-  /** @inheritdoc
-    */
-  override def tag: String = release.tag
+  /** @inheritdoc */
+  override def tag: String = ReleaseProvider.TagPrefix + release.tag
 
-  /** @inheritdoc
-    */
+  /** @inheritdoc */
   override def assets: Seq[Asset] = release.assets.map(GithubAsset)
 }

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/releases/github/GithubReleaseProvider.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/releases/github/GithubReleaseProvider.scala
@@ -1,7 +1,11 @@
 package org.enso.runtimeversionmanager.releases.github
 
 import org.enso.cli.task.TaskProgress
-import org.enso.runtimeversionmanager.releases.{Release, SimpleReleaseProvider}
+import org.enso.runtimeversionmanager.releases.{
+  Release,
+  ReleaseProvider,
+  SimpleReleaseProvider
+}
 
 import scala.util.Try
 
@@ -17,13 +21,15 @@ class GithubReleaseProvider(
 ) extends SimpleReleaseProvider {
   private val repo = GithubAPI.Repository(owner, repositoryName)
 
-  /** @inheritdoc
-    */
-  override def releaseForTag(tag: String): Try[Release] =
-    TaskProgress.waitForTask(GithubAPI.getRelease(repo, tag)).map(GithubRelease)
+  /** @inheritdoc */
+  override def releaseForTag(tag: String): Try[Release] = {
+    val gitHubTag = tag.stripPrefix(ReleaseProvider.TagPrefix)
+    TaskProgress
+      .waitForTask(GithubAPI.getRelease(repo, gitHubTag))
+      .map(GithubRelease)
+  }
 
-  /** @inheritdoc
-    */
+  /** @inheritdoc */
   override def listReleases(): Try[Seq[Release]] =
     GithubAPI.listReleases(repo).map(_.map(GithubRelease))
 }


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

GitHub CI creates releases without `enso-` prefix, while enso ecosystem uses tags with the prefix.

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] ~If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide dist` and `./run ide watch`.~
