### PR TITLE
set node output size on expression change

### DIFF
--- a/app/gui/src/presenter/graph/state.rs
+++ b/app/gui/src/presenter/graph/state.rs
@@ -377,9 +377,9 @@ impl State {
 
     /// Checks if the node should be synced with its AST automatically.
     pub fn should_receive_expression_auto_updates(&self, node: ast::Id) -> bool {
-        // When node is in process of being added, it is not yet added to the state. In that case
-        // the initial expression update needs to be processed. Otherwise the node would be created
-        // without any expression.
+        // When node is in process of being created, it is not yet present in the state. In that
+        // case the initial expression update needs to be processed. Otherwise the node would be
+        // created without any expression.
         self.nodes.borrow().get(node).map_or(true, |node| node.expression_auto_update)
     }
 

--- a/app/gui/src/presenter/graph/state.rs
+++ b/app/gui/src/presenter/graph/state.rs
@@ -377,7 +377,10 @@ impl State {
 
     /// Checks if the node should be synced with its AST automatically.
     pub fn should_receive_expression_auto_updates(&self, node: ast::Id) -> bool {
-        self.nodes.borrow().get(node).map_or(false, |node| node.expression_auto_update)
+        // When node is in process of being added, it is not yet added to the state. In that case
+        // the initial expression update needs to be processed. Otherwise the node would be created
+        // without any expression.
+        self.nodes.borrow().get(node).map_or(true, |node| node.expression_auto_update)
     }
 
     /// Set the flag that indicates if the node should be synced with its AST automatically.

--- a/app/gui/view/graph-editor/src/component/node.rs
+++ b/app/gui/view/graph-editor/src/component/node.rs
@@ -768,7 +768,7 @@ impl Node {
             // === Size ===
 
             new_size <- model.input.frp.width.map(f!((w) model.set_width(*w)));
-            eval new_size ((t) model.output.frp.set_size.emit(t));
+            model.output.frp.set_size <+ new_size;
 
 
             // === Action Bar ===

--- a/app/gui/view/graph-editor/src/component/node/output/area.rs
+++ b/app/gui/view/graph-editor/src/component/node/output/area.rs
@@ -148,6 +148,7 @@ ensogl::define_endpoints! {
         expression_label_visibility (bool),
         tooltip                     (tooltip::Style),
         view_mode                   (view::Mode),
+        size                        (Vector2),
     }
 }
 
@@ -330,11 +331,6 @@ impl Model {
     #[profile(Debug)]
     fn set_size(&self, size: Vector2) {
         self.ports.set_position_x(size.x / 2.0);
-        self.traverse_borrowed_expression_mut(|is_a_port, node, _| {
-            if is_a_port {
-                node.payload_mut().set_size(size)
-            }
-        })
     }
 
     #[profile(Debug)]
@@ -379,10 +375,12 @@ impl Model {
                     port_frp.set_type_label_visibility  <+ self.frp.type_label_visibility;
                     self.frp.source.tooltip             <+ port_frp.tooltip;
                     port_frp.set_view_mode              <+ self.frp.view_mode;
+                    port_frp.set_size                   <+ self.frp.size;
                 }
 
                 port_frp.set_type_label_visibility.emit(self.frp.type_label_visibility.value());
                 port_frp.set_view_mode.emit(self.frp.view_mode.value());
+                port_frp.set_size.emit(self.frp.size.value());
                 self.ports.add_child(&port_shape);
                 port_index += 1;
             }
@@ -483,6 +481,7 @@ impl Area {
 
             frp.source.port_size_multiplier <+ hysteretic_transition.value;
             eval frp.set_size ((t) model.set_size(*t));
+            frp.source.size <+ frp.set_size;
 
             frp.source.type_label_visibility <+ frp.set_type_label_visibility;
 


### PR DESCRIPTION
### Pull Request Description

Fixes regression about inaccessible node output port. https://www.pivotaltracker.com/n/projects/2539304/stories/183792368

Additionally, a related issue related to nodes not being visible after initial load has been uncovered and fixed in the process.

### Important Notes

Previously the output shape size was only updated when node size itself was updated. When node's expression was changed, the output port view is recreated from scratch, but the current node size has not been propagated to the newly created port. In some cases the node size was changed shortly after, masking the bug. In other cases, the newly created shape size was never set.

The port size management has been moved from model method into frp network, and the initial size value is emitted during network initialization.



### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
