### PR TITLE
Construct IR.Syntax.Error rather than throwing an exception

### DIFF
--- a/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
@@ -1237,26 +1237,30 @@ final class TreeToIr {
     * @return the [[IR]] representation of `imp`
     */
   @SuppressWarnings("unchecked")
-  IR$Module$Scope$Export$Module translateExport(Tree.Export exp) {
-    Option<IR$Name$Literal> rename = Option.apply(exp.getAs()).map(as -> buildName(as.getBody(), true));
-    Option<List<IR$Name$Literal>> hidingNames = Option.apply(exp.getHiding()).map(
-            hiding -> buildNameSequence(hiding.getBody()));
-    IR$Name$Qualified qualifiedName;
-    Option<List<IR$Name$Literal>> onlyNames = Option.empty();
-    if (exp.getFrom() != null) {
-      qualifiedName = buildQualifiedName(exp.getFrom().getBody(), Option.empty(), true);
-      var onlyBodies = exp.getExport().getBody();
-      if (exp.getAll() == null) {
-        onlyNames = Option.apply(buildNameSequence(onlyBodies));
+  IR$Module$Scope$Export translateExport(Tree.Export exp) {
+    try {
+      Option<IR$Name$Literal> rename = Option.apply(exp.getAs()).map(as -> buildName(as.getBody(), true));
+      Option<List<IR$Name$Literal>> hidingNames = Option.apply(exp.getHiding()).map(
+              hiding -> buildNameSequence(hiding.getBody()));
+      IR$Name$Qualified qualifiedName;
+      Option<List<IR$Name$Literal>> onlyNames = Option.empty();
+      if (exp.getFrom() != null) {
+        qualifiedName = buildQualifiedName(exp.getFrom().getBody(), Option.empty(), true);
+        var onlyBodies = exp.getExport().getBody();
+        if (exp.getAll() == null) {
+          onlyNames = Option.apply(buildNameSequence(onlyBodies));
+        }
+      } else {
+        qualifiedName = buildQualifiedName(exp.getExport().getBody(), Option.empty(), true);
       }
-    } else {
-      qualifiedName = buildQualifiedName(exp.getExport().getBody(), Option.empty(), true);
+      return new IR$Module$Scope$Export$Module(
+        qualifiedName, rename, (exp.getFrom() != null), onlyNames,
+        hidingNames, getIdentifiedLocation(exp), false,
+        meta(), diag()
+        );
+    } catch (UnhandledEntity err) {
+      return translateUnhandledEntity(err, IR$Error$Syntax$InvalidImport$.MODULE$);
     }
-    return new IR$Module$Scope$Export$Module(
-      qualifiedName, rename, (exp.getFrom() != null), onlyNames,
-      hidingNames, getIdentifiedLocation(exp), false,
-      meta(), diag()
-      );
   }
 
   /** Translates a comment from its [[AST]] representation into its [[IR]]

--- a/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
@@ -824,6 +824,7 @@ final class TreeToIr {
               yield fn.setLocation(loc);
           }
       }
+      case Tree.Invalid __ -> new IR$Error$Syntax(tree, IR$Error$Syntax$UnexpectedExpression$.MODULE$, meta(), diag());
       default -> throw new UnhandledEntity(tree, "translateExpression");
     };
   }

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
@@ -7433,6 +7433,7 @@ object IR {
     ) extends Error
         with Diagnostic.Kind.Interactive
         with IR.Module.Scope.Definition
+        with IR.Module.Scope.Export
         with IR.Module.Scope.Import
         with IRKind.Primitive {
       override protected var id: Identifier = randomId

--- a/engine/runtime/src/main/scala/org/enso/compiler/exception/UnhandledEntity.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/exception/UnhandledEntity.scala
@@ -3,10 +3,10 @@ package org.enso.compiler.exception
 /** This exception is thrown when compiler internal processing encounters an
   * entity that it doesn't know how to deal with.
   *
-  * @param entity the undhandled entity
+  * @param entity the unhandled entity
   * @param methodName the method throwing the exception
   */
-class UnhandledEntity(entity: Any, methodName: String)
+class UnhandledEntity(val entity: Any, methodName: String)
     extends RuntimeException(
       "Fatal: Unhandled entity in " + methodName + " = " + entity.toString
     ) {}

--- a/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import org.enso.compiler.core.IR;
 import org.enso.compiler.core.IR$Error$Syntax;
 import org.enso.compiler.core.IR$Error$Syntax$UnexpectedExpression$;
+import org.enso.syntax.text.Location;
 
 import org.junit.AfterClass;
 import static org.junit.Assert.assertEquals;
@@ -31,9 +32,50 @@ public class ErrorCompilerTest {
   @Test
   public void spaceRequired() throws Exception {
     var ir = parseTest("foo = if cond.x else.y");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 6, 8);
+  }
+
+  @Test
+  public void incompleteTypeDefinition() throws Exception {
+    var ir = parseTest("type");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 0, 4);
+  }
+
+  @Test
+  public void badCase1() throws Exception {
+    var ir = parseTest("""
+    foo = case x of
+     4
+    """);
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 6, 18);
+  }
+
+  @Test
+  public void badCase2() throws Exception {
+    var ir = parseTest("""
+    foo = case x of
+     4 ->
+    """);
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 6, 21);
+  }
+
+  @Test
+  public void badCase3() throws Exception {
+    var ir = parseTest("""
+    foo = case x of
+     4->
+    """);
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 6, 20);
+  }
+
+  private void assertSingleSyntaxError(
+      IR.Module ir, IR$Error$Syntax$UnexpectedExpression$ type,
+      String msg, int start, int end
+  ) {
     var errors = assertIR(ir, IR$Error$Syntax.class, 1);
-    assertEquals(IR$Error$Syntax$UnexpectedExpression$.MODULE$, errors.head().reason());
-    assertEquals("Unexpected expression.", errors.head().message());
+    assertEquals(type, errors.head().reason());
+    assertEquals(msg, errors.head().message());
+    assertEquals(new Location(start, end), errors.head().location().get().location());
   }
 
   private List<IR$Error$Syntax> assertIR(IR.Module ir, Class<IR$Error$Syntax> type, int count) {

--- a/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
@@ -281,6 +281,18 @@ public class ErrorCompilerTest {
     assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path.", 27, 30);
   }
 
+  @Test
+  public void invalidToken1() throws Exception {
+    var ir = parseTest("`");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 0, 1);
+  }
+
+  @Test
+  public void invalidToken2() throws Exception {
+    var ir = parseTest("splice_outside_text = `");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 22, 23);
+  }
+
   private void assertSingleSyntaxError(
       IR.Module ir, IR$Error$Syntax$Reason type,
       String msg, int start, int end

--- a/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
@@ -1,0 +1,53 @@
+package org.enso.compiler;
+
+import com.oracle.truffle.api.source.Source;
+
+import java.io.IOException;
+
+import org.enso.compiler.core.IR;
+import org.enso.compiler.core.IR$Error$Syntax;
+import org.enso.compiler.core.IR$Error$Syntax$UnexpectedExpression$;
+
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import scala.collection.immutable.List;
+
+public class ErrorCompilerTest {
+  private static EnsoCompiler ensoCompiler;
+
+  @BeforeClass
+  public static void initEnsoCompiler() {
+    ensoCompiler = new EnsoCompiler();
+  }
+
+  @AfterClass
+  public static void closeEnsoCompiler() throws Exception {
+    ensoCompiler.close();
+  }
+
+  @Test
+  public void spaceRequired() throws Exception {
+    var ir = parseTest("foo = if cond.x else.y");
+    var errors = assertIR(ir, IR$Error$Syntax.class, 1);
+    assertEquals(IR$Error$Syntax$UnexpectedExpression$.MODULE$, errors.head().reason());
+    assertEquals("Unexpected expression.", errors.head().message());
+  }
+
+  private List<IR$Error$Syntax> assertIR(IR.Module ir, Class<IR$Error$Syntax> type, int count) {
+    var errors = ir.preorder().filter(type::isInstance).map(type::cast);
+    assertEquals("Expecting errors: " + errors, count, errors.size());
+    return errors;
+  }
+
+  private static IR.Module parseTest(String code) throws IOException {
+    var src =
+        Source.newBuilder("enso", code, "test-" + Integer.toHexString(code.hashCode()) + ".enso")
+            .build();
+    var ir = ensoCompiler.compile(src);
+    assertNotNull("IR was generated", ir);
+    return ir;
+  }
+}

--- a/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
@@ -293,6 +293,30 @@ public class ErrorCompilerTest {
     assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 22, 23);
   }
 
+  @Test
+  public void illegalForeignBody1() throws Exception {
+    var ir = parseTest("foreign 4");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 0, 9);
+  }
+
+  @Test
+  public void illegalForeignBody2() throws Exception {
+    var ir = parseTest("foreign 4 * 4");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 0, 13);
+  }
+
+  @Test
+  public void illegalForeignBody3() throws Exception {
+    var ir = parseTest("foreign foo = \"4\"");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 0, 17);
+  }
+
+  @Test
+  public void illegalForeignBody4() throws Exception {
+    var ir = parseTest("foreign js foo = 4");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 0, 18);
+  }
+
   private void assertSingleSyntaxError(
       IR.Module ir, IR$Error$Syntax$Reason type,
       String msg, int start, int end

--- a/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
@@ -215,6 +215,72 @@ public class ErrorCompilerTest {
     assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path.", 27, 30);
   }
 
+  @Test
+  public void malformedExport1() throws Exception {
+    var ir = parseTest("export");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 0, 6);
+  }
+
+  @Test
+  public void malformedExport2() throws Exception {
+    var ir = parseTest("export as Foo");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 0, 13);
+  }
+
+  @Test
+  public void malformedExport3() throws Exception {
+    var ir = parseTest("export Foo as Foo, Bar");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path.", 14, 22);
+  }
+
+  @Test
+  public void malformedExport4() throws Exception {
+    var ir = parseTest("export Foo as Foo.Bar");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path.", 14, 21);
+  }
+
+  @Test
+  public void malformedExport5() throws Exception {
+    var ir = parseTest("export Foo as");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path.", 13, 13);
+  }
+
+  @Test
+  public void malformedExport6() throws Exception {
+    var ir = parseTest("export Foo as Bar.Baz");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path.", 14, 21);
+  }
+
+  @Test
+  public void malformedExport7() throws Exception {
+    var ir = parseTest("export Foo hiding");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path.", 7, 17);
+  }
+
+  @Test
+  public void malformedExport8() throws Exception {
+    var ir = parseTest("export Foo hiding X,");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path.", 7, 20);
+  }
+
+  @Test
+  public void malformedExport9() throws Exception {
+    var ir = parseTest("from export all");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path.", 4, 4);
+  }
+
+  @Test
+  public void malformedExport10() throws Exception {
+    var ir = parseTest("from Foo export all hiding");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path.", 26, 26);
+  }
+
+  @Test
+  public void malformedExport11() throws Exception {
+    var ir = parseTest("from Foo export all hiding X.Y");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path.", 27, 30);
+  }
+
   private void assertSingleSyntaxError(
       IR.Module ir, IR$Error$Syntax$Reason type,
       String msg, int start, int end

--- a/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
@@ -68,6 +68,66 @@ public class ErrorCompilerTest {
     assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 6, 20);
   }
 
+  @Test
+  public void malformedSequence1() throws Exception {
+    var ir = parseTest("(1, )");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 0, 5);
+  }
+
+  @Test
+  public void malformedSequence2() throws Exception {
+    var ir = parseTest("foo = (1, )");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 7, 9);
+  }
+
+  @Test
+  public void unmatchedDemiliter1() throws Exception {
+    var ir = parseTest("(");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 0, 1);
+  }
+
+  @Test
+  public void unmatchedDemiliter2() throws Exception {
+    var ir = parseTest(")");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 0, 1);
+  }
+
+  @Test
+  public void unmatchedDemiliter3() throws Exception {
+    var ir = parseTest("[");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 0, 1);
+  }
+
+  @Test
+  public void unmatchedDemiliter4() throws Exception {
+    var ir = parseTest("[");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 0, 1);
+  }
+
+  @Test
+  public void unmatchedDemiliter5() throws Exception {
+    var ir = parseTest("foo = (");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 6, 7);
+  }
+
+  @Test
+  public void unmatchedDemiliter6() throws Exception {
+    var ir = parseTest("foo = )");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 6, 7);
+  }
+
+  @Test
+  public void unmatchedDemiliter7() throws Exception {
+    var ir = parseTest("foo = [");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 6, 7);
+  }
+
+  @Test
+  public void unmatchedDemiliter8() throws Exception {
+    var ir = parseTest("foo = ]");
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 6, 7);
+  }
+
   private void assertSingleSyntaxError(
       IR.Module ir, IR$Error$Syntax$UnexpectedExpression$ type,
       String msg, int start, int end


### PR DESCRIPTION
### Pull Request Description

This PR mimics test cases from #3860 and makes sure `IR.Syntax.Error` is constructed at appropriate places rather than just yielding an `UnhandledEntity` exception.

### Important Notes

Merge before #3611 to minimize disruption when changing the parser.

### Checklist

Please include the following checklist in your PR:

- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
