### PR TITLE
Fix text sync with Engine

### DIFF
--- a/app/gui/src/model/module/synchronized.rs
+++ b/app/gui/src/model/module/synchronized.rs
@@ -20,9 +20,10 @@ use double_representation::module::ImportId;
 use engine_protocol::language_server;
 use engine_protocol::language_server::TextEdit;
 use engine_protocol::types::Sha3_224;
-use enso_text::{text, Utf16CodeUnit};
+use enso_text::text;
 use enso_text::Location;
 use enso_text::Range;
+use enso_text::Utf16CodeUnit;
 use flo_stream::Subscriber;
 use parser::api::SourceFile;
 use parser::Parser;
@@ -357,7 +358,8 @@ impl Module {
                 NotificationKind::Invalidate =>
                     profiler::await_!(self.partial_invalidation(summary, new_file), _profiler),
                 NotificationKind::CodeChanged { change, replaced_location } => {
-                    let to_engine_location = |l: Location<Byte>| summary.source.utf16_code_unit_location_of_location(l);
+                    let to_engine_location =
+                        |l: Location<Byte>| summary.source.utf16_code_unit_location_of_location(l);
                     let code_change = TextEdit {
                         range: replaced_location.map(to_engine_location).into(),
                         text:  change.text,

--- a/app/gui/src/model/module/synchronized.rs
+++ b/app/gui/src/model/module/synchronized.rs
@@ -20,7 +20,7 @@ use double_representation::module::ImportId;
 use engine_protocol::language_server;
 use engine_protocol::language_server::TextEdit;
 use engine_protocol::types::Sha3_224;
-use enso_text::text;
+use enso_text::{text, Utf16CodeUnit};
 use enso_text::Location;
 use enso_text::Range;
 use flo_stream::Subscriber;
@@ -95,6 +95,14 @@ impl ParsedContentSummary {
     /// Get fragment of string with metadata.
     pub fn metadata_slice(&self) -> text::Rope {
         self.slice(&self.metadata)
+    }
+
+    pub fn id_map_engine_range(&self) -> Range<Location<Utf16CodeUnit>> {
+        self.id_map.map(|l| self.source.utf16_code_unit_location_of_location(l))
+    }
+
+    pub fn metadata_engine_range(&self) -> Range<Location<Utf16CodeUnit>> {
+        self.metadata.map(|l| self.source.utf16_code_unit_location_of_location(l))
     }
 
     fn slice(&self, range: &Range<Location<Byte>>) -> text::Rope {
@@ -342,8 +350,6 @@ impl Module {
         let Notification { new_file, kind, profiler } = notification;
         let _profiler = profiler::start_debug!(profiler, "handle_notification");
         debug!("Handling notification: {content:?}.");
-        let code = enso_text::Rope::from(self.model.serialized_content()?.content);
-        let to_engine_location = |l: Location<Byte>| code.utf16_code_unit_location_of_location(l);
         match content {
             LanguageServerContent::Desynchronized(summary) =>
                 profiler::await_!(self.full_invalidation(summary, new_file), _profiler),
@@ -351,12 +357,13 @@ impl Module {
                 NotificationKind::Invalidate =>
                     profiler::await_!(self.partial_invalidation(summary, new_file), _profiler),
                 NotificationKind::CodeChanged { change, replaced_location } => {
+                    let to_engine_location = |l: Location<Byte>| summary.source.utf16_code_unit_location_of_location(l);
                     let code_change = TextEdit {
                         range: replaced_location.map(to_engine_location).into(),
                         text:  change.text,
                     };
                     let id_map_change = TextEdit {
-                        range: summary.id_map.map(to_engine_location).into(),
+                        range: summary.id_map_engine_range().into(),
                         text:  new_file.id_map_slice().to_string(),
                     };
                     //id_map goes first, because code change may alter its position.
@@ -366,7 +373,7 @@ impl Module {
                 }
                 NotificationKind::MetadataChanged => {
                     let edits = vec![TextEdit {
-                        range: summary.metadata.map(to_engine_location).into(),
+                        range: summary.metadata_engine_range().into(),
                         text:  new_file.metadata_slice().to_string(),
                     }];
                     let notify_ls = self.notify_language_server(&summary.summary, &new_file, edits);

--- a/app/gui/src/model/module/synchronized.rs
+++ b/app/gui/src/model/module/synchronized.rs
@@ -23,7 +23,6 @@ use engine_protocol::types::Sha3_224;
 use enso_text::text;
 use enso_text::Location;
 use enso_text::Range;
-use enso_text::Utf16CodeUnit;
 use flo_stream::Subscriber;
 use parser::api::SourceFile;
 use parser::Parser;
@@ -98,11 +97,11 @@ impl ParsedContentSummary {
         self.slice(&self.metadata)
     }
 
-    pub fn id_map_engine_range(&self) -> Range<Location<Utf16CodeUnit>> {
+    pub fn id_map_engine_range(&self) -> Range<Location<enso_text::Utf16CodeUnit>> {
         self.id_map.map(|l| self.source.utf16_code_unit_location_of_location(l))
     }
 
-    pub fn metadata_engine_range(&self) -> Range<Location<Utf16CodeUnit>> {
+    pub fn metadata_engine_range(&self) -> Range<Location<enso_text::Utf16CodeUnit>> {
         self.metadata.map(|l| self.source.utf16_code_unit_location_of_location(l))
     }
 


### PR DESCRIPTION
[ci no changelog needed]

### Pull Request Description

There was a regression introduced by PR #3678 with text synchronization between IDE and the Engine. This PR fixes it.

It was reproducible as an error log about version mismatch in a case when the metadata becomes shorter (e.g. on removing node).

### Important Notes
[ci no changelog needed]

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
