### PR TITLE
Git should ignore user config

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -105,7 +105,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: LogLevel) {
   val fileSystem: FileSystem = new FileSystem
   log.trace("Created file system [{}].", fileSystem)
 
-  val git = Git()
+  val git = Git.withEmptyUserConfig()
   log.trace("Created git [{}].", git)
 
   implicit val versionCalculator: ContentBasedVersioning =

--- a/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/EmptyUserConfigReader.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/EmptyUserConfigReader.scala
@@ -1,0 +1,65 @@
+package org.enso.languageserver.vcsmanager
+
+import org.apache.commons.io.FileUtils
+import org.eclipse.jgit.lib.Config
+import org.eclipse.jgit.storage.file.FileBasedConfig
+import org.eclipse.jgit.util.{FS, SystemReader}
+
+import java.io.File
+import java.nio.file.Files
+
+/** Config reader that ignores gitconfig file in user's home directory.
+  */
+final class EmptyUserConfigReader extends SystemReader {
+
+  import EmptyUserConfigReader._
+
+  val proxy: SystemReader = SystemReader.getInstance()
+
+  /** @inheritdoc */
+  override def getHostname: String =
+    proxy.getHostname
+
+  /** @inheritdoc */
+  override def getenv(variable: String): String =
+    proxy.getenv(variable)
+
+  /** @inheritdoc */
+  override def getProperty(key: String): String =
+    proxy.getProperty(key)
+
+  /** @inheritdoc */
+  override def openUserConfig(parent: Config, fs: FS): FileBasedConfig =
+    new EmptyConfig(parent, fs)
+
+  /** @inheritdoc */
+  override def openSystemConfig(parent: Config, fs: FS): FileBasedConfig =
+    proxy.openSystemConfig(parent, fs)
+
+  /** @inheritdoc */
+  override def openJGitConfig(parent: Config, fs: FS): FileBasedConfig =
+    proxy.openJGitConfig(parent, fs)
+
+  /** @inheritdoc */
+  override def getCurrentTime: Long =
+    proxy.getCurrentTime
+
+  /** @inheritdoc */
+  override def getTimezone(when: Long): Int =
+    proxy.getTimezone(when)
+}
+
+object EmptyUserConfigReader {
+
+  private val gitconfig: File =
+    Files.createTempFile("gitconfig", null).toFile
+
+  sys.addShutdownHook(FileUtils.deleteQuietly(gitconfig))
+
+  final private class EmptyConfig(parent: Config, fs: FS)
+      extends FileBasedConfig(parent, gitconfig, fs) {
+    override def load(): Unit  = ()
+    override def save(): Unit  = ()
+    override def clear(): Unit = ()
+  }
+}

--- a/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/VcsManager.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/VcsManager.scala
@@ -37,7 +37,7 @@ class VcsManager(
       .absolve
 
   private def toVcsError: FileSystemFailure => VcsFailure = {
-    case ex: FileSystemFailure => ProjectNotFound(ex.toString)
+    ex: FileSystemFailure => ProjectNotFound(ex.toString)
   }
 
   private def resolvePath(path: Path): IO[VcsFailure, File] =

--- a/engine/language-server/src/test/scala/org/enso/languageserver/vcsmanager/GitSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/vcsmanager/GitSpec.scala
@@ -312,7 +312,7 @@ class GitSpec extends AnyWordSpecLike with Matchers with Effects {
         .build()
     }
 
-    val vcs = Git()
+    val vcs = Git.withEmptyUserConfig()
 
     def listCommits(repoDir: Path): List[RevCommit] = {
       listCommits(testRepo(repoDir))

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
@@ -170,7 +170,7 @@ class BaseServerTest
     val vcsManager = system.actorOf(
       VcsManager.props(
         config.vcsManager,
-        Git(),
+        Git.withEmptyUserConfig(),
         contentRootManagerWrapper,
         zioExec
       ),


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Ignore gitconfig located in the user's home directory when creating Git instance.

For example, I setup git to automatically sign commits. And all git related tests are failing because of that:

```
[info] - should return last X commits *** FAILED ***
[info]   org.eclipse.jgit.api.errors.ServiceUnavailableException: Signing service is not available
[info]   at org.eclipse.jgit.api.CommitCommand.sign(CommitCommand.java:328)
[info]   at org.eclipse.jgit.api.CommitCommand.call(CommitCommand.java:283)
[info]   at org.enso.languageserver.vcsmanager.GitSpec$InitialRepoSetup.setup(GitSpec.scala:360)
[info]   at org.enso.languageserver.vcsmanager.GitSpec$InitialRepoSetup.setup$(GitSpec.scala:348)
[info]   at org.enso.languageserver.vcsmanager.GitSpec$$anon$16.setup(GitSpec.scala:275)
[info]   at org.enso.languageserver.vcsmanager.GitSpec$InitialRepoSetup.$init$(GitSpec.scala:346)
[info]   at org.enso.languageserver.vcsmanager.GitSpec$$anon$16.<init>(GitSpec.scala:275)
[info]   at org.enso.languageserver.vcsmanager.GitSpec.$anonfun$new$35(GitSpec.scala:275)
[info]   at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
[info]   ...
```

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] ~If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.~
