### PR TITLE
Parse text literals

### DIFF
--- a/lib/rust/metamodel/src/rust/to_meta.rs
+++ b/lib/rust/metamodel/src/rust/to_meta.rs
@@ -132,6 +132,7 @@ impl ToMeta {
         ty.abstract_ = true;
         ty.closed = true;
         ty.discriminants = children.enumerate().collect();
+        ty.child_field = Some(0);
         self.graph.types.bind(id_, ty);
     }
 

--- a/lib/rust/parser/generate-java/java/org/enso/syntax2/Message.java
+++ b/lib/rust/parser/generate-java/java/org/enso/syntax2/Message.java
@@ -10,22 +10,22 @@ final class Message {
     private final long metadata;
     private boolean encounteredUnsupportedSyntax;
 
-    public Message(java.nio.ByteBuffer bufferIn, java.nio.ByteBuffer contextIn, long baseIn, long metadataIn) {
+    Message(java.nio.ByteBuffer bufferIn, java.nio.ByteBuffer contextIn, long baseIn, long metadataIn) {
         buffer = bufferIn;
         context = contextIn;
         base = (int)baseIn;
         metadata = metadataIn;
     }
 
-    public long get64() {
+    long get64() {
         return buffer.getLong();
     }
 
-    public int get32() {
+    int get32() {
         return buffer.getInt();
     }
 
-    public boolean getBoolean() {
+    boolean getBoolean() {
         switch (buffer.get()) {
             case 0: return false;
             case 1: return true;
@@ -33,18 +33,18 @@ final class Message {
         }
     }
 
-    public String getString() {
+    String getString() {
         int len = (int)get64();
         byte[] dst = new byte[len];
         buffer.get(dst);
         return new String(dst, StandardCharsets.UTF_8);
     }
 
-    public java.nio.ByteBuffer context() {
+    java.nio.ByteBuffer context() {
         return context;
     }
 
-    public int offset(int xLow32) {
+    int offset(int xLow32) {
         // Given the low bits of `x`, the low bits of `base`, and the invariant `x >= base`,
         // return `x - base`.
         int tmp = xLow32 - base;
@@ -59,15 +59,15 @@ final class Message {
         return "Message[buffer=" + buffer.position() + "]";
     }
 
-    public boolean getEncounteredUnsupportedSyntax() {
+    boolean getEncounteredUnsupportedSyntax() {
         return encounteredUnsupportedSyntax;
     }
 
-    public void markEncounteredUnsupportedSyntax() {
+    void markEncounteredUnsupportedSyntax() {
         encounteredUnsupportedSyntax = true;
     }
 
-    public java.util.UUID getUuid(long nodeOffset, long nodeLength) {
+    java.util.UUID getUuid(long nodeOffset, long nodeLength) {
         long high = Parser.getUuidHigh(metadata, nodeOffset, nodeLength);
         long low = Parser.getUuidLow(metadata, nodeOffset, nodeLength);
         if (high == 0 && low == 0) {

--- a/lib/rust/parser/src/lexer.rs
+++ b/lib/rust/parser/src/lexer.rs
@@ -495,11 +495,25 @@ impl token::Variant {
 impl<'s> Lexer<'s> {
     /// Parse an identifier.
     fn ident(&mut self) {
-        if let Some(token) = self.token(|this| this.take_while_1(is_ident_char)) {
+        if let Some(token) = self.token(|this| {
+            if this.ident_start_char() {
+                this.take_while_1(is_ident_char);
+            }
+        }) {
             let tp = token::Variant::new_ident_or_wildcard_unchecked(&token.code);
             let token = token.with_variant(tp);
             self.submit_token(token);
         }
+    }
+
+    /// If the current char could start an identifier, consume it and return true; otherwise, return
+    /// false.
+    fn ident_start_char(&mut self) -> bool {
+        if let Some(char) = self.current_char && is_ident_char(char) && char != '\'' {
+            self.take_next();
+            return true;
+        }
+        false
     }
 }
 
@@ -626,55 +640,134 @@ impl<'s> Lexer<'s> {
 // === Text ===
 // ============
 
-#[inline(always)]
-fn is_inline_text_body(t: char) -> bool {
-    t != '"' && !is_newline_char(t) && t != '\\'
-}
-
 impl<'s> Lexer<'s> {
-    /// Parse a text literal.
+    /// Read a text literal.
     fn text(&mut self) {
-        let token = self.token(|this| this.take_1('"'));
-        if let Some(token) = token {
-            self.submit_token(token.with_variant(token::Variant::text_start()));
-            let line_empty = self.current_char.map(is_newline_char).unwrap_or(true);
-            if line_empty {
-                // FIXME: Handle this case; test this function. Issue: #182496940
-                let char = self.current_char;
-                self.internal_error.get_or_insert_with(|| format!("text: line_empty ({:?})", char));
-                return;
+        // TODO: Interpolation within "'" quotes (#182496932); for now, treat them as raw.
+        let quote_char = match self.current_char {
+            Some(char @ ('"' | '\'')) => char,
+            _ => return,
+        };
+        let indent = self.last_spaces_visible_offset;
+        let open_quote_start = self.mark();
+        self.last_spaces_visible_offset = VisibleOffset(0);
+        self.last_spaces_offset = Bytes(0);
+        self.take_next();
+        let mut multiline = false;
+        // At least two quote characters.
+        if let Some(char) = self.current_char && char == quote_char {
+            let close_quote_start = self.mark();
+            self.take_next();
+            // If more than two quote characters: Start a multiline quote.
+            while let Some(char) = self.current_char && char == quote_char {
+                multiline = true;
+                self.take_next();
             }
-            let mut parsed_element;
-            loop {
-                parsed_element = false;
-
-                let section = self.token(|this| this.take_while_1(is_inline_text_body));
-                if let Some(tok) = section {
-                    parsed_element = true;
-                    self.submit_token(tok.with_variant(token::Variant::text_section()));
+            if multiline {
+                let text_start = self.mark();
+                let token = self.make_token(open_quote_start, text_start.clone(), token::Variant::TextStart(token::variant::TextStart()));
+                self.output.push(token);
+                self.take_rest_of_line();
+                let next_line_start = self.mark();
+                let token = self.make_token(text_start, next_line_start, token::Variant::TextSection(token::variant::TextSection()));
+                if !token.code.len().is_zero() {
+                    self.output.push(token);
                 }
-
-                let escape = self.token(|this| {
-                    if this.take_1('\\') {
-                        this.take_1('"');
-                    }
-                });
-                if let Some(token) = escape {
-                    parsed_element = true;
-                    self.submit_token(token.with_variant(token::Variant::text_escape()));
-                }
-
-                let end = self.token(|this| this.take_1('"'));
-                if let Some(token) = end {
-                    self.submit_token(token.with_variant(token::Variant::text_end()));
-                    break;
-                }
-
-                if !parsed_element {
-                    break;
-                }
+                self.text_lines(indent);
+            } else {
+                // Exactly two quote characters: Open and shut case.
+                let close_quote_end = self.mark();
+                let token = self.make_token(open_quote_start, close_quote_start.clone(), token::Variant::TextStart(token::variant::TextStart()));
+                self.output.push(token);
+                let token = self.make_token(close_quote_start, close_quote_end, token::Variant::TextEnd(token::variant::TextEnd()));
+                self.output.push(token);
+            }
+        } else {
+            // One quote followed by non-quote character: Inline quote.
+            let text_start = self.mark();
+            let token = self.make_token(open_quote_start, text_start.clone(), token::Variant::TextStart(token::variant::TextStart()));
+            self.output.push(token);
+            while let Some(char) = self.current_char && char != quote_char && !is_newline_char(char) {
+                self.take_next();
+            }
+            let close_quote_start = self.mark();
+            let token = self.make_token(text_start, close_quote_start.clone(), token::Variant::TextSection(token::variant::TextSection()));
+            if !token.code.len().is_zero() {
+                self.output.push(token);
+            }
+            if let Some(char) = self.current_char && char == quote_char {
+                self.take_next();
+                let close_quote_end = self.mark();
+                let token = self.make_token(close_quote_start, close_quote_end, token::Variant::TextEnd(token::variant::TextEnd()));
+                self.output.push(token);
             }
         }
+        self.spaces_after_lexeme();
+    }
+
+    /// Read the lines of a text literal, after the initial line introducing it.
+    fn text_lines(&mut self, indent: VisibleOffset) {
+        while self.current_char.is_some() {
+            let start = self.mark();
+            // Consume the newline and any spaces.
+            if !self.take_1('\n') && self.take_1('\r') {
+                self.take_1('\n');
+            }
+            let before_space = self.mark();
+            self.spaces_after_lexeme();
+            let after_space = self.mark();
+            // Check indent, unless this is an empty line.
+            if let Some(char) = self.current_char {
+                if self.last_spaces_visible_offset <= indent && !is_newline_char(char) {
+                    let token = self.make_token(
+                        start,
+                        before_space,
+                        token::Variant::Newline(token::variant::Newline()),
+                    );
+                    self.output.push(token);
+                    return;
+                }
+            };
+            // Output the newline as a text section.
+            self.last_spaces_visible_offset = VisibleOffset(0);
+            self.last_spaces_offset = Bytes(0);
+            let token = self.make_token(
+                start,
+                before_space,
+                token::Variant::TextSection(token::variant::TextSection()),
+            );
+            self.output.push(token);
+            // Output the line as a text section.
+            self.take_rest_of_line();
+            let next_line_start = self.mark();
+            let token = self.make_token(
+                after_space,
+                next_line_start,
+                token::Variant::TextSection(token::variant::TextSection()),
+            );
+            self.output.push(token);
+        }
+    }
+
+    fn mark(&self) -> (Bytes, Offset<'s>) {
+        let start = self.current_offset;
+        let left_offset_start = start - self.last_spaces_offset;
+        let offset_code = self.input.slice(left_offset_start..start);
+        let visible_offset = self.last_spaces_visible_offset;
+        (start, Offset(visible_offset, offset_code))
+    }
+
+    fn make_token(
+        &self,
+        from: (Bytes, Offset<'s>),
+        to: (Bytes, Offset<'s>),
+        variant: token::Variant,
+    ) -> Token<'s> {
+        let (start, offset) = from;
+        let end = to.0;
+        let start = start.unchecked_raw();
+        let end = end.unchecked_raw();
+        Token(offset, &self.input[start..end], variant)
     }
 }
 

--- a/lib/rust/parser/src/syntax/item.rs
+++ b/lib/rust/parser/src/syntax/item.rs
@@ -55,12 +55,13 @@ impl<'s> Item<'s> {
                 ),
                 token::Variant::TextSection(section) => {
                     let trim = token.left_offset.visible;
-                    let section = tree::TextElement::Section(token.with_variant(section));
+                    let section = tree::TextElement::Section { text: token.with_variant(section) };
                     Tree::text_literal(default(), vec![section], default(), trim)
                 }
                 token::Variant::TextEscape(escape) => {
                     let trim = token.left_offset.visible;
-                    let section = tree::TextElement::Escape(token.with_variant(escape));
+                    let backslash = token.with_variant(escape);
+                    let section = tree::TextElement::Escape { backslash };
                     Tree::text_literal(default(), vec![section], default(), trim)
                 }
                 token::Variant::TextEnd(close) => Tree::text_literal(

--- a/lib/rust/parser/src/syntax/item.rs
+++ b/lib/rust/parser/src/syntax/item.rs
@@ -47,7 +47,12 @@ impl<'s> Item<'s> {
             Item::Token(token) => match token.variant {
                 token::Variant::Ident(ident) => Tree::ident(token.with_variant(ident)),
                 token::Variant::Number(number) => Tree::number(token.with_variant(number)),
-                token::Variant::TextSection(text) => Tree::text_section(token.with_variant(text)),
+                token::Variant::TextStart(open) =>
+                    Tree::text_literal(Some(token.with_variant(open)), default(), default()),
+                token::Variant::TextSection(section) =>
+                    Tree::text_literal(default(), vec![token.with_variant(section)], default()),
+                token::Variant::TextEnd(close) =>
+                    Tree::text_literal(default(), default(), Some(token.with_variant(close))),
                 _ => {
                     let message = format!("to_ast: Item::Token({token:?})");
                     let value = Tree::ident(token.with_variant(token::variant::Ident(false, 0)));

--- a/lib/rust/parser/src/syntax/item.rs
+++ b/lib/rust/parser/src/syntax/item.rs
@@ -49,8 +49,14 @@ impl<'s> Item<'s> {
                 token::Variant::Number(number) => Tree::number(token.with_variant(number)),
                 token::Variant::TextStart(open) =>
                     Tree::text_literal(Some(token.with_variant(open)), default(), default()),
-                token::Variant::TextSection(section) =>
-                    Tree::text_literal(default(), vec![token.with_variant(section)], default()),
+                token::Variant::TextSection(section) => {
+                    let section = tree::TextElement::Section(token.with_variant(section));
+                    Tree::text_literal(default(), vec![section], default())
+                }
+                token::Variant::TextEscape(escape) => {
+                    let section = tree::TextElement::Escape(token.with_variant(escape));
+                    Tree::text_literal(default(), vec![section], default())
+                }
                 token::Variant::TextEnd(close) =>
                     Tree::text_literal(default(), default(), Some(token.with_variant(close))),
                 _ => {

--- a/lib/rust/parser/src/syntax/item.rs
+++ b/lib/rust/parser/src/syntax/item.rs
@@ -47,18 +47,28 @@ impl<'s> Item<'s> {
             Item::Token(token) => match token.variant {
                 token::Variant::Ident(ident) => Tree::ident(token.with_variant(ident)),
                 token::Variant::Number(number) => Tree::number(token.with_variant(number)),
-                token::Variant::TextStart(open) =>
-                    Tree::text_literal(Some(token.with_variant(open)), default(), default()),
+                token::Variant::TextStart(open) => Tree::text_literal(
+                    Some(token.with_variant(open)),
+                    default(),
+                    default(),
+                    default(),
+                ),
                 token::Variant::TextSection(section) => {
+                    let trim = token.left_offset.visible;
                     let section = tree::TextElement::Section(token.with_variant(section));
-                    Tree::text_literal(default(), vec![section], default())
+                    Tree::text_literal(default(), vec![section], default(), trim)
                 }
                 token::Variant::TextEscape(escape) => {
+                    let trim = token.left_offset.visible;
                     let section = tree::TextElement::Escape(token.with_variant(escape));
-                    Tree::text_literal(default(), vec![section], default())
+                    Tree::text_literal(default(), vec![section], default(), trim)
                 }
-                token::Variant::TextEnd(close) =>
-                    Tree::text_literal(default(), default(), Some(token.with_variant(close))),
+                token::Variant::TextEnd(close) => Tree::text_literal(
+                    default(),
+                    default(),
+                    Some(token.with_variant(close)),
+                    default(),
+                ),
                 _ => {
                     let message = format!("to_ast: Item::Token({token:?})");
                     let value = Tree::ident(token.with_variant(token::variant::Ident(false, 0)));

--- a/lib/rust/parser/src/syntax/operator.rs
+++ b/lib/rust/parser/src/syntax/operator.rs
@@ -197,8 +197,9 @@ impl<'s> ExpressionBuilder<'s> {
                 Arity::Unary(opr) => syntax::Tree::unary_opr_app(opr, rhs_),
                 Arity::Binary(opr) => {
                     let lhs = self.output.pop().map(|t| t.to_ast());
-                    self.was_section_used =
-                        self.was_section_used || lhs.is_none() || rhs_.is_none();
+                    let can_form_section = opr.len() != 1 || opr[0].can_form_section;
+                    self.was_section_used = self.was_section_used
+                        || (can_form_section && (lhs.is_none() || rhs_.is_none()));
                     syntax::tree::apply_operator(lhs, opr, rhs_)
                 }
             };

--- a/lib/rust/parser/src/syntax/token.rs
+++ b/lib/rust/parser/src/syntax/token.rs
@@ -266,6 +266,7 @@ macro_rules! with_token_definition { ($f:ident ($($args:tt)*)) => { $f! { $($arg
             pub binary_infix_precedence: Option<Precedence>,
             pub unary_prefix_precedence: Option<Precedence>,
             pub is_type_annotation: bool,
+            pub can_form_section: bool,
         },
         Modifier,
         DocComment,

--- a/lib/rust/parser/src/syntax/tree.rs
+++ b/lib/rust/parser/src/syntax/tree.rs
@@ -369,12 +369,12 @@ pub enum TextElement<'s> {
     /// part of the content, after trimming appropriately.
     Section {
         /// The text content.
-        text: token::TextSection<'s>
+        text: token::TextSection<'s>,
     },
     /// A \ character.
     Escape {
         /// The \ character.
-        backslash: token::TextEscape<'s>
+        backslash: token::TextEscape<'s>,
     },
 }
 

--- a/lib/rust/parser/src/syntax/tree.rs
+++ b/lib/rust/parser/src/syntax/tree.rs
@@ -367,16 +367,22 @@ impl<'s> span::Builder<'s> for TypeConstructorDef<'s> {
 pub enum TextElement<'s> {
     /// The text content of the literal. If it is multiline, the offset information may contain
     /// part of the content, after trimming appropriately.
-    Section(token::TextSection<'s>),
+    Section {
+        /// The text content.
+        text: token::TextSection<'s>
+    },
     /// A \ character.
-    Escape(token::TextEscape<'s>),
+    Escape {
+        /// The \ character.
+        backslash: token::TextEscape<'s>
+    },
 }
 
 impl<'s> span::Builder<'s> for TextElement<'s> {
     fn add_to_span(&mut self, span: Span<'s>) -> Span<'s> {
         match self {
-            TextElement::Section(section) => section.add_to_span(span),
-            TextElement::Escape(escape) => escape.add_to_span(span),
+            TextElement::Section { text } => text.add_to_span(span),
+            TextElement::Escape { backslash } => backslash.add_to_span(span),
         }
     }
 }
@@ -471,8 +477,9 @@ pub fn apply<'s>(mut func: Tree<'s>, mut arg: Tree<'s>) -> Tree<'s> {
         Variant::TextLiteral(lhs) if let Variant::TextLiteral(rhs) = &mut *arg.variant
                 && lhs.close_quote.is_none() && rhs.open_quote.is_none() => {
             match rhs.elements.first_mut() {
-                Some(TextElement::Section(section)) => section.left_offset = arg.span.left_offset,
-                Some(TextElement::Escape(escape)) => escape.left_offset = arg.span.left_offset,
+                Some(TextElement::Section { text }) => text.left_offset = arg.span.left_offset,
+                Some(TextElement::Escape { backslash }) =>
+                    backslash.left_offset = arg.span.left_offset,
                 None => (),
             }
             lhs.elements.append(&mut rhs.elements);

--- a/lib/rust/parser/src/syntax/tree.rs
+++ b/lib/rust/parser/src/syntax/tree.rs
@@ -365,8 +365,8 @@ impl<'s> span::Builder<'s> for TypeConstructorDef<'s> {
 /// A component of a text literal, within the quotation marks.
 #[derive(Clone, Debug, Eq, PartialEq, Visitor, Serialize, Reflect, Deserialize)]
 pub enum TextElement<'s> {
-    /// The text content of the literal. If it is multiline, the offset information may contain part
-    /// of the content, after trimming appropriately.
+    /// The text content of the literal. If it is multiline, the offset information may contain
+    /// part of the content, after trimming appropriately.
     Section(token::TextSection<'s>),
     /// A \ character.
     Escape(token::TextEscape<'s>),
@@ -387,7 +387,9 @@ impl<'a, 't, 's> SpanVisitable<'s, 'a> for VisibleOffset {}
 impl<'a, 't, 's> SpanVisitableMut<'s, 'a> for VisibleOffset {}
 impl<'a, 't, 's> ItemVisitable<'s, 'a> for VisibleOffset {}
 impl<'s> span::Builder<'s> for VisibleOffset {
-    fn add_to_span(&mut self, span: Span<'s>) -> Span<'s> { span }
+    fn add_to_span(&mut self, span: Span<'s>) -> Span<'s> {
+        span
+    }
 }
 
 

--- a/lib/rust/parser/tests/parse.rs
+++ b/lib/rust/parser/tests/parse.rs
@@ -564,26 +564,26 @@ fn inline_text_literals() {
     #[rustfmt::skip]
     let cases = [
         (r#""I'm an inline raw text!""#, block![
-            (TextLiteral "\"" #((Section "I'm an inline raw text!")) "\"")]),
+            (TextLiteral "\"" #((Section "I'm an inline raw text!")) "\"" 0)]),
         (r#"zero_length = """#, block![
-            (Assignment (Ident zero_length) "=" (TextLiteral "\"" #() "\""))]),
-        (r#"unclosed = ""#, block![(Assignment (Ident unclosed) "=" (TextLiteral "\"" #() ()))]),
+            (Assignment (Ident zero_length) "=" (TextLiteral "\"" #() "\"" 0))]),
+        (r#"unclosed = ""#, block![(Assignment (Ident unclosed) "=" (TextLiteral "\"" #() () 0))]),
         (r#"unclosed = "a"#, block![
-            (Assignment (Ident unclosed) "=" (TextLiteral "\"" #((Section "a")) ()))]),
-        (r#"'Other quote type'"#, block![(TextLiteral "'" #((Section "Other quote type")) "'")]),
-        (r#""Non-escape: \n""#, block![(TextLiteral "\"" #((Section "Non-escape: \\n")) "\"")]),
+            (Assignment (Ident unclosed) "=" (TextLiteral "\"" #((Section "a")) () 0))]),
+        (r#"'Other quote type'"#, block![(TextLiteral "'" #((Section "Other quote type")) "'" 0)]),
+        (r#""Non-escape: \n""#, block![(TextLiteral "\"" #((Section "Non-escape: \\n")) "\"" 0)]),
         (r#""String with \" escape""#, block![
             (TextLiteral
              "\""
              #((Section "String with ") (Escape "\\") (Section "\" escape"))
-             "\"")]),
+             "\"" 0)]),
     ];
     cases.into_iter().for_each(|(code, expected)| test(code, expected));
 }
 
 #[test]
 fn multiline_text_literals() {
-    test("'''", block![(TextLiteral "'''" #() ())]);
+    test("'''", block![(TextLiteral "'''" #() () 0)]);
     const CODE: &str = r#"'''
     part of the string
        3-spaces indented line, part of the Text Block
@@ -602,7 +602,7 @@ fn multiline_text_literals() {
            (Section "\n") (Section "")
            (Section "\n") (Section "also part of the string")
            (Section "\n") (Section ""))
-        ())
+        () 4)
         (Number 3)
     ];
     test(CODE, expected);

--- a/lib/rust/parser/tests/parse.rs
+++ b/lib/rust/parser/tests/parse.rs
@@ -418,7 +418,7 @@ fn minus_unary() {
 }
 
 
-// === Import ===
+// === Import/Export ===
 
 #[test]
 fn import() {
@@ -443,8 +443,7 @@ fn import() {
              ()
              ((Ident import) (Ident all))
              ()
-             ((Ident hiding)
-              (App (OprSectionBoundary (OprApp (Ident Number) (Ok ",") ())) (Ident Boolean))))]),
+             ((Ident hiding) (OprApp (Ident Number) (Ok ",") (Ident Boolean))))]),
         ("from Standard.Table as Column_Module import Column", block![
             (Import ()
              ((Ident from) (OprApp (Ident Standard) (Ok ".") (Ident Table)))
@@ -468,6 +467,37 @@ fn import() {
               (OprApp (OprApp (Ident java) (Ok ".") (Ident net)) (Ok ".") (Ident URI)))
              ((Ident as) (Ident Java_URI))
              ())]),
+    ];
+    cases.into_iter().for_each(|(code, expected)| test(code, expected));
+}
+
+#[test]
+fn export() {
+    #[rustfmt::skip]
+    let cases = [
+        ("export Foo", block![(Export () () ((Ident export) (Ident Foo)) () ())]),
+        ("export Foo as Bar", block![
+            (Export () () ((Ident export) (Ident Foo)) ((Ident as) (Ident Bar)) ())]),
+        ("from Foo export Bar, Baz", block![
+            (Export
+             ((Ident from) (Ident Foo))
+             ()
+             ((Ident export) (OprApp (Ident Bar) (Ok ",") (Ident Baz)))
+             () ())]),
+        ("from Foo export all hiding Bar, Baz", block![
+            (Export
+             ((Ident from) (Ident Foo))
+             ()
+             ((Ident export) (Ident all))
+             ()
+             ((Ident hiding) (OprApp (Ident Bar) (Ok ",") (Ident Baz))))]),
+        ("from Foo as Bar export Baz, Quux", block![
+            (Export
+             ((Ident from) (Ident Foo))
+             ((Ident as) (Ident Bar))
+             ((Ident export) (OprApp (Ident Baz) (Ok ",") (Ident Quux)))
+             () ())
+        ]),
     ];
     cases.into_iter().for_each(|(code, expected)| test(code, expected));
 }


### PR DESCRIPTION
### Pull Request Description

Parse text literals. See: https://www.pivotaltracker.com/story/show/182496940

### Important Notes

- The left-trimming algorithm (https://github.com/enso-org/design/blob/wip/wd/enso-spec/epics/enso-spec-1.0/04.%20Expressions.md#inline-and-block-text-literals) requires two passes over the sequence of text segments. This implementation performs one pass while parsing (identifying the correct amount of trim). The other pass (applying the trim) can be done when building the value of the quoted string: Trim the amount of whitespace identified by the `trim` field off of the whitespace of each `TextSection` (the value will not exceed the amount of whitespace found in the tokens' offsets, except for tokens with 0 offset, in which case no trimming is necessary/possible).

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.

[ci no changelog needed]