### PR TITLE
Fix changelog check: fetch the remote branch before comparing.

### DIFF
--- a/build/build/src/changelog/check.rs
+++ b/build/build/src/changelog/check.rs
@@ -50,6 +50,7 @@ pub async fn check(repo_path: RepoRoot, context: ide_ci::actions::Context) -> Re
     let default_branch =
         repository.default_branch.context("Missing default branch information.")?;
     let git = Git::new(&repo_path).await?;
+    git.fetch_branch(REMOTE_NAME, &default_branch).await?;
     let remote_base = format!("{REMOTE_NAME}/{default_branch}");
     let files_changed = git.diff_against(remote_base).await?;
     debug!("Files changed: {files_changed:#?}.");

--- a/build/ci_utils/src/programs/git.rs
+++ b/build/ci_utils/src/programs/git.rs
@@ -50,6 +50,12 @@ impl Git {
         self.cmd()?.args(["rev-parse", "--verify", "HEAD"]).output_ok().await?.single_line_stdout()
     }
 
+    /// Fetch a branch from a remote repository.
+    #[context("Failed to fetch branch {} from remote {}.", branch, remote)]
+    pub async fn fetch_branch(&self, remote: &str, branch: &str) -> Result {
+        self.cmd()?.args(["fetch", remote, branch]).run_ok().await
+    }
+
     /// List of files that are different than the compared commit.
     #[context("Failed to list files that are different than {}.", compare_against.as_ref())]
     pub async fn diff_against(&self, compare_against: impl AsRef<str>) -> Result<Vec<PathBuf>> {


### PR DESCRIPTION
### Pull Request Description
This should help with issues like https://github.com/enso-org/enso/actions/runs/3236721746/jobs/5312757595#step:10:5126

I am not sure why it has not happened with the previous check, as it is susceptible to the very same issue,

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
