### PR TITLE
Use ArraySlice to slice a Vector

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -655,15 +655,7 @@ type Vector a
 
              [1, 2, 3, 4, 5, 6, 7, 8].slice 2 5 == [3, 4, 5]
     slice : Integer -> Integer -> Vector Any
-    slice self start end =
-        slice_start = Math.max 0 start
-        slice_end = Math.min self.length end
-        if slice_start >= slice_end then [] else
-            if (slice_start == 0) && (slice_end == self.length) then self else
-                Vector.from_polyglot_array (self.slice_builtin slice_start slice_end)
-
-    ## PRIVATE
-    slice_builtin self start end = @Builtin_Method "Vector.slice_builtin"
+    slice self start end = @Builtin_Method "Vector.slice_builtin"
 
     ## Creates a new vector with only the specified range of elements from the
        input, removing any elements outside the range.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -655,7 +655,7 @@ type Vector a
 
              [1, 2, 3, 4, 5, 6, 7, 8].slice 2 5 == [3, 4, 5]
     slice : Integer -> Integer -> Vector Any
-    slice self start end = @Builtin_Method "Vector.slice_builtin"
+    slice self start end = @Builtin_Method "Vector.slice"
 
     ## Creates a new vector with only the specified range of elements from the
        input, removing any elements outside the range.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -660,10 +660,10 @@ type Vector a
         slice_end = Math.min self.length end
         if slice_start >= slice_end then [] else
             if (slice_start == 0) && (slice_end == self.length) then self else
-                len = slice_end - slice_start
-                arr = Array.new len
-                Array.copy self.to_array slice_start arr 0 len
-                Vector.from_polyglot_array arr
+                Vector.from_polyglot_array (self.slice_builtin slice_start slice_end)
+
+    ## PRIVATE
+    slice_builtin self start end = @Builtin_Method "Vector.slice_builtin"
 
     ## Creates a new vector with only the specified range of elements from the
        input, removing any elements outside the range.

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/VectorBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/VectorBenchmarks.java
@@ -67,6 +67,7 @@ public class VectorBenchmarks {
       "\n" +
       "to_vector arr = Vector.from_polyglot_array arr\n" +
       "to_array vec = vec.to_array\n" +
+      "slice vec = vec.slice\n" +
       "\n");
 
     this.self = module.invokeMember("get_associated_type");
@@ -81,7 +82,7 @@ public class VectorBenchmarks {
         break;
       }
       case "averageOverSlice": {
-        this.arrayOfFibNumbers = getMethod.apply("slice").execute(self, arr, 10, length);
+        this.arrayOfFibNumbers = getMethod.apply("slice").execute(self, arr, 1, length);
         break;
       }
       case "averageOverArray": {
@@ -143,7 +144,8 @@ public class VectorBenchmarks {
       throw new AssertionError("Shall be a double: " + average);
     }
     var result = (long) average.asDouble();
-    if (result < 1019950590 || result > 1019950600) {
+    boolean isResultCorrect = (result >= 1019950590 && result <= 1019950600) || (result >= 1020971561 && result <= 1020971571);
+    if (!isResultCorrect) {
       throw new AssertionError("Expecting reasonable average but was " + result + "\n" + arrayOfFibNumbers);
     }
     matter.consume(result);

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/VectorBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/VectorBenchmarks.java
@@ -72,11 +72,16 @@ public class VectorBenchmarks {
     this.self = module.invokeMember("get_associated_type");
     Function<String,Value> getMethod = (name) -> module.invokeMember("get_method", self, name);
 
-    Value arr = getMethod.apply("fibarr").execute(self, 1000, Integer.MAX_VALUE);
+    var length = 1000;
+    Value arr = getMethod.apply("fibarr").execute(self, length, Integer.MAX_VALUE);
 
     switch (params.getBenchmark().replaceFirst(".*\\.", "")) {
       case "averageOverVector": {
         this.arrayOfFibNumbers = arr;
+        break;
+      }
+      case "averageOverSlice": {
+        this.arrayOfFibNumbers = getMethod.apply("slice").execute(self, arr, 10, length);
         break;
       }
       case "averageOverArray": {
@@ -109,6 +114,11 @@ public class VectorBenchmarks {
 
   @Benchmark
   public void averageOverVector(Blackhole matter) {
+    performBenchmark(matter);
+  }
+
+  @Benchmark
+  public void averageOverSlice(Blackhole matter) {
     performBenchmark(matter);
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArraySlice.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArraySlice.java
@@ -1,0 +1,113 @@
+package org.enso.interpreter.runtime.data;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.interop.*;
+import com.oracle.truffle.api.library.CachedLibrary;
+import com.oracle.truffle.api.library.ExportLibrary;
+import com.oracle.truffle.api.library.ExportMessage;
+import org.enso.interpreter.node.expression.builtin.interop.syntax.HostValueToEnsoNode;
+
+@ExportLibrary(InteropLibrary.class)
+public class ArraySlice implements TruffleObject {
+  private final Object storage;
+  private final long start;
+  private final long length;
+
+  public ArraySlice(Object storage, long start, long length) {
+    if (storage instanceof ArraySlice slice) {
+      this.storage = slice.storage;
+      this.start = slice.start + start;
+      this.length = length;
+    } else {
+      if (CompilerDirectives.inInterpreter()) {
+        if (!InteropLibrary.getUncached().hasArrayElements(storage)) {
+          throw new IllegalStateException("Vector needs array-like delegate, but got: " + storage);
+        }
+      }
+
+      this.storage = storage;
+      this.start = start;
+      this.length = length;
+    }
+  }
+
+  /**
+   * Marks the object as array-like for Polyglot APIs.
+   *
+   * @return {@code true}
+   */
+  @ExportMessage
+  public boolean hasArrayElements() {
+    return true;
+  }
+
+  @ExportMessage
+  public long getArraySize(@CachedLibrary(limit = "3") InteropLibrary interop)
+      throws UnsupportedMessageException {
+    long storageSize = interop.getArraySize(storage);
+    return Math.min(storageSize - start, length);
+  }
+
+  /**
+   * Handles reading an element by index through the polyglot API.
+   *
+   * @param index the index to read
+   * @return the element value at the provided index
+   * @throws InvalidArrayIndexException when the index is out of bounds.
+   */
+  @ExportMessage
+  public Object readArrayElement(
+      long index,
+      @CachedLibrary(limit = "3") InteropLibrary interop,
+      @Cached HostValueToEnsoNode toEnso)
+      throws InvalidArrayIndexException, UnsupportedMessageException {
+    if (index < 0 || index >= length) {
+      throw InvalidArrayIndexException.create(index);
+    }
+
+    var v = interop.readArrayElement(storage, start + index);
+    return toEnso.execute(v);
+  }
+
+  /**
+   * Exposes an index validity check through the polyglot API.
+   *
+   * @param index the index to check
+   * @return {@code true} if the index is valid, {@code false} otherwise.
+   */
+  @ExportMessage
+  boolean isArrayElementReadable(long index, @CachedLibrary(limit = "3") InteropLibrary interop) {
+    try {
+      return index >= 0 && index < getArraySize(interop);
+    } catch (UnsupportedMessageException e) {
+      return false;
+    }
+  }
+
+  @ExportMessage
+  boolean isArrayElementModifiable(long index) {
+    return false;
+  }
+
+  @ExportMessage
+  final void writeArrayElement(long index, Object value)
+      throws UnsupportedMessageException {
+    throw UnsupportedMessageException.create();
+  }
+
+  @ExportMessage
+  boolean isArrayElementInsertable(long index) {
+    return false;
+  }
+
+  @ExportMessage
+  boolean isArrayElementRemovable(long index) {
+    return false;
+  }
+
+  @ExportMessage
+  final void removeArrayElement(long index) throws UnsupportedMessageException {
+    throw UnsupportedMessageException.create();
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
@@ -63,9 +63,7 @@ public final class Vector implements TruffleObject {
     return this.storage;
   }
 
-  @Builtin.Method(
-      name = "slice_builtin",
-      description = "Returns a slice of this Vector.")
+  @Builtin.Method(name = "slice_builtin", description = "Returns a slice of this Vector.")
   public final ArraySlice slice(long start, long end) {
     return new ArraySlice(this.storage, start, end);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
@@ -64,6 +64,7 @@ public final class Vector implements TruffleObject {
   }
 
   @Builtin.Method(name = "slice", description = "Returns a slice of this Vector.")
+  @Builtin.Specialize
   @Builtin.WrapException(from = UnsupportedMessageException.class, to = PanicException.class)
   public final Vector slice(long start, long end, InteropLibrary interop)
       throws UnsupportedMessageException {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
@@ -13,12 +13,8 @@ import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.enso.interpreter.dsl.Builtin;
-import org.enso.interpreter.node.expression.builtin.error.PolyglotError;
 import org.enso.interpreter.node.expression.builtin.interop.syntax.HostValueToEnsoNode;
-import org.enso.interpreter.node.expression.builtin.interop.syntax.HostValueToEnsoNodeGen;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.error.DataflowError;
@@ -65,6 +61,13 @@ public final class Vector implements TruffleObject {
       description = "Returns an Array representation of this Vector.")
   public final Object toArray() {
     return this.storage;
+  }
+
+  @Builtin.Method(
+      name = "slice_builtin",
+      description = "Returns a slice of this Vector.")
+  public final ArraySlice slice(long start, long end) {
+    return new ArraySlice(this.storage, start, end);
   }
 
   @Builtin.Method(description = "Returns the length of this Vector.")

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
@@ -63,9 +63,25 @@ public final class Vector implements TruffleObject {
     return this.storage;
   }
 
-  @Builtin.Method(name = "slice_builtin", description = "Returns a slice of this Vector.")
-  public final ArraySlice slice(long start, long end) {
-    return new ArraySlice(this.storage, start, end);
+  @Builtin.Method(name = "slice", description = "Returns a slice of this Vector.")
+  @Builtin.WrapException(from = UnsupportedMessageException.class, to = PanicException.class)
+  public final Vector slice(
+      long start,
+      long end,
+      InteropLibrary interop) throws UnsupportedMessageException {
+    long this_length = length(interop);
+    long slice_start = Math.max(0, start);
+    long slice_end = Math.min(this_length, end);
+
+    if (slice_start >= slice_end) {
+      return new Vector(new Array(0));
+    }
+
+    if ((slice_start == 0) && (slice_end == this_length)) {
+      return this;
+    }
+
+    return new Vector(new ArraySlice(this.storage, slice_start, slice_end));
   }
 
   @Builtin.Method(description = "Returns the length of this Vector.")

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
@@ -65,10 +65,8 @@ public final class Vector implements TruffleObject {
 
   @Builtin.Method(name = "slice", description = "Returns a slice of this Vector.")
   @Builtin.WrapException(from = UnsupportedMessageException.class, to = PanicException.class)
-  public final Vector slice(
-      long start,
-      long end,
-      InteropLibrary interop) throws UnsupportedMessageException {
+  public final Vector slice(long start, long end, InteropLibrary interop)
+      throws UnsupportedMessageException {
     long this_length = length(interop);
     long slice_start = Math.max(0, start);
     long slice_end = Math.min(this_length, end);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/type/Types.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/type/Types.java
@@ -42,7 +42,6 @@ import org.enso.polyglot.data.TypeGraph;
   UnresolvedSymbol.class,
   Array.class,
   ArrayOverBuffer.class,
-  ArraySlice.class,
   EnsoBigInteger.class,
   ManagedResource.class,
   ModuleScope.class,

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/type/Types.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/type/Types.java
@@ -42,6 +42,7 @@ import org.enso.polyglot.data.TypeGraph;
   UnresolvedSymbol.class,
   Array.class,
   ArrayOverBuffer.class,
+  ArraySlice.class,
   EnsoBigInteger.class,
   ManagedResource.class,
   ModuleScope.class,
@@ -58,7 +59,7 @@ import org.enso.polyglot.data.TypeGraph;
 })
 public class Types {
 
-  private static TypeGraph typeHierarchy = buildTypeHierarchy();
+  private static final TypeGraph typeHierarchy = buildTypeHierarchy();
 
   /**
    * A simple pair type
@@ -67,8 +68,8 @@ public class Types {
    * @param <B> the type of the second element
    */
   public static class Pair<A, B> {
-    private A first;
-    private B second;
+    private final A first;
+    private final B second;
 
     private Pair(A first, B second) {
       this.first = first;

--- a/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/builtins/TypeWithKind.java
+++ b/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/builtins/TypeWithKind.java
@@ -2,6 +2,7 @@ package org.enso.interpreter.dsl.builtins;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * TypeWithKind provides a convenience wrapper for the types that can be encountered
@@ -30,19 +31,20 @@ public record TypeWithKind(String baseType, TypeKind kind) {
     }
 
     private final static List<String> primitiveTypes =
-            List.of(Boolean.TYPE, Long.TYPE, Double.TYPE, Float.TYPE).stream().map(Class::getSimpleName).collect(Collectors.toList());
+            Stream.of(Boolean.TYPE, Long.TYPE, Double.TYPE, Float.TYPE).map(Class::getSimpleName).collect(Collectors.toList());
     /**
      * A list of hard-coded types that can be used in the parameter or return type position
      * that are valid host types i.e extend TruffleObject.
      * Cannot go via reflection and check that they implement the interface, unfortunately.
      */
-    private static List<String> validGuestTypes =
+    private final static List<String> validGuestTypes =
             List.of(
                     "org.enso.interpreter.runtime.callable.atom.Atom",
                     "org.enso.interpreter.runtime.callable.function.Function",
                     "org.enso.interpreter.runtime.data.Array",
                     "org.enso.interpreter.runtime.data.Vector",
                     "org.enso.interpreter.runtime.data.ArrayOverBuffer",
+                    "org.enso.interpreter.runtime.data.ArraySlice",
                     "org.enso.interpreter.runtime.data.EnsoFile",
                     "org.enso.interpreter.runtime.data.EnsoDate",
                     "org.enso.interpreter.runtime.data.EnsoDateTime",

--- a/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/builtins/TypeWithKind.java
+++ b/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/builtins/TypeWithKind.java
@@ -44,7 +44,6 @@ public record TypeWithKind(String baseType, TypeKind kind) {
                     "org.enso.interpreter.runtime.data.Array",
                     "org.enso.interpreter.runtime.data.Vector",
                     "org.enso.interpreter.runtime.data.ArrayOverBuffer",
-                    "org.enso.interpreter.runtime.data.ArraySlice",
                     "org.enso.interpreter.runtime.data.EnsoFile",
                     "org.enso.interpreter.runtime.data.EnsoDate",
                     "org.enso.interpreter.runtime.data.EnsoDateTime",

--- a/test/Benchmarks/src/Vector.enso
+++ b/test/Benchmarks/src/Vector.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base
 
 import Standard.Test.Bench
 

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -212,6 +212,15 @@ spec = Test.group "Vectors" <|
         concat = [1, 2, 3] + [4, 5, 6]
         concat.should_equal [1, 2, 3, 4, 5, 6]
 
+    Test.specify "Vector slice should return a Vector" <|
+        vec = [1, 2, 3, 4, 5, 6]
+        vec.slice 0 3 . should_equal [1, 2, 3]
+        vec.slice 1 3 . should_equal [2, 3, 4]
+        vec.slice 1 1 . should_equal []
+        vec.slice 0 100 . should_equal [1, 2, 3, 4, 5, 6]
+        Meta.is_same_object vec (vec.slice 0 100) . should_be_true
+        Meta.get_qualified_type_name vec . should_equal (Meta.get_qualified_type_name (vec.slice 1 1))
+
     Test.specify "should define take and drop family of operations" <|
         vec = [1, 2, 3, 4, 5, 6]
         first_four = [1, 2, 3, 4]

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -215,7 +215,7 @@ spec = Test.group "Vectors" <|
     Test.specify "Vector slice should return a Vector" <|
         vec = [1, 2, 3, 4, 5, 6]
         vec.slice 0 3 . should_equal [1, 2, 3]
-        vec.slice 1 3 . should_equal [2, 3, 4]
+        vec.slice 1 3 . should_equal [2, 3]
         vec.slice 1 1 . should_equal []
         vec.slice 0 100 . should_equal [1, 2, 3, 4, 5, 6]
         Meta.is_same_object vec (vec.slice 0 100) . should_be_true


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

Use an `ArraySlice` to slice `Vector`.
Avoids memory copying for the slice function.

### Important Notes
| Test | Ref | New |
| --- | --- | --- |
| New Vector | 71.9 | 71.0 |
| Append Single | 26.0 | 27.7 |
| Append Large | 15.1 | 14.9 |
| Sum | 156.4 | 165.8 |
| Drop First 20 and Sum | 171.2 | 165.3 |
| Drop Last 20 and Sum | 170.7 | 163.0 |
| Filter | 76.9 | 76.9 |
| Filter With Index | 166.3 | 168.3 |
| Partition | 278.5 | 273.8 |
| Partition With Index | 392.0 | 393.7 |
| Each | 101.9 | 102.7 |

- Note: the performance of New and Append has got slower from previous tests.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
