### PR TITLE
Vector distinct fails with Nothing value

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -604,6 +604,15 @@ Text.compare_to self that =
         if comparison_result < 0 then Ordering.Less else
             Ordering.Greater
 
+#    case Meta.type_of that of
+#        Text_Matcher.Text_Matcher ->
+#            comparison_result = Text_Utils.compare_normalized self that
+#            if comparison_result == 0 then Ordering.Equal else
+#                if comparison_result < 0 then Ordering.Less else
+#                    Ordering.Greater
+#        _ ->
+#            Panic.throw (Type_Error_Data Text that "that")
+
 ## Compare two texts to discover their ordering.
 
    Arguments:

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeRegressionsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeRegressionsTest.scala
@@ -1,0 +1,179 @@
+package org.enso.interpreter.test.instrument
+
+import org.enso.distribution.FileSystem
+import org.enso.distribution.locking.ThreadSafeFileLockManager
+import org.enso.interpreter.instrument.execution.Timer
+import org.enso.interpreter.runtime.`type`.ConstantsGen
+import org.enso.interpreter.runtime.{Context => EnsoContext}
+import org.enso.interpreter.test.Metadata
+import org.enso.pkg.{Package, PackageManager}
+import org.enso.polyglot._
+import org.enso.polyglot.runtime.Runtime.Api
+import org.graalvm.polyglot.Context
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.{ByteArrayOutputStream, File}
+import java.nio.file.{Files, Path, Paths}
+import java.util.UUID
+
+@scala.annotation.nowarn("msg=multiarg infix syntax")
+class RuntimeRegressionsTest
+    extends AnyFlatSpec
+    with Matchers
+    with BeforeAndAfterEach {
+
+  // === Test Timer ===========================================================
+
+  class TestTimer extends Timer {
+    override def getTime(): Long = 0
+  }
+
+  // === Test Utilities =======================================================
+
+  var context: TestContext = _
+
+  class TestContext(packageName: String) extends InstrumentTestContext {
+
+    val tmpDir: Path = Files.createTempDirectory("enso-test-packages")
+    sys.addShutdownHook(FileSystem.removeDirectoryIfExists(tmpDir))
+    val lockManager = new ThreadSafeFileLockManager(tmpDir.resolve("locks"))
+    val runtimeServerEmulator =
+      new RuntimeServerEmulator(messageQueue, lockManager)
+
+    val pkg: Package[File] =
+      PackageManager.Default.create(tmpDir.toFile, packageName, "Enso_Test")
+    val out: ByteArrayOutputStream    = new ByteArrayOutputStream()
+    val logOut: ByteArrayOutputStream = new ByteArrayOutputStream()
+    val executionContext = new PolyglotContext(
+      Context
+        .newBuilder(LanguageInfo.ID)
+        .allowExperimentalOptions(true)
+        .allowAllAccess(true)
+        .option(RuntimeOptions.PROJECT_ROOT, pkg.root.getAbsolutePath)
+        .option(RuntimeOptions.LOG_LEVEL, "WARNING")
+        .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
+        .option(RuntimeOptions.ENABLE_PROJECT_SUGGESTIONS, "false")
+        .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")
+        .option(
+          RuntimeOptions.DISABLE_IR_CACHES,
+          InstrumentTestContext.DISABLE_IR_CACHE
+        )
+        .option(RuntimeServerInfo.ENABLE_OPTION, "true")
+        .option(RuntimeOptions.INTERACTIVE_MODE, "true")
+        .option(
+          RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
+          Paths
+            .get("../../distribution/component")
+            .toFile
+            .getAbsolutePath
+        )
+        .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
+        .logHandler(logOut)
+        .out(out)
+        .serverTransport(runtimeServerEmulator.makeServerTransport)
+        .build()
+    )
+    executionContext.context.initialize(LanguageInfo.ID)
+
+    val languageContext = executionContext.context
+      .getBindings(LanguageInfo.ID)
+      .invokeMember(MethodNames.TopScope.LEAK_CONTEXT)
+      .asHostObject[EnsoContext]
+    val info =
+      languageContext.getEnvironment.getPublicLanguages.get(LanguageInfo.ID)
+    languageContext.getLanguage.getIdExecutionService.ifPresent(
+      _.overrideTimer(new TestTimer)
+    );
+
+    def writeMain(contents: String): File =
+      Files.write(pkg.mainFile.toPath, contents.getBytes).toFile
+
+    def writeFile(file: File, contents: String): File =
+      Files.write(file.toPath, contents.getBytes).toFile
+
+    def writeInSrcDir(moduleName: String, contents: String): File = {
+      val file = new File(pkg.sourceDir, s"$moduleName.enso")
+      Files.write(file.toPath, contents.getBytes).toFile
+    }
+
+    def send(msg: Api.Request): Unit = runtimeServerEmulator.sendToRuntime(msg)
+
+    def consumeOut: List[String] = {
+      val result = out.toString
+      out.reset()
+      result.linesIterator.toList
+    }
+
+    def executionComplete(contextId: UUID): Api.Response =
+      Api.Response(Api.ExecutionComplete(contextId))
+
+    // === The Tests ==========================================================
+
+  }
+
+  override protected def beforeEach(): Unit = {
+    context = new TestContext("Test")
+    val Some(Api.Response(_, Api.InitializedNotification())) = context.receive
+  }
+
+  it should "test1" in {
+    val contextId  = UUID.randomUUID()
+    val requestId  = UUID.randomUUID()
+    val moduleName = "Enso_Test.Test.Main"
+
+    val metadata = new Metadata
+    val idVar1   = metadata.addItem(49, 25)
+    val idMain   = metadata.addItem(37, 55)
+    val code =
+      """from Standard.Base import all
+        |
+        |main =
+        |    var1 = ["A","A","B",Nothing,"C"]
+        |    var1.distinct
+        |""".stripMargin.linesIterator.mkString("\n")
+    val contents = metadata.appendToCode(code)
+    val mainFile = context.writeMain(contents)
+
+    // create context
+    context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
+    context.receive shouldEqual Some(
+      Api.Response(requestId, Api.CreateContextResponse(contextId))
+    )
+
+    // open file
+    context.send(
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
+    )
+    context.receiveNone shouldEqual None
+
+    // push main
+    context.send(
+      Api.Request(
+        requestId,
+        Api.PushContextRequest(
+          contextId,
+          Api.StackItem.ExplicitCall(
+            Api.MethodPointer(moduleName, "Enso_Test.Test.Main", "main"),
+            None,
+            Vector()
+          )
+        )
+      )
+    )
+    context.receiveNIgnorePendingExpressionUpdates(
+      4
+    ) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PushContextResponse(contextId)),
+      TestMessages.update(contextId, idVar1, ConstantsGen.VECTOR),
+      TestMessages.error(
+        contextId,
+        idMain,
+        Api.ExpressionUpdate.Payload.DataflowError(Seq())
+      ),
+      context.executionComplete(contextId)
+    )
+  }
+
+}

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -574,6 +574,7 @@ spec = Test.group "Vectors" <|
         ["a", 2].distinct . should_fail_with Incomparable_Values_Error
         [2, "a", Integer, "a", 2].distinct . should_fail_with Incomparable_Values_Error
         [Pair_Data 1 2, Pair_Data 3 4].distinct . should_fail_with Incomparable_Values_Error
+        ["a", Nothing].distinct . should_fail_with Incomparable_Values_Error
 
     Test.specify "should correctly handle distinct with custom types like Atoms that implement compare_to" <|
         [T.Value 1 2, T.Value 3 3, T.Value 1 2].distinct . should_equal [T.Value 1 2, T.Value 3 3]

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Main.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Main.enso
@@ -22,6 +22,9 @@ from project.Data.Numbers export Number
 import project.Data.Vector
 from project.Data.Vector export Vector
 
+import project.Nothing
+from project.Nothing export Nothing
+
 import project.Polyglot
 from project.Polyglot export all
 


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

` ["a",Nothing].distinct` fails with `com.oracle.truffle.host.HostException`

#### Issue

```py
> ["a",Nothing].distinct
Evaluation failed with: com.oracle.truffle.host.HostException
java.lang.Exception: com.oracle.truffle.host.HostException
	at <unknown>.com.oracle.truffle.host.HostObject.doInvoke(Unknown Source)
	at <unknown>.com.oracle.truffle.host.HostObject.doInvoke(Unknown Source)
	at <enso>.Standard.Base.Data.Text.Extensions::Standard.Base.Data.Text.Text::compare_to(Extensions.enso:601)
	at <enso>.Any.><arg-0>(Any.enso:143)
	at <enso>.Standard.Base.Data.Any::Standard.Base.Data.Any.Any::>(Any.enso:143)
	at <enso>.case_branch<arg-0>(Map.enso:222)
	at <enso>.case_branch<arg-2>(Map.enso:221)
	at <enso>.Boolean.if_then_else(Unknown Source)
	at <enso>.case_branch(Map.enso:220)
	at <enso>.go(Map.enso:218)
	at <enso>.Standard.Base.Data.Map::Standard.Base.Data.Map.Map::get_or_else(Map.enso:217)
	at <enso>.<anonymous><arg-0>(Vector.enso:911)
	at <enso>.<anonymous>(Vector.enso:908)
	at <enso>.f(Vector.enso:169)
	at <enso>.go<arg-2>(Range.enso:183)
	at <enso>.Boolean.if_then_else(Unknown Source)
	at <enso>.go(Range.enso:182)
	at <enso>.Vector.distinct<arg-1>(Vector.enso:906)
	at <enso>.Vector.handle_incomparable_value<arg-1>(Vector.enso:1110)
	at <enso>.Panic.throw(Unknown Source)
	at <enso>.case_branch(Common.enso:406)
	at <enso>.case_branch(Common.enso:404)
	at <enso>.<anonymous>(Common.enso:402)
	at <enso>.Panic.catch_primitive(Unknown Source)
	at <enso>.Standard.Base.Error.Common::Standard.Base.Error.Common.Panic::catch(Common.enso:401)
	at <enso>.Function.<|(Unknown Source)
	at <enso>.Vector.handle_incomparable_value<arg-1>(Vector.enso:1109)
	at <enso>.Panic.throw(Unknown Source)
	at <enso>.case_branch(Common.enso:406)
	at <enso>.case_branch(Common.enso:404)
	at <enso>.<anonymous>(Common.enso:402)
	at <enso>.Panic.catch_primitive(Unknown Source)
	at <enso>.Standard.Base.Error.Common::Standard.Base.Error.Common.Panic::catch(Common.enso:401)
	at <enso>.Function.<|(Unknown Source)
	at <enso>.Vector.handle_incomparable_value<arg-1>(Vector.enso:1108)
	at <enso>.Panic.throw(Unknown Source)
	at <enso>.case_branch(Common.enso:406)
	at <enso>.case_branch(Common.enso:404)
	at <enso>.<anonymous>(Common.enso:402)
	at <enso>.Panic.catch_primitive(Unknown Source)
	at <enso>.Standard.Base.Error.Common::Standard.Base.Error.Common.Panic::catch(Common.enso:401)
	at <enso>.Function.<|(Unknown Source)
	at <enso>.Vector.handle_incomparable_value<arg-1>(Vector.enso:1107)
	at <enso>.Panic.throw(Unknown Source)
	at <enso>.case_branch(Common.enso:411)
	at <enso>.case_branch(Common.enso:408)
	at <enso>.case_branch(Common.enso:407)
	at <enso>.<anonymous>(Common.enso:402)
	at <enso>.Panic.catch_primitive(Unknown Source)
	at <enso>.Standard.Base.Error.Common::Standard.Base.Error.Common.Panic::catch(Common.enso:401)
	at <enso>.Function.<|(Unknown Source)
	at <enso>.Standard.Base.Data.Vector::Standard.Base.Data.Vector::handle_incomparable_value(Vector.enso:1105)
	at <enso>.Function.<|(Unknown Source)
	at <enso>.Standard.Base.Data.Vector::Standard.Base.Data.Vector.Vector::distinct(Vector.enso:895)
	at <enso>.<eval>(Unknown Source)
	at <enso>.Debug.breakpoint(Unknown Source)
	at <enso>.Internal_Repl_Module___::Internal_Repl_Module___::internal_repl_entry_point___(Internal_Repl_Module___:4)
	at <unknown>.org.graalvm.polyglot.Value<Function>.execute(Unknown Source)
```

The issue is that [`Vector.distinct`](https://github.com/enso-org/enso/blob/85d4337f262286ad42836c29f810e854a247be8c/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso#L895) uses [handle_incomparable_value](https://github.com/enso-org/enso/blob/85d4337f262286ad42836c29f810e854a247be8c/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso#L1105) helper function, that converts a list of exceptions `ClassCastException`, `No_Such_Method_Error_Data`, `Type_Error_Data` and `Unsupported_Argument_Types_Data` into an error.

In the case `["a", Nothing]`, the `com.oracle.truffle.host.HostException` is thrown. This happens in the [`Map.get_or_else`](https://github.com/enso-org/enso/blob/85d4337f262286ad42836c29f810e854a247be8c/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Map.enso#L222) method when the string `"a"` is compared to `Nothing` (`if k > key` line).

```py
> "a" > Nothing
Evaluation failed with: com.oracle.truffle.host.HostException
java.lang.Exception: com.oracle.truffle.host.HostException
	at <unknown>.com.oracle.truffle.host.HostObject.doInvoke(Unknown Source)
	at <unknown>.com.oracle.truffle.host.HostObject.doInvoke(Unknown Source)
	at <enso>.Standard.Base.Data.Text.Extensions::Standard.Base.Data.Text.Text::compare_to(Extensions.enso:601)
	at <enso>.Any.><arg-0>(Any.enso:143)
	at <enso>.Standard.Base.Data.Any::Standard.Base.Data.Any.Any::>(Any.enso:143)
	at <enso>.<eval>(Unknown Source)
	at <enso>.Debug.breakpoint(Unknown Source)
	at <enso>.Internal_Repl_Module___::Internal_Repl_Module___::internal_repl_entry_point___(Internal_Repl_Module___:4)
	at <unknown>.org.graalvm.polyglot.Value<Function>.execute(Unknown Source)
```

In fact `"a" > Nothing` throws `NullPointerException`:
```py
> Panic.catch_primitive ("a" > Nothing) (e -> e)
>>> (Caught_Panic_Data (Polyglot_Error_Data java.lang.NullPointerException) java.lang.NullPointerException)
```

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
