### PR TITLE
Remove `here.` from Javascript code.

### DIFF
--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/geoMap.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/geoMap.js
@@ -104,7 +104,7 @@ class GeoMapVisualization extends Visualization {
         this.initMapElement()
         this.initStyle()
         this.dataPoints = []
-        this.setPreprocessor('here.process_to_json_text', 'Standard.Visualization.Geo_Map')
+        this.setPreprocessor('process_to_json_text', 'Standard.Visualization.Geo_Map')
     }
 
     initMapElement() {

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/heatmap.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/heatmap.js
@@ -13,7 +13,7 @@ class Heatmap extends Visualization {
     constructor(data) {
         super(data)
         this.setPreprocessorModule('Standard.Visualization.Table.Visualization')
-        this.setPreprocessorCode(`x -> here.prepare_visualization x 1000`)
+        this.setPreprocessorCode(`x -> prepare_visualization x 1000`)
     }
 
     onDataReceived(data) {
@@ -177,7 +177,7 @@ class Heatmap extends Visualization {
             .tickSize(0)
             .tickValues(
                 myGroups.filter((d, i) => {
-                    if (i == myGroups.length - 1) {
+                    if (i === myGroups.length - 1) {
                         return 1
                     }
                     let divisor = (5 * self.canvas.outer.width) / 200
@@ -200,7 +200,7 @@ class Heatmap extends Visualization {
             .tickSize(0)
             .tickValues(
                 myVars.filter((d, i) => {
-                    if (i == myVars.length - 1) {
+                    if (i === myVars.length - 1) {
                         return 1
                     }
                     let divisor = (9 * self.canvas.outer.height) / 200

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/histogram.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/histogram.js
@@ -44,7 +44,7 @@ class Histogram extends Visualization {
 
     constructor(data) {
         super(data)
-        this.setPreprocessor('here.process_to_json_text', 'Standard.Visualization.Histogram')
+        this.setPreprocessor('process_to_json_text', 'Standard.Visualization.Histogram')
         this._dataBins = []
     }
 

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/scatterPlot.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/scatterPlot.js
@@ -49,7 +49,7 @@ class ScatterPlot extends Visualization {
 
     constructor(data) {
         super(data)
-        this.setPreprocessor('here.process_to_json_text', 'Standard.Visualization.Scatter_Plot')
+        this.setPreprocessor('process_to_json_text', 'Standard.Visualization.Scatter_Plot')
         this.dataPoints = []
         this.axis = {
             x: { scale: LINEAR_SCALE },

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/sql.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/sql.js
@@ -88,7 +88,7 @@ class SqlVisualization extends Visualization {
     constructor(api) {
         super(api)
         this.setPreprocessorModule('Standard.Visualization.Sql.Visualization')
-        this.setPreprocessorCode(`x -> here.prepare_visualization x`)
+        this.setPreprocessorCode(`x -> prepare_visualization x`)
     }
 
     onDataReceived(data) {
@@ -108,7 +108,7 @@ class SqlVisualization extends Visualization {
             )
 
             let language = 'sql'
-            if (parsedData.dialect == 'postgresql') {
+            if (parsedData.dialect === 'postgresql') {
                 language = 'postgresql'
             }
 
@@ -264,7 +264,7 @@ function renderInterpolationParameter(theme, param) {
     const actualType = param.actual_type
     let value = param.value
 
-    if (actualType == textType) {
+    if (actualType === textType) {
         value = "'" + value.replaceAll("'", "''") + "'"
     }
 
@@ -273,7 +273,7 @@ function renderInterpolationParameter(theme, param) {
     let bgColor = replaceAlpha(fgColor, interpolationBacgroundOpacity)
     const expectedEnsoType = param.expected_enso_type
 
-    if (actualType == expectedEnsoType) {
+    if (actualType === expectedEnsoType) {
         return renderRegularInterpolation(value, fgColor, bgColor)
     } else {
         let expectedType = expectedEnsoType
@@ -372,7 +372,7 @@ class Tooltip {
      * ignored.
      */
     hide(actor) {
-        if (this.tooltipOwner === null || this.tooltipOwner == actor) {
+        if (this.tooltipOwner === null || this.tooltipOwner === actor) {
             this.tooltipOwner = null
             this.tooltip.style.opacity = 0
         }

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -17,7 +17,7 @@ class TableVisualization extends Visualization {
     constructor(data) {
         super(data)
         this.setPreprocessorModule('Standard.Visualization.Table.Visualization')
-        this.setPreprocessorCode(`x -> here.prepare_visualization x 1000`)
+        this.setPreprocessorCode(`x -> prepare_visualization x 1000`)
     }
 
     onDataReceived(data) {
@@ -369,7 +369,7 @@ class TableVisualization extends Visualization {
                 const hiddenCount = allRowsCount - includedRowsCount
                 if (hiddenCount > 0) {
                     let rows = 'rows'
-                    if (hiddenCount == 1) {
+                    if (hiddenCount === 1) {
                         rows = 'row'
                     }
                     suffix =


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

Visualization within the UI is no longer working since the removal of the `here` keyword.
This PR fixes the JavaScript calls.

### Important Notes

There are various lines of rust code which still have `here.` within them and these will need to be fixed at some point.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide dist` and `./run ide watch`.
