### PR TITLE
Print final test report at the end

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -208,6 +208,10 @@ ThisBuild / scalacOptions ++= Seq(
   "-Ywarn-unused:privates"              // Warn if a private member is unused.
 )
 
+ThisBuild / Test / testOptions += Tests.Argument(
+  "-oI"
+)
+
 val jsSettings = Seq(
   scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.ESModule) }
 )


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

The option asks to print a final test report for each projects at the
end `sbt> run`.
That way, when running the task in aggregate mode, we have a summary at
the end, rather than somewhere in the large output of the individual
subproject.
