### PR TITLE
Force recompilation if imported module has changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -354,6 +354,7 @@
 - [Implement new specification of data types: `type` has a runtime
   representation, every atom has a type][3671]
 - [main = "Hello World!" is valid Enso sample][3696]
+- [Invalidate module's IR cache if imported module changed][3703]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -399,6 +400,7 @@
 [3658]: https://github.com/enso-org/enso/pull/3658
 [3671]: https://github.com/enso-org/enso/pull/3671
 [3696]: https://github.com/enso-org/enso/pull/3696
+[3696]: https://github.com/enso-org/enso/pull/3703
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/docs/runtime/ir-caching.md
+++ b/docs/runtime/ir-caching.md
@@ -30,6 +30,7 @@ startup performance.
 - [Loading the IR](#loading-the-ir)
   - [Integrity Checking](#integrity-checking)
   - [Error Handling](#error-handling)
+  - [Imports](#imports)
 - [Testing the Serialisation](#testing-the-serialisation)
 - [Future Directions](#future-directions)
 
@@ -200,6 +201,19 @@ working state. This means that:
 
 At no point should this mechanism be exposed to the user in any visible way,
 other than the fact that they may be seeing the actual files on disk.
+
+### Imports
+
+Integrity Checking does not check the situation when the cached module imports a
+module which cache has been invalidated. For example, module `A` uses a method
+`foo` from module `B` and a successful compilation resulted in IR cache for both
+`A` and `B`. Later, someone modifed module `B` by renaming method `foo` to
+`bar`. If we only compared source hashes, `B`'s IR would be re-generated while
+`A`'s would be loaded from cache, thus failing to notice method name change,
+until a complete cache invalidation was forced.
+
+Therefore, the compiler performs an additional check by invalidating module's
+cache if any of its imported modules have been invalidated.
 
 ## Testing the Serialisation
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -218,7 +218,23 @@ class Compiler(
     initialize()
     modules.foreach(m => parseModule(m))
 
-    var requiredModules = modules.flatMap(runImportsAndExportsResolution)
+    var requiredModules = modules.flatMap { module =>
+      val modules = runImportsAndExportsResolution(module)
+      if (
+        module
+          .wasLoadedFromCache() && modules.exists(!_.wasLoadedFromCache())
+      ) {
+        logger.log(
+          Compiler.defaultLogLevel,
+          s"Some imported modules' caches were invalided, forcing invalidation of ${module.getName.toString}"
+        )
+        module.getCache.invalidate(context)
+        parseModule(module)
+        runImportsAndExportsResolution(module)
+      } else {
+        modules
+      }
+    }
 
     var hasInvalidModuleRelink = false
     if (irCachingEnabled) {
@@ -432,6 +448,7 @@ class Compiler(
       recognizeBindings(exprWithModuleExports, moduleContext)
     module.unsafeSetIr(discoveredModule)
     module.unsafeSetCompilationStage(Module.CompilationStage.AFTER_PARSING)
+    module.setLoadedFromCache(false)
     module.setHasCrossModuleLinks(true)
   }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/ModuleCache.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/ModuleCache.scala
@@ -122,6 +122,20 @@ class ModuleCache(private val module: Module) {
       }
     }
 
+  /** Invalidates all caches associated with the module.
+    *
+    * @param context the langage context in which loading is taking place
+    */
+  def invalidate(context: Context): Unit = {
+    this.synchronized {
+      implicit val logger: TruffleLogger = context.getLogger(this.getClass)
+      getIrCacheRoots(context).foreach { roots =>
+        invalidateCache(roots.globalCacheRoot)
+        invalidateCache(roots.localCacheRoot)
+      }
+    }
+  }
+
   // === Internals ============================================================
 
   /** Saves the cache into the provided `cacheRoot`.

--- a/engine/runtime/src/test/resources/Test_Caching_Invalidation/package.yaml
+++ b/engine/runtime/src/test/resources/Test_Caching_Invalidation/package.yaml
@@ -1,0 +1,6 @@
+name: Test_Caching_Invalidation
+license: APLv2
+enso-version: default
+version: "0.0.1"
+author: "Enso Team <contact@enso.org>"
+maintainer: "Enso Team <contact@enso.org>"

--- a/engine/runtime/src/test/resources/Test_Caching_Invalidation/src/Atom_1.enso
+++ b/engine/runtime/src/test/resources/Test_Caching_Invalidation/src/Atom_1.enso
@@ -1,0 +1,1 @@
+foo a = "ABC"+a.to_text

--- a/engine/runtime/src/test/resources/Test_Caching_Invalidation/src/Atom_2.enso
+++ b/engine/runtime/src/test/resources/Test_Caching_Invalidation/src/Atom_2.enso
@@ -1,0 +1,1 @@
+foo a = "ABC"+a.to_text

--- a/engine/runtime/src/test/resources/Test_Caching_Invalidation/src/Atom_3.enso
+++ b/engine/runtime/src/test/resources/Test_Caching_Invalidation/src/Atom_3.enso
@@ -1,0 +1,1 @@
+bar a = "ABC"+a.to_text

--- a/engine/runtime/src/test/resources/Test_Caching_Invalidation/src/Main.enso
+++ b/engine/runtime/src/test/resources/Test_Caching_Invalidation/src/Main.enso
@@ -1,6 +1,6 @@
 from Standard.Base import IO
+from Standard.Base.Data.Boolean import False
 from project.Atom import all
 
 main =
-    false = 0 == 1
-    if false then IO.println (foo 1) else IO.println "hmm..."
+    if False then IO.println (foo 1) else IO.println "hmm..."

--- a/engine/runtime/src/test/resources/Test_Caching_Invalidation/src/Main.enso
+++ b/engine/runtime/src/test/resources/Test_Caching_Invalidation/src/Main.enso
@@ -1,0 +1,6 @@
+from Standard.Base import IO
+from project.Atom import all
+
+main =
+    false = 0 == 1
+    if false then IO.println (foo 1) else IO.println "hmm..."

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/CachingTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/CachingTest.scala
@@ -3,7 +3,7 @@ package org.enso.compiler.test
 import org.enso.interpreter.test.InterpreterException
 
 class CachingTest extends ModifiedTest {
-  "Atoms and methods" should "be available for import" in {
+  "IR caching" should "should propagate invalidation" in {
     evalTestProjectIteration("Test_Caching_Invalidation", iteration = 1)
     val outLines = consumeOut
     outLines(0) shouldEqual "hmm..."

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/CachingTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/CachingTest.scala
@@ -4,15 +4,15 @@ import org.enso.interpreter.test.InterpreterException
 
 class CachingTest extends ModifiedTest {
   "Atoms and methods" should "be available for import" in {
-    evalTestProject("Test_Caching_Invalidation", iteration = 1)
+    evalTestProjectIteration("Test_Caching_Invalidation", iteration = 1)
     val outLines = consumeOut
     outLines(0) shouldEqual "hmm..."
 
-    evalTestProject("Test_Caching_Invalidation", iteration = 2)
+    evalTestProjectIteration("Test_Caching_Invalidation", iteration = 2)
     val outLines2 = consumeOut
     outLines2(0) shouldEqual "hmm..."
 
-    the[InterpreterException] thrownBy (evalTestProject(
+    the[InterpreterException] thrownBy (evalTestProjectIteration(
       "Test_Caching_Invalidation",
       iteration = 3
     )) should have message "Compilation aborted due to errors."

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/CachingTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/CachingTest.scala
@@ -1,0 +1,22 @@
+package org.enso.compiler.test
+
+import org.enso.interpreter.test.InterpreterException
+
+class CachingTest extends ModifiedTest {
+  "Atoms and methods" should "be available for import" in {
+    evalTestProject("Test_Caching_Invalidation", iteration = 1)
+    val outLines = consumeOut
+    outLines(0) shouldEqual "hmm..."
+
+    evalTestProject("Test_Caching_Invalidation", iteration = 2)
+    val outLines2 = consumeOut
+    outLines2(0) shouldEqual "hmm..."
+
+    the[InterpreterException] thrownBy (evalTestProject(
+      "Test_Caching_Invalidation",
+      iteration = 3
+    )) should have message "Compilation aborted due to errors."
+    val outLines3 = consumeOut
+    outLines3(2) should endWith("The name `foo` could not be found.")
+  }
+}

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/CachingTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/CachingTest.scala
@@ -1,9 +1,11 @@
 package org.enso.compiler.test
 
+import org.apache.commons.lang3.SystemUtils
 import org.enso.interpreter.test.InterpreterException
 
 class CachingTest extends ModifiedTest {
   "IR caching" should "should propagate invalidation" in {
+    assume(!SystemUtils.IS_OS_WINDOWS)
     evalTestProjectIteration("Test_Caching_Invalidation", iteration = 1)
     val outLines = consumeOut
     outLines(0) shouldEqual "hmm..."

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/ModifiedTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/ModifiedTest.scala
@@ -21,7 +21,19 @@ trait ModifiedTest
   val output                            = new ByteArrayOutputStream()
   private[this] var testDirectory: File = _
 
-  def evalTestProject(name: String, iteration: Int): Value = {
+  /** Compile and run a project defined in the resources directory.
+    * The project may contain files that are changed in the process.
+    * The changes to files are specified via iteration suffix. E.g.,
+    * A_1.enso, A_2.enso and A_3.enso represents three states of the
+    * A.enso file.
+    *
+    * @param name name of the project to run
+    * @param iteration iteration used to identify the correct version of the module
+    * @return result of executing the project
+    */
+  def evalTestProjectIteration(name: String, iteration: Int): Value = {
+    assert(iteration > 0)
+
     val pkgPath =
       new File(getClass.getClassLoader.getResource(name).getPath)
 

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/ModifiedTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/ModifiedTest.scala
@@ -1,0 +1,122 @@
+package org.enso.compiler.test
+
+import org.apache.commons.io.FileUtils
+import org.apache.commons.io.filefilter.{IOFileFilter, TrueFileFilter}
+import org.enso.interpreter.test.{InterpreterException, ValueEquality}
+import org.enso.pkg.PackageManager
+import org.enso.polyglot.{LanguageInfo, PolyglotContext, RuntimeOptions}
+import org.graalvm.polyglot.{Context, Value}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.{ByteArrayOutputStream, File, FileFilter}
+import java.nio.file.{Files, Paths, StandardCopyOption}
+
+trait ModifiedTest
+    extends AnyFlatSpec
+    with Matchers
+    with ValueEquality
+    with BeforeAndAfterAll {
+  val output                            = new ByteArrayOutputStream()
+  private[this] var testDirectory: File = _
+
+  def evalTestProject(name: String, iteration: Int): Value = {
+    val pkgPath =
+      new File(getClass.getClassLoader.getResource(name).getPath)
+
+    val testPkgPath = testDirectory.toPath.resolve(name).toFile
+    if (!testPkgPath.exists()) {
+      initialCopy(pkgPath, testPkgPath)
+    }
+    copyIterationFiles(pkgPath, testPkgPath, iteration)
+    val pkg        = PackageManager.Default.fromDirectory(testPkgPath).get
+    val mainFile   = pkg.mainFile
+    val mainModule = pkg.moduleNameForFile(mainFile)
+    val context = Context
+      .newBuilder(LanguageInfo.ID)
+      .allowExperimentalOptions(true)
+      .allowAllAccess(true)
+      .option(RuntimeOptions.PROJECT_ROOT, testPkgPath.getAbsolutePath)
+      .option(
+        RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
+        Paths
+          .get("../../test/micro-distribution/component")
+          .toFile
+          .getAbsolutePath
+      )
+      .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
+      .option(RuntimeOptions.STRICT_ERRORS, "true")
+      .option(RuntimeOptions.DISABLE_IR_CACHES, "false")
+      .out(output)
+      .in(System.in)
+      .option(RuntimeOptions.LOG_LEVEL, "WARNING")
+      .logHandler(System.err)
+      .build()
+    context.initialize(LanguageInfo.ID)
+    val executionContext = new PolyglotContext(context)
+    InterpreterException.rethrowPolyglot {
+      val topScope        = executionContext.getTopScope
+      val mainModuleScope = topScope.getModule(mainModule.toString)
+      val assocCons       = mainModuleScope.getAssociatedType
+      val mainFun         = mainModuleScope.getMethod(assocCons, "main").get
+      mainFun.execute()
+    }
+  }
+
+  private def initialCopy(from: File, to: File): Unit = {
+    val filter = new FileFilter {
+      override def accept(pathname: File): Boolean = {
+        !pathname.getName.matches(".+_(\\d+)\\.enso")
+      }
+    }
+    copySources(from, to, filter)
+  }
+
+  private def copyIterationFiles(from: File, to: File, iteration: Int): Unit = {
+    val iterationFileFilter = new IOFileFilter {
+      override def accept(pathname: File): Boolean = {
+        pathname.getName.matches(s".+_$iteration\\.enso")
+      }
+
+      override def accept(dir: File, name: String): Boolean = {
+        name.matches(s".+_$iteration\\.enso")
+      }
+    }
+    val allIterationFiles =
+      FileUtils.listFiles(from, iterationFileFilter, TrueFileFilter.INSTANCE)
+    allIterationFiles.forEach(f => {
+      val path          = from.toPath.relativize(f.toPath)
+      val fixedFileName = path.toString.replaceFirst("_\\d+\\.enso", ".enso")
+      val targetFile    = to.toPath.resolve(fixedFileName)
+      FileUtils.copyFile(
+        f,
+        targetFile.toFile,
+        StandardCopyOption.REPLACE_EXISTING
+      )
+    })
+  }
+
+  private def copySources(
+    from: File,
+    to: File,
+    fileFilter: FileFilter
+  ): Unit = {
+    to.mkdir()
+    FileUtils.copyDirectory(from, to, fileFilter)
+  }
+
+  override def beforeAll(): Unit = {
+    testDirectory = Files.createTempDirectory("enso-projects").toFile
+  }
+
+  override def afterAll(): Unit = {
+    FileUtils.forceDelete(testDirectory)
+  }
+
+  def consumeOut: List[String] = {
+    val result = output.toString
+    output.reset()
+    result.linesIterator.toList
+  }
+}


### PR DESCRIPTION
### Pull Request Description

IR cache never really took into account a situation when a binding from the imported module has changed. In other words, it would continue to happily use the serialized metadata without noticing that it changed.

This change forces cache invalidation when any of the imported modules was invalidated (or rather not loaded from cache). 

### Important Notes

Added simple test infrastructure that simulates file modifications that would trigger the initial cache invalidation.
If they succeed, cache invalidation is propagated thus causing an error.

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
