### PR TITLE
More improvements that work with both parsers

### DIFF
--- a/engine/runtime/src/main/java/org/enso/compiler/EnsoCompiler.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/EnsoCompiler.java
@@ -9,12 +9,24 @@ public final class EnsoCompiler implements AutoCloseable {
   private final Parser parser;
 
   public EnsoCompiler() {
-    this.parser = Parser.create();
+    Parser p;
+    try {
+      p = Parser.create();
+    } catch (LinkageError err) {
+      p = null;
+    }
+    this.parser = p;
   }
 
   @Override
   public void close() throws Exception {
-    this.parser.close();
+    if (parser != null) {
+      parser.close();
+    }
+  }
+
+  boolean isReady() {
+    return parser != null;
   }
 
   IR.Module compile(Source src) {

--- a/engine/runtime/src/test/java/org/enso/compiler/EnsoCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/EnsoCompilerTest.java
@@ -41,14 +41,14 @@ public class EnsoCompilerTest {
   public void testLocationsSimpleArithmeticExpression() throws Exception {
     parseTest("""
     main = 2 + 45 * 20
-    """, true, false, true);
+    """, true, true, true);
   }
 
   @Test
   public void testLocationsApplicationsAndMethodCalls() throws Exception {
     parseTest("""
     main = (2-2 == 0).if_then_else (Cons 5 6) 0
-    """, true, false, true);
+    """, true, true, true);
   }
 
   @Test
@@ -58,7 +58,7 @@ public class EnsoCompilerTest {
         x = 2 + 2 * 2
         y = x * x
         IO.println y
-    """, true, false, true);
+    """, true, true, true);
   }
 
   @Test
@@ -69,7 +69,7 @@ public class EnsoCompilerTest {
         x = a + 1
         y = b - 2
         x * y
-    """, true, false, true);
+    """, true, true, true);
   }
 
   @Test
@@ -78,7 +78,7 @@ public class EnsoCompilerTest {
     main =
         foo a = a + 1
         foo 42
-    """, true, false, true);
+    """, true, true, true);
   }
 
   @Test
@@ -86,7 +86,7 @@ public class EnsoCompilerTest {
     parseTest("""
         foo = a -> b ->
             IO.println a
-        """, true, false, true);
+        """, true, true, true);
   }
 
   @Test
@@ -96,7 +96,7 @@ public class EnsoCompilerTest {
         add = a -> b -> a + b
 
     main = Nothing.method
-    """, true, false, true);
+    """, true, true, true);
   }
 
   @Test
@@ -501,7 +501,6 @@ public class EnsoCompilerTest {
   }
 
   @Test
-  @Ignore
   public void testRawBlockLiteral() throws Exception {
     // mimics TextTest
     parseTest("""
@@ -515,9 +514,10 @@ public class EnsoCompilerTest {
   @Test
   @Ignore
   public void testVariousKindsOfUnicodeWhitespace() throws Exception {
-    // mimics Text_Spec.enso:1049
+    // mimics Text_Spec.enso:1049 and 722
+    // search for: # Disabled in the New Parser
     parseTest("""
-    '\\v\\f\\u{200a}\\u{202f}\\u{205F}\\u{3000}\\u{feff}'.trim
+    t = '\\v\\f\\u{200a}\\u{202f}\\u{205F}\\u{3000}\\u{feff}'.trim
     """);
   }
 
@@ -795,19 +795,19 @@ public class EnsoCompilerTest {
     type My_Type
         Cons_A x
         Cons_B y=(Self.Cons_A 10)
-    
+
         static = 123
-    
+
         static_use = Self.static + (Self.Cons_A 5).x
         instance_use self = Self.static + self.x + (Self.Cons_A 5).x
 
         static_match x = case x of
             Self -> "it matched"
             _ -> "it didn't match"
-                  
+
         matching_method self = case self of
             Self.Cons_A y -> y + 2
-      
+
         match_by_type x = case x of
             _ : Self -> "it's a Self"
             _ -> "it's a something else"
@@ -1080,7 +1080,7 @@ public class EnsoCompilerTest {
         y = self + 3
         z = y * x
         z
-    """, true, false, true);
+    """, true, true, true);
   }
 
   @Test
@@ -1100,7 +1100,98 @@ public class EnsoCompilerTest {
   }
 
   @Test
-  @Ignore
+  public void testAtomBenchmarks1() throws Exception {
+    parseTest("""
+    from Standard.Base.Data.List import Cons,Nil
+
+    main =
+        generator fn acc i end = if i == end then acc else @Tail_Call generator fn (fn acc i) i+1 end
+        res = generator (acc -> x -> Cons x acc) Nil 1 1000000
+        res
+    """);
+  }
+
+  @Test
+  public void testAtomBenchmarks3() throws Exception {
+    parseTest("""
+    from Standard.Base.Data.List import all
+
+    List.List.mapReverse self f acc = case self of
+        Cons h t -> @Tail_Call t.mapReverse f (Cons (f h) acc)
+        _ -> acc
+
+    main = list ->
+        res = list.mapReverse (x -> x + 1) Nil
+        res
+    """, true, true, false);
+  }
+
+  @Test
+  public void testShouldQuoteValuesContainingTheCommentSymbol() throws Exception {
+    parseTest("""
+    suite =
+        Test.specify "should quote values containing the comment symbol if comments are enabled" <|
+            format = Delimited ',' . with_comments
+            table.write file format on_problems=Report_Error . should_succeed
+            expected_text_2 = normalize_lines <| \"""
+                "#",B
+                b,
+                x,"#"
+                "#",abc
+            text_2 = File.read_text file
+            text_2.should_equal expected_text_2
+            file.delete
+    """, true, true, false);
+  }
+
+  @Test
+  public void testEmptyValueBetweenComments() throws Exception {
+    parseTest("""
+    expected_text = normalize_lines <| \"""
+                A,B
+                1,
+                ,""
+                3,abc
+    """, true, true, false);
+  }
+
+  @Test
+  @Ignore // problem in Delimited_Write_Spec.enso:172
+  public void testQuotedValues() throws Exception {
+    parseTest("""
+    expected_text = normalize_lines <| \"""
+        "one, two, three",-1.5,42,"4\"000",
+    """, true, true, false);
+  }
+
+  @Test
+  public void testSimpleTrippleQuote() throws Exception {
+    parseTest("""
+    expected_response = Json.parse <| '''
+        {
+          "headers": {
+            "Content-Length": "13",
+            "Content-Type": "application/json",
+            "User-Agent": "Java-http-client/11.0.13"
+          },
+          "origin": "127.0.0.1",
+          "url": "",
+          "args": {},
+          "data": "{\\"key\\":\\"val\\"}",
+          "files": null,
+          "form": null,
+          "json": {
+            "key": "val"
+          }
+        }
+    json = Json.parse <| '''
+        {"key":"val"}
+    res = Http.new.post_json url_post json
+        """, true, true, false);
+  }
+
+  @Test
+  @Ignore // enable CodeLocationsTest: "be correct in the presence of comments"
   public void testInThePresenceOfComments() throws Exception {
     parseTest("""
     # this is a comment

--- a/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 
 import org.enso.compiler.core.IR;
 import org.enso.compiler.core.IR$Error$Syntax;
+import org.enso.compiler.core.IR$Error$Syntax$InvalidEscapeSequence$;
 import org.enso.compiler.core.IR$Error$Syntax$Reason;
 import org.enso.compiler.core.IR$Error$Syntax$InvalidImport$;
 import org.enso.compiler.core.IR$Error$Syntax$UnexpectedExpression$;
@@ -315,6 +316,14 @@ public class ErrorCompilerTest {
   public void illegalForeignBody4() throws Exception {
     var ir = parseTest("foreign js foo = 4");
     assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 0, 18);
+  }
+
+  @Test
+  public void illegalEscapeSequence() throws Exception {
+    var ir = parseTest("""
+    escape = 'wrong \\c sequence'
+    """);
+    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidEscapeSequence$.MODULE$.apply("wrong  sequence"), "Invalid escape sequence wrong  sequence.", 9, 28);
   }
 
   private void assertSingleSyntaxError(

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/RuntimeManagementTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/RuntimeManagementTest.scala
@@ -74,6 +74,20 @@ class RuntimeManagementTest extends InterpreterTest {
       }
     }
 
+    def consumeWithGC(expect: Int): List[String] = {
+      forceGC()
+      var round                  = 0
+      var totalOut: List[String] = Nil
+      totalOut = consumeOut
+      while (totalOut.length < expect && round < 500) {
+        round = round + 1
+        if (round % 10 == 0) forceGC();
+        Thread.sleep(100)
+        totalOut ++= consumeOut
+      }
+      totalOut
+    }
+
     "Automatically free managed resources" in {
       val code =
         """
@@ -98,15 +112,7 @@ class RuntimeManagementTest extends InterpreterTest {
           |    create_resource 4
           |""".stripMargin
       eval(code)
-      var totalOut: List[String] = Nil
-
-      forceGC()
-
-      totalOut = consumeOut
-      while (totalOut.length < 10) {
-        Thread.sleep(100)
-        totalOut ++= consumeOut
-      }
+      val totalOut = consumeWithGC(10)
 
       def mkAccessStr(i: Int): String = s"Accessing: (Mock_File.Value $i)"
       def mkFreeStr(i: Int): String   = s"Freeing: (Mock_File.Value $i)"
@@ -140,15 +146,7 @@ class RuntimeManagementTest extends InterpreterTest {
           |    create_resource 4
           |""".stripMargin
       eval(code)
-      var totalOut: List[String] = Nil
-
-      forceGC()
-
-      totalOut = consumeOut
-      while (totalOut.length < 10) {
-        Thread.sleep(100)
-        totalOut ++= consumeOut
-      }
+      val totalOut = consumeWithGC(10)
 
       def mkAccessStr(i: Int): String = s"Accessing: (Mock_File.Value $i)"
       def mkFreeStr(i: Int): String   = s"Freeing: (Mock_File.Value $i)"
@@ -182,15 +180,7 @@ class RuntimeManagementTest extends InterpreterTest {
           |    create_resource 4
           |""".stripMargin
       eval(code)
-      var totalOut: List[String] = Nil
-
-      forceGC()
-
-      totalOut = consumeOut
-      while (totalOut.length < 7) {
-        Thread.sleep(100)
-        totalOut ++= consumeOut
-      }
+      val totalOut = consumeWithGC(7)
 
       def mkAccessStr(i: Int): String = s"Accessing: (Mock_File.Value $i)"
       def mkFreeStr(i: Int): String   = s"Freeing: (Mock_File.Value $i)"

--- a/lib/rust/parser/generate-java/java/org/enso/syntax2/Parser.java
+++ b/lib/rust/parser/generate-java/java/org/enso/syntax2/Parser.java
@@ -25,7 +25,6 @@ public final class Parser implements AutoCloseable {
       parser = new File(dir, name);
       System.load(parser.getAbsolutePath());
     } catch (URISyntaxException | LinkageError e) {
-      System.err.println("Cannot load " + parser);
       File root = new File(".").getAbsoluteFile();
       if (!searchFromDirToTop(e, root, "target", "rust", "debug", name)) {
         throw new IllegalStateException("Cannot load parser from " + parser, e);
@@ -41,7 +40,6 @@ public final class Parser implements AutoCloseable {
       }
       try {
         System.load(parser.getAbsolutePath());
-        System.err.println("Succeeded loading " + parser.getAbsolutePath());
         return true;
       } catch (LinkageError err) {
         while (chain.getCause() != null) {

--- a/test/Table_Tests/src/Delimited_Write_Spec.enso
+++ b/test/Table_Tests/src/Delimited_Write_Spec.enso
@@ -158,18 +158,18 @@ spec =
             text.should_equal expected_text
             file.delete
 
-        Test.specify 'should allow to always quote text and custom values, but for non-text primitves only if absolutely necessary' <|
+        Test.specify 'should allow to always quote text and custom values, but for non-text primitives only if absolutely necessary' <|
             format = Delimited "," value_formatter=(Data_Formatter.Value thousand_separator='"' date_formats=["E, d MMM y"]) . with_quotes always_quote=True quote_escape='\\'
             table = Table.new [['The Column "Name"', ["foo","'bar'",'"baz"', 'one, two, three']], ["B", [1.0, 1000000.5, 2.2, -1.5]], ["C", ["foo", My_Type.Value 44, (Date.new 2022 06 21), 42]], ["D", [1,2,3,4000]], ["E", [Nothing, (Time_Of_Day.new 13 55), Nothing, Nothing]]]
             file = (enso_project.data / "transient" / "quote_always.csv")
             file.delete_if_exists
             table.write file format on_problems=Report_Error . should_succeed
-            expected_text = normalize_lines <| """
+            expected_text1 = normalize_lines <| """
                 "The Column \"Name\"","B","C","D","E"
                 "foo",1.0,"foo",1,
                 "'bar'","1\"000\"000.5","[[[My Type :: 44]]]",2,13:55:00
                 "\"baz\"",2.2,"Tue, 21 Jun 2022",3,
-                "one, two, three",-1.5,42,"4\"000",
+            expected_text = expected_text1 + '"one, two, three",-1.5,42,"4\\"000",\n'
             text = File.read_text file
             text.should_equal expected_text
             file.delete


### PR DESCRIPTION
### Pull Request Description

I have problems getting #3611 run on Windows. This PR is my attempt to made the differences smaller and more easily analyze what can be wrong on the Windows platform. Either this PR passes and the error remains in #3611 or vice-versa.

### Important Notes

The #3611 failures are [here](https://github.com/enso-org/enso/actions/runs/3446149075/jobs/5750699835).

### Checklist

Please include the following checklist in your PR:

- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
