### PR TITLE
Accept Array-like objects seamlessly in builtins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -400,6 +400,7 @@
 - [Fix performance of method calls on polyglot arrays][3781]
 - [Missing foreign language generates proper Enso error][3798]
 - [Made Vector performance to be on par with Array][3811]
+- [Accept Array-like object seamlessly in builtins][3817]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -455,6 +456,7 @@
 [3781]: https://github.com/enso-org/enso/pull/3781
 [3798]: https://github.com/enso-org/enso/pull/3798
 [3811]: https://github.com/enso-org/enso/pull/3811
+[3817]: https://github.com/enso-org/enso/pull/3817
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/immutable/FromArrayBuiltinVectorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/immutable/FromArrayBuiltinVectorNode.java
@@ -8,6 +8,7 @@ import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.dsl.*;
 import org.enso.interpreter.epb.node.CoercePrimitiveNode;
+import org.enso.interpreter.node.expression.builtin.mutable.CoerceArrayNode;
 import org.enso.interpreter.node.expression.foreign.CoerceNothing;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.data.Array;
@@ -19,9 +20,6 @@ import org.enso.interpreter.runtime.data.Vector;
     name = "from_array",
     description = "Creates a Vector by copying Array content.")
 public abstract class FromArrayBuiltinVectorNode extends Node {
-  private @Child CoercePrimitiveNode coercePrimitiveNode = CoercePrimitiveNode.build();
-  private @Child CoerceNothing coerceNothingNode = CoerceNothing.build();
-
   static FromArrayBuiltinVectorNode build() {
     return FromArrayBuiltinVectorNodeGen.create();
   }
@@ -34,24 +32,11 @@ public abstract class FromArrayBuiltinVectorNode extends Node {
   }
 
   @Specialization(guards = "interop.hasArrayElements(arr)")
-  Vector fromArrayLikeObject(Object arr, @CachedLibrary(limit = "3") InteropLibrary interop) {
-    try {
-      long length = interop.getArraySize(arr);
-      Object[] target = new Object[(int) length];
-      for (int i = 0; i < length; i++) {
-        try {
-          var value = interop.readArrayElement(arr, i);
-          target[i] = coerceNothingNode.execute(coercePrimitiveNode.execute(value));
-        } catch (InvalidArrayIndexException ex) {
-          var ctx = Context.get(this);
-          var err = ctx.getBuiltins().error().makeInvalidArrayIndexError(arr, i);
-          throw new PanicException(err, this);
-        }
-      }
-      return Vector.fromArray(new Array(target));
-    } catch (UnsupportedMessageException ex) {
-      throw unsupportedException(arr);
-    }
+  Vector fromArrayLikeObject(
+      Object arr,
+      @Cached CoerceArrayNode coerce,
+      @CachedLibrary(limit = "3") InteropLibrary interop) {
+    return Vector.fromArray(new Array(coerce.execute(arr)));
   }
 
   @Fallback

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/ExecuteNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/ExecuteNode.java
@@ -1,5 +1,7 @@
 package org.enso.interpreter.node.expression.builtin.interop.generic;
 
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
@@ -9,6 +11,7 @@ import com.oracle.truffle.api.profiles.BranchProfile;
 import org.enso.interpreter.Constants;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.interop.syntax.HostValueToEnsoNode;
+import org.enso.interpreter.node.expression.builtin.mutable.CoerceArrayNode;
 import org.enso.interpreter.runtime.data.Array;
 import org.enso.interpreter.runtime.error.PanicException;
 
@@ -16,15 +19,22 @@ import org.enso.interpreter.runtime.error.PanicException;
     type = "Polyglot",
     name = "execute",
     description = "Executes a polyglot function object (e.g. a lambda).")
-public class ExecuteNode extends Node {
+public abstract class ExecuteNode extends Node {
   private @Child InteropLibrary library =
       InteropLibrary.getFactory().createDispatched(Constants.CacheSizes.BUILTIN_INTEROP_DISPATCH);
   private @Child HostValueToEnsoNode hostValueToEnsoNode = HostValueToEnsoNode.build();
   private final BranchProfile err = BranchProfile.create();
 
-  Object execute(Object callable, Array arguments) {
+  public static ExecuteNode build() {
+    return ExecuteNodeGen.create();
+  }
+
+  public abstract Object execute(Object callable, Object arguments);
+
+  @Specialization
+  Object execute(Object callable, Object arguments, @Cached("build()") CoerceArrayNode coerce) {
     try {
-      return hostValueToEnsoNode.execute(library.execute(callable, arguments.getItems()));
+      return hostValueToEnsoNode.execute(library.execute(callable, coerce.execute(arguments)));
     } catch (UnsupportedMessageException | ArityException | UnsupportedTypeException e) {
       err.enter();
       throw new PanicException(e.getMessage(), this);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/ExecuteNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/ExecuteNode.java
@@ -25,14 +25,14 @@ public abstract class ExecuteNode extends Node {
   private @Child HostValueToEnsoNode hostValueToEnsoNode = HostValueToEnsoNode.build();
   private final BranchProfile err = BranchProfile.create();
 
-  public static ExecuteNode build() {
+  static ExecuteNode build() {
     return ExecuteNodeGen.create();
   }
 
-  public abstract Object execute(Object callable, Object arguments);
+  abstract Object execute(Object callable, Object arguments);
 
   @Specialization
-  Object execute(Object callable, Object arguments, @Cached("build()") CoerceArrayNode coerce) {
+  Object doExecute(Object callable, Object arguments, @Cached("build()") CoerceArrayNode coerce) {
     try {
       return hostValueToEnsoNode.execute(library.execute(callable, coerce.execute(arguments)));
     } catch (UnsupportedMessageException | ArityException | UnsupportedTypeException e) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/InstantiateNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/InstantiateNode.java
@@ -23,14 +23,15 @@ public abstract class InstantiateNode extends Node {
       InteropLibrary.getFactory().createDispatched(Constants.CacheSizes.BUILTIN_INTEROP_DISPATCH);
   private final BranchProfile err = BranchProfile.create();
 
-  public static InstantiateNode build() {
+  static InstantiateNode build() {
     return InstantiateNodeGen.create();
   }
 
-  public abstract Object execute(Object constructor, Object arguments);
+  abstract Object execute(Object constructor, Object arguments);
 
   @Specialization
-  Object execute(Object constructor, Object arguments, @Cached("build()") CoerceArrayNode coerce) {
+  Object doExecute(
+      Object constructor, Object arguments, @Cached("build()") CoerceArrayNode coerce) {
     try {
       return library.instantiate(constructor, coerce.execute(arguments));
     } catch (UnsupportedMessageException | ArityException | UnsupportedTypeException e) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/InstantiateNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/InstantiateNode.java
@@ -1,5 +1,7 @@
 package org.enso.interpreter.node.expression.builtin.interop.generic;
 
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
@@ -8,22 +10,29 @@ import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.BranchProfile;
 import org.enso.interpreter.Constants;
 import org.enso.interpreter.dsl.BuiltinMethod;
-import org.enso.interpreter.runtime.data.Array;
+import org.enso.interpreter.node.expression.builtin.mutable.CoerceArrayNode;
 import org.enso.interpreter.runtime.error.PanicException;
 
 @BuiltinMethod(
     type = "Polyglot",
     name = "new",
     description = "Instantiates a polyglot constructor.")
-public class InstantiateNode extends Node {
+public abstract class InstantiateNode extends Node {
 
   private @Child InteropLibrary library =
       InteropLibrary.getFactory().createDispatched(Constants.CacheSizes.BUILTIN_INTEROP_DISPATCH);
   private final BranchProfile err = BranchProfile.create();
 
-  Object execute(Object constructor, Array arguments) {
+  public static InstantiateNode build() {
+    return InstantiateNodeGen.create();
+  }
+
+  public abstract Object execute(Object constructor, Object arguments);
+
+  @Specialization
+  Object execute(Object constructor, Object arguments, @Cached("build()") CoerceArrayNode coerce) {
     try {
-      return library.instantiate(constructor, arguments.getItems());
+      return library.instantiate(constructor, coerce.execute(arguments));
     } catch (UnsupportedMessageException | ArityException | UnsupportedTypeException e) {
       err.enter();
       throw new PanicException(e.getMessage(), this);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/InvokeNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/InvokeNode.java
@@ -1,27 +1,42 @@
 package org.enso.interpreter.node.expression.builtin.interop.generic;
 
-import com.oracle.truffle.api.interop.*;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.interop.ArityException;
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.UnknownIdentifierException;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
+import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.BranchProfile;
 import org.enso.interpreter.Constants;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.node.expression.builtin.mutable.CoerceArrayNode;
 import org.enso.interpreter.node.expression.builtin.text.util.ExpectStringNode;
-import org.enso.interpreter.runtime.data.Array;
 import org.enso.interpreter.runtime.error.PanicException;
 
 @BuiltinMethod(
     type = "Polyglot",
     name = "invoke",
     description = "Invokes a polyglot method by name, dispatching by the target argument.")
-public class InvokeNode extends Node {
+public abstract class InvokeNode extends Node {
   private @Child InteropLibrary library =
       InteropLibrary.getFactory().createDispatched(Constants.CacheSizes.BUILTIN_INTEROP_DISPATCH);
   private @Child ExpectStringNode expectStringNode = ExpectStringNode.build();
   private final BranchProfile err = BranchProfile.create();
 
-  Object execute(Object target, Object name, Array arguments) {
+  public static InvokeNode build() {
+    return InvokeNodeGen.create();
+  }
+
+  public abstract Object execute(Object target, Object name, Object arguments);
+
+  @Specialization
+  Object execute(
+      Object target, Object name, Object arguments, @Cached("build()") CoerceArrayNode coerce) {
     try {
-      return library.invokeMember(target, expectStringNode.execute(name), arguments.getItems());
+      return library.invokeMember(
+          target, expectStringNode.execute(name), coerce.execute(arguments));
     } catch (UnsupportedMessageException
         | ArityException
         | UnsupportedTypeException

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/InvokeNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/InvokeNode.java
@@ -25,14 +25,14 @@ public abstract class InvokeNode extends Node {
   private @Child ExpectStringNode expectStringNode = ExpectStringNode.build();
   private final BranchProfile err = BranchProfile.create();
 
-  public static InvokeNode build() {
+  static InvokeNode build() {
     return InvokeNodeGen.create();
   }
 
-  public abstract Object execute(Object target, Object name, Object arguments);
+  abstract Object execute(Object target, Object name, Object arguments);
 
   @Specialization
-  Object execute(
+  Object doExecute(
       Object target, Object name, Object arguments, @Cached("build()") CoerceArrayNode coerce) {
     try {
       return library.invokeMember(

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/NewAtomInstanceNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/NewAtomInstanceNode.java
@@ -1,17 +1,27 @@
 package org.enso.interpreter.node.expression.builtin.meta;
 
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.node.expression.builtin.mutable.CoerceArrayNode;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
-import org.enso.interpreter.runtime.data.Array;
 
 @BuiltinMethod(
     type = "Meta",
     name = "new_atom",
     description = "Creates a new atom with given constructor and fields.")
-public class NewAtomInstanceNode extends Node {
-  Atom execute(AtomConstructor constructor, Array fields) {
-    return constructor.newInstance(fields.getItems());
+public abstract class NewAtomInstanceNode extends Node {
+
+  static NewAtomInstanceNode build() {
+    return NewAtomInstanceNodeGen.create();
+  }
+
+  abstract Atom execute(AtomConstructor constructor, Object fields);
+
+  @Specialization
+  Atom execute(AtomConstructor constructor, Object fields, @Cached CoerceArrayNode coerce) {
+    return constructor.newInstance(coerce.execute(fields));
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/NewAtomInstanceNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/NewAtomInstanceNode.java
@@ -21,7 +21,7 @@ public abstract class NewAtomInstanceNode extends Node {
   abstract Atom execute(AtomConstructor constructor, Object fields);
 
   @Specialization
-  Atom execute(AtomConstructor constructor, Object fields, @Cached CoerceArrayNode coerce) {
+  Atom doExecute(AtomConstructor constructor, Object fields, @Cached CoerceArrayNode coerce) {
     return constructor.newInstance(coerce.execute(fields));
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/CoerceArrayNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/CoerceArrayNode.java
@@ -39,7 +39,6 @@ public abstract class CoerceArrayNode extends Node {
       Builtins builtins = Context.get(this).getBuiltins();
       Atom err = builtins.error().makeTypeError(builtins.array(), arr, "arr");
       throw new PanicException(err, this);
-
     } catch (InvalidArrayIndexException e) {
       Builtins builtins = Context.get(this).getBuiltins();
       throw new PanicException(

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/CoerceArrayNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/CoerceArrayNode.java
@@ -1,0 +1,85 @@
+package org.enso.interpreter.node.expression.builtin.mutable;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Fallback;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.InvalidArrayIndexException;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
+import com.oracle.truffle.api.library.CachedLibrary;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
+import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.node.expression.builtin.interop.syntax.HostValueToEnsoNode;
+import org.enso.interpreter.runtime.Context;
+import org.enso.interpreter.runtime.builtin.Builtins;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.data.Vector;
+import org.enso.interpreter.runtime.data.Array;
+import org.enso.interpreter.runtime.error.PanicException;
+
+public abstract class CoerceArrayNode extends Node {
+  private @Child InteropLibrary library = InteropLibrary.getFactory().createDispatched(10);
+
+  public static CoerceArrayNode build() {
+    return CoerceArrayNodeGen.create();
+  }
+
+  public abstract Object[] execute(Object value);
+
+  @Specialization
+  Object[] doArray(Array arr) {
+    return arr.getItems();
+  }
+
+  @Specialization
+  Object[] doVector(Vector arr, @Cached HostValueToEnsoNode hostValueToEnsoNode) {
+    try {
+      return convertToArray(arr, hostValueToEnsoNode);
+    } catch (UnsupportedMessageException e) {
+      Builtins builtins = Context.get(this).getBuiltins();
+      Atom err = builtins.error().makeTypeError(builtins.array(), arr, "arr");
+      throw new PanicException(err, this);
+
+    } catch (InvalidArrayIndexException e) {
+      Builtins builtins = Context.get(this).getBuiltins();
+      throw new PanicException(
+          builtins.error().makeInvalidArrayIndexError(arr, e.getInvalidIndex()), this);
+    }
+  }
+
+  @Specialization(guards = "interop.hasArrayElements(arr)")
+  Object[] doArrayLike(
+      Object arr,
+      @CachedLibrary(limit = "5") InteropLibrary interop,
+      @Cached HostValueToEnsoNode hostValueToEnsoNode) {
+    try {
+      return convertToArray(arr, hostValueToEnsoNode);
+    } catch (UnsupportedMessageException e) {
+      Builtins builtins = Context.get(this).getBuiltins();
+      Atom err = builtins.error().makeTypeError(builtins.array(), arr, "arr");
+      throw new PanicException(err, this);
+    } catch (InvalidArrayIndexException e) {
+      Builtins builtins = Context.get(this).getBuiltins();
+      throw new PanicException(
+          builtins.error().makeInvalidArrayIndexError(arr, e.getInvalidIndex()), this);
+    }
+  }
+
+  @ExplodeLoop
+  private Object[] convertToArray(Object arr, HostValueToEnsoNode hostValueToEnsoNode)
+      throws UnsupportedMessageException, InvalidArrayIndexException {
+    int argsLength = (int) library.getArraySize(arr);
+    Object[] arr1 = new Object[argsLength];
+    for (int i = 0; i < argsLength; i++) {
+      arr1[i] = hostValueToEnsoNode.execute(library.readArrayElement(arr, i));
+    }
+    return arr1;
+  }
+
+  @Fallback
+  public Object[] doOther(Object arr) {
+    Builtins builtins = Context.get(this).getBuiltins();
+    Atom error = builtins.error().makeTypeError("array", arr, "arr");
+    throw new PanicException(error, this);
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/CoerceArrayNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/CoerceArrayNode.java
@@ -65,7 +65,6 @@ public abstract class CoerceArrayNode extends Node {
     }
   }
 
-  @ExplodeLoop
   private Object[] convertToArray(Object arr, HostValueToEnsoNode hostValueToEnsoNode)
       throws UnsupportedMessageException, InvalidArrayIndexException {
     int argsLength = (int) library.getArraySize(arr);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/CoerceArrayNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/CoerceArrayNode.java
@@ -76,7 +76,7 @@ public abstract class CoerceArrayNode extends Node {
   }
 
   @Fallback
-  public Object[] doOther(Object arr) {
+  Object[] doOther(Object arr) {
     Builtins builtins = Context.get(this).getBuiltins();
     Atom error = builtins.error().makeTypeError("array", arr, "arr");
     throw new PanicException(error, this);

--- a/test/Tests/src/Data/Polyglot_Spec.enso
+++ b/test/Tests/src/Data/Polyglot_Spec.enso
@@ -1,0 +1,26 @@
+from Standard.Base import all
+
+from Standard.Test import Test, Test_Suite
+
+polyglot java import java.time.LocalDate
+polyglot java import java.lang.String
+polyglot java import java.util.function.Function
+
+spec = Test.group "Polyglot" <|
+    Test.specify "should be able to invoke a polyglot method by name and pass arguments" <|
+        poly_date = LocalDate.now
+        date = Date.now.to_date_time
+
+        Polyglot.invoke poly_date "atStartOfDay" [] . should_equal date
+        Polyglot.invoke poly_date "atStartOfDay" [].to_array . should_equal date
+
+    Test.specify "should be able to crate a new polyglot object using the constructor" <|
+        Polyglot.new String ["42"] . should_equal "42"
+        Polyglot.new String ["42"].to_array . should_equal "42"
+
+    Test.specify "should be able to execute a polyglot function object along with corresponding arguments" <|
+        fun = Function.identity
+        Polyglot.execute fun ["42"] . should_equal "42"
+        Polyglot.execute fun ["42"].to_array . should_equal "42"
+
+main = Test_Suite.run_main spec

--- a/test/Tests/src/Data/Polyglot_Spec.enso
+++ b/test/Tests/src/Data/Polyglot_Spec.enso
@@ -14,7 +14,7 @@ spec = Test.group "Polyglot" <|
         Polyglot.invoke poly_date "atStartOfDay" [] . should_equal date
         Polyglot.invoke poly_date "atStartOfDay" [].to_array . should_equal date
 
-    Test.specify "should be able to crate a new polyglot object using the constructor" <|
+    Test.specify "should be able to create a new polyglot object using the constructor" <|
         Polyglot.new String ["42"] . should_equal "42"
         Polyglot.new String ["42"].to_array . should_equal "42"
 

--- a/test/Tests/src/Main.enso
+++ b/test/Tests/src/Main.enso
@@ -9,6 +9,7 @@ import project.Semantic.Deep_Export.Spec as Deep_Export_Spec
 import project.Semantic.Error_Spec
 import project.Semantic.Import_Loop.Spec as Import_Loop_Spec
 import project.Semantic.Meta_Spec
+import project.Semantic.Meta_Location_Spec
 import project.Semantic.Names_Spec
 import project.Semantic.Runtime_Spec
 import project.Semantic.Warnings_Spec
@@ -101,6 +102,7 @@ main = Test_Suite.run_main <|
     Map_Spec.spec
     Maybe_Spec.spec
     Meta_Spec.spec
+    Meta_Location_Spec.spec
     Names_Spec.spec
     Noise_Generator_Spec.spec
     Noise_Spec.spec

--- a/test/Tests/src/Semantic/Meta_Location_Spec.enso
+++ b/test/Tests/src/Semantic/Meta_Location_Spec.enso
@@ -1,0 +1,30 @@
+from Standard.Base import all
+import Standard.Base
+
+import Standard.Base.System.Platform
+from Standard.Test import Test, Test_Suite
+
+type My_Type
+    Value foo bar baz
+
+spec = Test.group "Meta-Value Inspection" <|
+    location_pending = case Platform.os of
+        Platform.Windows -> "This test is disabled on Windows until issue 1561 is fixed."
+        _ -> Nothing
+
+    Test.specify "should allow to get the source location of a frame" pending=location_pending <|
+        src = Meta.get_source_location 0
+        loc = "Meta_Location_Spec.enso:16:15-40"
+        src.take (Last loc.length) . should_equal loc
+
+    Test.specify "should allow to get qualified type names of values" <|
+        x = 42
+        y = My_Type.Value 1 2 3
+        Meta.get_qualified_type_name x . should_equal "Standard.Base.Data.Numbers.Integer"
+        Meta.get_qualified_type_name y . should_equal "enso_dev.Tests.Semantic.Meta_Location_Spec.My_Type.Value"
+
+    Test.specify "should allow access to package names" <|
+        enso_project.name.should_equal 'Tests'
+        Base.enso_project.name.should_equal 'Base'
+
+main = Test_Suite.run_main spec

--- a/test/Tests/src/Semantic/Meta_Spec.enso
+++ b/test/Tests/src/Semantic/Meta_Spec.enso
@@ -35,6 +35,11 @@ spec = Test.group "Meta-Value Manipulation" <|
         meta_atom.constructor.should_equal My_Type.Value
         meta_atom.fields.should_equal [1, "foo", Nothing]
         Meta.meta (meta_atom.constructor) . new [1, "foo", Nothing] . should_equal atom
+    Test.specify "should allow creating atoms from atom constructors" <|
+        atom_1 = Meta.new_atom My_Type.Value [1,"foo", Nothing]
+        (Meta.meta atom_1).constructor . should_equal My_Type.Value
+        atom_2 = Meta.new_atom My_Type.Value [1,"foo", Nothing].to_array
+        (Meta.meta atom_2).constructor . should_equal My_Type.Value
     Test.specify "should correctly return representations of different classes of objects" <|
         Meta.meta 1 . should_equal (Meta.Primitive_Data 1)
         Meta.meta "foo" . should_equal (Meta.Primitive_Data "foo")
@@ -148,7 +153,7 @@ spec = Test.group "Meta-Value Manipulation" <|
 
     Test.specify "should allow to get the source location of a frame" pending=location_pending <|
         src = Meta.get_source_location 0
-        loc = "Meta_Spec.enso:150:15-40"
+        loc = "Meta_Spec.enso:155:15-40"
         src.take (Last loc.length) . should_equal loc
 
     Test.specify "should allow to get qualified type names of values" <|

--- a/test/Tests/src/Semantic/Meta_Spec.enso
+++ b/test/Tests/src/Semantic/Meta_Spec.enso
@@ -147,25 +147,6 @@ spec = Test.group "Meta-Value Manipulation" <|
         e_tpe . should_equal_type IOException
         e_tpe . should_not_equal_type JException
 
-    location_pending = case Platform.os of
-        Platform.Windows -> "This test is disabled on Windows until issue 1561 is fixed."
-        _ -> Nothing
-
-    Test.specify "should allow to get the source location of a frame" pending=location_pending <|
-        src = Meta.get_source_location 0
-        loc = "Meta_Spec.enso:155:15-40"
-        src.take (Last loc.length) . should_equal loc
-
-    Test.specify "should allow to get qualified type names of values" <|
-        x = 42
-        y = My_Type.Value 1 2 3
-        Meta.get_qualified_type_name x . should_equal "Standard.Base.Data.Numbers.Integer"
-        Meta.get_qualified_type_name y . should_equal "enso_dev.Tests.Semantic.Meta_Spec.My_Type.Value"
-
-    Test.specify "should allow access to package names" <|
-        enso_project.name.should_equal 'Tests'
-        Base.enso_project.name.should_equal 'Base'
-
     Test.specify "should correctly handle Java values" <|
         java_meta = Meta.meta Random.new
         java_meta . should_be_a Meta.Polyglot_Data

--- a/test/Tests/src/System/System_Spec.enso
+++ b/test/Tests/src/System/System_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 import Standard.Base.System
+import Standard.Base.System.Platform
 
 from Standard.Test import Test, Test_Suite
 
@@ -8,5 +9,14 @@ spec = Test.group "System" <|
     Test.specify "should provide nanosecond timer" <|
         result = System.nano_time
         (result > 0).should_equal True
+
+    if Platform.is_unix then
+        Test.specify "should be able to create a process, returning an exit code" <|
+            result = System.create_process "echo" ["foo", "bar"] "" False False False
+            result.exit_code . should_equal 0
+
+            result_2 = System.create_process "echo" ["foo", "bar"].to_array "" False False False
+            result_2.exit_code . should_equal 0
+
 
 main = Test_Suite.run_main spec


### PR DESCRIPTION
### Pull Request Description

Most of the time, rather than defining the type of the parameter of the builtin, we want to accept every Array-like object i.e. Vector, Array, polyglot Array etc.
Rather than writing all possible combinations, and likely causing bugs on the way anyway as we already saw, one should use `CoerceArrayNode` to convert to Java's `Object[]`.
Added various test cases to illustrate the problem.

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
