### PR TITLE
Disable npm install in tests on CI

### DIFF
--- a/lib/scala/library-manager-test/src/main/scala/org/enso/librarymanager/published/repository/DummyRepository.scala
+++ b/lib/scala/library-manager-test/src/main/scala/org/enso/librarymanager/published/repository/DummyRepository.scala
@@ -177,6 +177,8 @@ abstract class DummyRepository {
     val serverDirectory =
       Path.of("tools/simple-library-server").toAbsolutePath.normalize
 
+    // We can ommit installation step on CI because there is a separate step
+    // executing `npm install` command before the tests.
     if (!DummyRepository.isCI) {
       val preinstallCommand =
         commandPrefix ++ Seq(npmCommand, "install")

--- a/lib/scala/library-manager-test/src/main/scala/org/enso/librarymanager/published/repository/DummyRepository.scala
+++ b/lib/scala/library-manager-test/src/main/scala/org/enso/librarymanager/published/repository/DummyRepository.scala
@@ -177,20 +177,22 @@ abstract class DummyRepository {
     val serverDirectory =
       Path.of("tools/simple-library-server").toAbsolutePath.normalize
 
-    val preinstallCommand =
-      commandPrefix ++ Seq(npmCommand, "install")
-    val preinstallExitCode = new ProcessBuilder()
-      .command(preinstallCommand: _*)
-      .directory(serverDirectory.toFile)
-      .inheritIO()
-      .start()
-      .waitFor()
+    if (!DummyRepository.isCI) {
+      val preinstallCommand =
+        commandPrefix ++ Seq(npmCommand, "install")
+      val preinstallExitCode = new ProcessBuilder()
+        .command(preinstallCommand: _*)
+        .directory(serverDirectory.toFile)
+        .inheritIO()
+        .start()
+        .waitFor()
 
-    if (preinstallExitCode != 0)
-      throw new RuntimeException(
-        s"Failed to preinstall the Library Repository Server dependencies: " +
-        s"npm exited with code $preinstallCommand."
-      )
+      if (preinstallExitCode != 0)
+        throw new RuntimeException(
+          s"Failed to preinstall the Library Repository Server dependencies: " +
+          s"npm exited with code $preinstallCommand."
+        )
+    }
 
     val uploadsArgs = if (uploads) Seq("--upload", "no-auth") else Seq()
     val command = commandPrefix ++ Seq(
@@ -223,4 +225,6 @@ abstract class DummyRepository {
 }
 object DummyRepository {
   private val lock = new Object
+
+  private def isCI = sys.env.contains("CI")
 }


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

Fixes random timeout failures on CI.
```
 INFO ide_ci::program::command: sbtℹ️ up to date, audited 98 packages in 3s
```
`npm install` takes 3s of test time doing unnecessary package auditing. On CI the command is executed once before running the tests and redundant `npm install` calls can be omitted.

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] ~If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide dist` and `./run ide watch`.~
