### PR TITLE
Fix lambda removing when it gets connection inside

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,7 +1593,7 @@ dependencies = [
  "ensogl-text-msdf",
  "ide-view",
  "js-sys",
- "nalgebra 0.26.2",
+ "nalgebra",
  "serde_json",
  "wasm-bindgen",
  "web-sys",

--- a/app/gui/src/presenter/graph/state.rs
+++ b/app/gui/src/presenter/graph/state.rs
@@ -323,12 +323,16 @@ impl State {
         &self,
         connection: AstConnection,
     ) -> Option<(EdgeEndpoint, EdgeEndpoint)> {
-        let nodes = self.nodes.borrow();
-        let src_node = nodes.get(connection.source.node)?.view_id?;
-        let dst_node = nodes.get(connection.destination.node)?.view_id?;
-        let src = EdgeEndpoint::new(src_node, connection.source.port);
-        let data = EdgeEndpoint::new(dst_node, connection.destination.port);
-        Some((src, data))
+        let convertible_source = connection.source.var_crumbs.is_empty();
+        let convertible_dest = connection.destination.var_crumbs.is_empty();
+        (convertible_source && convertible_dest).and_option_from(|| {
+            let nodes = self.nodes.borrow();
+            let src_node = nodes.get(connection.source.node)?.view_id?;
+            let dst_node = nodes.get(connection.destination.node)?.view_id?;
+            let src = EdgeEndpoint::new(src_node, connection.source.port);
+            let data = EdgeEndpoint::new(dst_node, connection.destination.port);
+            Some((src, data))
+        })
     }
 
     /// Convert the pair of [`EdgeEndpoint`]s to AST connection.


### PR DESCRIPTION
### Pull Request Description

This is a part 1 of the fix for https://discordapp.com/channels/401396655599124480/1041669067188219914/1041669067188219914

Every time the node would have a connection going into a lambda body, the entire lambda in the destination node was replaced with the input variable. That because the lambda for some reason is not decomposed into span tree, and the presenter created a connection going to the port spanned over the entire lambda, and then thought this was a connection created by the user.

Such connections, going into "inside" of the span tree, should not break nodes expression, so they are not displayed at all after this fix. The proper fix will be making span-tree lambda decomposition, but it will be a next PR.

### Important Notes

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
