### PR TITLE
Fix repl

### DIFF
--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -765,7 +765,7 @@ object Main {
       val mainFun  = mainModule.getMethod(mainType, mainMethodName)
       mainFun match {
         case Some(main) if mainMethodName != "main" =>
-          main.execute(mainType.newInstance())
+          main.execute(mainType)
         case Some(main) =>
           // Opportunistically parse arguments and convert to ints.
           // This avoids conversions in main function.


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

Can't instantiate the associated type:
```
Exception in thread "main" java.lang.UnsupportedOperationException: Unsupported operation Value.newInstance(Object...) for 'Internal_Repl_Module___'(language: Java, type: com.oracle.truffle.polyglot.PolyglotMap). You can ensure that the operation is supported using Value.canInstantiate().
	at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotEngineException.unsupported(PolyglotEngineException.java:137)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotValueDispatch.unsupported(PolyglotValueDispatch.java:1257)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotValueDispatch.newInstanceUnsupported(PolyglotValueDispatch.java:613)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotValueDispatch$InteropValue$NewInstanceNode.doCached(PolyglotValueDispatch.java:4382)
...
```

### Important Notes

I thought we had a CI check that would prevent us from introducing such regressions? 
EDIT: we don't