### PR TITLE
Add `Table.take` and `Table.drop` functions to In-Memory table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,7 @@
   method.][3644]
 - [Removed `Array.set_at`.][3634]
 - [Added various date part functions to `Date` and `Date_Time`.][3669]
+- [Implemented `Table.take` and `Table.drop` for the in-memory backend.][3647]
 
 [debug-shortcuts]:
   https://github.com/enso-org/enso/blob/develop/app/gui/docs/product/shortcuts.md#debug
@@ -295,6 +296,7 @@
 [3648]: https://github.com/enso-org/enso/pull/3648
 [3634]: https://github.com/enso-org/enso/pull/3634
 [3669]: https://github.com/enso-org/enso/pull/3669
+[3647]: https://github.com/enso-org/enso/pull/3647
 
 #### Enso Compiler
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Index_Sub_Range.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Index_Sub_Range.enso
@@ -141,9 +141,11 @@ sort_and_merge_ranges ranges =
      collection, possibly empty.
    - slice_ranges: A function that takes a vector of ranges and indices and
      constructs a new collection containing the provided subranges and indices
-     in the provided order.
+     in the provided order. The input ranges do not need to be normalized, so if
+     the method wants to work only with normalized ranges, it must perform
+     normalization on its own.
    - range: The `Index_Sub_Range` to take from the collection.
-take_helper : (Integer -> Any) -> (Integer -> Integer -> Any) -> (Vector (Integer | Range) -> Vector Any) -> Index_Sub_Range -> Any
+take_helper : Integer -> (Integer -> Any) -> (Integer -> Integer -> Any) -> (Vector (Integer | Range) -> Vector Any) -> Index_Sub_Range -> Any
 take_helper length at single_slice slice_ranges index_sub_range = case index_sub_range of
     Range _ _ _ -> take_helper length at single_slice slice_ranges (By_Index index_sub_range)
     First count -> single_slice 0 (Math.min length count)
@@ -189,9 +191,10 @@ take_helper length at single_slice slice_ranges index_sub_range = case index_sub
      collection, possibly empty.
    - slice_ranges: A function that takes a vector of ranges and indices and
      constructs a new collection containing the provided subranges and indices
-     in the provided order.
+     in the provided order. The function may assume that the ranges have been
+     normalized.
    - range: The `Index_Sub_Range` to drop from the collection.
-drop_helper : (Integer -> Any) -> (Integer -> Integer -> Any) -> (Vector (Integer | Range) -> Vector Any) -> Index_Sub_Range -> Any
+drop_helper : Integer -> (Integer -> Any) -> (Integer -> Integer -> Any) -> (Vector (Integer | Range) -> Vector Any) -> Index_Sub_Range -> Any
 drop_helper length at single_slice slice_ranges index_sub_range = case index_sub_range of
     Range _ _ _ -> drop_helper length at single_slice slice_ranges (By_Index index_sub_range)
     First count -> single_slice count length

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Index_Sub_Range.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Index_Sub_Range.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 import Standard.Base.Random
+import Standard.Base.Runtime.Ref
 
 type Index_Sub_Range
     ## Select the first `count` items.
@@ -43,3 +44,176 @@ type Index_Sub_Range
        - first: The first entry to include. If it is outside of bounds of the
          input, an error is raised.
     type Every (step:Integer) (first:Integer=0)
+
+## PRIVATE
+   Resolves a vector of ranges or indices into a vector of ranges that fit
+   within a sequence.
+resolve_ranges : Vector (Integer | Range) -> Integer -> Vector Range
+resolve_ranges ranges length =
+    ## Ensures that a descriptor fits within the range of the current
+       vector, trimming it or reporting an error if it is invalid.
+    trim descriptor = case descriptor of
+        Integer ->
+            actual_index = if descriptor < 0 then length + descriptor else descriptor
+            if (actual_index < 0) || (actual_index >= length) then Panic.throw (Index_Out_Of_Bounds_Error descriptor length) else
+                actual_index
+        Range start end step ->
+            if step <= 0 then Panic.throw (Illegal_Argument_Error "Range step must be positive.") else
+                if (start < 0) || (end < 0) then Panic.throw (Illegal_Argument_Error "Range start and end must not be negative.") else
+                    if start >= length then Panic.throw (Index_Out_Of_Bounds_Error start length) else
+                        actual_end = Math.min end length
+                        if actual_end < start then Range start start step else
+                            Range start actual_end step
+    ranges.map trim
+
+## PRIVATE
+   Takes a list of descriptors and returns a new one where ranges with
+   non-unitary step have been replaced with series of ranges covering the same
+   set of indices with step equal to 1, and indices have been replaced with
+   single-element ranges.
+normalize_ranges descriptors =
+    normalize descriptor = case descriptor of
+        Integer -> [Range descriptor descriptor+1]
+        Range _ _ _ ->
+            if descriptor.step == 1 then [descriptor] else
+                descriptor.to_vector.map ix->
+                    Range ix ix+1
+    descriptors.flat_map normalize
+
+## PRIVATE
+   Inverts the selection determined by the input list of ranges.
+
+   The input ranges are assumed to be normalized (i.e. all of them have step
+   equal to 1).
+
+   Arguments:
+   - ranges: The list of ranges determining indices which are selected. The
+     result will be a list of ranges containing all the indices which were not
+     originally selected here.
+   - length: Length of the related sequence.
+   - needs_sorting: Determines if `ranges` need to be sorted and merged or if it
+     can be assumed that they are sorted already.
+invert_range_selection : Vector Range -> Integer -> Boolean -> Vector Range
+invert_range_selection ranges length needs_sorting =
+    sorted = if needs_sorting then sort_and_merge_ranges ranges else ranges
+    ranges_with_sentinels = [Range 0 0] + sorted + [Range length length]
+    ranges_with_sentinels.zip ranges_with_sentinels.tail prev-> next->
+        Range prev.end next.start
+
+## PRIVATE
+   Returns a new sorted list of ranges where intersecting ranges have been
+   merged.
+
+   Empty subranges are discarded.
+sort_and_merge_ranges ranges =
+    sorted = ranges.filter (range-> range.is_empty.not) . sort on=(.start)
+    if sorted.is_empty then [] else
+        current_ref = Ref.new sorted.first
+        builder = Vector.new_builder
+        sorted.tail.each range->
+            current = current_ref.get
+            case range.start <= current.end of
+                True -> current_ref.put (Range current.start (Math.max current.end range.end))
+                False ->
+                    builder.append current
+                    current_ref.put range
+        builder.append current_ref.get
+        builder.to_vector
+
+## PRIVATE
+   A helper that implements taking from an arbitrary collection using a set of
+   callbacks.
+
+   Arguments:
+   - length: The length of the collection.
+   - at: An accessor returning ith element of the collection. Used only for
+     `While`.
+   - single_slice: A two argument function that returns a slice of the
+     collection starting from the index `start` (inclusive) and continuing until
+     the `end` (exclusive). The slice operation should be robust to negative
+     indices - if `start` is less than 0 it should just start slicing from the
+     beginning of the collection. If `end` is less than `start`, an empty
+     collection should be returned. If `end` is greater than `length`, the
+     collection should be sliced until the end of the collection. It should
+     avoid copying and just return the original collection if the whole
+     collection is included in the slice. It should never throw out of bounds
+     errors (these are handled at a higher level), but always return some
+     collection, possibly empty.
+   - slice_ranges: A function that takes a vector of ranges and indices and
+     constructs a new collection containing the provided subranges and indices
+     in the provided order.
+   - range: The `Index_Sub_Range` to take from the collection.
+take_helper : (Integer -> Any) -> (Integer -> Integer -> Any) -> (Vector (Integer | Range) -> Vector Any) -> Index_Sub_Range -> Any
+take_helper length at single_slice slice_ranges index_sub_range = case index_sub_range of
+    Range _ _ _ -> take_helper length at single_slice slice_ranges (By_Index index_sub_range)
+    First count -> single_slice 0 (Math.min length count)
+    Last count -> single_slice length-count length
+    While predicate ->
+        end = 0.up_to length . find i-> (predicate (at i)).not
+        true_end = if end.is_nothing then length else end
+        single_slice 0 true_end
+    By_Index one_or_many_descriptors -> Panic.recover [Index_Out_Of_Bounds_Error, Illegal_Argument_Error] <|
+        indices = case one_or_many_descriptors of
+            Vector.Vector _ -> one_or_many_descriptors
+            _ -> [one_or_many_descriptors]
+        trimmed = resolve_ranges indices length
+        slice_ranges trimmed
+    Sample count seed ->
+        rng = Random.new seed
+        indices_to_take = Random.random_indices length count rng
+        take_helper length at single_slice slice_ranges (By_Index indices_to_take)
+    Every step start ->
+        if step <= 0 then Error.throw (Illegal_Argument_Error "Step within Every must be positive.") else
+            if start >= length then single_slice 0 0 else
+                range = Range start length step
+                take_helper length at single_slice slice_ranges (By_Index range)
+
+## PRIVATE
+   A helper that implements dropping from an arbitrary collection using a set of
+   callbacks.
+
+   Arguments:
+   - length: The length of the collection.
+   - at: An accessor returning ith element of the collection. Used only for
+     `While`.
+   - single_slice: A two argument function that returns a slice of the
+     collection starting from the index `start` (inclusive) and continuing until
+     the `end` (exclusive). The slice operation should be robust to negative
+     indices - if `start` is less than 0 it should just start slicing from the
+     beginning of the collection. If `end` is less than `start`, an empty
+     collection should be returned. If `end` is greater than `length`, the
+     collection should be sliced until the end of the collection. It should
+     avoid copying and just return the original collection if the whole
+     collection is included in the slice. It should never throw out of bounds
+     errors (these are handled at a higher level), but always return some
+     collection, possibly empty.
+   - slice_ranges: A function that takes a vector of ranges and indices and
+     constructs a new collection containing the provided subranges and indices
+     in the provided order.
+   - range: The `Index_Sub_Range` to drop from the collection.
+drop_helper : (Integer -> Any) -> (Integer -> Integer -> Any) -> (Vector (Integer | Range) -> Vector Any) -> Index_Sub_Range -> Any
+drop_helper length at single_slice slice_ranges index_sub_range = case index_sub_range of
+    Range _ _ _ -> drop_helper length at single_slice slice_ranges (By_Index index_sub_range)
+    First count -> single_slice count length
+    Last count -> single_slice 0 length-count
+    While predicate ->
+        end = 0.up_to length . find i-> (predicate (at i)).not
+        true_end = if end.is_nothing then length else end
+        single_slice true_end length
+    By_Index one_or_many_descriptors -> Panic.recover [Index_Out_Of_Bounds_Error, Illegal_Argument_Error] <|
+        indices = case one_or_many_descriptors of
+            Vector.Vector _ -> one_or_many_descriptors
+            _ -> [one_or_many_descriptors]
+        trimmed = resolve_ranges indices length
+        normalized = normalize_ranges trimmed
+        inverted = invert_range_selection normalized length needs_sorting=True
+        slice_ranges inverted
+    Sample count seed ->
+        rng = Random.new seed
+        indices_to_drop = Random.random_indices length count rng
+        drop_helper length at single_slice slice_ranges (By_Index indices_to_drop)
+    Every step start ->
+        if step <= 0 then Error.throw (Illegal_Argument_Error "Step within Every must be positive.") else
+            if start >= length then single_slice 0 length else
+                range = Range start length step
+                drop_helper length at single_slice slice_ranges (By_Index range)

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -10,6 +10,7 @@ import Standard.Base.Data.Text.Case
 import Standard.Base.Data.Text.Location
 import Standard.Base.Data.Text.Line_Ending_Style
 
+import Standard.Base.Data.Index_Sub_Range
 import Standard.Base.Data.Text.Text_Sub_Range
 
 from Standard.Base.Error.Problem_Behavior import Report_Warning
@@ -1150,7 +1151,7 @@ Text.drop self range=(First 1) =
         Text_Sub_Range.Codepoint_Ranges _ _ ->
             sorted_char_ranges_to_remove = ranges.sorted_and_distinct_ranges
             char_length = Text_Utils.char_length self
-            inverted = Vector.invert_range_selection sorted_char_ranges_to_remove char_length needs_sorting=False
+            inverted = Index_Sub_Range.invert_range_selection sorted_char_ranges_to_remove char_length needs_sorting=False
             slice_text self inverted
 
 ## ALIAS lower, upper, title, proper

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Text_Sub_Range.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Text_Sub_Range.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 from Standard.Base.Error.Common import Index_Out_Of_Bounds_Error
 from Standard.Base.Data.Text.Span import Span, range_to_char_indices
+import Standard.Base.Data.Index_Sub_Range
 from Standard.Base.Data.Index_Sub_Range import First, Last, While, By_Index, Sample, Every
 import Standard.Base.Random
 
@@ -117,7 +118,7 @@ type Codepoint_Ranges
        Empty subranges are not discarded.
     sorted_and_distinct_ranges : Vector Range
     sorted_and_distinct_ranges self = if self.is_sorted_and_distinct then self.ranges else
-        Vector.sort_and_merge_ranges self.ranges
+        Index_Sub_Range.sort_and_merge_ranges self.ranges
 
 ## PRIVATE
    Utility function to find char indices for Text_Sub_Range.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -701,8 +701,7 @@ type Vector
                     range = Range start self.length step
                     self.take (By_Index range)
 
-    ## Creates a new vector with only the specified range of elements from the
-       input, removing any elements outside the range.
+    ## Creates a new vector, removing any elements from the specified range.
 
        Arguments:
        - range: The section of the this Vector to return.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -1,9 +1,8 @@
 from Standard.Base import all
-import Standard.Base.Runtime.Ref
-import Standard.Base.Runtime.Unsafe
-from Standard.Base.Data.Index_Sub_Range import While, By_Index, Sample, Every
+import Standard.Base.Data.Index_Sub_Range
 import Standard.Base.Polyglot.Proxy_Polyglot_Array
 import Standard.Base.Random
+import Standard.Base.Runtime.Unsafe
 
 polyglot java import java.util.ArrayList
 polyglot java import java.lang.IndexOutOfBoundsException
@@ -680,26 +679,11 @@ type Vector
          If a `Range`, the selection is specified by two indices, from and to.
     take : (Index_Sub_Range | Range) -> Vector Any
     take self range=(First 1) = case range of
-        Range _ _ _ -> self.take (By_Index range)
-        First count -> self.slice 0 (Math.min self.length count)
-        Last count -> self.slice self.length-count self.length
-        While predicate ->
-            end = 0.up_to self.length . find i-> (predicate (self.at i)).not
-            if end.is_nothing then self else self.slice 0 end
-        By_Index one_or_many_descriptors -> Panic.recover [Index_Out_Of_Bounds_Error, Illegal_Argument_Error] <|
-            indices = case one_or_many_descriptors of
-                Vector _ -> one_or_many_descriptors
-                _ -> [one_or_many_descriptors]
-            trimmed = resolve_ranges indices self.length
-            slice_ranges self trimmed
-        Sample count seed ->
+        Index_Sub_Range.Sample count seed ->
             rng = Random.new seed
             Random.sample self count rng
-        Every step start ->
-            if step <= 0 then Error.throw (Illegal_Argument_Error "Step within Every must be positive.") else
-                if start >= self.length then [] else
-                    range = Range start self.length step
-                    self.take (By_Index range)
+        _ ->
+            Index_Sub_Range.take_helper self.length (self.at _) self.slice (slice_ranges self) range
 
     ## Creates a new vector, removing any elements from the specified range.
 
@@ -709,30 +693,8 @@ type Vector
          the rules of that type.
          If a `Range`, the selection is specified by two indices, from and to.
     drop : (Index_Sub_Range | Range) -> Vector Any
-    drop self range=(First 1) = case range of
-        Range _ _ _ -> self.drop (By_Index range)
-        First count -> self.slice count self.length
-        Last count -> self.slice 0 self.length-count
-        While predicate ->
-            end = 0.up_to self.length . find i-> (predicate (self.at i)).not
-            if end.is_nothing then [] else self.slice end self.length
-        By_Index one_or_many_descriptors -> Panic.recover [Index_Out_Of_Bounds_Error, Illegal_Argument_Error] <|
-            indices = case one_or_many_descriptors of
-                Vector _ -> one_or_many_descriptors
-                _ -> [one_or_many_descriptors]
-            trimmed = resolve_ranges indices self.length
-            normalized = normalize_ranges trimmed
-            inverted = invert_range_selection normalized self.length needs_sorting=True
-            slice_ranges self inverted
-        Sample count seed ->
-            rng = Random.new seed
-            indices_to_drop = Random.random_indices self.length count rng
-            self.drop (By_Index indices_to_drop)
-        Every step start ->
-            if step <= 0 then Error.throw (Illegal_Argument_Error "Step within Every must be positive.") else
-                if start >= self.length then self else
-                    range = Range start self.length step
-                    self.drop (By_Index range)
+    drop self range=(First 1) =
+        Index_Sub_Range.drop_helper self.length (self.at _) self.slice (slice_ranges self) range
 
     ## Performs a pair-wise operation passed in `function` on consecutive
        elements of `self` and `that`.
@@ -1180,27 +1142,6 @@ handle_incomparable_value ~function =
     handle No_Such_Method_Error <| handle Type_Error <| handle Unsupported_Argument_Types <| function
 
 ## PRIVATE
-   Resolves a vector of ranges or indices into a vector of ranges that fit
-   within a sequence.
-resolve_ranges : Vector (Integer | Range) -> Integer -> Vector Range
-resolve_ranges ranges length =
-    ## Ensures that a descriptor fits within the range of the current
-       vector, trimming it or reporting an error if it is invalid.
-    trim descriptor = case descriptor of
-        Integer ->
-            actual_index = if descriptor < 0 then length + descriptor else descriptor
-            if (actual_index < 0) || (actual_index >= length) then Panic.throw (Index_Out_Of_Bounds_Error descriptor length) else
-                actual_index
-        Range start end step ->
-            if step <= 0 then Panic.throw (Illegal_Argument_Error "Range step must be positive.") else
-                if (start < 0) || (end < 0) then Panic.throw (Illegal_Argument_Error "Range start and end must not be negative.") else
-                    if start >= length then Panic.throw (Index_Out_Of_Bounds_Error start length) else
-                        actual_end = Math.min end length
-                        if actual_end < start then Range start start step else
-                            Range start actual_end step
-    ranges.map trim
-
-## PRIVATE
    Creates a new vector where for each range, a corresponding section of the
    source vector is added to the result.
 
@@ -1232,57 +1173,3 @@ slice_many_ranges vector ranges =
                 descriptor.each ix->
                     builder.append (vector.unsafe_at ix)
     builder.to_vector
-
-## PRIVATE
-   Takes a list of descriptors and returns a new one where ranges with
-   non-unitary step have been replaced with series of ranges covering the same
-   set of indices with step equal to 1, and indices have been replaced with
-   single-element ranges.
-normalize_ranges descriptors =
-    normalize descriptor = case descriptor of
-        Integer -> [Range descriptor descriptor+1]
-        Range _ _ _ ->
-            if descriptor.step == 1 then [descriptor] else
-                descriptor.to_vector.map ix->
-                    Range ix ix+1
-    descriptors.flat_map normalize
-
-## PRIVATE
-   Inverts the selection determined by the input list of ranges.
-
-   The input ranges are assumed to be normalized (i.e. all of them have step
-   equal to 1).
-
-   Arguments:
-   - ranges: The list of ranges determining indices which are selected. The
-     result will be a list of ranges containing all the indices which were not
-     originally selected here.
-   - length: Length of the related sequence.
-   - needs_sorting: Determines if `ranges` need to be sorted and merged or if it
-     can be assumed that they are sorted already.
-invert_range_selection : Vector Range -> Integer -> Boolean -> Vector Range
-invert_range_selection ranges length needs_sorting =
-    sorted = if needs_sorting then sort_and_merge_ranges ranges else ranges
-    ranges_with_sentinels = [Range 0 0] + sorted + [Range length length]
-    ranges_with_sentinels.zip ranges_with_sentinels.tail prev-> next->
-        Range prev.end next.start
-
-## PRIVATE
-   Returns a new sorted list of ranges where intersecting ranges have been
-   merged.
-
-   Empty subranges are discarded.
-sort_and_merge_ranges ranges =
-    sorted = ranges.filter (range-> range.is_empty.not) . sort on=(.start)
-    if sorted.is_empty then [] else
-        current_ref = Ref.new sorted.first
-        builder = new_builder
-        sorted.tail.each range->
-            current = current_ref.get
-            case range.start <= current.end of
-                True -> current_ref.put (Range current.start (Math.max current.end range.end))
-                False ->
-                    builder.append current
-                    current_ref.put range
-        builder.append current_ref.get
-        builder.to_vector

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -679,6 +679,10 @@ type Vector
          If a `Range`, the selection is specified by two indices, from and to.
     take : (Index_Sub_Range | Range) -> Vector Any
     take self range=(First 1) = case range of
+        ## We are using a specialized implementation for `take Sample`, because
+           the default implementation (which needs to be generic for any
+           collection) generates a random set of indices and then selects these
+           indices, but we can sample the vector directly.
         Index_Sub_Range.Sample count seed ->
             rng = Random.new seed
             Random.sample self count rng

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
@@ -467,6 +467,30 @@ type Column
         self.to_table.order_by (Sort_Column_Selector.By_Column [Sort_Column.Column self order]) . at self.name
 
     ## UNSTABLE
+       Creates a new Column with the specified range of rows from the input
+       Column.
+
+       Arguments:
+       - range: The selection of rows from the table to return.
+    take : (Index_Sub_Range | Range) -> Column
+    take self range=(First 1) =
+        _ = range
+        msg = "`Column.take` is not yet implemented."
+        Error.throw (Unsupported_Database_Operation_Error msg)
+
+    ## UNSTABLE
+       Creates a new Column from the input with the specified range of rows
+       removed.
+
+       Arguments:
+       - range: The selection of rows from the table to remove.
+    drop : (Index_Sub_Range | Range) -> Column
+    drop self range=(First 1) =
+        _ = range
+        msg = "`Column.drop` is not yet implemented."
+        Error.throw (Unsupported_Database_Operation_Error msg)
+
+    ## UNSTABLE
 
        Checks for each element of the column if it starts with `other`.
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -361,7 +361,7 @@ type Table
        Arguments:
        - range: The selection of rows from the table to return.
     take : (Index_Sub_Range | Range) -> Table
-    take range=(First 1) =
+    take self range=(First 1) =
         _ = range
         msg = "`Table.take` is not yet implemented."
         Error.throw (Unsupported_Database_Operation_Error msg)
@@ -374,7 +374,7 @@ type Table
        Arguments:
        - range: The selection of rows from the table to remove.
     drop : (Index_Sub_Range | Range) -> Table
-    drop range=(First 1) =
+    drop self range=(First 1) =
         _ = range
         msg = "`Table.drop` is not yet implemented."
         Error.throw (Unsupported_Database_Operation_Error msg)

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -355,6 +355,29 @@ type Table
                 self.updated_context new_ctx
 
     ## UNSTABLE
+       Creates a new Table with the specified range of rows from the input
+       Table.
+
+       Arguments:
+       - range: The selection of rows from the table to return.
+    take : (Index_Sub_Range | Range) -> Table
+    take _ =
+        msg = "`Table.take` is not yet implemented."
+        Error.throw (Unsupported_Database_Operation_Error msg)
+
+    ## UNSTABLE
+       Creates a new Table from the input with the specified range of rows
+       removed.
+
+
+       Arguments:
+       - range: The selection of rows from the table to remove.
+    drop : (Index_Sub_Range | Range) -> Table
+    drop _ =
+        msg = "`Table.drop` is not yet implemented."
+        Error.throw (Unsupported_Database_Operation_Error msg)
+
+    ## UNSTABLE
 
        Returns a new Table that will include at most `max_rows` rows from the
        original Table.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -361,7 +361,8 @@ type Table
        Arguments:
        - range: The selection of rows from the table to return.
     take : (Index_Sub_Range | Range) -> Table
-    take _ =
+    take range=(First 1) =
+        _ = range
         msg = "`Table.take` is not yet implemented."
         Error.throw (Unsupported_Database_Operation_Error msg)
 
@@ -373,7 +374,8 @@ type Table
        Arguments:
        - range: The selection of rows from the table to remove.
     drop : (Index_Sub_Range | Range) -> Table
-    drop _ =
+    drop range=(First 1) =
+        _ = range
         msg = "`Table.drop` is not yet implemented."
         Error.throw (Unsupported_Database_Operation_Error msg)
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -1,8 +1,9 @@
 from Standard.Base import all
+import Standard.Base.Data.Ordering.Comparator
+import Standard.Base.Data.Index_Sub_Range
 
 import Standard.Table.Data.Table
 import Standard.Table.Data.Storage
-import Standard.Base.Data.Ordering.Comparator
 
 polyglot java import org.enso.table.data.table.Column as Java_Column
 polyglot java import org.enso.table.operations.OrderBuilder
@@ -1007,45 +1008,33 @@ type Column
         Column new_col
 
     ## UNSTABLE
-
-       Returns a column containing the first `count` elements in this column.
+       Creates a new Column with the specified range of rows from the input
+       Column.
 
        Arguments:
-       - count: The number of elements to take from the start of this column.
-
-       If `self` has a number of items in it less than `count`, the entire
-       column will be returned.
-
-       > Example
-         Take the first 2 elements of a column.
-
-             import Standard.Examples
-
-             example_take_start = Examples.integer_column.take (First 2)
-    take_start : Integer -> Column
-    take_start self count =
-        Column (self.java_column.slice 0 count)
+       - range: The selection of rows from the table to return.
+    take : (Index_Sub_Range | Range) -> Column
+    take self range=(First 1) =
+        Index_Sub_Range.take_helper self.length self.at self.slice (slice_ranges self) range
 
     ## UNSTABLE
-
-       Returns a column containing the last `count` elements in this column.
+       Creates a new Column from the input with the specified range of rows
+       removed.
 
        Arguments:
-       - count: The number of elements to take from the end of this column.
+       - range: The selection of rows from the table to remove.
+    drop : (Index_Sub_Range | Range) -> Column
+    drop self range=(First 1) =
+        Index_Sub_Range.drop_helper self.length self.at self.slice (slice_ranges self) range
 
-       If `self` has a number of items in it less than `count`, the entire
-       column will be returned.
-
-       > Example
-         Take the last 2 elements of a column.
-
-             import Standard.Examples
-
-             example_take_end = Examples.integer_column.take_end 2
-    take_end : Integer -> Column
-    take_end self count =
-        start_point = Math.max (self.length - count) 0
-        Column (self.java_column.slice start_point count)
+    ## PRIVATE
+       Returns a column with a continuous sub-range of rows taken.
+    slice : Integer -> Integer -> Column
+    slice self start end =
+        length = self.length
+        offset = Math.max (Math.min start length) 0
+        limit = Math.max (Math.min (end - offset) (length - offset)) 0
+        Column (self.java_column.slice offset limit)
 
     ## UNSTABLE
 
@@ -1387,3 +1376,8 @@ get_item_string column ix =
     if tp == storage_type_string then column.getItem ix else
         column.getItem ix . to_text
 
+## PRIVATE
+   A helper to create a new table consisting of slices of the original table.
+slice_ranges column ranges =
+    normalized = Index_Sub_Range.normalize_ranges ranges
+    Column (column.java_column.slice normalized.to_array)

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -783,7 +783,7 @@ type Table
             Sample _ _ -> take_by_indices
             Every step start ->
                 if step <= 0 then Error.throw (Illegal_Argument_Error "Step within Every must be positive.") else
-                    if start >= self.length then [] else
+                    if start >= self.length then self.slice 0 0 else
                         range = Range start self.length step
                         self.take (Index_Sub_Range.By_Index range)
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -752,10 +752,34 @@ type Table
        Arguments:
        - range: The selection of rows from the table to return.
     take : (Index_Sub_Range | Range) -> Table
-    take range =
-        indices = (Range 0 self.row_count . to_vector).take range
-        mask = OrderMask.new indices.to_array
-        Table <| self.java_table.applyMask mask
+    take range=(First 1) =
+        take_by_indices =
+            indices = (Range 0 self.row_count . to_vector).take range
+            mask = OrderMask.new indices.to_array
+            Table <| self.java_table.applyMask mask
+        case range of
+            Range _ _ _ -> self.take (By_Index range)
+            First count -> self.slice 0 count
+            Last count -> self.slice self.length-count self.length
+            While predicate ->
+                unimplemented "Table.take While cannot be implemented before the Row type is."
+            By_Index one_or_many_descriptors ->
+                indices = case one_or_many_descriptors of
+                    Vector _ -> one_or_many_descriptors
+                    _ -> [one_or_many_descriptors]
+                case indices.length == 1 of
+                    False -> take_by_indices
+                    True -> case indices.first of
+                        Range start end step -> case step == 1 of
+                            True -> self.slice start end
+                            False -> take_by_indices
+                        _ -> take_by_indices
+            Sample _ _ -> take_by_indices
+            Every step start ->
+                if step <= 0 then Error.throw (Illegal_Argument_Error "Step within Every must be positive.") else
+                    if start >= self.length then [] else
+                        range = Range start self.length step
+                        self.take (By_Index range)
 
     ## UNSTABLE
        Creates a new Table from the input with the specified range of rows
@@ -765,10 +789,34 @@ type Table
        Arguments:
        - range: The selection of rows from the table to remove.
     drop : (Index_Sub_Range | Range) -> Table
-    drop range =
-        indices = (Range 0 self.row_count . to_vector).drop range
-        mask = OrderMask.new indices.to_array
-        Table <| self.java_table.applyMask mask
+    drop range=(First 1) =
+        drop_by_indices =
+            indices = (Range 0 self.row_count . to_vector).drop range
+            mask = OrderMask.new indices.to_array
+            Table <| self.java_table.applyMask mask
+        case range of
+            Range _ _ _ -> self.drop (By_Index range)
+            First count -> self.slice count self.length
+            Last count -> self.slice 0 self.length-count
+            While predicate ->
+                unimplemented "Table.drop While cannot be implemented before the Row type is."
+            By_Index one_or_many_descriptors ->
+                indices = case one_or_many_descriptors of
+                    Vector _ -> one_or_many_descriptors
+                    _ -> [one_or_many_descriptors]
+                case indices.length == 1 of
+                    False -> drop_by_indices
+                    True -> case indices.first of
+                        Range start end step -> case step == 1 of
+                            True -> self.slice start end
+                            False -> drop_by_indices
+                        _ -> drop_by_indices
+            Sample count seed -> drop_by_indices
+            Every step start ->
+                if step <= 0 then Error.throw (Illegal_Argument_Error "Step within Every must be positive.") else
+                    if start >= self.length then self else
+                        range = Range start self.length step
+                        self.drop (By_Index range)
 
     ## ALIAS Add Column
 
@@ -966,45 +1014,13 @@ type Table
     concat : Table -> Table
     concat self other = Table (Java_Table.concat [self.java_table, other.java_table].to_array)
 
-    ## DEPRECATED
-
-       Returns a table containing the first `count` elements in this table.
-
-       Arguments:
-       - count: The number of elements to take from the start of this table.
-
-       If `self` has a number of rows in it less than `count`, the entire table
-       will be returned.
-
-       > Example
-         Get the first four rows from the table.
-
-             import Standard.Examples
-
-             example_take_start = Examples.inventory_table.take_start 4
-    take_start : Integer -> Table
-    take_start self count = Table (self.java_table.slice 0 count)
-
-    ## DEPRECATED
-
-       Returns a table containing the last `count` elements in this table.
-
-       Arguments:
-       - count: The number of elements to take from the end of this table.
-
-       If `self` has a number of rows in it less than `count`, the entire table
-       will be returned.
-
-       > Example
-         Get the last four rows from the table.
-
-             import Standard.Examples
-
-             example_take_end = Examples.inventory_table.take_end 4
-    take_end : Integer -> Table
-    take_end self count =
-        start_point = Math.max (self.row_count - count) 0
-        Table (self.java_table.slice start_point count)
+    ## PRIVATE
+       Returns a table with a continuous sub-range of rows taken.
+    slice : Integer -> Integer -> Table
+    slice self start end =
+        offset = start
+        limit = Math.max (end - start) 0
+        Table (self.java_table.slice offset limit)
 
     ## UNSTABLE
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -18,6 +18,8 @@ from Standard.Table.Data.Column_Type_Selection import Column_Type_Selection, Aut
 from Standard.Table.Data.Data_Formatter import Data_Formatter
 from Standard.Table.Errors import Missing_Input_Columns, Column_Indexes_Out_Of_Range, Duplicate_Type_Selector, No_Index_Set_Error, No_Such_Column_Error
 import Standard.Table.Data.Match_Columns
+from Standard.Base.Data.Index_Sub_Range import First, Last, While, Sample, Every
+import Standard.Base.Data.Index_Sub_Range
 
 import Standard.Table.Data.Column_Name_Mapping
 import Standard.Table.Data.Position
@@ -30,6 +32,7 @@ import Standard.Visualization
 polyglot java import org.enso.table.data.table.Table as Java_Table
 polyglot java import org.enso.table.data.table.Column as Java_Column
 polyglot java import org.enso.table.operations.OrderBuilder
+polyglot java import org.enso.table.data.mask.OrderMask
 
 ## Creates a new table from a vector of `[name, items]` pairs.
 
@@ -508,7 +511,7 @@ type Table
                 Nothing -> Nothing
                 _ -> val.to_text
         new_names = self.columns.map mapper
-        self.take_end (self.row_count - 1) . rename_columns (Column_Name_Mapping.By_Position new_names) on_problems=on_problems
+        self.drop (First 1) . rename_columns (Column_Name_Mapping.By_Position new_names) on_problems=on_problems
 
     ## ALIAS group, summarize
 
@@ -752,20 +755,23 @@ type Table
        Arguments:
        - range: The selection of rows from the table to return.
     take : (Index_Sub_Range | Range) -> Table
-    take range=(First 1) =
+    take self range=(First 1) =
         take_by_indices =
             indices = (Range 0 self.row_count . to_vector).take range
             mask = OrderMask.new indices.to_array
-            Table <| self.java_table.applyMask mask
+            IO.println mask
+            res = Table (self.java_table.applyMask mask)
+            IO.println "res="+res.to_text
+            res
         case range of
-            Range _ _ _ -> self.take (By_Index range)
+            Range _ _ _ -> self.take (Index_Sub_Range.By_Index range)
             First count -> self.slice 0 count
             Last count -> self.slice self.length-count self.length
-            While predicate ->
+            While _ ->
                 unimplemented "Table.take While cannot be implemented before the Row type is."
-            By_Index one_or_many_descriptors ->
+            Index_Sub_Range.By_Index one_or_many_descriptors ->
                 indices = case one_or_many_descriptors of
-                    Vector _ -> one_or_many_descriptors
+                    Vector.Vector _ -> one_or_many_descriptors
                     _ -> [one_or_many_descriptors]
                 case indices.length == 1 of
                     False -> take_by_indices
@@ -779,7 +785,7 @@ type Table
                 if step <= 0 then Error.throw (Illegal_Argument_Error "Step within Every must be positive.") else
                     if start >= self.length then [] else
                         range = Range start self.length step
-                        self.take (By_Index range)
+                        self.take (Index_Sub_Range.By_Index range)
 
     ## UNSTABLE
        Creates a new Table from the input with the specified range of rows
@@ -789,20 +795,20 @@ type Table
        Arguments:
        - range: The selection of rows from the table to remove.
     drop : (Index_Sub_Range | Range) -> Table
-    drop range=(First 1) =
+    drop self range=(First 1) =
         drop_by_indices =
             indices = (Range 0 self.row_count . to_vector).drop range
             mask = OrderMask.new indices.to_array
             Table <| self.java_table.applyMask mask
         case range of
-            Range _ _ _ -> self.drop (By_Index range)
+            Range _ _ _ -> self.drop (Index_Sub_Range.By_Index range)
             First count -> self.slice count self.length
             Last count -> self.slice 0 self.length-count
-            While predicate ->
+            While _ ->
                 unimplemented "Table.drop While cannot be implemented before the Row type is."
-            By_Index one_or_many_descriptors ->
+            Index_Sub_Range.By_Index one_or_many_descriptors ->
                 indices = case one_or_many_descriptors of
-                    Vector _ -> one_or_many_descriptors
+                    Vector.Vector _ -> one_or_many_descriptors
                     _ -> [one_or_many_descriptors]
                 case indices.length == 1 of
                     False -> drop_by_indices
@@ -811,12 +817,12 @@ type Table
                             True -> self.slice start end
                             False -> drop_by_indices
                         _ -> drop_by_indices
-            Sample count seed -> drop_by_indices
+            Sample _ _ -> drop_by_indices
             Every step start ->
                 if step <= 0 then Error.throw (Illegal_Argument_Error "Step within Every must be positive.") else
                     if start >= self.length then self else
                         range = Range start self.length step
-                        self.drop (By_Index range)
+                        self.drop (Index_Sub_Range.By_Index range)
 
     ## ALIAS Add Column
 
@@ -1018,8 +1024,8 @@ type Table
        Returns a table with a continuous sub-range of rows taken.
     slice : Integer -> Integer -> Table
     slice self start end =
-        offset = start
-        limit = Math.max (end - start) 0
+        offset = Math.max start 0
+        limit = Math.max (end - offset) 0
         Table (self.java_table.slice offset limit)
 
     ## UNSTABLE
@@ -1189,8 +1195,8 @@ print_table header rows indices_count format_term =
     divider = content_lengths . map (l -> "-".repeat l+2) . join '+'
     row_lines = rows.map r->
         x = r.zip content_lengths pad
-        ixes = x.take_start indices_count . map (ansi_bold format_term)
-        with_bold_ix = ixes + x.drop_start indices_count
+        ixes = x.take (First indices_count) . map (ansi_bold format_term)
+        with_bold_ix = ixes + x.drop (First indices_count)
         y = with_bold_ix . join ' | '
         " " + y
     ([" " + header_line, divider] + row_lines).join '\n'

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -745,6 +745,31 @@ type Table
     where self indexes =
         Table (self.java_table.mask indexes.java_column)
 
+    ## UNSTABLE
+       Creates a new Table with the specified range of rows from the input
+       Table.
+
+       Arguments:
+       - range: The selection of rows from the table to return.
+    take : (Index_Sub_Range | Range) -> Table
+    take range =
+        indices = (Range 0 self.row_count . to_vector).take range
+        mask = OrderMask.new indices.to_array
+        Table <| self.java_table.applyMask mask
+
+    ## UNSTABLE
+       Creates a new Table from the input with the specified range of rows
+       removed.
+
+
+       Arguments:
+       - range: The selection of rows from the table to remove.
+    drop : (Index_Sub_Range | Range) -> Table
+    drop range =
+        indices = (Range 0 self.row_count . to_vector).drop range
+        mask = OrderMask.new indices.to_array
+        Table <| self.java_table.applyMask mask
+
     ## ALIAS Add Column
 
        Sets the column value at the given name.
@@ -941,8 +966,7 @@ type Table
     concat : Table -> Table
     concat self other = Table (Java_Table.concat [self.java_table, other.java_table].to_array)
 
-    ## ALIAS First N Rows
-       UNSTABLE
+    ## DEPRECATED
 
        Returns a table containing the first `count` elements in this table.
 
@@ -961,8 +985,7 @@ type Table
     take_start : Integer -> Table
     take_start self count = Table (self.java_table.slice 0 count)
 
-    ## ALIAS Last N Rows
-       UNSTABLE
+    ## DEPRECATED
 
        Returns a table containing the last `count` elements in this table.
 
@@ -982,60 +1005,6 @@ type Table
     take_end self count =
         start_point = Math.max (self.row_count - count) 0
         Table (self.java_table.slice start_point count)
-
-    ## ALIAS First Row
-       UNSTABLE
-
-       Returns the first row in the table, if it exists.
-
-       If the table is empty, this method will return a dataflow error
-       containing an `Empty_Error`.
-
-       > Example
-         Get the first row from the table.
-
-             import Standard.Examples
-
-             example_first = Examples.inventory_table.first
-    first : Table ! Empty_Error
-    first self =
-        table = self.take_start 1
-        if table.row_count != 1 then Error.throw Empty_Error else table
-
-    ## UNSTABLE
-
-       Returns the first row in the table, if it exists.
-
-       If the table is empty, this method will return a dataflow error
-       containing an `Empty_Error`.
-
-       > Example
-         Get the first row from the table.
-
-             import Standard.Examples
-
-             example_head = Examples.inventory_table.head
-    head : Table ! Empty_Error
-    head self = self.first
-
-    ## ALIAS Last Row
-       UNSTABLE
-
-       Returns the last row in the table, if it exists.
-
-       If the table is empty, this method will return a dataflow error
-       containing an `Empty_Error`.
-
-       > Example
-         Get the last row from the table.
-
-             import Standard.Examples
-
-             example_last = Examples.inventory_table.last
-    last : Table ! Empty_Error
-    last self =
-        table = self.take_end 1
-        if table.row_count != 1 then Error.throw Empty_Error else table
 
     ## UNSTABLE
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -756,36 +756,8 @@ type Table
        - range: The selection of rows from the table to return.
     take : (Index_Sub_Range | Range) -> Table
     take self range=(First 1) =
-        take_by_indices =
-            indices = (Range 0 self.row_count . to_vector).take range
-            mask = OrderMask.new indices.to_array
-            Table (self.java_table.applyMask mask)
-        case range of
-            Range _ _ _ -> self.take (Index_Sub_Range.By_Index range)
-            First count -> self.slice 0 count
-            Last count -> self.slice self.row_count-count self.row_count
-            While _ ->
-                unimplemented "Table.take While cannot be implemented before the Row type is."
-            Index_Sub_Range.By_Index one_or_many_descriptors ->
-                indices = case one_or_many_descriptors of
-                    Vector.Vector _ -> one_or_many_descriptors
-                    _ -> [one_or_many_descriptors]
-                case indices.length == 1 of
-                    False -> take_by_indices
-                    True -> case indices.first of
-                        Range start end step -> case step == 1 of
-                            True ->
-                                if (start < 0) || (end < 0) then Error.throw (Illegal_Argument_Error "Range start and end must not be negative.") else
-                                    if start >= self.row_count then Error.throw (Index_Out_Of_Bounds_Error start self.row_count) else
-                                        self.slice start end
-                            False -> take_by_indices
-                        _ -> take_by_indices
-            Sample _ _ -> take_by_indices
-            Every step start ->
-                if step <= 0 then Error.throw (Illegal_Argument_Error "Step within Every must be positive.") else
-                    if start >= self.row_count then self.slice 0 0 else
-                        range = Range start self.row_count step
-                        self.take (Index_Sub_Range.By_Index range)
+        at _ = unimplemented "Table.take While cannot be implemented before the Row type is."
+        Index_Sub_Range.take_helper self.row_count at self.slice (slice_ranges self) range
 
     ## UNSTABLE
        Creates a new Table from the input with the specified range of rows
@@ -796,23 +768,8 @@ type Table
        - range: The selection of rows from the table to remove.
     drop : (Index_Sub_Range | Range) -> Table
     drop self range=(First 1) =
-        drop_by_indices =
-            indices = (Range 0 self.row_count . to_vector).drop range
-            mask = OrderMask.new indices.to_array
-            Table <| self.java_table.applyMask mask
-        case range of
-            Range _ _ _ -> self.drop (Index_Sub_Range.By_Index range)
-            First count -> self.slice count self.row_count
-            Last count -> self.slice 0 self.row_count-count
-            While _ ->
-                unimplemented "Table.drop While cannot be implemented before the Row type is."
-            Index_Sub_Range.By_Index _ -> drop_by_indices
-            Sample _ _ -> drop_by_indices
-            Every step start ->
-                if step <= 0 then Error.throw (Illegal_Argument_Error "Step within Every must be positive.") else
-                    if start >= self.row_count then self else
-                        range = Range start self.row_count step
-                        self.drop (Index_Sub_Range.By_Index range)
+        at _ = unimplemented "Table.take While cannot be implemented before the Row type is."
+        Index_Sub_Range.drop_helper self.row_count at self.slice (slice_ranges self) range
 
     ## ALIAS Add Column
 
@@ -1199,3 +1156,9 @@ Table.from (that : Text) (format:File_Format.Delimited|File_Format.Fixed_Width =
 Text.from (that : Table) (format:File_Format.Delimited|File_Format.Fixed_Width = File_Format.Delimited '\t') =
     if format.is_a File_Format.Delimited then Delimited_Writer.write_text that format else
         Errors.unimplemented "Text.from for fixed-width files is not yet implemented."
+
+## PRIVATE
+   A helper to create a new table consisting of slices of the original table.
+slice_ranges table ranges =
+    normalized = Index_Sub_Range.normalize_ranges ranges
+    Table (table.java_table.slice normalized.to_array)

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -759,14 +759,11 @@ type Table
         take_by_indices =
             indices = (Range 0 self.row_count . to_vector).take range
             mask = OrderMask.new indices.to_array
-            IO.println mask
-            res = Table (self.java_table.applyMask mask)
-            IO.println "res="+res.to_text
-            res
+            Table (self.java_table.applyMask mask)
         case range of
             Range _ _ _ -> self.take (Index_Sub_Range.By_Index range)
             First count -> self.slice 0 count
-            Last count -> self.slice self.length-count self.length
+            Last count -> self.slice self.row_count-count self.row_count
             While _ ->
                 unimplemented "Table.take While cannot be implemented before the Row type is."
             Index_Sub_Range.By_Index one_or_many_descriptors ->
@@ -777,14 +774,17 @@ type Table
                     False -> take_by_indices
                     True -> case indices.first of
                         Range start end step -> case step == 1 of
-                            True -> self.slice start end
+                            True ->
+                                if (start < 0) || (end < 0) then Error.throw (Illegal_Argument_Error "Range start and end must not be negative.") else
+                                    if start >= self.row_count then Error.throw (Index_Out_Of_Bounds_Error start self.row_count) else
+                                        self.slice start end
                             False -> take_by_indices
                         _ -> take_by_indices
             Sample _ _ -> take_by_indices
             Every step start ->
                 if step <= 0 then Error.throw (Illegal_Argument_Error "Step within Every must be positive.") else
-                    if start >= self.length then self.slice 0 0 else
-                        range = Range start self.length step
+                    if start >= self.row_count then self.slice 0 0 else
+                        range = Range start self.row_count step
                         self.take (Index_Sub_Range.By_Index range)
 
     ## UNSTABLE
@@ -802,26 +802,16 @@ type Table
             Table <| self.java_table.applyMask mask
         case range of
             Range _ _ _ -> self.drop (Index_Sub_Range.By_Index range)
-            First count -> self.slice count self.length
-            Last count -> self.slice 0 self.length-count
+            First count -> self.slice count self.row_count
+            Last count -> self.slice 0 self.row_count-count
             While _ ->
                 unimplemented "Table.drop While cannot be implemented before the Row type is."
-            Index_Sub_Range.By_Index one_or_many_descriptors ->
-                indices = case one_or_many_descriptors of
-                    Vector.Vector _ -> one_or_many_descriptors
-                    _ -> [one_or_many_descriptors]
-                case indices.length == 1 of
-                    False -> drop_by_indices
-                    True -> case indices.first of
-                        Range start end step -> case step == 1 of
-                            True -> self.slice start end
-                            False -> drop_by_indices
-                        _ -> drop_by_indices
+            Index_Sub_Range.By_Index _ -> drop_by_indices
             Sample _ _ -> drop_by_indices
             Every step start ->
                 if step <= 0 then Error.throw (Illegal_Argument_Error "Step within Every must be positive.") else
-                    if start >= self.length then self else
-                        range = Range start self.length step
+                    if start >= self.row_count then self else
+                        range = Range start self.row_count step
                         self.drop (Index_Sub_Range.By_Index range)
 
     ## ALIAS Add Column
@@ -1024,8 +1014,9 @@ type Table
        Returns a table with a continuous sub-range of rows taken.
     slice : Integer -> Integer -> Table
     slice self start end =
-        offset = Math.max start 0
-        limit = Math.max (end - offset) 0
+        length = self.row_count
+        offset = Math.max (Math.min start length) 0
+        limit = Math.max (Math.min (end - offset) (length - offset)) 0
         Table (self.java_table.slice offset limit)
 
     ## UNSTABLE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1,8 +1,9 @@
 from Standard.Base import all
-import Standard.Base.Data.Ordering.Comparator
-from Standard.Base.Error.Problem_Behavior import Report_Warning
-import Standard.Base.System.Platform
 import Standard.Base.Error.Common as Errors
+from Standard.Base.Error.Problem_Behavior import Report_Warning
+import Standard.Base.Data.Index_Sub_Range
+import Standard.Base.Data.Ordering.Comparator
+import Standard.Base.System.Platform
 
 import Standard.Table.Data.Column
 import Standard.Table.IO.File_Format
@@ -18,8 +19,6 @@ from Standard.Table.Data.Column_Type_Selection import Column_Type_Selection, Aut
 from Standard.Table.Data.Data_Formatter import Data_Formatter
 from Standard.Table.Errors import Missing_Input_Columns, Column_Indexes_Out_Of_Range, Duplicate_Type_Selector, No_Index_Set_Error, No_Such_Column_Error
 import Standard.Table.Data.Match_Columns
-from Standard.Base.Data.Index_Sub_Range import First, Last, While, Sample, Every
-import Standard.Base.Data.Index_Sub_Range
 
 import Standard.Table.Data.Column_Name_Mapping
 import Standard.Table.Data.Position
@@ -762,7 +761,6 @@ type Table
     ## UNSTABLE
        Creates a new Table from the input with the specified range of rows
        removed.
-
 
        Arguments:
        - range: The selection of rows from the table to remove.

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -21,7 +21,7 @@ import Standard.Visualization.Helpers
 prepare_visualization : Any -> Integer -> Json
 prepare_visualization x max_rows = Helpers.recover_errors <| case x of
     Dataframe_Table.Table _ ->
-        dataframe = x.take_start max_rows
+        dataframe = x.take (First max_rows)
         all_rows_count = x.row_count
         included_rows = dataframe.row_count
         index = dataframe.index.catch Any _->

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/BoolStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/BoolStorage.java
@@ -1,12 +1,14 @@
 package org.enso.table.data.column.storage;
 
 import java.util.BitSet;
+import java.util.List;
 
 import org.enso.table.data.column.operation.map.MapOpStorage;
 import org.enso.table.data.column.operation.map.MapOperation;
 import org.enso.table.data.column.operation.map.UnaryMapOperation;
 import org.enso.table.data.index.Index;
 import org.enso.table.data.mask.OrderMask;
+import org.enso.table.data.mask.SliceRange;
 import org.enso.table.error.UnexpectedColumnTypeException;
 import org.enso.table.error.UnexpectedTypeException;
 
@@ -307,5 +309,23 @@ public class BoolStorage extends Storage {
         isMissing.get(offset, offset + limit),
         newSize,
         negated);
+  }
+
+  @Override
+  public BoolStorage slice(List<SliceRange> ranges) {
+    int newSize = SliceRange.totalLength(ranges);
+    BitSet newValues = new BitSet(newSize);
+    BitSet newMissing = new BitSet(newSize);
+    int offset = 0;
+    for (SliceRange range : ranges) {
+      int length = range.end() - range.start();
+      for (int i = 0; i < length; ++i) {
+        newValues.set(offset + i, values.get(range.start() + i));
+        newMissing.set(offset + i, isMissing.get(range.start() + i));
+      }
+      offset += length;
+    }
+
+    return new BoolStorage(newValues, newMissing, newSize, negated);
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/DoubleStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/DoubleStorage.java
@@ -1,6 +1,7 @@
 package org.enso.table.data.column.storage;
 
 import java.util.BitSet;
+import java.util.List;
 
 import org.enso.table.data.column.builder.object.NumericBuilder;
 import org.enso.table.data.column.operation.map.MapOpStorage;
@@ -9,6 +10,7 @@ import org.enso.table.data.column.operation.map.numeric.DoubleBooleanOp;
 import org.enso.table.data.column.operation.map.numeric.DoubleNumericOp;
 import org.enso.table.data.index.Index;
 import org.enso.table.data.mask.OrderMask;
+import org.enso.table.data.mask.SliceRange;
 
 /** A column containing floating point numbers. */
 public class DoubleStorage extends NumericStorage {
@@ -258,5 +260,23 @@ public class DoubleStorage extends NumericStorage {
     System.arraycopy(data, offset, newData, 0, newSize);
     BitSet newMask = isMissing.get(offset, offset + limit);
     return new DoubleStorage(newData, newSize, newMask);
+  }
+
+  @Override
+  public DoubleStorage slice(List<SliceRange> ranges) {
+    int newSize = SliceRange.totalLength(ranges);
+    long[] newData = new long[newSize];
+    BitSet newMissing = new BitSet(newSize);
+    int offset = 0;
+    for (SliceRange range : ranges) {
+      int length = range.end() - range.start();
+      System.arraycopy(data, range.start(), newData, offset, length);
+      for (int i = 0; i < length; ++i) {
+        newMissing.set(offset + i, isMissing.get(range.start() + i));
+      }
+      offset += length;
+    }
+
+    return new DoubleStorage(newData, newSize, newMissing);
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/LongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/LongStorage.java
@@ -1,6 +1,7 @@
 package org.enso.table.data.column.storage;
 
 import java.util.BitSet;
+import java.util.List;
 import java.util.OptionalLong;
 import java.util.stream.LongStream;
 
@@ -13,6 +14,7 @@ import org.enso.table.data.column.operation.map.numeric.LongBooleanOp;
 import org.enso.table.data.column.operation.map.numeric.LongNumericOp;
 import org.enso.table.data.index.Index;
 import org.enso.table.data.mask.OrderMask;
+import org.enso.table.data.mask.SliceRange;
 
 /** A column storing 64-bit integers. */
 public class LongStorage extends NumericStorage {
@@ -369,5 +371,23 @@ public class LongStorage extends NumericStorage {
     System.arraycopy(data, offset, newData, 0, newSize);
     BitSet newMask = isMissing.get(offset, offset + limit);
     return new LongStorage(newData, newSize, newMask);
+  }
+
+  @Override
+  public LongStorage slice(List<SliceRange> ranges) {
+    int newSize = SliceRange.totalLength(ranges);
+    long[] newData = new long[newSize];
+    BitSet newMissing = new BitSet(newSize);
+    int offset = 0;
+    for (SliceRange range : ranges) {
+      int length = range.end() - range.start();
+      System.arraycopy(data, range.start(), newData, offset, length);
+      for (int i = 0; i < length; ++i) {
+        newMissing.set(offset + i, isMissing.get(range.start() + i));
+      }
+      offset += length;
+    }
+
+    return new LongStorage(newData, newSize, newMissing);
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/ObjectStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/ObjectStorage.java
@@ -4,8 +4,10 @@ import org.enso.table.data.column.operation.map.MapOpStorage;
 import org.enso.table.data.column.operation.map.UnaryMapOperation;
 import org.enso.table.data.index.Index;
 import org.enso.table.data.mask.OrderMask;
+import org.enso.table.data.mask.SliceRange;
 
 import java.util.BitSet;
+import java.util.List;
 
 /** A column storing arbitrary objects. */
 public class ObjectStorage extends Storage {
@@ -145,6 +147,20 @@ public class ObjectStorage extends Storage {
     int newSize = Math.min(size - offset, limit);
     Object[] newData = new Object[newSize];
     System.arraycopy(data, offset, newData, 0, newSize);
+    return new ObjectStorage(newData, newSize);
+  }
+
+  @Override
+  public ObjectStorage slice(List<SliceRange> ranges) {
+    int newSize = SliceRange.totalLength(ranges);
+    Object[] newData = new Object[newSize];
+    int offset = 0;
+    for (SliceRange range : ranges) {
+      int length = range.end() - range.start();
+      System.arraycopy(data, range.start(), newData, offset, length);
+      offset += length;
+    }
+
     return new ObjectStorage(newData, newSize);
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/Storage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/Storage.java
@@ -12,6 +12,8 @@ import java.util.function.Function;
 
 import org.enso.table.data.column.builder.object.ObjectBuilder;
 import org.enso.table.data.mask.OrderMask;
+import org.enso.table.data.mask.SliceRange;
+import org.enso.table.data.table.Column;
 
 /** An abstract representation of a data column. */
 public abstract class Storage {
@@ -268,6 +270,9 @@ public abstract class Storage {
 
   /** @return a copy of the storage containing a slice of the original data */
   public abstract Storage slice(int offset, int limit);
+
+  /** @return a copy of the storage consisting of slices of the original data */
+  public abstract Storage slice(List<SliceRange> ranges);
 
   public List<Object> toList() {
     return new StorageListView(this);

--- a/std-bits/table/src/main/java/org/enso/table/data/index/DefaultIndex.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/DefaultIndex.java
@@ -2,6 +2,7 @@ package org.enso.table.data.index;
 
 import org.enso.table.data.column.storage.LongStorage;
 import org.enso.table.data.mask.OrderMask;
+import org.enso.table.data.mask.SliceRange;
 import org.enso.table.data.table.Column;
 
 import java.util.BitSet;
@@ -78,5 +79,10 @@ public class DefaultIndex extends Index {
   @Override
   public DefaultIndex slice(int offset, int limit) {
     return new DefaultIndex(Math.min(size, limit));
+  }
+
+  @Override
+  public DefaultIndex slice(List<SliceRange> ranges) {
+    return new DefaultIndex(SliceRange.totalLength(ranges));
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/index/HashIndex.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/HashIndex.java
@@ -2,6 +2,7 @@ package org.enso.table.data.index;
 
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.mask.OrderMask;
+import org.enso.table.data.mask.SliceRange;
 import org.enso.table.data.table.Column;
 
 import java.util.*;
@@ -98,6 +99,12 @@ public class HashIndex extends Index {
   @Override
   public HashIndex slice(int offset, int limit) {
     var newStorage = items.slice(offset, limit);
+    return new HashIndex(name, newStorage, newStorage.size());
+  }
+
+  @Override
+  public HashIndex slice(List<SliceRange> ranges) {
+    var newStorage = items.slice(ranges);
     return new HashIndex(name, newStorage, newStorage.size());
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/index/Index.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/Index.java
@@ -3,6 +3,7 @@ package org.enso.table.data.index;
 import java.util.BitSet;
 import java.util.List;
 import org.enso.table.data.mask.OrderMask;
+import org.enso.table.data.mask.SliceRange;
 import org.enso.table.data.table.Column;
 
 /** A storage class for ordered multisets. */
@@ -84,4 +85,7 @@ public abstract class Index {
 
   /** @return a copy of the index containing a slice of the original data */
   public abstract Index slice(int offset, int limit);
+
+  /** @return a copy of the index consisting of slices of the original data */
+  public abstract Index slice(List<SliceRange> ranges);
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/mask/SliceRange.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/mask/SliceRange.java
@@ -1,0 +1,16 @@
+package org.enso.table.data.mask;
+
+import java.util.List;
+
+public interface SliceRange {
+  int start();
+  int end();
+
+  static int totalLength(List<SliceRange> ranges) {
+    int total = 0;
+    for (SliceRange range : ranges) {
+      total += range.end() - range.start();
+    }
+    return total;
+  }
+}

--- a/std-bits/table/src/main/java/org/enso/table/data/mask/SliceRange.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/mask/SliceRange.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public interface SliceRange {
   int start();
+
   int end();
 
   static int totalLength(List<SliceRange> ranges) {

--- a/std-bits/table/src/main/java/org/enso/table/data/table/Column.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/Column.java
@@ -14,6 +14,7 @@ import org.enso.table.data.index.DefaultIndex;
 import org.enso.table.data.index.HashIndex;
 import org.enso.table.data.index.Index;
 import org.enso.table.data.mask.OrderMask;
+import org.enso.table.data.mask.SliceRange;
 import org.enso.table.error.UnexpectedColumnTypeException;
 import org.graalvm.polyglot.Value;
 
@@ -205,6 +206,11 @@ public class Column {
   /** @return a copy of the Column containing a slice of the original data */
   public Column slice(int offset, int limit) {
     return new Column(name, index.slice(offset, limit), storage.slice(offset, limit));
+  }
+
+  /** @return a copy of the Column consisting of slices of the original data */
+  public Column slice(List<SliceRange> ranges) {
+    return new Column(name, index.slice(ranges), storage.slice(ranges));
   }
 
   /** @return a column counting value repetitions in this column. */

--- a/std-bits/table/src/main/java/org/enso/table/data/table/Table.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/Table.java
@@ -10,6 +10,7 @@ import org.enso.table.data.index.HashIndex;
 import org.enso.table.data.index.Index;
 import org.enso.table.data.index.MultiValueIndex;
 import org.enso.table.data.mask.OrderMask;
+import org.enso.table.data.mask.SliceRange;
 import org.enso.table.data.table.problems.AggregatedProblems;
 import org.enso.table.error.NoSuchColumnException;
 import org.enso.table.error.UnexpectedColumnTypeException;
@@ -467,12 +468,21 @@ public class Table {
     return new Table(newColumns, index);
   }
 
-  /** @return a copy of the Column containing a slice of the original data */
+  /** @return a copy of the Table containing a slice of the original data */
   public Table slice(int offset, int limit) {
     Column[] newColumns = new Column[columns.length];
     for (int i = 0; i < columns.length; i++) {
       newColumns[i] = columns[i].slice(offset, limit);
     }
     return new Table(newColumns, index.slice(offset, limit));
+  }
+
+  /** @return a copy of the Table consisting of slices of the original data */
+  public Table slice(List<SliceRange> ranges) {
+    Column[] newColumns = new Column[columns.length];
+    for (int i = 0; i < columns.length; i++) {
+      newColumns[i] = columns[i].slice(ranges);
+    }
+    return new Table(newColumns, index.slice(ranges));
   }
 }

--- a/test/Table_Tests/src/Column_Spec.enso
+++ b/test/Table_Tests/src/Column_Spec.enso
@@ -20,17 +20,17 @@ spec = Test.group "Columns" <|
         expected_1 = Column.from_vector "Test" [1, 3, 5]
         expected_2 = Column.from_vector "Test" [1, 3, 5, 2, 4, 6]
         expected_3 = Column.from_vector "Test" []
-        test_column.take_start 3 . to_vector . should_equal expected_1.to_vector
-        test_column.take_start 7 . to_vector . should_equal expected_2.to_vector
-        test_column.take_start 0 . to_vector . should_equal expected_3.to_vector
+        test_column.take (First 3) . to_vector . should_equal expected_1.to_vector
+        test_column.take (First 7) . to_vector . should_equal expected_2.to_vector
+        test_column.take (First 0) . to_vector . should_equal expected_3.to_vector
 
     Test.specify "should be able to take the last n elements" <|
         expected_1 = Column.from_vector "Test" [2, 4, 6]
         expected_2 = Column.from_vector "Test" [1, 3, 5, 2, 4, 6]
         expected_3 = Column.from_vector "Test" []
-        test_column.take_end 3 . to_vector . should_equal expected_1.to_vector
-        test_column.take_end 7 . to_vector . should_equal expected_2.to_vector
-        test_column.take_end 0 . to_vector . should_equal expected_3.to_vector
+        test_column.take (Last 3) . to_vector . should_equal expected_1.to_vector
+        test_column.take (Last 7) . to_vector . should_equal expected_2.to_vector
+        test_column.take (Last 0) . to_vector . should_equal expected_3.to_vector
 
     Test.specify "should be able to get the first / head element" <|
         test_column.first . should_equal 1

--- a/test/Table_Tests/src/Common_Table_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Spec.enso
@@ -1,4 +1,6 @@
 from Standard.Base import all
+from Standard.Base.Data.Index_Sub_Range import While, Sample, Every
+import Standard.Base.Data.Index_Sub_Range
 
 from Standard.Table import Column_Name_Mapping, Sort_Column, Sort_Column_Selector
 from Standard.Table.Errors as Table_Errors import all
@@ -8,7 +10,7 @@ from Standard.Table.Data.Position import all
 import Standard.Test
 import Standard.Test.Problems
 
-type Test_Selection supports_case_sensitive_columns=True order_by=True natural_ordering=False case_insensitive_ordering=True order_by_unicode_normalization_by_default=False case_insensitive_ascii_only=False
+type Test_Selection supports_case_sensitive_columns=True order_by=True natural_ordering=False case_insensitive_ordering=True order_by_unicode_normalization_by_default=False case_insensitive_ascii_only=False take_drop=True
 
 ## A common test suite for shared operations on the Table API.
 
@@ -22,9 +24,6 @@ type Test_Selection supports_case_sensitive_columns=True order_by=True natural_o
      builds a Table using the backend that is meant to be tested. Each column
      description is a triple of column name, column type and a vector containing
      column elements.
-   - materialize: A helper function which materializes a table from the tested
-     backend as an in-memory table. Used to easily inspect results of a
-     particular query/operation.
    - test_selection: A selection of which suites should be run. Can be used to
      skip checks for backends which do not support particular features.
    - pending: An optional mark to disable all test groups. Can be used to
@@ -776,3 +775,126 @@ spec prefix table_builder test_selection pending=Nothing =
             t1 = table.order_by (Sort_Column_Selector.By_Name [Sort_Column.Name "alpha"]) text_ordering=ordering
             t1.at "alpha" . to_vector . should_equal [0, 1, 2, 3]
             t1.at "gamma" . to_vector . should_equal [4, 3, 2, 1]
+
+    take_drop_by_pending = if pending.is_nothing.not then pending else
+        if test_selection.take_drop.not then "TODO: take/drop are not yet supported by this backend." else
+            Nothing
+    Test.group prefix+"Table.take/drop" pending=take_drop_by_pending <|
+        table =
+            col1 = ["alpha", [1,2,3,4,5,6,7,8]]
+            col2 = ["beta", ["A","B","C","D","E","F","G","H"]]
+            table_builder [col1, col2]
+        empty = table_builder [["alpha", []], ["beta", []]]
+
+        Test.specify "should allow selecting first or last N rows" <|
+            table.take.at "alpha" . to_vector . should_equal [1]
+            table.take.at "beta" . to_vector . should_equal ["A"]
+            table.drop.at "alpha" . to_vector . should_equal [2,3,4,5,6,7,8]
+
+            table.take (First 4) . at "alpha" . to_vector . should_equal [1,2,3,4]
+            table.take (First 0) . at "alpha" . to_vector . should_equal []
+            table.take (First -1) . at "alpha" . to_vector . should_equal []
+            table.take (First 100) . should_equal table
+
+            table.drop (First 2) . at "beta" . to_vector . should_equal ["C","D","E","F","G","H"]
+            table.drop (First 0) . should_equal table
+            table.drop (First -1) . should_equal table
+            table.drop (First 100) . should_equal empty
+
+            table.take (Last 4) . at "beta" . to_vector . should_equal ["E","F","G","H"]
+            table.take (Last 0) . should_equal []
+            table.take (Last -1) . should_equal []
+            table.take (Last 100) . should_equal table
+
+            table.drop (Last 2) . at "alpha" . to_vector . should_equal [1,2,3,4,5,6]
+            table.drop (Last 0) . should_equal table
+            table.drop (Last -1) . should_equal table
+            table.drop (Last 100) . should_equal []
+
+        Test.specify "should allow selecting rows by ranges or indices" pending="TODO" <|
+            table.take (Range 2 4) . at "beta" . to_vector . should_equal ["C", "D"]
+            table.take (Range 0 0) . should_equal empty
+            table.take (Range 100 100) . should_fail_with Index_Out_Of_Bounds_Error
+            table.take (Range 100 100) . catch . should_equal (Index_Out_Of_Bounds_Error 100 6)
+            table.take (Range 0 100) . should_equal table
+            empty.take (Range 0 0) . should_fail_with Index_Out_Of_Bounds_Error
+            empty.take (Range 0 0) . catch . should_equal (Index_Out_Of_Bounds_Error 0 0)
+            table.take (Range 100 99) . should_fail_with Index_Out_Of_Bounds_Error
+
+            table.drop (Range 2 4) . at "alpha" . to_vector . should_equal [1, 2, 5, 6, 7, 8]
+            table.drop (Range 0 0) . should_equal table
+            table.drop (Range 100 100) . should_fail_with Index_Out_Of_Bounds_Error
+            table.drop (Range 100 100) . catch . should_equal (Index_Out_Of_Bounds_Error 100 6)
+            table.drop (Range 0 100) . should_equal empty
+            empty.drop (Range 0 0) . should_fail_with Index_Out_Of_Bounds_Error
+            empty.drop (Range 0 0) . catch . should_equal (Index_Out_Of_Bounds_Error 0 0)
+            table.drop (Range 100 99) . should_fail_with Index_Out_Of_Bounds_Error
+            table.take (Index_Sub_Range.By_Index 0) . at "beta" . to_vector . should_equal ["A"]
+            empty.take (Index_Sub_Range.By_Index 0) . should_fail_with Index_Out_Of_Bounds_Error
+            table.take (Index_Sub_Range.By_Index []) . should_equal empty
+            table.take (Index_Sub_Range.By_Index [-1, -1]) . at "beta" . to_vector . should_equal ["H", "H"]
+            table.take (Index_Sub_Range.By_Index [0, 0, Range 3 100]) . at "alpha" . to_vector . should_equal [1, 1, 4, 5, 6, 7, 8]
+            table.take (Range 0 100 2) . at "alpha" . to_vector . should_equal [1, 3, 5, 7]
+            table.take (Index_Sub_Range.By_Index [Range 0 100 2, Range 1 6 2]) . at "alpha" . to_vector . should_equal [1, 3, 5, 7, 2, 4, 6]
+            table.take (Index_Sub_Range.By_Index [Range 1 3, Range 2 5]) . at "alpha" . to_vector . should_equal [2, 3, 3, 4, 5]
+            table.take (Index_Sub_Range.By_Index [Range 2 5, Range 1 3]) . at "alpha" . to_vector . should_equal [3, 4, 5, 2, 3]
+            table.take (Index_Sub_Range.By_Index [0, 1, Range 100 200]) . should_fail_with Index_Out_Of_Bounds_Error
+            table.take (Index_Sub_Range.By_Index 100) . should_fail_with Index_Out_Of_Bounds_Error
+
+            table.drop (Index_Sub_Range.By_Index 0) . at "alpha" . to_vector . should_equal [2, 3, 4, 5, 6, 7, 8]
+            table.drop (Index_Sub_Range.By_Index []) . should_equal table
+            table.drop (Index_Sub_Range.By_Index [-1, -1]) . at "alpha" . to_vector . should_equal [1, 2, 3, 4, 5, 6, 7]
+            table.drop (Index_Sub_Range.By_Index [0, 0, Range 3 100]) . at "alpha" . to_vector . should_equal [2, 3]
+            table.drop (Range 0 100 2) . at "alpha" . to_vector . should_equal [2, 4, 6, 8]
+            table.drop (Index_Sub_Range.By_Index [Range 0 100 2, Range 1 6 2]) . should_equal empty
+            table.drop (Index_Sub_Range.By_Index [Range 1 3, Range 2 5]) . at "alpha" . to_vector . should_equal [1, 6, 7, 8]
+            table.drop (Index_Sub_Range.By_Index [Range 2 5, Range 1 3]) . at "alpha" . to_vector . should_equal [1, 6, 7, 8]
+            table.drop (Index_Sub_Range.By_Index [0, 1, Range 100 200]) . should_fail_with Index_Out_Of_Bounds_Error
+            table.drop (Index_Sub_Range.By_Index 100) . should_fail_with Index_Out_Of_Bounds_Error
+
+        Test.specify "should allow selecting every Nth row" <|
+            table.take (Every 1) . should_equal table
+            table.take (Every 3) . at "alpha" . to_vector . should_equal [1, 4, 7]
+            table.take (Every 3 first=1) . at "alpha" . to_vector . should_equal [2, 5, 8]
+            table.take (Every 2 first=1) . at "beta" . to_vector . should_equal ["B", "D", "F", "H"]
+            table.take (Every 2 first=100) . at "alpha" . to_vector . should_equal []
+            table.take (Every 200) . should_equal [1]
+            empty.take (Every 2) . should_equal []
+            table.take (Every 0) . should_fail_with Illegal_Argument_Error
+            empty.take (Every 0) . should_fail_with Illegal_Argument_Error
+
+            table.take (Every 1) . should_equal empty
+            table.drop (Every 3) . at "alpha" . to_vector . should_equal [2, 3, 5, 6, 8]
+            table.drop (Every 3 first=1) . at "alpha" . to_vector . should_equal [1, 3, 4, 6, 7]
+            table.drop (Every 2 first=1) . at "alpha" . to_vector . should_equal [1, 3, 5, 7]
+            table.drop (Every 2 first=100) . should_equal table
+            table.drop (Every 200) . at "beta" . to_vector . should_equal ["B", "C", "D", "E", "F", "G", "H"]
+            empty.drop (Every 2) . should_equal empty
+            table.drop (Every 0) . should_fail_with Illegal_Argument_Error
+            empty.drop (Every 0) . should_fail_with Illegal_Argument_Error
+
+        Test.specify "should allow sampling rows" <|
+            empty = table_builder [["X", []]]
+            one = table_builder [["X", ["a"]]]
+            two = table_builder [["X", ["a", "a"]]]
+            three = table_builder [["X", ["a", "a", "a"]]]
+            table.take (Sample 0) . at "alpha" . to_vector . should_equal empty
+            empty.take (Sample 0) . should_equal empty
+            empty.take (Sample 1) . should_equal empty
+            three.take (Sample 1) . should_equal one
+            three.take (Sample 100) . should_equal three
+
+            three.drop (Sample 0) . should_equal three
+            empty.drop (Sample 0) . should_equal empty
+            empty.drop (Sample 1) . should_equal empty
+            one.drop (Sample 1) . should_equal empty
+            three.drop (Sample 1) . should_equal two
+            three.drop (Sample 100) . should_equal empty
+
+            rnd = table.take (Sample 3 seed=42)
+            # TODO
+            rnd.print
+
+        Test.specify "should allow selecting rows as long as they satisfy a predicate" pending="While is not implemented for Table until the Row type is implemented." <|
+            Nothing
+

--- a/test/Table_Tests/src/Common_Table_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Spec.enso
@@ -804,21 +804,22 @@ spec prefix table_builder test_selection pending=Nothing =
             table.drop (First 100) . should_equal empty
 
             table.take (Last 4) . at "beta" . to_vector . should_equal ["E","F","G","H"]
-            table.take (Last 0) . should_equal []
-            table.take (Last -1) . should_equal []
+            table.take (Last 0) . should_equal empty
+            table.take (Last -1) . should_equal empty
             table.take (Last 100) . should_equal table
 
             table.drop (Last 2) . at "alpha" . to_vector . should_equal [1,2,3,4,5,6]
             table.drop (Last 0) . should_equal table
             table.drop (Last -1) . should_equal table
-            table.drop (Last 100) . should_equal []
+            table.drop (Last 100) . should_equal empty
 
-        Test.specify "should allow selecting rows by ranges or indices" pending="TODO" <|
+        Test.specify "should allow selecting rows by ranges or indices" <|
             table.take (Range 2 4) . at "beta" . to_vector . should_equal ["C", "D"]
             table.take (Range 0 0) . should_equal empty
             table.take (Range 100 100) . should_fail_with Index_Out_Of_Bounds_Error
-            table.take (Range 100 100) . catch . should_equal (Index_Out_Of_Bounds_Error 100 6)
+            table.take (Range 100 100) . catch . should_equal (Index_Out_Of_Bounds_Error 100 8)
             table.take (Range 0 100) . should_equal table
+            table.take (Range 0 table.row_count) . should_equal table
             empty.take (Range 0 0) . should_fail_with Index_Out_Of_Bounds_Error
             empty.take (Range 0 0) . catch . should_equal (Index_Out_Of_Bounds_Error 0 0)
             table.take (Range 100 99) . should_fail_with Index_Out_Of_Bounds_Error
@@ -826,11 +827,13 @@ spec prefix table_builder test_selection pending=Nothing =
             table.drop (Range 2 4) . at "alpha" . to_vector . should_equal [1, 2, 5, 6, 7, 8]
             table.drop (Range 0 0) . should_equal table
             table.drop (Range 100 100) . should_fail_with Index_Out_Of_Bounds_Error
-            table.drop (Range 100 100) . catch . should_equal (Index_Out_Of_Bounds_Error 100 6)
+            table.drop (Range 100 100) . catch . should_equal (Index_Out_Of_Bounds_Error 100 8)
             table.drop (Range 0 100) . should_equal empty
+            table.drop (Range 0 table.row_count) . should_equal empty
             empty.drop (Range 0 0) . should_fail_with Index_Out_Of_Bounds_Error
             empty.drop (Range 0 0) . catch . should_equal (Index_Out_Of_Bounds_Error 0 0)
             table.drop (Range 100 99) . should_fail_with Index_Out_Of_Bounds_Error
+
             table.take (Index_Sub_Range.By_Index 0) . at "beta" . to_vector . should_equal ["A"]
             empty.take (Index_Sub_Range.By_Index 0) . should_fail_with Index_Out_Of_Bounds_Error
             table.take (Index_Sub_Range.By_Index []) . should_equal empty
@@ -848,7 +851,7 @@ spec prefix table_builder test_selection pending=Nothing =
             table.drop (Index_Sub_Range.By_Index [-1, -1]) . at "alpha" . to_vector . should_equal [1, 2, 3, 4, 5, 6, 7]
             table.drop (Index_Sub_Range.By_Index [0, 0, Range 3 100]) . at "alpha" . to_vector . should_equal [2, 3]
             table.drop (Range 0 100 2) . at "alpha" . to_vector . should_equal [2, 4, 6, 8]
-            table.drop (Index_Sub_Range.By_Index [Range 0 100 2, Range 1 6 2]) . should_equal empty
+            table.drop (Index_Sub_Range.By_Index [Range 0 100 2, Range 1 6 2]) . at "alpha" . to_vector . should_equal [8]
             table.drop (Index_Sub_Range.By_Index [Range 1 3, Range 2 5]) . at "alpha" . to_vector . should_equal [1, 6, 7, 8]
             table.drop (Index_Sub_Range.By_Index [Range 2 5, Range 1 3]) . at "alpha" . to_vector . should_equal [1, 6, 7, 8]
             table.drop (Index_Sub_Range.By_Index [0, 1, Range 100 200]) . should_fail_with Index_Out_Of_Bounds_Error
@@ -859,18 +862,13 @@ spec prefix table_builder test_selection pending=Nothing =
             table.take (Every 3) . at "alpha" . to_vector . should_equal [1, 4, 7]
             table.take (Every 3 first=1) . at "alpha" . to_vector . should_equal [2, 5, 8]
             table.take (Every 2 first=1) . at "beta" . to_vector . should_equal ["B", "D", "F", "H"]
-            IO.println "TABLE = "+table.to_text
-            table.print
-            taken = table.take (Every 2 first=100)
-            IO.println "TABLE.take = "+taken.to_text
-            taken.print
             table.take (Every 2 first=100) . at "alpha" . to_vector . should_equal []
-            table.take (Every 200) . should_equal [1]
-            empty.take (Every 2) . should_equal []
+            table.take (Every 200) . at "alpha" . to_vector . should_equal [1]
+            empty.take (Every 2) . should_equal empty
             table.take (Every 0) . should_fail_with Illegal_Argument_Error
             empty.take (Every 0) . should_fail_with Illegal_Argument_Error
 
-            table.take (Every 1) . should_equal empty
+            table.drop (Every 1) . should_equal empty
             table.drop (Every 3) . at "alpha" . to_vector . should_equal [2, 3, 5, 6, 8]
             table.drop (Every 3 first=1) . at "alpha" . to_vector . should_equal [1, 3, 4, 6, 7]
             table.drop (Every 2 first=1) . at "alpha" . to_vector . should_equal [1, 3, 5, 7]
@@ -885,7 +883,7 @@ spec prefix table_builder test_selection pending=Nothing =
             one = table_builder [["X", ["a"]]]
             two = table_builder [["X", ["a", "a"]]]
             three = table_builder [["X", ["a", "a", "a"]]]
-            table.take (Sample 0) . at "alpha" . to_vector . should_equal empty
+            three.take (Sample 0) . should_equal empty
             empty.take (Sample 0) . should_equal empty
             empty.take (Sample 1) . should_equal empty
             three.take (Sample 1) . should_equal one
@@ -899,8 +897,11 @@ spec prefix table_builder test_selection pending=Nothing =
             three.drop (Sample 100) . should_equal empty
 
             rnd = table.take (Sample 3 seed=42)
-            rnd.at "alpha" . to_vector . should_equal [6, 7, 3]
-            rnd.at "beta" . to_vector . should_equal ["F", "G", "C"]
+            random_indices = [5, 6, 2]
+            alpha_sample = random_indices.map (table.at "alpha" . to_vector . at)
+            beta_sample = random_indices.map (table.at "beta" . to_vector . at)
+            rnd.at "alpha" . to_vector . should_equal alpha_sample
+            rnd.at "beta" . to_vector . should_equal beta_sample
 
         Test.specify "should allow selecting rows as long as they satisfy a predicate" pending="While is not implemented for Table until the Row type is implemented." <|
             Nothing

--- a/test/Table_Tests/src/Common_Table_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Spec.enso
@@ -906,3 +906,143 @@ spec prefix table_builder test_selection pending=Nothing =
         Test.specify "should allow selecting rows as long as they satisfy a predicate" pending="While is not implemented for Table until the Row type is implemented." <|
             Nothing
 
+    Test.group prefix+"Column.take/drop" pending=take_drop_by_pending <|
+        table =
+            col1 = ["alpha", [1,2,3,4,5,6,7,8]]
+            col2 = ["beta", ["A","B","C","D","E","F","G","H"]]
+            table_builder [col1, col2]
+        alpha = table.at "alpha"
+        beta = table.at "beta"
+
+        empty_table = table_builder [["alpha", []], ["beta", []]]
+        empty_alpha = empty_table.at "alpha"
+        empty_beta = empty_table.at "beta"
+
+        Test.specify "should allow selecting first or last N rows" <|
+            alpha.take.to_vector . should_equal [1]
+            beta.take.to_vector . should_equal ["A"]
+            alpha.drop.to_vector . should_equal [2,3,4,5,6,7,8]
+
+            alpha.take (First 4) . to_vector . should_equal [1,2,3,4]
+            alpha.take (First 0) . should_equal empty_alpha
+            alpha.take (First -1) . should_equal empty_alpha
+            alpha.take (First 100) . should_equal alpha
+
+            beta.drop (First 2) . to_vector . should_equal ["C","D","E","F","G","H"]
+            alpha.drop (First 0) . should_equal alpha
+            alpha.drop (First -1) . should_equal alpha
+            alpha.drop (First 100) . should_equal empty_alpha
+
+            beta.take (Last 4) . to_vector . should_equal ["E","F","G","H"]
+            beta.take (Last 0) . should_equal empty_beta
+            beta.take (Last -1) . should_equal empty_beta
+            beta.take (Last 100) . should_equal beta
+
+            alpha.drop (Last 2) . to_vector . should_equal [1,2,3,4,5,6]
+            alpha.drop (Last 0) . should_equal alpha
+            alpha.drop (Last -1) . should_equal alpha
+            alpha.drop (Last 100) . should_equal empty_alpha
+
+        Test.specify "should allow selecting rows by ranges or indices" <|
+            beta.take (Range 2 4) . to_vector . should_equal ["C", "D"]
+            beta.take (Range 0 0) . should_equal empty_beta
+            beta.take (Range 100 100) . should_fail_with Index_Out_Of_Bounds_Error
+            beta.take (Range 100 100) . catch . should_equal (Index_Out_Of_Bounds_Error 100 8)
+            beta.take (Range 0 100) . should_equal beta
+            beta.take (Range 0 table.row_count) . should_equal beta
+            empty_beta.take (Range 0 0) . should_fail_with Index_Out_Of_Bounds_Error
+            empty_beta.take (Range 0 0) . catch . should_equal (Index_Out_Of_Bounds_Error 0 0)
+            beta.take (Range 100 99) . should_fail_with Index_Out_Of_Bounds_Error
+
+            alpha.drop (Range 2 4) . to_vector . should_equal [1, 2, 5, 6, 7, 8]
+            alpha.drop (Range 0 0) . should_equal alpha
+            alpha.drop (Range 100 100) . should_fail_with Index_Out_Of_Bounds_Error
+            alpha.drop (Range 100 100) . catch . should_equal (Index_Out_Of_Bounds_Error 100 8)
+            alpha.drop (Range 0 100) . should_equal empty_alpha
+            alpha.drop (Range 0 table.row_count) . should_equal empty_alpha
+            empty_alpha.drop (Range 0 0) . should_fail_with Index_Out_Of_Bounds_Error
+            empty_alpha.drop (Range 0 0) . catch . should_equal (Index_Out_Of_Bounds_Error 0 0)
+            alpha.drop (Range 100 99) . should_fail_with Index_Out_Of_Bounds_Error
+
+            beta.take (Index_Sub_Range.By_Index 0) . to_vector . should_equal ["A"]
+            empty_beta.take (Index_Sub_Range.By_Index 0) . should_fail_with Index_Out_Of_Bounds_Error
+            beta.take (Index_Sub_Range.By_Index []) . should_equal empty_beta
+            beta.take (Index_Sub_Range.By_Index [-1, -1]) . to_vector . should_equal ["H", "H"]
+            alpha.take (Index_Sub_Range.By_Index [0, 0, Range 3 100]) . to_vector . should_equal [1, 1, 4, 5, 6, 7, 8]
+            alpha.take (Range 0 100 2) . to_vector . should_equal [1, 3, 5, 7]
+            alpha.take (Index_Sub_Range.By_Index [Range 0 100 2, Range 1 6 2]) . to_vector . should_equal [1, 3, 5, 7, 2, 4, 6]
+            alpha.take (Index_Sub_Range.By_Index [Range 1 3, Range 2 5]) . to_vector . should_equal [2, 3, 3, 4, 5]
+            alpha.take (Index_Sub_Range.By_Index [Range 2 5, Range 1 3]) . to_vector . should_equal [3, 4, 5, 2, 3]
+            alpha.take (Index_Sub_Range.By_Index [0, 1, Range 100 200]) . should_fail_with Index_Out_Of_Bounds_Error
+            alpha.take (Index_Sub_Range.By_Index 100) . should_fail_with Index_Out_Of_Bounds_Error
+
+            alpha.drop (Index_Sub_Range.By_Index 0) . to_vector . should_equal [2, 3, 4, 5, 6, 7, 8]
+            alpha.drop (Index_Sub_Range.By_Index []) . should_equal alpha
+            alpha.drop (Index_Sub_Range.By_Index [-1, -1]) . to_vector . should_equal [1, 2, 3, 4, 5, 6, 7]
+            alpha.drop (Index_Sub_Range.By_Index [0, 0, Range 3 100]) . to_vector . should_equal [2, 3]
+            alpha.drop (Range 0 100 2) . to_vector . should_equal [2, 4, 6, 8]
+            alpha.drop (Index_Sub_Range.By_Index [Range 0 100 2, Range 1 6 2]) . to_vector . should_equal [8]
+            alpha.drop (Index_Sub_Range.By_Index [Range 1 3, Range 2 5]) . to_vector . should_equal [1, 6, 7, 8]
+            alpha.drop (Index_Sub_Range.By_Index [Range 2 5, Range 1 3]) . to_vector . should_equal [1, 6, 7, 8]
+            alpha.drop (Index_Sub_Range.By_Index [0, 1, Range 100 200]) . should_fail_with Index_Out_Of_Bounds_Error
+            alpha.drop (Index_Sub_Range.By_Index 100) . should_fail_with Index_Out_Of_Bounds_Error
+
+        Test.specify "should allow selecting every Nth row" <|
+            alpha.take (Every 1) . should_equal alpha
+            alpha.take (Every 3) . to_vector . should_equal [1, 4, 7]
+            alpha.take (Every 3 first=1) . to_vector . should_equal [2, 5, 8]
+            beta.take (Every 2 first=1) . to_vector . should_equal ["B", "D", "F", "H"]
+            alpha.take (Every 2 first=100) . to_vector . should_equal []
+            alpha.take (Every 200) . to_vector . should_equal [1]
+            empty_beta.take (Every 2) . should_equal empty_beta
+            beta.take (Every 0) . should_fail_with Illegal_Argument_Error
+            empty_beta.take (Every 0) . should_fail_with Illegal_Argument_Error
+
+            alpha.drop (Every 1) . should_equal empty_alpha
+            alpha.drop (Every 3) . to_vector . should_equal [2, 3, 5, 6, 8]
+            alpha.drop (Every 3 first=1) . to_vector . should_equal [1, 3, 4, 6, 7]
+            alpha.drop (Every 2 first=1) . to_vector . should_equal [1, 3, 5, 7]
+            alpha.drop (Every 2 first=100) . should_equal alpha
+            beta.drop (Every 200) . to_vector . should_equal ["B", "C", "D", "E", "F", "G", "H"]
+            empty_beta.drop (Every 2) . should_equal empty_beta
+            beta.drop (Every 0) . should_fail_with Illegal_Argument_Error
+            empty_beta.drop (Every 0) . should_fail_with Illegal_Argument_Error
+
+        Test.specify "should allow sampling rows" <|
+            three = table_builder [["X", ["a", "a", "a"]]] . at "X"
+            two = three.take (First 2)
+            one = three.take First
+            empty = three.take (First 0)
+
+            [three, two, one, empty].map .to_vector . should_equal [["a", "a", "a"], ["a", "a"], ["a"], []]
+
+            three.take (Sample 0) . should_equal empty
+            empty.take (Sample 0) . should_equal empty
+            empty.take (Sample 1) . should_equal empty
+            three.take (Sample 1) . should_equal one
+            three.take (Sample 100) . should_equal three
+
+            three.drop (Sample 0) . should_equal three
+            empty.drop (Sample 0) . should_equal empty
+            empty.drop (Sample 1) . should_equal empty
+            one.drop (Sample 1) . should_equal empty
+            three.drop (Sample 1) . should_equal two
+            three.drop (Sample 100) . should_equal empty
+
+            rnd = alpha.take (Sample 3 seed=42)
+            random_indices = [5, 6, 2]
+            sample = alpha.take (Index_Sub_Range.By_Index random_indices)
+            rnd.should_equal sample
+
+        Test.specify "should allow selecting rows as long as they satisfy a predicate" <|
+            col = table_builder [["X", [1, 3, 5, 6, 8, 9, 10, 11, 13]]] . at "X"
+            col.take (While (x-> x%2 == 1)) . to_vector . should_equal [1, 3, 5]
+            col.drop (While (x-> x%2 == 1)) . to_vector . should_equal [6, 8, 9, 10, 11, 13]
+
+            three = table_builder [["X", [1, 2, 3]]] . at "X"
+            empty = table_builder [["X", []]] . at "X"
+            three.take (While (_ > 10)) . should_equal empty
+            three.take (While (_ < 10)) . should_equal three
+
+            three.drop (While (_ > 10)) . should_equal three
+            three.drop (While (_ < 10)) . should_equal empty

--- a/test/Table_Tests/src/Common_Table_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Spec.enso
@@ -10,6 +10,8 @@ from Standard.Table.Data.Position import all
 import Standard.Test
 import Standard.Test.Problems
 
+from project.Util import all
+
 type Test_Selection supports_case_sensitive_columns=True order_by=True natural_ordering=False case_insensitive_ordering=True order_by_unicode_normalization_by_default=False case_insensitive_ascii_only=False take_drop=True
 
 ## A common test suite for shared operations on the Table API.
@@ -857,6 +859,11 @@ spec prefix table_builder test_selection pending=Nothing =
             table.take (Every 3) . at "alpha" . to_vector . should_equal [1, 4, 7]
             table.take (Every 3 first=1) . at "alpha" . to_vector . should_equal [2, 5, 8]
             table.take (Every 2 first=1) . at "beta" . to_vector . should_equal ["B", "D", "F", "H"]
+            IO.println "TABLE = "+table.to_text
+            table.print
+            taken = table.take (Every 2 first=100)
+            IO.println "TABLE.take = "+taken.to_text
+            taken.print
             table.take (Every 2 first=100) . at "alpha" . to_vector . should_equal []
             table.take (Every 200) . should_equal [1]
             empty.take (Every 2) . should_equal []
@@ -892,8 +899,8 @@ spec prefix table_builder test_selection pending=Nothing =
             three.drop (Sample 100) . should_equal empty
 
             rnd = table.take (Sample 3 seed=42)
-            # TODO
-            rnd.print
+            rnd.at "alpha" . to_vector . should_equal [6, 7, 3]
+            rnd.at "beta" . to_vector . should_equal ["F", "G", "C"]
 
         Test.specify "should allow selecting rows as long as they satisfy a predicate" pending="While is not implemented for Table until the Row type is implemented." <|
             Nothing

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -107,7 +107,7 @@ run_tests connection pending=Nothing =
 
     Common_Spec.spec prefix connection pending=pending
     postgres_specific_spec connection pending=pending
-    common_selection = Common_Table_Spec.Test_Selection supports_case_sensitive_columns=True order_by_unicode_normalization_by_default=True
+    common_selection = Common_Table_Spec.Test_Selection supports_case_sensitive_columns=True order_by_unicode_normalization_by_default=True take_drop=False
     Common_Table_Spec.spec prefix table_builder test_selection=common_selection pending=pending
 
     selection = Aggregate_Spec.Test_Selection first_last_row_order=False aggregation_problems=False

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -5,7 +5,7 @@ import Standard.Base.System.Process
 from Standard.Base.System.Process.Exit_Code import Exit_Success
 
 import Standard.Table as Materialized_Table
-from Standard.Table.Data.Aggregate_Column import all
+from Standard.Table.Data.Aggregate_Column import all hiding First
 
 from Standard.Database import all
 from Standard.Database.Connection.Connection import Sql_Error
@@ -114,7 +114,7 @@ run_tests connection pending=Nothing =
     agg_in_memory_table = (enso_project.data / "data.csv") . read
     agg_table = connection.upload_table (Name_Generator.random_name "Agg1") agg_in_memory_table
     tables.append agg_table.name
-    empty_agg_table = connection.upload_table (Name_Generator.random_name "Agg_Empty") (agg_in_memory_table.take_start 0)
+    empty_agg_table = connection.upload_table (Name_Generator.random_name "Agg_Empty") (agg_in_memory_table.take (First 0))
     tables.append empty_agg_table.name
     Aggregate_Spec.aggregate_spec prefix agg_table empty_agg_table table_builder materialize is_database=True selection pending=pending
 

--- a/test/Table_Tests/src/Database/Redshift_Spec.enso
+++ b/test/Table_Tests/src/Database/Redshift_Spec.enso
@@ -55,7 +55,7 @@ run_tests connection pending=Nothing =
 
     Common_Spec.spec prefix connection pending=pending
     redshift_specific_spec connection pending=pending
-    common_selection = Common_Table_Spec.Test_Selection supports_case_sensitive_columns=True order_by=False
+    common_selection = Common_Table_Spec.Test_Selection supports_case_sensitive_columns=True order_by=False take_drop=False
     Common_Table_Spec.spec prefix table_builder test_selection=common_selection pending=pending
 
     selection = Aggregate_Spec.Test_Selection text_concat=False text_shortest_longest=False first_last=False first_last_row_order=False multi_distinct=False aggregation_problems=False

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -59,7 +59,7 @@ sqlite_spec connection prefix =
 
     Common_Spec.spec prefix connection
     sqlite_specific_spec connection
-    common_selection = Common_Table_Spec.Test_Selection supports_case_sensitive_columns=False order_by=True natural_ordering=False case_insensitive_ordering=True case_insensitive_ascii_only=True
+    common_selection = Common_Table_Spec.Test_Selection supports_case_sensitive_columns=False order_by=True natural_ordering=False case_insensitive_ordering=True case_insensitive_ascii_only=True take_drop=False
     Common_Table_Spec.spec prefix table_builder test_selection=common_selection
 
     ## For now `advanced_stats`, `first_last`, `text_shortest_longest` and

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -73,7 +73,7 @@ sqlite_spec connection prefix =
     selection = Aggregate_Spec.Test_Selection advanced_stats=False text_shortest_longest=False first_last=False first_last_row_order=False multi_distinct=False aggregation_problems=False nan=False
     agg_in_memory_table = (enso_project.data / "data.csv") . read
     agg_table = connection.upload_table (Name_Generator.random_name "Agg1") agg_in_memory_table
-    empty_agg_table = connection.upload_table (Name_Generator.random_name "Agg_Empty") (agg_in_memory_table.take_start 0)
+    empty_agg_table = connection.upload_table (Name_Generator.random_name "Agg_Empty") (agg_in_memory_table.take (First 0))
     Aggregate_Spec.aggregate_spec prefix agg_table empty_agg_table table_builder materialize is_database=True selection
 
     connection.close

--- a/test/Table_Tests/src/Table_Spec.enso
+++ b/test/Table_Tests/src/Table_Spec.enso
@@ -482,9 +482,9 @@ spec =
             c_3 = ['col3', [False, True, Nothing]]
             t_1 = Table.new [i_1, c_1, c_2, c_3] . set_index 'ix'
 
-            t_1.take_start 10 . at 'col' . to_vector . should_equal (t_1.at 'col' . to_vector)
+            t_1.take (First 10) . at 'col' . to_vector . should_equal (t_1.at 'col' . to_vector)
 
-            t_2 = t_1.take_start 2
+            t_2 = t_1.take (First 2)
             t_2.index.to_vector . should_equal (t_1.index.to_vector . take (First 2))
             t_2.at 'col' . to_vector . should_equal (t_1.at 'col' . to_vector . take (First 2))
             t_2.at 'col2' . to_vector . should_equal (t_1.at 'col2' . to_vector . take (First 2))
@@ -499,63 +499,13 @@ spec =
             c_3 = ['col3', [False, True, Nothing]]
             t_1 = Table.new [i_1, c_1, c_2, c_3] . set_index 'ix'
 
-            t_1.take_end 10 . at 'col1' . to_vector . should_equal (t_1.at 'col1' . to_vector)
+            t_1.take (Last 10) . at 'col1' . to_vector . should_equal (t_1.at 'col1' . to_vector)
 
-            t_2 = t_1.take_end 2
+            t_2 = t_1.take (Last 2)
             t_2.index.to_vector . should_equal (t_1.index.to_vector . take (Last 2))
             t_2.at 'col1' . to_vector . should_equal (t_1.at 'col1' . to_vector . take (Last 2))
             t_2.at 'col2' . to_vector . should_equal (t_1.at 'col2' . to_vector . take (Last 2))
             t_2.at 'col3' . to_vector . should_equal (t_1.at 'col3' . to_vector . take (Last 2))
-
-        Test.specify "should allow getting the first / head row" <|
-            i_1 = ['ix', [1, 2, 3]]
-            c_1 = ['col1', [5, 6, 7]]
-            c_2 = ['col2', ["a", Nothing, "c"]]
-            c_3 = ['col3', [False, True, Nothing]]
-            t_1 = Table.new [i_1, c_1, c_2, c_3] . set_index 'ix'
-            expected_i_1 = ['ix', [1]]
-            expected_c_1 = ['col1', [5]]
-            expected_c_2 = ['col2', ["a"]]
-            expected_c_3 = ['col3', [False]]
-            expected_head = Table.new [expected_i_1, expected_c_1, expected_c_2, expected_c_3] . set_index 'ix'
-
-            t_2 = t_1.first
-
-            t_2.index.to_vector . should_equal expected_head.index.to_vector
-            t_2.at 'col1' . to_vector . should_equal (expected_head.at 'col1' . to_vector)
-            t_2.at 'col2' . to_vector . should_equal (expected_head.at 'col2' . to_vector)
-            t_2.at 'col3' . to_vector . should_equal (expected_head.at 'col3' . to_vector)
-
-            empty_ix = ['ix', []]
-            empty_col = ['col_1', []]
-            empty_table = Table.new [empty_ix, empty_col] . set_index 'ix'
-
-            empty_table.first.should_fail_with Empty_Error
-
-        Test.specify "should allow getting the last row" <|
-            i_1 = ['ix', [1, 2, 3]]
-            c_1 = ['col1', [5, 6, 7]]
-            c_2 = ['col2', ["a", Nothing, "c"]]
-            c_3 = ['col3', [False, True, Nothing]]
-            t_1 = Table.new [i_1, c_1, c_2, c_3] . set_index 'ix'
-            expected_i_1 = ['ix', [3]]
-            expected_c_1 = ['col1', [7]]
-            expected_c_2 = ['col2', ["c"]]
-            expected_c_3 = ['col3', [Nothing]]
-            expected_last = Table.new [expected_i_1, expected_c_1, expected_c_2, expected_c_3] . set_index 'ix'
-
-            t_2 = t_1.last
-
-            t_2.index.to_vector . should_equal expected_last.index.to_vector
-            t_2.at 'col1' . to_vector . should_equal (expected_last.at 'col1' . to_vector)
-            t_2.at 'col2' . to_vector . should_equal (expected_last.at 'col2' . to_vector)
-            t_2.at 'col3' . to_vector . should_equal (expected_last.at 'col3' . to_vector)
-
-            empty_ix = ['ix', []]
-            empty_col = ['col_1', []]
-            empty_table = Table.new [empty_ix, empty_col] . set_index 'ix'
-
-            empty_table.last.should_fail_with Empty_Error
 
         Test.specify "should allow reversing the table" <|
             i_1 = ['ix', [1, 2, 3]]

--- a/test/Table_Tests/src/Table_Spec.enso
+++ b/test/Table_Tests/src/Table_Spec.enso
@@ -490,7 +490,7 @@ spec =
             t_2.at 'col2' . to_vector . should_equal (t_1.at 'col2' . to_vector . take (First 2))
             t_2.at 'col3' . to_vector . should_equal (t_1.at 'col3' . to_vector . take (First 2))
 
-            t_1.at 'col' . take_start 2 . to_vector . should_equal (t_1.at 'col' . to_vector . take (First 2))
+            t_1.at 'col' . take (First 2) . to_vector . should_equal (t_1.at 'col' . to_vector . take (First 2))
 
         Test.specify "should allow taking the last n rows" <|
             i_1 = ['ix', [1, 2, 3]]
@@ -506,6 +506,8 @@ spec =
             t_2.at 'col1' . to_vector . should_equal (t_1.at 'col1' . to_vector . take (Last 2))
             t_2.at 'col2' . to_vector . should_equal (t_1.at 'col2' . to_vector . take (Last 2))
             t_2.at 'col3' . to_vector . should_equal (t_1.at 'col3' . to_vector . take (Last 2))
+
+            t_1.at 'col1' . take (Last 2) . to_vector . should_equal (t_1.at 'col1' . to_vector . take (Last 2))
 
         Test.specify "should allow reversing the table" <|
             i_1 = ['ix', [1, 2, 3]]

--- a/test/Table_Tests/src/Util.enso
+++ b/test/Table_Tests/src/Util.enso
@@ -13,8 +13,10 @@ Table.Table.should_equal self expected =
     self_cols.map .to_vector . should_equal (that_cols.map .to_vector) frames_to_skip=1
 
 Column.Column.should_equal self expected =
-    self.name.should_equal expected.name
-    self.length.should_equal expected.length
+    if self.name != expected.name then
+        Test.fail "Expected column name "+expected.name+", but got "+self.name+"."
+    if self.length != expected.length then
+        Test.fail "Expected column length "+expected.length.to_text+", but got "+self.length.to_text+"."
     self.to_vector.should_equal expected.to_vector
 
 normalize_lines string line_separator=Line_Ending_Style.Unix.to_text newline_at_end=True =

--- a/test/Tests/src/Data/Text_Spec.enso
+++ b/test/Tests/src/Data/Text_Spec.enso
@@ -242,6 +242,7 @@ spec =
             text_2.to_text.should_equal "'\n\t\a\b\f\r\v\e\''"
 
         Test.specify "should allow taking or dropping every other character" <|
+            "ABCDE".take (Every 1) . should_equal "ABCDE"
             "ABCDE".take (Every 2) . should_equal "ACE"
             "ABCD".take (Every 2) . should_equal "AC"
             "ABCD".take (Every 2 first=1) . should_equal "BD"
@@ -252,6 +253,7 @@ spec =
             "ABCDEFG".take (Every 3 first=6) . should_equal "G"
             "ABCDEFG".take (Every 10) . should_equal "A"
 
+            "ABCDE".drop (Every 1) . should_equal ""
             "ABCDE".drop (Every 2) . should_equal "BD"
             "ABCD".drop (Every 2) . should_equal "BD"
             "ABCD".drop (Every 2 first=1) . should_equal "AC"
@@ -406,6 +408,7 @@ spec =
         Test.specify "take should work on grapheme clusters" <|
             txt_1 = 'He\u0302llo\u0308 Wo\u0301rld!'
             txt_2 = 'He\u0302llo\u0308 Wo\u0308rld!'
+            txt_1.take (Every 2) . should_equal 'Hlo\u0308Wrd'
             txt_1.take (First 2) . should_equal 'He\u{302}'
             txt_1.take (First 5) . should_equal 'He\u{302}llo\u{308}'
             txt_1.take (Last 6) . should_equal 'Wo\u{301}rld!'
@@ -531,6 +534,7 @@ spec =
         Test.specify "drop should work on grapheme clusters" <|
             txt_1 = 'He\u0302llo\u0308 Wo\u0301rld!'
             txt_2 = 'He\u0302llo\u0308 Wo\u0308rld!'
+            txt_1.drop (Every 2) . should_equal 'e\u0302l o\u0301l!'
             txt_1.drop (First 2) . should_equal 'llo\u{308} Wo\u{301}rld!'
             txt_1.drop (First 5) . should_equal ' Wo\u{301}rld!'
             txt_1.drop (Last 6) . should_equal 'He\u{302}llo\u{308} '

--- a/test/Tests/src/Data/Vector/Slicing_Helpers_Spec.enso
+++ b/test/Tests/src/Data/Vector/Slicing_Helpers_Spec.enso
@@ -1,10 +1,11 @@
 from Standard.Base import all
+import Standard.Base.Data.Index_Sub_Range
 
 import Standard.Test
 
 spec = Test.group "Vector Slicing Helpers" <|
     Test.specify "should be able to sort correctly merge neighboring sequences" <|
-        merge = Vector.sort_and_merge_ranges
+        merge = Index_Sub_Range.sort_and_merge_ranges
         merge [] . should_equal []
         merge [Range 0 0] . should_equal []
         merge [Range 0 10] . should_equal [Range 0 10]

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -253,6 +253,7 @@ spec = Test.group "Vectors" <|
         vec.drop (Last -1) . should_equal vec
         vec.drop (Last 100) . should_equal []
 
+        vec.take (Every 1) . should_equal vec
         vec.take (Every 3) . should_equal [1, 4]
         vec.take (Every 3 first=1) . should_equal [2, 5]
         vec.take (Every 2 first=1) . should_equal [2, 4, 6]
@@ -262,6 +263,7 @@ spec = Test.group "Vectors" <|
         vec.take (Every 0) . should_fail_with Illegal_Argument_Error
         [].take (Every 0) . should_fail_with Illegal_Argument_Error
 
+        vec.drop (Every 1) . should_equal []
         vec.drop (Every 3) . should_equal [2, 3, 5, 6]
         vec.drop (Every 3 first=1) . should_equal [1, 3, 4, 6]
         vec.drop (Every 2 first=1) . should_equal [1, 3, 5]


### PR DESCRIPTION
### Pull Request Description

Implements https://www.pivotaltracker.com/story/show/182307347

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
