### PR TITLE
Allowing passing electron flags to Enso app.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,7 +124,7 @@ build-cache/
 ######################
 ## Enso-Development ##
 ######################
-/dist
+dist/
 distribution/lib/Standard/Examples/*/data/scratch_file
 distribution/lib/Standard/Examples/*/data/image.png
 distribution/editions

--- a/app/ide-desktop/lib/client/package.json
+++ b/app/ide-desktop/lib/client/package.json
@@ -33,7 +33,8 @@
     "electron-notarize": "1.2.1",
     "enso-copy-plugin": "^1.0.0",
     "ts-node": "^10.9.1",
-    "fast-glob": "^3.2.12"
+    "fast-glob": "^3.2.12",
+    "dmg-builder": "^24.0.0-alpha.3"
   },
   "scripts": {
     "start": "electron ../../../../dist/content -- ",

--- a/app/ide-desktop/lib/client/src/index.js
+++ b/app/ide-desktop/lib/client/src/index.js
@@ -793,8 +793,6 @@ let mainWindow = null
 let origin = null
 
 async function main(args) {
-    console.log('args', args)
-
     // Note [Main error handling]
     try {
         runBackend()

--- a/app/ide-desktop/lib/client/src/index.js
+++ b/app/ide-desktop/lib/client/src/index.js
@@ -189,7 +189,8 @@ optParser.options('verbose', {
 
 optParser.options('entry-point', {
     group: debugOptionsGroup,
-    describe: 'Run an alternative entry point (e.g. one of the debug scenes). To see list of ' +
+    describe:
+        'Run an alternative entry point (e.g. one of the debug scenes). To see list of ' +
         'entry points, do not provide the argument.',
 })
 
@@ -205,7 +206,8 @@ optParser.options('devtron', {
 
 optParser.options('load-profile', {
     group: debugOptionsGroup,
-    describe: "Load a performance profile. For use with developer tools such as the " +
+    describe:
+        'Load a performance profile. For use with developer tools such as the ' +
         "'profiling-run-graph' entry point.",
     requiresArg: true,
     type: `array`,
@@ -553,7 +555,7 @@ async function parseCmdArgs() {
             console.log() // newline
             console.log(electronOptParserHelp)
         }
-        if(error) {
+        if (error) {
             console.log() // newline
             console.log(error)
         }
@@ -573,7 +575,9 @@ async function parseCmdArgs() {
 
 // Top-level await is not supported. This is a hack:
 // https://usefulangle.com/post/248/javascript-async-anonymous-function-iife
-let args = (async () =>  { await parseCmdArgs() })()
+let args = (async () => {
+    await parseCmdArgs()
+})()
 
 // Note: this is a conditional default to avoid issues with some window managers affecting
 // interactions at the top of a borderless window. Thus, we want borders on Win/Linux and

--- a/app/ide-desktop/lib/client/tsconfig.json
+++ b/app/ide-desktop/lib/client/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
 }

--- a/app/ide-desktop/lib/client/tsconfig.json
+++ b/app/ide-desktop/lib/client/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.json"
 }


### PR DESCRIPTION
### Pull Request Description

This PR enables passing electron flags to our desktop app. Unfortunately, it can be merged yet, as we need to update `yargs` to a newer version (the one that we use has a bug which causes app to quit after help page is printed and it does not expose alternative API that never versions expose). Unfortunately, bumping `yards` is not simple: https://github.com/enso-org/enso/pull/3725

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
