### PR TITLE
Don't rename imported Main module that only imports names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -355,6 +355,7 @@
   representation, every atom has a type][3671]
 - [main = "Hello World!" is valid Enso sample][3696]
 - [Invalidate module's IR cache if imported module changed][3703]
+- [Don't rename imported Main module that only imports names][3710]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -401,6 +402,7 @@
 [3671]: https://github.com/enso-org/enso/pull/3671
 [3696]: https://github.com/enso-org/enso/pull/3696
 [3696]: https://github.com/enso-org/enso/pull/3703
+[3696]: https://github.com/enso-org/enso/pull/3710
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base
 
 import Standard.Base.Data.Json.Internal
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json/Internal.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json/Internal.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all hiding Number, Boolean, Array
+import Standard.Base
 
 import Standard.Base.Data.Numbers as Base_Number
 import Standard.Base.Runtime.Ref

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Meta.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Meta.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base
 
 ## UNSTABLE
    ADVANCED

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Helpers.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Helpers.enso
@@ -87,8 +87,8 @@ recover_errors ~body =
    Returns all the columns in the table, including indices.
 
    Index columns are placed before other columns.
-Table.Table.all_columns : Vector
-Table.Table.all_columns self =
+Table.all_columns : Vector
+Table.all_columns self =
     index = self.index.catch_ []
     index_columns = case index of
         Vector.Vector -> index
@@ -103,8 +103,8 @@ Table.Table.all_columns self =
 
    Arguments:
    - text: the case-insensitive name of the searched column.
-Table.Table.lookup_ignore_case : Text -> Column ! Nothing
-Table.Table.lookup_ignore_case self name =
+Table.lookup_ignore_case : Text -> Column ! Nothing
+Table.lookup_ignore_case self name =
     self.all_columns.find <| col->
         col.name.equals_ignore_case name
 

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Histogram.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Histogram.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Table import Table, Column
+import Standard.Table
 import Standard.Visualization.Helpers
 
 ## PRIVATE

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Id.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Id.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base
 
 ## An ID used by the visualization system to identify different ways of
    displaying data.

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
@@ -1,6 +1,8 @@
 from Standard.Base import all
 
 from Standard.Table import Table, Column
+import Standard.Table
+
 import Standard.Visualization.Helpers
 from Standard.Base.Data.Index_Sub_Range import Sample
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/Imports.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/Imports.scala
@@ -52,6 +52,7 @@ case object Imports extends IRPass {
                 name = newName.copy(parts = parts :+ mainModuleName),
                 rename = computeRename(
                   i.rename,
+                  i.onlyNames.nonEmpty,
                   parts(1).asInstanceOf[IR.Name.Literal]
                 )
               )
@@ -75,6 +76,7 @@ case object Imports extends IRPass {
                 name = newName.copy(parts = parts :+ mainModuleName),
                 rename = computeRename(
                   ex.rename,
+                  ex.onlyNames.nonEmpty,
                   parts(1).asInstanceOf[IR.Name.Literal]
                 )
               )
@@ -113,8 +115,10 @@ case object Imports extends IRPass {
 
   private def computeRename(
     originalRename: Option[IR.Name.Literal],
+    onlyNames: Boolean,
     qualName: IR.Name.Literal
-  ): Some[IR.Name.Literal] = Some(originalRename.getOrElse(qualName))
+  ): Option[IR.Name.Literal] =
+    originalRename.orElse(Option.unless(onlyNames)(qualName))
 
   val currentProjectAlias = "project"
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/Imports.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/Imports.scala
@@ -52,7 +52,7 @@ case object Imports extends IRPass {
                 name = newName.copy(parts = parts :+ mainModuleName),
                 rename = computeRename(
                   i.rename,
-                  i.onlyNames.nonEmpty,
+                  i.onlyNames.nonEmpty || i.isAll,
                   parts(1).asInstanceOf[IR.Name.Literal]
                 )
               )
@@ -76,7 +76,7 @@ case object Imports extends IRPass {
                 name = newName.copy(parts = parts :+ mainModuleName),
                 rename = computeRename(
                   ex.rename,
-                  ex.onlyNames.nonEmpty,
+                  ex.onlyNames.nonEmpty || ex.isAll,
                   parts(1).asInstanceOf[IR.Name.Literal]
                 )
               )
@@ -115,10 +115,10 @@ case object Imports extends IRPass {
 
   private def computeRename(
     originalRename: Option[IR.Name.Literal],
-    onlyNames: Boolean,
+    onlyNamesOrAll: Boolean,
     qualName: IR.Name.Literal
   ): Option[IR.Name.Literal] =
-    originalRename.orElse(Option.unless(onlyNames)(qualName))
+    originalRename.orElse(Option.unless(onlyNamesOrAll)(qualName))
 
   val currentProjectAlias = "project"
 

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/ImportsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/ImportsTest.scala
@@ -52,32 +52,36 @@ class ImportsTest extends CompilerTest {
         |import Bar.Foo
         |import Bar.Foo as Bar
         |from Bar.Foo import Bar, Baz
-        |from Bar.Foo as Bar import Baz, Spam
+        |from Bar.Foo as Bar import Bar, Spam
+        |from Bar.Foo import all
         |
         |export Bar.Foo
         |export Bar.Foo as Bar
         |from Bar.Foo export Bar, Baz
-        |from Bar.Foo as Bar export all
+        |from Bar.Foo as Bar export Bar, Baz
+        |from Bar.Foo export all
         |
         |import Foo.Bar.Baz
         |export Foo.Bar.Baz
         |""".stripMargin.preprocessModule.analyse
 
     "desugar project name imports correctly" in {
-      ir.imports.take(4).map(_.showCode()) shouldEqual List(
+      ir.imports.take(5).map(_.showCode()) shouldEqual List(
         "import Bar.Foo.Main as Foo",
         "import Bar.Foo.Main as Bar",
         "from Bar.Foo.Main import Bar, Baz",
-        "from Bar.Foo.Main as Bar import Baz, Spam"
+        "from Bar.Foo.Main as Bar import Bar, Spam",
+        "from Bar.Foo.Main import all"
       )
     }
 
     "desugar project name exports correctly" in {
-      ir.exports.take(4).map(_.showCode()) shouldEqual List(
+      ir.exports.take(5).map(_.showCode()) shouldEqual List(
         "export Bar.Foo.Main as Foo",
         "export Bar.Foo.Main as Bar",
         "from Bar.Foo.Main export Bar, Baz",
-        "from Bar.Foo.Main as Bar export all"
+        "from Bar.Foo.Main as Bar export Bar, Baz",
+        "from Bar.Foo.Main export all"
       )
     }
 

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/ImportsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/ImportsTest.scala
@@ -67,7 +67,7 @@ class ImportsTest extends CompilerTest {
       ir.imports.take(4).map(_.showCode()) shouldEqual List(
         "import Bar.Foo.Main as Foo",
         "import Bar.Foo.Main as Bar",
-        "from Bar.Foo.Main as Foo import Bar, Baz",
+        "from Bar.Foo.Main import Bar, Baz",
         "from Bar.Foo.Main as Bar import Baz, Spam"
       )
     }
@@ -76,7 +76,7 @@ class ImportsTest extends CompilerTest {
       ir.exports.take(4).map(_.showCode()) shouldEqual List(
         "export Bar.Foo.Main as Foo",
         "export Bar.Foo.Main as Bar",
-        "from Bar.Foo.Main as Foo export Bar, Baz",
+        "from Bar.Foo.Main export Bar, Baz",
         "from Bar.Foo.Main as Bar export all"
       )
     }

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -8,6 +8,7 @@ import Standard.Table as Materialized_Table
 from Standard.Table.Data.Aggregate_Column import all hiding First
 
 from Standard.Database import all
+import Standard.Database
 from Standard.Database.Errors import Sql_Error
 from Standard.Database.Data.Sql import Sql_Type
 from Standard.Database.Internal.Postgres.Pgpass import Pgpass_Entry_Data

--- a/test/Table_Tests/src/Database/Redshift_Spec.enso
+++ b/test/Table_Tests/src/Database/Redshift_Spec.enso
@@ -4,6 +4,7 @@ import Standard.Base.Runtime.Ref
 import Standard.Table as Materialized_Table
 
 from Standard.Database import all
+import Standard.Database
 from Standard.Database.Connection.Connection import Sql_Error
 
 import Standard.Test

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -4,6 +4,7 @@ import Standard.Base.Runtime.Ref
 import Standard.Table as Materialized_Table
 
 from Standard.Database import all
+import Standard.Database
 from Standard.Database.Errors import Sql_Error_Data
 
 import Standard.Test

--- a/test/Tests/src/Semantic/Meta_Spec.enso
+++ b/test/Tests/src/Semantic/Meta_Spec.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base
 
 import Standard.Base.System.Platform
 
@@ -84,7 +85,7 @@ spec = Test.group "Meta-Value Manipulation" <|
         _ -> Nothing
     Test.specify "should allow to get the source location of a frame" pending=location_pending <|
         src = Meta.get_source_location 0
-        loc = "Meta_Spec.enso:86:15-40"
+        loc = "Meta_Spec.enso:87:15-40"
         src.take (Last loc.length) . should_equal loc
 
     Test.specify "should allow to get qualified type names of values" <|

--- a/test/Visualization_Tests/src/Geo_Map_Spec.enso
+++ b/test/Visualization_Tests/src/Geo_Map_Spec.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
 
-from Standard.Table import Table
+import Standard.Table
 
 import Standard.Visualization.Geo_Map
 

--- a/test/Visualization_Tests/src/Helpers_Spec.enso
+++ b/test/Visualization_Tests/src/Helpers_Spec.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
 
-from Standard.Table import Table
+import Standard.Table
 
 import Standard.Visualization.Helpers
 

--- a/test/Visualization_Tests/src/Histogram_Spec.enso
+++ b/test/Visualization_Tests/src/Histogram_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Table import Table, Column
+import Standard.Table
 
 import Standard.Visualization.Histogram
 

--- a/test/Visualization_Tests/src/Id_Spec.enso
+++ b/test/Visualization_Tests/src/Id_Spec.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base
 
 import Standard.Visualization
 

--- a/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
+++ b/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Table import Table, Column
+import Standard.Table
 
 import Standard.Visualization.Scatter_Plot
 

--- a/test/Visualization_Tests/src/Sql_Spec.enso
+++ b/test/Visualization_Tests/src/Sql_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Database import all
+import Standard.Database
 
 import Standard.Visualization.Sql.Visualization as Visualization
 

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 from Standard.Table import Table, Aggregate_Column
 
 from Standard.Database import all
+import Standard.Database
 import Standard.Database.Data.Table as Database_Table
 
 import Standard.Visualization.Table.Visualization as Visualization

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -1,8 +1,9 @@
 from Standard.Base import all
 
 from Standard.Table import Table, Aggregate_Column
+import Standard.Table
 
-from Standard.Database import all
+from Standard.Database import SQLite_Data
 import Standard.Database
 import Standard.Database.Data.Table as Database_Table
 


### PR DESCRIPTION
### Pull Request Description

Turns that if you import a two-part import we had special code that would a) add Main submodule b) add an explicit rename.

b) is problematic because sometimes we only want to import specific names.
E.g.,
```
from Bar.Foo import Bar, Baz
```
would be translated to
```
from Bar.Foo.Main as Foo import Bar, Baz
```
and it should only be translated to
```
from Bar.Foo.Main import Bar, Baz
```

This change detects this scenario and does not add renames in that case.

Fixes [183276486](https://www.pivotaltracker.com/story/show/183276486).

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
