### PR TITLE
Define Enso epoch start as 15th October 1582.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ package-lock.json
 
 .idea/
 .vscode/
+.metals/
 *.swp
 .projections.json
 .nvmrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,7 @@
   `Table.remove_columns Column_Selector.Blank_Columns` by adding the new column
   selector variant.][3812]
 - [Implemented `Table.rows` giving access to a vector of rows.][3827]
+- [Define Enso epoch start as 15th October 1582][3804]
 
 [debug-shortcuts]:
   https://github.com/enso-org/enso/blob/develop/app/gui/docs/product/shortcuts.md#debug
@@ -356,6 +357,7 @@
 [3823]: https://github.com/enso-org/enso/pull/3823
 [3827]: https://github.com/enso-org/enso/pull/3827
 [3824]: https://github.com/enso-org/enso/pull/3824
+[3804]: https://github.com/enso-org/enso/pull/3804
 
 #### Enso Compiler
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
@@ -184,7 +184,7 @@ type Date
 
     ## Returns the number of week of year this date falls into.
 
-       Throws `Time_Error` for a Date that is before epoch start.
+       Produces a warning for a Date that is before epoch start.
 
        Arguments:
        - locale: the locale used to define the notion of weeks of year.
@@ -198,22 +198,24 @@ type Date
          other hand, the first day of the week is Monday, and week 1 is the week
          containing the first Thursday of the year. Therefore it is important to
          properly specify the `locale` argument.
-    week_of_year : (Locale.Locale | Nothing) -> Integer ! Time_Error
+    week_of_year : (Locale.Locale | Nothing) -> Integer
     week_of_year self locale=Nothing =
         Date_Time.ensure_in_epoch self <|
-            if locale.is_nothing then Time_Utils.get_field_as_localdate self_in_epoch IsoFields.WEEK_OF_WEEK_BASED_YEAR else
-                Time_Utils.week_of_year_localdate self_in_epoch locale.java_locale
+            if locale.is_nothing then Time_Utils.get_field_as_localdate self IsoFields.WEEK_OF_WEEK_BASED_YEAR else
+                Time_Utils.week_of_year_localdate self locale.java_locale
 
     ## Returns if the date is in a leap year.
 
-       Throws `Time_Error` for a Date that is before epoch start.
-    is_leap_year : Boolean ! Time_Error
-    is_leap_year self = Time_Utils.is_leap_year (Date_Time.ensure_in_epoch self)
+       Produces a warning for a Date that is before epoch start.
+    is_leap_year : Boolean
+    is_leap_year self =
+        Date_Time.ensure_in_epoch self <|
+            Time_Utils.is_leap_year self
 
     ## Returns the number of days in the year represented by this date.
 
-       Throws `Time_Error` for a Date that is before epoch start.
-    length_of_year : Integer ! Time_Error
+       Produces a warning for a Date that is before epoch start.
+    length_of_year : Integer
     length_of_year self = if self.is_leap_year then 366 else 365
 
     ## Returns the century of the date.
@@ -227,11 +229,11 @@ type Date
 
     ## Returns the number of days in the month represented by this date.
 
-       Throws `Time_Error` for a Date that is before epoch start.
-    length_of_month : Integer ! Time_Error
+       Produces a warning for a Date that is before epoch start.
+    length_of_month : Integer
     length_of_month self =
         Date_Time.ensure_in_epoch self <|
-            Time_Utils.length_of_month
+            Time_Utils.length_of_month self
 
     ## Returns the day of the year.
     day_of_year : Integer
@@ -239,10 +241,11 @@ type Date
 
     ## Returns the day of the week.
 
-       Throws `Time_Error` for a Date that is before epoch start.
-    day_of_week : Day_Of_Week ! Time_Error
+       Produces a warning for a Date that is before epoch start.
+    day_of_week : Day_Of_Week
     day_of_week self =
-        Day_Of_Week.from (Time_Utils.get_field_as_localdate (Date_Time.ensure_in_epoch self) ChronoField.DAY_OF_WEEK) Day_Of_Week.Monday
+        Date_Time.ensure_in_epoch self <|
+            Day_Of_Week.from (Time_Utils.get_field_as_localdate self ChronoField.DAY_OF_WEEK) Day_Of_Week.Monday
 
     ## Returns the first date within the `Date_Period` containing self.
     start_of : Date_Period -> Date
@@ -255,8 +258,8 @@ type Date
     ## Counts workdays between self (inclusive) and the provided end date
        (exclusive).
 
-       Throws `Time_Error` if called on a Date that is before an epoch
-       start. See `Date_Time.enso_epoch_start`.
+       Produces a warning for a Date that is before epoch start.
+       See `Date_Time.enso_epoch_start`.
 
        Arguments:
        - end: the end date of the interval to count workdays in.
@@ -284,7 +287,7 @@ type Date
              from Standard.Base import Date
 
              example_workdays = Date.new 2020 1 1 . work_days_until (Date.new 2020 1 5)
-    work_days_until : Date -> Vector Date -> Boolean -> Integer ! Time_Error
+    work_days_until : Date -> Vector Date -> Boolean -> Integer
     work_days_until self end holidays=[] include_end_date=False =
         Date_Time.ensure_in_epoch self <|
             if include_end_date then self.work_days_until (end + 1.day) holidays include_end_date=False else
@@ -333,8 +336,8 @@ type Date
        For the purpose of this method, the business days are defined to be
        Monday through Friday.
 
-       Throws `Time_Error` if called on a Date that is before an epoch
-       start. See `Date_Time.enso_epoch_start`.
+       Produces a warning for a Date that is before epoch start. See
+       `Date_Time.enso_epoch_start`.
 
        This method always returns a day which is a business day - if the shift
        amount is zero, the closest following business day is returned. For the
@@ -362,84 +365,84 @@ type Date
          Shift the date by 5 business days.
 
              example_shift = Date.new 2020 2 3 . add_work_days 5
-    add_work_days : Integer -> Vector Date -> Date ! Time_Error
+    add_work_days : Integer -> Vector Date -> Date
     add_work_days self days=1 holidays=[] =
-        self_in_epoch = Date_Time.ensure_in_epoch self
-        case days >= 0 of
-            True ->
-                full_weeks = days.div 5
-                remaining_days = days % 5
+        Date_Time.ensure_in_epoch self <|
+            case days >= 0 of
+                True ->
+                    full_weeks = days.div 5
+                    remaining_days = days % 5
 
-                # If the current day is a Saturday, the ordinal will be 6.
-                ordinal = self_in_epoch.day_of_week.to_integer first_day=Day_Of_Week.Monday start_at_zero=False
+                    # If the current day is a Saturday, the ordinal will be 6.
+                    ordinal = self.day_of_week.to_integer first_day=Day_Of_Week.Monday start_at_zero=False
 
-                ## If the current day is a Sunday, we just need to shift by one day
-                   to 'escape' the weekend, regardless of the overall remaining
-                   shift. On any other day, we check if current day plus the shift
-                   overlaps a weekend, we need the shift to be 2 days since we need
-                   to skip both Saturday and Sunday.
-                additional_shift = if ordinal == 7 then 1 else
-                    if ordinal + remaining_days > 5 then 2 else 0
+                    ## If the current day is a Sunday, we just need to shift by one day
+                       to 'escape' the weekend, regardless of the overall remaining
+                       shift. On any other day, we check if current day plus the shift
+                       overlaps a weekend, we need the shift to be 2 days since we need
+                       to skip both Saturday and Sunday.
+                    additional_shift = if ordinal == 7 then 1 else
+                        if ordinal + remaining_days > 5 then 2 else 0
 
-                days_to_shift = full_weeks*7 + remaining_days + additional_shift
-                end = self_in_epoch + days_to_shift.days
+                    days_to_shift = full_weeks*7 + remaining_days + additional_shift
+                    end = self + days_to_shift.days
 
-                ## We have shifted the date so that weekends are taken into account,
-                   but other holidays may have happened during that shift period.
-                   Thus we may have shifted by less workdays than really desired. We
-                   compute the difference and if there are still remaining workdays
-                   to shift by, we re-run the whole shift procedure.
-                workdays = self_in_epoch.work_days_until end holidays include_end_date=False
-                diff = days - workdays
-                if diff > 0 then @Tail_Call end.add_work_days diff holidays else
-                    ## Otherwise we have accounted for all workdays we were asked
-                       to. But that is still not the end - we still need to ensure
-                       that the final day on which we have 'landed' is a workday
-                       too. Our procedure ensures that it is not a weekend, but it
-                       can still be a holiday. So we will be shifting the end date
-                       as long as needed to fall on a non-weekend non-holiday
-                       workday.
-                    go end_date =
-                        if holidays.contains end_date || is_weekend end_date then @Tail_Call go (end_date + 1.day) else end_date
-                    go end
-            False ->
-                ## We shift a bit so that if shifting by N full weeks, the 'last'
-                   shift is done on `remaining_days` and not full weeks. That is
-                   because shifting a Saturday back 5 days does not want us to get
-                   to the earlier Saturday and fall back to the Friday before it,
-                   but we want to stop at the Monday just after that Saturday.
-                full_weeks = (days + 1).div 5
-                remaining_days = (days + 1) % 5 - 1
+                    ## We have shifted the date so that weekends are taken into account,
+                       but other holidays may have happened during that shift period.
+                       Thus we may have shifted by less workdays than really desired. We
+                       compute the difference and if there are still remaining workdays
+                       to shift by, we re-run the whole shift procedure.
+                    workdays = self.work_days_until end holidays include_end_date=False
+                    diff = days - workdays
+                    if diff > 0 then @Tail_Call end.add_work_days diff holidays else
+                        ## Otherwise we have accounted for all workdays we were asked
+                           to. But that is still not the end - we still need to ensure
+                           that the final day on which we have 'landed' is a workday
+                           too. Our procedure ensures that it is not a weekend, but it
+                           can still be a holiday. So we will be shifting the end date
+                           as long as needed to fall on a non-weekend non-holiday
+                           workday.
+                        go end_date =
+                            if holidays.contains end_date || is_weekend end_date then @Tail_Call go (end_date + 1.day) else end_date
+                        go end
+                False ->
+                    ## We shift a bit so that if shifting by N full weeks, the 'last'
+                       shift is done on `remaining_days` and not full weeks. That is
+                       because shifting a Saturday back 5 days does not want us to get
+                       to the earlier Saturday and fall back to the Friday before it,
+                       but we want to stop at the Monday just after that Saturday.
+                    full_weeks = (days + 1).div 5
+                    remaining_days = (days + 1) % 5 - 1
 
-                # If the current day is a Sunday, the ordinal will be 1.
-                ordinal = self_in_epoch.day_of_week.to_integer first_day=Day_Of_Week.Sunday start_at_zero=False
+                    # If the current day is a Sunday, the ordinal will be 1.
+                    ordinal = self.day_of_week.to_integer first_day=Day_Of_Week.Sunday start_at_zero=False
 
-                ## If we overlapped the weekend, we need to increase the shift by
-                   one day (our current shift already shifts us by one day, but we
-                   need one more to skip the whole two-day weekend).
-                additional_shift = if ordinal == 1 then -1 else
-                    if ordinal + remaining_days <= 1 then -2 else 0
+                    ## If we overlapped the weekend, we need to increase the shift by
+                       one day (our current shift already shifts us by one day, but we
+                       need one more to skip the whole two-day weekend).
+                    additional_shift = if ordinal == 1 then -1 else
+                        if ordinal + remaining_days <= 1 then -2 else 0
 
-                ## The rest of the logic is analogous to the positive case, we
-                   just need to correctly handle the reverse order of dates. The
-                   `days_to_shift` will be negative so `end` will come _before_
-                   `self`.
-                days_to_shift = full_weeks*7 + remaining_days + additional_shift
-                end = self_in_epoch + days_to_shift.days
-                workdays = end.work_days_until self_in_epoch holidays include_end_date=False
+                    ## The rest of the logic is analogous to the positive case, we
+                       just need to correctly handle the reverse order of dates. The
+                       `days_to_shift` will be negative so `end` will come _before_
+                       `self`.
+                    days_to_shift = full_weeks*7 + remaining_days + additional_shift
+                    end = self + days_to_shift.days
+                    workdays = end.work_days_until self holidays include_end_date=False
 
-                ## `days` is negative but `workdays` is positive, `diff` will be
-                   zero if we accounted for all days or negative if there are
-                   still workdays we need to shift by - then it will be exactly
-                   the remaining offset that we need to shift by.
-                diff = days + workdays
-                if diff < 0 then @Tail_Call end.add_work_days diff holidays else
-                    ## As in the positive case, if the final end date falls on a
-                       holiday, we need to ensure that we move it - this time
-                       backwards - to the first workday.
-                    go end_date =
-                        if holidays.contains end_date || is_weekend end_date then @Tail_Call go (end_date - 1.day) else end_date
-                    go end
+                    ## `days` is negative but `workdays` is positive, `diff` will be
+                       zero if we accounted for all days or negative if there are
+                       still workdays we need to shift by - then it will be exactly
+                       the remaining offset that we need to shift by.
+                    diff = days + workdays
+                    if diff < 0 then @Tail_Call end.add_work_days diff holidays else
+                        ## As in the positive case, if the final end date falls on a
+                           holiday, we need to ensure that we move it - this time
+                           backwards - to the first workday.
+                        go end_date =
+                            if holidays.contains end_date || is_weekend end_date then @Tail_Call go (end_date - 1.day) else end_date
+                        go end
 
     ## Subtract the specified amount of time from this instant to get another
        date.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
@@ -200,9 +200,9 @@ type Date
          properly specify the `locale` argument.
     week_of_year : (Locale.Locale | Nothing) -> Integer ! Time_Error
     week_of_year self locale=Nothing =
-        self_in_epoch = Date_Time.ensure_in_epoch self
-        if locale.is_nothing then Time_Utils.get_field_as_localdate self_in_epoch IsoFields.WEEK_OF_WEEK_BASED_YEAR else
-            Time_Utils.week_of_year_localdate self_in_epoch locale.java_locale
+        Date_Time.ensure_in_epoch self <|
+            if locale.is_nothing then Time_Utils.get_field_as_localdate self_in_epoch IsoFields.WEEK_OF_WEEK_BASED_YEAR else
+                Time_Utils.week_of_year_localdate self_in_epoch locale.java_locale
 
     ## Returns if the date is in a leap year.
 
@@ -214,7 +214,7 @@ type Date
 
        Throws `Time_Error` for a Date that is before epoch start.
     length_of_year : Integer ! Time_Error
-    length_of_year self = if (Date_Time.ensure_in_epoch self).is_leap_year then 366 else 365
+    length_of_year self = if self.is_leap_year then 366 else 365
 
     ## Returns the century of the date.
     century : Integer
@@ -229,7 +229,9 @@ type Date
 
        Throws `Time_Error` for a Date that is before epoch start.
     length_of_month : Integer ! Time_Error
-    length_of_month self = Time_Utils.length_of_month (Date_Time.ensure_in_epoch self)
+    length_of_month self =
+        Date_Time.ensure_in_epoch self <|
+            Time_Utils.length_of_month
 
     ## Returns the day of the year.
     day_of_year : Integer
@@ -254,7 +256,7 @@ type Date
        (exclusive).
 
        Throws `Time_Error` if called on a Date that is before an epoch
-       start. See `Date_Time.epoch_start`.
+       start. See `Date_Time.enso_epoch_start`.
 
        Arguments:
        - end: the end date of the interval to count workdays in.
@@ -284,16 +286,16 @@ type Date
              example_workdays = Date.new 2020 1 1 . work_days_until (Date.new 2020 1 5)
     work_days_until : Date -> Vector Date -> Boolean -> Integer ! Time_Error
     work_days_until self end holidays=[] include_end_date=False =
-        self_in_epoch = Date_Time.ensure_in_epoch self
-        if include_end_date then self_in_epoch.work_days_until (end + 1.day) holidays include_end_date=False else
-            weekdays = week_days_between self_in_epoch end
-            ## We count holidays that occurred within the period, but not on the
-               weekends (as weekend days have already been excluded from the count).
-               We also need to ensure we exclude each holiday only once, even if the
-               user provided it multiple times.
-            overlapping_holidays = holidays.filter holiday->
-                fits_in_range self_in_epoch end holiday && (is_weekend holiday).not
-            weekdays - overlapping_holidays.distinct.length
+        Date_Time.ensure_in_epoch self <|
+            if include_end_date then self.work_days_until (end + 1.day) holidays include_end_date=False else
+                weekdays = week_days_between self end
+                ## We count holidays that occurred within the period, but not on the
+                   weekends (as weekend days have already been excluded from the count).
+                   We also need to ensure we exclude each holiday only once, even if the
+                   user provided it multiple times.
+                overlapping_holidays = holidays.filter holiday->
+                    fits_in_range self end holiday && (is_weekend holiday).not
+                weekdays - overlapping_holidays.distinct.length
 
     ## ALIAS Date to Time
 
@@ -332,7 +334,7 @@ type Date
        Monday through Friday.
 
        Throws `Time_Error` if called on a Date that is before an epoch
-       start. See `Date_Time.epoch_start`.
+       start. See `Date_Time.enso_epoch_start`.
 
        This method always returns a day which is a business day - if the shift
        amount is zero, the closest following business day is returned. For the

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
@@ -184,6 +184,8 @@ type Date
 
     ## Returns the number of week of year this date falls into.
 
+       Throws `Time_Error` for a Date that is before epoch start.
+
        Arguments:
        - locale: the locale used to define the notion of weeks of year.
          If no locale is provided, then the ISO 8601 week of year is used.
@@ -196,18 +198,23 @@ type Date
          other hand, the first day of the week is Monday, and week 1 is the week
          containing the first Thursday of the year. Therefore it is important to
          properly specify the `locale` argument.
-    week_of_year : (Locale.Locale | Nothing) -> Integer
+    week_of_year : (Locale.Locale | Nothing) -> Integer ! Time_Error
     week_of_year self locale=Nothing =
-        if locale.is_nothing then Time_Utils.get_field_as_localdate self IsoFields.WEEK_OF_WEEK_BASED_YEAR else
-            Time_Utils.week_of_year_localdate self locale.java_locale
+        self_in_epoch = Date_Time.ensure_in_epoch self
+        if locale.is_nothing then Time_Utils.get_field_as_localdate self_in_epoch IsoFields.WEEK_OF_WEEK_BASED_YEAR else
+            Time_Utils.week_of_year_localdate self_in_epoch locale.java_locale
 
     ## Returns if the date is in a leap year.
-    is_leap_year : Boolean
-    is_leap_year self = Time_Utils.is_leap_year self
+
+       Throws `Time_Error` for a Date that is before epoch start.
+    is_leap_year : Boolean ! Time_Error
+    is_leap_year self = Time_Utils.is_leap_year (Date_Time.ensure_in_epoch self)
 
     ## Returns the number of days in the year represented by this date.
-    length_of_year : Integer
-    length_of_year self = if self.is_leap_year then 366 else 365
+
+       Throws `Time_Error` for a Date that is before epoch start.
+    length_of_year : Integer ! Time_Error
+    length_of_year self = if (Date_Time.ensure_in_epoch self).is_leap_year then 366 else 365
 
     ## Returns the century of the date.
     century : Integer
@@ -219,17 +226,21 @@ type Date
     quarter self = Time_Utils.get_field_as_localdate self IsoFields.QUARTER_OF_YEAR
 
     ## Returns the number of days in the month represented by this date.
-    length_of_month : Integer
-    length_of_month self = Time_Utils.length_of_month self
+
+       Throws `Time_Error` for a Date that is before epoch start.
+    length_of_month : Integer ! Time_Error
+    length_of_month self = Time_Utils.length_of_month (Date_Time.ensure_in_epoch self)
 
     ## Returns the day of the year.
     day_of_year : Integer
     day_of_year self = Time_Utils.get_field_as_localdate self ChronoField.DAY_OF_YEAR
 
     ## Returns the day of the week.
-    day_of_week : Day_Of_Week
+
+       Throws `Time_Error` for a Date that is before epoch start.
+    day_of_week : Day_Of_Week ! Time_Error
     day_of_week self =
-        Day_Of_Week.from (Time_Utils.get_field_as_localdate self ChronoField.DAY_OF_WEEK) Day_Of_Week.Monday
+        Day_Of_Week.from (Time_Utils.get_field_as_localdate (Date_Time.ensure_in_epoch self) ChronoField.DAY_OF_WEEK) Day_Of_Week.Monday
 
     ## Returns the first date within the `Date_Period` containing self.
     start_of : Date_Period -> Date
@@ -241,6 +252,9 @@ type Date
 
     ## Counts workdays between self (inclusive) and the provided end date
        (exclusive).
+
+       Throws `Time_Error` if called on a Date that is before an epoch
+       start. See `Date_Time.epoch_start`.
 
        Arguments:
        - end: the end date of the interval to count workdays in.
@@ -268,16 +282,17 @@ type Date
              from Standard.Base import Date
 
              example_workdays = Date.new 2020 1 1 . work_days_until (Date.new 2020 1 5)
-    work_days_until : Date -> Vector Date -> Boolean -> Integer
+    work_days_until : Date -> Vector Date -> Boolean -> Integer ! Time_Error
     work_days_until self end holidays=[] include_end_date=False =
-        if include_end_date then self.work_days_until (end + 1.day) holidays include_end_date=False else
-            weekdays = week_days_between self end
+        self_in_epoch = Date_Time.ensure_in_epoch self
+        if include_end_date then self_in_epoch.work_days_until (end + 1.day) holidays include_end_date=False else
+            weekdays = week_days_between self_in_epoch end
             ## We count holidays that occurred within the period, but not on the
                weekends (as weekend days have already been excluded from the count).
                We also need to ensure we exclude each holiday only once, even if the
                user provided it multiple times.
             overlapping_holidays = holidays.filter holiday->
-                fits_in_range self end holiday && (is_weekend holiday).not
+                fits_in_range self_in_epoch end holiday && (is_weekend holiday).not
             weekdays - overlapping_holidays.distinct.length
 
     ## ALIAS Date to Time
@@ -316,6 +331,9 @@ type Date
        For the purpose of this method, the business days are defined to be
        Monday through Friday.
 
+       Throws `Time_Error` if called on a Date that is before an epoch
+       start. See `Date_Time.epoch_start`.
+
        This method always returns a day which is a business day - if the shift
        amount is zero, the closest following business day is returned. For the
        purpose of calculating the shift, the holidays are treated as if we were
@@ -342,82 +360,84 @@ type Date
          Shift the date by 5 business days.
 
              example_shift = Date.new 2020 2 3 . add_work_days 5
-    add_work_days : Integer -> Vector Date -> Date
-    add_work_days self days=1 holidays=[] = case days >= 0 of
-        True ->
-            full_weeks = days.div 5
-            remaining_days = days % 5
+    add_work_days : Integer -> Vector Date -> Date ! Time_Error
+    add_work_days self days=1 holidays=[] =
+        self_in_epoch = Date_Time.ensure_in_epoch self
+        case days >= 0 of
+            True ->
+                full_weeks = days.div 5
+                remaining_days = days % 5
 
-            # If the current day is a Saturday, the ordinal will be 6.
-            ordinal = self.day_of_week.to_integer first_day=Day_Of_Week.Monday start_at_zero=False
+                # If the current day is a Saturday, the ordinal will be 6.
+                ordinal = self_in_epoch.day_of_week.to_integer first_day=Day_Of_Week.Monday start_at_zero=False
 
-            ## If the current day is a Sunday, we just need to shift by one day
-               to 'escape' the weekend, regardless of the overall remaining
-               shift. On any other day, we check if current day plus the shift
-               overlaps a weekend, we need the shift to be 2 days since we need
-               to skip both Saturday and Sunday.
-            additional_shift = if ordinal == 7 then 1 else
-                if ordinal + remaining_days > 5 then 2 else 0
+                ## If the current day is a Sunday, we just need to shift by one day
+                   to 'escape' the weekend, regardless of the overall remaining
+                   shift. On any other day, we check if current day plus the shift
+                   overlaps a weekend, we need the shift to be 2 days since we need
+                   to skip both Saturday and Sunday.
+                additional_shift = if ordinal == 7 then 1 else
+                    if ordinal + remaining_days > 5 then 2 else 0
 
-            days_to_shift = full_weeks*7 + remaining_days + additional_shift
-            end = self + days_to_shift.days
+                days_to_shift = full_weeks*7 + remaining_days + additional_shift
+                end = self_in_epoch + days_to_shift.days
 
-            ## We have shifted the date so that weekends are taken into account,
-               but other holidays may have happened during that shift period.
-               Thus we may have shifted by less workdays than really desired. We
-               compute the difference and if there are still remaining workdays
-               to shift by, we re-run the whole shift procedure.
-            workdays = self.work_days_until end holidays include_end_date=False
-            diff = days - workdays
-            if diff > 0 then @Tail_Call end.add_work_days diff holidays else
-                ## Otherwise we have accounted for all workdays we were asked
-                   to. But that is still not the end - we still need to ensure
-                   that the final day on which we have 'landed' is a workday
-                   too. Our procedure ensures that it is not a weekend, but it
-                   can still be a holiday. So we will be shifting the end date
-                   as long as needed to fall on a non-weekend non-holiday
-                   workday.
-                go end_date =
-                    if holidays.contains end_date || is_weekend end_date then @Tail_Call go (end_date + 1.day) else end_date
-                go end
-        False ->
-            ## We shift a bit so that if shifting by N full weeks, the 'last'
-               shift is done on `remaining_days` and not full weeks. That is
-               because shifting a Saturday back 5 days does not want us to get
-               to the earlier Saturday and fall back to the Friday before it,
-               but we want to stop at the Monday just after that Saturday.
-            full_weeks = (days + 1).div 5
-            remaining_days = (days + 1) % 5 - 1
+                ## We have shifted the date so that weekends are taken into account,
+                   but other holidays may have happened during that shift period.
+                   Thus we may have shifted by less workdays than really desired. We
+                   compute the difference and if there are still remaining workdays
+                   to shift by, we re-run the whole shift procedure.
+                workdays = self_in_epoch.work_days_until end holidays include_end_date=False
+                diff = days - workdays
+                if diff > 0 then @Tail_Call end.add_work_days diff holidays else
+                    ## Otherwise we have accounted for all workdays we were asked
+                       to. But that is still not the end - we still need to ensure
+                       that the final day on which we have 'landed' is a workday
+                       too. Our procedure ensures that it is not a weekend, but it
+                       can still be a holiday. So we will be shifting the end date
+                       as long as needed to fall on a non-weekend non-holiday
+                       workday.
+                    go end_date =
+                        if holidays.contains end_date || is_weekend end_date then @Tail_Call go (end_date + 1.day) else end_date
+                    go end
+            False ->
+                ## We shift a bit so that if shifting by N full weeks, the 'last'
+                   shift is done on `remaining_days` and not full weeks. That is
+                   because shifting a Saturday back 5 days does not want us to get
+                   to the earlier Saturday and fall back to the Friday before it,
+                   but we want to stop at the Monday just after that Saturday.
+                full_weeks = (days + 1).div 5
+                remaining_days = (days + 1) % 5 - 1
 
-            # If the current day is a Sunday, the ordinal will be 1.
-            ordinal = self.day_of_week.to_integer first_day=Day_Of_Week.Sunday start_at_zero=False
+                # If the current day is a Sunday, the ordinal will be 1.
+                ordinal = self_in_epoch.day_of_week.to_integer first_day=Day_Of_Week.Sunday start_at_zero=False
 
-            ## If we overlapped the weekend, we need to increase the shift by
-               one day (our current shift already shifts us by one day, but we
-               need one more to skip the whole two-day weekend).
-            additional_shift = if ordinal == 1 then -1 else
-                if ordinal + remaining_days <= 1 then -2 else 0
+                ## If we overlapped the weekend, we need to increase the shift by
+                   one day (our current shift already shifts us by one day, but we
+                   need one more to skip the whole two-day weekend).
+                additional_shift = if ordinal == 1 then -1 else
+                    if ordinal + remaining_days <= 1 then -2 else 0
 
-            ## The rest of the logic is analogous to the positive case, we
-               just need to correctly handle the reverse order of dates. The
-               `days_to_shift` will be negative so `end` will come _before_
-               `self`.
-            days_to_shift = full_weeks*7 + remaining_days + additional_shift
-            end = self + days_to_shift.days
-            workdays = end.work_days_until self holidays include_end_date=False
+                ## The rest of the logic is analogous to the positive case, we
+                   just need to correctly handle the reverse order of dates. The
+                   `days_to_shift` will be negative so `end` will come _before_
+                   `self`.
+                days_to_shift = full_weeks*7 + remaining_days + additional_shift
+                end = self_in_epoch + days_to_shift.days
+                workdays = end.work_days_until self_in_epoch holidays include_end_date=False
 
-            ## `days` is negative but `workdays` is positive, `diff` will be
-               zero if we accounted for all days or negative if there are
-               still workdays we need to shift by - then it will be exactly
-               the remaining offset that we need to shift by.
-            diff = days + workdays
-            if diff < 0 then @Tail_Call end.add_work_days diff holidays else
-                ## As in the positive case, if the final end date falls on a
-                   holiday, we need to ensure that we move it - this time
-                   backwards - to the first workday.
-                go end_date =
-                    if holidays.contains end_date || is_weekend end_date then @Tail_Call go (end_date - 1.day) else end_date
-                go end
+                ## `days` is negative but `workdays` is positive, `diff` will be
+                   zero if we accounted for all days or negative if there are
+                   still workdays we need to shift by - then it will be exactly
+                   the remaining offset that we need to shift by.
+                diff = days + workdays
+                if diff < 0 then @Tail_Call end.add_work_days diff holidays else
+                    ## As in the positive case, if the final end date falls on a
+                       holiday, we need to ensure that we move it - this time
+                       backwards - to the first workday.
+                    go end_date =
+                        if holidays.contains end_date || is_weekend end_date then @Tail_Call go (end_date - 1.day) else end_date
+                    go end
 
     ## Subtract the specified amount of time from this instant to get another
        date.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
@@ -29,12 +29,16 @@ unix_epoch_start : Date_Time
 unix_epoch_start = Date_Time.new 1970
 
 ## PRIVATE
-ensure_in_epoch : (Date_Time | Date) -> Suspend (Any -> Any) -> Any ! Time_Error
+ensure_in_epoch : (Date_Time | Date) -> Suspend (Any -> Any) -> Any
 ensure_in_epoch date ~action =
     datetime = case date of
         x : Date_Time -> x
         x : Date.Date -> x.to_date_time
-    if enso_epoch_start <= datetime then action else Error.throw Time_Error.enso_epoch_start
+    ret_value = action
+    case enso_epoch_start <= datetime of
+        True -> ret_value
+        False ->
+            Warning.attach ("Date time '" + datetime.to_text + "' start before Enso epoch") ret_value
 
 ## ALIAS Current Time
 
@@ -274,22 +278,21 @@ type Date_Time
 
     ## Return the number of seconds from the Unix epoch start (1.1.1970)
 
-       If this Date_Time is before an epoch start, throws `Time_Error`.
+       If this Date_Time is before an epoch start, returns a negative number.
 
        > Example
-         Get the current number of seconds from the Enso epoch.
+         Get the current number of seconds from the Unix epoch.
 
              from Standard.Base import Date_Time
 
              example_epoch = Date_Time.now.to_unix_epoch_seconds
-    to_unix_epoch_seconds : Integer ! Time_Error
+    to_unix_epoch_seconds : Integer
     to_unix_epoch_seconds self =
-        if self >= unix_epoch_start then (Duration.between unix_epoch_start self).total_seconds.floor else
-            Error.throw (Time_Error_Data "Datetime is before Unix epoch")
+        (Duration.between unix_epoch_start self).total_seconds.floor
 
     ## Return the number of milliseconds from the Unix epoch start.
 
-       If this Date_Time is before an epoch start, throws `Time_Error`.
+       If this Date_Time is before an epoch start, returns a negative number.
 
        > Example
          Get the current number of milliseconds from the Enso epoch.
@@ -297,26 +300,23 @@ type Date_Time
              from Standard.Base import Date_Time
 
              example_epoch = Date_Time.now.to_unix_epoch_milliseconds
-    to_unix_epoch_milliseconds : Integer ! Time_Error
+    to_unix_epoch_milliseconds : Integer
     to_unix_epoch_milliseconds self =
-        if self >= unix_epoch_start then (Duration.between unix_epoch_start self).total_milliseconds.floor else
-            Error.throw (Time_Error_Data "Datetime is before Unix epoch")
+        (Duration.between unix_epoch_start self).total_milliseconds.floor
 
     ## Return the number of seconds from the Enso epoch start.
 
-       See `Date_Time.enso_epoch_start` If this Date_Time is before an Enso epoch
-       start, throws `Time_Error`.
-    to_enso_epoch_seconds : Integer ! Time_Error
+       See `Date_Time.enso_epoch_start`.
+    to_enso_epoch_seconds : Integer
     to_enso_epoch_seconds self =
-        ensure_in_epoch self <| (Duration.betwen enso_epoch_start self).total_seconds.floor
+        (Duration.between enso_epoch_start self).total_seconds.floor
 
     ## Return the number of milliseconds from the Enso epoch start.
 
-       See `Date_Time.enso_epoch_start` If this Date_Time is before an Enso epoch
-       start, throws `Time_Error`.
-    to_enso_epoch_milliseconds : Integer ! Time_Error
+       See `Date_Time.enso_epoch_start`.
+    to_enso_epoch_milliseconds : Integer
     to_enso_epoch_milliseconds self =
-        ensure_in_epoch self <| (Duration.betwen enso_epoch_start self).total_milliseconds.floor
+        (Duration.between enso_epoch_start self).total_milliseconds.floor
 
     ## Convert this point in time to time of day, discarding the time zone
        information.
@@ -332,7 +332,7 @@ type Date_Time
 
     ## Returns the number of week of year this date falls into.
 
-       Throws `Time_Error` for a Date_Time that is before epoch start.
+       Produces a warning for a Date that is before epoch start.
 
        Arguments:
        - locale: the locale used to define the notion of weeks of year.
@@ -346,22 +346,22 @@ type Date_Time
          other hand, the first day of the week is Monday, and week 1 is the week
          containing the first Thursday of the year. Therefore it is important to
          properly specify the `locale` argument.
-    week_of_year : (Locale.Locale | Nothing) -> Integer ! Time_Error
+    week_of_year : (Locale.Locale | Nothing) -> Integer
     week_of_year self locale=Nothing =
-        self_in_epoch = (ensure_in_epoch self)
-        if locale.is_nothing then Time_Utils.get_field_as_zoneddatetime self_in_epoch IsoFields.WEEK_OF_WEEK_BASED_YEAR else
-            Time_Utils.week_of_year_zoneddatetime self_in_epoch locale.java_locale
+        ensure_in_epoch self <|
+            if locale.is_nothing then Time_Utils.get_field_as_zoneddatetime self IsoFields.WEEK_OF_WEEK_BASED_YEAR else
+                Time_Utils.week_of_year_zoneddatetime self locale.java_locale
 
     ## Returns if the date is in a leap year.
 
-       Throws `Time_Error` for a Date_Time that is before epoch start.
-    is_leap_year : Boolean ! Time_Error
-    is_leap_year self = ensure_in_epoch self <| self.date.is_leap_year
+       Produces a warning for a Date that is before epoch start.
+    is_leap_year : Boolean
+    is_leap_year self = self.date.is_leap_year
 
     ## Returns the number of days in the year represented by this date.
 
-       Throws `Time_Error` for a Date_Time that is before epoch start.
-    length_of_year : Integer ! Time_Error
+       Produces a warning for a Date that is before epoch start.
+    length_of_year : Integer
     length_of_year self = ensure_in_epoch self <| self.date.length_of_year
 
     ## Returns the century of the date.
@@ -374,16 +374,16 @@ type Date_Time
 
     ## Returns the number of days in the month represented by this date.
 
-       Throws `Time_Error` for a Date_Time that is before epoch start.
-    length_of_month : Integer ! Time_Error
-    length_of_month self = (ensure_in_epoch self).date.length_of_month
+       Produces a warning for a Date that is before epoch start.
+    length_of_month : Integer
+    length_of_month self = ensure_in_epoch self <| self.date.length_of_month
 
     ## Returns the day of the year.
     day_of_year : Integer
     day_of_year self = Time_Utils.get_field_as_zoneddatetime self ChronoField.DAY_OF_YEAR
 
     ## Returns the day of the week.
-    day_of_week : Day_Of_Week ! Time_Error
+    day_of_week : Day_Of_Week
     day_of_week self =
         ensure_in_epoch self <|
             Day_Of_Week.from (Time_Utils.get_field_as_zoneddatetime self ChronoField.DAY_OF_WEEK) Day_Of_Week.Monday
@@ -457,7 +457,7 @@ type Date_Time
        For the purpose of this method, the business days are defined to be
        Monday through Friday.
 
-       Throws `Time_Error` if called on a Date_Time that is before an epoch
+       Produces a warning if called on a Date_Time that is before an epoch
        start. See `Date_Time.enso_epoch_start`.
 
        This method always returns a day which is a business day - if the shift
@@ -488,12 +488,15 @@ type Date_Time
          Shift the date by 5 business days.
 
              example_shift = Date_Time.new 2020 2 3 11 45 . add_work_days 5
-    add_work_days : Integer -> Vector Date -> Date_Time ! Time_Error
+    add_work_days : Integer -> Vector Date -> Date_Time
     add_work_days self days=1 holidays=[] =
-        (ensure_in_epoch self).date.add_work_days days holidays . to_date_time self.time_of_day self.zone
+        ensure_in_epoch self <|
+            self.date.add_work_days days holidays . to_date_time self.time_of_day self.zone
 
     ## Subtract the specified amount of time from this instant to get a new
        instant.
+
+       Produces a warning if the resulting date time is before an Enso epoch.
 
        Arguments:
        - amount: The amount of time to subtract from this instant.
@@ -507,7 +510,8 @@ type Date_Time
              example_minus = Date_Time.new 2020 - 1.year - 9.months
     - : Duration -> Date_Time ! Time_Error
     - self amount =
-        Panic.catch ArithmeticException (self.minus_builtin amount) (err -> Error.throw (Time_Error_Data err.getMessage))
+        result = Panic.catch ArithmeticException (self.minus_builtin amount) (err -> Error.throw (Time_Error_Data err.getMessage))
+        ensure_in_epoch result result
 
     ## Convert this time to text using the default formatter.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
@@ -12,6 +12,27 @@ polyglot java import java.lang.ArithmeticException
 
 polyglot java import org.enso.base.Time_Utils
 
+## Obtains the start of the epoch for Enso.
+
+    ? Start of the epoch
+    For Enso, start of the epoch is equal to the start of the Gregorian calendar,
+    which is on 15th October 1582. It is possible to create a Date_Time that is
+    before the start of the epoch, however, it is invalid to invoke any (Gregorian)
+    calendar related functionalities on such a Date_Time, e.g., `length_of_month` or
+    `day_of_week`. All the other operations, including `+` and `-` should succeed.
+
+epoch_start : Date_Time
+epoch_start = @Builtin_Method "Date_Time.epoch_start"
+
+## PRIVATE
+ensure_in_epoch : (Date_Time | Date) -> (Date_Time | Date) ! Time_Error
+ensure_in_epoch date =
+    datetime = case date of
+        x : Date_Time -> x
+        x : Date.Date -> x.to_date_time
+    if epoch_start <= datetime then date else Error.throw Time_Error.epoch_start
+
+
 ## ALIAS Current Time
 
    Obtains the current date-time from the system clock in the system timezone.
@@ -29,6 +50,7 @@ now = @Builtin_Method "Date_Time.now"
    second, nanosecond and timezone.
 
    Arguments:
+   - year: The year to represent, any Integer is valid.
    - month: the month-of-year to represent, from 1 (January) to 12 (December)
    - day: the day-of-month to represent, from 1 to 31 and must be valid for the
      year and month
@@ -247,27 +269,33 @@ type Date_Time
     zone : Time_Zone
     zone self = @Builtin_Method "Date_Time.zone"
 
-    ## Return the number of seconds from the Unix epoch.
+    ## Return the number of seconds from the Enso epoch. See Date_Time.epoch_start
+
+       If this Date_Time is before an epoch start, throws `Time_Error`.
 
        > Example
-         Get the current number of seconds from the Unix epoch.
+         Get the current number of seconds from the Enso epoch.
 
              from Standard.Base import Date_Time
 
              example_epoch = Date_Time.now.to_epoch_seconds
-    to_epoch_seconds : Integer
-    to_epoch_seconds self = @Builtin_Method "Date_Time.to_epoch_seconds"
+    to_epoch_seconds : Integer ! Time_Error
+    to_epoch_seconds self =
+        (Duration.between epoch_start (ensure_in_epoch self)).total_seconds.floor
 
-    ## Return the number of milliseconds from the Unix epoch.
+    ## Return the number of milliseconds from the Enso epoch. See Date_Time.epoch_start
+
+       If this Date_Time is before an epoch start, throws `Time_Error`.
 
        > Example
-         Get the current number of milliseconds from the unix epoch.
+         Get the current number of milliseconds from the Enso epoch.
 
              from Standard.Base import Date_Time
 
              example_epoch = Date_Time.now.to_epoch_milliseconds
-    to_epoch_milliseconds : Integer
-    to_epoch_milliseconds self = @Builtin_Method "Date_Time.to_epoch_milliseconds"
+    to_epoch_milliseconds : Integer ! Time_Error
+    to_epoch_milliseconds self =
+        (Duration.between epoch_start (ensure_in_epoch self)).total_milliseconds.floor
 
     ## Convert this point in time to time of day, discarding the time zone
        information.
@@ -283,6 +311,8 @@ type Date_Time
 
     ## Returns the number of week of year this date falls into.
 
+       Throws `Time_Error` for a Date_Time that is before epoch start.
+
        Arguments:
        - locale: the locale used to define the notion of weeks of year.
          If no locale is provided, then the ISO 8601 week of year is used.
@@ -295,18 +325,23 @@ type Date_Time
          other hand, the first day of the week is Monday, and week 1 is the week
          containing the first Thursday of the year. Therefore it is important to
          properly specify the `locale` argument.
-    week_of_year : (Locale.Locale | Nothing) -> Integer
+    week_of_year : (Locale.Locale | Nothing) -> Integer ! Time_Error
     week_of_year self locale=Nothing =
-        if locale.is_nothing then Time_Utils.get_field_as_zoneddatetime self IsoFields.WEEK_OF_WEEK_BASED_YEAR else
-            Time_Utils.week_of_year_zoneddatetime self locale.java_locale
+        self_in_epoch = (ensure_in_epoch self)
+        if locale.is_nothing then Time_Utils.get_field_as_zoneddatetime self_in_epoch IsoFields.WEEK_OF_WEEK_BASED_YEAR else
+            Time_Utils.week_of_year_zoneddatetime self_in_epoch locale.java_locale
 
     ## Returns if the date is in a leap year.
-    is_leap_year : Boolean
-    is_leap_year self = self.date.is_leap_year
+
+       Throws `Time_Error` for a Date_Time that is before epoch start.
+    is_leap_year : Boolean ! Time_Error
+    is_leap_year self = (ensure_in_epoch self).date.is_leap_year
 
     ## Returns the number of days in the year represented by this date.
-    length_of_year : Integer
-    length_of_year self = self.date.length_of_year
+
+       Throws `Time_Error` for a Date_Time that is before epoch start.
+    length_of_year : Integer ! Time_Error
+    length_of_year self = (ensure_in_epoch self).date.length_of_year
 
     ## Returns the century of the date.
     century : Integer
@@ -317,17 +352,19 @@ type Date_Time
     quarter self = Time_Utils.get_field_as_zoneddatetime self IsoFields.QUARTER_OF_YEAR
 
     ## Returns the number of days in the month represented by this date.
-    length_of_month : Integer
-    length_of_month self = self.date.length_of_month
+
+       Throws `Time_Error` for a Date_Time that is before epoch start.
+    length_of_month : Integer ! Time_Error
+    length_of_month self = (ensure_in_epoch self).date.length_of_month
 
     ## Returns the day of the year.
     day_of_year : Integer
     day_of_year self = Time_Utils.get_field_as_zoneddatetime self ChronoField.DAY_OF_YEAR
 
     ## Returns the day of the week.
-    day_of_week : Day_Of_Week
+    day_of_week : Day_Of_Week ! Time_Error
     day_of_week self =
-        Day_Of_Week.from (Time_Utils.get_field_as_zoneddatetime self ChronoField.DAY_OF_WEEK) Day_Of_Week.Monday
+        Day_Of_Week.from (Time_Utils.get_field_as_zoneddatetime (ensure_in_epoch self) ChronoField.DAY_OF_WEEK) Day_Of_Week.Monday
 
     ## Returns the first date within the `Time_Period` or `Date_Period`
        containing self.
@@ -398,6 +435,9 @@ type Date_Time
        For the purpose of this method, the business days are defined to be
        Monday through Friday.
 
+       Throws `Time_Error` if called on a Date_Time that is before an epoch
+       start. See `Date_Time.epoch_start`.
+
        This method always returns a day which is a business day - if the shift
        amount is zero, the closest following business day is returned. For the
        purpose of calculating the shift, the holidays are treated as if we were
@@ -426,9 +466,9 @@ type Date_Time
          Shift the date by 5 business days.
 
              example_shift = Date_Time.new 2020 2 3 11 45 . add_work_days 5
-    add_work_days : Integer -> Vector Date -> Date_Time
+    add_work_days : Integer -> Vector Date -> Date_Time ! Time_Error
     add_work_days self days=1 holidays=[] =
-        self.date.add_work_days days holidays . to_date_time self.time_of_day self.zone
+        (ensure_in_epoch self).date.add_work_days days holidays . to_date_time self.time_of_day self.zone
 
     ## Subtract the specified amount of time from this instant to get a new
        instant.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
@@ -22,7 +22,7 @@ polyglot java import org.enso.base.Time_Utils
     is computed for all the date times, including those before an epoch start,
     with today's rules. Trying to get some Gregorian calendar related properties
     for a historical date times that is defined before the epoch is likely an error,
-    as the Gregorian calendar had not yet been discovered. Therefore, for such
+    as the Gregorian calendar had not yet been introduced. Therefore, for such
     historical date times, a warning is attached to the result.
 enso_epoch_start : Date_Time
 enso_epoch_start = @Builtin_Method "Date_Time.epoch_start"
@@ -32,7 +32,7 @@ unix_epoch_start : Date_Time
 unix_epoch_start = Date_Time.new 1970
 
 ## PRIVATE
-ensure_in_epoch : (Date_Time | Date) -> Suspend (Any -> Any) -> Any
+ensure_in_epoch : (Date_Time | Date) -> (Any -> Any) -> Any
 ensure_in_epoch date ~action =
     datetime = case date of
         x : Date_Time -> x
@@ -41,7 +41,7 @@ ensure_in_epoch date ~action =
     case enso_epoch_start <= datetime of
         True -> ret_value
         False ->
-            Warning.attach ("Date time '" + datetime.to_text + "' start before Enso epoch") ret_value
+            Warning.attach (Time_Error_Data ("Date time '" + datetime.to_text + "' start before Enso epoch")) ret_value
 
 ## ALIAS Current Time
 
@@ -281,7 +281,7 @@ type Date_Time
 
     ## Return the number of seconds from the Unix epoch start (1.1.1970)
 
-       If this Date_Time is before an epoch start, returns a negative number.
+       If this Date_Time is before the epoch start, returns a negative number.
 
        > Example
          Get the current number of seconds from the Unix epoch.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
@@ -16,11 +16,14 @@ polyglot java import org.enso.base.Time_Utils
 
     ? Start of the epoch
     For Enso, start of the epoch is equal to the start of the Gregorian calendar,
-    which is on 15th October 1582. It is possible to create a Date_Time that is
-    before the start of the epoch, however, it is invalid to invoke any (Gregorian)
-    calendar related functionalities on such a Date_Time, e.g., `length_of_month` or
-    `day_of_week`. All the other operations, including `+` and `-` should succeed.
+    which is on 15th October 1582.
 
+    Invoking some Gregorian calendar related functionalities, like `is_leap_year`,
+    is computed for all the date times, including those before an epoch start,
+    with today's rules. Trying to get some Gregorian calendar related properties
+    for a historical date times that is defined before the epoch is likely an error,
+    as the Gregorian calendar had not yet been discovered. Therefore, for such
+    historical date times, a warning is attached to the result.
 enso_epoch_start : Date_Time
 enso_epoch_start = @Builtin_Method "Date_Time.epoch_start"
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
@@ -21,17 +21,20 @@ polyglot java import org.enso.base.Time_Utils
     calendar related functionalities on such a Date_Time, e.g., `length_of_month` or
     `day_of_week`. All the other operations, including `+` and `-` should succeed.
 
-epoch_start : Date_Time
-epoch_start = @Builtin_Method "Date_Time.epoch_start"
+enso_epoch_start : Date_Time
+enso_epoch_start = @Builtin_Method "Date_Time.epoch_start"
 
 ## PRIVATE
-ensure_in_epoch : (Date_Time | Date) -> (Date_Time | Date) ! Time_Error
-ensure_in_epoch date =
+unix_epoch_start : Date_Time
+unix_epoch_start = Date_Time.new 1970
+
+## PRIVATE
+ensure_in_epoch : (Date_Time | Date) -> Suspend (Any -> Any) -> Any ! Time_Error
+ensure_in_epoch date ~action =
     datetime = case date of
         x : Date_Time -> x
         x : Date.Date -> x.to_date_time
-    if epoch_start <= datetime then date else Error.throw Time_Error.epoch_start
-
+    if enso_epoch_start <= datetime then action else Error.throw Time_Error.enso_epoch_start
 
 ## ALIAS Current Time
 
@@ -269,7 +272,7 @@ type Date_Time
     zone : Time_Zone
     zone self = @Builtin_Method "Date_Time.zone"
 
-    ## Return the number of seconds from the Enso epoch. See Date_Time.epoch_start
+    ## Return the number of seconds from the Unix epoch start (1.1.1970)
 
        If this Date_Time is before an epoch start, throws `Time_Error`.
 
@@ -278,12 +281,13 @@ type Date_Time
 
              from Standard.Base import Date_Time
 
-             example_epoch = Date_Time.now.to_epoch_seconds
-    to_epoch_seconds : Integer ! Time_Error
-    to_epoch_seconds self =
-        (Duration.between epoch_start (ensure_in_epoch self)).total_seconds.floor
+             example_epoch = Date_Time.now.to_unix_epoch_seconds
+    to_unix_epoch_seconds : Integer ! Time_Error
+    to_unix_epoch_seconds self =
+        if self >= unix_epoch_start then (Duration.between unix_epoch_start self).total_seconds.floor else
+            Error.throw (Time_Error_Data "Datetime is before Unix epoch")
 
-    ## Return the number of milliseconds from the Enso epoch. See Date_Time.epoch_start
+    ## Return the number of milliseconds from the Unix epoch start.
 
        If this Date_Time is before an epoch start, throws `Time_Error`.
 
@@ -292,10 +296,27 @@ type Date_Time
 
              from Standard.Base import Date_Time
 
-             example_epoch = Date_Time.now.to_epoch_milliseconds
-    to_epoch_milliseconds : Integer ! Time_Error
-    to_epoch_milliseconds self =
-        (Duration.between epoch_start (ensure_in_epoch self)).total_milliseconds.floor
+             example_epoch = Date_Time.now.to_unix_epoch_milliseconds
+    to_unix_epoch_milliseconds : Integer ! Time_Error
+    to_unix_epoch_milliseconds self =
+        if self >= unix_epoch_start then (Duration.between unix_epoch_start self).total_milliseconds.floor else
+            Error.throw (Time_Error_Data "Datetime is before Unix epoch")
+
+    ## Return the number of seconds from the Enso epoch start.
+
+       See `Date_Time.enso_epoch_start` If this Date_Time is before an Enso epoch
+       start, throws `Time_Error`.
+    to_enso_epoch_seconds : Integer ! Time_Error
+    to_enso_epoch_seconds self =
+        ensure_in_epoch self <| (Duration.betwen enso_epoch_start self).total_seconds.floor
+
+    ## Return the number of milliseconds from the Enso epoch start.
+
+       See `Date_Time.enso_epoch_start` If this Date_Time is before an Enso epoch
+       start, throws `Time_Error`.
+    to_enso_epoch_milliseconds : Integer ! Time_Error
+    to_enso_epoch_milliseconds self =
+        ensure_in_epoch self <| (Duration.betwen enso_epoch_start self).total_milliseconds.floor
 
     ## Convert this point in time to time of day, discarding the time zone
        information.
@@ -335,13 +356,13 @@ type Date_Time
 
        Throws `Time_Error` for a Date_Time that is before epoch start.
     is_leap_year : Boolean ! Time_Error
-    is_leap_year self = (ensure_in_epoch self).date.is_leap_year
+    is_leap_year self = ensure_in_epoch self <| self.date.is_leap_year
 
     ## Returns the number of days in the year represented by this date.
 
        Throws `Time_Error` for a Date_Time that is before epoch start.
     length_of_year : Integer ! Time_Error
-    length_of_year self = (ensure_in_epoch self).date.length_of_year
+    length_of_year self = ensure_in_epoch self <| self.date.length_of_year
 
     ## Returns the century of the date.
     century : Integer
@@ -364,7 +385,8 @@ type Date_Time
     ## Returns the day of the week.
     day_of_week : Day_Of_Week ! Time_Error
     day_of_week self =
-        Day_Of_Week.from (Time_Utils.get_field_as_zoneddatetime (ensure_in_epoch self) ChronoField.DAY_OF_WEEK) Day_Of_Week.Monday
+        ensure_in_epoch self <|
+            Day_Of_Week.from (Time_Utils.get_field_as_zoneddatetime self ChronoField.DAY_OF_WEEK) Day_Of_Week.Monday
 
     ## Returns the first date within the `Time_Period` or `Date_Period`
        containing self.
@@ -436,7 +458,7 @@ type Date_Time
        Monday through Friday.
 
        Throws `Time_Error` if called on a Date_Time that is before an epoch
-       start. See `Date_Time.epoch_start`.
+       start. See `Date_Time.enso_epoch_start`.
 
        This method always returns a day which is a business day - if the shift
        amount is zero, the closest following business day is returned. For the

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Error/Common.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Error/Common.enso
@@ -762,6 +762,11 @@ type Time_Error
        - error_message: The message for the error.
     Time_Error_Data error_message
 
+    ## PRIVATE
+    epoch_start : Time_Error
+    epoch_start = Time_Error_Data "Epoch start underflow"
+
+
 ## TODO Dubious constructor export
 from project.Error.Common.Unsupported_File_Type import all
 from project.Error.Common.Unsupported_File_Type export all

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoDateTime.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoDateTime.java
@@ -34,6 +34,11 @@ public final class EnsoDateTime implements TruffleObject {
     this.dateTime = dateTime;
   }
 
+  @Builtin.Method(name = "epoch_start", description = "Return the Enso start of the Epoch")
+  public static EnsoDateTime epochStart() {
+    return epochStart;
+  }
+
   @Builtin.Method(description = "Return current DateTime")
   @CompilerDirectives.TruffleBoundary
   public static EnsoDateTime now() {
@@ -162,18 +167,6 @@ public final class EnsoDateTime implements TruffleObject {
     return new EnsoDateTime(dateTime.minus(interop.asDuration(durationObject)));
   }
 
-  @Builtin.Method(description = "Return the number of seconds from the Unix epoch.")
-  @CompilerDirectives.TruffleBoundary
-  public long toEpochSeconds() {
-    return dateTime.toEpochSecond();
-  }
-
-  @Builtin.Method(description = "Return the number of milliseconds from the Unix epoch.")
-  @CompilerDirectives.TruffleBoundary
-  public long toEpochMilliseconds() {
-    return dateTime.toInstant().toEpochMilli();
-  }
-
   @Builtin.Method(
       name = "to_localtime_builtin",
       description = "Return the localtime of this date time value.")
@@ -263,6 +256,11 @@ public final class EnsoDateTime implements TruffleObject {
   public final Object toDisplayString(boolean allowSideEffects) {
     return DateTimeFormatter.ISO_ZONED_DATE_TIME.format(dateTime);
   }
+
+  // 15. October 1582
+  /** 15. October 1582 in UTC timezone. Note that Java considers an epoch start 1.1.1970 UTC. */
+  private static final EnsoDateTime epochStart =
+      EnsoDateTime.create(1582, 10, 15, 0, 0, 0, 0, EnsoTimeZone.parse("UTC"));
 
   private static final DateTimeFormatter TIME_FORMAT =
       new DateTimeFormatterBuilder()

--- a/test/Tests/src/Data/Time/Date_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Spec.enso
@@ -146,7 +146,7 @@ spec_with name create_new_date parse_date =
 
         Test.specify "Gregorian calendar related functionality should produce warning before epoch start" <|
             expect_warning value =
-                ((Warning.get_all value).length > 0) . should_be_true
+                (Warning.get_all value . map .value . exists (_.is_a Time_Error_Data)) . should_be_true
             dates_before_epoch = [(create_new_date 100), (create_new_date 500 6 3)]
             dates_before_epoch.each date->
                 expect_warning date.week_of_year

--- a/test/Tests/src/Data/Time/Date_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Spec.enso
@@ -145,15 +145,16 @@ spec_with name create_new_date parse_date =
             (create_new_date 100 1 2).day    . should_equal 2
 
         Test.specify "Gregorian calendar related functionality should fail before epoch start" <|
-            handler err = err . should_equal Time_Error.enso_epoch_start
+            expect_warning value =
+                ((Warning.get_all value).length > 0) . should_be_true
             dates_before_epoch = [(create_new_date 100), (create_new_date 500 6 3)]
             dates_before_epoch.each date->
-                Panic.catch Time_Error_Data date.week_of_year handler
-                Panic.catch Time_Error_Data date.is_leap_year handler
-                Panic.catch Time_Error_Data date.day_of_week handler
-                Panic.catch Time_Error_Data date.length_of_month handler
-                Panic.catch Time_Error_Data date.length_of_year handler
-                Panic.catch Time_Error_Data date.week_of_year handler
+                expect_warning date.week_of_year
+                expect_warning date.is_leap_year
+                expect_warning date.day_of_week
+                expect_warning date.length_of_month
+                expect_warning date.length_of_year
+                expect_warning date.week_of_year
 
         Test.specify "should correctly determine the type of date" <|
             new_date = create_new_date 2020 6 1

--- a/test/Tests/src/Data/Time/Date_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Spec.enso
@@ -139,6 +139,22 @@ spec_with name create_new_date parse_date =
             date_1>=datetime . should_fail_with Type_Error_Data
             date_1==datetime . should_be_false
 
+        Test.specify "should create date before epoch start" <|
+            (create_new_date 100 1 2).year   . should_equal 100
+            (create_new_date 100 1 2).month  . should_equal 1
+            (create_new_date 100 1 2).day    . should_equal 2
+
+        Test.specify "Gregorian calendar related functionality should fail before epoch start" <|
+            handler err = err . should_equal Time_Error.epoch_start
+            dates_before_epoch = [(create_new_date 100), (create_new_date 500 6 3)]
+            dates_before_epoch.each date->
+                Panic.catch Time_Error_Data date.week_of_year handler
+                Panic.catch Time_Error_Data date.is_leap_year handler
+                Panic.catch Time_Error_Data date.day_of_week handler
+                Panic.catch Time_Error_Data date.length_of_month handler
+                Panic.catch Time_Error_Data date.length_of_year handler
+                Panic.catch Time_Error_Data date.week_of_year handler
+
         Test.specify "should correctly determine the type of date" <|
             new_date = create_new_date 2020 6 1
             parsed_date = parse_date "2021-01-02"

--- a/test/Tests/src/Data/Time/Date_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Spec.enso
@@ -144,7 +144,7 @@ spec_with name create_new_date parse_date =
             (create_new_date 100 1 2).month  . should_equal 1
             (create_new_date 100 1 2).day    . should_equal 2
 
-        Test.specify "Gregorian calendar related functionality should fail before epoch start" <|
+        Test.specify "Gregorian calendar related functionality should produce warning before epoch start" <|
             expect_warning value =
                 ((Warning.get_all value).length > 0) . should_be_true
             dates_before_epoch = [(create_new_date 100), (create_new_date 500 6 3)]
@@ -155,6 +155,18 @@ spec_with name create_new_date parse_date =
                 expect_warning date.length_of_month
                 expect_warning date.length_of_year
                 expect_warning date.week_of_year
+
+        Test.specify "Gregorian calendar related functionality should work after epoch start" <|
+            expect_no_warning value =
+                ((Warning.get_all value).length == 0) . should_be_true
+            dates_after_epoch = [(create_new_date 1583), (create_new_date 1582 10 16), (create_new_date 2020)]
+            dates_after_epoch.each date->
+                expect_no_warning date.week_of_year
+                expect_no_warning date.is_leap_year
+                expect_no_warning date.day_of_week
+                expect_no_warning date.length_of_month
+                expect_no_warning date.length_of_year
+                expect_no_warning date.week_of_year
 
         Test.specify "should correctly determine the type of date" <|
             new_date = create_new_date 2020 6 1

--- a/test/Tests/src/Data/Time/Date_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Spec.enso
@@ -145,7 +145,7 @@ spec_with name create_new_date parse_date =
             (create_new_date 100 1 2).day    . should_equal 2
 
         Test.specify "Gregorian calendar related functionality should fail before epoch start" <|
-            handler err = err . should_equal Time_Error.epoch_start
+            handler err = err . should_equal Time_Error.enso_epoch_start
             dates_before_epoch = [(create_new_date 100), (create_new_date 500 6 3)]
             dates_before_epoch.each date->
                 Panic.catch Time_Error_Data date.week_of_year handler

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -174,6 +174,7 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
         Test.specify "should get Enso epoch seconds" <|
             (create_new_datetime 1582 10 15 0 0 8 (zone = Time_Zone.utc)).to_enso_epoch_seconds . should_equal 8
             (Date_Time.enso_epoch_start + (Duration.new minutes=2)).to_enso_epoch_seconds . should_equal (2 * 60)
+            (Date_Time.enso_epoch_start - (Duration.new minutes=2)).to_enso_epoch_seconds . should_equal -(2 * 60)
 
         Test.specify "should get Enso epoch millis" <|
             (create_new_datetime 1582 10 15 0 0 8 (zone = Time_Zone.utc)).to_enso_epoch_milliseconds . should_equal 8000
@@ -324,16 +325,19 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time_1.compare_to date . should_fail_with Type_Error_Data
             time_1==date . should_be_false
 
-        Test.specify "simple computations can underflow Enso epoch start" <|
-            handler _ = Test.fail "Unexpected: should not throw an error"
+        Test.specify "simple computations before Enso epoch should produce a warning" <|
+            expect_value_with_warning actual_value expected_value=Nothing =
+                if expected_value != Nothing then actual_value . should_equal expected_value
+                (((Warning.get_all actual_value).length) > 0) . should_be_true
 
-            Panic.catch Time_Error_Data (create_new_datetime 100) handler
-            Panic.catch Time_Error_Data (Date_Time.enso_epoch_start - (Duration.new hours=15)) handler
-            Panic.catch Time_Error_Data (Date_Time.enso_epoch_start - (Duration.new minutes=1)) handler
+            expect_value_with_warning (Date_Time.enso_epoch_start - (Duration.new hours=3)) (create_new_datetime 1582 10 14 21 (zone = Time_Zone.utc))
+            expect_value_with_warning (Date_Time.enso_epoch_start - (Duration.new minutes=1)) (create_new_datetime 1582 10 14 23 59 (zone = Time_Zone.utc))
 
-            enso_epoch_start = create_new_datetime Date_Time.enso_epoch_start.year Date_Time.enso_epoch_start.month Date_Time.enso_epoch_start.day Date_Time.enso_epoch_start.hour Date_Time.enso_epoch_start.minute Date_Time.enso_epoch_start.second Date_Time.enso_epoch_start.nanosecond (Time_Zone.parse "UTC")
-            Panic.catch Time_Error_Data (enso_epoch_start - (Duration.new hours=15)) handler
-            Panic.catch Time_Error_Data (enso_epoch_start - (Duration.new minutes=1)) handler
+            expect_value_with_warning (create_new_datetime 100).week_of_year
+            expect_value_with_warning (create_new_datetime 100).is_leap_year
+            expect_value_with_warning (create_new_datetime 100).length_of_year
+            expect_value_with_warning (create_new_datetime 100 4).length_of_month
+            expect_value_with_warning (create_new_datetime 100 4 15).day_of_week
 
         Test.specify "should create datetime before epoch start" <|
             (create_new_datetime 100 1 2 3 4).year   . should_equal 100
@@ -341,16 +345,6 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             (create_new_datetime 100 1 2 3 4).day    . should_equal 2
             (create_new_datetime 100 1 2 3 4).hour   . should_equal 3
             (create_new_datetime 100 1 2 3 4).minute . should_equal 4
-
-        Test.specify "Gregorian calendar related functionality should fail before epoch start" <|
-            handler err = err . should_equal (Time_Error.enso_epoch_start)
-            datetimes_before_epoch = [(create_new_datetime 100), (create_new_datetime 500 6)]
-            datetimes_before_epoch.each datetime->
-                Panic.catch Time_Error_Data datetime.to_enso_epoch_seconds handler
-                Panic.catch Time_Error_Data datetime.to_enso_epoch_milliseconds handler
-                Panic.catch Time_Error_Data datetime.day_of_week handler
-                Panic.catch Time_Error_Data datetime.length_of_month handler
-                Panic.catch Time_Error_Data datetime.week_of_year handler
 
         Test.specify "should correctly determine the type of datetime" <|
             new_datetime = create_new_datetime 2020 6 1 10 0 0

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -92,12 +92,12 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . zone . should_equal Time_Zone.system
 
         Test.specify "should parse time Z" <|
-            time = parse_datetime "1970-01-01T00:00:01Z"
+            time = parse_datetime "1582-10-15T00:00:01Z"
             time . to_epoch_seconds . should_equal 1
             time . zone . zone_id . should_equal "Z"
 
         Test.specify "should parse time UTC" <|
-            time = parse_datetime "1970-01-01T00:00:01Z[UTC]"
+            time = parse_datetime "1582-10-15T00:00:01Z[UTC]"
             time . to_epoch_seconds . should_equal 1
             time . zone . zone_id . should_equal "UTC"
 
@@ -172,12 +172,12 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
                     Test.fail ("Unexpected result: " + result.to_text)
 
         Test.specify "should get epoch seconds" <|
-            time = create_new_datetime 1970 1 1 0 0 8 (zone = Time_Zone.utc)
-            time . to_epoch_seconds . should_equal 8
+            (create_new_datetime 1582 10 15 0 0 8 (zone = Time_Zone.utc)).to_epoch_seconds . should_equal 8
+            (Date_Time.epoch_start + (Duration.new minutes=2)).to_epoch_seconds . should_equal (2 * 60)
 
         Test.specify "should get epoch millis" <|
-            time = create_new_datetime 1970 1 1 0 0 8 (zone = Time_Zone.utc)
-            time . to_epoch_milliseconds . should_equal 8000
+            (create_new_datetime 1582 10 15 0 0 8 (zone = Time_Zone.utc)).to_epoch_milliseconds . should_equal 8000
+            (Date_Time.epoch_start + (Duration.new seconds=2)).to_epoch_milliseconds . should_equal (2 * 1000)
 
         Test.specify "should set offset-based timezone" <|
             tz = Time_Zone.new 1 1 1
@@ -323,6 +323,34 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             date = Date.new 2021 1 1
             time_1.compare_to date . should_fail_with Type_Error_Data
             time_1==date . should_be_false
+
+        Test.specify "simple computations can underflow epoch start" <|
+            handler _ = Test.fail "Unexpected: should not throw an error"
+
+            Panic.catch Time_Error_Data (create_new_datetime 100) handler
+            Panic.catch Time_Error_Data (Date_Time.epoch_start - (Duration.new hours=15)) handler
+            Panic.catch Time_Error_Data (Date_Time.epoch_start - (Duration.new minutes=1)) handler
+
+            epoch_start = create_new_datetime Date_Time.epoch_start.year Date_Time.epoch_start.month Date_Time.epoch_start.day Date_Time.epoch_start.hour Date_Time.epoch_start.minute Date_Time.epoch_start.second Date_Time.epoch_start.nanosecond (Time_Zone.parse "UTC")
+            Panic.catch Time_Error_Data (epoch_start - (Duration.new hours=15)) handler
+            Panic.catch Time_Error_Data (epoch_start - (Duration.new minutes=1)) handler
+
+        Test.specify "should create datetime before epoch start" <|
+            (create_new_datetime 100 1 2 3 4).year   . should_equal 100
+            (create_new_datetime 100 1 2 3 4).month  . should_equal 1
+            (create_new_datetime 100 1 2 3 4).day    . should_equal 2
+            (create_new_datetime 100 1 2 3 4).hour   . should_equal 3
+            (create_new_datetime 100 1 2 3 4).minute . should_equal 4
+
+        Test.specify "Gregorian calendar related functionality should fail before epoch start" <|
+            handler err = err . should_equal (Time_Error.epoch_start)
+            datetimes_before_epoch = [(create_new_datetime 100), (create_new_datetime 500 6)]
+            datetimes_before_epoch.each datetime->
+                Panic.catch Time_Error_Data datetime.to_epoch_seconds handler
+                Panic.catch Time_Error_Data datetime.to_epoch_milliseconds handler
+                Panic.catch Time_Error_Data datetime.day_of_week handler
+                Panic.catch Time_Error_Data datetime.length_of_month handler
+                Panic.catch Time_Error_Data datetime.week_of_year handler
 
         Test.specify "should correctly determine the type of datetime" <|
             new_datetime = create_new_datetime 2020 6 1 10 0 0

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -93,12 +93,12 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
 
         Test.specify "should parse time Z" <|
             time = parse_datetime "1582-10-15T00:00:01Z"
-            time . to_epoch_seconds . should_equal 1
+            time . to_enso_epoch_seconds . should_equal 1
             time . zone . zone_id . should_equal "Z"
 
         Test.specify "should parse time UTC" <|
             time = parse_datetime "1582-10-15T00:00:01Z[UTC]"
-            time . to_epoch_seconds . should_equal 1
+            time . to_enso_epoch_seconds . should_equal 1
             time . zone . zone_id . should_equal "UTC"
 
         Test.specify "should parse time with nanoseconds" <|
@@ -171,13 +171,13 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
                 result ->
                     Test.fail ("Unexpected result: " + result.to_text)
 
-        Test.specify "should get epoch seconds" <|
-            (create_new_datetime 1582 10 15 0 0 8 (zone = Time_Zone.utc)).to_epoch_seconds . should_equal 8
-            (Date_Time.epoch_start + (Duration.new minutes=2)).to_epoch_seconds . should_equal (2 * 60)
+        Test.specify "should get Enso epoch seconds" <|
+            (create_new_datetime 1582 10 15 0 0 8 (zone = Time_Zone.utc)).to_enso_epoch_seconds . should_equal 8
+            (Date_Time.enso_epoch_start + (Duration.new minutes=2)).to_enso_epoch_seconds . should_equal (2 * 60)
 
-        Test.specify "should get epoch millis" <|
-            (create_new_datetime 1582 10 15 0 0 8 (zone = Time_Zone.utc)).to_epoch_milliseconds . should_equal 8000
-            (Date_Time.epoch_start + (Duration.new seconds=2)).to_epoch_milliseconds . should_equal (2 * 1000)
+        Test.specify "should get Enso epoch millis" <|
+            (create_new_datetime 1582 10 15 0 0 8 (zone = Time_Zone.utc)).to_enso_epoch_milliseconds . should_equal 8000
+            (Date_Time.enso_epoch_start + (Duration.new seconds=2)).to_enso_epoch_milliseconds . should_equal (2 * 1000)
 
         Test.specify "should set offset-based timezone" <|
             tz = Time_Zone.new 1 1 1
@@ -324,16 +324,16 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time_1.compare_to date . should_fail_with Type_Error_Data
             time_1==date . should_be_false
 
-        Test.specify "simple computations can underflow epoch start" <|
+        Test.specify "simple computations can underflow Enso epoch start" <|
             handler _ = Test.fail "Unexpected: should not throw an error"
 
             Panic.catch Time_Error_Data (create_new_datetime 100) handler
-            Panic.catch Time_Error_Data (Date_Time.epoch_start - (Duration.new hours=15)) handler
-            Panic.catch Time_Error_Data (Date_Time.epoch_start - (Duration.new minutes=1)) handler
+            Panic.catch Time_Error_Data (Date_Time.enso_epoch_start - (Duration.new hours=15)) handler
+            Panic.catch Time_Error_Data (Date_Time.enso_epoch_start - (Duration.new minutes=1)) handler
 
-            epoch_start = create_new_datetime Date_Time.epoch_start.year Date_Time.epoch_start.month Date_Time.epoch_start.day Date_Time.epoch_start.hour Date_Time.epoch_start.minute Date_Time.epoch_start.second Date_Time.epoch_start.nanosecond (Time_Zone.parse "UTC")
-            Panic.catch Time_Error_Data (epoch_start - (Duration.new hours=15)) handler
-            Panic.catch Time_Error_Data (epoch_start - (Duration.new minutes=1)) handler
+            enso_epoch_start = create_new_datetime Date_Time.enso_epoch_start.year Date_Time.enso_epoch_start.month Date_Time.enso_epoch_start.day Date_Time.enso_epoch_start.hour Date_Time.enso_epoch_start.minute Date_Time.enso_epoch_start.second Date_Time.enso_epoch_start.nanosecond (Time_Zone.parse "UTC")
+            Panic.catch Time_Error_Data (enso_epoch_start - (Duration.new hours=15)) handler
+            Panic.catch Time_Error_Data (enso_epoch_start - (Duration.new minutes=1)) handler
 
         Test.specify "should create datetime before epoch start" <|
             (create_new_datetime 100 1 2 3 4).year   . should_equal 100
@@ -343,11 +343,11 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             (create_new_datetime 100 1 2 3 4).minute . should_equal 4
 
         Test.specify "Gregorian calendar related functionality should fail before epoch start" <|
-            handler err = err . should_equal (Time_Error.epoch_start)
+            handler err = err . should_equal (Time_Error.enso_epoch_start)
             datetimes_before_epoch = [(create_new_datetime 100), (create_new_datetime 500 6)]
             datetimes_before_epoch.each datetime->
-                Panic.catch Time_Error_Data datetime.to_epoch_seconds handler
-                Panic.catch Time_Error_Data datetime.to_epoch_milliseconds handler
+                Panic.catch Time_Error_Data datetime.to_enso_epoch_seconds handler
+                Panic.catch Time_Error_Data datetime.to_enso_epoch_milliseconds handler
                 Panic.catch Time_Error_Data datetime.day_of_week handler
                 Panic.catch Time_Error_Data datetime.length_of_month handler
                 Panic.catch Time_Error_Data datetime.week_of_year handler
@@ -471,8 +471,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
 
             d1_start = d1.start_of Time_Period.Hour
             d1_end = d1.end_of Time_Period.Hour
-            (d1.to_epoch_seconds - d1_start.to_epoch_seconds) . should_equal (34*60 + 15)
-            (d1_end.to_epoch_seconds - d1.to_epoch_seconds) . should_equal (60*60 - (34*60 + 15) - 1)
+            (d1.to_enso_epoch_seconds - d1_start.to_enso_epoch_seconds) . should_equal (34*60 + 15)
+            (d1_end.to_enso_epoch_seconds - d1.to_enso_epoch_seconds) . should_equal (60*60 - (34*60 + 15) - 1)
             d1_start . should_equal (Date_Time.new 2022 3 27 1 0 0 0 tz)
             d1_end . should_equal (Date_Time.new 2022 3 27 1 59 59 max_nanos tz)
             d1.start_of Time_Period.Minute . should_equal (Date_Time.new 2022 3 27 1 34 0 0 tz)
@@ -480,8 +480,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
 
             d2_start = d2.start_of Time_Period.Hour
             d2_end = d2.end_of Time_Period.Hour
-            (d2.to_epoch_seconds - d2_start.to_epoch_seconds) . should_equal (34*60 + 15)
-            (d2_end.to_epoch_seconds - d2.to_epoch_seconds) . should_equal (60*60 - (34*60 + 15) - 1)
+            (d2.to_enso_epoch_seconds - d2_start.to_enso_epoch_seconds) . should_equal (34*60 + 15)
+            (d2_end.to_enso_epoch_seconds - d2.to_enso_epoch_seconds) . should_equal (60*60 - (34*60 + 15) - 1)
             d2_start . should_equal (Date_Time.new 2022 3 27 3 0 0 0 tz)
             d2_end . should_equal (Date_Time.new 2022 3 27 3 59 59 max_nanos tz)
 
@@ -494,7 +494,7 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             d4.hour . should_equal 2
             d3.minute . should_equal 30
             d4.minute . should_equal 30
-            (d4.to_epoch_milliseconds - d3.to_epoch_milliseconds) . should_equal 60*60*1000
+            (d4.to_enso_epoch_milliseconds - d3.to_enso_epoch_milliseconds) . should_equal 60*60*1000
             Time_Utils.get_datetime_offset d3 . should_equal offset_2_h
             Time_Utils.get_datetime_offset d4 . should_equal offset_1_h
 
@@ -510,8 +510,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
 
             d3_start = d3.start_of Time_Period.Hour
             d3_end = d3.end_of Time_Period.Hour
-            (d3.to_epoch_seconds - d3_start.to_epoch_seconds) . should_equal (30*60 + 15)
-            (d3_end.to_epoch_seconds - d3.to_epoch_seconds) . should_equal (60*60 - (30*60 + 15) - 1)
+            (d3.to_enso_epoch_seconds - d3_start.to_enso_epoch_seconds) . should_equal (30*60 + 15)
+            (d3_end.to_enso_epoch_seconds - d3.to_enso_epoch_seconds) . should_equal (60*60 - (30*60 + 15) - 1)
             d3_start . should_equal (Date_Time.new 2022 10 30 2 0 0 0 tz)
             Time_Utils.get_datetime_offset d3_start . should_equal offset_2_h
             d3_end . should_equal (Date_Time.new 2022 10 30 2 59 59 max_nanos tz)
@@ -519,8 +519,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
 
             d4_start = d4.start_of Time_Period.Hour
             d4_end = d4.end_of Time_Period.Hour
-            (d4.to_epoch_seconds - d4_start.to_epoch_seconds) . should_equal (30*60 + 15)
-            (d4_end.to_epoch_seconds - d4.to_epoch_seconds) . should_equal (60*60 - (30*60 + 15) - 1)
+            (d4.to_enso_epoch_seconds - d4_start.to_enso_epoch_seconds) . should_equal (30*60 + 15)
+            (d4_end.to_enso_epoch_seconds - d4.to_enso_epoch_seconds) . should_equal (60*60 - (30*60 + 15) - 1)
             d4_start.hour . should_equal 2
             d4_start.minute . should_equal 0
             Time_Utils.get_datetime_offset d4_start . should_equal offset_1_h


### PR DESCRIPTION
### Pull Request Description

Define start of Enso epoch as 15th of October 1582 - start of the Gregorian calendar.

### Important Notes
- Some (Gregorian) calendar related functionalities within `Date` and `Date_Time` now produces a warning  if the receiving Date/Date_Time is before the epoch start, e.g., `week_of_year`, `is_leap_year`, etc.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
