### PR TITLE
Fix potential dobule-borrow panic.

### DIFF
--- a/lib/rust/frp/src/network.rs
+++ b/lib/rust/frp/src/network.rs
@@ -194,7 +194,7 @@ impl BridgeNetwork {
 
     fn destroy(&self) {
         self.data.take();
-        // Beware: doing it in another, also intuitive wayL
+        // Beware: doing it in another, also intuitive way
         // *self.data.borrow_mut() = None
         // May cause a panic, because the drop procedure is done while keeping data borrowed.
     }

--- a/lib/rust/frp/src/network.rs
+++ b/lib/rust/frp/src/network.rs
@@ -193,7 +193,10 @@ impl BridgeNetwork {
     }
 
     fn destroy(&self) {
-        *self.data.borrow_mut() = None
+        self.data.take();
+        // Beware: doing it in another, also intuitive wayL
+        // *self.data.borrow_mut() = None
+        // May cause a panic, because the drop procedure is done while keeping data borrowed.
     }
 }
 


### PR DESCRIPTION
### Pull Request Description

There is one place in code, where we can potentially panic on double borrow, because the drop routine is done while having data borrowed.

### Important Notes

The issue was easily reproducible on @Frizi machine.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
