### PR TITLE
Associate the argument root nodes with their function name

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -1696,7 +1696,7 @@ class IrToTruffle(
             argumentExpression.setTailStatus(getTailStatus(value))
 
             val displayName =
-              s"argument<${name.map(_.name).getOrElse(String.valueOf(position))}>"
+              s"${scopeName}<arg-${name.map(_.name).getOrElse(String.valueOf(position))}>"
 
             val section = value.location
               .map(loc => source.createSection(loc.start, loc.length))


### PR DESCRIPTION
### Pull Request Description

I found it hard to see all those `<argument-0>` or `<argument-1>` nodes in the IGV. Associating them with their _scope_.

[ci no changelog needed]
