### PR TITLE
Remove unnecessary watcher in dev server

### DIFF
--- a/app/ide-desktop/lib/content/esbuild-config.ts
+++ b/app/ide-desktop/lib/content/esbuild-config.ts
@@ -110,11 +110,6 @@ const config: esbuild.BuildOptions = {
     publicPath: '/assets',
     incremental: true,
     color: true,
-    watch: {
-        onRebuild(error, result) {
-            if (error) console.error('watch build failed:', error)
-        },
-    },
     logOverride: {
         // Happens in ScalaJS-generated parser (scala-parser.js):
         //    6 │   "fileLevelThis": this
@@ -132,10 +127,20 @@ const config: esbuild.BuildOptions = {
 }
 
 /**
- * Spawn the esbuild watch process. It continuously runs, rebuilding the package.
+ * Spawn the esbuild serve and watch process. It continuously runs, rebuilding the package and
+ * serves the content.
  */
-export async function watch() {
-    return esbuild.build(config)
+export async function watch(onRebuild?: () => void, banner?: esbuild.BuildOptions['banner']) {
+    return esbuild.build({
+        ...config,
+        banner: banner ?? config.banner,
+        watch: {
+            onRebuild(error, result) {
+                if (error) console.error('watch build failed:', error)
+                else onRebuild?.()
+            },
+        },
+    })
 }
 
 /**

--- a/app/ide-desktop/lib/content/esbuild-config.ts
+++ b/app/ide-desktop/lib/content/esbuild-config.ts
@@ -127,8 +127,7 @@ const config: esbuild.BuildOptions = {
 }
 
 /**
- * Spawn the esbuild serve and watch process. It continuously runs, rebuilding the package and
- * serves the content.
+ * Spawn the esbuild watch process. It continuously runs, rebuilding the package.
  */
 export async function watch(onRebuild?: () => void, banner?: esbuild.BuildOptions['banner']) {
     return esbuild.build({

--- a/app/ide-desktop/lib/content/esbuild-config.ts
+++ b/app/ide-desktop/lib/content/esbuild-config.ts
@@ -129,10 +129,10 @@ const config: esbuild.BuildOptions = {
 /**
  * Spawn the esbuild watch process. It continuously runs, rebuilding the package.
  */
-export async function watch(onRebuild?: () => void, banner?: esbuild.BuildOptions['banner']) {
+export async function watch(onRebuild?: () => void, inject?: esbuild.BuildOptions['inject']) {
     return esbuild.build({
         ...config,
-        banner: banner ?? config.banner,
+        inject: [...(config.inject ?? []), ...(inject ?? [])],
         watch: {
             onRebuild(error, result) {
                 if (error) console.error('watch build failed:', error)

--- a/app/ide-desktop/lib/content/src/index.html
+++ b/app/ide-desktop/lib/content/src/index.html
@@ -6,15 +6,12 @@
     <!-- FIXME https://github.com/validator/validator/issues/917 -->
     <!-- FIXME Security Vulnerabilities: https://github.com/enso-org/ide/issues/226 -->
     <!-- NOTE `frame-src` section of `http-equiv` required only for authorization -->
-    <!-- The sha-256 hash for `script-src` below is for the code injected by the live-server.
-         In case of bumping the server, it might need to be updated.
-         Fortunately, the error message gives an updated hash. -->
     <meta
       http-equiv="Content-Security-Policy"
       content="
             default-src 'self';
             frame-src   'self' data: https://accounts.google.com https://enso-org.firebaseapp.com;
-            script-src  'self' 'unsafe-eval' data: https://* 'sha256-iN7wpJdxHlpujRppkOA8N0+Mzp0ZqZr3lCtxM00Y63c=';
+            script-src  'self' 'unsafe-eval' data: https://*;
             style-src   'self' 'unsafe-inline' data: https://*;
             connect-src 'self' data: ws://localhost:* ws://127.0.0.1:* http://localhost:* https://*;
             worker-src  'self' blob:;

--- a/app/ide-desktop/lib/content/watch.ts
+++ b/app/ide-desktop/lib/content/watch.ts
@@ -2,11 +2,9 @@ import bundler from './esbuild-config.js'
 // @ts-ignore
 import * as server from 'enso-gui-server'
 
-const reloadListenerCode =
-    '(() => window.live_reload = window.live_reload ?? (new EventSource("/live-reload").onmessage = () => location.reload()))();'
-await bundler.watch(() => live_server?.reload(), { js: reloadListenerCode })
+await bundler.watch(() => liveServer?.reload(), [server.LIVE_RELOAD_LISTENER_PATH])
 
-const live_server = await server.start({
+const liveServer = await server.start({
     root: bundler.output_path,
     assets: bundler.output_path,
 })

--- a/app/ide-desktop/lib/content/watch.ts
+++ b/app/ide-desktop/lib/content/watch.ts
@@ -2,5 +2,11 @@ import bundler from './esbuild-config.js'
 // @ts-ignore
 import * as server from 'enso-gui-server'
 
-await bundler.watch()
-await server.start({ root: bundler.output_path, assets: bundler.output_path })
+const reloadListenerCode =
+    '(() => window.live_reload = window.live_reload ?? (new EventSource("/live-reload").onmessage = () => location.reload()))();'
+await bundler.watch(() => live_server?.reload(), { js: reloadListenerCode })
+
+const live_server = await server.start({
+    root: bundler.output_path,
+    assets: bundler.output_path,
+})

--- a/app/ide-desktop/lib/server/package.json
+++ b/app/ide-desktop/lib/server/package.json
@@ -16,7 +16,9 @@
     "url": "https://github.com/enso-org/enso/issues"
   },
   "dependencies": {
-    "live-server": "^1.2.2",
-    "portfinder": "^1.0.28"
+    "connect": "^3.7.0",
+    "morgan": "^1.10.0",
+    "portfinder": "^1.0.28",
+    "serve-static": "^1.15.0"
   }
 }

--- a/app/ide-desktop/lib/server/package.json
+++ b/app/ide-desktop/lib/server/package.json
@@ -19,6 +19,7 @@
     "connect": "^3.7.0",
     "morgan": "^1.10.0",
     "portfinder": "^1.0.28",
-    "serve-static": "^1.15.0"
+    "serve-static": "^1.15.0",
+    "ws": "^8.11.0"
   }
 }

--- a/app/ide-desktop/lib/server/src/index.mjs
+++ b/app/ide-desktop/lib/server/src/index.mjs
@@ -2,7 +2,6 @@ import path from 'node:path'
 import url from 'node:url'
 import portfinder from 'portfinder'
 import connect from 'connect'
-// import { WebSocket } from 'faye-websocket'
 import { WebSocketServer } from 'ws'
 import serveStatic from 'serve-static'
 import logger from 'morgan'
@@ -24,10 +23,7 @@ export async function start({ root, assets, port }) {
         .use('/assets', serveStatic(assets))
 
     const server = app.listen(freePort)
-
-    const reloadSockets = []
-    const wsServer = new WebSocketServer({ server, path: '/live-reload' })
-    wsServer.on('connection', socket => reloadSockets.push(socket))
+    const wsServer = new WebSocketServer({ server, clientTracking: true, path: '/live-reload' })
 
     var serverUrl = `http://localhost:${freePort}`
     console.log('Serving %s', serverUrl)
@@ -35,8 +31,7 @@ export async function start({ root, assets, port }) {
     return {
         port: freePort,
         reload() {
-            reloadSockets.forEach(sock => sock.send('reload'))
-            reloadSockets.length = 0
+            wsServer.clients.forEach(sock => sock.send('reload'))
         },
     }
 }

--- a/app/ide-desktop/lib/server/src/index.mjs
+++ b/app/ide-desktop/lib/server/src/index.mjs
@@ -1,30 +1,41 @@
 import path from 'node:path'
-import liveServer from 'live-server'
-import * as portfinder from 'portfinder'
+import portfinder from 'portfinder'
+import connect from 'connect'
+import serveStatic from 'serve-static'
+import logger from 'morgan'
 
 export const DEFAULT_PORT = 8080
 
-async function findPort(startPort = DEFAULT_PORT) {
-    return portfinder.getPortPromise({ startPort, port: startPort })
-}
-
 export async function start({ root, assets, port }) {
     assets = assets ?? path.join(root, 'assets')
-    const parameters = {
-        cors: true,
-        open: false, // When false, it won't load your browser by default.
-        // When set, serve this file (server root relative) for every 404 (useful for single-page
-        // applications).
-        file: '/assets/index.html',
-        wait: 0, // Waits for all changes, before reloading. Defaults to 0 sec.
-        logLevel: 2, // 0 = errors only, 1 = some, 2 = lots
-        port: await findPort(port ?? DEFAULT_PORT),
-        root: root ?? '.',
-        assets,
-        mount: [['/assets', assets]], // Mount a directory to a route.
+
+    const freePort = await portfinder.getPortPromise({ port: port ?? DEFAULT_PORT});
+    const reload_requests = []
+
+    let app = connect()
+        .use(logger('dev', { skip: (req, res) => res.statusCode < 400 }))
+        .use(serveStatic(root))
+        .use('/assets', serveStatic(assets))
+        .use('/live-reload', (req, res) => {
+            reload_requests.push(
+                res.writeHead(200, {
+                  "Content-Type": "text/event-stream",
+                  "Cache-Control": "no-cache",
+                  Connection: "keep-alive",
+                })
+            );
+        });
+
+
+    await app.listen(freePort);
+    var serverUrl = `http://127.0.0.1:${freePort}`;
+    console.log(("Serving %s"), serverUrl);
+
+    return {
+        port: freePort,
+        reload() {
+            reload_requests.forEach((res) => res.write("data: reload\n\n"));
+            reload_requests.length = 0;
+        }
     }
-    console.log(`Server configuration:`, parameters)
-    const server = liveServer.start(parameters)
-    console.log(`Server started.`)
-    return parameters.port
 }

--- a/app/ide-desktop/lib/server/src/index.mjs
+++ b/app/ide-desktop/lib/server/src/index.mjs
@@ -16,27 +16,27 @@ export const LIVE_RELOAD_LISTENER_PATH = path.join(dirname, 'live-reload.js')
 export async function start({ root, assets, port }) {
     assets = assets ?? path.join(root, 'assets')
 
-    const freePort = await portfinder.getPortPromise({ port: port ?? DEFAULT_PORT});
+    const freePort = await portfinder.getPortPromise({ port: port ?? DEFAULT_PORT })
 
     const app = connect()
         .use(logger('dev', { skip: (req, res) => res.statusCode < 400 }))
         .use(serveStatic(root))
         .use('/assets', serveStatic(assets))
 
-    const server = app.listen(freePort);
+    const server = app.listen(freePort)
 
     const reloadSockets = []
-    const wsServer = new WebSocketServer({ server, path: '/live-reload' });
-    wsServer.on('connection', (socket) => reloadSockets.push(socket));
+    const wsServer = new WebSocketServer({ server, path: '/live-reload' })
+    wsServer.on('connection', socket => reloadSockets.push(socket))
 
-    var serverUrl = `http://localhost:${freePort}`;
-    console.log(("Serving %s"), serverUrl);
+    var serverUrl = `http://localhost:${freePort}`
+    console.log('Serving %s', serverUrl)
 
     return {
         port: freePort,
         reload() {
-            reloadSockets.forEach((sock) => sock.send("reload"));
-            reloadSockets.length = 0;
-        }
+            reloadSockets.forEach(sock => sock.send('reload'))
+            reloadSockets.length = 0
+        },
     }
 }

--- a/app/ide-desktop/lib/server/src/index.mjs
+++ b/app/ide-desktop/lib/server/src/index.mjs
@@ -1,41 +1,42 @@
 import path from 'node:path'
+import url from 'node:url'
 import portfinder from 'portfinder'
 import connect from 'connect'
+// import { WebSocket } from 'faye-websocket'
+import { WebSocketServer } from 'ws'
 import serveStatic from 'serve-static'
 import logger from 'morgan'
 
 export const DEFAULT_PORT = 8080
 
+let dirname = path.dirname(url.fileURLToPath(import.meta.url))
+// Path of a file that needs to be injected into the bundle for live-reload to work.
+export const LIVE_RELOAD_LISTENER_PATH = path.join(dirname, 'live-reload.js')
+
 export async function start({ root, assets, port }) {
     assets = assets ?? path.join(root, 'assets')
 
     const freePort = await portfinder.getPortPromise({ port: port ?? DEFAULT_PORT});
-    const reload_requests = []
 
-    let app = connect()
+    const app = connect()
         .use(logger('dev', { skip: (req, res) => res.statusCode < 400 }))
         .use(serveStatic(root))
         .use('/assets', serveStatic(assets))
-        .use('/live-reload', (req, res) => {
-            reload_requests.push(
-                res.writeHead(200, {
-                  "Content-Type": "text/event-stream",
-                  "Cache-Control": "no-cache",
-                  Connection: "keep-alive",
-                })
-            );
-        });
 
+    const server = app.listen(freePort);
 
-    await app.listen(freePort);
-    var serverUrl = `http://127.0.0.1:${freePort}`;
+    const reloadSockets = []
+    const wsServer = new WebSocketServer({ server, path: '/live-reload' });
+    wsServer.on('connection', (socket) => reloadSockets.push(socket));
+
+    var serverUrl = `http://localhost:${freePort}`;
     console.log(("Serving %s"), serverUrl);
 
     return {
         port: freePort,
         reload() {
-            reload_requests.forEach((res) => res.write("data: reload\n\n"));
-            reload_requests.length = 0;
+            reloadSockets.forEach((sock) => sock.send("reload"));
+            reloadSockets.length = 0;
         }
     }
 }

--- a/app/ide-desktop/lib/server/src/live-reload.js
+++ b/app/ide-desktop/lib/server/src/live-reload.js
@@ -1,11 +1,9 @@
-(() => {
-    // This file is injected into every entry point, but it needs to run only once.
-    // A global variable is used to ensure that.
-    if (!window.live_reload_listening) {
-        window.live_reload_listening = true;
-        const protocol = window.location.protocol === "http:" ? "ws://" : "wss://";
-        const address = protocol + window.location.host + "/live-reload";
-        const socket = new WebSocket(address);
-        socket.onmessage = (msg) => msg.data == "reload" && window.location.reload();
-    }
-})();
+// This file is injected into every entry point, but it needs to run only once.
+// A global variable is used to ensure that.
+if (!window.live_reload_listening) {
+    window.live_reload_listening = true
+    const protocol = window.location.protocol === 'http:' ? 'ws://' : 'wss://'
+    const address = protocol + window.location.host + '/live-reload'
+    const socket = new WebSocket(address)
+    socket.onmessage = msg => msg.data == 'reload' && window.location.reload()
+}

--- a/app/ide-desktop/lib/server/src/live-reload.js
+++ b/app/ide-desktop/lib/server/src/live-reload.js
@@ -1,0 +1,11 @@
+(() => {
+    // This file is injected into every entry point, but it needs to run only once.
+    // A global variable is used to ensure that.
+    if (!window.live_reload_listening) {
+        window.live_reload_listening = true;
+        const protocol = window.location.protocol === "http:" ? "ws://" : "wss://";
+        const address = protocol + window.location.host + "/live-reload";
+        const socket = new WebSocket(address);
+        socket.onmessage = (msg) => msg.data == "reload" && window.location.reload();
+    }
+})();


### PR DESCRIPTION
### Pull Request Description

Fixes a windows bug in watch server: https://www.pivotaltracker.com/story/show/183853860

Removes static file watching from watch server, as we already know when rebuilds happen in esbuild. Now the server is directly notified when to refresh after a successful build. This gets rid of file locking issues on Windows in most cases, as the browser is not being reloaded during file copy process.

### Important Notes

The old server implementation was insufficient to implement that change. The watcher functionality was mandatory and not extensible. Instead of hacking it around, it got replaced with stripped-down implementation relying on exactly the same set of underlying libraries (most notably `connect`), but with all unnecessary features removed. As a bonus, we end up with a little less dependencies.

For live-reload functionality, I used a combination of esbuild "inject" feature that injects an `EventSource` listener, and a server-side handler that simply responds to that listener to trigger a client reload.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
