### PR TITLE
Prevent reading broken IR caches by changing their serialVersionUID

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
@@ -298,6 +298,9 @@ object IR {
     * @param passData the pass metadata associated with this node
     * @param diagnostics compiler diagnostics for this node
     */
+  @SerialVersionUID(
+    3692L
+  ) // prevents reading broken caches, see PR-3692 for details
   sealed case class Module(
     imports: List[Module.Scope.Import],
     exports: List[Module.Scope.Export],


### PR DESCRIPTION
### Pull Request Description

Many engine PRs modify builtins or other engine internals and then they are subject to [incremental CI runtime errors](https://www.pivotaltracker.com/n/projects/2539304/stories/182868680) as outdated `IR` caches from global space at `~/.local/share/enso/cache/ir/Standard/Builtins/0.0.0-dev/0.0.0-dev/Standard/Builtins` are read in.

This PR provides solution for that problem by explicitly defining `IR.Module` `serialVersionUID`. By changing the `serialVersionUID` one prevents previously saved `IR` caches to be loaded into the running process. Change the `serialVersionUID` whenever you see errors caused by reading outdated `IR` caches in the CI.

### Important Notes

Whenever one needs to avoid loading previous `IR` caches, go to `case class IR.Module` and change the `@SerialVersionUID(3692L)` to **number of your pull request**.

### Checklist

Please include the following checklist in your PR:

- [x] All code conforms to the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md) style guides.
- All code has been tested:
  - it has been verified in debugger that changing the `serialVersionUID` prevents reading previous `IR` caches

[ci no changelog needed]