### PR TITLE
Process documentation in type definitions

### DIFF
--- a/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
@@ -1923,14 +1923,13 @@ final class TreeToIr {
       for (var t : doc.getDocumentation().getElements()) {
         switch (t) {
           case TextElement.Section s -> {
+            var whitespace = s.getText().getWhitespace();
             var txt = s.getText().codeRepr();
-            if (txt.startsWith("#")) {
-              txt = txt.substring(1);
+            if (whitespace.length() > 0) {
+              whitespace = whitespace.subSequence(1, whitespace.length());
             }
-            if (msg.length() > 0) {
-              msg.append(" ");
-            }
-            msg.append(txt);
+            msg.append(whitespace);
+            msg.append(txt.replaceAll("\n", ""));
           }
 
           default -> throw new UnhandledEntity(t, "translateComment");

--- a/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
@@ -1155,18 +1155,11 @@ final class TreeToIr {
   IR.Literal translateLiteral(Tree.TextLiteral txt) {
     StringBuilder sb = new StringBuilder();
     for (var t : txt.getElements()) {
-      var sectionTxt = switch (t) {
-          case TextElement.Section s -> s.getText().codeRepr();
-          case TextElement.Escape e -> switch (e.getToken().codeRepr()) {
-            case "\\n" -> "\n";
-            case "\\t" -> "\t";
-            case "\\r" -> "\r";
-            case "\\f" -> "\f";
-            default -> throw new UnhandledEntity(e, "translateLiteral");
-          };
+      switch (t) {
+          case TextElement.Section s -> sb.append(s.getText().codeRepr());
+          case TextElement.Escape e -> sb.appendCodePoint(e.getToken().getValue());
           default -> throw new UnhandledEntity(t, "translateLiteral");
-      };
-      sb.append(sectionTxt);
+      }
     }
     return new IR$Literal$Text(sb.toString(), getIdentifiedLocation(txt), meta(), diag());
   }

--- a/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
@@ -230,47 +230,47 @@ final class TreeToIr {
         var translatedConstructors = CollectionConverters.asScala(translatedConstructorsIt).toList();
         // type
         List<IR.DefinitionArgument> args = translateArgumentsDefinition(def.getParams());
-        var t = new IR$Module$Scope$Definition$SugaredType(
+        var type = new IR$Module$Scope$Definition$SugaredType(
           typeName,
           args,
           translatedConstructors.appendedAll(translatedBody),
           getIdentifiedLocation(inputAst),
           meta(), diag()
         );
-        yield cons(t, appendTo);
+        yield cons(type, appendTo);
       }
       case Tree.Function fn -> {
         var methodRef = translateMethodReference(fn.getName(), false);
         var args = translateArgumentsDefinition(fn.getArgs());
         var body = translateExpression(fn.getBody(), false);
 
-        var b = new IR$Module$Scope$Definition$Method$Binding(
+        var binding = new IR$Module$Scope$Definition$Method$Binding(
           methodRef,
           args,
           body,
           getIdentifiedLocation(inputAst),
           meta(), diag()
         );
-        yield cons(b, appendTo);
+        yield cons(binding, appendTo);
       }
       case Tree.Annotated anno -> {
-        var n = new IR$Name$Annotation("@" + anno.getAnnotation().codeRepr(), getIdentifiedLocation(anno), meta(), diag());
-        yield translateModuleSymbol(anno.getExpression(), cons(n, appendTo));
+        var annotation = new IR$Name$Annotation("@" + anno.getAnnotation().codeRepr(), getIdentifiedLocation(anno), meta(), diag());
+        yield translateModuleSymbol(anno.getExpression(), cons(annotation, appendTo));
       }
       case Tree.Documented doc -> {
-        var c = translateComment(doc, doc.getDocumentation());
-        yield translateModuleSymbol(doc.getExpression(), cons(c, appendTo));
+        var comment = translateComment(doc, doc.getDocumentation());
+        yield translateModuleSymbol(doc.getExpression(), cons(comment, appendTo));
       }
       case Tree.Assignment a -> {
-        var r = translateMethodReference(a.getPattern(), false);
-        var m = new IR$Module$Scope$Definition$Method$Binding(
-          r,
+        var reference = translateMethodReference(a.getPattern(), false);
+        var binding = new IR$Module$Scope$Definition$Method$Binding(
+          reference,
           nil(),
           translateExpression(a.getExpr(), false),
           getIdentifiedLocation(a),
           meta(), diag()
         );
-        yield cons(m, appendTo);
+        yield cons(binding, appendTo);
       }
     /*
       case AstView.FunctionSugar(
@@ -315,7 +315,7 @@ final class TreeToIr {
 //      case AstView.TypeAscription(typed, sig) =>
         var methodReference = translateMethodReference(sig.getVariable(), true);
         var signature = translateExpression(sig.getType(), true);
-        var t = new IR$Type$Ascription(methodReference, signature, getIdentifiedLocation(sig), meta(), diag());
+        var ascription = new IR$Type$Ascription(methodReference, signature, getIdentifiedLocation(sig), meta(), diag());
         /*
         typed match {
           case AST.Ident.any(ident)       => buildAscription(ident)
@@ -331,11 +331,11 @@ final class TreeToIr {
       case _ => Error.Syntax(inputAst, Error.Syntax.UnexpectedExpression)
     }
     */
-        yield cons(t, appendTo);
+        yield cons(ascription, appendTo);
       }
       default -> {
-        var e = new IR$Error$Syntax(inputAst, new IR$Error$Syntax$UnexpectedExpression$(), meta(), diag());
-        yield cons(e, appendTo);
+        var error = new IR$Error$Syntax(inputAst, new IR$Error$Syntax$UnexpectedExpression$(), meta(), diag());
+        yield cons(error, appendTo);
       }
     };
   }
@@ -436,8 +436,8 @@ final class TreeToIr {
       }
       case Tree.Annotated anno -> {
         var ir = new IR$Name$Annotation("@" + anno.getAnnotation().codeRepr(), getIdentifiedLocation(anno), meta(), diag());
-        var a = translateAnnotation(ir, anno.getExpression(), nil());
-        yield cons(a, appendTo);
+        var annotation = translateAnnotation(ir, anno.getExpression(), nil());
+        yield cons(annotation, appendTo);
       }
       /*
       case AstView.Binding(AST.App.Section.Right(opr, arg), body) =>
@@ -487,8 +487,8 @@ final class TreeToIr {
               name = new IR$Name$Literal(name.name(), true, name.location(), name.passData(), name.diagnostics());
               var tail = ((List)fullQualifiedNames.tail()).reverse();
               final Option<IdentifiedLocation> loc = getIdentifiedLocation(app);
-              var q = new IR$Name$Qualified(tail, loc, meta(), diag());
-              var ca = new IR$CallArgument$Specified(Option.empty(), q, loc, meta(), diag());
+              var qualified = new IR$Name$Qualified(tail, loc, meta(), diag());
+              var ca = new IR$CallArgument$Specified(Option.empty(), qualified, loc, meta(), diag());
               args = cons(ca, args);
               yield name;
           }
@@ -919,7 +919,7 @@ final class TreeToIr {
           n.copy$default$5(),
           n.copy$default$6()
         );
-        case IR.Expression e -> e;
+        case IR.Expression expr -> expr;
       };
       case Tree.TypeSignature sig -> {
         var methodName = buildName(sig.getVariable());
@@ -1364,9 +1364,9 @@ final class TreeToIr {
   @SuppressWarnings("unchecked")
   private List<IR.CallArgument> translateCallArguments(List<Tree> args, List<IR.CallArgument> res, boolean insideTypeSignature) {
     while (args.nonEmpty()) {
-      var a = translateCallArgument(args.head(), insideTypeSignature);
-      if (a != null) {
-        res = cons(a, res);
+      var argument = translateCallArgument(args.head(), insideTypeSignature);
+      if (argument != null) {
+        res = cons(argument, res);
       }
       args = (List<Tree>) args.tail();
     }

--- a/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
@@ -215,7 +215,7 @@ final class TreeToIr {
       */
       case Tree.TypeDef def -> {
         var typeName = buildName(def.getName());
-        var translatedBody = translateTypeBody(def.getBlock(), true);
+        var translatedBody = translateTypeBody(def.getBlock());
         var translatedConstructorsIt = def.getConstructors().stream().map((c) -> {
           var cExpr = c.getExpression();
           if (cExpr == null) {
@@ -348,7 +348,7 @@ final class TreeToIr {
     * @param body the body to be translated
     * @return the [[IR]] representation of `body`
     */
-  private List<IR> translateTypeBody(java.util.List<Line> block, boolean found) {
+  private List<IR> translateTypeBody(java.util.List<Line> block) {
     List<IR> res = nil();
     for (var line : block) {
       res = translateTypeBodyExpression(line.getExpression(), res);

--- a/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
@@ -50,6 +50,7 @@ import org.enso.compiler.exception.UnhandledEntity;
 import org.enso.syntax.text.Location;
 import org.enso.syntax2.ArgumentDefinition;
 import org.enso.syntax2.Case;
+import org.enso.syntax2.DocComment;
 import org.enso.syntax2.Either;
 import org.enso.syntax2.FractionalDigits;
 import org.enso.syntax2.Line;
@@ -257,7 +258,7 @@ final class TreeToIr {
         yield translateModuleSymbol(anno.getExpression(), cons(n, appendTo));
       }
       case Tree.Documented doc -> {
-        var c = translateComment(doc);
+        var c = translateComment(doc, doc.getDocumentation());
         yield translateModuleSymbol(doc.getExpression(), cons(c, appendTo));
       }
       case Tree.Assignment a -> {
@@ -430,7 +431,7 @@ final class TreeToIr {
       case fs @ AstView.FunctionSugar(_, _, _) => translateExpression(fs)
       */
       case Tree.Documented doc -> {
-        var irDoc = translateComment(doc);
+        var irDoc = translateComment(doc, doc.getDocumentation());
         yield translateTypeBodyExpression(doc.getExpression(), cons(irDoc, appendTo));
       }
       case Tree.Annotated anno -> {
@@ -1905,9 +1906,9 @@ final class TreeToIr {
     * @param doc the comment to transform
     * @return the [[IR]] representation of `comment`
     */
-  IR.Comment translateComment(Tree.Documented doc) {
+  IR.Comment translateComment(Tree where, DocComment doc) {
       var msg = new StringBuilder();
-      for (var t : doc.getDocumentation().getElements()) {
+      for (var t : doc.getElements()) {
         switch (t) {
           case TextElement.Section s -> {
             var whitespace = s.getText().getWhitespace();
@@ -1922,7 +1923,7 @@ final class TreeToIr {
           default -> throw new UnhandledEntity(t, "translateComment");
         }
       }
-      return new IR$Comment$Documentation(msg.toString(), getIdentifiedLocation(doc), meta(), diag());
+      return new IR$Comment$Documentation(msg.toString(), getIdentifiedLocation(where), meta(), diag());
   }
 
   private IR$Name$Literal buildName(Token name) {

--- a/engine/runtime/src/test/java/org/enso/compiler/EnsoCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/EnsoCompilerTest.java
@@ -132,6 +132,14 @@ public class EnsoCompilerTest {
   }
 
   @Test
+  public void testCaseTypeOfWithSpace() throws Exception {
+    parseTest("""
+    filter self filter = case filter of
+        _ : Filter -> 42
+    """);
+  }
+
+  @Test
   public void testAnnotation0() throws Exception {
     parseTest("""
     dont_stop = @Tail_Call dont_stop
@@ -260,7 +268,6 @@ public class EnsoCompilerTest {
   }
 
   @Test
-  @Ignore // because of https://github.com/enso-org/enso/pull/3653#issuecomment-1221841342
   public void testDocumentationComment() throws Exception {
     parseTest("""
     ## A type representing computations that may fail.
@@ -269,32 +276,13 @@ public class EnsoCompilerTest {
   }
 
   @Test
-  @Ignore
   public void testColumnSelector() throws Exception {
     parseTest("""
+    ## Specifies a selection of columns from the table on which an operation is
+       going to be performed.
     type Column_Selector
-
-        ## Selects columns based on their names.
-
-           The `matcher` can be used to specify if the names should be matched
-           exactly or should be treated as regular expressions. It also allows to
-           specify if the matching should be case-sensitive.
-        type By_Name (names : Vector Text) (matcher : Matcher = Text_Matcher)
-
-        ## Selects columns by their index.
-
-           The index of the first column in the table is 0. If the provided index is
-           negative, it counts from the end of the table (e.g. -1 refers to the last
-           column in the table).
-        type By_Index (indexes : Vector Integer)
-
-        ## Selects columns having exactly the same names as the columns provided in
-           the input.
-
-           The input columns do not necessarily have to come from the same table, so
-           this approach can be used to match columns with the same names as a set
-           of columns of some other table, for example, when preparing for a join.
-        type By_Column (columns : Vector Column)
+        By_Index (indexes : Vector Integer)
+        By_Column (columns : Vector Column)
     """);
   }
 
@@ -389,6 +377,13 @@ public class EnsoCompilerTest {
   }
 
   @Test
+  public void testTextLiteralWithEscape() throws Exception {
+    parseTest("""
+    wrap_junit_testsuites = '<?xml version="1.0" encoding="UTF-8"?>\\n'
+    """);
+  }
+
+  @Test
   public void testLambda() throws Exception {
     parseTest("""
     f = map _->alphabet
@@ -405,6 +400,31 @@ public class EnsoCompilerTest {
     measure = ~act -> label -> iter_size -> num_iters ->
         42
     """);
+  }
+
+  @Test
+  @Ignore // shifted positions confused `Tree.codeRepr()` for identifiers
+  public void testTestGroup() throws Exception {
+    parseTest("""
+    type Test
+        ## Creates a new test group, describing properties of the object
+           described by `self`.
+
+           Arguments:
+           - name: The name of the test group.
+           - behaviors: An action containing a set of specs for the group.
+           - pending: A reason for why the test is pending, or `Nothing` when it is not
+             pending.
+
+           > Example
+             Adding a test group.
+
+                 from Standard.Test import Test, Test_Suite
+
+                 example_group = Test_Suite.run <|
+                     Test.group "Number" <| Nothing
+        group : Text -> Any -> (Text | Nothing) -> Nothing
+        """);
   }
 
   @Test
@@ -562,15 +582,6 @@ public class EnsoCompilerTest {
     parseTest("""
     type Foo
         id x = x
-    """);
-  }
-
-  @Test
-  @Ignore
-  public void testMethodDefQualified() throws Exception {
-    parseTest("""
-    type Foo
-        Identity.id x = x
     """);
   }
 

--- a/engine/runtime/src/test/java/org/enso/compiler/EnsoCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/EnsoCompilerTest.java
@@ -422,7 +422,7 @@ public class EnsoCompilerTest {
 
                  example_group = Test_Suite.run <|
                      Test.group "Number" <| Nothing
-        group : Text -> Any -> (Text | Nothing) -> Nothing
+        group : Text -> Any
         """);
   }
 

--- a/engine/runtime/src/test/java/org/enso/compiler/EnsoCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/EnsoCompilerTest.java
@@ -379,7 +379,7 @@ public class EnsoCompilerTest {
   @Test
   public void testTextLiteralWithEscape() throws Exception {
     parseTest("""
-    wrap_junit_testsuites = '<?xml version="1.0" encoding="UTF-8"?>\\n'
+    wrap_junit_testsuites = '<?xml version="1.0"\\tencoding="UTF-8"?>\\n'
     """);
   }
 

--- a/lib/rust/parser/generate-java/src/serialization.rs
+++ b/lib/rust/parser/generate-java/src/serialization.rs
@@ -16,6 +16,7 @@ use enso_metamodel::java::bincode::MaterializerInput;
 //  generated fields in Java classes by starting from a `str -> rust::FieldId` query on Rust
 //  type data, and mapping fields analogously to `rust_to_java` for types.
 const CODE_GETTER: &str = "codeRepr";
+const WHITESPACE_GETTER: &str = "getWhitespace";
 const TREE_BEGIN: &str = "fieldSpanLeftOffsetCodeReprBegin";
 const TREE_LEN: &str = "fieldSpanLeftOffsetCodeReprLen";
 
@@ -24,7 +25,9 @@ pub fn derive(graph: &mut TypeGraph, tree: ClassId, token: ClassId) {
     let source = "source";
     impl_deserialize(graph, tree, token, source);
     graph[token].methods.push(impl_getter(CODE_GETTER));
+    graph[token].methods.push(impl_whitespace_getter(WHITESPACE_GETTER));
     graph[tree].methods.push(impl_getter(CODE_GETTER));
+    graph[tree].methods.push(impl_whitespace_getter(WHITESPACE_GETTER));
 }
 
 
@@ -169,5 +172,12 @@ fn impl_getter(name: &str) -> Method {
     let mut method = syntax::Method::new(name, syntax::Type::named("String"));
     method.body =
         "return source.subSequence((int)startCode, (int)endCode).toString();\n".to_string();
+    Method::Raw(method)
+}
+
+fn impl_whitespace_getter(name: &str) -> Method {
+    let mut method = syntax::Method::new(name, syntax::Type::named("CharSequence"));
+    method.body =
+        "return source.subSequence((int)startWhitespace, (int)startCode);\n".to_string();
     Method::Raw(method)
 }

--- a/lib/rust/parser/generate-java/src/serialization.rs
+++ b/lib/rust/parser/generate-java/src/serialization.rs
@@ -177,7 +177,6 @@ fn impl_getter(name: &str) -> Method {
 
 fn impl_whitespace_getter(name: &str) -> Method {
     let mut method = syntax::Method::new(name, syntax::Type::named("CharSequence"));
-    method.body =
-        "return source.subSequence((int)startWhitespace, (int)startCode);\n".to_string();
+    method.body = "return source.subSequence((int)startWhitespace, (int)startCode);\n".to_string();
     Method::Raw(method)
 }


### PR DESCRIPTION
### Pull Request Description

Another part of #3611 ready for integration into `develop` branch.

### Important Notes

Test `org.enso.compiler.EnsoCompilerTest.testTestGroup` is ignored as it has problems with source offsets - identifiers don't have the appropriate names due to `Tree.codeRepr()` being _off_. 

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md) style guides.
- [x] All code conforms to the `cargo fmt` style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
 