### PR TITLE
Tidy up the default imports for Standard.Table

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Ordering/Comparator.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Ordering/Comparator.enso
@@ -1,6 +1,4 @@
 from Standard.Base import all
-import Standard.Base.Data.Ordering.Natural_Order
-from Standard.Base.Data.Text.Text_Ordering import Text_Ordering
 
 polyglot java import org.enso.base.ObjectComparator
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Ordering/Natural_Order.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Ordering/Natural_Order.enso
@@ -1,9 +1,5 @@
 from Standard.Base import all
 
-import Standard.Base.Data.Text.Regex
-import Standard.Base.Data.Text.Regex.Mode
-import Standard.Base.Data.Ordering.Vector_Lexicographic_Order
-
 polyglot java import org.enso.base.Text_Utils
 polyglot java import com.ibm.icu.text.BreakIterator
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text.enso
@@ -1,4 +1,6 @@
+from Standard.Base import Any, Boolean
 import Standard.Base.Meta
+
 polyglot java import org.enso.base.Text_Utils
 
 ## Enso's text type.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -4,15 +4,15 @@ from Standard.Base import all
 
 import Standard.Base.Data.Text.Regex
 import Standard.Base.Data.Text.Regex.Mode
+
 import Standard.Base.Data.Text.Matching_Mode
 import Standard.Base.Data.Text.Case
 import Standard.Base.Data.Text.Location
 import Standard.Base.Data.Text.Line_Ending_Style
-import Standard.Base.Data.Text.Span as Span_Module
+
 import Standard.Base.Data.Text.Text_Sub_Range
-from Standard.Base.Data.Text.Text_Sub_Range import First
+
 from Standard.Base.Error.Problem_Behavior import Report_Warning
-import Standard.Base.Data.Locale
 import Standard.Base.Meta
 
 export Standard.Base.Data.Text.Matching_Mode

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Line_Ending_Style.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Line_Ending_Style.enso
@@ -1,4 +1,4 @@
-from Standard.Base import all
+from Standard.Base import Text
 
 ## An enumeration of different line ending styles.
 type Line_Ending_Style

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Matching.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Matching.enso
@@ -1,8 +1,6 @@
 from Standard.Base import all
 
-import Standard.Base.Data.Locale
-import Standard.Base.Data.Text.Regex
-from Standard.Base.Error.Problem_Behavior import Problem_Behavior, Report_Warning
+from Standard.Base.Error.Problem_Behavior import Report_Warning
 from Standard.Base.Error.Common import Wrapped_Dataflow_Error
 
 ## UNSTABLE

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
@@ -5,14 +5,11 @@
 
 from Standard.Base import all
 
-import Standard.Base.Data.Map
-import Standard.Base.Data.Text.Span
 import Standard.Base.Data.Text.Regex
 import Standard.Base.Data.Text.Regex.Engine
 import Standard.Base.Data.Text.Regex.Engine.Default as Default_Engine
 import Standard.Base.Data.Text.Regex.Mode
 import Standard.Base.Data.Text.Regex.Option
-import Standard.Base.Data.Map
 
 ## Compile the provided `expression` into a regex pattern that can be used for
    matching.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Engine/Default.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Engine/Default.enso
@@ -39,7 +39,6 @@ import Standard.Base.Data.Text.Regex
 import Standard.Base.Data.Text.Regex.Engine
 import Standard.Base.Data.Text.Regex.Option as Global_Option
 import Standard.Base.Data.Text.Regex.Mode
-import Standard.Base.Data.Text.Matching_Mode
 import Standard.Base.Polyglot.Java
 
 polyglot java import java.lang.IllegalArgumentException

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Span.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Span.enso
@@ -11,7 +11,7 @@
 
 from Standard.Base import all
 
-from Standard.Base.Data.Text.Extensions import Index_Out_Of_Bounds_Error
+from Standard.Base.Error.Common import Index_Out_Of_Bounds_Error
 
 polyglot java import org.enso.base.Text_Utils
 polyglot java import com.ibm.icu.text.BreakIterator

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Text_Sub_Range.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Text_Sub_Range.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
-from Standard.Base.Data.Text.Extensions import Index_Out_Of_Bounds_Error
-from Standard.Base.Data.Text.Span as Span_Module import Span
+from Standard.Base.Error.Common import Index_Out_Of_Bounds_Error
+from Standard.Base.Data.Text.Span import Span, range_to_char_indices
 from Standard.Base.Data.Index_Sub_Range import First, Last, While, By_Index, Sample, Every
 import Standard.Base.Random
 
@@ -158,7 +158,7 @@ resolve_index_or_range text descriptor = Panic.recover [Index_Out_Of_Bounds_Erro
             true_range = normalize_range descriptor len
             if descriptor.is_empty then Range 0 0 else
                 case true_range.step == 1 of
-                    True -> Span_Module.range_to_char_indices text true_range
+                    True -> range_to_char_indices text true_range
                     False ->
                         ranges = Vector.new_builder
                         if true_range.step <= 0 then panic_on_non_positive_step

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time.enso
@@ -1,10 +1,8 @@
 from Standard.Base import all
 
-import Standard.Base.Data.Locale
 import Standard.Base.Data.Time.Duration
 import Standard.Base.Data.Time.Time_Of_Day
 import Standard.Base.Data.Time.Zone
-import Standard.Base.Data.Ordering
 
 polyglot java import java.time.format.DateTimeFormatter
 polyglot java import java.time.ZonedDateTime

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
@@ -1,6 +1,5 @@
 from Standard.Base import all
 
-import Standard.Base.Data.Locale
 import Standard.Base.Data.Time
 import Standard.Base.Data.Time.Duration
 import Standard.Base.Data.Time.Zone

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Error/Common.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Error/Common.enso
@@ -1,5 +1,4 @@
 from Standard.Base import all
-import Standard.Base.Data.Json
 import Standard.Base.Runtime
 
 polyglot java import java.lang.IllegalArgumentException

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Main.enso
@@ -22,7 +22,6 @@ import project.Data.Text
 import project.Data.Text.Encoding
 import project.Data.Text.Extensions
 import project.Data.Text.Matching
-import project.Data.Text.Matching_Mode
 import project.Data.Text.Text_Ordering
 import project.Data.Text.Span
 import project.Data.Time.Date
@@ -42,6 +41,7 @@ import project.Runtime.State
 import project.System.Environment
 import project.System.File
 import project.System.File.Existing_File_Behavior
+import project.Data.Text.Regex
 import project.Data.Text.Regex.Mode as Regex_Mode
 import project.Warning
 
@@ -51,13 +51,14 @@ export project.Data.Locale
 export project.Data.Map
 export project.Data.Maybe
 export project.Data.Ordering
+
 export project.Data.Ordering.Natural_Order
 export project.Data.Ordering.Sort_Direction
 export project.Data.Regression
 export project.Data.Statistics
 export project.Data.Statistics.Rank_Method
+export project.Data.Text.Regex
 export project.Data.Text.Regex.Mode as Regex_Mode
-export project.Data.Text.Matching_Mode
 export project.Data.Time.Date
 export project.Data.Vector
 export project.Error.Problem_Behavior
@@ -87,7 +88,7 @@ from project.Data.Range export all
    Relevant issues:
    https://www.pivotaltracker.com/story/show/181403340
    https://www.pivotaltracker.com/story/show/181309938
-from project.Data.Text.Extensions export Text, Line_Ending_Style, Case, Location
+from project.Data.Text.Extensions export Text, Line_Ending_Style, Case, Location, Matching_Mode
 from project.Data.Text.Matching export Case_Insensitive, Text_Matcher, Regex_Matcher, No_Matches_Found
 from project.Data.Text export all hiding Encoding, Span, Text_Ordering
 from project.Data.Text.Encoding export Encoding, Encoding_Error

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Http.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Http.enso
@@ -1,6 +1,5 @@
 from Standard.Base import all
 
-import Standard.Base.Data.Json
 import Standard.Base.Data.Time.Duration
 import Standard.Base.Data.Time
 import Standard.Base.Network.Http.Form
@@ -12,7 +11,6 @@ import Standard.Base.Network.Http.Response
 import Standard.Base.Network.Http.Version
 import Standard.Base.Network.Proxy
 import Standard.Base.Network.URI
-import Standard.Base.System.File
 
 polyglot java import java.net.http.HttpClient
 polyglot java import java.net.http.HttpRequest

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Http/Form.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Http/Form.enso
@@ -1,7 +1,5 @@
 from Standard.Base import all
 
-import Standard.Base.Data.Vector
-
 ## Create Form data from Parts.
 
    Arguments:

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Http/Request.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Http/Request.enso
@@ -5,7 +5,6 @@ import Standard.Base.Network.Http.Header
 import Standard.Base.Network.Http.Method
 import Standard.Base.Network.Http.Request.Body as Request_Body
 import Standard.Base.Network.URI
-import Standard.Base.System.File
 
 ## Create new HTTP request.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Http/Response.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Http/Response.enso
@@ -1,6 +1,5 @@
 from Standard.Base import all
 
-import Standard.Base.Data.Vector
 import Standard.Base.Network.Http.Header
 import Standard.Base.Network.Http.Response.Body as Response_Body
 import Standard.Base.Network.Http.Status_Code

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Http/Response/Body.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Http/Response/Body.enso
@@ -1,8 +1,5 @@
 from Standard.Base import all
 
-import Standard.Base.Data.Json
-import Standard.Base.System.File
-
 type Body
 
     ## Response body

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -1,7 +1,6 @@
 from Standard.Base import all
 
 import Standard.Base.System.File.Option
-import Standard.Base.System.File.Existing_File_Behavior
 import Standard.Base.System.File.File_Permissions
 import Standard.Base.Error.Problem_Behavior
 import Standard.Base.Data.Text.Matching_Mode

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -2,8 +2,6 @@ from Standard.Base import all
 
 import Standard.Base.System.File.Option
 import Standard.Base.System.File.File_Permissions
-import Standard.Base.Error.Problem_Behavior
-import Standard.Base.Data.Text.Matching_Mode
 import Standard.Base.Data.Text.Text_Sub_Range
 from Standard.Base.Error.Problem_Behavior import Report_Warning
 import Standard.Base.Runtime.Resource

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/Process.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/Process.enso
@@ -3,8 +3,6 @@ import Standard.Base.System
 
 import Standard.Base.System.Process.Exit_Code
 
-from Standard.Base.Data.Vector import Vector
-
 ## ALIAS Run a Command
    UNSTABLE
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Dialect.enso
@@ -4,9 +4,9 @@ import Standard.Base.Error.Common as Errors
 import Standard.Table.Data.Aggregate_Column
 import Standard.Database.Data.Sql
 import Standard.Database.Data.Internal.IR
-import Standard.Database.Data.Dialect.Postgres as Postgres_Module
-import Standard.Database.Data.Dialect.Redshift as Redshift_Module
-import Standard.Database.Data.Dialect.SQLite as SQLite_Module
+import Standard.Database.Data.Dialect.Postgres
+import Standard.Database.Data.Dialect.Redshift
+import Standard.Database.Data.Dialect.SQLite
 
 ## PRIVATE
 
@@ -52,18 +52,18 @@ type Dialect
 
    The dialect of SQLite databases.
 sqlite : Dialect
-sqlite = SQLite_Module.sqlite
+sqlite = SQLite.sqlite
 
 ## PRIVATE
 
    The dialect of PostgreSQL databases.
 postgres : Dialect
-postgres = Postgres_Module.postgres
+postgres = Postgres.postgres
 
 ## PRIVATE
 
    The dialect of Redshift databases.
 redshift : Dialect
-redshift = Redshift_Module.redshift
+redshift = Redshift.redshift
 
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Internal/Aggregate_Helper.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Internal/Aggregate_Helper.enso
@@ -1,5 +1,4 @@
 from Standard.Base import all hiding First, Last
-from Standard.Base.Data.Text.Text_Ordering import Text_Ordering
 
 from Standard.Table.Data.Aggregate_Column import all
 import Standard.Database.Data.Internal.IR

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -4,13 +4,14 @@ import Standard.Database.Data.Internal.Helpers
 import Standard.Database.Data.Internal.Aggregate_Helper
 import Standard.Database.Data.Internal.IR
 import Standard.Database.Data.Sql
+
 import Standard.Table.Data.Column as Materialized_Column
 import Standard.Table.Data.Table as Materialized_Table
+import Standard.Table.IO.File_Format
+
 import Standard.Table.Internal.Java_Exports
 import Standard.Table.Internal.Table_Helpers
 import Standard.Table.Internal.Problem_Builder
-import Standard.Table.IO.File_Format
-import Standard.Base.System.File.Existing_File_Behavior
 
 import Standard.Table.Data.Aggregate_Column
 import Standard.Table.Internal.Aggregate_Column_Helper

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+from Standard.Base.Error.Problem_Behavior import Report_Warning
 
 import Standard.Database.Data.Internal.Helpers
 import Standard.Database.Data.Internal.Aggregate_Helper
@@ -19,9 +20,7 @@ from Standard.Database.Data.Column import Column, Aggregate_Column_Builder
 from Standard.Database.Data.Internal.IR import Internal_Column
 from Standard.Table.Errors import No_Such_Column_Error
 from Standard.Table.Data.Column_Selector import Column_Selector, By_Index
-from Standard.Base.Data.Text.Text_Ordering import Text_Ordering
 from Standard.Table.Data.Data_Formatter import Data_Formatter
-from Standard.Base.Error.Problem_Behavior import Problem_Behavior, Report_Warning
 from Standard.Database.Error import Unsupported_Database_Operation_Error
 import Standard.Table.Data.Column_Name_Mapping
 import Standard.Table.Data.Position

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Main.enso
@@ -25,4 +25,4 @@ from Standard.Database.Connection.Connection_Options export Connection_Options
 from Standard.Database.Connection.Database export connect
 from Standard.Database.Connection.Postgres export Postgres
 from Standard.Database.Connection.SQLite export SQLite, In_Memory
-from Standard.Database.Connection.Redshift export Redshift, AWS_Profile
+from Standard.Database.Connection.Redshift export Redshift, AWS_Profile, AWS_Key

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Main.enso
@@ -15,10 +15,11 @@ import Standard.Database.Connection.Redshift
 export Standard.Database.Data.Table
 export Standard.Database.Data.Column
 
+export Standard.Database.Connection.SSL_Mode
 from Standard.Database.Connection.Connection export Sql_Error, Sql_Timeout_Error
+
 from Standard.Database.Connection.Credentials export Credentials
 from Standard.Database.Connection.Client_Certificate export Client_Certificate
-from Standard.Database.Connection.SSL_Mode export SSL_Mode
 from Standard.Database.Connection.Connection_Options export Connection_Options
 
 from Standard.Database.Connection.Database export connect

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Main.enso
@@ -14,14 +14,14 @@ import Standard.Database.Connection.Redshift
 
 export Standard.Database.Data.Table
 export Standard.Database.Data.Column
-export Standard.Database.Connection.Connection
 
-from Standard.Database.Connection.Credentials export all
-from Standard.Database.Connection.Client_Certificate export all
-from Standard.Database.Connection.SSL_Mode export all
-from Standard.Database.Connection.Connection_Options export all
+from Standard.Database.Connection.Connection export Sql_Error, Sql_Timeout_Error
+from Standard.Database.Connection.Credentials export Credentials
+from Standard.Database.Connection.Client_Certificate export Client_Certificate
+from Standard.Database.Connection.SSL_Mode export SSL_Mode
+from Standard.Database.Connection.Connection_Options export Connection_Options
 
-from Standard.Database.Connection.Database export all
-from Standard.Database.Connection.Postgres export all
-from Standard.Database.Connection.SQLite export all
-from Standard.Database.Connection.Redshift export all
+from Standard.Database.Connection.Database export connect
+from Standard.Database.Connection.Postgres export Postgres
+from Standard.Database.Connection.SQLite export SQLite, In_Memory
+from Standard.Database.Connection.Redshift export Redshift, AWS_Profile

--- a/distribution/lib/Standard/Examples/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Examples/0.0.0-dev/src/Main.enso
@@ -3,20 +3,15 @@ from Standard.Base import all
 import Standard.Base.Data.Time
 import Standard.Base.Network.Http
 import Standard.Base.System.Platform
-import Standard.Image.Codecs
+import Standard.Base.Data.Time.Duration
+import Standard.Base.Network.URI
+import Standard.Base.Data.Text.Regex.Engine.Default as Default_Engine
+
 import Standard.Table
 
-# Renamed to avoid clashing with an uppercase name resolution for the relevant
-# items in this file.
-import Standard.Base.Data.Json as Enso_Json
-import Standard.Base.Data.List as Enso_List
-import Standard.Base.Data.Map as Enso_Map
-import Standard.Base.Data.Text.Regex.Engine.Default as Default_Engine
-import Standard.Base.Data.Text.Regex.Mode as Regex_Mode
-import Standard.Base.Data.Time.Duration as Enso_Duration
-import Standard.Base.Network.URI
-import Standard.Image as Enso_Image
-import Standard.Image.Data.Matrix as Enso_Matrix
+import Standard.Image
+import Standard.Image.Codecs
+import Standard.Image.Data.Matrix
 
 ## An example error type used in a number of examples.
 
@@ -75,7 +70,7 @@ scratch_file =
 
 ## An example duration for experimenting with duration APIs.
 duration : Duration
-duration = Enso_Duration.between (Time.new 2020 10 20) Time.now
+duration = Duration.between (Time.new 2020 10 20) Time.now
 
 ## An example amount of JSON as text.
 json_text : Text
@@ -105,20 +100,20 @@ json_text = """
     ]
 
 ## Example JSON for working with.
-json : Enso_Json.Json
-json = Enso_Json.parse json_text
+json : Json.Json
+json = Json.parse json_text
 
 ## An example JSON object.
-json_object : Enso_Json.Object
+json_object : Json.Object
 json_object = json.items.head
 
 ## An example cons-list.
-list : Enso_List.List
+list : List
 list = Cons 1 (Cons 2 (Cons 3 Nil))
 
 ## A simple map that contains some numbers mapped to their word equivalents.
-map : Enso_Map.Map
-map = Enso_Map.empty . insert 1 "one" . insert 3 "three" . insert 5 "five"
+map : Map
+map = Map.empty . insert 1 "one" . insert 3 "three" . insert 5 "five"
 
 ## A dummy type that is used for example purposes.
 type No_Methods
@@ -189,11 +184,11 @@ image_file =
      the internet if it is not already present on your disk. If you do not want
      this to happen, please place the image in the
      `lib/Standard/Examples/<version>/data` folder for your Enso distribution.
-image : Enso_Image.Image
-image = Enso_Image.read image_file [Codecs.Read_Alpha_Channel]
+image : Image.Image
+image = Image.read image_file [Codecs.Read_Alpha_Channel]
 
 ## A matrix that corresponds to `image`.
-matrix : Enso_Matrix.Matrix
+matrix : Matrix.Matrix
 matrix = image.to_matrix
 
 ## A silly little function that adds one to the provided number.
@@ -205,11 +200,11 @@ get_boolean : Boolean
 get_boolean = False
 
 ## A simple small piece of JSON that can easily be converted into a table.
-simple_table_json : Enso_Json.Json
+simple_table_json : Json.Json
 simple_table_json =
-    row_1 = Enso_Json.from_pairs [['foo', 20], ['bar', 'baz'], ['baz', False]]
-    row_2 = Enso_Json.from_pairs [['bar', 'xyz'], ['baz', True]]
-    row_3 = Enso_Json.from_pairs [['baz', False], ['foo', 13]]
+    row_1 = Json.from_pairs [['foo', 20], ['bar', 'baz'], ['baz', False]]
+    row_2 = Json.from_pairs [['bar', 'xyz'], ['baz', True]]
+    row_3 = Json.from_pairs [['baz', False], ['foo', 13]]
     [row_1, row_2, row_3].to_json
 
 ## The headers for the columns in the JSON table `simple_table_json`.
@@ -217,8 +212,8 @@ simple_table_json_headers : Vector Text
 simple_table_json_headers = ["foo", "bar", "baz"]
 
 ## Some simple GeoJSON.
-geo_json : Enso_Json.Json
-geo_json = Enso_Json.parse <| '''
+geo_json : Json.Json
+geo_json = Json.parse <| '''
     {
       "type": "FeatureCollection",
       "features": [

--- a/distribution/lib/Standard/Geo/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Geo/0.0.0-dev/src/Main.enso
@@ -1,5 +1,5 @@
 from Standard.Base import all
-from Standard.Table import all
+import Standard.Table
 
 ## UNSTABLE
 

--- a/distribution/lib/Standard/Image/0.0.0-dev/src/Codecs.enso
+++ b/distribution/lib/Standard/Image/0.0.0-dev/src/Codecs.enso
@@ -1,6 +1,5 @@
 from Standard.Base import all
 
-import Standard.Base.System.File
 import Standard.Image.Codecs.Internal
 import Standard.Image.Data.Image
 

--- a/distribution/lib/Standard/Image/0.0.0-dev/src/Data/Image.enso
+++ b/distribution/lib/Standard/Image/0.0.0-dev/src/Data/Image.enso
@@ -1,6 +1,5 @@
 from Standard.Base import all
 
-import Standard.Base.System.File
 import Standard.Image.Data.Image.Internal
 import Standard.Image.Data.Matrix
 

--- a/distribution/lib/Standard/Searcher/0.0.0-dev/src/Data_Science.enso
+++ b/distribution/lib/Standard/Searcher/0.0.0-dev/src/Data_Science.enso
@@ -9,7 +9,6 @@
      Read the active sheet of an XLSX from disk and convert it into a table.
 
          import Standard.Table
-         import Standard.Table.IO.File_Read
          import Standard.Examples
 
          example_xlsx_to_table = Examples.xlsx.read

--- a/distribution/lib/Standard/Searcher/0.0.0-dev/src/Data_Science/Input_And_Output.enso
+++ b/distribution/lib/Standard/Searcher/0.0.0-dev/src/Data_Science/Input_And_Output.enso
@@ -10,7 +10,6 @@
      Read the active sheet of an XLSX from disk and convert it into a table.
 
          import Standard.Table
-         import Standard.Table.IO.File_Read
          import Standard.Examples
 
          example_xlsx_to_table = Examples.xlsx.read

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Aggregate_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Aggregate_Column.enso
@@ -1,8 +1,6 @@
 from Standard.Base import all
 
-from Standard.Table.Data.Column import Column
-import Standard.Table.Data.Column_Selector
-import Standard.Table.Data.Sort_Column_Selector
+from Standard.Table import Column, Column_Selector, Sort_Column_Selector
 
 ## Defines an Aggregate Column
 type Aggregate_Column

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Aggregate_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Aggregate_Column.enso
@@ -1,6 +1,8 @@
 from Standard.Base import all
 
-from Standard.Table import Column, Column_Selector, Sort_Column_Selector
+from Standard.Table.Data.Column import Column
+from Standard.Table.Data.Column_Selector import Column_Selector
+from Standard.Table.Data.Sort_Column_Selector import Sort_Column_Selector
 
 ## Defines an Aggregate Column
 type Aggregate_Column

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Data_Formatter.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Data_Formatter.enso
@@ -2,9 +2,9 @@ from Standard.Base import all
 
 from Standard.Base.Data.Time import Time
 from Standard.Base.Data.Time.Time_Of_Day import Time_Of_Day
-from Standard.Table.Data.Column_Type_Selection import Auto
 import Standard.Base.Error.Common as Errors
-import Standard.Base.Error.Problem_Behavior
+
+from Standard.Table.Data.Column_Type_Selection import Auto
 import Standard.Table.Data.Storage
 import Standard.Table.Internal.Parse_Values_Helper
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -4,8 +4,6 @@ import Standard.Base.System.Platform
 import Standard.Table.Data.Column
 import Standard.Visualization
 import Standard.Table.IO.File_Format
-import Standard.Base.System.File
-import Standard.Base.System.File.Existing_File_Behavior
 import Standard.Base.Error.Common as Errors
 import Standard.Table.Internal.Table_Helpers
 import Standard.Table.Internal.Aggregate_Column_Helper

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1,10 +1,11 @@
 from Standard.Base import all
-
+import Standard.Base.Data.Ordering.Comparator
+from Standard.Base.Error.Problem_Behavior import Report_Warning
 import Standard.Base.System.Platform
-import Standard.Table.Data.Column
-import Standard.Visualization
-import Standard.Table.IO.File_Format
 import Standard.Base.Error.Common as Errors
+
+import Standard.Table.Data.Column
+import Standard.Table.IO.File_Format
 import Standard.Table.Internal.Table_Helpers
 import Standard.Table.Internal.Aggregate_Column_Helper
 import Standard.Table.Internal.Parse_Values_Helper
@@ -15,8 +16,6 @@ import Standard.Table.Internal.Problem_Builder
 from Standard.Table.Data.Column_Selector import Column_Selector, By_Index
 from Standard.Table.Data.Column_Type_Selection import Column_Type_Selection, Auto
 from Standard.Table.Data.Data_Formatter import Data_Formatter
-from Standard.Base.Data.Text.Text_Ordering import Text_Ordering
-from Standard.Base.Error.Problem_Behavior import Problem_Behavior, Report_Warning
 from Standard.Table.Errors import Missing_Input_Columns, Column_Indexes_Out_Of_Range, Duplicate_Type_Selector, No_Index_Set_Error, No_Such_Column_Error
 import Standard.Table.Data.Match_Columns
 
@@ -26,7 +25,7 @@ import Standard.Table.Data.Sort_Column_Selector
 import Standard.Table.Data.Sort_Column
 
 import Standard.Table.Data.Aggregate_Column
-import Standard.Base.Data.Ordering.Comparator
+import Standard.Visualization
 
 polyglot java import org.enso.table.data.table.Table as Java_Table
 polyglot java import org.enso.table.data.table.Column as Java_Column

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/IO/Excel.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/IO/Excel.enso
@@ -1,5 +1,4 @@
 from Standard.Base import all
-from Standard.Base.Error.Problem_Behavior import Problem_Behavior
 import Standard.Base.System.File.Option
 import Standard.Base.Error.Common as Errors
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/IO/Excel.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/IO/Excel.enso
@@ -1,12 +1,11 @@
 from Standard.Base import all
 from Standard.Base.Error.Problem_Behavior import Problem_Behavior
-import Standard.Base.System.File.Existing_File_Behavior
 import Standard.Base.System.File.Option
-from Standard.Table.IO.File_Format import Infer
+import Standard.Base.Error.Common as Errors
 
 import Standard.Table.Data.Table
+from Standard.Table.IO.File_Format import Infer
 from Standard.Table.Errors import Invalid_Location, Duplicate_Output_Column_Names, Invalid_Output_Column_Names, Range_Exceeded, Existing_Data, Column_Count_Mismatch, Column_Name_Mismatch
-import Standard.Base.Error.Common as Errors
 import Standard.Table.Data.Match_Columns
 
 polyglot java import org.enso.table.excel.ExcelRange as Java_Range

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/IO/File_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/IO/File_Format.enso
@@ -1,12 +1,10 @@
 from Standard.Base import all
-import Standard.Table
-
-import Standard.Base.Error.Common as Errors
 import Standard.Base.System
-import Standard.Table.Data.Match_Columns
-from Standard.Base.Error.Problem_Behavior import Problem_Behavior
-from Standard.Base.Data.Text.Encoding import Encoding
 import Standard.Base.Runtime.Ref
+import Standard.Base.Error.Common as Errors
+
+import Standard.Table
+import Standard.Table.Data.Match_Columns
 import Standard.Table.Internal.Delimited_Reader
 import Standard.Table.Internal.Delimited_Writer
 from Standard.Table.Errors import Unsupported_File_Type

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/IO/File_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/IO/File_Format.enso
@@ -3,7 +3,7 @@ import Standard.Base.System
 import Standard.Base.Runtime.Ref
 import Standard.Base.Error.Common as Errors
 
-import Standard.Table
+import Standard.Table.Data.Table
 import Standard.Table.Data.Match_Columns
 import Standard.Table.Internal.Delimited_Reader
 import Standard.Table.Internal.Delimited_Writer

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/IO/File_Read.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/IO/File_Read.enso
@@ -40,7 +40,6 @@ File.read path (format=File_Format.Auto) (on_problems=Report_Warning) =
      Read the first sheet of an XLSX from disk and convert it into a table.
 
          import Standard.Table
-         import Standard.Table.IO.File_Read
          import Standard.Examples
 
          example_xlsx_to_table = Examples.xlsx.read
@@ -49,7 +48,6 @@ File.read path (format=File_Format.Auto) (on_problems=Report_Warning) =
      Read the sheet named `Dates` from an XLS and convert it to a table.
 
          import Standard.Table
-         import Standard.Table.IO.File_Read
          from Standard.Table.IO.File_Format import Excel
          from Standard.Table.IO.Excel import Excel_Section
          import Standard.Examples

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/IO/File_Read.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/IO/File_Read.enso
@@ -1,5 +1,5 @@
 from Standard.Base import all
-from Standard.Base.Error.Problem_Behavior import Problem_Behavior, Report_Warning
+from Standard.Base.Error.Problem_Behavior import Report_Warning
 
 import Standard.Table.IO.File_Format
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Delimited_Reader.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Delimited_Reader.enso
@@ -1,11 +1,9 @@
 from Standard.Base import all
-import Standard.Table
-
-import Standard.Base.Data.Statistics
 import Standard.Base.Error.Common as Errors
-from Standard.Base.Error.Problem_Behavior import Problem_Behavior, Ignore, Report_Error
+from Standard.Base.Error.Problem_Behavior import Ignore, Report_Error
+
+import Standard.Table
 from Standard.Table.Errors import Duplicate_Output_Column_Names, Invalid_Output_Column_Names, Invalid_Row, Mismatched_Quote, Parser_Error, Additional_Invalid_Rows
-from Standard.Base.Data.Text.Encoding import Encoding, Encoding_Error
 from Standard.Table.IO.File_Format import Infer
 from Standard.Table.Data.Data_Formatter import Data_Formatter
 import Standard.Table.IO.Quote_Style

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Delimited_Reader.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Delimited_Reader.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base.Error.Common as Errors
 from Standard.Base.Error.Problem_Behavior import Ignore, Report_Error
 
-import Standard.Table
+import Standard.Table.Data.Table
 from Standard.Table.Errors import Duplicate_Output_Column_Names, Invalid_Output_Column_Names, Invalid_Row, Mismatched_Quote, Parser_Error, Additional_Invalid_Rows
 from Standard.Table.IO.File_Format import Infer
 from Standard.Table.Data.Data_Formatter import Data_Formatter

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Delimited_Writer.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Delimited_Writer.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base.System
 import Standard.Base.Error.Common as Errors
 
-import Standard.Table
+import Standard.Table.Data.Table
 from Standard.Table.Errors as Table_Errors import Duplicate_Output_Column_Names, Invalid_Output_Column_Names, Invalid_Row, Mismatched_Quote, Parser_Error, Additional_Invalid_Rows, Column_Count_Mismatch, Column_Name_Mismatch
 from Standard.Table.IO.File_Format import Infer
 from Standard.Table.Data.Data_Formatter import Data_Formatter

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Delimited_Writer.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Delimited_Writer.enso
@@ -1,17 +1,14 @@
 from Standard.Base import all
-import Standard.Table
-
-import Standard.Base.Error.Common as Errors
 import Standard.Base.System
+import Standard.Base.Error.Common as Errors
 from Standard.Base.Error.Problem_Behavior import Problem_Behavior
-import Standard.Base.System.File.Existing_File_Behavior
+
+import Standard.Table
 from Standard.Table.Errors as Table_Errors import Duplicate_Output_Column_Names, Invalid_Output_Column_Names, Invalid_Row, Mismatched_Quote, Parser_Error, Additional_Invalid_Rows, Column_Count_Mismatch, Column_Name_Mismatch
-from Standard.Base.Data.Text.Encoding import Encoding, Encoding_Error
 from Standard.Table.IO.File_Format import Infer
 from Standard.Table.Data.Data_Formatter import Data_Formatter
 import Standard.Table.Data.Storage
 import Standard.Table.IO.Quote_Style
-import Standard.Base.Data.Text.Line_Ending_Style
 from Standard.Table.Internal.Delimited_Reader import Existing_Headers, No_Headers
 import Standard.Table.Internal.Delimited_Reader
 import Standard.Table.Data.Match_Columns

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Delimited_Writer.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Delimited_Writer.enso
@@ -1,7 +1,6 @@
 from Standard.Base import all
 import Standard.Base.System
 import Standard.Base.Error.Common as Errors
-from Standard.Base.Error.Problem_Behavior import Problem_Behavior
 
 import Standard.Table
 from Standard.Table.Errors as Table_Errors import Duplicate_Output_Column_Names, Invalid_Output_Column_Names, Invalid_Row, Mismatched_Quote, Parser_Error, Additional_Invalid_Rows, Column_Count_Mismatch, Column_Name_Mismatch

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Problem_Builder.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Problem_Builder.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
-
-from Standard.Base.Error.Problem_Behavior import Problem_Behavior, Report_Warning
+from Standard.Base.Error.Problem_Behavior import Report_Warning
 import Standard.Base.Runtime.Ref
+
 import Standard.Table.Internal.Vector_Builder
 
 from Standard.Table.Errors import Missing_Input_Columns, Column_Indexes_Out_Of_Range, No_Output_Columns, Duplicate_Column_Selectors, Input_Indices_Already_Matched, Too_Many_Column_Names_Provided, Duplicate_Output_Column_Names, Invalid_Output_Column_Names, Column_Matched_By_Multiple_Selectors

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -1,17 +1,15 @@
 from Standard.Base import all
-
-import Standard.Base.Warning
 import Standard.Base.Data.Text.Matching
 import Standard.Base.Data.Ordering.Vector_Lexicographic_Order
 from Standard.Base.Data.Text.Text_Ordering import Text_Ordering
-from Standard.Base.Error.Problem_Behavior import Problem_Behavior, Report_Warning
+from Standard.Base.Error.Problem_Behavior import Report_Warning
+
 import Standard.Table.Data.Position
 from Standard.Table.Errors import Missing_Input_Columns, Column_Indexes_Out_Of_Range, No_Output_Columns, Duplicate_Column_Selectors, Input_Indices_Already_Matched, Too_Many_Column_Names_Provided, Duplicate_Output_Column_Names, Invalid_Output_Column_Names, No_Input_Columns_Selected
 from Standard.Table.Data.Column_Selector import Column_Selector, By_Name, By_Index, By_Column
 import Standard.Table.Data.Column_Name_Mapping
 import Standard.Table.Internal.Unique_Name_Strategy
 import Standard.Table.Internal.Problem_Builder
-import Standard.Base.Data.Ordering.Natural_Order
 import Standard.Table.Data.Sort_Column_Selector
 import Standard.Table.Data.Sort_Column
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
@@ -3,20 +3,33 @@ from Standard.Base import all
 import project.Data.Table
 import project.Data.Column
 import project.Data.Column_Selector
+import project.Data.Sort_Column
 import project.Data.Sort_Column_Selector
+import project.Data.Column_Name_Mapping
+import project.Data.Data_Formatter
+import project.Data.Match_Columns
 
 import project.IO.File_Read
 import project.IO.File_Format
 import project.IO.Excel
+import project.IO.Quote_Style
+
 import project.Errors
 
 from project.Data.Table export new, from_rows, join, concat, Table
 export project.Data.Column
 export project.Data.Column_Selector
+export project.Data.Sort_Column
 export project.Data.Sort_Column_Selector
+export project.Data.Column_Name_Mapping
+export project.Data.Match_Columns
+
 export project.IO.File_Read
 export project.IO.File_Format
+export project.IO.Quote_Style
+
 from project.IO.Excel export Excel_Section, Excel_Range
+from project.Data.Data_Formatter export Data_Formatter
 
 import Standard.Geo.Geo_Json
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
@@ -1,21 +1,24 @@
 from Standard.Base import all
 
+import project.Data.Table
+import project.Data.Column
+import project.Data.Column_Selector
+import project.Data.Sort_Column_Selector
+
+import project.IO.File_Read
+import project.IO.File_Format
+import project.IO.Excel
+import project.Errors
+
+from project.Data.Table export new, from_rows, join, concat, Table
+export project.Data.Column
+export project.Data.Column_Selector
+export project.Data.Sort_Column_Selector
+export project.IO.File_Read
+export project.IO.File_Format
+from project.IO.Excel export Excel_Section, Excel_Range
+
 import Standard.Geo.Geo_Json
-import Standard.Table.IO.File_Read
-import Standard.Table.IO.File_Format
-import Standard.Table.IO.Excel
-import Standard.Table.Errors
-import Standard.Table.Data.Table
-import Standard.Table.Data.Column
-
-from Standard.Table.IO.Excel export Excel_Section, Excel_Range
-
-export Standard.Table.Data.Column
-export Standard.Table.IO.File_Read
-export Standard.Table.IO.File_Format
-
-from Standard.Table.Data.Table export new, from_rows, join, concat, Table
-from Standard.Table.Errors export No_Such_Column_Error
 
 ## ALIAS To Table
 

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/File_Upload.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/File_Upload.enso
@@ -1,7 +1,5 @@
 from Standard.Base import all
 
-import Standard.Base.System.File as Base_File
-
 ## UNSTABLE
 
    A function that throws an error to indicate that a file is being uploaded to
@@ -9,11 +7,11 @@ import Standard.Base.System.File as Base_File
 
    Arguments:
    - `path`: The path to which the file is being uploaded.
-file_uploading : (Base_File.File | Text) -> Base_File.File ! File_Being_Uploaded
+file_uploading : (File.File | Text) -> File.File ! File_Being_Uploaded
 file_uploading path =
     err = File_Being_Uploaded <| case path of
         Text -> path
-        Base_File.File -> path.path
+        File.File -> path.path
         _ -> ""
     Error.throw err
 

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Geo_Map.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Geo_Map.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
 
-import Standard.Table.Data.Table
+import Standard.Table
 import Standard.Test
 import Standard.Visualization.Helpers
 

--- a/test/Benchmarks/src/Natural_Order_Sort.enso
+++ b/test/Benchmarks/src/Natural_Order_Sort.enso
@@ -1,5 +1,4 @@
 from Standard.Base import all
-import Standard.Base.Data.Ordering.Natural_Order
 
 import Standard.Test.Bench
 import Standard.Test.Faker

--- a/test/Benchmarks/src/Table/Aggregate.enso
+++ b/test/Benchmarks/src/Table/Aggregate.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
-import Standard.Table.Data.Table
-import Standard.Table.Data.Column_Selector
+import Standard.Table
+from Standard.Table import Column_Selector
 from Standard.Table.Data.Aggregate_Column import all
 
 import Standard.Test.Bench

--- a/test/Image_Tests/src/Codecs_Spec.enso
+++ b/test/Image_Tests/src/Codecs_Spec.enso
@@ -1,5 +1,4 @@
 from Standard.Base import all
-import Standard.Base.System.File
 import Standard.Base.System.Platform
 import Standard.Base.System.Process
 import Standard.Base.System.Process.Exit_Code

--- a/test/Table_Tests/src/Aggregate_Column_Spec.enso
+++ b/test/Table_Tests/src/Aggregate_Column_Spec.enso
@@ -1,8 +1,9 @@
 from Standard.Base import all hiding First, Last
 
-import Standard.Table.Data.Table
+import Standard.Table
 from Standard.Table.Data.Aggregate_Column import all
 from Standard.Table.Data.Column_Selector import By_Name, By_Index
+
 import Standard.Table.Internal.Aggregate_Column_Helper
 import Standard.Table.Internal.Problem_Builder
 

--- a/test/Table_Tests/src/Aggregate_Spec.enso
+++ b/test/Table_Tests/src/Aggregate_Spec.enso
@@ -5,8 +5,8 @@ from Standard.Table import Sort_Column, Sort_Column_Selector
 from Standard.Table.Data.Column_Selector import By_Name, By_Index
 from Standard.Table.Data.Aggregate_Column import all
 
-from Standard.Table.Errors as Error_Module import Missing_Input_Columns, Column_Indexes_Out_Of_Range, No_Output_Columns, Duplicate_Output_Column_Names, Invalid_Output_Column_Names, Invalid_Aggregation, Floating_Point_Grouping, Unquoted_Delimiter, Additional_Warnings
-from Standard.Database.Error as Database_Errors import Unsupported_Database_Operation_Error
+from Standard.Table.Errors import Missing_Input_Columns, Column_Indexes_Out_Of_Range, No_Output_Columns, Duplicate_Output_Column_Names, Invalid_Output_Column_Names, Invalid_Aggregation, Floating_Point_Grouping, Unquoted_Delimiter, Additional_Warnings
+from Standard.Database.Error import Unsupported_Database_Operation_Error
 
 import Standard.Test
 import Standard.Test.Problems

--- a/test/Table_Tests/src/Aggregate_Spec.enso
+++ b/test/Table_Tests/src/Aggregate_Spec.enso
@@ -10,7 +10,6 @@ from Standard.Database.Error as Database_Errors import Unsupported_Database_Oper
 
 import Standard.Test
 import Standard.Test.Problems
-import Standard.Base.Error.Problem_Behavior
 
 polyglot java import java.lang.Double
 

--- a/test/Table_Tests/src/Aggregate_Spec.enso
+++ b/test/Table_Tests/src/Aggregate_Spec.enso
@@ -1,10 +1,10 @@
 from Standard.Base import all hiding First, Last
 
 import Standard.Table
+from Standard.Table import Sort_Column, Sort_Column_Selector
 from Standard.Table.Data.Column_Selector import By_Name, By_Index
-import Standard.Table.Data.Sort_Column
-import Standard.Table.Data.Sort_Column_Selector
 from Standard.Table.Data.Aggregate_Column import all
+
 from Standard.Table.Errors as Error_Module import Missing_Input_Columns, Column_Indexes_Out_Of_Range, No_Output_Columns, Duplicate_Output_Column_Names, Invalid_Output_Column_Names, Invalid_Aggregation, Floating_Point_Grouping, Unquoted_Delimiter, Additional_Warnings
 from Standard.Database.Error as Database_Errors import Unsupported_Database_Operation_Error
 

--- a/test/Table_Tests/src/Column_Spec.enso
+++ b/test/Table_Tests/src/Column_Spec.enso
@@ -1,8 +1,8 @@
 from Standard.Base import all
-from Standard.Table import all
+from Standard.Table import Column
 
 import Standard.Examples
-import Standard.Table.Data.Column
+
 import Standard.Test
 
 spec = Test.group "Columns" <|

--- a/test/Table_Tests/src/Common_Table_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Spec.enso
@@ -1,11 +1,9 @@
 from Standard.Base import all
 
-import Standard.Table.Data.Column_Name_Mapping
+from Standard.Table import Column_Name_Mapping, Sort_Column, Sort_Column_Selector
 from Standard.Table.Errors as Table_Errors import all
 from Standard.Table.Data.Column_Selector import all
 from Standard.Table.Data.Position import all
-import Standard.Table.Data.Sort_Column_Selector
-import Standard.Table.Data.Sort_Column
 
 import Standard.Test
 import Standard.Test.Problems

--- a/test/Table_Tests/src/Csv_Spec.enso
+++ b/test/Table_Tests/src/Csv_Spec.enso
@@ -1,9 +1,8 @@
 from Standard.Base import all
 
 import Standard.Table
-import Standard.Table.Data.Column
+from Standard.Table import Column, File_Format
 from Standard.Table.Data.Column_Selector import By_Index
-import Standard.Table.IO.File_Format
 
 import Standard.Test
 

--- a/test/Table_Tests/src/Data_Formatter_Spec.enso
+++ b/test/Table_Tests/src/Data_Formatter_Spec.enso
@@ -1,13 +1,10 @@
 from Standard.Base import all
-
 import Standard.Base.Data.Time
 import Standard.Base.Data.Time.Time_Of_Day
 
 import Standard.Table
-import Standard.Table.Data.Column
+from Standard.Table import Column, Data_Formatter, Quote_Style
 from Standard.Table.Errors import all
-from Standard.Table.Data.Data_Formatter as Data_Formatter_Module import Data_Formatter
-import Standard.Table.IO.Quote_Style
 
 import Standard.Test
 import Standard.Test.Problems

--- a/test/Table_Tests/src/Database/Codegen_Spec.enso
+++ b/test/Table_Tests/src/Database/Codegen_Spec.enso
@@ -1,8 +1,7 @@
 from Standard.Base import all
 
+from Standard.Table import Sort_Column, Sort_Column_Selector
 from Standard.Table.Data.Column_Selector as Column_Selector_Module import By_Name
-import Standard.Table.Data.Sort_Column_Selector
-import Standard.Table.Data.Sort_Column
 from Standard.Table.Data.Aggregate_Column import all
 from Standard.Table.Errors as Table_Errors import No_Input_Columns_Selected, Missing_Input_Columns, No_Such_Column_Error
 

--- a/test/Table_Tests/src/Database/Codegen_Spec.enso
+++ b/test/Table_Tests/src/Database/Codegen_Spec.enso
@@ -1,15 +1,15 @@
 from Standard.Base import all
 
 from Standard.Table import Sort_Column, Sort_Column_Selector
-from Standard.Table.Data.Column_Selector as Column_Selector_Module import By_Name
+from Standard.Table.Data.Column_Selector import By_Name
 from Standard.Table.Data.Aggregate_Column import all
-from Standard.Table.Errors as Table_Errors import No_Input_Columns_Selected, Missing_Input_Columns, No_Such_Column_Error
+from Standard.Table.Errors import No_Input_Columns_Selected, Missing_Input_Columns, No_Such_Column_Error
 
 from Standard.Database import all
 from Standard.Database.Data.Sql import Sql_Type
 import Standard.Database.Data.Dialect
-import Standard.Database.Data.Table as Table_Module
-from Standard.Database.Error as Database_Errors import Unsupported_Database_Operation_Error
+from Standard.Database.Data.Table import combine_names, fresh_names
+from Standard.Database.Error import Unsupported_Database_Operation_Error
 
 import Standard.Test
 import Standard.Test.Problems
@@ -176,15 +176,15 @@ spec =
         Test.specify "combine_names should combine lists of names" <|
             v1 = ["A", "B"]
             v2 = ["A", "C"]
-            combined = Table_Module.combine_names v1 v2 "_1" "_2"
+            combined = combine_names v1 v2 "_1" "_2"
             combined.first . should_equal ["A_1", "B"]
             combined.second . should_equal ["A_2", "C"]
 
-            Test.expect_panic_with (Table_Module.combine_names ["A", "A_1"] ["A"] "_1" "_2") Illegal_State_Error
+            Test.expect_panic_with (combine_names ["A", "A_1"] ["A"] "_1" "_2") Illegal_State_Error
         Test.specify "fresh_names should provide fresh names" <|
             used_names = ["A", "A_1"]
             preferred_names = ["A", "A", "B"]
-            Table_Module.fresh_names used_names preferred_names . should_equal ["A_2", "A_3", "B"]
+            fresh_names used_names preferred_names . should_equal ["A_2", "A_3", "B"]
 
     Test.group "[Codegen] Aggregation" <|
         Test.specify "should allow to count rows" <|

--- a/test/Table_Tests/src/Database/Common_Spec.enso
+++ b/test/Table_Tests/src/Database/Common_Spec.enso
@@ -1,11 +1,10 @@
 from Standard.Base import all
 
+import Standard.Table as Materialized_Table
+from Standard.Table import Sort_Column, Sort_Column_Selector
 from Standard.Table.Data.Column_Selector as Column_Selector_Module import By_Name
-import Standard.Table.Data.Table as Materialized_Table
-import Standard.Table.Data.Sort_Column_Selector
-import Standard.Table.Data.Sort_Column
-from Standard.Table.Errors as Table_Errors import No_Input_Columns_Selected, Missing_Input_Columns
 from Standard.Table.Data.Aggregate_Column import all
+from Standard.Table.Errors as Table_Errors import No_Input_Columns_Selected, Missing_Input_Columns
 
 from Standard.Database import all
 

--- a/test/Table_Tests/src/Database/Helpers/Fake_Test_Connection.enso
+++ b/test/Table_Tests/src/Database/Helpers/Fake_Test_Connection.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 
+import Standard.Table.Data.Table as Materialized_Table
 import Standard.Database.Data.Table as Database_Table
 
 type Fake_Test_Connection

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -1,5 +1,4 @@
 from Standard.Base import all
-import Standard.Base.System.Environment
 import Standard.Base.Runtime.Ref
 import Standard.Base.System.Platform
 import Standard.Base.System.Process

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -135,24 +135,24 @@ table_spec =
             Database.connect (Postgres db_host db_port db_name (Credentials db_user db_password)) . should_succeed
 
         Test.specify "should connect, requiring SSL" <|
-            Database.connect (Postgres db_host db_port db_name (Credentials db_user db_password) use_ssl=Require) . should_succeed
+            Database.connect (Postgres db_host db_port db_name (Credentials db_user db_password) use_ssl=SSL_Mode.Require) . should_succeed
 
         Test.specify "should connect be able to verify the certificate" <|
-            Database.connect (Postgres db_host db_port db_name (Credentials db_user db_password) use_ssl=(Verify_CA ca_cert_file)) . should_succeed
+            Database.connect (Postgres db_host db_port db_name (Credentials db_user db_password) use_ssl=(SSL_Mode.Verify_CA ca_cert_file)) . should_succeed
 
             ## Default certificate should not accept the self signed certificate.
-            ca_fail = Database.connect (Postgres db_host db_port db_name (Credentials db_user db_password) use_ssl=Verify_CA)
+            ca_fail = Database.connect (Postgres db_host db_port db_name (Credentials db_user db_password) use_ssl=SSL_Mode.Verify_CA)
             ca_fail.is_error . should_equal True
             ca_fail.catch Sql_Error . is_a Sql_Error . should_equal True
 
         Test.specify "should connect be able to verify the host name against the certificate" <|
-            Database.connect (Postgres db_host db_port db_name (Credentials db_user db_password) use_ssl=(Full_Verification ca_cert_file)) . should_succeed
+            Database.connect (Postgres db_host db_port db_name (Credentials db_user db_password) use_ssl=(SSL_Mode.Full_Verification ca_cert_file)) . should_succeed
 
         alternate_host = Environment.get "ENSO_DATABASE_TEST_ALTERNATE_HOST" . if_nothing <|
             if db_host == "127.0.0.1" then "localhost" else Nothing
         pending_alternate = if alternate_host.is_nothing then "Alternative host name not configured." else Nothing
         Test.specify "should fail to connect with alternate host name not valid in certificate" pending=pending_alternate <|
-            ca_fail = Database.connect (Postgres alternate_host db_port db_name (Credentials db_user db_password) use_ssl=(Full_Verification ca_cert_file))
+            ca_fail = Database.connect (Postgres alternate_host db_port db_name (Credentials db_user db_password) use_ssl=(SSL_Mode.Full_Verification ca_cert_file))
             ca_fail.is_error . should_equal True
             ca_fail.catch Sql_Error . is_a Sql_Error . should_equal True
 

--- a/test/Table_Tests/src/Database/Redshift_Spec.enso
+++ b/test/Table_Tests/src/Database/Redshift_Spec.enso
@@ -1,5 +1,4 @@
 from Standard.Base import all
-import Standard.Base.System.Environment
 import Standard.Base.Runtime.Ref
 
 import Standard.Table as Materialized_Table

--- a/test/Table_Tests/src/Delimited_Read_Spec.enso
+++ b/test/Table_Tests/src/Delimited_Read_Spec.enso
@@ -1,14 +1,11 @@
 from Standard.Base import all
 
 import Standard.Table
-import Standard.Table.Data.Column
-from Standard.Table.Errors import all
-import Standard.Table.IO.File_Read
+from Standard.Table import Column, File_Format
 from Standard.Table.IO.File_Format import Delimited
-import Standard.Table.IO.File_Format
-from Standard.Table.Data.Data_Formatter as Data_Formatter_Module import Data_Formatter
+from Standard.Table.Errors import all
+from Standard.Table.Data.Data_Formatter import Data_Formatter
 import Standard.Table.IO.Quote_Style
-import Standard.Base.Data.Text.Line_Ending_Style
 
 import Standard.Test
 import Standard.Test.Problems

--- a/test/Table_Tests/src/Delimited_Read_Spec.enso
+++ b/test/Table_Tests/src/Delimited_Read_Spec.enso
@@ -1,11 +1,9 @@
 from Standard.Base import all
 
 import Standard.Table
-from Standard.Table import Column, File_Format
+from Standard.Table import Column, File_Format, Data_Formatter, Quote_Style
 from Standard.Table.IO.File_Format import Delimited
 from Standard.Table.Errors import all
-from Standard.Table.Data.Data_Formatter import Data_Formatter
-import Standard.Table.IO.Quote_Style
 
 import Standard.Test
 import Standard.Test.Problems

--- a/test/Table_Tests/src/Delimited_Write_Spec.enso
+++ b/test/Table_Tests/src/Delimited_Write_Spec.enso
@@ -4,13 +4,9 @@ import Standard.Base.System
 from Standard.Base.Error.Problem_Behavior import all
 
 import Standard.Table
-import Standard.Table.Data.Column
+from Standard.Table import Column, Data_Formatter, Quote_Style, Column_Name_Mapping, Match_Columns
 from Standard.Table.Errors import all
 from Standard.Table.IO.File_Format import Delimited
-from Standard.Table.Data.Data_Formatter as Data_Formatter_Module import Data_Formatter
-import Standard.Table.IO.Quote_Style
-import Standard.Table.Data.Match_Columns
-import Standard.Table.Data.Column_Name_Mapping
 from Standard.Table.Data.Column_Selector as Column_Selector_Module import By_Name
 from Standard.Table.Errors as Table_Errors import Column_Count_Mismatch, Column_Name_Mismatch
 

--- a/test/Table_Tests/src/Delimited_Write_Spec.enso
+++ b/test/Table_Tests/src/Delimited_Write_Spec.enso
@@ -1,5 +1,4 @@
 from Standard.Base import all
-import Standard.Base.Data.Text.Line_Ending_Style
 import Standard.Base.Data.Time.Time_Of_Day
 import Standard.Base.System
 from Standard.Base.Error.Problem_Behavior import all

--- a/test/Table_Tests/src/Delimited_Write_Spec.enso
+++ b/test/Table_Tests/src/Delimited_Write_Spec.enso
@@ -7,7 +7,6 @@ from Standard.Base.Error.Problem_Behavior import all
 import Standard.Table
 import Standard.Table.Data.Column
 from Standard.Table.Errors import all
-import Standard.Table.IO.File_Read
 from Standard.Table.IO.File_Format import Delimited
 from Standard.Table.Data.Data_Formatter as Data_Formatter_Module import Data_Formatter
 import Standard.Table.IO.Quote_Style

--- a/test/Table_Tests/src/Excel_Spec.enso
+++ b/test/Table_Tests/src/Excel_Spec.enso
@@ -4,13 +4,10 @@ from Standard.Base.System.File import File_Already_Exists_Error
 from Standard.Base.Error.Problem_Behavior import all
 
 import Standard.Table
-from Standard.Table import File_Format
-import Standard.Table.Data.Column_Name_Mapping
-import Standard.Table.Data.Match_Columns
+from Standard.Table import File_Format, Match_Columns, Column_Name_Mapping, Data_Formatter, Excel_Range
 from Standard.Table.Data.Column_Selector as Column_Selector_Module import By_Index
-from Standard.Table.IO.Excel import Excel_Range, Sheet_Names, Range_Names, Sheet, Cell_Range
+from Standard.Table.IO.Excel import Sheet_Names, Range_Names, Sheet, Cell_Range
 from Standard.Table.Errors as Table_Errors import Invalid_Output_Column_Names, Duplicate_Output_Column_Names, Invalid_Location, Range_Exceeded, Existing_Data, Column_Count_Mismatch, Column_Name_Mismatch
-from Standard.Table.Data.Data_Formatter import Data_Formatter
 
 import Standard.Test
 import Standard.Test.Problems

--- a/test/Table_Tests/src/Excel_Spec.enso
+++ b/test/Table_Tests/src/Excel_Spec.enso
@@ -4,14 +4,13 @@ from Standard.Base.System.File import File_Already_Exists_Error
 from Standard.Base.Error.Problem_Behavior import all
 
 import Standard.Table
-import Standard.Table.IO.File_Read
-import Standard.Table.IO.File_Format
+from Standard.Table import File_Format
 import Standard.Table.Data.Column_Name_Mapping
 import Standard.Table.Data.Match_Columns
 from Standard.Table.Data.Column_Selector as Column_Selector_Module import By_Index
 from Standard.Table.IO.Excel import Excel_Range, Sheet_Names, Range_Names, Sheet, Cell_Range
 from Standard.Table.Errors as Table_Errors import Invalid_Output_Column_Names, Duplicate_Output_Column_Names, Invalid_Location, Range_Exceeded, Existing_Data, Column_Count_Mismatch, Column_Name_Mismatch
-from Standard.Table.Data.Data_Formatter as Data_Formatter_Module import Data_Formatter
+from Standard.Table.Data.Data_Formatter import Data_Formatter
 
 import Standard.Test
 import Standard.Test.Problems

--- a/test/Table_Tests/src/Parse_Values_Spec.enso
+++ b/test/Table_Tests/src/Parse_Values_Spec.enso
@@ -2,11 +2,11 @@ from Standard.Base import all
 import Standard.Base.Data.Time
 import Standard.Base.Data.Time.Time_Of_Day
 
-from Standard.Table import all
-from Standard.Table.Data.Table as Table_Internal import Empty_Error
-from Standard.Table.Data.Data_Formatter as Data_Formatter_Module import Data_Formatter
-from Standard.Table.Data.Column_Type_Selection as Column_Type_Selection_Module import Column_Type_Selection, Auto
-from Standard.Table.Errors as Table_Errors import Invalid_Format, Leading_Zeros, Missing_Input_Columns, Column_Indexes_Out_Of_Range, Duplicate_Type_Selector
+import Standard.Table
+from Standard.Table import Data_Formatter
+from Standard.Table.Data.Table import Empty_Error
+from Standard.Table.Data.Column_Type_Selection import Column_Type_Selection, Auto
+from Standard.Table.Errors import Invalid_Format, Leading_Zeros, Missing_Input_Columns, Column_Indexes_Out_Of_Range, Duplicate_Type_Selector
 
 import Standard.Visualization
 

--- a/test/Table_Tests/src/Table_Date_Spec.enso
+++ b/test/Table_Tests/src/Table_Date_Spec.enso
@@ -1,10 +1,8 @@
 from Standard.Base import all
-import Standard.Base.Data.Text.Line_Ending_Style
 
 import Standard.Table
-import Standard.Table.Data.Column
-import Standard.Table.IO.File_Format
-from Standard.Table.Data.Data_Formatter as Data_Formatter_Module import Data_Formatter
+from Standard.Table import Column, File_Format
+from Standard.Table.Data.Data_Formatter import Data_Formatter
 
 import Standard.Test
 

--- a/test/Table_Tests/src/Table_Date_Spec.enso
+++ b/test/Table_Tests/src/Table_Date_Spec.enso
@@ -1,8 +1,7 @@
 from Standard.Base import all
 
 import Standard.Table
-from Standard.Table import Column, File_Format
-from Standard.Table.Data.Data_Formatter import Data_Formatter
+from Standard.Table import Column, File_Format, Data_Formatter
 
 import Standard.Test
 

--- a/test/Table_Tests/src/Table_Spec.enso
+++ b/test/Table_Tests/src/Table_Spec.enso
@@ -1,9 +1,8 @@
 from Standard.Base import all
-from Standard.Table import all
 
-import Standard.Table.Data.Sort_Column_Selector
-import Standard.Table.Data.Sort_Column
-from Standard.Table.Data.Table as Table_Internal import Empty_Error
+import Standard.Table
+from Standard.Table import Column, Sort_Column, Sort_Column_Selector
+from Standard.Table.Data.Table import Empty_Error
 from Standard.Table.Errors as Table_Errors import Invalid_Output_Column_Names, Duplicate_Output_Column_Names, No_Input_Columns_Selected, Missing_Input_Columns
 import Standard.Table.Data.Storage
 

--- a/test/Table_Tests/src/Util.enso
+++ b/test/Table_Tests/src/Util.enso
@@ -1,6 +1,5 @@
 from Standard.Base import all
 import Standard.Base.System
-import Standard.Base.Data.Text.Line_Ending_Style
 
 import Standard.Table
 import Standard.Table.Data.Column

--- a/test/Table_Tests/src/Util.enso
+++ b/test/Table_Tests/src/Util.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base.System
 
 import Standard.Table
-import Standard.Table.Data.Column
+from Standard.Table import Column
 
 import Standard.Test
 

--- a/test/Tests/src/Data/Text/Regex_Spec.enso
+++ b/test/Tests/src/Data/Text/Regex_Spec.enso
@@ -1,6 +1,5 @@
 from Standard.Base import all
 
-import Standard.Base.Data.Text.Regex
 import Standard.Base.Data.Text.Regex.Option
 import Standard.Base.Data.Text.Regex.Engine.Default as Default_Engine
 

--- a/test/Tests/src/Data/Text_Spec.enso
+++ b/test/Tests/src/Data/Text_Spec.enso
@@ -4,7 +4,6 @@ from Standard.Base.Data.Text.Extensions import Index_Out_Of_Bounds_Error
 import Standard.Base.Data.Text.Regex.Engine.Default as Default_Engine
 
 from Standard.Base.Data.Text.Text_Sub_Range import all
-from Standard.Base.Data.Index_Sub_Range import First, Last, While, By_Index, Sample, Every
 
 import Standard.Test
 

--- a/test/Tests/src/Semantic/Java_Interop_Spec.enso
+++ b/test/Tests/src/Semantic/Java_Interop_Spec.enso
@@ -1,5 +1,4 @@
 from Standard.Base import all
-import Standard.Base.Data.Time.Date
 
 polyglot java import java.lang.Float
 polyglot java import java.lang.Integer

--- a/test/Tests/src/Semantic/Meta_Spec.enso
+++ b/test/Tests/src/Semantic/Meta_Spec.enso
@@ -82,7 +82,7 @@ spec = Test.group "Meta-Value Manipulation" <|
         _ -> Nothing
     Test.specify "should allow to get the source location of a frame" pending=location_pending <|
         src = Meta.get_source_location 0
-        loc = "Meta_Spec.enso:85:15-40"
+        loc = "Meta_Spec.enso:84:15-40"
         src.take (Last loc.length) . should_equal loc
 
     Test.specify "should allow to get qualified type names of values" <|

--- a/test/Tests/src/Semantic/Meta_Spec.enso
+++ b/test/Tests/src/Semantic/Meta_Spec.enso
@@ -1,6 +1,5 @@
 from Standard.Base import all
 
-from Standard.Base.Data.Text.Text_Sub_Range import Last
 import Standard.Base.System.Platform
 
 polyglot java import java.util.Random

--- a/test/Tests/src/System/Environment_Spec.enso
+++ b/test/Tests/src/System/Environment_Spec.enso
@@ -1,6 +1,5 @@
 from Standard.Base import all
 
-import Standard.Base.System.Environment
 import Standard.Test
 import Standard.Test.Test_Environment
 


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

- Removed various unnecessary `Standard.Base` imports still left behind.
- Added `Regex` to default `Standard.Base`.
- Removed aliasing from the examples as no longer needed (case coercion no long occurs).
- Remove `import Standard.Table` from within the Table library (directly importing types).
- Reviewed what was in `Standard.Database` - a few tweaks and removals.
- Removed various un-needed aliasing following Hubert's import work.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
