### PR TITLE
Unique job for visualizations

### DIFF
--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -1791,9 +1791,9 @@ class RuntimeVisualizationsTest
     context.send(
       Api.Request(requestId, Api.PushContextRequest(contextId, item1))
     )
-    val responses = context.receiveN(n = 5, timeoutSeconds = 60)
+    val responses = context.receiveNIgnoreStdLib(n = 3)
 
-    responses should contain allOf (
+    responses should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       TestMessages.error(
         contextId,
@@ -1802,12 +1802,6 @@ class RuntimeVisualizationsTest
       ),
       context.executionComplete(contextId)
     )
-
-    val loadedLibraries = responses.collect {
-      case Api.Response(None, Api.LibraryLoaded(namespace, name, _, _)) =>
-        (namespace, name)
-    }
-    loadedLibraries should contain(("Standard", "Base"))
 
     // attach visualisation
     context.send(
@@ -1826,7 +1820,7 @@ class RuntimeVisualizationsTest
         )
       )
     )
-    val attachVisualisationResponses = context.receiveN(5)
+    val attachVisualisationResponses = context.receiveN(4, timeoutSeconds = 60)
     attachVisualisationResponses should contain allOf (
       Api.Response(requestId, Api.VisualisationAttached()),
       context.executionComplete(contextId)

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/Job.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/Job.scala
@@ -25,5 +25,19 @@ abstract class Job[+A](
   def run(implicit ctx: RuntimeContext): A
 
   override def toString: String = this.getClass.getSimpleName
-
 }
+
+/** The job queue can contain only one job of this type with the same `key`.
+  * When a job of this type is added to the job queue, previous duplicate jobs
+  * are cancelled.
+  *
+  * @param key a unique job key
+  * @param contextIds affected executions contests' ids
+  * @param mayInterruptIfRunning determines if the job may be interruptd when
+  *                              running
+  */
+abstract class UniqueJob[+A](
+  val key: UUID,
+  contextIds: List[UUID],
+  mayInterruptIfRunning: Boolean
+) extends Job[A](contextIds, isCancellable = false, mayInterruptIfRunning)

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualisationJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualisationJob.scala
@@ -37,9 +37,9 @@ class UpsertVisualisationJob(
   visualisationId: VisualisationId,
   expressionId: ExpressionId,
   config: Api.VisualisationConfiguration
-) extends Job[Option[Executable]](
+) extends UniqueJob[Option[Executable]](
+      expressionId,
       List(config.executionContextId),
-      false,
       false
     ) {
 


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

PR adds special kind of jobs for visualizations. It should
- prevent cancelling visualization jobs when the program is re-executed (resulting in the fact that visualization is not showing up)
- omit unnecessary executions of visualization jobs (the case when the user goes through menu items in the component browser)

I skipped the tests because testing of the last scenario involves indeterminism. I.e. when preparing the test, we can't control which of submitted visualization jobs will be actually executed, and which will be cancelled.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [ ] ~Unit tests have been written where possible.~
  - [ ] ~If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.~
