### PR TITLE
Fix for native image generation

### DIFF
--- a/engine/runner-native/src/main/resources/META-INF/native-image/org/enso/runner/reflect-config.json
+++ b/engine/runner-native/src/main/resources/META-INF/native-image/org/enso/runner/reflect-config.json
@@ -782,6 +782,9 @@
     "methods":[{"name":"<init>","parameterTypes":[] }]}
 ,
   {
+    "name":"org.enso.interpreter.node.expression.builtin.meta.TypeOfMethodGen"}
+,
+  {
     "name":"org.enso.interpreter.node.expression.builtin.mutable.Array",
     "methods":[{"name":"<init>","parameterTypes":[] }]}
 ,

--- a/engine/runner-native/src/main/resources/META-INF/native-image/org/enso/runner/serialization-config.json
+++ b/engine/runner-native/src/main/resources/META-INF/native-image/org/enso/runner/serialization-config.json
@@ -6,6 +6,9 @@
     "name":"java.lang.Number"
   },
   {
+    "name":"java.lang.String"
+  },
+  {
     "name":"java.util.UUID"
   },
   {
@@ -330,10 +333,19 @@
     "name":"scala.collection.immutable.HashMap$"
   },
   {
+    "name":"scala.collection.immutable.HashMap"
+  },
+  {
     "name":"scala.collection.immutable.HashSet$"
   },
   {
+    "name":"scala.collection.immutable.HashSet"
+  },
+  {
     "name":"scala.collection.immutable.List$"
+  },
+  {
+    "name":"scala.collection.immutable.List"
   },
   {
     "name":"scala.collection.immutable.Map$EmptyMap$"
@@ -349,6 +361,9 @@
   },
   {
     "name":"scala.collection.immutable.Map$Map4"
+  },
+  {
+    "name":"scala.collection.immutable.Map"
   },
   {
     "name":"scala.collection.immutable.Set$EmptySet$"

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/PolyglotSymbolTypeBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/PolyglotSymbolTypeBranchNode.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.node.controlflow.caseexpr;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -62,14 +63,17 @@ public abstract class PolyglotSymbolTypeBranchNode extends BranchNode {
           accept(frame, state, new Object[] {target});
         }
       } catch (UnsupportedMessageException e) {
-        Builtins builtins = Context.get(this).getBuiltins();
-        Atom err =
-            builtins
-                .error()
-                .makeCompileError(
-                    "unable to check if " + target + " is an instance of " + polyglotSymbol);
+        Atom err = reportError(polyglotSymbol, target);
         throw new PanicException(err, this);
       }
     }
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  private Atom reportError(Object expected, Object target) {
+    Builtins builtins = Context.get(this).getBuiltins();
+    return builtins
+        .error()
+        .makeCompileError("unable to check if " + target + " is an instance of " + polyglotSymbol);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNode.java
@@ -131,6 +131,7 @@ public abstract class TypeOfNode extends Node {
   }
 
   @Fallback
+  @CompilerDirectives.TruffleBoundary
   Object doAny(Object value) {
     return Context.get(this).getBuiltins().error().makeCompileError("unknown type_of for " + value);
   }


### PR DESCRIPTION
[ci no changelog needed]
### Pull Request Description

Missing `@TruffleBoundary` annotations and entries in the configs were preventing us from generating native image. Again.

### Important Notes

@mwu-tow This check is easy to miss so it would be good to have it in CI.

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
