### PR TITLE
Tidy up type signatures and error types

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json.enso
@@ -169,12 +169,12 @@ type Json
 type Parse_Error
     Parse_Error_Data message
 
-## UNSTABLE
+    ## PRIVATE
 
-   Converts the error to a display representation.
-Parse_Error.to_display_text : Text
-Parse_Error.to_display_text self =
-    "Parse error in parsing JSON: " + self.message.to_text + "."
+       Converts the error to a display representation.
+    to_display_text : Text
+    to_display_text self =
+        "Parse error in parsing JSON: " + self.message.to_text + "."
 
 ## UNSTABLE
 
@@ -182,12 +182,12 @@ Parse_Error.to_display_text self =
 type No_Such_Field_Error
     No_Such_Field_Error_Data field_name
 
-## UNSTABLE
+    ## PRIVATE
 
-   Pretty prints the no such field error.
-No_Such_Field_Error.to_display_text : Text
-No_Such_Field_Error.to_display_text self =
-    "The field " + self.field_name.to_text + " is not present in this object."
+       Pretty prints the no such field error.
+    to_display_text : Text
+    to_display_text self =
+        "The field " + self.field_name.to_text + " is not present in this object."
 
 ## UNSTABLE
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/List.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/List.enso
@@ -351,12 +351,11 @@ type List
 
    An error representing that the list is empty.
 type Empty_Error
+    ## PRIVATE
 
-## UNSTABLE
-
-   Pretty prints the empty error.
-Empty_Error.to_display_text : Text
-Empty_Error.to_display_text self = "The List is empty."
+       Pretty prints the empty error.
+    to_display_text : Text
+    to_display_text self = "The List is empty."
 
 ## PRIVATE
    A helper for the `map` function.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Locale.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Locale.enso
@@ -428,7 +428,3 @@ type Locale
    - java: The java locale value.
 from_java : JavaLocale -> Locale
 from_java java = Locale_Data java
-
-## PRIVATE
-javaLocaleBuilder = JavaLocale.Builder
-

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Map.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Map.enso
@@ -467,10 +467,9 @@ type Map
 type No_Value_For_Key_Error
     No_Value_For_Key_Error_Data key
 
-## UNSTABLE
+    ## PRIVATE
 
-   Converts the error into a human-readable representation.
-No_Value_For_Key_Error.to_display_text : Text
-No_Value_For_Key_Error.to_display_text self =
-    "The map contained no value for the key " + self.key.to_text + "."
-
+       Converts the error into a human-readable representation.
+    to_display_text : Text
+    to_display_text self =
+        "The map contained no value for the key " + self.key.to_text + "."

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
@@ -983,9 +983,9 @@ type Integer
 type Parse_Error
     Parse_Error_Data text
 
-## UNSTABLE
+    ## UNSTABLE
 
-   Pretty print the syntax error.
-Parse_Error.to_display_text : Text
-Parse_Error.to_display_text =
-    "Could not parse " + self.text.to_text + " as a double."
+       Pretty print the syntax error.
+    to_display_text : Text
+    to_display_text =
+        "Could not parse " + self.text.to_text + " as a double."

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Ordering/Comparator.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Ordering/Comparator.enso
@@ -9,7 +9,7 @@ polyglot java import org.enso.base.ObjectComparator
    - custom_comparator:
      If `Nothing` will get a singleton instance for `.compare_to`.
      Otherwise can support a custom fallback comparator.
-new : Nothing | (Any->Any->Ordering) -> ObjectComparator
+new : Nothing | (Any -> Any -> Ordering) -> ObjectComparator
 new custom_comparator=Nothing =
     comparator_to_java cmp x y = Vector.handle_incomparable_value (cmp x y . to_sign)
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Regression.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Regression.enso
@@ -19,7 +19,7 @@ type Model
 ## Use Least Squares to fit a line to the data.
 fit_least_squares : Vector -> Vector -> Model -> Fitted_Model ! Illegal_Argument_Error | Fit_Error
 fit_least_squares known_xs known_ys model=Linear_Model =
-    Illegal_Argument_Error.handle_java_exception <| handle_fit_java_exception <| case model of
+    Illegal_Argument_Error.handle_java_exception <| Fit_Error.handle_java_exception <| case model of
         Linear_Model intercept ->
             fitted = if intercept.is_nothing then Regression.fit_linear known_xs.to_array known_ys.to_array else
                 Regression.fit_linear known_xs.to_array known_ys.to_array intercept
@@ -98,12 +98,12 @@ ln_series xs series_name="Values" =
 type Fit_Error
     Fit_Error_Data message
 
-## PRIVATE
+    ## PRIVATE
 
-   Converts the `Fit_Error` to a human-readable representation.
-Fit_Error.to_display_text : Text
-Fit_Error.to_display_text self = "Could not fit the model: " + self.message.to_text
+       Converts the `Fit_Error` to a human-readable representation.
+    to_display_text : Text
+    to_display_text self = "Could not fit the model: " + self.message.to_text
 
-## PRIVATE
-handle_fit_java_exception =
-    Panic.catch_java FitError handler=(java_exception-> Error.throw (Fit_Error_Data java_exception.getMessage))
+    ## PRIVATE
+    handle_java_exception =
+        Panic.catch_java FitError handler=(java_exception-> Error.throw (Fit_Error_Data java_exception.getMessage))

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Encoding.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Encoding.enso
@@ -99,5 +99,8 @@ type Encoding
 type Encoding_Error
     Encoding_Error_Data (message:Text)
 
-Encoding_Error.to_display_text : Text
-Encoding_Error.to_display_text self = "Encoding_Error: " + self.message
+    ## PRIVATE
+
+       Provides a human-readable representation of the encoding error.
+    to_display_text : Text
+    to_display_text self = "Encoding_Error: " + self.message

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Matching.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Matching.enso
@@ -13,7 +13,6 @@ type No_Matches_Found
     to_display_text self =
         "The criteria "+self.criteria.to_text+" did not match any names in the input."
 
-
 ## Represents exact text matching mode.
 
    Arguments:
@@ -21,6 +20,66 @@ type No_Matches_Found
      insensitive using the specified locale.
 type Text_Matcher
     Text_Matcher_Data (case_sensitive : (True | Case_Insensitive) = True)
+
+    ## UNSTABLE
+       Checks if a name matches the provided criterion according to the specified
+       matching strategy.
+
+       Arguments:
+       - name: A `Text` representing the name being matched.
+       - criterion: A `Text` representing the name to be matched.
+
+       > Example
+         Check if the provided name matches a regular expression.
+
+             Text_Matcher.match_single_criterion "Foobar" "foo" == False
+    match_single_criterion : Text -> Text -> Boolean
+    match_single_criterion self name criterion =
+        case self.case_sensitive of
+            True -> name == criterion
+            Case_Insensitive_Data locale -> name.equals_ignore_case criterion locale=locale
+
+    ## UNSTABLE
+       Selects objects from an input list that match any of the provided criteria.
+
+       Arguments:
+       - objects: A list of objects to be matched.
+       - criteria: A list of texts representing the matching criteria. Their meaning
+         depends on the matching strategy.
+       - reorder: Specifies whether to reorder the matched objects according to the
+         order of the matching criteria.
+         If `False`, the matched entries are returned in the same order as in the
+         input.
+         If `True`, the matched entries are returned in the order of the criteria
+         matching them. If a single object has been matched by multiple criteria, it
+         is placed in the group belonging to the first matching criterion on the
+         list.
+         If a single criterion's group has more than one element, their relative
+         order is the same as in the input.
+       - name_mapper: A function mapping a provided object to its name, which will
+         then be matched with the criteria. It is set to the identity function by
+         default, thus allowing the input to be a list of names to match. But it can
+         be overridden to enable matching more complex objects.
+       - matcher: A `Matcher` instance specifying how to interpret the criterion.
+       - on_problems: Specifies the behavior when a problem occurs during the
+         function.
+         By default, a warning is issued, but the operation proceeds.
+         If set to `Report_Error`, the operation fails with a dataflow error.
+         If set to `Ignore`, the operation proceeds without errors or warnings.
+
+       > Example
+         Selects objects matching one of the provided patterns, preserving the input order.
+
+             Regex_Matcher case_sensitive=True . match_criteria ["foo", "foobar", "quux", "baz", "Foo"] [".*ba.*", "f.*"] == ["foo", "foobar", "baz"]
+
+       > Example
+         Selects pairs matching their first element with the provided criteria and
+         ordering the result according to the order of criteria that matched them.
+
+             Text_Matcher.match_criteria [Pair_Data "foo" 42, Pair_Data "bar" 33, Pair_Data "baz" 10, Pair_Data "foo" 0, Pair_Data 10 10] ["bar", "foo"] reorder=True name_mapper=_.name == [Pair_Data "bar" 33, Pair_Data "foo" 42, Pair_Data "foo" 0]
+    match_criteria : Vector Any -> Vector Text -> Boolean -> (Any -> Text) -> Problem_Behavior -> Vector Any ! No_Matches_Found
+    match_criteria self = match_criteria_implementation self
+
 
 ## Represents regex matching mode.
 
@@ -50,136 +109,77 @@ type Text_Matcher
 type Regex_Matcher
     Regex_Matcher_Data (case_sensitive : (True | Case_Insensitive) = True) (multiline : Boolean = False) (match_ascii : Boolean = False) (dot_matches_newline : Boolean = False) (comments : Boolean = False)
 
-## UNSTABLE
-   Compiles a provided pattern according to the rules defined in this
-   `Regex_Matcher`.
-Regex_Matcher.compile : Text -> Pattern
-Regex_Matcher.compile self pattern =
-    case_insensitive = case self.case_sensitive of
-        True -> False
-        ## TODO [RW] Currently locale is not supported in case-insensitive
-           Regex matching. There are plans to revisit it:
-           https://www.pivotaltracker.com/story/show/181313576
-        Case_Insensitive_Data _ -> True
-    compiled_pattern = Regex.compile pattern case_insensitive=case_insensitive match_ascii=self.match_ascii dot_matches_newline=self.dot_matches_newline multiline=self.multiline comments=self.comments
-    compiled_pattern
+    ## UNSTABLE
+       Compiles a provided pattern according to the rules defined in this
+       `Regex_Matcher`.
+    compile : Text -> Pattern
+    compile self pattern =
+        case_insensitive = case self.case_sensitive of
+            True -> False
+            ## TODO [RW] Currently locale is not supported in case-insensitive
+               Regex matching. There are plans to revisit it:
+               https://www.pivotaltracker.com/story/show/181313576
+            Case_Insensitive_Data _ -> True
+        compiled_pattern = Regex.compile pattern case_insensitive=case_insensitive match_ascii=self.match_ascii dot_matches_newline=self.dot_matches_newline multiline=self.multiline comments=self.comments
+        compiled_pattern
 
-## UNSTABLE
-   Checks if a name matches the provided criterion according to the specified
-   matching strategy.
+    ## UNSTABLE
+       Checks if a name matches the provided criterion according to the specified
+       matching strategy.
 
-   Arguments:
-   - name: A `Text` representing the name being matched.
-   - criterion: A `Text` representing the name to be matched.
+       Arguments:
+       - name: A `Text` representing the name being matched.
+       - criterion: A `Text` representing the regular expression specifying the
+         matching criterion.
 
-   > Example
-     Check if the provided name matches a regular expression.
+       > Example
+         Check if the provided name matches a regular expression.
 
-         Text_Matcher.match_single_criterion "Foobar" "foo" == False
-Text_Matcher.match_single_criterion : Text -> Text -> Boolean
-Text_Matcher.match_single_criterion self name criterion =
-    case self.case_sensitive of
-        True -> name == criterion
-        Case_Insensitive_Data locale -> name.equals_ignore_case criterion locale=locale
+             Regex_Matcher case_sensitive=Case_Insensitive . match_single_criterion "Foobar" "f.*" == True
+    match_single_criterion : Text -> Text -> Boolean
+    match_single_criterion self name criterion =
+        self.compile criterion . matches name
 
-## UNSTABLE
-   Checks if a name matches the provided criterion according to the specified
-   matching strategy.
+    ## UNSTABLE
+       Selects objects from an input list that match any of the provided criteria.
 
-   Arguments:
-   - name: A `Text` representing the name being matched.
-   - criterion: A `Text` representing the regular expression specifying the
-     matching criterion.
+       Arguments:
+       - objects: A list of objects to be matched.
+       - criteria: A list of texts representing the matching criteria. Their meaning
+         depends on the matching strategy.
+       - reorder: Specifies whether to reorder the matched objects according to the
+         order of the matching criteria.
+         If `False`, the matched entries are returned in the same order as in the
+         input.
+         If `True`, the matched entries are returned in the order of the criteria
+         matching them. If a single object has been matched by multiple criteria, it
+         is placed in the group belonging to the first matching criterion on the
+         list.
+         If a single criterion's group has more than one element, their relative
+         order is the same as in the input.
+       - name_mapper: A function mapping a provided object to its name, which will
+         then be matched with the criteria. It is set to the identity function by
+         default, thus allowing the input to be a list of names to match. But it can
+         be overridden to enable matching more complex objects.
+       - matcher: A `Matcher` instance specifying how to interpret the criterion.
+       - on_problems: Specifies the behavior when a problem occurs during the
+         function.
+         By default, a warning is issued, but the operation proceeds.
+         If set to `Report_Error`, the operation fails with a dataflow error.
+         If set to `Ignore`, the operation proceeds without errors or warnings.
 
-   > Example
-     Check if the provided name matches a regular expression.
+       > Example
+         Selects objects matching one of the provided patterns, preserving the input order.
 
-         Regex_Matcher case_sensitive=Case_Insensitive . match_single_criterion "Foobar" "f.*" == True
-Regex_Matcher.match_single_criterion : Text -> Text -> Boolean
-Regex_Matcher.match_single_criterion self name criterion =
-    self.compile criterion . matches name
+             Regex_Matcher case_sensitive=True . match_criteria ["foo", "foobar", "quux", "baz", "Foo"] [".*ba.*", "f.*"] == ["foo", "foobar", "baz"]
 
-## UNSTABLE
-   Selects objects from an input list that match any of the provided criteria.
+       > Example
+         Selects pairs matching their first element with the provided criteria and
+         ordering the result according to the order of criteria that matched them.
 
-   Arguments:
-   - objects: A list of objects to be matched.
-   - criteria: A list of texts representing the matching criteria. Their meaning
-     depends on the matching strategy.
-   - reorder: Specifies whether to reorder the matched objects according to the
-     order of the matching criteria.
-     If `False`, the matched entries are returned in the same order as in the
-     input.
-     If `True`, the matched entries are returned in the order of the criteria
-     matching them. If a single object has been matched by multiple criteria, it
-     is placed in the group belonging to the first matching criterion on the
-     list.
-     If a single criterion's group has more than one element, their relative
-     order is the same as in the input.
-   - name_mapper: A function mapping a provided object to its name, which will
-     then be matched with the criteria. It is set to the identity function by
-     default, thus allowing the input to be a list of names to match. But it can
-     be overridden to enable matching more complex objects.
-   - matcher: A `Matcher` instance specifying how to interpret the criterion.
-   - on_problems: Specifies the behavior when a problem occurs during the
-     function.
-     By default, a warning is issued, but the operation proceeds.
-     If set to `Report_Error`, the operation fails with a dataflow error.
-     If set to `Ignore`, the operation proceeds without errors or warnings.
-
-   > Example
-     Selects objects matching one of the provided patterns, preserving the input order.
-
-         Regex_Matcher case_sensitive=True . match_criteria ["foo", "foobar", "quux", "baz", "Foo"] [".*ba.*", "f.*"] == ["foo", "foobar", "baz"]
-
-   > Example
-     Selects pairs matching their first element with the provided criteria and
-     ordering the result according to the order of criteria that matched them.
-
-         Text_Matcher.match_criteria [Pair_Data "foo" 42, Pair_Data "bar" 33, Pair_Data "baz" 10, Pair_Data "foo" 0, Pair_Data 10 10] ["bar", "foo"] reorder=True name_mapper=_.name == [Pair_Data "bar" 33, Pair_Data "foo" 42, Pair_Data "foo" 0]
-Text_Matcher.match_criteria : Vector Any -> Vector Text -> Boolean -> (Any -> Text) -> Problem_Behavior -> Vector Any ! No_Matches_Found
-Text_Matcher.match_criteria self = match_criteria_implementation self
-
-## UNSTABLE
-   Selects objects from an input list that match any of the provided criteria.
-
-   Arguments:
-   - objects: A list of objects to be matched.
-   - criteria: A list of texts representing the matching criteria. Their meaning
-     depends on the matching strategy.
-   - reorder: Specifies whether to reorder the matched objects according to the
-     order of the matching criteria.
-     If `False`, the matched entries are returned in the same order as in the
-     input.
-     If `True`, the matched entries are returned in the order of the criteria
-     matching them. If a single object has been matched by multiple criteria, it
-     is placed in the group belonging to the first matching criterion on the
-     list.
-     If a single criterion's group has more than one element, their relative
-     order is the same as in the input.
-   - name_mapper: A function mapping a provided object to its name, which will
-     then be matched with the criteria. It is set to the identity function by
-     default, thus allowing the input to be a list of names to match. But it can
-     be overridden to enable matching more complex objects.
-   - matcher: A `Matcher` instance specifying how to interpret the criterion.
-   - on_problems: Specifies the behavior when a problem occurs during the
-     function.
-     By default, a warning is issued, but the operation proceeds.
-     If set to `Report_Error`, the operation fails with a dataflow error.
-     If set to `Ignore`, the operation proceeds without errors or warnings.
-
-   > Example
-     Selects objects matching one of the provided patterns, preserving the input order.
-
-         Regex_Matcher case_sensitive=True . match_criteria ["foo", "foobar", "quux", "baz", "Foo"] [".*ba.*", "f.*"] == ["foo", "foobar", "baz"]
-
-   > Example
-     Selects pairs matching their first element with the provided criteria and
-     ordering the result according to the order of criteria that matched them.
-
-         Text_Matcher.match_criteria [Pair_Data "foo" 42, Pair_Data "bar" 33, Pair_Data "baz" 10, Pair_Data "foo" 0, Pair_Data 10 10] ["bar", "foo"] reorder=True name_mapper=_.name == [Pair_Data "bar" 33, Pair_Data "foo" 42, Pair_Data "foo" 0]
-Regex_Matcher.match_criteria : Vector Any -> Vector Text -> Boolean -> (Any -> Text) -> Problem_Behavior -> Vector Any ! No_Matches_Found
-Regex_Matcher.match_criteria self = match_criteria_implementation self
+             Text_Matcher.match_criteria [Pair_Data "foo" 42, Pair_Data "bar" 33, Pair_Data "baz" 10, Pair_Data "foo" 0, Pair_Data 10 10] ["bar", "foo"] reorder=True name_mapper=_.name == [Pair_Data "bar" 33, Pair_Data "foo" 42, Pair_Data "foo" 0]
+    match_criteria : Vector Any -> Vector Text -> Boolean -> (Any -> Text) -> Problem_Behavior -> Vector Any ! No_Matches_Found
+    match_criteria self = match_criteria_implementation self
 
 ## PRIVATE
 match_criteria_implementation matcher objects criteria reorder=False name_mapper=(x->x) on_problems=Report_Warning =

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Matching.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Matching.enso
@@ -9,9 +9,9 @@ from Standard.Base.Error.Common import Wrapped_Dataflow_Error_Data
 type No_Matches_Found
     No_Matches_Found_Data (criteria : Vector Text)
 
-No_Matches_Found.to_display_text : Text
-No_Matches_Found.to_display_text self =
-    "The criteria "+self.criteria.to_text+" did not match any names in the input."
+    to_display_text : Text
+    to_display_text self =
+        "The criteria "+self.criteria.to_text+" did not match any names in the input."
 
 
 ## Represents exact text matching mode.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
@@ -123,10 +123,10 @@ from_flags match_ascii case_insensitive dot_matches_newline multiline comments e
 type No_Such_Group_Error
     No_Such_Group_Error_Data (id : Text | Integer)
 
-## PRIVATE
+    ## PRIVATE
 
-   Provides a human-readable representation of the `No_Such_Group_Error`.
-No_Such_Group_Error.to_display_text : Text
-No_Such_Group_Error.to_display_text self = case self.id of
-    Integer -> "No group exists with the index " + self.id.to_text + "."
-    Text -> "No group exists with the name " + self.id + "."
+       Provides a human-readable representation of the `No_Such_Group_Error`.
+    to_display_text : Text
+    to_display_text self = case self.id of
+        Integer -> "No group exists with the index " + self.id.to_text + "."
+        Text -> "No group exists with the name " + self.id + "."

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Engine.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Engine.enso
@@ -66,7 +66,7 @@ type Pattern
          mode that permits multiple matches, it will always return a `Vector`,
          even if only a single match is found.
     match : Text -> Mode.Mode -> Match | Vector.Vector Match | Nothing
-    match self _ _ _ = Errors.unimplemented "This is an interface only."
+    match self _ _ = Errors.unimplemented "This is an interface only."
 
     ## PRIVATE
 
@@ -76,7 +76,7 @@ type Pattern
        Arguments:
        - input: The text to check for matching.
     matches : Text -> Boolean
-    matches self _ _ = Errors.unimplemented "This is an interface only."
+    matches self _ = Errors.unimplemented "This is an interface only."
 
     ## PRIVATE
 
@@ -96,7 +96,7 @@ type Pattern
          mode that permits multiple matches, it will always return a `Vector`,
          even if only a single match is found.
     find : Text -> Mode.Mode -> Text | Vector.Vector Text | Nothing
-    find self _ _ _ = Errors.unimplemented "This is an interface only."
+    find self _ _ = Errors.unimplemented "This is an interface only."
 
     ## PRIVATE
 
@@ -109,7 +109,7 @@ type Pattern
        This method will _always_ return a vector. If no splits take place, the
        vector will contain a single element.
     split : Text -> (Mode.First | Integer | Mode.All) -> Vector.Vector Text
-    split self _ _ _ = Errors.unimplemented "This is an interface only."
+    split self _ _ = Errors.unimplemented "This is an interface only."
 
     ## PRIVATE
 
@@ -125,7 +125,7 @@ type Pattern
        If this method performs no replacements it will return the `input` text
        unchanged.
     replace : Text -> Text -> (Mode.First | Integer | Mode.All | Mode.Full) -> Text
-    replace self _ _ _ _ = Errors.unimplemented "This is an interface only."
+    replace self _ _ _ = Errors.unimplemented "This is an interface only."
 
 ## The `Data.Text.Regex.Engine.Match` interface.
 type Match

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Engine/Default.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Engine/Default.enso
@@ -890,12 +890,12 @@ from_enso_options opts =
    An error representing that the bounds for a match are invalid.
 type Invalid_Bounds_Error
 
-## PRIVATE
+    ## PRIVATE
 
-   Provides a human-readable representation of the invalid bounds error.
-Invalid_Bounds_Error.to_display_text : Text
-Invalid_Bounds_Error.to_display_text =
-    "The start bound cannot be greater than the end bound."
+       Provides a human-readable representation of the invalid bounds error.
+    to_display_text : Text
+    to_display_text =
+        "The start bound cannot be greater than the end bound."
 
 ## PRIVATE
 
@@ -907,11 +907,11 @@ Invalid_Bounds_Error.to_display_text =
 type Mode_Error
     Mode_Error_Data (message : Text)
 
-## PRIVATE
+    ## PRIVATE
 
-   Provides a human-readable representation of the invalid bounds error.
-Mode_Error.to_display_text : Text
-Mode_Error.to_display_text self = self.message.to_text
+       Provides a human-readable representation of the mode error.
+    to_display_text : Text
+    to_display_text self = self.message.to_text
 
 ## PRIVATE
 
@@ -922,10 +922,9 @@ Mode_Error.to_display_text self = self.message.to_text
 type Invalid_Option_Error
     Invalid_Option_Error_Data (opt : Any)
 
-## PRIVATE
+    ## PRIVATE
 
-   Provides a human-readable representation of the invalid option error.
-Invalid_Option_Error.to_display_text : Text
-Invalid_Option_Error.to_display_text self =
-    "The option " + self.opt.to_text + " is not valid for the default regex engine."
-
+       Provides a human-readable representation of the invalid option error.
+    to_display_text : Text
+    to_display_text self =
+        "The option " + self.opt.to_text + " is not valid for the default regex engine."

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Text_Sub_Range.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Text_Sub_Range.enso
@@ -131,7 +131,7 @@ type Codepoint_Ranges
      If the predicate returns True for a given character, the loop will exit.
    Returns: either a Pair of char indices for current grapheme cluster or
      Pair Nothing (char array length) if not found.
-find_sub_range_end = text->predicate->
+find_sub_range_end text predicate =
     iterator = BreakIterator.getCharacterInstance
     iterator.setText text
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -809,7 +809,7 @@ type Vector a
     first : Vector ! Empty_Error
     first self = self.head
 
-    ## Get the second element from the vector, or a `Singleton_Error` if the
+    ## Get the second element from the vector, or a `Index_Out_Of_Bounds_Error` if the
        vector doesn't have a second element.
 
        Useful when tuples are implemented as vectors.
@@ -818,9 +818,9 @@ type Vector a
          The following code returns 2.
 
              [1, 2, 3, 4].second
-    second : Vector ! Singleton_Error
+    second : Vector ! Index_Out_Of_Bounds_Error
     second self = if self.length >= 2 then self.unsafe_at 1 else
-        Error.throw (Singleton_Error_Data self)
+        Error.throw (Index_Out_Of_Bounds_Error_Data 1 self.length)
 
     ## Get all elements in the vector except the first.
 
@@ -1108,31 +1108,11 @@ type Builder
    An error that indicates that the vector is empty.
 type Empty_Error
 
-## UNSTABLE
+    ## UNSTABLE
 
-   Pretty prints the empty error.
-Empty_Error.to_display_text : Text
-Empty_Error.to_display_text self = "The vector is empty."
-
-## UNSTABLE
-
-   An error that indicates that the vector only has one element.
-
-   Arguments:
-   - vec: The vector that only has one element.
-type Singleton_Error
-    Singleton_Error_Data vec
-
-## UNSTABLE
-
-   Pretty prints the singleton error.
-Singleton_Error.to_display_text : Text
-Singleton_Error.to_display_text self =
-    "The vector " + self.vec.to_text  + " has only one element."
-
-## PRIVATE
-type Partition_Accumulator
-    Partition_Accumulator_Data true_builder false_builder ix
+       Pretty prints the empty error.
+    to_display_text : Text
+    to_display_text self = "The vector is empty."
 
 ## UNSTABLE
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -1034,7 +1034,7 @@ type Builder
 
              builder = Vector.new_builder
              builder . append_vector_range [20, 30, 40, 50] 1 3 . to_vector == [30, 40]
-    append_vector_range : Vector Any ! Error -> Builder ! Error
+    append_vector_range : Vector Any ! Error -> Integer -> Integer -> Builder ! Error
     append_vector_range self vector start end =
         subrange = vector.slice start end
         ## This workaround is needed because

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -819,8 +819,7 @@ type Vector a
 
              [1, 2, 3, 4].second
     second : Vector ! Index_Out_Of_Bounds_Error
-    second self = if self.length >= 2 then self.unsafe_at 1 else
-        Error.throw (Index_Out_Of_Bounds_Error_Data 1 self.length)
+    second self = self.at 1
 
     ## Get all elements in the vector except the first.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -993,7 +993,7 @@ type Builder
          Make a new builder
 
              Vector.new_builder
-    new : Integer->Builder
+    new : Integer -> Builder
     new (capacity=10) = Builder_Data (ArrayList.new capacity)
 
     ## Checks if this builder is empty.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Error/Common.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Error/Common.enso
@@ -210,12 +210,12 @@ type Illegal_Argument_Error
 type Index_Out_Of_Bounds_Error
     Index_Out_Of_Bounds_Error_Data index length
 
-## UNSTABLE
+    ## PRIVATE
 
-   Pretty prints an index out of bounds error.
-Index_Out_Of_Bounds_Error.to_display_text : Text
-Index_Out_Of_Bounds_Error.to_display_text self =
-    "The index " + self.index.to_text + " is out of bounds in a collection of length " + self.length.to_text + "."
+       Pretty prints an index out of bounds error.
+    to_display_text : Text
+    to_display_text self =
+        "The index " + self.index.to_text + " is out of bounds in a collection of length " + self.length.to_text + "."
 
 ## PRIVATE
    Wraps a dataflow error lifted to a panic, making possible to distinguish it
@@ -223,9 +223,9 @@ Index_Out_Of_Bounds_Error.to_display_text self =
 type Wrapped_Dataflow_Error
     Wrapped_Dataflow_Error_Data payload
 
-## PRIVATE
-   Throws the original error.
-Wrapped_Dataflow_Error.unwrap self = Error.throw self.payload
+    ## PRIVATE
+       Throws the original error.
+    unwrap self = Error.throw self.payload
 
 @Builtin_Type
 type Caught_Panic
@@ -537,23 +537,22 @@ type Uninitialized_State
 type No_Such_Method_Error
     No_Such_Method_Error_Data target symbol
 
-## ADVANCED
-   UNSTABLE
+    ## ADVANCED
+       UNSTABLE
 
-   Returns the method name of the method that could not be found.
+       Returns the method name of the method that could not be found.
 
-   > Example
-     Getting the method name from a no such method error.
+       > Example
+         Getting the method name from a no such method error.
 
-         import Standard.Examples
+             import Standard.Examples
 
-         example_method_name =
-             error = Examples.no_such_method
-             error.method_name
-No_Such_Method_Error.method_name : Text
-No_Such_Method_Error.method_name self =
-    Meta.meta self.symbol . name
-
+             example_method_name =
+                 error = Examples.no_such_method
+                 error.method_name
+    method_name : Text
+    method_name self =
+        Meta.meta self.symbol . name
 
 ## An error that occurred across a polyglot boundary.
 
@@ -641,11 +640,11 @@ type No_Such_Conversion_Error
 type Unimplemented_Error
     Unimplemented_Error_Data message
 
-## UNSTABLE
+    ## PRIVATE
 
-   Converts the unimplemented error to a human-readable error message.
-Unimplemented_Error.to_display_text : Text
-Unimplemented_Error.to_display_text self = "An implementation is missing: " + self.message
+       Converts the unimplemented error to a human-readable error message.
+    to_display_text : Text
+    to_display_text self = "An implementation is missing: " + self.message
 
 ## ADVANCED
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Http.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/Http.enso
@@ -696,11 +696,12 @@ type Http
 type Request_Error
     Request_Error_Data error_type message
 
-## UNSTABLE
+    ## PRIVATE
 
-   Convert a request error to a human-readable form.
-Request_Error.to_display_text self =
-    description_text = case self.message of
-        Nothing -> ""
-        _ -> " " + self.message
-    self.error_type + " error when sending request." + description_text
+       Convert a request error to a human-readable form.
+    to_display_text : Text
+    to_display_text self =
+        description_text = case self.message of
+            Nothing -> ""
+            _ -> " " + self.message
+        self.error_type + " error when sending request." + description_text

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System.enso
@@ -58,7 +58,7 @@ default_line_separator = Java_System.lineSeparator
 
 ## PRIVATE
 
-   The type representing the result of a subprocess exiting.
+   The type representing the result of a process.
 
    Arguments:
    - exit_code: The exit code of the child process.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/Process.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/Process.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 import Standard.Base.System
 
 import Standard.Base.System.Process.Exit_Code
+from Standard.Base.System import System_Process_Result, System_Process_Result_Data
 
 ## ALIAS Run a Command
    UNSTABLE
@@ -115,15 +116,4 @@ type Builder
     create : Result
     create self =
         result = System.create_process self.command self.arguments.to_array self.stdin redirect_in=False redirect_out=False redirect_err=False
-        Result_Data (Exit_Code.from_number result.exit_code) result.stdout result.stderr
-
-## UNSTABLE
-
-   The result of the process invocation.
-
-   Arguments:
-   - exit_code: The exit code for the process.
-   - stdout: The contents of the process' standard output.
-   - stderr: The contents of the process' standard error.
-type Result
-    Result_Data exit_code stdout stderr
+        System_Process_Result_Data (Exit_Code.from_number result.exit_code) result.stdout result.stderr

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Internal/Helpers.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Internal/Helpers.enso
@@ -46,14 +46,15 @@ unify_vector_singleton x = case x of
    Currently the names can only include ASCII letters, numbers and the
    underscore. This is a temporary limitation simplifying name handling. It will
    be removed in a future version.
-type Unsupported_Name_Error text
+type Unsupported_Name_Error
+    Unsupported_Name_Error_Data text
 
-## UNSTABLE
+    ## PRIVATE
 
-   Creates a human-readable representation of the unsupported name error.
-Unsupported_Name_Error.to_display_text : Text
-Unsupported_Name_Error.to_display_text self =
-    "The name " + self.text + " is not currently supported by the Database library."
+       Creates a human-readable representation of the unsupported name error.
+    to_display_text : Text
+    to_display_text self =
+        "The name " + self.text + " is not currently supported by the Database library."
 
 ## PRIVATE
 
@@ -72,5 +73,5 @@ ensure_name_is_sane name =
     is_safe =
         Pattern.matches "[A-Za-z_0-9]+" name
     if is_safe then True else
-        Error.throw <| Unsupported_Name_Error (name + " is not a valid name for a column. Please use english letters, numbers and underscore only.")
+        Error.throw <| Unsupported_Name_Error_Data (name + " is not a valid name for a column. Please use english letters, numbers and underscore only.")
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -1267,23 +1267,13 @@ type Aggregate_Column
 
 ## UNSTABLE
 
-   Pretty-prints the index out of bounds error.
-Index_Out_Of_Bounds_Error.to_display_text : Text
-Index_Out_Of_Bounds_Error.to_display_text self =
-    ix_text = self.index.to_text
-    len_text = self.length.to_text
-    "The index " + ix_text + " is out of bounds in a column of length " + len_text + "."
-
-## UNSTABLE
-
    An error for when the column contains no elements.
 type Empty_Error
+    ## PRIVATE
 
-## UNSTABLE
-
-   Pretty prints the error.
-Empty_Error.to_display_text : Text
-Empty_Error.to_display_text self = "The column is empty."
+       Pretty prints the empty column error.
+    to_display_text : Text
+    to_display_text self = "The column is empty."
 
 ## PRIVATE
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Data_Formatter.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Data_Formatter.enso
@@ -126,7 +126,7 @@ type Data_Formatter
 
     ## PRIVATE
        Clone the instance with some properties overridden.
-    clone : Boolean->Boolean->Text->Text->Boolean->[Text]->[Text]->[Text]->Locale->[Text]->[Text]->Data_Formatter
+    clone : Boolean -> Boolean -> Text -> Text -> Boolean -> [Text] -> [Text] -> [Text] -> Locale -> [Text] -> [Text] -> Data_Formatter
     clone self (trim_values=self.trim_values) (allow_leading_zeros=self.allow_leading_zeros) (decimal_point=self.decimal_point) (thousand_separator=self.thousand_separator) (allow_exponential_notation=self.allow_exponential_notation) (datetime_formats=self.datetime_formats) (date_formats=self.date_formats) (time_formats=self.time_formats) (datetime_locale=self.datetime_locale) (true_values=self.true_values) (false_values=self.false_values) =
         Data_Formatter_Data trim_values=trim_values allow_leading_zeros=allow_leading_zeros decimal_point=decimal_point thousand_separator=thousand_separator allow_exponential_notation=allow_exponential_notation datetime_formats=datetime_formats date_formats=date_formats time_formats=time_formats datetime_locale=datetime_locale true_values=true_values false_values=false_values
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1128,12 +1128,11 @@ type Table
 
    An error returned when the table contains no rows.
 type Empty_Error
+    ## PRIVATE
 
-## UNSTABLE
-
-   Pretty prints the error.
-Empty_Error.to_display_text : Text
-Empty_Error.to_display_text self = "The table is empty."
+       Pretty prints the empty table error.
+    to_display_text : Text
+    to_display_text self = "The table is empty."
 
 ## PRIVATE
 from_columns cols = Table_Data (Java_Table.new cols.to_array)

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
@@ -8,61 +8,79 @@ polyglot java import org.enso.table.error.ColumnNameMismatchException
 type Missing_Input_Columns
     Missing_Input_Columns_Data (criteria : [Text])
 
-Missing_Input_Columns.to_display_text : Text
-Missing_Input_Columns.to_display_text self =
-    "The criteria "+self.criteria.to_text+" did not match any columns."
+    ## PRIVATE
+
+       Convert a missing input error to a human-readable form.
+    to_display_text : Text
+    to_display_text self =
+        "The criteria "+self.criteria.to_text+" did not match any columns."
 
 ## One or more column indexes were invalid on the input table.
    Can occur when using By_Index.
 type Column_Indexes_Out_Of_Range
     Column_Indexes_Out_Of_Range_Data (indexes : [Integer])
 
-Column_Indexes_Out_Of_Range.to_display_text : Text
-Column_Indexes_Out_Of_Range.to_display_text self = case self.indexes.length == 1 of
-    True -> "The index " + (self.indexes.at 0).to_text + " is out of range."
-    False -> "The indexes "+self.indexes.short_display_text+" are out of range."
+    ## PRIVATE
+
+       Convert a column indexes out of bounds error to a human-readable form.
+    to_display_text : Text
+    to_display_text self = case self.indexes.length == 1 of
+        True -> "The index " + (self.indexes.at 0).to_text + " is out of range."
+        False -> "The indexes "+self.indexes.short_display_text+" are out of range."
 
 ## More names than the column count provided to the function.
    Can occur when using By_Position.
 type Too_Many_Column_Names_Provided
     Too_Many_Column_Names_Provided_Data (column_names : [Text])
 
-Too_Many_Column_Names_Provided.to_display_text : Text
-Too_Many_Column_Names_Provided.to_display_text self =
-    "Too many column names provided. " + (self.column_names.at 0).to_text + " unused."
+    ## PRIVATE
+
+       Convert a too many columns error to a human-readable form.
+    to_display_text : Text
+    to_display_text self =
+        "Too many column names provided. " + (self.column_names.at 0).to_text + " unused."
 
 ## One or more column names were invalid during a rename operation.
 type Invalid_Output_Column_Names
     Invalid_Output_Column_Names_Data (column_names : [Text])
 
-Invalid_Output_Column_Names.to_display_text : Text
-Invalid_Output_Column_Names.to_display_text self = case self.column_names.length == 1 of
-    True -> "The name " + (self.column_names.at 0).to_text + " is invalid."
-    False -> "The names "+self.column_names.short_display_text+" are invalid."
+    ## PRIVATE
+
+       Pretty prints the invalid output columns error.
+    to_display_text : Text
+    to_display_text self = case self.column_names.length == 1 of
+        True -> "The name " + (self.column_names.at 0).to_text + " is invalid."
+        False -> "The names "+self.column_names.short_display_text+" are invalid."
 
 ## One or more column names clashed during a rename operation.
 type Duplicate_Output_Column_Names
     Duplicate_Output_Column_Names_Data (column_names : [Text])
 
-Duplicate_Output_Column_Names.to_display_text : Text
-Duplicate_Output_Column_Names.to_display_text self = case self.column_names.length == 1 of
-    True -> "The name " + (self.column_names.at 0).to_text + " was repeated in the output, so was renamed."
-    False -> "The names "+self.column_names.short_display_text+" were repeated in the output, and were renamed."
+    ## PRIVATE
+
+       Pretty prints the duplicate output column names error.
+    to_display_text : Text
+    to_display_text self = case self.column_names.length == 1 of
+        True -> "The name " + (self.column_names.at 0).to_text + " was repeated in the output, so was renamed."
+        False -> "The names "+self.column_names.short_display_text+" were repeated in the output, and were renamed."
 
 ## No columns in the output result.
 type No_Output_Columns
 
-No_Output_Columns.to_display_text : Text
-No_Output_Columns.to_display_text self =
-    "The result contains no columns."
+    ## PRIVATE
+
+       Pretty prints the no output columns error.
+    to_display_text : Text
+    to_display_text self =
+        "The result contains no columns."
 
 ## Indicates that the provided Column_Selector has duplicate entries.
 type Duplicate_Column_Selectors
     Duplicate_Column_Selectors_Data (duplicate_selectors : [(Text | Integer)])
 
-Duplicate_Column_Selectors.to_display_text : Text
-Duplicate_Column_Selectors.to_display_text self =
-    "The provided Column_Selector has duplicate entries: "+self.duplicate_selectors.short_display_text+"."
+    to_display_text : Text
+    to_display_text self =
+        "The provided Column_Selector has duplicate entries: "+self.duplicate_selectors.short_display_text+"."
 
 ## Indicates that one column has been matched by multiple selectors.
 
@@ -71,9 +89,12 @@ Duplicate_Column_Selectors.to_display_text self =
 type Column_Matched_By_Multiple_Selectors
     Column_Matched_By_Multiple_Selectors_Data (column_name : Text) (selectors : [Any])
 
-Column_Matched_By_Multiple_Selectors.to_display_text : Text
-Column_Matched_By_Multiple_Selectors.to_display_text self =
-    'The column "' + self.column_name + '" is matched by multiple selectors: ' + self.selectors.short_display_text + "."
+    ## PRIVATE
+
+       Pretty prints the error.
+    to_display_text : Text
+    to_display_text self =
+        'The column "' + self.column_name + '" is matched by multiple selectors: ' + self.selectors.short_display_text + "."
 
 ## Indicates that the provided indices matched columns already matched by
    others, so they do not introduce any new columns to the input.
@@ -84,50 +105,49 @@ Column_Matched_By_Multiple_Selectors.to_display_text self =
 type Input_Indices_Already_Matched
     Input_Indices_Already_Matched_Data (indices : [Integer])
 
-Input_Indices_Already_Matched.to_display_text : Text
-Input_Indices_Already_Matched.to_display_text self =
-    "The indices "+self.indices.short_display_text+" matched columns which have been matched earlier by other indices, so they did not introduce any new columns into the result."
+    to_display_text : Text
+    to_display_text self =
+        "The indices "+self.indices.short_display_text+" matched columns which have been matched earlier by other indices, so they did not introduce any new columns into the result."
 
 ## Indicates that no input columns were selected for the operation, so the
    operation will cause no effect.
 type No_Input_Columns_Selected
-
-No_Input_Columns_Selected.to_display_text : Text
-No_Input_Columns_Selected.to_display_text self =
-    "No input columns have been selected for the operation."
+    to_display_text : Text
+    to_display_text self =
+        "No input columns have been selected for the operation."
 
 
 ## Indicates that an aggregation calculation could not be completed.
 type Invalid_Aggregation
     Invalid_Aggregation_Data (column:Text) (rows:[Integer]) (message:Text)
 
-Invalid_Aggregation.to_display_text : Text
-Invalid_Aggregation.to_display_text self =
-    "The "+self.column+" could not be calculated at "+self.row.to_text+" : "+self.message
+    to_display_text : Text
+    to_display_text self =
+        "The "+self.column+" could not be calculated at "+self.row.to_text+" : "+self.message
 
 ## Indicates that a floating point number was used in a grouping.
 type Floating_Point_Grouping
     Floating_Point_Grouping_Data (column:Text) (rows:[Integer])
 
-Floating_Point_Grouping.to_display_text : Text
-Floating_Point_Grouping.to_display_text self =
-    "Grouping on floating points is not recommended within "+self.column+" at row "+self.row.to_text+"."
+    to_display_text : Text
+    to_display_text self =
+        "Grouping on floating points is not recommended within "+self.column+" at row "+self.row.to_text+"."
 
 ## Indicates that a text value with a delimiter was included in a concatenation without any quote character
 type Unquoted_Delimiter
     Unquoted_Delimiter_Data (column:Text) (rows:[Integer])
 
-Unquoted_Delimiter.to_display_text : Text
-Unquoted_Delimiter.to_display_text self =
-    "The "+self.column+" at row "+self.row.to_text+" contains the delimiter and there is no specified quote character."
+    to_display_text : Text
+    to_display_text self =
+        "The "+self.column+" at row "+self.row.to_text+" contains the delimiter and there is no specified quote character."
 
 ## Warning when additional warnings occurred.
 type Additional_Warnings
     Additional_Warnings_Data (count:Integer)
 
-Additional_Warnings.to_display_text : Text
-Additional_Warnings.to_display_text self =
-    "There were "+self.count.to_text+" additional issues."
+    to_display_text : Text
+    to_display_text self =
+        "There were "+self.count.to_text+" additional issues."
 
 ## Indicates that when loading a delimited file, a row was encountered which had
    too many or too few columns.
@@ -153,9 +173,9 @@ type Parser_Error
 type Invalid_Location
     Invalid_Location_Data (location:Text)
 
-Invalid_Location.to_display_text : Text
-Invalid_Location.to_display_text self =
-    "The location '"+self.location+"' is not valid."
+    to_display_text : Text
+    to_display_text self =
+        "The location '"+self.location+"' is not valid."
 
 ## Indicates that some values did not match the expected datatype format.
 
@@ -168,9 +188,9 @@ Invalid_Location.to_display_text self =
 type Invalid_Format
     Invalid_Format_Data column:(Text|Nothing) (datatype:(Integer|Number|Date|Time|Time_Of_Day|Boolean)) (cells:[Text])
 
-Invalid_Format.to_display_text : Text
-Invalid_Format.to_display_text self =
-    self.cells.length+" cells in column "+self.column+" had invalid format for datatype "+self.datatype.to_text+"."
+    to_display_text : Text
+    to_display_text self =
+        self.cells.length+" cells in column "+self.column+" had invalid format for datatype "+self.datatype.to_text+"."
 
 ## Indicates that some values contained leading zeros even though these were not allowed.
 
@@ -194,33 +214,33 @@ type Duplicate_Type_Selector
 type Unsupported_File_Type
     Unsupported_File_Type_Data filename
 
-Unsupported_File_Type.to_display_text : Text
-Unsupported_File_Type.to_display_text self =
-    "The "+self.filename+" has a type that is not supported by the Auto format."
+    to_display_text : Text
+    to_display_text self =
+        "The "+self.filename+" has a type that is not supported by the Auto format."
 
 ## Indicates that the target range contains existing data and the user did not
    specify to overwrite.
 type Existing_Data
     Existing_Data_Data message
 
-Existing_Data.to_display_text : Text
-Existing_Data.to_display_text self = self.message
+    to_display_text : Text
+    to_display_text self = self.message
 
 ## Indicates that the specified range is not large enough to fit the data.
 type Range_Exceeded
     Range_Exceeded_Data message
 
-Range_Exceeded.to_display_text : Text
-Range_Exceeded.to_display_text self = self.message
+    to_display_text : Text
+    to_display_text self = self.message
 
 ## Indicates that the existing table has a different number of columns to the
    new table.
 type Column_Count_Mismatch
     Column_Count_Mismatch_Data expected actual
 
-Column_Count_Mismatch.to_display_text : Text
-Column_Count_Mismatch.to_display_text self =
-    "Expected " + self.expected.to_text + " columns, got " + self.actual.to_text + "."
+    to_display_text : Text
+    to_display_text self =
+        "Expected " + self.expected.to_text + " columns, got " + self.actual.to_text + "."
 
 ## PRIVATE
 Column_Count_Mismatch.handle_java_exception self =
@@ -234,8 +254,8 @@ Column_Count_Mismatch.handle_java_exception self =
 type Column_Name_Mismatch
     Column_Name_Mismatch_Data missing extras message
 
-Column_Name_Mismatch.to_display_text : Text
-Column_Name_Mismatch.to_display_text self = self.message
+    to_display_text : Text
+    to_display_text self = self.message
 
 ## PRIVATE
 Column_Name_Mismatch.handle_java_exception =
@@ -253,20 +273,19 @@ Column_Name_Mismatch.handle_java_exception =
 type No_Such_Column_Error
     No_Such_Column_Error_Data column_name
 
-## UNSTABLE
+    ## PRIVATE
 
-   Create a human-readable version of the no such column error.
-No_Such_Column_Error.to_display_text : Text
-No_Such_Column_Error.to_display_text self =
-    "The column " + self.column_name + " does not exist."
+       Create a human-readable version of the no such column error.
+    to_display_text : Text
+    to_display_text self =
+        "The column " + self.column_name + " does not exist."
 
 ## UNSTABLE
 
    An error returned when getting an index but no index is set for that table.
 type No_Index_Set_Error
+    ## PRIVATE
 
-## UNSTABLE
-
-   Create a human-readable version of the no such column error.
-No_Index_Set_Error.to_display_text : Text
-No_Index_Set_Error.to_display_text self = "The table does not have an index set."
+       Create a human-readable version of the no index set error.
+    to_display_text : Text
+    to_display_text self = "The table does not have an index set."

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
@@ -242,12 +242,12 @@ type Column_Count_Mismatch
     to_display_text self =
         "Expected " + self.expected.to_text + " columns, got " + self.actual.to_text + "."
 
-## PRIVATE
-Column_Count_Mismatch.handle_java_exception self =
-    throw_column_count_mismatch caught_panic =
-        cause = caught_panic.payload.cause
-        Error.throw (Column_Count_Mismatch_Data cause.getExpected cause.getActual)
-    Panic.catch ColumnCountMismatchException handler=throw_column_count_mismatch
+    ## PRIVATE
+    handle_java_exception self =
+        throw_column_count_mismatch caught_panic =
+            cause = caught_panic.payload.cause
+            Error.throw (Column_Count_Mismatch_Data cause.getExpected cause.getActual)
+        Panic.catch ColumnCountMismatchException handler=throw_column_count_mismatch
 
 ## Indicates that the existing table has a different set of column names to the
    new table.
@@ -257,12 +257,12 @@ type Column_Name_Mismatch
     to_display_text : Text
     to_display_text self = self.message
 
-## PRIVATE
-Column_Name_Mismatch.handle_java_exception =
-    throw_column_name_mismatch caught_panic =
-        cause = caught_panic.payload.cause
-        Error.throw (Column_Name_Mismatch_Data (Vector.from_polyglot_array cause.getMissing) (Vector.from_polyglot_array cause.getExtras) cause.getMessage)
-    Panic.catch ColumnNameMismatchException handler=throw_column_name_mismatch
+    ## PRIVATE
+    handle_java_exception =
+        throw_column_name_mismatch caught_panic =
+            cause = caught_panic.payload.cause
+            Error.throw (Column_Name_Mismatch_Data (Vector.from_polyglot_array cause.getMissing) (Vector.from_polyglot_array cause.getExtras) cause.getMessage)
+        Panic.catch ColumnNameMismatchException handler=throw_column_name_mismatch
 
 ## UNSTABLE
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/IO/File_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/IO/File_Format.enso
@@ -21,7 +21,7 @@ import Standard.Table.IO.Quote_Style
 type Auto
     ## ADVANCED
        Gets the underlying File_Format for the specified file
-    materialise : File->File_Format
+    materialise : File -> File_Format
     materialise self file =
         extension = file.extension
 
@@ -129,12 +129,12 @@ type Delimited
     ## PRIVATE
        Clone the instance with some properties overridden.
        Note: This function is internal until such time as Atom cloning with modification is built into Enso.
-    clone : Text->Text->(Boolean|Infer)->Data_Formatter->Boolean->(Text|Nothing)->(Text|Nothing)->Delimited
+    clone : Text -> Text -> (Boolean|Infer) -> Data_Formatter -> Boolean -> (Text|Nothing) -> (Text|Nothing) -> Delimited
     clone self (quote_style=self.quote_style) (headers=self.headers) (value_formatter=self.value_formatter) (keep_invalid_rows=self.keep_invalid_rows) (line_endings=self.line_endings) (comment_character=self.comment_character) =
         Delimited_Data self.delimiter self.encoding self.skip_rows self.row_limit quote_style headers value_formatter keep_invalid_rows line_endings comment_character
 
     ## Create a clone of this with specified quoting settings.
-    with_quotes : Text->Text->Boolean->Delimited
+    with_quotes : Text -> Text -> Boolean -> Delimited
     with_quotes self quote='"' quote_escape=quote always_quote=False =
         self.clone quote_style=(Quote_Style.With_Quotes always_quote=always_quote quote=quote quote_escape=quote_escape)
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Aggregate_Column_Helper.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Aggregate_Column_Helper.enso
@@ -176,7 +176,7 @@ type Internal_Missing_Column_Error
 
 ## PRIVATE
    Creates a Java Aggregator for the Aggregate_Column
-java_aggregator : Aggregate_Column->Aggregator
+java_aggregator : Aggregate_Column -> Aggregator
 java_aggregator name column =
     case column of
         Group_By c _ -> GroupByAggregator.new name c.java_column
@@ -225,4 +225,4 @@ parse_aggregated_problems problems =
                         Invalid_Aggregation_Data Nothing -1 "Unknown Error"
 
         if problems.getCount == problems_array.length then parsed else
-            parsed + [Additional_Warnings_Data (problems.getCount - problems_array.length)]
+            parsed + [Additional_Warnings_Data (problems.getCount - problems_array.length)

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Aggregate_Column_Helper.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Aggregate_Column_Helper.enso
@@ -225,4 +225,4 @@ parse_aggregated_problems problems =
                         Invalid_Aggregation_Data Nothing -1 "Unknown Error"
 
         if problems.getCount == problems_array.length then parsed else
-            parsed + [Additional_Warnings_Data (problems.getCount - problems_array.length)
+            parsed + [Additional_Warnings_Data (problems.getCount - problems_array.length)]

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -299,13 +299,13 @@ select_indices_preserving_order vector indices =
    If the negative index is sufficiently large, a negative result can still be
    returned. This function does not ensure that the resulting indices are within
    bounds.
-resolve_index : Integer->Integer->Integer
+resolve_index : Integer -> Integer -> Integer
 resolve_index length ix =
     if ix < 0 then length+ix else ix
 
 ## PRIVATE
    Checks if the given index is in the valid range for the provided vector.
-is_index_valid : Integer->Integer->Boolean
+is_index_valid : Integer -> Integer -> Boolean
 is_index_valid length ix =
     actual_ix = resolve_index length ix
     actual_ix>=0 && actual_ix<length

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
@@ -16,7 +16,7 @@ import project.IO.Quote_Style
 
 import project.Errors
 
-from project.Data.Table export new, from_rows, join, concat, Table, Table_Data
+from project.Data.Table export new, from_columns, from_rows, join, concat, Table, Table_Data
 export project.Data.Column
 export project.Data.Column_Selector
 export project.Data.Sort_Column

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
@@ -104,9 +104,9 @@ Json.Json.to_table self fields=Nothing = case self of
 type Invalid_Format_Error
     Invalid_Format_Error_Data input message
 
-## UNSTABLE
+    ## PRIVATE
 
-   Provides a human-readable representation of the Invalid_Format_Error.
-Invalid_Format_Error.to_display_text : Text
-Invalid_Format_Error.to_display_text self =
-    "The input " + self.input.to_text + " had an invalid format due to: " + self.message.to_text + "."
+       Provides a human-readable representation of the Invalid_Format_Error.
+    to_display_text : Text
+    to_display_text self =
+        "The input " + self.input.to_text + " had an invalid format due to: " + self.message.to_text + "."

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Faker.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Faker.enso
@@ -46,7 +46,7 @@ type Faker
        Arguments:
        - length: length of text to generate
        - upper_case: use upper_case letters
-    alpha : Integer->Boolean->Text
+    alpha : Integer -> Boolean -> Text
     alpha self length=1 upper_case=False =
         alphabet = if upper_case then upper_case_letters else lower_case_letters
         self.string_value <| 0.up_to length . map _->alphabet
@@ -56,7 +56,7 @@ type Faker
        Arguments:
        - length: length of text to generate
        - upper_case: use upper_case letters
-    alpha_numeric : Integer->Boolean->Text
+    alpha_numeric : Integer -> Boolean -> Text
     alpha_numeric self length=1 upper_case=False =
         alphabet = (if upper_case then upper_case_letters else lower_case_letters) + numbers
         self.string_value <| 0.up_to length . map _->alphabet
@@ -65,7 +65,7 @@ type Faker
 
        Arguments:
        - length: length of text to generate
-    hexadecimal : Integer->Text
+    hexadecimal : Integer -> Text
     hexadecimal self length=1 =
         alphabet = "0123456789ABCDEF".char_vector
         self.string_value <| 0.up_to length . map _->alphabet
@@ -76,12 +76,12 @@ type Faker
         if self.generator.nextDouble < 0.5 then True else False
 
     ## Create a random Integer value
-    integer : Integer->Integer->Integer
+    integer : Integer -> Integer -> Integer
     integer self minimum=0 maximum=100 =
         minimum + (self.generator.nextInt (maximum - minimum))
 
     ## Create a random Decimal value
-    decimal : Decimal->Decimal->Decimal
+    decimal : Decimal -> Decimal -> Decimal
     decimal self  minimum=0.0 maximum=1.0 =
         minimum + self.generator.nextDouble * (maximum - minimum)
 
@@ -90,11 +90,11 @@ type Faker
        Arguments:
        - items: Vector of items to pick from
        - generator: Random number generator
-    vector_item : Vector->Any
+    vector_item : Vector -> Any
     vector_item self items =
         items.at (self.generator.nextInt items.length)
 
     ## Randomly converts some values to Nothing
-    make_some_nothing : Any->Decimal->Any
+    make_some_nothing : Any -> Decimal -> Any
     make_some_nothing self value (chance=0.1) =
         if self.generator.nextDouble <= chance then Nothing else value

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
@@ -93,11 +93,10 @@ type Point_Data
 
 ## PRIVATE
 type No_Fallback_Column
-
-## PRIVATE
-No_Fallback_Column.to_display_text : Text
-No_Fallback_Column.to_display_text self =
-    "No fallback column found for the scatter plot."
+    ## PRIVATE
+    to_display_text : Text
+    to_display_text self =
+        "No fallback column found for the scatter plot."
 
 ## PRIVATE
 

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
@@ -198,7 +198,7 @@ json_from_vector vec bounds limit =
 
    Arguments:
    - value: the value to be visualized.
-process_to_json_text : Any -> Text
+process_to_json_text : Any -> Integer | Nothing -> Integer | Nothing -> Text
 process_to_json_text value bounds=Nothing limit=Nothing =
     json = case value of
         Column.Column_Data _ -> json_from_table  value.to_table bounds limit

--- a/test/Benchmarks/src/Statistics/CountMinMax.enso
+++ b/test/Benchmarks/src/Statistics/CountMinMax.enso
@@ -10,7 +10,7 @@ vector_size = 10000000
 iter_size = 5
 num_iterations = 5
 
-create_vector : Integer->Integer->Vector
+create_vector : Integer -> Integer -> Vector
 create_vector rows (seed=1646322139) =
     faker = Faker.new seed
     0.up_to rows . map _-> faker.make_some_nothing (faker.integer 0 1000000)

--- a/test/Benchmarks/src/Table/Aggregate.enso
+++ b/test/Benchmarks/src/Table/Aggregate.enso
@@ -13,7 +13,7 @@ vector_size = 2500
 iter_size = 20
 num_iterations = 3
 
-create_table : Integer->Integer->Table
+create_table : Integer -> Integer -> Table
 create_table rows (seed=1646322139) =
     faker = Faker.new seed
     key1 = ["Code", 0.up_to rows . map _-> faker.alpha 3]


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

Small clean up PR.

- Aligns a few type signatures with their functions.
- Some formatting fixes.
- Remove a few unused types.
- Make error extension functions be standard methods.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
