### PR TITLE
Support Autosave for open buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,6 +308,7 @@
 - [Enable caching in visualisation functions][3618]
 - [Update Scala compiler and libraries][3631]
 - [Support importing module methods][3633]
+- [Support Autosave for open buffers][3637]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -347,6 +348,7 @@
 [3608]: https://github.com/enso-org/enso/pull/3608
 [3631]: https://github.com/enso-org/enso/pull/3631
 [3633]: https://github.com/enso-org/enso/pull/3633
+[3637]: https://github.com/enso-org/enso/pull/3637
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/docs/language-server/protocol-language-server.md
+++ b/docs/language-server/protocol-language-server.md
@@ -108,6 +108,7 @@ transport formats, please look [here](./protocol-architecture).
   - [`text/applyEdit`](#textapplyedit)
   - [`text/applyExpressionValue`](#textapplyexpressionvalue)
   - [`text/didChange`](#textdidchange)
+  - [`text/autoSave`](#textautosave)
 - [Workspace Operations](#workspace-operations)
   - [`workspace/projectInfo`](#workspaceprojectinfo)
 - [Monitoring](#monitoring)
@@ -2867,6 +2868,32 @@ This notification must _only_ be sent for files that the client has open.
 ```typescript
 {
   edits: [FileEdit];
+}
+```
+
+#### Errors
+
+```typescript
+null;
+```
+
+### `text/autoSave`
+
+This is a notification sent from the server to the clients to inform them of any
+successful auto-save action.
+
+- **Type:** Notification
+- **Direction:** Server -> Client
+- **Connection:** Protocol
+- **Visibility:** Public
+
+This notification must _only_ be sent for files that the client has open.
+
+#### Parameters
+
+```typescript
+{
+  path: Path;
 }
 ```
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -196,7 +196,11 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: LogLevel) {
 
   lazy val bufferRegistry =
     system.actorOf(
-      BufferRegistry.props(fileManager, runtimeConnector),
+      BufferRegistry.props(
+        fileManager,
+        runtimeConnector,
+        TimingsConfig.default().withAutoSave(60.seconds)
+      ),
       "buffer-registry"
     )
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -199,7 +199,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: LogLevel) {
       BufferRegistry.props(
         fileManager,
         runtimeConnector,
-        TimingsConfig.default().withAutoSave(60.seconds)
+        TimingsConfig.default().withAutoSave(6.seconds)
       ),
       "buffer-registry"
     )

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/TimingsConfig.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/TimingsConfig.scala
@@ -4,12 +4,22 @@ import scala.concurrent.duration._
 
 /** TimingsConfig encapsulates information about timings or delays in messages being sent between services.
   *
+  * @param autoSave a request timeout
   * @param autoSave if non-empty value, determines the delay when auto-save should be triggered
   */
-class TimingsConfig(private[this] var autoSave: Option[FiniteDuration]) {
-  def this() = {
-    this(None)
+class TimingsConfig(
+  private[this] val timeout: FiniteDuration,
+  private[this] var autoSave: Option[FiniteDuration]
+) {
+  def this(timeout: FiniteDuration) = {
+    this(timeout, None)
   }
+
+  /** A request timeout.
+    *
+    * @return a duration to wait for the request to be handled
+    */
+  def requestTimeout: FiniteDuration = timeout
 
   /** Auto-save delay.
     *
@@ -29,5 +39,5 @@ class TimingsConfig(private[this] var autoSave: Option[FiniteDuration]) {
 }
 
 object TimingsConfig {
-  def default(): TimingsConfig = new TimingsConfig()
+  def default(): TimingsConfig = new TimingsConfig(10.seconds)
 }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/TimingsConfig.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/TimingsConfig.scala
@@ -1,0 +1,33 @@
+package org.enso.languageserver.boot
+
+import scala.concurrent.duration._
+
+/** TimingsConfig encapsulates information about timings or delays in messages being sent between services.
+  *
+  * @param autoSave if non-empty value, determines the delay when auto-save should be triggered
+  */
+class TimingsConfig(private[this] var autoSave: Option[FiniteDuration]) {
+  def this() = {
+    this(None)
+  }
+
+  /** Auto-save delay.
+    *
+    * @return if non-empty, determines the delay when auto-save should be triggered after the last edit
+    */
+  def autoSaveDelay: Option[FiniteDuration] = autoSave
+
+  /** Sets the delay for auto-save action that should be triggered after the last edit action.
+    *
+    * @param delay delay for auto-save action
+    * @return updated config
+    */
+  def withAutoSave(delay: FiniteDuration): TimingsConfig = {
+    autoSave = Some(delay)
+    this
+  }
+}
+
+object TimingsConfig {
+  def default(): TimingsConfig = new TimingsConfig()
+}

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
@@ -298,6 +298,9 @@ class JsonConnectionController(
     case TextProtocol.TextDidChange(changes) =>
       webActor ! Notification(TextDidChange, TextDidChange.Params(changes))
 
+    case TextProtocol.FileAutoSaved(path) =>
+      webActor ! Notification(FileAutoSaved, FileAutoSaved.Params(path))
+
     case PathWatcherProtocol.FileEventResult(event) =>
       webActor ! Notification(
         EventFile,

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonRpc.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonRpc.scala
@@ -93,6 +93,7 @@ object JsonRpc {
     .registerNotification(ForceReleaseCapability)
     .registerNotification(GrantCapability)
     .registerNotification(TextDidChange)
+    .registerNotification(FileAutoSaved)
     .registerNotification(EventFile)
     .registerNotification(ContentRootAdded)
     .registerNotification(ContentRootRemoved)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/text/SaveFileHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/text/SaveFileHandler.scala
@@ -62,12 +62,12 @@ class SaveFileHandler(
       replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
       context.stop(self)
 
-    case FileSaved =>
+    case FileSaved(_) =>
       replyTo ! ResponseResult(SaveFile, id, Unused)
       cancellable.cancel()
       context.stop(self)
 
-    case SaveFailed(fsFailure) =>
+    case SaveFailed(fsFailure, _) =>
       replyTo ! ResponseError(
         Some(id),
         FileSystemFailureMapper.mapFailure(fsFailure)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/text/SaveFileHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/text/SaveFileHandler.scala
@@ -62,12 +62,12 @@ class SaveFileHandler(
       replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
       context.stop(self)
 
-    case FileSaved(_) =>
+    case FileSaved =>
       replyTo ! ResponseResult(SaveFile, id, Unused)
       cancellable.cancel()
       context.stop(self)
 
-    case SaveFailed(fsFailure, _) =>
+    case SaveFailed(fsFailure) =>
       replyTo ! ResponseError(
         Some(id),
         FileSystemFailureMapper.mapFailure(fsFailure)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/Buffer.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/Buffer.scala
@@ -9,9 +9,15 @@ import org.enso.text.buffer.Rope
   *
   * @param file the file linked to the buffer.
   * @param contents the contents of the buffer.
+  * @param inMemory determines if the buffer is in-memory
   * @param version the current version of the buffer contents.
   */
-case class Buffer(file: File, contents: Rope, version: ContentVersion)
+case class Buffer(
+  file: File,
+  contents: Rope,
+  inMemory: Boolean,
+  version: ContentVersion
+)
 
 object Buffer {
 
@@ -19,25 +25,34 @@ object Buffer {
     *
     * @param file the file linked to the buffer.
     * @param contents the contents of this buffer.
+    * @param inMemory determines if the buffer is in-memory
     * @param versionCalculator a digest calculator for content based versioning.
     * @return a new buffer instance.
     */
   def apply(
     file: File,
-    contents: Rope
+    contents: Rope,
+    inMemory: Boolean
   )(implicit versionCalculator: ContentBasedVersioning): Buffer =
-    Buffer(file, contents, versionCalculator.evalVersion(contents.toString))
+    Buffer(
+      file,
+      contents,
+      inMemory,
+      versionCalculator.evalVersion(contents.toString)
+    )
 
   /** Creates a new buffer with a freshly generated version.
     *
     * @param file the file linked to the buffer.
     * @param contents the contents of this buffer.
+    * @param inMemory determines if the buffer is in-memory
     * @param versionCalculator a digest calculator for content based versioning.
     * @return a new buffer instance.
     */
   def apply(
     file: File,
-    contents: String
+    contents: String,
+    inMemory: Boolean
   )(implicit versionCalculator: ContentBasedVersioning): Buffer =
-    Buffer(file, Rope(contents))
+    Buffer(file, Rope(contents), inMemory)
 }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/BufferRegistry.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/BufferRegistry.scala
@@ -2,6 +2,7 @@ package org.enso.languageserver.text
 
 import akka.actor.{Actor, ActorRef, Props, Stash, Terminated}
 import com.typesafe.scalalogging.LazyLogging
+import org.enso.languageserver.boot.TimingsConfig
 import org.enso.languageserver.capability.CapabilityProtocol.{
   AcquireCapability,
   CapabilityAcquisitionBadRequest,
@@ -58,10 +59,12 @@ import org.enso.text.ContentBasedVersioning
   * @param fileManager a file manager
   * @param runtimeConnector a gateway to the runtime
   * @param versionCalculator a content based version calculator
+  * @param timingsConfig a config with timeout/delay values
   */
 class BufferRegistry(
   fileManager: ActorRef,
-  runtimeConnector: ActorRef
+  runtimeConnector: ActorRef,
+  timingsConfig: TimingsConfig
 )(implicit
   versionCalculator: ContentBasedVersioning
 ) extends Actor
@@ -100,7 +103,8 @@ class BufferRegistry(
             CollaborativeBuffer.props(
               path,
               fileManager,
-              runtimeConnector
+              runtimeConnector,
+              timingsConfig = timingsConfig
             )
           )
         context.watch(bufferRef)
@@ -117,7 +121,8 @@ class BufferRegistry(
             CollaborativeBuffer.props(
               path,
               fileManager,
-              runtimeConnector
+              runtimeConnector,
+              timingsConfig = timingsConfig
             )
           )
         context.watch(bufferRef)
@@ -180,14 +185,16 @@ object BufferRegistry {
     * @param fileManager a file manager actor
     * @param runtimeConnector a gateway to the runtime
     * @param versionCalculator a content based version calculator
+    * @param timingsConfig a config with timout/delay values
     * @return a configuration object
     */
   def props(
     fileManager: ActorRef,
-    runtimeConnector: ActorRef
+    runtimeConnector: ActorRef,
+    timingsConfig: TimingsConfig
   )(implicit
     versionCalculator: ContentBasedVersioning
   ): Props =
-    Props(new BufferRegistry(fileManager, runtimeConnector))
+    Props(new BufferRegistry(fileManager, runtimeConnector, timingsConfig))
 
 }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/TextApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/TextApi.scala
@@ -87,6 +87,13 @@ object TextApi {
     }
   }
 
+  case object FileAutoSaved extends Method("text/autoSave") {
+    case class Params(path: Path)
+    implicit val hasParams = new HasParams[this.type] {
+      type Params = FileAutoSaved.Params
+    }
+  }
+
   case object FileNotOpenedError extends Error(3001, "File not opened")
 
   case class TextEditValidationError(msg: String) extends Error(3002, msg)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/TextProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/TextProtocol.scala
@@ -125,6 +125,13 @@ object TextProtocol {
     */
   case class TextDidChange(changes: List[FileEdit])
 
+  /** A notification sent by the Language Server, notifying a client about
+    * a successful auto-save action.
+    *
+    * @param path path to the saved file
+    */
+  case class FileAutoSaved(path: Path)
+
   /** Requests the language server to save a file on behalf of a given user.
     *
     * @param clientId the client closing the file.

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/TextProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/TextProtocol.scala
@@ -149,10 +149,8 @@ object TextProtocol {
   sealed trait SaveFileResult
 
   /** Signals that saving a file was executed successfully.
-    *
-    * @param autoSave if true, saving was triggered by autoSave action
     */
-  case class FileSaved(autoSave: Boolean) extends SaveFileResult
+  case object FileSaved extends SaveFileResult
 
   /** Signals that the client doesn't hold write lock to the buffer.
     */
@@ -172,9 +170,7 @@ object TextProtocol {
   /** Signals that saving a file failed due to IO error.
     *
     * @param fsFailure a filesystem failure
-    * @param autoSave if true, saving was triggered by autoSave action
     */
-  case class SaveFailed(fsFailure: FileSystemFailure, autoSave: Boolean)
-      extends SaveFileResult
+  case class SaveFailed(fsFailure: FileSystemFailure) extends SaveFileResult
 
 }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/TextProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/TextProtocol.scala
@@ -142,8 +142,10 @@ object TextProtocol {
   sealed trait SaveFileResult
 
   /** Signals that saving a file was executed successfully.
+    *
+    * @param autoSave if true, saving was triggered by autoSave action
     */
-  case object FileSaved extends SaveFileResult
+  case class FileSaved(autoSave: Boolean) extends SaveFileResult
 
   /** Signals that the client doesn't hold write lock to the buffer.
     */
@@ -163,7 +165,9 @@ object TextProtocol {
   /** Signals that saving a file failed due to IO error.
     *
     * @param fsFailure a filesystem failure
+    * @param autoSave if true, saving was triggered by autoSave action
     */
-  case class SaveFailed(fsFailure: FileSystemFailure) extends SaveFileResult
+  case class SaveFailed(fsFailure: FileSystemFailure, autoSave: Boolean)
+      extends SaveFileResult
 
 }

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
@@ -12,7 +12,7 @@ import org.enso.editions.{EditionResolver, Editions}
 import org.enso.jsonrpc.test.JsonRpcServerTestKit
 import org.enso.jsonrpc.{ClientControllerFactory, Protocol}
 import org.enso.languageserver.TestClock
-import org.enso.languageserver.boot.ProfilingConfig
+import org.enso.languageserver.boot.{ProfilingConfig, TimingsConfig}
 import org.enso.languageserver.boot.resource.{
   DirectoriesInitialization,
   RepoInitialization,
@@ -144,9 +144,12 @@ class BaseServerTest
 
   var cleanupCallbacks: List[() => Unit] = Nil
 
+  var timingsConfig = TimingsConfig.default()
+
   override def afterEach(): Unit = {
     cleanupCallbacks.foreach(_())
     cleanupCallbacks = Nil
+    timingsConfig    = TimingsConfig.default()
     super.afterEach()
   }
 
@@ -165,7 +168,8 @@ class BaseServerTest
       system.actorOf(
         BufferRegistry.props(
           fileManager,
-          runtimeConnectorProbe.ref
+          runtimeConnectorProbe.ref,
+          timingsConfig
         )(
           Sha3_224VersionCalculator
         )

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
@@ -5,6 +5,7 @@ import io.circe.literal._
 import org.enso.languageserver.event.BufferClosed
 import org.enso.languageserver.filemanager.Path
 import org.enso.testkit.FlakySpec
+import scala.concurrent.duration._
 
 class TextOperationsTest extends BaseServerTest with FlakySpec {
 
@@ -2200,6 +2201,265 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
           { "jsonrpc": "2.0",
             "id": 4,
             "result": { "contents": "bar" }
+          }
+          """)
+    }
+
+  }
+
+  "auto-save" must {
+
+    "persist changes from a opened file to disk with autosave" in {
+      this.timingsConfig.withAutoSave(2.seconds)
+
+      val client = getInitialisedWsClient()
+      client.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "file/write",
+            "id": 0,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "foo.txt" ]
+              },
+              "contents": "123456789"
+            }
+          }
+          """)
+      client.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 0,
+            "result": null
+          }
+          """)
+      client.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "text/openFile",
+            "id": 1,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "foo.txt" ]
+              }
+            }
+          }
+          """)
+      client.expectJson(json"""
+          {
+            "jsonrpc" : "2.0",
+            "id" : 1,
+            "result" : {
+              "writeCapability" : {
+                "method" : "text/canEdit",
+                "registerOptions" : {
+                  "path" : {
+                    "rootId" : $testContentRootId,
+                    "segments" : [
+                      "foo.txt"
+                    ]
+                  }
+                }
+              },
+              "content" : "123456789",
+              "currentVersion" : "5795c3d628fd638c9835a4c79a55809f265068c88729a1a3fcdf8522"
+            }
+          }
+          """)
+
+      client.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "text/applyEdit",
+            "id": 2,
+            "params": {
+              "edit": {
+                "path": {
+                  "rootId": $testContentRootId,
+                  "segments": [ "foo.txt" ]
+                },
+                "oldVersion": "5795c3d628fd638c9835a4c79a55809f265068c88729a1a3fcdf8522",
+                "newVersion": "ebe55342f9c8b86857402797dd723fb4a2174e0b56d6ace0a6929ec3",
+                "edits": [
+                  {
+                    "range": {
+                      "start": { "line": 0, "character": 0 },
+                      "end": { "line": 0, "character": 0 }
+                    },
+                    "text": "bar"
+                  },
+                  {
+                    "range": {
+                      "start": { "line": 0, "character": 12 },
+                      "end": { "line": 0, "character": 12 }
+                    },
+                    "text": "foo"
+                  }
+                ]
+              }
+            }
+          }
+          """)
+      client.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 2,
+            "result": null
+          }
+          """)
+      Thread.sleep(8.seconds.toMillis)
+      // No explicit file save
+      client.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "file/read",
+            "id": 3,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "foo.txt" ]
+              }
+            }
+          }
+          """)
+      client.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 3,
+            "result": { "contents": "bar123456789foo" }
+          }
+          """)
+    }
+
+    "not be triggered when a file was closed before the delay expired" in {
+      this.timingsConfig.withAutoSave(5.seconds)
+
+      val client1 = getInitialisedWsClient()
+      val client2 = getInitialisedWsClient()
+      client1.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "file/write",
+            "id": 0,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "foo.txt" ]
+              },
+              "contents": "123456789"
+            }
+          }
+          """)
+      client1.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 0,
+            "result": null
+          }
+          """)
+      client1.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "text/openFile",
+            "id": 1,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "foo.txt" ]
+              }
+            }
+          }
+          """)
+      client1.expectJson(json"""
+          {
+            "jsonrpc" : "2.0",
+            "id" : 1,
+            "result" : {
+              "writeCapability" : {
+                "method" : "text/canEdit",
+                "registerOptions" : {
+                  "path" : {
+                    "rootId" : $testContentRootId,
+                    "segments" : [
+                      "foo.txt"
+                    ]
+                  }
+                }
+              },
+              "content" : "123456789",
+              "currentVersion" : "5795c3d628fd638c9835a4c79a55809f265068c88729a1a3fcdf8522"
+            }
+          }
+          """)
+
+      client1.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "text/applyEdit",
+            "id": 2,
+            "params": {
+              "edit": {
+                "path": {
+                  "rootId": $testContentRootId,
+                  "segments": [ "foo.txt" ]
+                },
+                "oldVersion": "5795c3d628fd638c9835a4c79a55809f265068c88729a1a3fcdf8522",
+                "newVersion": "ebe55342f9c8b86857402797dd723fb4a2174e0b56d6ace0a6929ec3",
+                "edits": [
+                  {
+                    "range": {
+                      "start": { "line": 0, "character": 0 },
+                      "end": { "line": 0, "character": 0 }
+                    },
+                    "text": "bar"
+                  },
+                  {
+                    "range": {
+                      "start": { "line": 0, "character": 12 },
+                      "end": { "line": 0, "character": 12 }
+                    },
+                    "text": "foo"
+                  }
+                ]
+              }
+            }
+          }
+          """)
+      client1.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 2,
+            "result": null
+          }
+          """)
+
+      // Close file without waiting on auto-save
+      client1.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "text/closeFile",
+            "id": 3,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "foo.txt" ]
+              }
+            }
+          }
+          """)
+      client1.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 3,
+            "result": null
+          }
+          """)
+      Thread.sleep(5.seconds.toMillis)
+      // Should return the original contents of the file
+      client2.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "file/read",
+            "id": 4,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "foo.txt" ]
+              }
+            }
+          }
+          """)
+      client2.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 4,
+            "result": { "contents": "123456789" }
           }
           """)
     }

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
@@ -2306,6 +2306,17 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
           """)
       Thread.sleep(8.seconds.toMillis)
       // No explicit file save
+      client.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "method":"text/autoSave",
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "foo.txt" ]
+              }
+            }
+          }
+          """)
       client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/read",


### PR DESCRIPTION
### Pull Request Description

This change adds Autosave action for open buffers. The action is scheduled
after every edit request and is cancelled by every explicit save file request, if
necessary. Successful autosave also notifies any active clients of the buffer.

Related to https://www.pivotaltracker.com/story/show/182721656

### Important Notes

WIP

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide dist` and `./run ide watch`.
