### PR TITLE
Parser: type definition bodies

### DIFF
--- a/lib/rust/parser/src/macros/built_in.rs
+++ b/lib/rust/parser/src/macros/built_in.rs
@@ -44,42 +44,151 @@ pub fn type_def<'s>() -> Definition<'s> {
         identifier() / "name" % "type name" >>
         many(identifier() % "type parameter" / "param") % "type parameters" >>
         block(
-            many(identifier() / "constructor") % "type constructors" >> 
-            everything()
+            everything() / "statements" % "type methods definitions"
         ) % "type definition body";
-    // let pattern2 = Everything;
     crate::macro_definition! {
         ("type", pattern)
         type_def_body
     }
 }
 
-// TODO: The comments in the code were left in order to allow easy debugging of this struct. They
-//       should be removed in the future.
 fn type_def_body(matched_segments: NonEmptyVec<MatchedSegment>) -> syntax::Tree {
-    let segment = matched_segments.to_vec().pop().unwrap();
-    // println!(">>>");
-    // println!("{:#?}", segment);
-    // println!(">>>");
+    let segment = matched_segments.pop().0;
     let match_tree = segment.result.into_var_map();
-    // println!("{:#?}", match_tree);
-    // println!("\n\n------------- 1");
-
     let mut v = match_tree.view();
     let name = &v.query("name").unwrap()[0];
     let name = operator::resolve_operator_precedence_if_non_empty(name.clone()).unwrap();
-    // println!("{:#?}", name);
-    // println!("\n\n------------- 2");
-
-    let no_params = vec![];
+    let no_params = [];
     let params = v.nested().query("param").unwrap_or(&no_params);
-    // println!("{:#?}", params);
-    // println!("\n\n------------- 3");
-
     let params = params
         .iter()
         .map(|tokens| operator::resolve_operator_precedence_if_non_empty(tokens.clone()).unwrap())
         .collect_vec();
-    // println!("{:#?}", params);
-    syntax::Tree::type_def(segment.header, name, params)
+    let mut constructors = default();
+    let mut body = default();
+    if let Some(statements) = v.query("statements") {
+        let statements = &statements[0];
+        let mut builder = TypeDefBodyBuilder::default();
+        for (i, item) in statements.iter().enumerate() {
+            if let syntax::Item::Token(syntax::Token {
+                variant: syntax::token::Variant::Newline(newline),
+                left_offset,
+                code,
+            }) = item
+            {
+                let newline = syntax::Token(left_offset.clone(), code.clone(), *newline);
+                builder.line(i, newline, statements);
+            }
+        }
+        let (constructors_, body_) = builder.finish(statements);
+        constructors = constructors_;
+        body = body_;
+    }
+    syntax::Tree::type_def(segment.header, name, params, constructors, body)
+}
+
+#[derive(Default)]
+struct TypeDefBodyBuilder<'s> {
+    constructors: Vec<syntax::tree::TypeConstructorLine<'s>>,
+    body:         Vec<syntax::tree::block::Line<'s>>,
+    line_items:   Vec<syntax::Item<'s>>,
+    newline:      Option<(usize, syntax::token::Newline<'s>)>,
+}
+
+impl<'s> TypeDefBodyBuilder<'s> {
+    /// Add the line beginning at the given newline token to the state.
+    pub fn line(
+        &mut self,
+        i: usize,
+        newline: syntax::token::Newline<'s>,
+        body: &[syntax::Item<'s>],
+    ) {
+        let prev_newline = self.newline.replace((i + 1, newline));
+        if i != 0 {
+            let (start, newline) =
+                prev_newline.unwrap_or_else(|| (0, syntax::token::newline("", "")));
+            self.line_(newline, &body[start..i]);
+        }
+    }
+
+    /// Finish building the constructor/body sequences, and return them.
+    pub fn finish(
+        mut self,
+        body: &[syntax::Item<'s>],
+    ) -> (Vec<syntax::tree::TypeConstructorLine<'s>>, Vec<syntax::tree::block::Line<'s>>) {
+        if let Some((start, newline)) = self.newline.clone() {
+            self.line_(newline, &body[start..]);
+        }
+        (self.constructors, self.body)
+    }
+
+    fn line_(&mut self, newline: syntax::token::Newline<'s>, items: &[syntax::Item<'s>]) {
+        self.line_items.extend(items.iter().cloned());
+        let expression = (!self.line_items.is_empty())
+            .as_some_from(|| operator::resolve_operator_precedence(self.line_items.drain(..)));
+        if self.body.is_empty() {
+            if let Some(expression) = expression {
+                match Self::to_constructor_line(expression) {
+                    Ok(expression) => {
+                        let expression = Some(expression);
+                        let line = syntax::tree::TypeConstructorLine { newline, expression };
+                        self.constructors.push(line);
+                    }
+                    Err(expression) => {
+                        let expression = crate::expression_to_statement(expression);
+                        let expression = Some(expression);
+                        self.body.push(syntax::tree::block::Line { newline, expression });
+                    }
+                }
+            } else {
+                self.constructors.push(newline.into());
+            }
+        } else {
+            let expression = expression.map(crate::expression_to_statement);
+            self.body.push(syntax::tree::block::Line { newline, expression });
+        }
+    }
+
+    /// Interpret the given expression as an `TypeConstructorDef`, if its syntax is compatible.
+    fn to_constructor_line(
+        expression: syntax::Tree<'_>,
+    ) -> Result<syntax::tree::TypeConstructorDef<'_>, syntax::Tree<'_>> {
+        use syntax::tree::*;
+        if let Tree {
+            variant:
+                box Variant::ArgumentBlockApplication(ArgumentBlockApplication {
+                    lhs: Some(Tree { variant: box Variant::Ident(ident), span: span_ }),
+                    arguments,
+                }),
+            span,
+        } = expression
+        {
+            let mut left_offset = span.left_offset;
+            left_offset += span_.left_offset;
+            let mut constructor = ident.token;
+            left_offset += constructor.left_offset;
+            constructor.left_offset = left_offset;
+            let block = arguments;
+            let arguments = default();
+            return Ok(TypeConstructorDef { constructor, arguments, block });
+        }
+        let mut arguments = vec![];
+        let mut lhs = &expression;
+        let mut left_offset = crate::source::span::Offset::default();
+        while let Tree { variant: box Variant::App(App { func, arg }), span } = lhs {
+            left_offset += &span.left_offset;
+            lhs = func;
+            arguments.push(arg.clone());
+        }
+        if let Tree { variant: box Variant::Ident(Ident { token }), span } = lhs {
+            left_offset += &span.left_offset;
+            let mut constructor = token.clone();
+            left_offset += constructor.left_offset;
+            constructor.left_offset = left_offset;
+            arguments.reverse();
+            let block = default();
+            return Ok(TypeConstructorDef { constructor, arguments, block });
+        }
+        Err(expression)
+    }
 }

--- a/lib/rust/parser/src/macros/expand.rs
+++ b/lib/rust/parser/src/macros/expand.rs
@@ -310,7 +310,7 @@ impl<'t, 's, V: Validator> VarMapView<'t, 's, V> {
 
 impl<'t, 's, V: Validator> VarMapView<'t, 's, V> {
     /// Query for a variable.
-    pub fn query(&mut self, name: &str) -> Option<&'t Vec<Vec<syntax::Item<'s>>>> {
+    pub fn query(&mut self, name: &str) -> Option<&'t [Vec<syntax::Item<'s>>]> {
         self.tree.and_then(|t| {
             t.map.get(name).map(|entry| {
                 match &self.resolved_validator {
@@ -342,7 +342,7 @@ impl<'t, 's, V: Validator> VarMapView<'t, 's, V> {
                         self.resolved_validator = Some(resolved_validator);
                     }
                 }
-                &entry.tokens
+                &entry.tokens[..]
             })
         })
     }

--- a/lib/rust/parser/src/macros/pattern.rs
+++ b/lib/rust/parser/src/macros/pattern.rs
@@ -349,8 +349,7 @@ impl Pattern {
                     },
             },
             PatternData::Block(body) => match input.pop_front() {
-                Some(syntax::Item::Block(tokens)) =>
-                    body.resolve(tokens.into_iter().rev().map_into().collect()),
+                Some(syntax::Item::Block(tokens)) => body.resolve(tokens.into()),
                 Some(t) => {
                     input.push_front(t);
                     Err(input)

--- a/lib/rust/parser/src/syntax/token.rs
+++ b/lib/rust/parser/src/syntax/token.rs
@@ -170,7 +170,7 @@ impl<'s, T> Token<'s, T> {
 
 impl<'s, T: Debug> Debug for Token<'s, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[{}:\"{}\"] ", self.left_offset.visible, self.code)?;
+        write!(f, "[{}:{:?}] ", self.left_offset.visible, self.code)?;
         Debug::fmt(&self.variant, f)
     }
 }

--- a/lib/rust/parser/tests/parse.rs
+++ b/lib/rust/parser/tests/parse.rs
@@ -76,16 +76,85 @@ fn parentheses_nested() {
     test("((a b) c)", expected);
 }
 
+
+// === Type Definitions ===
+
 #[test]
-fn type_definition() {
-    test("type Bool", block![(TypeDef (Ident type) (Ident Bool) #())]);
-    test("type Option a", block![(TypeDef (Ident type) (Ident Option) #((Ident a)))]);
+fn type_definition_no_body() {
+    test("type Bool", block![(TypeDef (Ident type) (Ident Bool) #() #() #())]);
+    test("type Option a", block![(TypeDef (Ident type) (Ident Option) #((Ident a)) #() #())]);
 }
+
+#[test]
+fn type_constructors() {
+    let code = [
+        "type Geo",
+        "    Circle",
+        "        radius",
+        "        4",
+        "    Rectangle width height",
+        "    Point",
+    ];
+    #[rustfmt::skip]
+    let expected = block![
+        (TypeDef (Ident type) (Ident Geo) #()
+         #(((Circle #() #((Ident radius) (Number 4))))
+           ((Rectangle #((Ident width) (Ident height)) #()))
+           ((Point #() #())))
+         #())
+    ];
+    test(&code.join("\n"), expected);
+}
+
+#[test]
+fn type_methods() {
+    let code = ["type Geo", "    number =", "        23", "    area self = 1 + 1"];
+    #[rustfmt::skip]
+        let expected = block![
+        (TypeDef (Ident type) (Ident Geo) #() #()
+         #((Function number #() "=" (BodyBlock #((Number 23))))
+           (Function area #((Ident self)) "=" (OprApp (Number 1) (Ok "+") (Number 1)))))
+    ];
+    test(&code.join("\n"), expected);
+}
+
+#[test]
+fn type_def_full() {
+    let code = [
+        "type Geo",
+        "    Circle",
+        "        radius",
+        "        4",
+        "    Rectangle width height",
+        "    Point",
+        "",
+        "    number =",
+        "        23",
+        "    area self = 1 + 1",
+    ];
+    #[rustfmt::skip]
+        let expected = block![
+        (TypeDef (Ident type) (Ident Geo) #()
+         #(((Circle #() #((Ident radius) (Number 4))))
+           ((Rectangle #((Ident width) (Ident height)) #()))
+           ((Point #() #()))
+           (()))
+         #((Function number #() "=" (BodyBlock #((Number 23))))
+           (Function area #((Ident self)) "=" (OprApp (Number 1) (Ok "+") (Number 1)))))
+    ];
+    test(&code.join("\n"), expected);
+}
+
+
+// === Variable Assignment ===
 
 #[test]
 fn assignment_simple() {
     test("foo = 23", block![(Assignment (Ident foo) "=" (Number 23))]);
 }
+
+
+// === Functions ===
 
 #[test]
 fn function_inline_simple_args() {
@@ -105,6 +174,9 @@ fn function_block_simple_args() {
     test("foo a b =", block![(Function foo #((Ident a) (Ident b)) "=" ())]);
     test("foo a b c =", block![(Function foo #((Ident a) (Ident b) (Ident c)) "=" ())]);
 }
+
+
+// === Code Blocks ===
 
 #[test]
 fn code_block_body() {


### PR DESCRIPTION
### Pull Request Description

Type definition bodies: constructors with fields, and methods.

Implements:
- https://www.pivotaltracker.com/story/show/182745069
- https://www.pivotaltracker.com/story/show/182497507

### Important Notes

- This PR is based on #3585.
- I was not able to use `Pattern` to distinguish constructors from methods: I think what distinguishes a constructor from a method is that a method has an application of the `=` operator at the top of the expression, and a constructor does not. This distinction cannot be made before resolving operator precedence, i.e. parsing. So this implementation parses the lines before testing whether they match constructor syntax.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide dist` and `./run ide watch`.
[ci no changelog needed]