### PR TITLE
Parser: hide internal APIs in generated Java

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,7 +1750,7 @@ dependencies = [
 [[package]]
 name = "enso-build"
 version = "0.1.0"
-source = "git+https://github.com/enso-org/ci-build?branch=develop#acc5a7dacc223ad69ebfc7651c5ed0e3c0f1c9e5"
+source = "git+https://github.com/enso-org/ci-build?branch=develop#94389f9c820f76009b05419d661636b2dc199f20"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "enso-build-cli"
 version = "0.1.0"
-source = "git+https://github.com/enso-org/ci-build?branch=develop#acc5a7dacc223ad69ebfc7651c5ed0e3c0f1c9e5"
+source = "git+https://github.com/enso-org/ci-build?branch=develop#94389f9c820f76009b05419d661636b2dc199f20"
 dependencies = [
  "anyhow",
  "byte-unit",
@@ -3734,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "ide-ci"
 version = "0.1.0"
-source = "git+https://github.com/enso-org/ci-build?branch=develop#acc5a7dacc223ad69ebfc7651c5ed0e3c0f1c9e5"
+source = "git+https://github.com/enso-org/ci-build?branch=develop#94389f9c820f76009b05419d661636b2dc199f20"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/lib/rust/metamodel/src/java/bincode.rs
+++ b/lib/rust/metamodel/src/java/bincode.rs
@@ -217,6 +217,7 @@ impl DeserializerBuilder {
         method.static_ = true;
         method.body = body;
         method.arguments = vec![(message_ty, message.to_owned())];
+        method.visibility = None;
         method
     }
 
@@ -351,6 +352,7 @@ impl DeserializerBuilder {
         method.static_ = true;
         method.body = body;
         method.arguments = vec![(message_ty, message.to_owned())];
+        method.visibility = None;
         method
     }
 }

--- a/lib/rust/parser/generate-java/java/org/enso/syntax2/Either.java
+++ b/lib/rust/parser/generate-java/java/org/enso/syntax2/Either.java
@@ -1,4 +1,4 @@
-package org.enso.syntax2.serialization;
+package org.enso.syntax2;
 
 public class Either<Left, Right> {
     protected Left left;

--- a/lib/rust/parser/generate-java/java/org/enso/syntax2/FormatException.java
+++ b/lib/rust/parser/generate-java/java/org/enso/syntax2/FormatException.java
@@ -1,4 +1,4 @@
-package org.enso.syntax2.serialization;
+package org.enso.syntax2;
 
 public class FormatException
   extends RuntimeException {

--- a/lib/rust/parser/generate-java/java/org/enso/syntax2/Message.java
+++ b/lib/rust/parser/generate-java/java/org/enso/syntax2/Message.java
@@ -1,6 +1,6 @@
-package org.enso.syntax2.serialization;
+package org.enso.syntax2;
 
-public final class Message {
+final class Message {
     private final java.nio.ByteBuffer buffer;
     private final java.nio.ByteBuffer context;
     private final int base;

--- a/lib/rust/parser/generate-java/src/bin/java-tests.rs
+++ b/lib/rust/parser/generate-java/src/bin/java-tests.rs
@@ -32,6 +32,8 @@ fn main() {
     let reject = fmt_cases(&cases.reject);
     let package = enso_parser_generate_java::PACKAGE;
     let serialization = enso_parser_generate_java::SERIALIZATION_SUPPORT;
+    println!("package {package};");
+    println!();
     println!("import {package}.Tree;");
     println!("import {serialization}.Message;",);
     println!("import java.nio.ByteBuffer;");

--- a/lib/rust/parser/generate-java/src/lib.rs
+++ b/lib/rust/parser/generate-java/src/lib.rs
@@ -36,9 +36,9 @@ pub mod serialization;
 /// The package for the generated code.
 pub const PACKAGE: &str = "org.enso.syntax2";
 /// The package for the non-generated serialization support code.
-pub const SERIALIZATION_SUPPORT: &str = "org.enso.syntax2.serialization";
+pub const SERIALIZATION_SUPPORT: &str = "org.enso.syntax2";
 /// The fully-qualified name of an `Either` type.
-pub const EITHER_TYPE: &str = "org.enso.syntax2.serialization.Either";
+pub const EITHER_TYPE: &str = "org.enso.syntax2.Either";
 
 
 


### PR DESCRIPTION
### Pull Request Description

Now that there's a public `org.enso.syntax2.Parser` interface (after #3599), make APIs that don't need to be exposed package-private.

### Important Notes

- This depends on a change to the build script, which must be merged first: enso-org/ci-build#6

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide dist` and `./run ide watch`.

[ci no changelog needed]