### PR TITLE
Create execution context with provided id

### DIFF
--- a/docs/language-server/protocol-language-server.md
+++ b/docs/language-server/protocol-language-server.md
@@ -3224,7 +3224,10 @@ stack is empty.
 
 Sent from the client to the server to create a new execution context. Return
 capabilities [`executionContext/canModify`](#executioncontextcanmodify) and
-[`executionContext/receivesUpdates`](#executioncontextreceivesupdates).
+[`executionContext/receivesUpdates`](#executioncontextreceivesupdates). The
+command takes optional `contextId` parameter with the id to create. The command
+is idempotent and returns success if the context with provided id already
+exists.
 
 - **Type:** Request
 - **Direction:** Client -> Server
@@ -3234,7 +3237,9 @@ capabilities [`executionContext/canModify`](#executioncontextcanmodify) and
 #### Parameters
 
 ```typescript
-null;
+{
+  contextId?: ContextId
+}
 ```
 
 #### Result

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/CreateHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/CreateHandler.scala
@@ -39,8 +39,12 @@ class CreateHandler(
   override def receive: Receive = requestStage
 
   private def requestStage: Receive = {
-    case Request(ExecutionContextCreate, id, _) =>
-      contextRegistry ! CreateContextRequest(session)
+    case Request(
+          ExecutionContextCreate,
+          id,
+          params: ExecutionContextCreate.Params
+        ) =>
+      contextRegistry ! CreateContextRequest(session, params.contextId)
       val cancellable =
         context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
       context.become(responseStage(id, sender(), cancellable))

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
@@ -23,8 +23,12 @@ object ContextRegistryProtocol {
   /** A request to the context registry to create a new execution context.
     *
     * @param rpcSession reference to the client
+    * @param contextId the context id to create
     */
-  case class CreateContextRequest(rpcSession: JsonSession)
+  case class CreateContextRequest(
+    rpcSession: JsonSession,
+    contextId: Option[ContextId]
+  )
 
   /** A response about creation of a new execution context.
     *

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/ExecutionContextJsonMessages.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/ExecutionContextJsonMessages.scala
@@ -30,6 +30,17 @@ object ExecutionContextJsonMessages {
             }
             """
 
+  def executionContextCreateRequest(reqId: Int, contextId: Api.ContextId) =
+    json"""
+            { "jsonrpc": "2.0",
+              "method": "executionContext/create",
+              "id": $reqId,
+              "params": {
+                "contextId": $contextId
+              }
+            }
+            """
+
   def executionContextCreateResponse(reqId: Int, contextId: Api.ContextId) =
     json"""
           { "jsonrpc": "2.0",


### PR DESCRIPTION
[no ci changelog needed]

### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Adds ability to specify the execution context id when creating context with `executionContext/create` command. This is handy when setting up the language server form scripts. The API change is backward compatible.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] ~If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide dist` and `./run ide watch`.~
