### PR TITLE
Adding a shorthand for the Table API until widgets available

### DIFF
--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -102,7 +102,7 @@ type Table
        dropped from the output.
 
        Arguments:
-       - columns: Column selection criteria.
+       - columns: Column selection criteria or vector of column names.
        - reorder: By default, or if set to `False`, columns in the output will
          be in the same order as in the input table. If `True`, the order in the
          output table will match the order in the columns list.
@@ -125,10 +125,10 @@ type Table
 
              table.select_columns (By_Name ["bar", "foo"])
 
-       ## TODO [RW] default arguments do not work on atoms, once this is fixed,
-          the above should be replaced with just `By_Name`.
-          See: https://github.com/enso-org/enso/issues/1600
+       > Example
+         Select columns using names passed as a Vector.
 
+             table.select_columns ["bar", "foo"]
 
        > Example
          Select columns matching a regular expression.
@@ -146,7 +146,7 @@ type Table
              table.select_columns (By_Column [column1, column2])
 
        Icon: select_column
-    select_columns : Column_Selector -> Boolean -> Problem_Behavior -> Table
+    select_columns : Vector | Column_Selector -> Boolean -> Problem_Behavior -> Table
     select_columns self (columns = By_Index [0]) (reorder = False) (on_problems = Report_Warning) =
         new_columns = Table_Helpers.select_columns internal_columns=self.internal_columns selector=columns reorder=reorder on_problems=on_problems
         self.updated_columns new_columns
@@ -157,7 +157,7 @@ type Table
        input.
 
        Arguments:
-       - columns: Criteria specifying which columns should be removed.
+       - columns: Column selection criteria or vector of column names to remove.
        - on_problems: Specifies how to handle problems if they occur, reporting
          them as warnings by default.
 
@@ -177,9 +177,10 @@ type Table
 
              table.remove_columns (By_Name ["bar", "foo"])
 
-       ## TODO [RW] default arguments do not work on atoms, once this is fixed,
-          the above should be replaced with just `By_Name`.
-          See: https://github.com/enso-org/enso/issues/1600
+       > Example
+         Remove columns using names passed as a Vector.
+
+             table.remove_columns ["bar", "foo"]
 
        > Example
          Remove columns matching a regular expression.
@@ -195,7 +196,7 @@ type Table
          Remove columns with the same names as the ones provided.
 
              table.remove_columns (By_Column [column1, column2])
-    remove_columns : Column_Selector -> Problem_Behavior -> Table
+    remove_columns : Vector | Column_Selector -> Problem_Behavior -> Table
     remove_columns self (columns = By_Index [0]) (on_problems = Report_Warning) =
         new_columns = Table_Helpers.remove_columns internal_columns=self.internal_columns selector=columns on_problems=on_problems
         self.updated_columns new_columns
@@ -226,9 +227,10 @@ type Table
 
              table.reorder_columns (By_Name ["foo"]) position=After_Other_Columns
 
-       ## TODO [RW] default arguments do not work on atoms, once this is fixed,
-          the above should be replaced with just `By_Name`.
-          See: https://github.com/enso-org/enso/issues/1600
+       > Example
+         Move columns using names passed as a Vector.
+
+             table.reorder_columns ["bar", "foo"] position=After_Other_Columns
 
        > Example
          Move columns matching a regular expression to front, keeping columns matching "foo.+" before columns matching "b.*".
@@ -249,7 +251,7 @@ type Table
          Move the columns with names matching the provided columns to the front.
 
              table.reorder_columns (By_Column [column1, column2])
-    reorder_columns : Column_Selector -> Position.Position -> Problem_Behavior -> Table
+    reorder_columns : Vector | Column_Selector -> Position.Position -> Problem_Behavior -> Table
     reorder_columns self (columns = By_Index [0]) (position = Position.Before_Other_Columns) (on_problems = Report_Warning) =
         new_columns = Table_Helpers.reorder_columns internal_columns=self.internal_columns selector=columns position=position on_problems=on_problems
         self.updated_columns new_columns
@@ -304,12 +306,15 @@ type Table
            other, a Duplicate_Output_Column_Names.
 
        > Example
-    rename_columns : Column_Name_Mapping -> Problem_Behavior -> Table
-    rename_columns self (column_map=(Column_Name_Mapping.By_Position ["Column"])) (on_problems=Report_Warning) =
-        new_names = Table_Helpers.rename_columns internal_columns=self.internal_columns mapping=column_map on_problems=on_problems
-        if new_names.is_error then new_names else
-            new_columns = self.internal_columns.map_with_index i->c->(c.rename (new_names.at i))
-            self.updated_columns new_columns
+    rename_columns : Vector | Column_Name_Mapping -> Problem_Behavior -> Table
+    rename_columns self (column_map=(Column_Name_Mapping.By_Position ["Column"])) (on_problems=Report_Warning) = case column_map of
+        Vector.Vector ->
+            self.rename_columns (Column_Name_Mapping.By_Position column_map) on_problems
+        _ ->
+            new_names = Table_Helpers.rename_columns internal_columns=self.internal_columns mapping=column_map on_problems=on_problems
+            if new_names.is_error then new_names else
+                new_columns = self.internal_columns.map_with_index i->c->(c.rename (new_names.at i))
+                self.updated_columns new_columns
 
     ## PRIVATE
 
@@ -572,7 +577,7 @@ type Table
          - If no valid columns are selected, a `No_Input_Columns_Selected`.
          - If floating points values are present in the distinct columns, a
            `Floating_Point_Grouping` warning.
-    distinct : Column_Selector -> Case_Sensitivity -> Problem_Behavior -> Table
+    distinct : Vector | Column_Selector -> Case_Sensitivity -> Problem_Behavior -> Table
     distinct self (columns = By_Name (self.columns.map .name)) case_sensitivity=Case_Sensitivity.Sensitive on_problems=Report_Warning =
         _ = [columns, case_sensitivity, on_problems]
         Error.throw (Unsupported_Database_Operation_Error_Data "`Table.distinct` is not yet implemented for the database backend.")

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -534,7 +534,7 @@ type Table
          descending order.
 
              table.order_by (Sort_Column_Selector.By_Index [1, Sort_Column.Index -7 Sort_Direction.Descending])
-    order_by : Sort_Column_Selector -> Text_Ordering -> Problem_Behavior -> Table ! Incomparable_Values_Error
+    order_by : Vector | Sort_Column_Selector -> Text_Ordering -> Problem_Behavior -> Table ! Incomparable_Values_Error
     order_by self (columns = (Sort_Column_Selector.By_Name [(Sort_Column.Name (self.columns.at 0 . name))])) text_ordering=Text_Ordering.Default on_problems=Report_Warning = Panic.handle_wrapped_dataflow_error <|
         problem_builder = Problem_Builder.new
         columns_for_ordering = Table_Helpers.prepare_order_by self.columns columns problem_builder

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -317,7 +317,7 @@ type Table
               table.rename_columns ["FirstColumn"]
     rename_columns : Vector Text | Column_Name_Mapping -> Problem_Behavior -> Table
     rename_columns self (column_map=(Column_Name_Mapping.By_Position ["Column"])) (on_problems=Report_Warning) = case column_map of
-        Vector.Vector ->
+        _ : Vector.Vector ->
             self.rename_columns (Column_Name_Mapping.By_Position column_map) on_problems
         _ ->
             new_names = Table_Helpers.rename_columns internal_columns=self.internal_columns mapping=column_map on_problems=on_problems

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -146,7 +146,7 @@ type Table
              table.select_columns (By_Column [column1, column2])
 
        Icon: select_column
-    select_columns : Vector | Column_Selector -> Boolean -> Problem_Behavior -> Table
+    select_columns : Vector Text | Column_Selector -> Boolean -> Problem_Behavior -> Table
     select_columns self (columns = By_Index [0]) (reorder = False) (on_problems = Report_Warning) =
         new_columns = Table_Helpers.select_columns internal_columns=self.internal_columns selector=columns reorder=reorder on_problems=on_problems
         self.updated_columns new_columns
@@ -196,7 +196,7 @@ type Table
          Remove columns with the same names as the ones provided.
 
              table.remove_columns (By_Column [column1, column2])
-    remove_columns : Vector | Column_Selector -> Problem_Behavior -> Table
+    remove_columns : Vector Text | Column_Selector -> Problem_Behavior -> Table
     remove_columns self (columns = By_Index [0]) (on_problems = Report_Warning) =
         new_columns = Table_Helpers.remove_columns internal_columns=self.internal_columns selector=columns on_problems=on_problems
         self.updated_columns new_columns
@@ -251,7 +251,7 @@ type Table
          Move the columns with names matching the provided columns to the front.
 
              table.reorder_columns (By_Column [column1, column2])
-    reorder_columns : Vector | Column_Selector -> Position.Position -> Problem_Behavior -> Table
+    reorder_columns : Vector Text | Column_Selector -> Position.Position -> Problem_Behavior -> Table
     reorder_columns self (columns = By_Index [0]) (position = Position.Before_Other_Columns) (on_problems = Report_Warning) =
         new_columns = Table_Helpers.reorder_columns internal_columns=self.internal_columns selector=columns position=position on_problems=on_problems
         self.updated_columns new_columns
@@ -287,7 +287,8 @@ type Table
        from the old name to the new or a positional list of new names.
 
        Arguments:
-       - column_map: Mapping from old column names to new.
+       - column_map: Mapping from old column names to new or a vector of new
+         column names to apply by position.
        - on_problems: Specifies how to handle problems if they occur, reporting
          them as warnings by default.
 
@@ -306,7 +307,15 @@ type Table
            other, a Duplicate_Output_Column_Names.
 
        > Example
-    rename_columns : Vector | Column_Name_Mapping -> Problem_Behavior -> Table
+         Rename the first column to "FirstColumn"
+
+              table.rename_columns (Column_Name_Mapping.By_Position ["FirstColumn"])
+
+       > Example
+         Rename the first column to "FirstColumn" passed as a Vector
+
+              table.rename_columns ["FirstColumn"]
+    rename_columns : Vector Text | Column_Name_Mapping -> Problem_Behavior -> Table
     rename_columns self (column_map=(Column_Name_Mapping.By_Position ["Column"])) (on_problems=Report_Warning) = case column_map of
         Vector.Vector ->
             self.rename_columns (Column_Name_Mapping.By_Position column_map) on_problems
@@ -520,7 +529,7 @@ type Table
          Sorting `table` in ascending order by the value in column `'Quantity'`,
          using the value in column `'Rating'` for breaking ties.
 
-             table.order_by (Sort_Column_Selector.By_Name ['Quantity', 'Rating'])
+             table.order_by ['Quantity', 'Rating']
 
        > Example
          Sorting `table` in ascending order by the value in column `'Quantity'`,
@@ -534,7 +543,7 @@ type Table
          descending order.
 
              table.order_by (Sort_Column_Selector.By_Index [1, Sort_Column.Index -7 Sort_Direction.Descending])
-    order_by : Vector | Sort_Column_Selector -> Text_Ordering -> Problem_Behavior -> Table ! Incomparable_Values_Error
+    order_by : Vector Text | Sort_Column_Selector -> Text_Ordering -> Problem_Behavior -> Table ! Incomparable_Values_Error
     order_by self (columns = (Sort_Column_Selector.By_Name [(Sort_Column.Name (self.columns.at 0 . name))])) text_ordering=Text_Ordering.Default on_problems=Report_Warning = Panic.handle_wrapped_dataflow_error <|
         problem_builder = Problem_Builder.new
         columns_for_ordering = Table_Helpers.prepare_order_by self.columns columns problem_builder
@@ -577,7 +586,7 @@ type Table
          - If no valid columns are selected, a `No_Input_Columns_Selected`.
          - If floating points values are present in the distinct columns, a
            `Floating_Point_Grouping` warning.
-    distinct : Vector | Column_Selector -> Case_Sensitivity -> Problem_Behavior -> Table
+    distinct : Vector Text | Column_Selector -> Case_Sensitivity -> Problem_Behavior -> Table
     distinct self (columns = By_Name (self.columns.map .name)) case_sensitivity=Case_Sensitivity.Sensitive on_problems=Report_Warning =
         _ = [columns, case_sensitivity, on_problems]
         Error.throw (Unsupported_Database_Operation_Error_Data "`Table.distinct` is not yet implemented for the database backend.")

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -279,7 +279,7 @@ type Table
        dropped from the output.
 
        Arguments:
-       - columns: Column selection criteria.
+       - columns: Column selection criteria or vector of column names.
        - reorder: By default, or if set to `False`, columns in the output will
          be in the same order as in the input table. If `True`, the order in the
          output table will match the order in the columns list.
@@ -302,9 +302,10 @@ type Table
 
              table.select_columns (By_Name ["bar", "foo"])
 
-       ## TODO [RW] default arguments do not work on atoms, once this is fixed,
-          the above should be replaced with just `By_Name`.
-          See: https://github.com/enso-org/enso/issues/1600
+       > Example
+         Select columns using names passed as a Vector.
+
+             table.select_columns ["bar", "foo"]
 
        > Example
          Select columns matching a regular expression.
@@ -322,7 +323,7 @@ type Table
              table.select_columns (By_Column [column1, column2])
 
        Icon: select_column
-    select_columns : Column_Selector -> Boolean -> Problem_Behavior -> Table
+    select_columns : Vector | Column_Selector -> Boolean -> Problem_Behavior -> Table
     select_columns self (columns = By_Index [0]) (reorder = False) (on_problems = Report_Warning) =
         new_columns = Table_Helpers.select_columns internal_columns=self.columns selector=columns reorder=reorder on_problems=on_problems
         new new_columns
@@ -333,7 +334,7 @@ type Table
        input.
 
        Arguments:
-       - columns: Criteria specifying which columns should be removed.
+       - columns: Column selection criteria or vector of column names to remove.
        - on_problems: Specifies how to handle problems if they occur, reporting
          them as warnings by default.
 
@@ -353,9 +354,10 @@ type Table
 
              table.remove_columns (By_Name ["bar", "foo"])
 
-       ## TODO [RW] default arguments do not work on atoms, once this is fixed,
-          the above should be replaced with just `By_Name`.
-          See: https://github.com/enso-org/enso/issues/1600
+       > Example
+         Remove columns using names passed as a Vector.
+
+             table.remove_columns ["bar", "foo"]
 
        > Example
          Remove columns matching a regular expression.
@@ -371,7 +373,7 @@ type Table
          Remove columns with the same names as the ones provided.
 
              table.remove_columns (By_Column [column1, column2])
-    remove_columns : Column_Selector -> Problem_Behavior -> Table
+    remove_columns : Vector | Column_Selector -> Problem_Behavior -> Table
     remove_columns self (columns = By_Index [0]) (on_problems = Report_Warning) =
         new_columns = Table_Helpers.remove_columns internal_columns=self.columns selector=columns on_problems=on_problems
         new new_columns
@@ -380,8 +382,8 @@ type Table
        either the start or the end in the specified order.
 
        Arguments:
-       - columns: Criteria specifying which columns should be reordered and
-         specifying their order.
+       - columns: Column selection criteria or vector of column names which
+         should be reordered and specifying their order.
        - position: Specifies how to place the selected columns in relation to
          the remaining columns which were not matched by `columns` (if any).
        - on_problems: Specifies how to handle problems if they occur, reporting
@@ -402,9 +404,10 @@ type Table
 
              table.reorder_columns (By_Name ["foo"]) position=After_Other_Columns
 
-       ## TODO [RW] default arguments do not work on atoms, once this is fixed,
-          the above should be replaced with just `By_Name`.
-          See: https://github.com/enso-org/enso/issues/1600
+       > Example
+         Move columns using names passed as a Vector.
+
+             table.reorder_columns ["bar", "foo"] position=After_Other_Columns
 
        > Example
          Move columns matching a regular expression to front, keeping columns matching "foo.+" before columns matching "b.*".
@@ -425,7 +428,7 @@ type Table
          Move the columns with names matching the provided columns to the front.
 
              table.reorder_columns (By_Column [column1, column2])
-    reorder_columns : Column_Selector -> Position.Position -> Problem_Behavior -> Table
+    reorder_columns : Vector | Column_Selector -> Position.Position -> Problem_Behavior -> Table
     reorder_columns self (columns = By_Index [0]) (position = Position.Before_Other_Columns) (on_problems = Report_Warning) =
         new_columns = Table_Helpers.reorder_columns internal_columns=self.columns selector=columns position=position on_problems=on_problems
         new new_columns
@@ -485,12 +488,15 @@ type Table
          Rename the first column to "FirstColumn"
 
               table.rename_columns (Column_Name_Mapping.By_Position ["FirstColumn"])
-    rename_columns : Column_Name_Mapping -> Problem_Behavior -> Table
-    rename_columns self (column_map=(Column_Name_Mapping.By_Position ["Column"])) (on_problems=Report_Warning) =
-        new_names = Table_Helpers.rename_columns internal_columns=self.columns mapping=column_map on_problems=on_problems
-        if new_names.is_error then new_names else
-            new_columns = self.columns.map_with_index i->c->(c.rename (new_names.at i))
-            new new_columns
+    rename_columns : Vector | Column_Name_Mapping -> Problem_Behavior -> Table
+    rename_columns self (column_map=(Column_Name_Mapping.By_Position ["Column"])) (on_problems=Report_Warning) = case column_map of
+        Vector.Vector ->
+            self.rename_columns (Column_Name_Mapping.By_Position column_map) on_problems
+        _ ->
+            new_names = Table_Helpers.rename_columns internal_columns=self.columns mapping=column_map on_problems=on_problems
+            if new_names.is_error then new_names else
+                new_columns = self.columns.map_with_index i->c->(c.rename (new_names.at i))
+                new new_columns
 
     ## Returns a new table with the columns renamed based on entries in the
        first row.
@@ -689,7 +695,7 @@ type Table
          - If no valid columns are selected, a `No_Input_Columns_Selected`.
          - If floating points values are present in the distinct columns, a
            `Floating_Point_Grouping` warning.
-    distinct : Column_Selector -> Case_Sensitivity -> Problem_Behavior -> Table
+    distinct : Vector | Column_Selector -> Case_Sensitivity -> Problem_Behavior -> Table
     distinct self (columns = By_Name (self.columns.map .name)) case_sensitivity=Case_Sensitivity.Sensitive on_problems=Report_Warning =
         warning_mapper error = case error of
             No_Output_Columns -> Maybe.Some No_Input_Columns_Selected

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -323,7 +323,7 @@ type Table
              table.select_columns (By_Column [column1, column2])
 
        Icon: select_column
-    select_columns : Vector | Column_Selector -> Boolean -> Problem_Behavior -> Table
+    select_columns : Vector Text | Column_Selector -> Boolean -> Problem_Behavior -> Table
     select_columns self (columns = By_Index [0]) (reorder = False) (on_problems = Report_Warning) =
         new_columns = Table_Helpers.select_columns internal_columns=self.columns selector=columns reorder=reorder on_problems=on_problems
         new new_columns
@@ -373,7 +373,7 @@ type Table
          Remove columns with the same names as the ones provided.
 
              table.remove_columns (By_Column [column1, column2])
-    remove_columns : Vector | Column_Selector -> Problem_Behavior -> Table
+    remove_columns : Vector Text | Column_Selector -> Problem_Behavior -> Table
     remove_columns self (columns = By_Index [0]) (on_problems = Report_Warning) =
         new_columns = Table_Helpers.remove_columns internal_columns=self.columns selector=columns on_problems=on_problems
         new new_columns
@@ -428,7 +428,7 @@ type Table
          Move the columns with names matching the provided columns to the front.
 
              table.reorder_columns (By_Column [column1, column2])
-    reorder_columns : Vector | Column_Selector -> Position.Position -> Problem_Behavior -> Table
+    reorder_columns : Vector Text | Column_Selector -> Position.Position -> Problem_Behavior -> Table
     reorder_columns self (columns = By_Index [0]) (position = Position.Before_Other_Columns) (on_problems = Report_Warning) =
         new_columns = Table_Helpers.reorder_columns internal_columns=self.columns selector=columns position=position on_problems=on_problems
         new new_columns
@@ -465,7 +465,8 @@ type Table
        from the old name to the new or a positional list of new names.
 
        Arguments:
-       - column_map: Mapping from old column names to new.
+       - column_map: Mapping from old column names to new or a vector of new
+         column names to apply by position.
        - on_problems: Specifies how to handle problems if they occur, reporting
          them as warnings by default.
 
@@ -488,7 +489,12 @@ type Table
          Rename the first column to "FirstColumn"
 
               table.rename_columns (Column_Name_Mapping.By_Position ["FirstColumn"])
-    rename_columns : Vector | Column_Name_Mapping -> Problem_Behavior -> Table
+
+       > Example
+         Rename the first column to "FirstColumn" passed as a Vector
+
+              table.rename_columns ["FirstColumn"]
+    rename_columns : Vector Text | Column_Name_Mapping -> Problem_Behavior -> Table
     rename_columns self (column_map=(Column_Name_Mapping.By_Position ["Column"])) (on_problems=Report_Warning) = case column_map of
         Vector.Vector ->
             self.rename_columns (Column_Name_Mapping.By_Position column_map) on_problems
@@ -602,7 +608,7 @@ type Table
          Sorting `table` in ascending order by the value in column `'Quantity'`,
          using the value in column `'Rating'` for breaking ties.
 
-             table.order_by (Sort_Column_Selector.By_Name ['Quantity', 'Rating'])
+             table.order_by ['Quantity', 'Rating']
 
        > Example
          Sorting `table` in ascending order by the value in column `'Quantity'`,
@@ -656,7 +662,7 @@ type Table
                  table = Examples.inventory_table
                  table.order_by (Sort_Column_Selector.By_Name ["total_stock", Sort_Column.Name "sold_stock" Sort_Direction.Descending])
 
-    order_by : Vector | Sort_Column_Selector -> Text_Ordering -> Problem_Behavior -> Table ! Incomparable_Values_Error
+    order_by : Vector Text | Sort_Column_Selector -> Text_Ordering -> Problem_Behavior -> Table ! Incomparable_Values_Error
     order_by self (columns = (Sort_Column_Selector.By_Name [(Sort_Column.Name (self.columns.at 0 . name))])) text_ordering=Text_Ordering.Default on_problems=Report_Warning =
         problem_builder = Problem_Builder.new
         columns_for_ordering = Table_Helpers.prepare_order_by self.columns columns problem_builder
@@ -695,7 +701,7 @@ type Table
          - If no valid columns are selected, a `No_Input_Columns_Selected`.
          - If floating points values are present in the distinct columns, a
            `Floating_Point_Grouping` warning.
-    distinct : Vector | Column_Selector -> Case_Sensitivity -> Problem_Behavior -> Table
+    distinct : Vector Text | Column_Selector -> Case_Sensitivity -> Problem_Behavior -> Table
     distinct self (columns = By_Name (self.columns.map .name)) case_sensitivity=Case_Sensitivity.Sensitive on_problems=Report_Warning =
         warning_mapper error = case error of
             No_Output_Columns -> Maybe.Some No_Input_Columns_Selected

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -656,7 +656,7 @@ type Table
                  table = Examples.inventory_table
                  table.order_by (Sort_Column_Selector.By_Name ["total_stock", Sort_Column.Name "sold_stock" Sort_Direction.Descending])
 
-    order_by : Sort_Column_Selector -> Text_Ordering -> Problem_Behavior -> Table ! Incomparable_Values_Error
+    order_by : Vector | Sort_Column_Selector -> Text_Ordering -> Problem_Behavior -> Table ! Incomparable_Values_Error
     order_by self (columns = (Sort_Column_Selector.By_Name [(Sort_Column.Name (self.columns.at 0 . name))])) text_ordering=Text_Ordering.Default on_problems=Report_Warning =
         problem_builder = Problem_Builder.new
         columns_for_ordering = Table_Helpers.prepare_order_by self.columns columns problem_builder

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -496,7 +496,7 @@ type Table
               table.rename_columns ["FirstColumn"]
     rename_columns : Vector Text | Column_Name_Mapping -> Problem_Behavior -> Table
     rename_columns self (column_map=(Column_Name_Mapping.By_Position ["Column"])) (on_problems=Report_Warning) = case column_map of
-        Vector.Vector ->
+        _ : Vector.Vector ->
             self.rename_columns (Column_Name_Mapping.By_Position column_map) on_problems
         _ ->
             new_names = Table_Helpers.rename_columns internal_columns=self.columns mapping=column_map on_problems=on_problems

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -26,7 +26,7 @@ polyglot java import java.util.HashSet
 
    Arguments:
    - internal_columns: A list of all columns in a table.
-   - selector: Column selection criteria.
+   - selector: Column selection criteria or vector of column names.
    - reorder: Specifies whether to reorder the matched columns according to the
      order of the selection criteria.
      If `False`, the matched entries are returned in the same order as in the
@@ -40,7 +40,7 @@ polyglot java import java.util.HashSet
      operation. By default, a warning is issued, but the operation proceeds.
      If set to `Report_Error`, the operation fails with a dataflow error.
      If set to `Ignore`, the operation proceeds without errors or warnings.
-select_columns : Vector -> Column_Selector -> Boolean -> Problem_Behavior -> Vector
+select_columns : Vector -> Vector | Column_Selector -> Boolean -> Problem_Behavior -> Vector
 select_columns internal_columns selector reorder on_problems =
     problem_builder = Problem_Builder.new
     result = select_columns_helper internal_columns selector reorder problem_builder
@@ -59,12 +59,12 @@ select_columns internal_columns selector reorder on_problems =
 
    Arguments:
    - internal_columns: A list of all columns in a table.
-   - selector: Column selection criteria.
+   - selector: Column selection criteria or vector of column names.
    - on_problems: Specifies the behavior when a problem occurs during the
      operation. By default, a warning is issued, but the operation proceeds.
      If set to `Report_Error`, the operation fails with a dataflow error.
      If set to `Ignore`, the operation proceeds without errors or warnings.
-remove_columns : Vector -> Column_Selector -> Problem_Behavior -> Vector
+remove_columns : Vector -> Vector | Column_Selector -> Problem_Behavior -> Vector
 remove_columns internal_columns selector on_problems =
     problem_builder = Problem_Builder.new
     selection = select_columns_helper internal_columns selector reorder=False problem_builder
@@ -95,7 +95,7 @@ remove_columns internal_columns selector on_problems =
      operation. By default, a warning is issued, but the operation proceeds.
      If set to `Report_Error`, the operation fails with a dataflow error.
      If set to `Ignore`, the operation proceeds without errors or warnings.
-reorder_columns : Vector -> Column_Selector -> Position.Position -> Problem_Behavior -> Vector
+reorder_columns : Vector -> Vector | Column_Selector -> Position.Position -> Problem_Behavior -> Vector
 reorder_columns internal_columns selector position on_problems =
     problem_builder = Problem_Builder.new
     selection = select_columns_helper internal_columns selector reorder=True problem_builder
@@ -220,7 +220,7 @@ sort_columns internal_columns direction text_ordering =
 
    Arguments:
    - internal_columns: A list of all columns in a table.
-   - selector: Column selection criteria.
+   - selector: Column selection criteria or vector of column names.
    - reorder: Specifies whether to reorder the matched columns according to the
      order of the selection criteria.
      If `False`, the matched entries are returned in the same order as in the
@@ -231,8 +231,10 @@ sort_columns internal_columns direction text_ordering =
      list. If a single criterion's group has more than one element, their
      relative order is the same as in the input.
    - problem_builder: Encapsulates the aggregation of encountered problems.
-select_columns_helper : Vector -> Column_Selector -> Boolean -> Problem_Builder -> Vector
+select_columns_helper : Vector -> Vector | Column_Selector -> Boolean -> Problem_Builder -> Vector
 select_columns_helper internal_columns selector reorder problem_builder = case selector of
+    Vector.Vector ->
+        select_columns_helper internal_columns (By_Name selector) reorder problem_builder
     By_Name names matcher ->
         valid_names = validate_unique names problem_builder.report_duplicate_column_selectors
         Matching.match_criteria_callback matcher internal_columns valid_names reorder=reorder name_mapper=(_.name) problem_callback=problem_builder.report_missing_input_columns

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -369,6 +369,9 @@ type Column_Transform_Element
 prepare_order_by : Vector -> Problem_Builder -> Vector Column_Transform_Element
 prepare_order_by internal_columns column_selectors problem_builder =
     selected_elements = case column_selectors of
+        Vector.Vector ->
+            unified_name_selectors = column_selectors.map (Sort_Column.Name _)
+            select_columns_by_name internal_columns unified_name_selectors Text_Matcher.Case_Sensitive problem_builder name_extractor=(_.name)
         Sort_Column_Selector.By_Name name_selectors matcher ->
             unified_name_selectors = name_selectors.map selector-> case selector of
                 _ : Text -> Sort_Column.Name selector

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -233,7 +233,7 @@ sort_columns internal_columns direction text_ordering =
    - problem_builder: Encapsulates the aggregation of encountered problems.
 select_columns_helper : Vector -> Vector | Column_Selector -> Boolean -> Problem_Builder -> Vector
 select_columns_helper internal_columns selector reorder problem_builder = case selector of
-    Vector.Vector ->
+    _ : Vector.Vector ->
         select_columns_helper internal_columns (By_Name selector) reorder problem_builder
     By_Name names matcher ->
         valid_names = validate_unique names problem_builder.report_duplicate_column_selectors
@@ -369,7 +369,7 @@ type Column_Transform_Element
 prepare_order_by : Vector -> Problem_Builder -> Vector Column_Transform_Element
 prepare_order_by internal_columns column_selectors problem_builder =
     selected_elements = case column_selectors of
-        Vector.Vector ->
+        _ : Vector.Vector ->
             unified_name_selectors = column_selectors.map (Sort_Column.Name _)
             select_columns_by_name internal_columns unified_name_selectors Text_Matcher.Case_Sensitive problem_builder name_extractor=(_.name)
         Sort_Column_Selector.By_Name name_selectors matcher ->

--- a/test/Table_Tests/src/Common_Table_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Spec.enso
@@ -80,6 +80,7 @@ spec prefix table_builder test_selection pending=Nothing =
     Test.group prefix+"Table.select_columns" pending=pending <|
         Test.specify "should work as shown in the doc examples" <|
             expect_column_names ["foo", "bar"] <| table.select_columns (By_Name ["bar", "foo"])
+            expect_column_names ["foo", "bar"] <| table.select_columns (["bar", "foo"])
             expect_column_names ["bar", "Baz", "foo_1", "foo_2"] <| table.select_columns (By_Name ["foo.+", "b.*"] (Regex_Matcher.Regex_Matcher_Data case_sensitivity=Case_Sensitivity.Insensitive))
             expect_column_names ["abcd123", "foo", "bar"] <| table.select_columns (By_Index [-1, 0, 1]) reorder=True
 
@@ -208,6 +209,7 @@ spec prefix table_builder test_selection pending=Nothing =
     Test.group prefix+"Table.remove_columns" pending=pending <|
         Test.specify "should work as shown in the doc examples" <|
             expect_column_names ["Baz", "foo_1", "foo_2", "ab.+123", "abcd123"] <| table.remove_columns (By_Name ["bar", "foo"])
+            expect_column_names ["Baz", "foo_1", "foo_2", "ab.+123", "abcd123"] <| table.remove_columns ["bar", "foo"]
             expect_column_names ["foo", "ab.+123", "abcd123"] <| table.remove_columns (By_Name ["foo.+", "b.*"] (Regex_Matcher.Regex_Matcher_Data case_sensitivity=Case_Sensitivity.Insensitive))
             expect_column_names ["Baz", "foo_1", "foo_2", "ab.+123"] <| table.remove_columns (By_Index [-1, 0, 1])
 
@@ -331,6 +333,7 @@ spec prefix table_builder test_selection pending=Nothing =
     Test.group prefix+"Table.reorder_columns" pending=pending <|
         Test.specify "should work as shown in the doc examples" <|
             expect_column_names ["bar", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123", "foo"] <| table.reorder_columns (By_Name ["foo"]) position=After_Other_Columns
+            expect_column_names ["Baz", "foo_1", "foo_2", "ab.+123", "abcd123", "foo", "bar"] <| table.reorder_columns ["foo", "bar"] position=After_Other_Columns
             expect_column_names ["foo_1", "foo_2", "bar", "Baz", "foo", "ab.+123", "abcd123"] <| table.reorder_columns (By_Name ["foo.+", "b.*"] (Regex_Matcher.Regex_Matcher_Data case_sensitivity=Case_Sensitivity.Insensitive))
             expect_column_names ["bar", "foo", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123"] <| table.reorder_columns (By_Index [1, 0]) position=Before_Other_Columns
             expect_column_names ["bar", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123", "foo"] <| table.reorder_columns (By_Index [0]) position=After_Other_Columns
@@ -473,6 +476,11 @@ spec prefix table_builder test_selection pending=Nothing =
             vec = ["one", "two", "three"]
             expect_column_names ["one", "two", "three", "delta"] <|
                 table.rename_columns (Column_Name_Mapping.By_Position vec)
+
+        Test.specify "should work by Vector" <|
+            vec = ["one", "two", "three"]
+            expect_column_names ["one", "two", "three", "delta"] <|
+                table.rename_columns vec
 
         Test.specify "should work by name" <|
             map = Map.from_vector [["alpha", "FirstColumn"], ["delta", "Another"]]

--- a/test/Table_Tests/src/Table_Spec.enso
+++ b/test/Table_Tests/src/Table_Spec.enso
@@ -795,6 +795,16 @@ spec =
             r2.at "B" . to_vector . should_equal [1, 2]
             r2.at "C" . to_vector . should_equal [0.1, 0.3]
 
+            r3 = t.distinct ["A"] on_problems=Report_Error
+            r3.at "A" . to_vector . should_equal ["a"]
+            r3.at "B" . to_vector . should_equal [1]
+            r3.at "C" . to_vector . should_equal [0.1]
+
+            r4 = t.distinct ["A", "B"] on_problems=Report_Error
+            r4.at "A" . to_vector . should_equal ["a", "a"]
+            r4.at "B" . to_vector . should_equal [1, 2]
+            r4.at "C" . to_vector . should_equal [0.1, 0.3]
+
         Test.specify "should handle nulls correctly" <|
             a = ["A", ["a", Nothing, "b", "a", "b", Nothing, "a", "b"]]
             b = ["B", [1, 2, 3, 4, 5, 6, 7, 8]]


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

Allows using `Vector ColumnName` for the various table functions as short hand. 

- `select_columns`, `remove_columns`,`reorder_columns`, `distinct` all map to an exact By_Name match.
- `rename_columns` does a positional rename on the Vector passed.
- `order_by` sorts ascending on each column passed in order.

### Important Notes

This may be reversed once widgets are available and working but this makes the APIs much more usable in current UI.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [ ] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
