### PR TITLE
Always report errors for all modules

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -822,14 +822,19 @@ class Compiler(
   private def reportDiagnostics(
     diagnostics: List[(Module, List[IR.Diagnostic])]
   ): Boolean = {
-    diagnostics.find { case (mod, diags) =>
-      if (diags.nonEmpty) {
-        context.getOut.println(s"In module ${mod.getName}:")
-        reportDiagnostics(diags, mod.getSource)
-      } else {
-        false
+    diagnostics
+      .map { case (mod, diags) =>
+        if (diags.nonEmpty) {
+          context.getOut.println(s"In module ${mod.getName}:")
+          reportDiagnostics(diags, mod.getSource)
+        } else {
+          false
+        }
       }
-    }.nonEmpty
+      // It may be tempting to replace `.map(..).exists(identity)` with
+      // `.find(...). Don't. We want to report diagnostics for all modules
+      // not just the first one.
+      .exists(identity)
   }
 
   /** Reports compilation diagnostics to the standard output and throws an

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -822,19 +822,18 @@ class Compiler(
   private def reportDiagnostics(
     diagnostics: List[(Module, List[IR.Diagnostic])]
   ): Boolean = {
+    // It may be tempting to replace `.foldLeft(..)` with
+    // `.find(...).nonEmpty. Don't. We want to report diagnostics for all modules
+    // not just the first one.
     diagnostics
-      .map { case (mod, diags) =>
+      .foldLeft(false) { case (result, (mod, diags)) =>
         if (diags.nonEmpty) {
           context.getOut.println(s"In module ${mod.getName}:")
-          reportDiagnostics(diags, mod.getSource)
+          reportDiagnostics(diags, mod.getSource) || result
         } else {
-          false
+          result
         }
       }
-      // It may be tempting to replace `.map(..).exists(identity)` with
-      // `.find(...). Don't. We want to report diagnostics for all modules
-      // not just the first one.
-      .exists(identity)
   }
 
   /** Reports compilation diagnostics to the standard output and throws an


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

`.find(...)` wasn't equivalent to `.map(...).exists(identity)` in this case because of side-effects related to diagnostics reporting. That is why we were reporting errors only for the first erroneous module.

/cc @jdunkerley 