### PR TITLE
Simple HTTPBin to replace Go equivalent

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -299,7 +299,8 @@ lazy val enso = (project in file("."))
     `std-database`,
     `std-google-api`,
     `std-image`,
-    `std-table`
+    `std-table`,
+    `simple-httpbin`
   )
   .settings(Global / concurrentRestrictions += Tags.exclusive(Exclusive))
   .settings(
@@ -2081,6 +2082,17 @@ val stdBitsProjects =
   List("Base", "Database", "Google_Api", "Image", "Table", "All")
 val allStdBits: Parser[String] =
   stdBitsProjects.map(v => v: Parser[String]).reduce(_ | _)
+
+lazy val `simple-httpbin` = project
+  .in(file("tools") / "simple-httpbin")
+  .settings(
+    frgaalJavaCompilerSetting,
+    Compile / javacOptions ++= Seq("-XDignore.symbol.file", "-Xlint:all"),
+    libraryDependencies ++= Seq(
+      "org.apache.commons" % "commons-text" % commonsTextVersion
+    )
+  )
+  .configs(Test)
 
 lazy val buildStdLib =
   inputKey[Unit]("Build an individual standard library package")

--- a/test/Tests/README.md
+++ b/test/Tests/README.md
@@ -5,5 +5,5 @@ the localhost. If it is present, the port it listens to should be provided by
 setting the `ENSO_HTTP_TEST_HTTPBIN_URL` environment variable to a value like
 `http://localhost:8080`. The URL may contain a trailing slash.
 
-`tools/simple-httpbin` provides a simple implementation of `httpbin` server.
-See its README for instructions on how to run it.
+`tools/simple-httpbin` provides a simple implementation of `httpbin` server. See
+its README for instructions on how to run it.

--- a/test/Tests/README.md
+++ b/test/Tests/README.md
@@ -4,3 +4,6 @@ The run test suite for the HTTP component requires an active `httbin` server on
 the localhost. If it is present, the port it listens to should be provided by
 setting the `ENSO_HTTP_TEST_HTTPBIN_URL` environment variable to a value like
 `http://localhost:8080`. The URL may contain a trailing slash.
+
+`tools/simple-httpbin` provides a simple implementation of `httpbin` server.
+See its README for instructions on how to run it.

--- a/test/Tests/src/Network/Http_Spec.enso
+++ b/test/Tests/src/Network/Http_Spec.enso
@@ -13,7 +13,7 @@ import Standard.Base.Network.Http.Version
 import Standard.Base.Network.Proxy
 import Standard.Base.Network.URI
 
-from Standard.Test import Test
+from Standard.Test import Test, Test_Suite
 
 polyglot java import java.lang.System
 
@@ -336,3 +336,5 @@ spec =
             res = Http.new.request req_with_body
             res.code.should_equal Status_Code.ok
             res.body.to_json.should_equal expected_response
+
+main = Test_Suite.run_main spec

--- a/tools/simple-httpbin/README.md
+++ b/tools/simple-httpbin/README.md
@@ -1,0 +1,18 @@
+# Simple HTTPBin
+
+A simple HTTP Request/Response clone of [httpbin](http://httpbin.org) for
+testing purposes.
+
+## Usage
+
+Simple HTTPBin can be compiled like any other SBT project i.e.
+
+```
+sbt> simple-httpbin/compile
+```
+
+To run, simply invoke the `main` method with the appropriate hostname and port:
+
+```
+sbt> simple-httpbin/run localhost 8080
+```

--- a/tools/simple-httpbin/src/main/java/org/enso/shttp/DummyHandler.java
+++ b/tools/simple-httpbin/src/main/java/org/enso/shttp/DummyHandler.java
@@ -1,0 +1,96 @@
+package org.enso.shttp;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.text.StringEscapeUtils;
+
+public class DummyHandler implements HttpHandler {
+
+  private enum Method {
+    GET,
+    POST,
+    HEAD;
+  }
+
+  private static final Set<String> requiredHeaders =
+      Set.of("Content-length", "Content-type", "User-agent");
+
+  @Override
+  public void handle(HttpExchange exchange) throws IOException {
+    boolean first = true;
+    String contentType = null;
+    Method meth = method(exchange.getRequestMethod());
+
+    String response;
+    if (meth == Method.HEAD) {
+      response = "";
+      exchange.sendResponseHeaders(200, -1);
+    } else {
+      response = "{\n";
+      response += "  \"headers\": {\n";
+      for (Map.Entry<String, List<String>> entry : exchange.getRequestHeaders().entrySet()) {
+        if (requiredHeaders.contains(entry.getKey())) {
+          if (!first) {
+            response += ",\n";
+          } else {
+            first = false;
+          }
+          response +=
+              "    \""
+                  + formatHeaderKey(entry.getKey())
+                  + "\": \""
+                  + entry.getValue().get(0)
+                  + "\"";
+        }
+        if (entry.getKey().equals("Content-type")) {
+          contentType = entry.getValue().get(0);
+        }
+      }
+      response += "\n";
+      response += "  },\n";
+      response += "  \"origin\": \"127.0.0.1\",\n";
+      response += "  \"url\": \"\",\n";
+      if (meth == Method.POST) {
+        boolean isJson = contentType != null && contentType.equals("application/json");
+        InputStreamReader isr = new InputStreamReader(exchange.getRequestBody(), "utf-8");
+        BufferedReader br = new BufferedReader(isr);
+        String value = br.readLine();
+        response += "  \"form\": null,\n";
+        response += "  \"files\": null,\n";
+        response +=
+            "  \"data\": \"" + (value == null ? "" : StringEscapeUtils.escapeJson(value)) + "\",\n";
+        response += "  \"json\": " + (isJson ? value : "null") + ",\n";
+      }
+      response += "  \"args\": {}\n";
+      response += "}";
+      exchange.sendResponseHeaders(200, response.getBytes().length);
+    }
+    OutputStream os = exchange.getResponseBody();
+    os.write(response.getBytes());
+    os.close();
+  }
+
+  private Method method(String v) {
+    return v.equals("HEAD") ? Method.HEAD : (v.equals("POST") ? Method.POST : Method.GET);
+  }
+
+  private String formatHeaderKey(String key) {
+    int idx = key.indexOf('-');
+    if (idx != -1 && key.length() >= idx) {
+      return key.substring(0, idx + 1)
+          + key.substring(idx + 1, idx + 2).toUpperCase()
+          + key.substring(idx + 2);
+    } else {
+      return key;
+    }
+  }
+}

--- a/tools/simple-httpbin/src/main/java/org/enso/shttp/SimpleHTTPBin.java
+++ b/tools/simple-httpbin/src/main/java/org/enso/shttp/SimpleHTTPBin.java
@@ -3,9 +3,11 @@ package org.enso.shttp;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import sun.misc.Signal;
+import sun.misc.SignalHandler;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.List;
 
 public class SimpleHTTPBin {
 
@@ -57,18 +59,14 @@ public class SimpleHTTPBin {
       server.addHandler("/post", new DummyHandler());
 
       final SimpleHTTPBin server1 = server;
-      Signal.handle(
-          new Signal("TERM"),
+      SignalHandler stopServerHandler =
           (Signal sig) -> {
             System.out.println("Stopping server...");
             server1.stop();
-          });
-      Signal.handle(
-          new Signal("INT"),
-          (Signal sig) -> {
-            System.out.println("Stopping server...");
-            server1.stop();
-          });
+          };
+      for (String signalName : List.of("TERM", "INT")) {
+        Signal.handle(new Signal(signalName), stopServerHandler);
+      }
       server.start();
     } catch (IOException e) {
       e.printStackTrace();

--- a/tools/simple-httpbin/src/main/java/org/enso/shttp/SimpleHTTPBin.java
+++ b/tools/simple-httpbin/src/main/java/org/enso/shttp/SimpleHTTPBin.java
@@ -1,0 +1,97 @@
+package org.enso.shttp;
+
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import sun.misc.Signal;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+public class SimpleHTTPBin {
+
+  private final HttpServer server;
+  private final State state;
+
+  public SimpleHTTPBin(String hostname, int port) throws IOException {
+    InetSocketAddress address = new InetSocketAddress(hostname, port);
+    server = HttpServer.create(address, 0);
+    server.setExecutor(null);
+    state = new State();
+  }
+
+  public void start() {
+    server.start();
+    state.start();
+
+    try {
+      while (state.isRunning()) {
+        Thread.sleep(1000);
+      }
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  public void stop() {
+    state.stop();
+  }
+
+  public void addHandler(String path, HttpHandler handler) {
+    server.createContext(path, handler);
+  }
+
+  public static void main(String[] args) {
+    if (args.length != 2) {
+      System.err.println("Usage: SimpleHTTPServer <host> <port>");
+      System.exit(1);
+    }
+
+    String host = args[0];
+    SimpleHTTPBin server = null;
+    try {
+      int port = Integer.valueOf(args[1]);
+      server = new SimpleHTTPBin(host, port);
+      server.addHandler("/get", new DummyHandler());
+      server.addHandler("/post", new DummyHandler());
+
+      final SimpleHTTPBin server1 = server;
+      Signal.handle(
+          new Signal("TERM"),
+          (Signal sig) -> {
+            System.out.println("Stopping server...");
+            server1.stop();
+          });
+      Signal.handle(
+          new Signal("INT"),
+          (Signal sig) -> {
+            System.out.println("Stopping server...");
+            server1.stop();
+          });
+      server.start();
+    } catch (IOException e) {
+      e.printStackTrace();
+    } finally {
+      if (server != null) {
+        server.stop();
+      }
+    }
+  }
+
+  private class State {
+    private boolean running = false;
+
+    void stop() {
+      running = false;
+    }
+
+    void start() {
+      running = true;
+    }
+
+    boolean isRunning() {
+      return running;
+    }
+  }
+}

--- a/tools/simple-httpbin/src/main/java/org/enso/shttp/SimpleHTTPBin.java
+++ b/tools/simple-httpbin/src/main/java/org/enso/shttp/SimpleHTTPBin.java
@@ -44,7 +44,7 @@ public class SimpleHTTPBin {
 
   public static void main(String[] args) {
     if (args.length != 2) {
-      System.err.println("Usage: SimpleHTTPServer <host> <port>");
+      System.err.println("Usage: SimpleHTTPBin <host> <port>");
       System.exit(1);
     }
 


### PR DESCRIPTION
### Pull Request Description

1-to-1 translation of the HTTPBin expected by our testsuite using Java's HttpServer.
Can be started from SBT via
```
sbt:enso> simple-httpbin/run <hostname> <port>
```

### Important Notes

@mwu-tow this will mean we can ditch Go dependency completely and replace it with the above call. 

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
