### PR TITLE
Print result of main (if not Nothing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -348,6 +348,7 @@
   support][3658]
 - [Implement new specification of data types: `type` has a runtime
   representation, every atom has a type][3671]
+- [main = "Hello World!" is valid Enso sample][3696]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -392,6 +393,7 @@
 [3641]: https://github.com/enso-org/enso/pull/3641
 [3658]: https://github.com/enso-org/enso/pull/3658
 [3671]: https://github.com/enso-org/enso/pull/3671
+[3696]: https://github.com/enso-org/enso/pull/3696
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -20,6 +20,7 @@ import java.nio.file.{Path, Paths}
 import java.util.{HashMap, UUID}
 
 import scala.Console.err
+import scala.Console.out
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.util.control.NonFatal
@@ -759,7 +760,10 @@ object Main {
         case Some(main) if mainMethodName != "main" =>
           main.execute(mainType.newInstance())
         case Some(main) =>
-          main.execute()
+          val res = main.execute()
+          if (!res.isNull()) {
+            out.println(res);
+          }
         case None =>
           err.println(
             s"The module ${mainModule.getName} does not contain a `main` " +


### PR DESCRIPTION
### Pull Request Description

The goal of this request is to simplify hello world and other trivial Enso programs. No need to learn any standard library functions, enough to write:
```
main = "Hello World!"
```
and the result is going to be printed:
```bash
enso$ ./built-distribution/enso-engine-0.0.0-dev-linux-amd64/enso-0.0.0-dev/bin/enso --run hello.enso 
'Hello World!'
```
the result is only printed, if it is not `Nothing`. E.g. if the last statement is `IO.print ...` (which returns `Nothing`), then no value is printed at the end by the launcher.

### Why is this Important?

The simplification of _hello world_ is a nice side-effect, but it is not the primary reason why this functionality is important.

There is a task to [Add missing @TruffleBoundary](https://www.pivotaltracker.com/story/show/183136313) to make Enso code compilation more effective. The only way to verify that there are no missing `@TruffleBoundary` annotations is to build the `engine-runner` project with _GraalVM Native Image_ - #3638. However just building the engine isn't enough, we also need to test it by [executing a sample script](https://github.com/enso-org/enso/pull/3638#issuecomment-1243354448) and verify it computes the right output. However, at current stage, the _Native Image compiled Enso executable_  cannot load standard library - e.g. it cannot use `Standard.Base.IO.println` to print anything...

With here in proposed functionality we can invoke [the script](https://github.com/enso-org/enso/pull/3638#issuecomment-1243354448), compute its result and _let the `engine-runner` infrastructure_ print the output. We can compile all of that into _native executable_ right now - e.g. we will be able to properly test the  [Add missing @TruffleBoundary](https://www.pivotaltracker.com/story/show/183136313) task in our CI.

### Checklist

Please include the following checklist in your PR:

- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
