### PR TITLE
Missing foreign language generates proper Enso error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -391,6 +391,7 @@
 - [Distinguish static and instance methods][3740]
 - [By-type pattern matching][3742]
 - [Fix performance of method calls on polyglot arrays][3781]
+- [Missing foreign language generates proper Enso error][3798]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -444,6 +445,7 @@
 [3764]: https://github.com/enso-org/enso/pull/3764
 [3742]: https://github.com/enso-org/enso/pull/3742
 [3781]: https://github.com/enso-org/enso/pull/3781
+[3798]: https://github.com/enso-org/enso/pull/3798
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/ForeignEvalNode.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/ForeignEvalNode.java
@@ -54,6 +54,7 @@ public class ForeignEvalNode extends RootNode {
     if (foreign != null) {
       return foreign.execute(frame.getArguments());
     } else {
+      CompilerDirectives.transferToInterpreter();
       throw parseException;
     }
   }

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/ForeignEvalNode.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/ForeignEvalNode.java
@@ -4,8 +4,10 @@ import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.exception.AbstractTruffleException;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.Source;
 import java.util.Arrays;
@@ -22,6 +24,8 @@ public class ForeignEvalNode extends RootNode {
   private final EpbParser.Result code;
   private @Child ForeignFunctionCallNode foreign;
   private @Child ContextRewrapNode rewrapNode = ContextRewrapNode.build();
+
+  private @Child ContextRewrapExceptionNode rewrapExceptionNode = ContextRewrapExceptionNode.build();
   private @CompilationFinal ForeignParsingException parseException;
   private final String[] argNames;
 
@@ -116,28 +120,42 @@ public class ForeignEvalNode extends RootNode {
       CallTarget ct = EpbContext.get(this).getEnv().parsePublic(source);
       Object fn = rewrapNode.execute(ct.call(), inner, outer);
       foreign = insert(JsForeignNode.build(fn, argNames.length));
+    } catch (Throwable e) {
+      if (InteropLibrary.getUncached().isException(e)) {
+        throw rewrapExceptionNode.execute((AbstractTruffleException) e, inner, outer);
+      } else {
+        throw e;
+      }
     } finally {
       inner.leave(this, p);
     }
   }
 
   private void parsePy() {
-    String args = Arrays.stream(argNames).collect(Collectors.joining(","));
-    String head =
-        "import polyglot\n"
-            + "@polyglot.export_value\n"
-            + "def polyglot_enso_python_eval("
-            + args
-            + "):\n";
-    String indentLines =
-        code.getForeignSource().lines().map(l -> "    " + l).collect(Collectors.joining("\n"));
-    Source source =
-        Source.newBuilder(code.getLanguage().getTruffleId(), head + indentLines, "").build();
-    EpbContext context = EpbContext.get(this);
-    CallTarget ct = context.getEnv().parsePublic(source);
-    ct.call();
-    Object fn = context.getEnv().importSymbol("polyglot_enso_python_eval");
-    foreign = insert(PyForeignNodeGen.create(fn));
+    try {
+      String args = Arrays.stream(argNames).collect(Collectors.joining(","));
+      String head =
+          "import polyglot\n"
+              + "@polyglot.export_value\n"
+              + "def polyglot_enso_python_eval("
+              + args
+              + "):\n";
+      String indentLines =
+          code.getForeignSource().lines().map(l -> "    " + l).collect(Collectors.joining("\n"));
+      Source source =
+          Source.newBuilder(code.getLanguage().getTruffleId(), head + indentLines, "").build();
+      EpbContext context = EpbContext.get(this);
+      CallTarget ct = context.getEnv().parsePublic(source);
+      ct.call();
+      Object fn = context.getEnv().importSymbol("polyglot_enso_python_eval");
+      foreign = insert(PyForeignNodeGen.create(fn));
+    } catch (Throwable e) {
+      if (InteropLibrary.getUncached().isException(e)) {
+        throw (AbstractTruffleException) e;
+      } else {
+        throw e;
+      }
+    }
   }
 
   private void parseR() {
@@ -155,6 +173,12 @@ public class ForeignEvalNode extends RootNode {
       CallTarget ct = EpbContext.get(this).getEnv().parsePublic(source);
       Object fn = rewrapNode.execute(ct.call(), inner, outer);
       foreign = insert(RForeignNodeGen.create(fn));
+    }  catch (Throwable e) {
+      if (InteropLibrary.getUncached().isException(e)) {
+        throw rewrapExceptionNode.execute((AbstractTruffleException) e, inner, outer);
+      } else {
+        throw e;
+      }
     } finally {
       inner.leave(this, p);
     }

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/runtime/ForeignParsingException.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/runtime/ForeignParsingException.java
@@ -1,0 +1,45 @@
+package org.enso.interpreter.epb.runtime;
+
+import com.oracle.truffle.api.exception.AbstractTruffleException;
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.library.ExportLibrary;
+import com.oracle.truffle.api.library.ExportMessage;
+import com.oracle.truffle.api.nodes.Node;
+
+/**
+ * This exception is thrown once a foreign method cannot be parsed because the associated foreign
+ * language is not installed, or enabled, in the Truffle engine.
+ */
+@ExportLibrary(InteropLibrary.class)
+public class ForeignParsingException extends AbstractTruffleException {
+  private final String message;
+
+  public ForeignParsingException(String truffleLangId, Node location) {
+    super(createMessage(truffleLangId), location);
+    this.message = createMessage(truffleLangId);
+  }
+
+  private static String createMessage(String truffleLangId) {
+    return "Failed to parse Truffle language with ID " + truffleLangId;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+
+  @ExportMessage
+  boolean isException() {
+    return true;
+  }
+
+  @ExportMessage
+  RuntimeException throwException() {
+    return this;
+  }
+
+  @ExportMessage
+  String toDisplayString(boolean hasSideEffects) {
+    return "ForeignParsingException: '" + message + "'";
+  }
+}

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/runtime/ForeignParsingException.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/runtime/ForeignParsingException.java
@@ -5,6 +5,7 @@ import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.Node;
+import java.util.Set;
 
 /**
  * This exception is thrown once a foreign method cannot be parsed because the associated foreign
@@ -14,13 +15,22 @@ import com.oracle.truffle.api.nodes.Node;
 public class ForeignParsingException extends AbstractTruffleException {
   private final String message;
 
-  public ForeignParsingException(String truffleLangId, Node location) {
-    super(createMessage(truffleLangId), location);
-    this.message = createMessage(truffleLangId);
+  /**
+   * @param truffleLangId ID of the language that caused the parsing exception, i.e., ID of the
+   *     language that is not installed in the GraalVM distribution.
+   * @param installedLangs Set of all the installed (supported) language IDs in the GraalVM
+   *     distribution.
+   * @param location Location node passed to {@link AbstractTruffleException}.
+   */
+  public ForeignParsingException(String truffleLangId, Set<String> installedLangs, Node location) {
+    super(createMessage(truffleLangId, installedLangs), location);
+    this.message = createMessage(truffleLangId, installedLangs);
   }
 
-  private static String createMessage(String truffleLangId) {
-    return "Failed to parse Truffle language with ID " + truffleLangId;
+  private static String createMessage(String truffleLangId, Set<String> installedLangs) {
+    return String.format(
+        "Cannot parse foreign %s method. Only available languages are %s",
+        truffleLangId, installedLangs);
   }
 
   @Override

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/ForeignMethodInvokeTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/ForeignMethodInvokeTest.java
@@ -57,5 +57,11 @@ public class ForeignMethodInvokeTest {
     Value module = ctx.eval("enso", source);
     Value res = module.invokeMember("eval_expression", "main");
     assertTrue("Invoking non-installed foreign function should recover", res.isException());
+    try {
+      throw res.throwException();
+    } catch (Exception e) {
+      assertTrue("Wrong error message",
+          e.getMessage().matches("Cannot parse foreign python method. Only available languages are .+"));
+    }
   }
 }

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/ForeignMethodInvokeTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/ForeignMethodInvokeTest.java
@@ -1,0 +1,61 @@
+package org.enso.interpreter.test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeNotNull;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Paths;
+import java.util.Map;
+import org.enso.polyglot.RuntimeOptions;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.Language;
+import org.graalvm.polyglot.Value;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ForeignMethodInvokeTest {
+  private Context ctx;
+
+  @Before
+  public void prepareCtx() {
+    Engine eng = Engine.newBuilder()
+        .allowExperimentalOptions(true)
+        .logHandler(new ByteArrayOutputStream())
+        .option(
+            RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
+            Paths.get("../../distribution/component").toFile().getAbsolutePath()
+        ).build();
+    this.ctx = Context.newBuilder("enso")
+        .engine(eng)
+        .allowIO(true)
+        .allowAllAccess(true)
+        .build();
+    final Map<String, Language> langs = ctx.getEngine().getLanguages();
+    assumeNotNull("Enso not found: " + langs, langs.get("enso"));
+  }
+
+  @After
+  public void disposeCtx() {
+    this.ctx.close();
+  }
+
+  @Test
+  public void testForeignFunctionParseFailure() {
+    // python is not a permitted language, therefore, invoking `py_array` method
+    // should fail with a Polyglot_Error, rather than crashing whole engine.
+    String source = """
+        from Standard.Base import all
+        
+        foreign python py_array = \"\"\"
+            return [1,2,3]
+        
+        main =
+            Panic.recover Any py_array
+        """.trim();
+    Value module = ctx.eval("enso", source);
+    Value res = module.invokeMember("eval_expression", "main");
+    assertTrue("Invoking non-installed foreign function should recover", res.isException());
+  }
+}


### PR DESCRIPTION
### Pull Request Description

Trying to invoke a foreign method with non-installed language (either not enabled in the Truffle `Context`, or not installed in the GraalVM distribution) results in `Polyglot_Error`, rather than crashing the entire engine.

### Important Notes

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
