### PR TITLE
Increase library upload timeout in tests

### DIFF
--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/LibrariesTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/LibrariesTest.scala
@@ -1,16 +1,17 @@
 package org.enso.languageserver.websocket.json
 
+import akka.testkit._
 import io.circe.literal._
 import io.circe.{Json, JsonObject}
 import nl.gn0s1s.bump.SemVer
 import org.enso.distribution.FileSystem
 import org.enso.editions.{Editions, LibraryName}
+import org.enso.languageserver.libraries.LibraryEntry.PublishedLibraryVersion
 import org.enso.languageserver.libraries.{
   LibraryComponentGroup,
   LibraryComponentGroups,
   LibraryEntry
 }
-import org.enso.languageserver.libraries.LibraryEntry.PublishedLibraryVersion
 import org.enso.languageserver.runtime.TestComponentGroups
 import org.enso.librarymanager.published.bundles.LocalReadOnlyRepository
 import org.enso.librarymanager.published.repository.{
@@ -22,6 +23,8 @@ import org.enso.pkg.{Config, Contact, Package, PackageManager}
 import org.enso.yaml.YamlHelper
 
 import java.nio.file.Files
+
+import scala.concurrent.duration._
 
 class LibrariesTest extends BaseServerTest {
   private val libraryRepositoryPort: Int = 47308
@@ -434,7 +437,7 @@ class LibrariesTest extends BaseServerTest {
 
         var found = false
         while (!found) {
-          val rawResponse = client.expectSomeJson()
+          val rawResponse = client.expectSomeJson(timeout = 8.seconds.dilated)
           val response    = rawResponse.asObject.value
           val idMatches = response("id")
             .flatMap(_.asNumber)


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

An attempt to fix arbitrary timeouts when testing library uploads https://github.com/enso-org/enso/runs/7831299289?check_suite_focus=true#step:9:4501

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] ~If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.~
