### PR TITLE
use share-generics rustflag to improve compile times

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,6 +6,6 @@ rustflags = ["--cfg", "tokio_unstable"]
 rustflags = [
   # Increas the stack size from 1MB to 2MB. This is required to avoid running out of stack space
   # in debug builds. The error is reported as `RuntimeError: memory access out of bounds`.
-  "-C",
-  "link-args=-z stack-size=2097152",
+  "-Clink-args=-z stack-size=2097152",
+  "-Zshare-generics=y",
 ]


### PR DESCRIPTION
### Pull Request Description

Add `-Zshare-generics=y` to our `RUSTFLAGS`. This improves build times significantly, especially for our crates with slowest builds. That means there is a noticeable build time decrease when modifying dependencies of those crates.

Timings of full build (including all dependenceis) on my machine:
- Without `share-generics`: total time 12m 25s
- With `share-generics`: total time 11m 5s

Comparsion of compile timings for downstream crates, left graph is with the new flag:
![image](https://user-images.githubusercontent.com/919491/199008622-35b46ad0-826c-4bdc-9e55-f43a48d250e5.png)


### Important Notes

This is an unstable option. We are using nightly everywhere, so this shouldn't be a problem, but it might add some instability in the future.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
