### PR TITLE
Fix REPL runner

### DIFF
--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -756,7 +756,10 @@ object Main {
       val mainCons = mainModule.getAssociatedConstructor
       val mainFun  = mainModule.getMethod(mainCons, mainMethodName)
       mainFun match {
-        case Some(main) => main.execute()
+        case Some(main) if mainMethodName != "main" =>
+          main.execute(mainCons.newInstance())
+        case Some(main) =>
+          main.execute()
         case None =>
           err.println(
             s"The module ${mainModule.getName} does not contain a `main` " +


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

`main` method is now special because it is trully static i.e. no
implicit `self` is being generated for it.
But since REPL's `main` isn't called `main` its invocation was missing
an argument.

Follow up on https://github.com/enso-org/enso/pull/3569

### Important Notes

Will work on adding a CI test for REPL to avoid problems with REPL in a
follow up PR.

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide dist` and `./run ide watch`.
