### PR TITLE
Allow for importing methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,6 +302,7 @@
 - [Explicit `self`][3569]
 - [Added benchmarking tool for the language server][3578]
 - [Support module imports using a qualified name][3608]
+- [Support importing module methods][3633]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -338,6 +339,7 @@
 [3538]: https://github.com/enso-org/enso/pull/3569
 [3578]: https://github.com/enso-org/enso/pull/3578
 [3608]: https://github.com/enso-org/enso/pull/3608
+[3633]: https://github.com/enso-org/enso/pull/3633
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/AstToIrTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/codegen/AstToIrTest.scala
@@ -1048,6 +1048,8 @@ class AstToIrTest extends CompilerTest with Inside {
         "from project import all",
         "from Username.Bar.Quux import Baz",
         "from Username.Bar.Test import Baz, Spam",
+        "from Username.Bar.Test import Baz, Spam, foo, Bar",
+        "from Username.Bar.Test import foo, bar",
         "from username.Foo.Bar import all",
         "from username.Foo.Bar as Eggs import all hiding Spam",
         "from project.Foo.Bar import all hiding Spam, Eggs"

--- a/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
+++ b/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/AST.scala
@@ -345,8 +345,8 @@ object Shape extends ShapeImplicit {
     path: List1[AST.Ident],
     rename: Option[AST.Ident.Cons],
     isAll: Boolean,
-    onlyNames: Option[List1[AST.Ident.Cons]],
-    hidingNames: Option[List1[AST.Ident.Cons]]
+    onlyNames: Option[List1[AST.Ident]],
+    hidingNames: Option[List1[AST.Ident]]
   ) extends SpacelessAST[T]
   final case class Export[T](
     path: List1[AST.Ident],
@@ -2395,8 +2395,8 @@ object AST {
       path: List1[AST.Ident],
       rename: Option[AST.Ident.Cons],
       isAll: Boolean,
-      onlyNames: Option[List1[AST.Ident.Cons]],
-      hidingNames: Option[List1[AST.Ident.Cons]]
+      onlyNames: Option[List1[AST.Ident]],
+      hidingNames: Option[List1[AST.Ident]]
     ): Import =
       Shape.Import[AST](path, rename, isAll, onlyNames, hidingNames)
     def unapply(t: AST): Option[
@@ -2404,8 +2404,8 @@ object AST {
         List1[AST.Ident],
         Option[AST.Ident.Cons],
         Boolean,
-        Option[List1[AST.Ident.Cons]],
-        Option[List1[AST.Ident.Cons]]
+        Option[List1[AST.Ident]],
+        Option[List1[AST.Ident]]
       )
     ] =
       Unapply[Import].run(t =>

--- a/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/ast/meta/Builtin.scala
+++ b/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/ast/meta/Builtin.scala
@@ -289,7 +289,7 @@ object Builtin {
         (name, rename)
       }
 
-      def consOrVar: PartialFunction[AST, AST.Ident] = {
+      val consOrVar: PartialFunction[AST, AST.Ident] = {
         case AST.Ident.Var.any(v)  => v: AST.Ident
         case AST.Ident.Cons.any(c) => c: AST.Ident
       }

--- a/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/ast/meta/Builtin.scala
+++ b/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/ast/meta/Builtin.scala
@@ -310,6 +310,7 @@ object Builtin {
                 case Match.Or(_, Left(hidden)) =>
                   val hiddenItems = hidden.toStream
                     .map(_.wrapped)
+                    .drop(2)
                     .collect(consOrVar)
                   (List1(hiddenItems), None)
 

--- a/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/ast/meta/Builtin.scala
+++ b/lib/scala/syntax/definition/src/main/scala/org/enso/syntax/text/ast/meta/Builtin.scala
@@ -289,6 +289,11 @@ object Builtin {
         (name, rename)
       }
 
+      def consOrVar: PartialFunction[AST, AST.Ident] = {
+        case AST.Ident.Var.any(v)  => v: AST.Ident
+        case AST.Ident.Cons.any(c) => c: AST.Ident
+      }
+
       val itemsImport = {
         val all: Pattern = Var("all")
         val items        = Pattern.SepList(Pattern.Cons() | Pattern.Var(), Opr(","))
@@ -305,13 +310,13 @@ object Builtin {
                 case Match.Or(_, Left(hidden)) =>
                   val hiddenItems = hidden.toStream
                     .map(_.wrapped)
-                    .flatMap(AST.Ident.Cons.any.unapply)
+                    .collect(consOrVar)
                   (List1(hiddenItems), None)
 
                 case Match.Or(_, Right(imported)) =>
                   val importedItems = imported.toStream
                     .map(_.wrapped)
-                    .flatMap(AST.Ident.Cons.any.unapply)
+                    .collect(consOrVar)
                   (None, List1(importedItems))
                 case _ => internalError
               }
@@ -339,19 +344,13 @@ object Builtin {
                   val hiddenItems = hidden.toStream
                     .map(_.wrapped)
                     .drop(2)
-                    .collect {
-                      case AST.Ident.Var.any(v)  => v: AST.Ident
-                      case AST.Ident.Cons.any(c) => c: AST.Ident
-                    }
+                    .collect(consOrVar)
                   (List1(hiddenItems), None)
 
                 case Match.Or(_, Right(imported)) =>
                   val importedItems = imported.toStream
                     .map(_.wrapped)
-                    .collect {
-                      case AST.Ident.Var.any(v)  => v: AST.Ident
-                      case AST.Ident.Cons.any(c) => c: AST.Ident
-                    }
+                    .collect(consOrVar)
                   (None, List1(importedItems))
                 case _ => internalError
               }

--- a/test/Tests/src/Semantic/Names_Spec.enso
+++ b/test/Tests/src/Semantic/Names_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
-from project.Semantic.Names.Definitions import another_method, another_constant, method_with_local_vars
+from project.Semantic.Names.Definitions import another_method, another_constant, method_with_local_vars, Bar
+import project.Semantic.Names.Definitions
 
 import Standard.Test
 


### PR DESCRIPTION
### Pull Request Description

Importing individual methods didn't work as advertised because parser
would allow them but later drop that information. This slipped by because we never had mixed atoms and methods in stdlib.

### Important Notes

Added some basic tests but we need to ensure that the new parser allows for this.
@jdunkerley will be adding some changes to stdlib that will be testing this functionality as well.

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide dist` and `./run ide watch`.
