### PR TITLE
Parser: identify lines earlier

### DIFF
--- a/lib/rust/parser/debug/tests/parse.rs
+++ b/lib/rust/parser/debug/tests/parse.rs
@@ -48,7 +48,7 @@ macro_rules! test {
 
 #[test]
 fn nothing() {
-    test("", block![]);
+    test("", block![()]);
 }
 
 #[test]
@@ -107,7 +107,7 @@ fn else_block() {
 
 #[test]
 fn plain_comments() {
-    test!("# a b c", ());
+    test!("# a b c", ()());
     test!("main = # define main\n 4",
         (Function (Ident main) #() "=" (BodyBlock #(() (Number () "4" ())))));
 }

--- a/lib/rust/parser/src/macros/resolver.rs
+++ b/lib/rust/parser/src/macros/resolver.rs
@@ -232,8 +232,9 @@ impl<'s> TryAsRef<PartiallyMatchedMacro<'s>> for ItemOrPartiallyMatchedMacro<'s>
 #[derive(Debug)]
 pub struct Resolver<'s> {
     macro_stack: Vec<PartiallyMatchedMacro<'s>>,
-    scopes:      Vec<Scope<'s>>,
+    scopes:      Vec<Scope>,
     open_blocks: Vec<syntax::Item<'s>>,
+    context:     Context,
 }
 
 /// Result of the macro resolution step.
@@ -249,8 +250,7 @@ enum Step<'s> {
 ///
 /// See the module docs ([`self`]) for about the interaction between blocks and macros.
 #[derive(Debug)]
-struct Scope<'s> {
-    parent_tokens: std::vec::IntoIter<syntax::Item<'s>>,
+struct Scope {
     macros_start:  usize,
     outputs_start: usize,
 }
@@ -262,7 +262,8 @@ impl<'s> Resolver<'s> {
         let macro_stack = default();
         let scopes = default();
         let open_blocks = vec![Token("", "", token::Variant::newline()).into()];
-        Self { macro_stack, scopes, open_blocks }
+        let context = Context::Statement;
+        Self { macro_stack, scopes, open_blocks, context }
     }
 
     /// Returns the index of the first element in `self.macro_stack` that is active in the current
@@ -282,67 +283,58 @@ impl<'s> Resolver<'s> {
     }
 
     /// Run the resolver. Returns the resolved AST.
-    pub fn run(
-        mut self,
-        root_macro_map: &MacroMap,
-        tokens: Vec<syntax::Item<'s>>,
-    ) -> syntax::Tree<'s> {
-        let mut tokens = tokens.into_iter();
-        let mut opt_item: Option<syntax::Item<'s>>;
-        opt_item = tokens.next();
-        let mut context = Context::Statement;
-        loop {
-            while let Some(token) = opt_item {
-                if let syntax::Item::Token(Token { variant: token::Variant::Newline(_), .. }) =
-                    &token
-                {
-                    self.finish_current_line();
-                    self.open_blocks.push(token);
-                    opt_item = tokens.next();
-                    context = Context::Statement;
-                    continue;
-                }
-                let step_result = match token {
-                    syntax::Item::Token(token) =>
-                        self.process_token(root_macro_map, token, context),
-                    syntax::Item::Block(tokens_) => {
-                        let parent_tokens = mem::replace(&mut tokens, tokens_.into_iter());
-                        let macros_start = self.macro_stack.len();
-                        let outputs_start = self.open_blocks.len();
-                        let scope = Scope { parent_tokens, macros_start, outputs_start };
-                        self.scopes.push(scope);
-                        opt_item = tokens.next();
-                        context = Context::Statement;
-                        continue;
-                    }
-                    _ => Step::NormalToken(token),
-                };
-                match step_result {
-                    Step::MacroStackPop(item) => opt_item = Some(item),
-                    Step::NewSegmentStarted => {
-                        opt_item = tokens.next();
-                        context = Context::Expression;
-                    }
-                    Step::NormalToken(item) => {
-                        self.push(item);
-                        opt_item = tokens.next();
-                        context = Context::Expression;
-                    }
-                }
-            }
-            self.finish_current_line();
-            if let Some(Scope { parent_tokens, macros_start, outputs_start }) = self.scopes.pop() {
-                tokens = parent_tokens;
-                opt_item = tokens.next();
-                debug_assert_eq!(macros_start, self.macro_stack.len());
-                let block = self.open_blocks.drain(outputs_start..).collect();
-                self.push(syntax::Item::Block(block));
-            } else {
-                break;
-            }
-        }
+    pub fn run(mut self, root_macro_map: &MacroMap, tokens: Vec<Token<'s>>) -> syntax::Tree<'s> {
+        tokens.into_iter().for_each(|t| self.push(root_macro_map, t));
+        self.finish_current_line();
         let lines = syntax::tree::block::lines(self.open_blocks.into_iter());
         syntax::tree::block::body_from_lines(lines)
+    }
+
+    /// Append a token to the state.
+    fn push(&mut self, root_macro_map: &MacroMap, token: Token<'s>) {
+        match token.variant {
+            token::Variant::Newline(_) => {
+                self.finish_current_line();
+                self.open_blocks.push(token.into());
+                self.context = Context::Statement;
+            }
+            token::Variant::BlockStart(_) => {
+                let macros_start = self.macro_stack.len();
+                let outputs_start = self.open_blocks.len();
+                let scope = Scope { macros_start, outputs_start };
+                self.scopes.push(scope);
+                self.context = Context::Statement;
+            }
+            token::Variant::BlockEnd(_) => {
+                self.finish_current_line();
+                if let Some(Scope { macros_start, outputs_start }) = self.scopes.pop() {
+                    debug_assert_eq!(macros_start, self.macro_stack.len());
+                    let block = self.open_blocks.drain(outputs_start..).collect();
+                    self.push_item(syntax::Item::Block(block));
+                }
+            }
+            _ => {
+                let mut token = token;
+                loop {
+                    token = match self.process_token(root_macro_map, token, self.context) {
+                        Step::MacroStackPop(syntax::Item::Token(t)) => t,
+                        Step::MacroStackPop(item) => {
+                            self.push_item(item);
+                            break;
+                        }
+                        Step::NewSegmentStarted => {
+                            self.context = Context::Expression;
+                            break;
+                        }
+                        Step::NormalToken(item) => {
+                            self.push_item(item);
+                            self.context = Context::Expression;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
     }
 
     fn finish_current_line(&mut self) {
@@ -358,7 +350,7 @@ impl<'s> Resolver<'s> {
         }
     }
 
-    fn push(&mut self, item: syntax::Item<'s>) {
+    fn push_item(&mut self, item: syntax::Item<'s>) {
         let i = self.macro_scope_start();
         if let Some(mac) = self.macro_stack[i..].last_mut() {
             mac.push(item);

--- a/lib/rust/parser/src/syntax/tree.rs
+++ b/lib/rust/parser/src/syntax/tree.rs
@@ -997,64 +997,6 @@ impl<'s> From<token::Ident<'s>> for Tree<'s> {
 
 
 
-// =============================
-// === Traversing operations ===
-// =============================
-
-/// Recurse into the lexical LHS of the tree, applying a function to each node reached, until the
-/// function returns `false`.
-pub fn recurse_left_mut_while<'s>(
-    mut tree: &'_ mut Tree<'s>,
-    mut f: impl FnMut(&'_ mut Tree<'s>) -> bool,
-) {
-    while f(tree) {
-        tree = match &mut *tree.variant {
-            // No LHS.
-            Variant::Invalid(_)
-            | Variant::BodyBlock(_)
-            | Variant::Ident(_)
-            | Variant::Number(_)
-            | Variant::Wildcard(_)
-            | Variant::AutoScope(_)
-            | Variant::TextLiteral(_)
-            | Variant::UnaryOprApp(_)
-            | Variant::MultiSegmentApp(_)
-            | Variant::TypeDef(_)
-            | Variant::Import(_)
-            | Variant::Export(_)
-            | Variant::Group(_)
-            | Variant::CaseOf(_)
-            | Variant::Lambda(_)
-            | Variant::Array(_)
-            | Variant::Annotated(_)
-            | Variant::Documented(_)
-            | Variant::ForeignFunction(_)
-            | Variant::Tuple(_) => break,
-            // Optional LHS.
-            Variant::ArgumentBlockApplication(ArgumentBlockApplication { lhs, .. })
-            | Variant::OperatorBlockApplication(OperatorBlockApplication { lhs, .. })
-            | Variant::OprApp(OprApp { lhs, .. }) =>
-                if let Some(lhs) = lhs {
-                    lhs
-                } else {
-                    break;
-                },
-            // Unconditional LHS.
-            Variant::App(App { func: lhs, .. })
-            | Variant::NamedApp(NamedApp { func: lhs, .. })
-            | Variant::OprSectionBoundary(OprSectionBoundary { ast: lhs, .. })
-            | Variant::TemplateFunction(TemplateFunction { ast: lhs, .. })
-            | Variant::DefaultApp(DefaultApp { func: lhs, .. })
-            | Variant::Assignment(Assignment { pattern: lhs, .. })
-            | Variant::TypeSignature(TypeSignature { variable: lhs, .. })
-            | Variant::Function(Function { name: lhs, .. })
-            | Variant::TypeAnnotated(TypeAnnotated { expression: lhs, .. }) => lhs,
-        }
-    }
-}
-
-
-
 // ================
 // === Visitors ===
 // ================


### PR DESCRIPTION
### Pull Request Description

Unify line-finding by doing it at the beginning of parsing. See: https://www.pivotaltracker.com/story/show/183797744

### Important Notes

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
