### PR TITLE
Try fixing JUnit reports for CI

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Duration.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Duration.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 import Standard.Base.System
 
+polyglot java import java.lang.ArithmeticException
 polyglot java import java.time.Duration as Java_Duration
 polyglot java import java.time.Period as Java_Period
 polyglot java import org.enso.base.Time_Utils
@@ -125,6 +126,13 @@ type Duration
              example_millis = Examples.duration.milliseconds
     milliseconds : Integer
     milliseconds self = self.internal_duration . toMillisPart
+
+    ## UNSTABLE
+       Convert the duration to total milliseconds.
+    total_milliseconds : Integer ! Illegal_Argument_Error
+    total_milliseconds self =
+        Panic.catch ArithmeticException (self.internal_duration . toMillis) _->
+            Error.throw (Illegal_Argument_Error_Data "The duration is too large to convert it to milliseconds.")
 
     ## Get the portion of the duration expressed in seconds.
 

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Main.enso
@@ -853,7 +853,8 @@ Spec.print_report self config builder =
             case behavior.result of
                 Success -> Nothing
                 Failure msg details ->
-                    builder.append ('\n            <error message="' + (escape_xml msg) + '">\n')
+                    escaped_message = escape_xml msg . replace '\n' '&#10;'
+                    builder.append ('\n            <error message="' + escaped_message + '">\n')
                     if details.is_nothing.not then
                         ## We duplicate the message, because sometimes the
                            attribute is skipped if the node has any content.

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Main.enso
@@ -848,6 +848,10 @@ Spec.print_report self config builder =
                 Failure msg details ->
                     builder.append ('\n            <error message="' + (escape_xml msg) + '">\n')
                     if details.is_nothing.not then
+                        ## We duplicate the message, because sometimes the
+                           attribute is skipped if the node has any content.
+                        builder.append (escape_xml msg)
+                        builder.append '\n'
                         builder.append (escape_xml details)
                     builder.append '</error>\n'
                 Pending msg -> builder.append ('\n            <skipped message="' + (escape_xml msg) + '"/>\n        ')

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Main.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base.Data.Time.Duration
 import Standard.Base.Runtime.State
 import Standard.Base.System
 
@@ -163,11 +164,13 @@ group name ~behaviors pending=Nothing =
                      2+3 . should_equal 5
 specify : Text -> Any -> (Text | Nothing) -> Nothing
 specify label ~behavior pending=Nothing =
-    result = case pending of
-        Nothing -> run_spec behavior
-        reason -> Pending reason
+    pair = case pending of
+        Nothing -> Duration.time_execution (run_spec behavior)
+        reason -> Pair_Data 0.milliseconds (Pending reason)
+    result = pair.second
+    time_taken = pair.first
     spec = State.get Spec
-    new_spec = Spec_Data spec.name (Cons (Behavior_Data label result) spec.behaviors)
+    new_spec = Spec_Data spec.name (Cons (Behavior_Data label result time_taken) spec.behaviors)
     State.put Spec new_spec
 
 ## PRIVATE
@@ -695,8 +698,9 @@ from project.Main.Behavior import all
    Arguments:
    - name: The name of the behavior.
    - result: The result of the behavior.
+   - time_taken: The duration that the behaviour took to run.
 type Behavior
-    Behavior_Data name result
+    Behavior_Data name result time_taken
 
 ## PRIVATE
 
@@ -834,15 +838,18 @@ report_pending_group name reason config builder =
    Prints a report on the tests to standard output.
 Spec.print_report : Suite_Config -> (StringBuilder|Nothing) -> Nothing
 Spec.print_report self config builder =
+    total_time = self.behaviors.fold 0.milliseconds acc-> behavior->
+        acc + behavior.time_taken
     if config.should_output_junit then
         builder.append ('    <testsuite name="' + (escape_xml self.name) + '" timestamp="' + (Date_Time.now.format "yyyy-MM-dd'T'HH:mm:ss") + '"')
         builder.append (' tests="' + self.behaviors.length.to_text + '"')
         builder.append (' disabled="' + self.behaviors.filter (x->(x.is_a Pending)) . length . to_text + '"')
         builder.append (' errors="' + self.behaviors.filter (x->(x.is_a Failure)) . length . to_text + '"')
+        builder.append (' time="' + (total_time.total_milliseconds / 1000.0).to_text + '"')
         builder.append ('>\n')
 
         self.behaviors.reverse.each behavior->
-            builder.append ('        <testcase name="' + (escape_xml behavior.name) + '">')
+            builder.append ('        <testcase name="' + (escape_xml behavior.name) + '" time="' + ((behavior.time_taken.total_milliseconds / 1000.0).to_text) + '">')
             case behavior.result of
                 Success -> Nothing
                 Failure msg details ->
@@ -860,14 +867,14 @@ Spec.print_report self config builder =
 
     should_print_behavior = config.print_only_failures.not || self.behaviors.any (b -> b.result.is_a Failure)
     if should_print_behavior then
-        IO.println (self.name + ":")
+        IO.println (self.name + ":  [" + total_time.total_milliseconds.to_text + "ms]")
         self.behaviors.reverse.each behavior->
             case behavior.result of
                 Success ->
                     if config.print_only_failures.not then
-                        IO.println ("    - " + behavior.name)
+                        IO.println ("    - " + behavior.name + " [" + behavior.time_taken.total_milliseconds.to_text + "ms]")
                 Failure msg details ->
-                    IO.println ("    - [FAILED] " + behavior.name)
+                    IO.println ("    - [FAILED] " + behavior.name + " [" + behavior.time_taken.total_milliseconds.to_text + "ms]")
                     IO.println ("        Reason: " + msg)
                     if details.is_nothing.not then
                         IO.println details

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Main.enso
@@ -192,8 +192,8 @@ Any.should self verb argument = verb Verbs self argument
 
          example_fail = Test.fail "Something went wrong."
 fail : Text -> Assertion
-fail message =
-    failure = Failure message
+fail message details=Nothing =
+    failure = Failure message details
     Panic.throw failure
 
 ## Expect a function to fail with the provided dataflow error.
@@ -399,7 +399,7 @@ Number.should_equal self that epsilon=0 frames_to_skip=0 =
         False ->
             loc = Meta.get_source_location 2+frames_to_skip
             msg = self.to_text + " did not equal " + that.to_text + " (at " + loc + ")."
-            Panic.throw (Failure msg)
+            fail msg
 
 ## Asserts that `self` value is not an error.
 
@@ -746,7 +746,8 @@ type Assertion
 
        Arguments:
        - message: The reason why the test failed.
-    Failure message
+       - details: Additional context of the error, for example the stack trace.
+    Failure message details
 
     ## PRIVATE
 
@@ -762,7 +763,7 @@ type Assertion
     is_fail : Boolean
     is_fail self = case self of
         Success -> False
-        Failure _ -> True
+        Failure _ _ -> True
         Pending _ -> False
 
 ## PRIVATE
@@ -782,10 +783,10 @@ run_spec ~behavior =
         _ -> Success
     result = maybeExc.catch Any ex->
         case ex of
-            Failure _ -> ex
+            Failure _ _ -> ex
             Finished_With_Error_Data err stack_trace_text ->
-                Failure ("An unexpected error was returned: " + err.to_text + '\n' + stack_trace_text)
-            _ -> Failure ("An unexpected panic was thrown: " + ex.to_text + '\n' + maybeExc.get_stack_trace_text)
+                Failure ("An unexpected error was returned: " + err.to_text) details=stack_trace_text
+            _ -> Failure ("An unexpected panic was thrown: " + ex.to_text) details=maybeExc.get_stack_trace_text
     result
 
 ## PRIVATE
@@ -844,7 +845,11 @@ Spec.print_report self config builder =
             builder.append ('        <testcase name="' + (escape_xml behavior.name) + '">')
             case behavior.result of
                 Success -> Nothing
-                Failure msg -> builder.append ('\n            <error message="' + (escape_xml msg) + '"/>\n        ')
+                Failure msg details ->
+                    builder.append ('\n            <error message="' + (escape_xml msg) + '">\n')
+                    if details.is_nothing.not then
+                        builder.append (escape_xml details)
+                    builder.append '</error>\n'
                 Pending msg -> builder.append ('\n            <skipped message="' + (escape_xml msg) + '"/>\n        ')
             builder.append '</testcase>\n'
         builder.append '    </testsuite>\n'
@@ -857,9 +862,11 @@ Spec.print_report self config builder =
                 Success ->
                     if config.print_only_failures.not then
                         IO.println ("    - " + behavior.name)
-                Failure msg ->
+                Failure msg details ->
                     IO.println ("    - [FAILED] " + behavior.name)
                     IO.println ("        Reason: " + msg)
+                    if details.is_nothing.not then
+                        IO.println details
                 Pending reason ->
                     if config.print_only_failures.not then
                         IO.println ("    - [PENDING] " + behavior.name)

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Main.enso
@@ -826,7 +826,7 @@ wrap_junit_testsuites config builder ~action =
 report_pending_group : Text -> Text -> Suite_Config -> (StringBuilder|Nothing) -> Nothing
 report_pending_group name reason config builder =
     if config.should_output_junit then
-        builder.append ('    <testsuite name="' + (escape_xml name) + '" timestamp="' + (Date_Time.now.format "yyyy-MM-dd'T'HH:mm:ss") + '">\n')
+        builder.append ('    <testsuite name="' + (escape_xml name) + '" timestamp="' + (Date_Time.now.format "yyyy-MM-dd'T'HH:mm:ss") + '" time="0">\n')
         builder.append ('        <testcase name="' + (escape_xml name) + '"><skipped message="' + (escape_xml reason) + '" /></testcase>\n')
         builder.append '    </testsuite>\n'
 

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -99,6 +99,7 @@ spec = Test.group "Vectors" <|
         [1,2,3].sum . should_equal 6
         [].sum . should_fail_with Vector.Empty_Error
         [T.Value 1 2, T.Value 3 4].sum . should_fail_with No_Such_Method_Error_Data
+        Panic.throw (Illegal_Argument_Error_Data "Testing JUNIT!")
 
     Test.specify "should check exists" <|
         vec = [1, 2, 3, 4, 5]

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -99,7 +99,6 @@ spec = Test.group "Vectors" <|
         [1,2,3].sum . should_equal 6
         [].sum . should_fail_with Vector.Empty_Error
         [T.Value 1 2, T.Value 3 4].sum . should_fail_with No_Such_Method_Error_Data
-        Panic.throw (Illegal_Argument_Error_Data "Testing JUNIT!")
 
     Test.specify "should check exists" <|
         vec = [1, 2, 3, 4, 5]


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

- Adds a `details` field to `Failure` for additional contextual information.
- Stacktraces are moved from main message (which should generally be short and fit in one line) to the `details`.
- Ensuring that the attribute does not contain multiple lines fixes the CI viewer which seems to have been breaking on multiline attributes.
- Additionally, test execution time is now measured and printed in the CLI as well as included in the JUnit report for the CI - we can use this to catch tests running unexpectedly slowly.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
