### PR TITLE
Switching to Java 19 Frgaal compiler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1154,7 +1154,7 @@ val distributionEnvironmentOverrides = {
   )
 }
 
-val frgaalSourceLevel = "18"
+val frgaalSourceLevel = "19"
 
 /** A setting to replace javac with Frgaal compiler, allowing to use latest Java features in the code
   * and still compile down to JDK 11

--- a/project/FrgaalJavaCompiler.scala
+++ b/project/FrgaalJavaCompiler.scala
@@ -23,7 +23,7 @@ import scala.sys.process.Process
 
 object FrgaalJavaCompiler {
 
-  val frgaal = "org.frgaal" % "compiler" % "18.0.0" % "provided"
+  val frgaal = "org.frgaal" % "compiler" % "19.0.0-RC1" % "provided"
 
   def compilers(classpath: sbt.Keys.Classpath, sbtCompilers: xsbti.compile.Compilers, javaVersion: String) = {
     // Enable Java 11+ features by invoking Frgaal instead of regular javac
@@ -69,7 +69,7 @@ object FrgaalJavaCompiler {
     withArgumentFile(allArguments) { argsFile =>
       // Need to disable standard compiler tools that come with used jdk and replace them
       // with the ones provided with Frgaal.
-      val forkArgs = (jArgs ++ Seq("--limit-modules", "java.base,jdk.zipfs", "-jar", compilerJar.toString)) :+
+      val forkArgs = (jArgs ++ Seq("--limit-modules", "java.base,jdk.zipfs,jdk.internal.vm.compiler.management", "-jar", compilerJar.toString)) :+
          s"@${normalizeSlash(argsFile.getAbsolutePath)}"
       val exe = getJavaExecutable(javaHome, "java")
       val cwd = new File(new File(".").getAbsolutePath).getCanonicalFile


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

Updating to Frgaal 19.0.0-RC1 to give us access to latest Java features including pattern matching on `record` classes. Builds upon #3421.

