### PR TITLE
Sign MacOS package on CI only

### DIFF
--- a/app/ide-desktop/lib/client/electron-builder-config.ts
+++ b/app/ide-desktop/lib/client/electron-builder-config.ts
@@ -159,7 +159,7 @@ const config: Configuration = {
 
     afterSign: async context => {
         // Notarization for macOS.
-        if (args.platform === Platform.MAC || process.env['CSC_LINK']) {
+        if (args.platform === Platform.MAC && process.env['CSC_LINK']) {
             const { packager, appOutDir } = context
             const appName = packager.appInfo.productFilename
 

--- a/app/ide-desktop/lib/client/electron-builder-config.ts
+++ b/app/ide-desktop/lib/client/electron-builder-config.ts
@@ -159,7 +159,7 @@ const config: Configuration = {
 
     afterSign: async context => {
         // Notarization for macOS.
-        if (args.platform === Platform.MAC) {
+        if (args.platform === Platform.MAC || process.env['CSC_LINK']) {
             const { packager, appOutDir } = context
             const appName = packager.appInfo.productFilename
 

--- a/app/ide-desktop/lib/client/package.json
+++ b/app/ide-desktop/lib/client/package.json
@@ -27,7 +27,7 @@
   "//": "`yargs` dependency is pinned to version 15.4.1 because newer version triggers https://github.com/evanw/esbuild/issues/2441",
   "devDependencies": {
     "electron": "17.1.0",
-    "electron-builder": "^23.3.3",
+    "electron-builder": "^22.14.13",
     "esbuild": "^0.14.43",
     "crypto-js": "4.1.1",
     "electron-notarize": "1.2.1",

--- a/app/ide-desktop/lib/client/package.json
+++ b/app/ide-desktop/lib/client/package.json
@@ -27,7 +27,7 @@
   "//": "`yargs` dependency is pinned to version 15.4.1 because newer version triggers https://github.com/evanw/esbuild/issues/2441",
   "devDependencies": {
     "electron": "17.1.0",
-    "electron-builder": "^22.14.13",
+    "electron-builder": "^23.3.3",
     "esbuild": "^0.14.43",
     "crypto-js": "4.1.1",
     "electron-notarize": "1.2.1",


### PR DESCRIPTION
### Pull Request Description

This is a quickfix for problems with `./run ide build` command on macOS. The signing archive should is skipped if not on CI.

### Important Notes


### Checklist

Please include the following checklist in your PR:

-  ~~The documentation has been updated if necessary.~~
-  ~~All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)~~
      style guides.
- All code has been tested:
  -  ~~Unit tests have been written where possible.~~
  -  ~~If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.~~
