### PR TITLE
Import modules' extension methods only with unqualified import statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -456,6 +456,7 @@
 - [Add the `Self` keyword referring to current type][3844]
 - [Support VCS for projects in Language Server][3851]
 - [Support multiple exports of the same module][3897]
+- [Import modules' extension methods only with unqualified imports][3906]
 - [Don't export polyglot symbols][3915]
 - [From/all import must not include module in name resolution][3931]
 
@@ -526,6 +527,7 @@
 [3844]: https://github.com/enso-org/enso/pull/3844
 [3851]: https://github.com/enso-org/enso/pull/3851
 [3897]: https://github.com/enso-org/enso/pull/3897
+[3906]: https://github.com/enso-org/enso/pull/3906
 [3915]: https://github.com/enso-org/enso/pull/3915
 [3931]: https://github.com/enso-org/enso/pull/3931
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -15,8 +15,8 @@ import project.Random
 
 from project.Data.Boolean import Boolean, True, False
 from project.Data.Index_Sub_Range import Index_Sub_Range, take_helper, drop_helper
-from project.Data.Json import Json
-from project.Data.Range import Range
+from project.Data.Json import all
+from project.Data.Range import all
 from project.Error.Common import Error, Panic, Index_Out_Of_Bounds_Error, Index_Out_Of_Bounds_Error_Data, No_Such_Method_Error, No_Such_Method_Error_Data, Illegal_Argument_Error_Data, Incomparable_Values_Error, Type_Error_Data, Unsupported_Argument_Types_Data
 
 polyglot java import java.lang.IndexOutOfBoundsException

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
@@ -40,6 +40,7 @@ export project.Excel.Excel_Range.Excel_Range
 export project.Data.Data_Formatter.Data_Formatter
 
 from Standard.Geo.Geo_Json import Object_Type
+import Standard.Geo.Geo_Json
 
 ## ALIAS To Table
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.logging.Level;
+
 import org.enso.compiler.ModuleCache;
 import org.enso.compiler.context.SimpleUpdate;
 import org.enso.compiler.core.IR;
@@ -432,6 +433,20 @@ public final class Module implements TruffleObject {
   /** @return the runtime scope of this module. */
   public ModuleScope getScope() {
     return scope;
+  }
+
+  /**
+   * Returns the runtime scope of this module that filters out only the requested types. If the list
+   * of requested types is empty, returns the unchanged runtime scope.
+   *
+   * @param namesOnly a list of types to include in the scope
+   */
+  public ModuleScope getScope(List<String> namesOnly) {
+    if (namesOnly.isEmpty()) {
+      return scope;
+    } else {
+      return scope.copyOnly(namesOnly);
+    }
   }
 
   /** @return the qualified name of this module. */

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -439,13 +439,13 @@ public final class Module implements TruffleObject {
    * Returns the runtime scope of this module that filters out only the requested types. If the list
    * of requested types is empty, returns the unchanged runtime scope.
    *
-   * @param namesOnly a list of types to include in the scope
+   * @param types a list of types to include in the scope
    */
-  public ModuleScope getScope(List<String> namesOnly) {
-    if (namesOnly.isEmpty()) {
+  public ModuleScope getScope(List<String> types) {
+    if (types.isEmpty()) {
       return scope;
     } else {
-      return scope.copyOnly(namesOnly);
+      return scope.withTypes(types);
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
@@ -23,12 +23,12 @@ import java.util.Set;
 public final class ModuleScope implements TruffleObject {
   private final Type associatedType;
   private final Module module;
-  private @CompilationFinal Map<String, Object> polyglotSymbols;
-  private @CompilationFinal Map<String, Type> types;
-  private @CompilationFinal Map<Type, Map<String, Function>> methods;
-  private @CompilationFinal Map<Type, Map<Type, Function>> conversions;
-  private @CompilationFinal Set<ModuleScope> imports;
-  private @CompilationFinal Set<ModuleScope> exports;
+  private Map<String, Object> polyglotSymbols;
+  private Map<String, Type> types;
+  private Map<Type, Map<String, Function>> methods;
+  private Map<Type, Map<Type, Function>> conversions;
+  private Set<ModuleScope> imports;
+  private Set<ModuleScope> exports;
 
   /**
    * Creates a new object of this class.
@@ -303,7 +303,7 @@ public final class ModuleScope implements TruffleObject {
    */
   public ModuleScope withTypes(List<String> typeNames) {
     Map<String, Object> polyglotSymbols = new HashMap<>(this.polyglotSymbols);
-    Map<String, Type> types = new HashMap<>(this.types);
+    Map<String, Type> requestedTypes = new HashMap<>(this.types);
     Map<Type, Map<String, Function>> methods = new HashMap<>();
     Map<Type, Map<Type, Function>> conversions = new HashMap<>();
     Set<ModuleScope> imports = new HashSet<>(this.imports);
@@ -313,10 +313,10 @@ public final class ModuleScope implements TruffleObject {
         .forEach(
             entry -> {
               if (typeNames.contains(entry.getKey())) {
-                types.put(entry.getKey(), entry.getValue());
+                requestedTypes.put(entry.getKey(), entry.getValue());
               }
             });
-    Collection<Type> validTypes = types.values();
+    Collection<Type> validTypes = requestedTypes.values();
     this.methods.forEach(
         (tpe, meths) -> {
           if (validTypes.contains(tpe)) {
@@ -331,6 +331,13 @@ public final class ModuleScope implements TruffleObject {
         });
 
     return new ModuleScope(
-        module, associatedType, polyglotSymbols, types, methods, conversions, imports, exports);
+        module,
+        associatedType,
+        polyglotSymbols,
+        requestedTypes,
+        methods,
+        conversions,
+        imports,
+        exports);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
@@ -23,8 +23,7 @@ import java.util.Set;
 public final class ModuleScope implements TruffleObject {
   private final Type associatedType;
   private final Module module;
-  private @CompilationFinal
-  Map<String, Object> polyglotSymbols;
+  private @CompilationFinal Map<String, Object> polyglotSymbols;
   private @CompilationFinal Map<String, Type> types;
   private @CompilationFinal Map<Type, Map<String, Function>> methods;
   private @CompilationFinal Map<Type, Map<Type, Function>> conversions;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
@@ -291,10 +291,10 @@ public final class ModuleScope implements TruffleObject {
   /**
    * Create a copy of this `ModuleScope` while taking into account only the provided list of types.
    *
-   * @param only list of types to copy to the new scope
+   * @param typeNames list of types to copy to the new scope
    * @return a copy of this scope modulo the requested types
    */
-  public ModuleScope copyOnly(List<String> only) {
+  public ModuleScope withTypes(List<String> typeNames) {
     Map<String, Object> polyglotSymbols = new HashMap<>(this.polyglotSymbols);
     Map<String, Type> types = new HashMap<>(this.types);
     Map<Type, Map<String, Function>> methods = new HashMap<>();
@@ -305,7 +305,7 @@ public final class ModuleScope implements TruffleObject {
         .entrySet()
         .forEach(
             entry -> {
-              if (only.contains(entry.getKey())) {
+              if (typeNames.contains(entry.getKey())) {
                 types.put(entry.getKey(), entry.getValue());
               }
             });

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
@@ -1,9 +1,7 @@
 package org.enso.interpreter.runtime.scope;
 
-import com.oracle.truffle.api.CompilerDirectives;
-
-import java.util.*;
-
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.interop.TruffleObject;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.Module;
@@ -12,16 +10,26 @@ import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.error.RedefinedMethodException;
 import org.enso.interpreter.runtime.error.RedefinedConversionException;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
 /** A representation of Enso's per-file top-level scope. */
 public final class ModuleScope implements TruffleObject {
   private final Type associatedType;
   private final Module module;
-  private Map<String, Object> polyglotSymbols = new HashMap<>();
-  private Map<String, Type> types = new HashMap<>();
-  private Map<Type, Map<String, Function>> methods = new HashMap<>();
-  private Map<Type, Map<Type, Function>> conversions = new HashMap<>();
-  private Set<ModuleScope> imports = new HashSet<>();
-  private Set<ModuleScope> exports = new HashSet<>();
+  private @CompilationFinal
+  Map<String, Object> polyglotSymbols;
+  private @CompilationFinal Map<String, Type> types;
+  private @CompilationFinal Map<Type, Map<String, Function>> methods;
+  private @CompilationFinal Map<Type, Map<Type, Function>> conversions;
+  private @CompilationFinal Set<ModuleScope> imports;
+  private @CompilationFinal Set<ModuleScope> exports;
 
   /**
    * Creates a new object of this class.
@@ -175,7 +183,7 @@ public final class ModuleScope implements TruffleObject {
    * @param name the method name.
    * @return the matching method definition or null if not found.
    */
-  @CompilerDirectives.TruffleBoundary
+  @TruffleBoundary
   public Function lookupMethodDefinition(Type type, String name) {
     Function definedWithAtom = type.getDefinitionScope().getMethodMapFor(type).get(name);
     if (definedWithAtom != null) {
@@ -194,7 +202,7 @@ public final class ModuleScope implements TruffleObject {
         .orElse(null);
   }
 
-  @CompilerDirectives.TruffleBoundary
+  @TruffleBoundary
   public Function lookupConversionDefinition(Type type, Type target) {
     Function definedWithAtom = type.getDefinitionScope().getConversionsFor(target).get(type);
     if (definedWithAtom != null) {

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -84,6 +84,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.OptionConverters._
+import scala.jdk.CollectionConverters._
 
 /** This is an implementation of a codegeneration pass that lowers the Enso
   * [[IR]] into the truffle [[org.enso.compiler.core.Core.Node]] structures that
@@ -178,7 +179,11 @@ class IrToTruffle(
       imp.target match {
         case BindingsMap.ResolvedType(_, _) =>
         case ResolvedModule(module) =>
-          moduleScope.addImport(module.unsafeAsModule().getScope)
+          val mod = module.unsafeAsModule()
+          val scope: ModuleScope = imp.importDef.onlyNames
+            .map(only => mod.getScope(only.map(_.name).asJava))
+            .getOrElse(mod.getScope())
+          moduleScope.addImport(scope)
       }
     }
 

--- a/engine/runtime/src/test/resources/Test_Extension_Methods_Failure/package.yaml
+++ b/engine/runtime/src/test/resources/Test_Extension_Methods_Failure/package.yaml
@@ -1,0 +1,6 @@
+name: Test_Extension_Methods_Success
+license: APLv2
+enso-version: default
+version: "0.0.1"
+author: "Enso Team <contact@enso.org>"
+maintainer: "Enso Team <contact@enso.org>"

--- a/engine/runtime/src/test/resources/Test_Extension_Methods_Failure/src/Atom.enso
+++ b/engine/runtime/src/test/resources/Test_Extension_Methods_Failure/src/Atom.enso
@@ -1,0 +1,7 @@
+from Standard.Base.Data.Numbers import Integer
+
+type Foo
+    A
+    B
+
+Integer.foo self a = 1 + a

--- a/engine/runtime/src/test/resources/Test_Extension_Methods_Failure/src/Main.enso
+++ b/engine/runtime/src/test/resources/Test_Extension_Methods_Failure/src/Main.enso
@@ -1,0 +1,5 @@
+import project.Atom.Foo
+from project.Atom.Foo import A
+
+main =
+    1.foo 41

--- a/engine/runtime/src/test/resources/Test_Extension_Methods_Success_1/package.yaml
+++ b/engine/runtime/src/test/resources/Test_Extension_Methods_Success_1/package.yaml
@@ -1,0 +1,6 @@
+name: Test_Extension_Methods_Success
+license: APLv2
+enso-version: default
+version: "0.0.1"
+author: "Enso Team <contact@enso.org>"
+maintainer: "Enso Team <contact@enso.org>"

--- a/engine/runtime/src/test/resources/Test_Extension_Methods_Success_1/package.yaml
+++ b/engine/runtime/src/test/resources/Test_Extension_Methods_Success_1/package.yaml
@@ -1,4 +1,4 @@
-name: Test_Extension_Methods_Success
+name: Test_Extension_Methods_Success_1
 license: APLv2
 enso-version: default
 version: "0.0.1"

--- a/engine/runtime/src/test/resources/Test_Extension_Methods_Success_1/src/Atom.enso
+++ b/engine/runtime/src/test/resources/Test_Extension_Methods_Success_1/src/Atom.enso
@@ -1,0 +1,7 @@
+from Standard.Base.Data.Numbers import Integer
+
+type Foo
+    A
+    B
+
+Integer.foo self a = 1 + a

--- a/engine/runtime/src/test/resources/Test_Extension_Methods_Success_1/src/Main.enso
+++ b/engine/runtime/src/test/resources/Test_Extension_Methods_Success_1/src/Main.enso
@@ -1,0 +1,4 @@
+import project.Atom
+
+main =
+    1.foo 41

--- a/engine/runtime/src/test/resources/Test_Extension_Methods_Success_2/package.yaml
+++ b/engine/runtime/src/test/resources/Test_Extension_Methods_Success_2/package.yaml
@@ -1,0 +1,6 @@
+name: Test_Extension_Methods_Success
+license: APLv2
+enso-version: default
+version: "0.0.1"
+author: "Enso Team <contact@enso.org>"
+maintainer: "Enso Team <contact@enso.org>"

--- a/engine/runtime/src/test/resources/Test_Extension_Methods_Success_2/package.yaml
+++ b/engine/runtime/src/test/resources/Test_Extension_Methods_Success_2/package.yaml
@@ -1,4 +1,4 @@
-name: Test_Extension_Methods_Success
+name: Test_Extension_Methods_Success_2
 license: APLv2
 enso-version: default
 version: "0.0.1"

--- a/engine/runtime/src/test/resources/Test_Extension_Methods_Success_2/src/Atom.enso
+++ b/engine/runtime/src/test/resources/Test_Extension_Methods_Success_2/src/Atom.enso
@@ -1,0 +1,7 @@
+from Standard.Base.Data.Numbers import Integer
+
+type Foo
+    A
+    B
+
+Integer.foo self a = 1 + a

--- a/engine/runtime/src/test/resources/Test_Extension_Methods_Success_2/src/Main.enso
+++ b/engine/runtime/src/test/resources/Test_Extension_Methods_Success_2/src/Main.enso
@@ -1,0 +1,4 @@
+from project.Atom import all
+
+main =
+    1.foo 41

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ImportsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ImportsTest.scala
@@ -90,6 +90,20 @@ class ImportsTest extends PackageTest {
     outLines(3) shouldEqual "(Mk_C 10)"
   }
 
+  "Importing module" should "bring extension methods into the scope " in {
+    evalTestProject("Test_Extension_Methods_Success_1") shouldEqual 42
+  }
+
+  "The unqualified import of a module" should "bring extension methods into the scope " in {
+    evalTestProject("Test_Extension_Methods_Success_2") shouldEqual 42
+  }
+
+  "Importing module's types" should "not bring extension methods into the scope " in {
+    the[InterpreterException] thrownBy evalTestProject(
+      "Test_Extension_Methods_Failure"
+    ) should have message "Method `foo` of 1 (Integer) could not be found."
+  }
+
   "Compiler" should "detect name conflicts preventing users from importing submodules" in {
     the[InterpreterException] thrownBy evalTestProject(
       "TestSubmodulesNameConflict"

--- a/test/Examples_Tests/src/Examples_Spec.enso
+++ b/test/Examples_Tests/src/Examples_Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 import Standard.Examples
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 # While we're lacking the ability to run the documentation examples
 # automatically (#1706), these tests at least check that each of the examples

--- a/test/Examples_Tests/src/Examples_Spec.enso
+++ b/test/Examples_Tests/src/Examples_Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 import Standard.Examples
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 # While we're lacking the ability to run the documentation examples
 # automatically (#1706), these tests at least check that each of the examples

--- a/test/Geo_Tests/src/Geo_Spec.enso
+++ b/test/Geo_Tests/src/Geo_Spec.enso
@@ -4,7 +4,7 @@ from Standard.Table.Data.Table.Table import Table_Data
 import Standard.Geo
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     Test.group "Geo Points" <|

--- a/test/Geo_Tests/src/Geo_Spec.enso
+++ b/test/Geo_Tests/src/Geo_Spec.enso
@@ -4,6 +4,7 @@ from Standard.Table.Data.Table.Table import Table_Data
 import Standard.Geo
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 spec =
     Test.group "Geo Points" <|

--- a/test/Image_Tests/src/Data/Image_Spec.enso
+++ b/test/Image_Tests/src/Data/Image_Spec.enso
@@ -4,6 +4,7 @@ from Standard.Image import Image, Matrix
 import Standard.Image.Data.Matrix_Error.Matrix_Error
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec =
     Test.group "Image with 1 channel" <|

--- a/test/Image_Tests/src/Data/Image_Spec.enso
+++ b/test/Image_Tests/src/Data/Image_Spec.enso
@@ -4,7 +4,7 @@ from Standard.Image import Image, Matrix
 import Standard.Image.Data.Matrix_Error.Matrix_Error
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     Test.group "Image with 1 channel" <|

--- a/test/Image_Tests/src/Data/Matrix_Spec.enso
+++ b/test/Image_Tests/src/Data/Matrix_Spec.enso
@@ -4,7 +4,7 @@ from Standard.Image import Matrix
 import Standard.Image.Data.Matrix_Error.Matrix_Error
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     Test.group "Matrix_Error" <|

--- a/test/Image_Tests/src/Data/Matrix_Spec.enso
+++ b/test/Image_Tests/src/Data/Matrix_Spec.enso
@@ -4,6 +4,7 @@ from Standard.Image import Matrix
 import Standard.Image.Data.Matrix_Error.Matrix_Error
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec =
     Test.group "Matrix_Error" <|

--- a/test/Image_Tests/src/Image_Read_Spec.enso
+++ b/test/Image_Tests/src/Image_Read_Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 from Standard.Image import Image, Read_Flag, Write_Flag
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 polyglot java import java.lang.System as Java_System
 

--- a/test/Image_Tests/src/Image_Read_Spec.enso
+++ b/test/Image_Tests/src/Image_Read_Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 from Standard.Image import Image, Read_Flag, Write_Flag
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 polyglot java import java.lang.System as Java_System
 

--- a/test/Table_Tests/src/Aggregate_Column_Spec.enso
+++ b/test/Table_Tests/src/Aggregate_Column_Spec.enso
@@ -7,7 +7,7 @@ import Standard.Table.Internal.Aggregate_Column_Helper
 import Standard.Table.Internal.Problem_Builder.Problem_Builder
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec = Test.group "Aggregate Columns" <|
     simple_table = Table.new [["count", [1, 2, Nothing, 3, Nothing]], ["is_valid", [Nothing, False, True, False, Nothing]], ["float", [3.4, 1, 5.6, 2.1, Nothing]], ["text", ["A", "", Nothing, "B,C", Nothing]]]

--- a/test/Table_Tests/src/Aggregate_Column_Spec.enso
+++ b/test/Table_Tests/src/Aggregate_Column_Spec.enso
@@ -7,6 +7,7 @@ import Standard.Table.Internal.Aggregate_Column_Helper
 import Standard.Table.Internal.Problem_Builder.Problem_Builder
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec = Test.group "Aggregate Columns" <|
     simple_table = Table.new [["count", [1, 2, Nothing, 3, Nothing]], ["is_valid", [Nothing, False, True, False, Nothing]], ["float", [3.4, 1, 5.6, 2.1, Nothing]], ["text", ["A", "", Nothing, "B,C", Nothing]]]

--- a/test/Table_Tests/src/Aggregate_Spec.enso
+++ b/test/Table_Tests/src/Aggregate_Spec.enso
@@ -7,6 +7,7 @@ from Standard.Table.Errors import Missing_Input_Columns_Data, Column_Indexes_Out
 from Standard.Database.Errors import Unsupported_Database_Operation_Error_Data
 
 from Standard.Test import Test, Test_Suite, Problems
+import Standard.Test.Main as Test_Module
 
 polyglot java import java.lang.Double
 

--- a/test/Table_Tests/src/Aggregate_Spec.enso
+++ b/test/Table_Tests/src/Aggregate_Spec.enso
@@ -7,7 +7,7 @@ from Standard.Table.Errors import Missing_Input_Columns_Data, Column_Indexes_Out
 from Standard.Database.Errors import Unsupported_Database_Operation_Error_Data
 
 from Standard.Test import Test, Test_Suite, Problems
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 polyglot java import java.lang.Double
 

--- a/test/Table_Tests/src/Column_Spec.enso
+++ b/test/Table_Tests/src/Column_Spec.enso
@@ -5,7 +5,7 @@ import Standard.Table.Data.Storage.Storage
 import Standard.Examples
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 polyglot java import org.enso.table.data.column.storage.Storage as Java_Storage
 

--- a/test/Table_Tests/src/Column_Spec.enso
+++ b/test/Table_Tests/src/Column_Spec.enso
@@ -5,6 +5,7 @@ import Standard.Table.Data.Storage.Storage
 import Standard.Examples
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 polyglot java import org.enso.table.data.column.storage.Storage as Java_Storage
 

--- a/test/Table_Tests/src/Common_Table_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Spec.enso
@@ -12,6 +12,7 @@ from Standard.Table.Errors import all
 from Standard.Database.Errors import SQL_Error_Data, Unsupported_Database_Operation_Error_Data
 
 from Standard.Test import Test, Problems
+import Standard.Test.Main as Test_Module
 
 from project.Util import all
 

--- a/test/Table_Tests/src/Common_Table_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Spec.enso
@@ -12,7 +12,7 @@ from Standard.Table.Errors import all
 from Standard.Database.Errors import SQL_Error_Data, Unsupported_Database_Operation_Error_Data
 
 from Standard.Test import Test, Problems
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 from project.Util import all
 

--- a/test/Table_Tests/src/Csv_Spec.enso
+++ b/test/Table_Tests/src/Csv_Spec.enso
@@ -1,8 +1,10 @@
 from Standard.Base import all
 
 from Standard.Table import Table, Column, Delimited, Column_Selector
+import Standard.Table.Main as Table_Module
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 from project.Util import all
 

--- a/test/Table_Tests/src/Csv_Spec.enso
+++ b/test/Table_Tests/src/Csv_Spec.enso
@@ -4,7 +4,7 @@ from Standard.Table import Table, Column, Delimited, Column_Selector
 import Standard.Table.Main as Table_Module
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 from project.Util import all
 

--- a/test/Table_Tests/src/Data_Formatter_Spec.enso
+++ b/test/Table_Tests/src/Data_Formatter_Spec.enso
@@ -4,6 +4,7 @@ from Standard.Table import Table, Column, Data_Formatter, Quote_Style
 from Standard.Table.Errors import all
 
 from Standard.Test import Test, Test_Suite, Problems
+import Standard.Test.Main as Test_Module
 
 type Custom_Type
     Value field

--- a/test/Table_Tests/src/Data_Formatter_Spec.enso
+++ b/test/Table_Tests/src/Data_Formatter_Spec.enso
@@ -4,7 +4,7 @@ from Standard.Table import Table, Column, Data_Formatter, Quote_Style
 from Standard.Table.Errors import all
 
 from Standard.Test import Test, Test_Suite, Problems
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 type Custom_Type
     Value field

--- a/test/Table_Tests/src/Database/Codegen_Spec.enso
+++ b/test/Table_Tests/src/Database/Codegen_Spec.enso
@@ -11,6 +11,7 @@ from Standard.Database.Data.Table import combine_names, fresh_names
 from Standard.Database.Errors import Unsupported_Database_Operation_Error_Data
 
 from Standard.Test import Test, Test_Suite, Problems
+import Standard.Test.Main as Test_Module
 
 import project.Database.Helpers.Fake_Test_Connection
 

--- a/test/Table_Tests/src/Database/Codegen_Spec.enso
+++ b/test/Table_Tests/src/Database/Codegen_Spec.enso
@@ -11,7 +11,7 @@ from Standard.Database.Data.Table import combine_names, fresh_names
 from Standard.Database.Errors import Unsupported_Database_Operation_Error_Data
 
 from Standard.Test import Test, Test_Suite, Problems
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 import project.Database.Helpers.Fake_Test_Connection
 

--- a/test/Table_Tests/src/Database/Common_Spec.enso
+++ b/test/Table_Tests/src/Database/Common_Spec.enso
@@ -8,7 +8,7 @@ from Standard.Database import all
 from Standard.Database.Errors import Unsupported_Database_Operation_Error_Data
 
 from Standard.Test import Test, Problems
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 import project.Database.Helpers.Name_Generator
 

--- a/test/Table_Tests/src/Database/Common_Spec.enso
+++ b/test/Table_Tests/src/Database/Common_Spec.enso
@@ -8,6 +8,7 @@ from Standard.Database import all
 from Standard.Database.Errors import Unsupported_Database_Operation_Error_Data
 
 from Standard.Test import Test, Problems
+import Standard.Test.Main as Test_Module
 
 import project.Database.Helpers.Name_Generator
 

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -11,7 +11,7 @@ import Standard.Database.Data.SQL_Type.SQL_Type
 import Standard.Database.Internal.Postgres.Pgpass
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 import Standard.Test.Test_Environment
 
 import project.Database.Common_Spec

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -11,6 +11,7 @@ import Standard.Database.Data.SQL_Type.SQL_Type
 import Standard.Database.Internal.Postgres.Pgpass
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 import Standard.Test.Test_Environment
 
 import project.Database.Common_Spec

--- a/test/Table_Tests/src/Database/Redshift_Spec.enso
+++ b/test/Table_Tests/src/Database/Redshift_Spec.enso
@@ -6,6 +6,7 @@ from Standard.Table import Table
 from Standard.Database import Database, Redshift, AWS_Credential, SQL_Query
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 import project.Database.Common_Spec
 import project.Database.Helpers.Name_Generator

--- a/test/Table_Tests/src/Database/Redshift_Spec.enso
+++ b/test/Table_Tests/src/Database/Redshift_Spec.enso
@@ -6,7 +6,7 @@ from Standard.Table import Table
 from Standard.Database import Database, Redshift, AWS_Credential, SQL_Query
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 import project.Database.Common_Spec
 import project.Database.Helpers.Name_Generator

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -7,7 +7,7 @@ from Standard.Database import Database, SQLite, In_Memory, SQL_Query
 from Standard.Database.Errors import SQL_Error_Data
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 import project.Database.Common_Spec
 import project.Database.Helpers.Name_Generator

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -7,6 +7,7 @@ from Standard.Database import Database, SQLite, In_Memory, SQL_Query
 from Standard.Database.Errors import SQL_Error_Data
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 import project.Database.Common_Spec
 import project.Database.Helpers.Name_Generator

--- a/test/Table_Tests/src/Delimited_Read_Spec.enso
+++ b/test/Table_Tests/src/Delimited_Read_Spec.enso
@@ -1,11 +1,12 @@
 from Standard.Base import all
 
 from Standard.Table import Table, Column, Data_Formatter, Quote_Style, Delimited
+import Standard.Table.Data.Table_Conversions
 import Standard.Table.Main as Table_Module
 from Standard.Table.Errors import all
 
 from Standard.Test import Test, Test_Suite, Problems
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 import project.Util
 

--- a/test/Table_Tests/src/Delimited_Read_Spec.enso
+++ b/test/Table_Tests/src/Delimited_Read_Spec.enso
@@ -1,9 +1,11 @@
 from Standard.Base import all
 
 from Standard.Table import Table, Column, Data_Formatter, Quote_Style, Delimited
+import Standard.Table.Main as Table_Module
 from Standard.Table.Errors import all
 
 from Standard.Test import Test, Test_Suite, Problems
+import Standard.Test.Main as Test_Module
 
 import project.Util
 

--- a/test/Table_Tests/src/Delimited_Write_Spec.enso
+++ b/test/Table_Tests/src/Delimited_Write_Spec.enso
@@ -4,7 +4,7 @@ from Standard.Table import Table, Column, Data_Formatter, Quote_Style, Column_Na
 from Standard.Table.Errors import all
 
 from Standard.Test import Test, Test_Suite, Problems
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 from project.Util import all
 

--- a/test/Table_Tests/src/Delimited_Write_Spec.enso
+++ b/test/Table_Tests/src/Delimited_Write_Spec.enso
@@ -4,6 +4,7 @@ from Standard.Table import Table, Column, Data_Formatter, Quote_Style, Column_Na
 from Standard.Table.Errors import all
 
 from Standard.Test import Test, Test_Suite, Problems
+import Standard.Test.Main as Test_Module
 
 from project.Util import all
 

--- a/test/Table_Tests/src/Excel_Spec.enso
+++ b/test/Table_Tests/src/Excel_Spec.enso
@@ -5,7 +5,7 @@ from Standard.Table import Table, Match_Columns, Column_Name_Mapping, Excel, Exc
 from Standard.Table.Errors import Invalid_Output_Column_Names_Data, Duplicate_Output_Column_Names_Data, Invalid_Location_Data, Range_Exceeded_Data, Existing_Data_Data, Column_Count_Mismatch_Data, Column_Name_Mismatch_Data
 
 from Standard.Test import Test, Test_Suite, Problems
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 import Standard.Examples
 

--- a/test/Table_Tests/src/Excel_Spec.enso
+++ b/test/Table_Tests/src/Excel_Spec.enso
@@ -5,6 +5,7 @@ from Standard.Table import Table, Match_Columns, Column_Name_Mapping, Excel, Exc
 from Standard.Table.Errors import Invalid_Output_Column_Names_Data, Duplicate_Output_Column_Names_Data, Invalid_Location_Data, Range_Exceeded_Data, Existing_Data_Data, Column_Count_Mismatch_Data, Column_Name_Mismatch_Data
 
 from Standard.Test import Test, Test_Suite, Problems
+import Standard.Test.Main as Test_Module
 
 import Standard.Examples
 

--- a/test/Table_Tests/src/Expression_Spec.enso
+++ b/test/Table_Tests/src/Expression_Spec.enso
@@ -6,6 +6,7 @@ import Standard.Table.Data.Expression.Expression_Error
 import Standard.Visualization
 
 from Standard.Test import Test, Test_Suite, Problems
+import Standard.Test.Main as Test_Module
 
 import project.Common_Table_Spec
 from project.Util import all

--- a/test/Table_Tests/src/Expression_Spec.enso
+++ b/test/Table_Tests/src/Expression_Spec.enso
@@ -6,7 +6,7 @@ import Standard.Table.Data.Expression.Expression_Error
 import Standard.Visualization
 
 from Standard.Test import Test, Test_Suite, Problems
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 import project.Common_Table_Spec
 from project.Util import all

--- a/test/Table_Tests/src/Json_Spec.enso
+++ b/test/Table_Tests/src/Json_Spec.enso
@@ -3,7 +3,7 @@ from Standard.Table import Table
 import Standard.Table.Main as Table_Module
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 import project.Util
 

--- a/test/Table_Tests/src/Json_Spec.enso
+++ b/test/Table_Tests/src/Json_Spec.enso
@@ -1,7 +1,9 @@
 from Standard.Base import all
 from Standard.Table import Table
+import Standard.Table.Main as Table_Module
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 import project.Util
 

--- a/test/Table_Tests/src/Parse_Values_Spec.enso
+++ b/test/Table_Tests/src/Parse_Values_Spec.enso
@@ -8,6 +8,7 @@ from Standard.Table.Errors import Invalid_Format, Leading_Zeros, Missing_Input_C
 import Standard.Visualization
 
 from Standard.Test import Test, Test_Suite, Problems
+import Standard.Test.Main as Test_Module
 
 spec = Test.group "Table.parse_values" <|
     Test.specify "should correctly parse integers" <|

--- a/test/Table_Tests/src/Parse_Values_Spec.enso
+++ b/test/Table_Tests/src/Parse_Values_Spec.enso
@@ -8,7 +8,7 @@ from Standard.Table.Errors import Invalid_Format, Leading_Zeros, Missing_Input_C
 import Standard.Visualization
 
 from Standard.Test import Test, Test_Suite, Problems
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec = Test.group "Table.parse_values" <|
     Test.specify "should correctly parse integers" <|

--- a/test/Table_Tests/src/Table_Date_Spec.enso
+++ b/test/Table_Tests/src/Table_Date_Spec.enso
@@ -1,11 +1,11 @@
 from Standard.Base import all
 
 from Standard.Table import Table, Column, Delimited, Data_Formatter
-import Standard.Table.Main as Table_Module
+import Standard.Table.Data.Table_Conversions
 import Standard.Table.Data.Storage.Storage
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 from project.Util import all
 
 spec =

--- a/test/Table_Tests/src/Table_Date_Spec.enso
+++ b/test/Table_Tests/src/Table_Date_Spec.enso
@@ -1,9 +1,11 @@
 from Standard.Base import all
 
 from Standard.Table import Table, Column, Delimited, Data_Formatter
+import Standard.Table.Main as Table_Module
 import Standard.Table.Data.Storage.Storage
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 from project.Util import all
 
 spec =

--- a/test/Table_Tests/src/Table_Spec.enso
+++ b/test/Table_Tests/src/Table_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Table import Table, Column, Sort_Column, Column_Selector, Sort_Column_Selector, Aggregate_Column
+import Standard.Table.Main as Table_Module
 from Standard.Table.Data.Aggregate_Column.Aggregate_Column import all hiding First, Last
 from Standard.Table.Data.Table import Empty_Error
 from Standard.Table.Data.Storage import Storage
@@ -10,6 +11,7 @@ from Standard.Table.Errors import Invalid_Output_Column_Names_Data, Duplicate_Ou
 import Standard.Visualization
 
 from Standard.Test import Test, Test_Suite, Problems
+import Standard.Test.Main as Test_Module
 
 import project.Common_Table_Spec
 from project.Util import all

--- a/test/Table_Tests/src/Table_Spec.enso
+++ b/test/Table_Tests/src/Table_Spec.enso
@@ -11,7 +11,7 @@ from Standard.Table.Errors import Invalid_Output_Column_Names_Data, Duplicate_Ou
 import Standard.Visualization
 
 from Standard.Test import Test, Test_Suite, Problems
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 import project.Common_Table_Spec
 from project.Util import all

--- a/test/Table_Tests/src/Table_Time_Of_Day_Spec.enso
+++ b/test/Table_Tests/src/Table_Time_Of_Day_Spec.enso
@@ -4,6 +4,7 @@ from Standard.Table import Table, Delimited, Column, Data_Formatter
 import Standard.Table.Data.Storage
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 from project.Util import all
 

--- a/test/Table_Tests/src/Table_Time_Of_Day_Spec.enso
+++ b/test/Table_Tests/src/Table_Time_Of_Day_Spec.enso
@@ -4,7 +4,7 @@ from Standard.Table import Table, Delimited, Column, Data_Formatter
 import Standard.Table.Data.Storage
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 from project.Util import all
 

--- a/test/Table_Tests/src/Table_Time_Spec.enso
+++ b/test/Table_Tests/src/Table_Time_Spec.enso
@@ -4,6 +4,7 @@ from Standard.Table import Table, Delimited, Column, Data_Formatter
 import Standard.Table.Data.Storage
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 from project.Util import all
 

--- a/test/Table_Tests/src/Table_Time_Spec.enso
+++ b/test/Table_Tests/src/Table_Time_Spec.enso
@@ -4,7 +4,7 @@ from Standard.Table import Table, Delimited, Column, Data_Formatter
 import Standard.Table.Data.Storage
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 from project.Util import all
 

--- a/test/Table_Tests/src/Unique_Naming_Strategy_Spec.enso
+++ b/test/Table_Tests/src/Unique_Naming_Strategy_Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 import Standard.Table.Internal.Unique_Name_Strategy.Unique_Name_Strategy
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec = Test.group 'Unique_Name_Strategy Helper' <|
     Test.specify 'should change an empty name to "Column"' <|

--- a/test/Table_Tests/src/Unique_Naming_Strategy_Spec.enso
+++ b/test/Table_Tests/src/Unique_Naming_Strategy_Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 import Standard.Table.Internal.Unique_Name_Strategy.Unique_Name_Strategy
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec = Test.group 'Unique_Name_Strategy Helper' <|
     Test.specify 'should change an empty name to "Column"' <|

--- a/test/Table_Tests/src/Util.enso
+++ b/test/Table_Tests/src/Util.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 from Standard.Table import Table, Column
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 Table.should_equal self expected =
     self_cols = self.columns

--- a/test/Table_Tests/src/Util.enso
+++ b/test/Table_Tests/src/Util.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 from Standard.Table import Table, Column
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 Table.should_equal self expected =
     self_cols = self.columns

--- a/test/Tests/src/Data/Array_Polyglot_Spec.enso
+++ b/test/Tests/src/Data/Array_Polyglot_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     Test.group "JavaScript Objects, Arrays & Functions" <|

--- a/test/Tests/src/Data/Array_Polyglot_Spec.enso
+++ b/test/Tests/src/Data/Array_Polyglot_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec =
     Test.group "JavaScript Objects, Arrays & Functions" <|

--- a/test/Tests/src/Data/Array_Proxy_Spec.enso
+++ b/test/Tests/src/Data/Array_Proxy_Spec.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 from Standard.Base.Data.Array_Proxy import Array_Proxy
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 type Proxy_Object
     Value length

--- a/test/Tests/src/Data/Array_Proxy_Spec.enso
+++ b/test/Tests/src/Data/Array_Proxy_Spec.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 from Standard.Base.Data.Array_Proxy import Array_Proxy
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 type Proxy_Object
     Value length

--- a/test/Tests/src/Data/Array_Spec.enso
+++ b/test/Tests/src/Data/Array_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 polyglot java import java.util.LinkedHashSet
 

--- a/test/Tests/src/Data/Array_Spec.enso
+++ b/test/Tests/src/Data/Array_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 polyglot java import java.util.LinkedHashSet
 

--- a/test/Tests/src/Data/Bool_Spec.enso
+++ b/test/Tests/src/Data/Bool_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 Boolean.method self = self
 

--- a/test/Tests/src/Data/Bool_Spec.enso
+++ b/test/Tests/src/Data/Bool_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 Boolean.method self = self
 

--- a/test/Tests/src/Data/Function_Spec.enso
+++ b/test/Tests/src/Data/Function_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec =
     Test.group "identity" <|

--- a/test/Tests/src/Data/Function_Spec.enso
+++ b/test/Tests/src/Data/Function_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     Test.group "identity" <|

--- a/test/Tests/src/Data/Interval_Spec.enso
+++ b/test/Tests/src/Data/Interval_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec =
     Test.group "Bound" <|

--- a/test/Tests/src/Data/Interval_Spec.enso
+++ b/test/Tests/src/Data/Interval_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     Test.group "Bound" <|

--- a/test/Tests/src/Data/Json_Spec.enso
+++ b/test/Tests/src/Data/Json_Spec.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 from Standard.Base.Data.Json import Json_Parse_Error, No_Such_Field
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 import Standard.Test.Test_Result.Test_Result
 
 type Author

--- a/test/Tests/src/Data/Json_Spec.enso
+++ b/test/Tests/src/Data/Json_Spec.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 from Standard.Base.Data.Json import Json_Parse_Error, No_Such_Field
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 import Standard.Test.Test_Result.Test_Result
 
 type Author

--- a/test/Tests/src/Data/List_Spec.enso
+++ b/test/Tests/src/Data/List_Spec.enso
@@ -3,6 +3,7 @@ import Standard.Base.Runtime.State
 from Standard.Base.Data.List import Empty_Error
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec = Test.group "List" <|
     l = List.Cons 1 <| List.Cons 2 <| List.Cons 3 <| List.Nil

--- a/test/Tests/src/Data/List_Spec.enso
+++ b/test/Tests/src/Data/List_Spec.enso
@@ -3,7 +3,7 @@ import Standard.Base.Runtime.State
 from Standard.Base.Data.List import Empty_Error
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec = Test.group "List" <|
     l = List.Cons 1 <| List.Cons 2 <| List.Cons 3 <| List.Nil

--- a/test/Tests/src/Data/Locale_Spec.enso
+++ b/test/Tests/src/Data/Locale_Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 polyglot java import java.util.Locale as JavaLocale
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 with_locale locale ~test =
     default_locale = JavaLocale.getDefault

--- a/test/Tests/src/Data/Locale_Spec.enso
+++ b/test/Tests/src/Data/Locale_Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 polyglot java import java.util.Locale as JavaLocale
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 with_locale locale ~test =
     default_locale = JavaLocale.getDefault

--- a/test/Tests/src/Data/Map_Spec.enso
+++ b/test/Tests/src/Data/Map_Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 from Standard.Base.Data.Map import No_Value_For_Key
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec = Test.group "Maps" <|
     m = Map.empty . insert 1 2 . insert 2 4

--- a/test/Tests/src/Data/Map_Spec.enso
+++ b/test/Tests/src/Data/Map_Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 from Standard.Base.Data.Map import No_Value_For_Key
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec = Test.group "Maps" <|
     m = Map.empty . insert 1 2 . insert 2 4

--- a/test/Tests/src/Data/Maybe_Spec.enso
+++ b/test/Tests/src/Data/Maybe_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec = Test.group "Maybe" <|
     Test.specify "should have a None variant" <|

--- a/test/Tests/src/Data/Maybe_Spec.enso
+++ b/test/Tests/src/Data/Maybe_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec = Test.group "Maybe" <|
     Test.specify "should have a None variant" <|

--- a/test/Tests/src/Data/Noise/Generator_Spec.enso
+++ b/test/Tests/src/Data/Noise/Generator_Spec.enso
@@ -5,6 +5,7 @@ import Standard.Base.Data.Noise.Deterministic_Random
 import Standard.Base.Error.Common
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec =
     Test.group "Generator Interface" <|

--- a/test/Tests/src/Data/Noise/Generator_Spec.enso
+++ b/test/Tests/src/Data/Noise/Generator_Spec.enso
@@ -5,7 +5,7 @@ import Standard.Base.Data.Noise.Deterministic_Random
 import Standard.Base.Error.Common
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     Test.group "Generator Interface" <|

--- a/test/Tests/src/Data/Noise_Spec.enso
+++ b/test/Tests/src/Data/Noise_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 type My_Generator
 My_Generator.step self _ _ = 1

--- a/test/Tests/src/Data/Noise_Spec.enso
+++ b/test/Tests/src/Data/Noise_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 type My_Generator
 My_Generator.step self _ _ = 1

--- a/test/Tests/src/Data/Numbers_Spec.enso
+++ b/test/Tests/src/Data/Numbers_Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 from Standard.Base.Data.Numbers import Number_Parse_Error
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 Integer.is_even self = self % 2 == 0
 

--- a/test/Tests/src/Data/Numbers_Spec.enso
+++ b/test/Tests/src/Data/Numbers_Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 from Standard.Base.Data.Numbers import Number_Parse_Error
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 Integer.is_even self = self % 2 == 0
 

--- a/test/Tests/src/Data/Ordering/Comparator_Spec.enso
+++ b/test/Tests/src/Data/Ordering/Comparator_Spec.enso
@@ -5,6 +5,7 @@ import Standard.Base.Data.Ordering.Comparator
 polyglot java import java.lang.ClassCastException
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 # === Test Resources ===
 

--- a/test/Tests/src/Data/Ordering/Comparator_Spec.enso
+++ b/test/Tests/src/Data/Ordering/Comparator_Spec.enso
@@ -5,7 +5,7 @@ import Standard.Base.Data.Ordering.Comparator
 polyglot java import java.lang.ClassCastException
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 # === Test Resources ===
 

--- a/test/Tests/src/Data/Ordering/Natural_Order_Spec.enso
+++ b/test/Tests/src/Data/Ordering/Natural_Order_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec = Test.group "Natural Order" <|
     case_insensitive_compare a b = Natural_Order.compare a b Case_Sensitivity.Insensitive

--- a/test/Tests/src/Data/Ordering/Natural_Order_Spec.enso
+++ b/test/Tests/src/Data/Ordering/Natural_Order_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec = Test.group "Natural Order" <|
     case_insensitive_compare a b = Natural_Order.compare a b Case_Sensitivity.Insensitive

--- a/test/Tests/src/Data/Ordering/Vector_Lexicographic_Order_Spec.enso
+++ b/test/Tests/src/Data/Ordering/Vector_Lexicographic_Order_Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 import Standard.Base.Data.Ordering.Vector_Lexicographic_Order
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 type My_Type
     Value a b

--- a/test/Tests/src/Data/Ordering/Vector_Lexicographic_Order_Spec.enso
+++ b/test/Tests/src/Data/Ordering/Vector_Lexicographic_Order_Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 import Standard.Base.Data.Ordering.Vector_Lexicographic_Order
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 type My_Type
     Value a b

--- a/test/Tests/src/Data/Ordering_Spec.enso
+++ b/test/Tests/src/Data/Ordering_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 # === Test Resources ===
 

--- a/test/Tests/src/Data/Ordering_Spec.enso
+++ b/test/Tests/src/Data/Ordering_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 # === Test Resources ===
 

--- a/test/Tests/src/Data/Polyglot_Spec.enso
+++ b/test/Tests/src/Data/Polyglot_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 polyglot java import java.time.LocalDate
 polyglot java import java.lang.String

--- a/test/Tests/src/Data/Polyglot_Spec.enso
+++ b/test/Tests/src/Data/Polyglot_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 polyglot java import java.time.LocalDate
 polyglot java import java.lang.String

--- a/test/Tests/src/Data/Range_Spec.enso
+++ b/test/Tests/src/Data/Range_Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 import Standard.Base.Runtime.Ref.Ref
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec = Test.group "Range" <|
     Test.specify "should be created with a start, an end and a step" <|

--- a/test/Tests/src/Data/Range_Spec.enso
+++ b/test/Tests/src/Data/Range_Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 import Standard.Base.Runtime.Ref.Ref
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec = Test.group "Range" <|
     Test.specify "should be created with a start, an end and a step" <|

--- a/test/Tests/src/Data/Ref_Spec.enso
+++ b/test/Tests/src/Data/Ref_Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 import Standard.Base.Runtime.Ref.Ref
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec = Test.group "Refs" <|
     Test.specify "should be able to store and retrieve value in references" <|

--- a/test/Tests/src/Data/Ref_Spec.enso
+++ b/test/Tests/src/Data/Ref_Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 import Standard.Base.Runtime.Ref.Ref
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec = Test.group "Refs" <|
     Test.specify "should be able to store and retrieve value in references" <|

--- a/test/Tests/src/Data/Regression_Spec.enso
+++ b/test/Tests/src/Data/Regression_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import Nothing, Vector, Number, Decimal, True, Illegal_Argument_Error_Data, False, Regression
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     ## Regression test data produced using an Excel spreadsheet.

--- a/test/Tests/src/Data/Regression_Spec.enso
+++ b/test/Tests/src/Data/Regression_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import Nothing, Vector, Number, Decimal, True, Illegal_Argument_Error_Data, False, Regression
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec =
     ## Regression test data produced using an Excel spreadsheet.

--- a/test/Tests/src/Data/Statistics_Spec.enso
+++ b/test/Tests/src/Data/Statistics_Spec.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 from Standard.Base.Data.Vector import Empty_Error
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 # === Test Resources ===
 

--- a/test/Tests/src/Data/Statistics_Spec.enso
+++ b/test/Tests/src/Data/Statistics_Spec.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 from Standard.Base.Data.Vector import Empty_Error
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 # === Test Resources ===
 

--- a/test/Tests/src/Data/Text/Default_Regex_Engine_Spec.enso
+++ b/test/Tests/src/Data/Text/Default_Regex_Engine_Spec.enso
@@ -7,7 +7,7 @@ import Standard.Base.Data.Text.Regex.Option as Global_Option
 polyglot java import java.util.regex.Pattern as Java_Pattern
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 default_mask = Java_Pattern.CANON_EQ.bit_or Java_Pattern.UNICODE_CASE . bit_or Java_Pattern.UNICODE_CHARACTER_CLASS
 

--- a/test/Tests/src/Data/Text/Default_Regex_Engine_Spec.enso
+++ b/test/Tests/src/Data/Text/Default_Regex_Engine_Spec.enso
@@ -7,6 +7,7 @@ import Standard.Base.Data.Text.Regex.Option as Global_Option
 polyglot java import java.util.regex.Pattern as Java_Pattern
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 default_mask = Java_Pattern.CANON_EQ.bit_or Java_Pattern.UNICODE_CASE . bit_or Java_Pattern.UNICODE_CHARACTER_CLASS
 

--- a/test/Tests/src/Data/Text/Encoding_Spec.enso
+++ b/test/Tests/src/Data/Text/Encoding_Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 from Standard.Base.Data.Text.Encoding import all_character_sets, all_encodings, Encoding
 
 from Standard.Test import Test, Test_Suite, Problems
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     Test.group "Encoding object" <|

--- a/test/Tests/src/Data/Text/Encoding_Spec.enso
+++ b/test/Tests/src/Data/Text/Encoding_Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 from Standard.Base.Data.Text.Encoding import all_character_sets, all_encodings, Encoding
 
 from Standard.Test import Test, Test_Suite, Problems
+import Standard.Test.Main as Test_Module
 
 spec =
     Test.group "Encoding object" <|

--- a/test/Tests/src/Data/Text/Matching_Spec.enso
+++ b/test/Tests/src/Data/Text/Matching_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite, Problems
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 type Foo_Error
 

--- a/test/Tests/src/Data/Text/Matching_Spec.enso
+++ b/test/Tests/src/Data/Text/Matching_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite, Problems
+import Standard.Test.Main as Test_Module
 
 type Foo_Error
 

--- a/test/Tests/src/Data/Text/Regex_Spec.enso
+++ b/test/Tests/src/Data/Text/Regex_Spec.enso
@@ -4,7 +4,7 @@ import Standard.Base.Data.Text.Regex.Option
 import Standard.Base.Data.Text.Regex.Engine.Default as Default_Engine
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     Test.group "Regex options handling" <|

--- a/test/Tests/src/Data/Text/Regex_Spec.enso
+++ b/test/Tests/src/Data/Text/Regex_Spec.enso
@@ -4,6 +4,7 @@ import Standard.Base.Data.Text.Regex.Option
 import Standard.Base.Data.Text.Regex.Engine.Default as Default_Engine
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec =
     Test.group "Regex options handling" <|

--- a/test/Tests/src/Data/Text/Span_Spec.enso
+++ b/test/Tests/src/Data/Text/Span_Spec.enso
@@ -2,6 +2,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec = Test.group "Text.Span" <|
 

--- a/test/Tests/src/Data/Text/Span_Spec.enso
+++ b/test/Tests/src/Data/Text/Span_Spec.enso
@@ -2,7 +2,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec = Test.group "Text.Span" <|
 

--- a/test/Tests/src/Data/Text/Text_Sub_Range_Spec.enso
+++ b/test/Tests/src/Data/Text/Text_Sub_Range_Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 from Standard.Base.Data.Text.Text_Sub_Range import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec = Test.group "Text_Sub_Range_Data" <|
     Test.specify "should correctly split a text into grapheme cluster ranges expressed in codepoint indices" <|

--- a/test/Tests/src/Data/Text/Text_Sub_Range_Spec.enso
+++ b/test/Tests/src/Data/Text/Text_Sub_Range_Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 from Standard.Base.Data.Text.Text_Sub_Range import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec = Test.group "Text_Sub_Range_Data" <|
     Test.specify "should correctly split a text into grapheme cluster ranges expressed in codepoint indices" <|

--- a/test/Tests/src/Data/Text/Utils_Spec.enso
+++ b/test/Tests/src/Data/Text/Utils_Spec.enso
@@ -5,6 +5,7 @@ polyglot java import org.enso.base.text.CaseFoldedString
 polyglot java import com.ibm.icu.text.BreakIterator
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec =
     Test.group "Text_Utils" <|

--- a/test/Tests/src/Data/Text/Utils_Spec.enso
+++ b/test/Tests/src/Data/Text/Utils_Spec.enso
@@ -5,7 +5,7 @@ polyglot java import org.enso.base.text.CaseFoldedString
 polyglot java import com.ibm.icu.text.BreakIterator
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     Test.group "Text_Utils" <|

--- a/test/Tests/src/Data/Text_Spec.enso
+++ b/test/Tests/src/Data/Text_Spec.enso
@@ -7,6 +7,7 @@ from Standard.Base.Data.Text.Text_Sub_Range.Text_Sub_Range import all
 from Standard.Base.Data.Index_Sub_Range.Index_Sub_Range import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 type Auto
     Value a

--- a/test/Tests/src/Data/Text_Spec.enso
+++ b/test/Tests/src/Data/Text_Spec.enso
@@ -7,7 +7,7 @@ from Standard.Base.Data.Text.Text_Sub_Range.Text_Sub_Range import all
 from Standard.Base.Data.Index_Sub_Range.Index_Sub_Range import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 type Auto
     Value a

--- a/test/Tests/src/Data/Time/Date_Part_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Part_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec name create_new_date =
     Test.group (name + "date part tests")  <|

--- a/test/Tests/src/Data/Time/Date_Part_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Part_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 spec name create_new_date =
     Test.group (name + "date part tests")  <|

--- a/test/Tests/src/Data/Time/Date_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 from Standard.Base.Error.Common import Time_Error
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 import project.Data.Time.Date_Part_Spec
 

--- a/test/Tests/src/Data/Time/Date_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 from Standard.Base.Error.Common import Time_Error
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 import project.Data.Time.Date_Part_Spec
 

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 import project.Data.Time.Date_Part_Spec
 

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 import project.Data.Time.Date_Part_Spec
 

--- a/test/Tests/src/Data/Time/Day_Of_Week_Spec.enso
+++ b/test/Tests/src/Data/Time/Day_Of_Week_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     Test.group "Day_Of_Week conversions" <|

--- a/test/Tests/src/Data/Time/Day_Of_Week_Spec.enso
+++ b/test/Tests/src/Data/Time/Day_Of_Week_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec =
     Test.group "Day_Of_Week conversions" <|

--- a/test/Tests/src/Data/Time/Duration_Spec.enso
+++ b/test/Tests/src/Data/Time/Duration_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 polyglot java import java.time.Duration as Java_Duration
 polyglot java import java.time.LocalDate

--- a/test/Tests/src/Data/Time/Duration_Spec.enso
+++ b/test/Tests/src/Data/Time/Duration_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 polyglot java import java.time.Duration as Java_Duration
 polyglot java import java.time.LocalDate

--- a/test/Tests/src/Data/Time/Period_Spec.enso
+++ b/test/Tests/src/Data/Time/Period_Spec.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec =
     Test.group "Period" <|

--- a/test/Tests/src/Data/Time/Period_Spec.enso
+++ b/test/Tests/src/Data/Time/Period_Spec.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     Test.group "Period" <|

--- a/test/Tests/src/Data/Time/Spec.enso
+++ b/test/Tests/src/Data/Time/Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test_Suite
+import Standard.Test.Main as Test_Module
 
 import project.Data.Time.Duration_Spec
 import project.Data.Time.Period_Spec

--- a/test/Tests/src/Data/Time/Spec.enso
+++ b/test/Tests/src/Data/Time/Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 import project.Data.Time.Duration_Spec
 import project.Data.Time.Period_Spec

--- a/test/Tests/src/Data/Time/Time_Of_Day_Spec.enso
+++ b/test/Tests/src/Data/Time/Time_Of_Day_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 polyglot java import java.time.LocalTime
 polyglot java import java.time.format.DateTimeFormatter

--- a/test/Tests/src/Data/Time/Time_Of_Day_Spec.enso
+++ b/test/Tests/src/Data/Time/Time_Of_Day_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 polyglot java import java.time.LocalTime
 polyglot java import java.time.format.DateTimeFormatter

--- a/test/Tests/src/Data/Time/Time_Zone_Spec.enso
+++ b/test/Tests/src/Data/Time/Time_Zone_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 polyglot java import java.time.ZoneId
 polyglot java import java.time.ZoneOffset

--- a/test/Tests/src/Data/Time/Time_Zone_Spec.enso
+++ b/test/Tests/src/Data/Time/Time_Zone_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 polyglot java import java.time.ZoneId
 polyglot java import java.time.ZoneOffset

--- a/test/Tests/src/Data/Vector/Slicing_Helpers_Spec.enso
+++ b/test/Tests/src/Data/Vector/Slicing_Helpers_Spec.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base.Data.Index_Sub_Range
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec = Test.group "Vector Slicing Helpers" <|
     Test.specify "should be able to sort correctly merge neighboring sequences" <|

--- a/test/Tests/src/Data/Vector/Slicing_Helpers_Spec.enso
+++ b/test/Tests/src/Data/Vector/Slicing_Helpers_Spec.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 import Standard.Base.Data.Index_Sub_Range
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec = Test.group "Vector Slicing Helpers" <|
     Test.specify "should be able to sort correctly merge neighboring sequences" <|

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -4,6 +4,7 @@ from Standard.Base.Data.Vector import Empty_Error
 import Standard.Base.Runtime.Ref.Ref
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 type T
     Value a b

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -4,7 +4,7 @@ from Standard.Base.Data.Vector import Empty_Error
 import Standard.Base.Runtime.Ref.Ref
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 type T
     Value a b

--- a/test/Tests/src/Main.enso
+++ b/test/Tests/src/Main.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 import project.Semantic.Any_Spec
 import project.Semantic.Case_Spec

--- a/test/Tests/src/Main.enso
+++ b/test/Tests/src/Main.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test_Suite
+import Standard.Test.Main as Test_Module
 
 import project.Semantic.Any_Spec
 import project.Semantic.Case_Spec

--- a/test/Tests/src/Network/Http/Header_Spec.enso
+++ b/test/Tests/src/Network/Http/Header_Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 import Standard.Base.Network.Http.Header
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     Test.group "Header" <|

--- a/test/Tests/src/Network/Http/Header_Spec.enso
+++ b/test/Tests/src/Network/Http/Header_Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 import Standard.Base.Network.Http.Header
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 spec =
     Test.group "Header" <|

--- a/test/Tests/src/Network/Http/Request_Spec.enso
+++ b/test/Tests/src/Network/Http/Request_Spec.enso
@@ -8,7 +8,7 @@ import Standard.Base.Network.Http.Request.Body as Request_Body
 import Standard.Base.Network.URI
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     test_uri = URI.parse "https://httpbin.org/post"

--- a/test/Tests/src/Network/Http/Request_Spec.enso
+++ b/test/Tests/src/Network/Http/Request_Spec.enso
@@ -8,6 +8,7 @@ import Standard.Base.Network.Http.Request.Body as Request_Body
 import Standard.Base.Network.URI
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 spec =
     test_uri = URI.parse "https://httpbin.org/post"

--- a/test/Tests/src/Network/Http_Spec.enso
+++ b/test/Tests/src/Network/Http_Spec.enso
@@ -12,7 +12,7 @@ import Standard.Base.Network.Proxy
 import Standard.Base.Network.URI
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 polyglot java import java.lang.System
 

--- a/test/Tests/src/Network/Http_Spec.enso
+++ b/test/Tests/src/Network/Http_Spec.enso
@@ -12,6 +12,7 @@ import Standard.Base.Network.Proxy
 import Standard.Base.Network.URI
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 polyglot java import java.lang.System
 

--- a/test/Tests/src/Network/URI_Spec.enso
+++ b/test/Tests/src/Network/URI_Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 import Standard.Base.Network.URI
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 spec =
     Test.group "URI" <|

--- a/test/Tests/src/Network/URI_Spec.enso
+++ b/test/Tests/src/Network/URI_Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 import Standard.Base.Network.URI
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     Test.group "URI" <|

--- a/test/Tests/src/Random_Spec.enso
+++ b/test/Tests/src/Random_Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 import Standard.Base.Random
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec = Test.group "Random" <|
     Test.specify "should allow to generate random indices" <|

--- a/test/Tests/src/Random_Spec.enso
+++ b/test/Tests/src/Random_Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 import Standard.Base.Random
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec = Test.group "Random" <|
     Test.specify "should allow to generate random indices" <|

--- a/test/Tests/src/Runtime/Lazy_Generator_Spec.enso
+++ b/test/Tests/src/Runtime/Lazy_Generator_Spec.enso
@@ -1,5 +1,5 @@
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 type Generator
     Value h t

--- a/test/Tests/src/Runtime/Lazy_Generator_Spec.enso
+++ b/test/Tests/src/Runtime/Lazy_Generator_Spec.enso
@@ -1,4 +1,5 @@
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 type Generator
     Value h t

--- a/test/Tests/src/Runtime/Managed_Resource_Spec.enso
+++ b/test/Tests/src/Runtime/Managed_Resource_Spec.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base.Runtime.Managed_Resource.Managed_Resource
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec = Test.group "Managed_Resource" <|
     Test.specify "should call the destructor even if the action fails" <|

--- a/test/Tests/src/Runtime/Managed_Resource_Spec.enso
+++ b/test/Tests/src/Runtime/Managed_Resource_Spec.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 import Standard.Base.Runtime.Managed_Resource.Managed_Resource
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec = Test.group "Managed_Resource" <|
     Test.specify "should call the destructor even if the action fails" <|

--- a/test/Tests/src/Runtime/Stack_Traces_Spec.enso
+++ b/test/Tests/src/Runtime/Stack_Traces_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 type My_Type
 

--- a/test/Tests/src/Runtime/Stack_Traces_Spec.enso
+++ b/test/Tests/src/Runtime/Stack_Traces_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 type My_Type
 

--- a/test/Tests/src/Semantic/Any_Spec.enso
+++ b/test/Tests/src/Semantic/Any_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 type My_Type
     Value a

--- a/test/Tests/src/Semantic/Any_Spec.enso
+++ b/test/Tests/src/Semantic/Any_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 type My_Type
     Value a

--- a/test/Tests/src/Semantic/Case_Spec.enso
+++ b/test/Tests/src/Semantic/Case_Spec.enso
@@ -12,7 +12,7 @@ polyglot java import java.util.List as JList
 
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec = Test.group "Pattern Matches" <|
     Test.specify "should be able to match on the Boolean type" <|

--- a/test/Tests/src/Semantic/Case_Spec.enso
+++ b/test/Tests/src/Semantic/Case_Spec.enso
@@ -12,6 +12,7 @@ polyglot java import java.util.List as JList
 
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec = Test.group "Pattern Matches" <|
     Test.specify "should be able to match on the Boolean type" <|

--- a/test/Tests/src/Semantic/Conversion_Spec.enso
+++ b/test/Tests/src/Semantic/Conversion_Spec.enso
@@ -4,6 +4,7 @@ import project.Semantic.Conversion.Methods
 import project.Semantic.Conversion.Types
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 type Foo
     Value foo

--- a/test/Tests/src/Semantic/Conversion_Spec.enso
+++ b/test/Tests/src/Semantic/Conversion_Spec.enso
@@ -4,7 +4,7 @@ import project.Semantic.Conversion.Methods
 import project.Semantic.Conversion.Types
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 type Foo
     Value foo

--- a/test/Tests/src/Semantic/Deep_Export/Spec.enso
+++ b/test/Tests/src/Semantic/Deep_Export/Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 import project.Semantic.Deep_Export.Internal
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 spec =
     Test.group "Deep Exports" <|

--- a/test/Tests/src/Semantic/Deep_Export/Spec.enso
+++ b/test/Tests/src/Semantic/Deep_Export/Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 import project.Semantic.Deep_Export.Internal
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     Test.group "Deep Exports" <|

--- a/test/Tests/src/Semantic/Default_Args_Spec.enso
+++ b/test/Tests/src/Semantic/Default_Args_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 from project.Semantic.Default_Args_Spec.Box import all
 

--- a/test/Tests/src/Semantic/Default_Args_Spec.enso
+++ b/test/Tests/src/Semantic/Default_Args_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 from project.Semantic.Default_Args_Spec.Box import all
 

--- a/test/Tests/src/Semantic/Error_Spec.enso
+++ b/test/Tests/src/Semantic/Error_Spec.enso
@@ -7,6 +7,7 @@ polyglot java import java.lang.Long
 polyglot java import java.lang.NumberFormatException
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 type My_Type
     Value foo

--- a/test/Tests/src/Semantic/Error_Spec.enso
+++ b/test/Tests/src/Semantic/Error_Spec.enso
@@ -7,7 +7,7 @@ polyglot java import java.lang.Long
 polyglot java import java.lang.NumberFormatException
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 type My_Type
     Value foo

--- a/test/Tests/src/Semantic/Import_Loop/Spec.enso
+++ b/test/Tests/src/Semantic/Import_Loop/Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 import project.Semantic.Import_Loop.B
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec = Test.group "Looping Imports" <|
     Test.specify "should behave correctly and not loop the compiler" <|

--- a/test/Tests/src/Semantic/Import_Loop/Spec.enso
+++ b/test/Tests/src/Semantic/Import_Loop/Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 import project.Semantic.Import_Loop.B
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 spec = Test.group "Looping Imports" <|
     Test.specify "should behave correctly and not loop the compiler" <|

--- a/test/Tests/src/Semantic/Java_Interop_Spec.enso
+++ b/test/Tests/src/Semantic/Java_Interop_Spec.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 polyglot java import java.lang.Float
 polyglot java import java.lang.Integer

--- a/test/Tests/src/Semantic/Java_Interop_Spec.enso
+++ b/test/Tests/src/Semantic/Java_Interop_Spec.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 polyglot java import java.lang.Float
 polyglot java import java.lang.Integer

--- a/test/Tests/src/Semantic/Js_Interop_Spec.enso
+++ b/test/Tests/src/Semantic/Js_Interop_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 foreign js my_method a b = """
     return a + b;

--- a/test/Tests/src/Semantic/Js_Interop_Spec.enso
+++ b/test/Tests/src/Semantic/Js_Interop_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 foreign js my_method a b = """
     return a + b;

--- a/test/Tests/src/Semantic/Meta_Location_Spec.enso
+++ b/test/Tests/src/Semantic/Meta_Location_Spec.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 type My_Type
     Value foo bar baz

--- a/test/Tests/src/Semantic/Meta_Location_Spec.enso
+++ b/test/Tests/src/Semantic/Meta_Location_Spec.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 import Standard.Base
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 type My_Type
     Value foo bar baz
@@ -13,7 +14,7 @@ spec = Test.group "Meta-Value Inspection" <|
 
     Test.specify "should allow to get the source location of a frame" pending=location_pending <|
         src = Meta.get_source_location 0
-        loc = "Meta_Location_Spec.enso:15:15-40"
+        loc = "Meta_Location_Spec.enso:16:15-40"
         src.take (Last loc.length) . should_equal loc
 
     Test.specify "should allow to get qualified type names of values" <|

--- a/test/Tests/src/Semantic/Meta_Spec.enso
+++ b/test/Tests/src/Semantic/Meta_Spec.enso
@@ -10,6 +10,7 @@ polyglot java import java.util.Random
 polyglot java import java.util.Locale as JavaLocale
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 type My_Type
     Value foo bar baz

--- a/test/Tests/src/Semantic/Meta_Spec.enso
+++ b/test/Tests/src/Semantic/Meta_Spec.enso
@@ -10,7 +10,7 @@ polyglot java import java.util.Random
 polyglot java import java.util.Locale as JavaLocale
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 type My_Type
     Value foo bar baz

--- a/test/Tests/src/Semantic/Names_Spec.enso
+++ b/test/Tests/src/Semantic/Names_Spec.enso
@@ -4,6 +4,7 @@ from project.Semantic.Names.Definitions import another_method, another_constant,
 import project.Semantic.Names.Definitions
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 Definitions.Foo.my_method self = case self of
     Definitions.Foo_Data x y z -> x * y * z

--- a/test/Tests/src/Semantic/Names_Spec.enso
+++ b/test/Tests/src/Semantic/Names_Spec.enso
@@ -4,7 +4,7 @@ from project.Semantic.Names.Definitions import another_method, another_constant,
 import project.Semantic.Names.Definitions
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 Definitions.Foo.my_method self = case self of
     Definitions.Foo_Data x y z -> x * y * z

--- a/test/Tests/src/Semantic/Python_Interop_Spec.enso
+++ b/test/Tests/src/Semantic/Python_Interop_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 foreign python my_method a b = """
     return a + b

--- a/test/Tests/src/Semantic/Python_Interop_Spec.enso
+++ b/test/Tests/src/Semantic/Python_Interop_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 foreign python my_method a b = """
     return a + b

--- a/test/Tests/src/Semantic/R_Interop_Spec.enso
+++ b/test/Tests/src/Semantic/R_Interop_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 foreign js my_method a b = """
     return a + b;

--- a/test/Tests/src/Semantic/R_Interop_Spec.enso
+++ b/test/Tests/src/Semantic/R_Interop_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 foreign js my_method a b = """
     return a + b;

--- a/test/Tests/src/Semantic/Runtime_Spec.enso
+++ b/test/Tests/src/Semantic/Runtime_Spec.enso
@@ -1,7 +1,7 @@
 import Standard.Base.Runtime
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 in_fn : Int -> Int in Input
 in_fn a = a * 2

--- a/test/Tests/src/Semantic/Runtime_Spec.enso
+++ b/test/Tests/src/Semantic/Runtime_Spec.enso
@@ -1,6 +1,7 @@
 import Standard.Base.Runtime
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 in_fn : Int -> Int in Input
 in_fn a = a * 2

--- a/test/Tests/src/Semantic/Self_Type_Spec.enso
+++ b/test/Tests/src/Semantic/Self_Type_Spec.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
 from Standard.Test import Test
-
+import Standard.Test.Main as Test_Module
 
 type My_Type
     Cons_A x

--- a/test/Tests/src/Semantic/Self_Type_Spec.enso
+++ b/test/Tests/src/Semantic/Self_Type_Spec.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 type My_Type
     Cons_A x

--- a/test/Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Tests/src/Semantic/Warnings_Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 polyglot java import java.lang.Long
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 type My_Warning
     Value reason

--- a/test/Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Tests/src/Semantic/Warnings_Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 polyglot java import java.lang.Long
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 type My_Warning
     Value reason

--- a/test/Tests/src/System/Environment_Spec.enso
+++ b/test/Tests/src/System/Environment_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 import Standard.Test.Test_Environment
 
 spec = Test.group "Environment" <|

--- a/test/Tests/src/System/Environment_Spec.enso
+++ b/test/Tests/src/System/Environment_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 import Standard.Test.Test_Environment
 
 spec = Test.group "Environment" <|

--- a/test/Tests/src/System/File_Read_Spec.enso
+++ b/test/Tests/src/System/File_Read_Spec.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 from Standard.Base.Error.Common import Unsupported_File_Type
 
 from Standard.Test import Test, Test_Suite, Problems
+import Standard.Test.Main as Test_Module
 
 spec =
     sample_xxx = enso_project.data / "sample.xxx"

--- a/test/Tests/src/System/File_Read_Spec.enso
+++ b/test/Tests/src/System/File_Read_Spec.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 from Standard.Base.Error.Common import Unsupported_File_Type
 
 from Standard.Test import Test, Test_Suite, Problems
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     sample_xxx = enso_project.data / "sample.xxx"

--- a/test/Tests/src/System/File_Spec.enso
+++ b/test/Tests/src/System/File_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite, Problems
+import Standard.Test.Main as Test_Module
 
 spec =
     sample_file = enso_project.data / "sample.txt"

--- a/test/Tests/src/System/File_Spec.enso
+++ b/test/Tests/src/System/File_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite, Problems
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     sample_file = enso_project.data / "sample.txt"

--- a/test/Tests/src/System/Process_Spec.enso
+++ b/test/Tests/src/System/Process_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec = Test.group "Process" <|
     Test.specify "should call simple command" <|

--- a/test/Tests/src/System/Process_Spec.enso
+++ b/test/Tests/src/System/Process_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec = Test.group "Process" <|
     Test.specify "should call simple command" <|

--- a/test/Tests/src/System/Reporting_Stream_Decoder_Spec.enso
+++ b/test/Tests/src/System/Reporting_Stream_Decoder_Spec.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 polyglot java import java.nio.CharBuffer
 
 from Standard.Test import Test, Test_Suite, Problems
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     windows_file = enso_project.data / "windows.txt"

--- a/test/Tests/src/System/Reporting_Stream_Decoder_Spec.enso
+++ b/test/Tests/src/System/Reporting_Stream_Decoder_Spec.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 polyglot java import java.nio.CharBuffer
 
 from Standard.Test import Test, Test_Suite, Problems
+import Standard.Test.Main as Test_Module
 
 spec =
     windows_file = enso_project.data / "windows.txt"

--- a/test/Tests/src/System/Reporting_Stream_Encoder_Spec.enso
+++ b/test/Tests/src/System/Reporting_Stream_Encoder_Spec.enso
@@ -4,6 +4,7 @@ polyglot java import org.enso.base.Encoding_Utils
 polyglot java import java.nio.CharBuffer
 
 from Standard.Test import Test, Test_Suite, Problems
+import Standard.Test.Main as Test_Module
 
 spec =
     Test.group "ReportingStreamEncoder" <|

--- a/test/Tests/src/System/Reporting_Stream_Encoder_Spec.enso
+++ b/test/Tests/src/System/Reporting_Stream_Encoder_Spec.enso
@@ -4,7 +4,7 @@ polyglot java import org.enso.base.Encoding_Utils
 polyglot java import java.nio.CharBuffer
 
 from Standard.Test import Test, Test_Suite, Problems
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec =
     Test.group "ReportingStreamEncoder" <|

--- a/test/Tests/src/System/System_Spec.enso
+++ b/test/Tests/src/System/System_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 spec = Test.group "System" <|
     Test.specify "should provide nanosecond timer" <|

--- a/test/Tests/src/System/System_Spec.enso
+++ b/test/Tests/src/System/System_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 spec = Test.group "System" <|
     Test.specify "should provide nanosecond timer" <|

--- a/test/Visualization_Tests/src/Geo_Map_Spec.enso
+++ b/test/Visualization_Tests/src/Geo_Map_Spec.enso
@@ -4,7 +4,7 @@ from Standard.Table import Table
 import Standard.Visualization.Geo_Map
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 import project.Helpers
 

--- a/test/Visualization_Tests/src/Geo_Map_Spec.enso
+++ b/test/Visualization_Tests/src/Geo_Map_Spec.enso
@@ -4,6 +4,7 @@ from Standard.Table import Table
 import Standard.Visualization.Geo_Map
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 import project.Helpers
 

--- a/test/Visualization_Tests/src/Helpers.enso
+++ b/test/Visualization_Tests/src/Helpers.enso
@@ -3,6 +3,7 @@ from Standard.Base import all
 from Standard.Table import Column
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 import Standard.Test.Test_Result.Test_Result
 
 Column.expect : Text -> Vector -> Test_Result

--- a/test/Visualization_Tests/src/Helpers.enso
+++ b/test/Visualization_Tests/src/Helpers.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 from Standard.Table import Column
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 import Standard.Test.Test_Result.Test_Result
 
 Column.expect : Text -> Vector -> Test_Result

--- a/test/Visualization_Tests/src/Helpers_Spec.enso
+++ b/test/Visualization_Tests/src/Helpers_Spec.enso
@@ -5,7 +5,7 @@ from Standard.Table import Table
 import Standard.Visualization.Helpers
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 import project.Helpers
 

--- a/test/Visualization_Tests/src/Helpers_Spec.enso
+++ b/test/Visualization_Tests/src/Helpers_Spec.enso
@@ -5,6 +5,7 @@ from Standard.Table import Table
 import Standard.Visualization.Helpers
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 import project.Helpers
 

--- a/test/Visualization_Tests/src/Histogram_Spec.enso
+++ b/test/Visualization_Tests/src/Histogram_Spec.enso
@@ -5,7 +5,7 @@ from Standard.Table import Table, Column
 import Standard.Visualization.Histogram
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 import project
 

--- a/test/Visualization_Tests/src/Histogram_Spec.enso
+++ b/test/Visualization_Tests/src/Histogram_Spec.enso
@@ -5,6 +5,7 @@ from Standard.Table import Table, Column
 import Standard.Visualization.Histogram
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 import project
 

--- a/test/Visualization_Tests/src/Id_Spec.enso
+++ b/test/Visualization_Tests/src/Id_Spec.enso
@@ -4,6 +4,7 @@ import Standard.Base
 import Standard.Visualization
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 type My_Type
     Value my_field

--- a/test/Visualization_Tests/src/Id_Spec.enso
+++ b/test/Visualization_Tests/src/Id_Spec.enso
@@ -4,7 +4,7 @@ import Standard.Base
 import Standard.Visualization
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 type My_Type
     Value my_field

--- a/test/Visualization_Tests/src/SQL_Spec.enso
+++ b/test/Visualization_Tests/src/SQL_Spec.enso
@@ -5,6 +5,7 @@ from Standard.Database import Database, SQLite, SQL_Query
 import Standard.Visualization.SQL.Visualization
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 visualization_spec connection =
     connection.execute_update 'CREATE TABLE "T" ("A" VARCHAR, "B" INTEGER, "C" INTEGER)'

--- a/test/Visualization_Tests/src/SQL_Spec.enso
+++ b/test/Visualization_Tests/src/SQL_Spec.enso
@@ -5,7 +5,7 @@ from Standard.Database import Database, SQLite, SQL_Query
 import Standard.Visualization.SQL.Visualization
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 visualization_spec connection =
     connection.execute_update 'CREATE TABLE "T" ("A" VARCHAR, "B" INTEGER, "C" INTEGER)'

--- a/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
+++ b/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
@@ -5,7 +5,7 @@ from Standard.Table import Table, Column
 import Standard.Visualization.Scatter_Plot
 
 from Standard.Test import Test, Test_Suite
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 import project
 

--- a/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
+++ b/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
@@ -5,6 +5,7 @@ from Standard.Table import Table, Column
 import Standard.Visualization.Scatter_Plot
 
 from Standard.Test import Test, Test_Suite
+import Standard.Test.Main as Test_Module
 
 import project
 

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -9,7 +9,7 @@ import Standard.Database.Data.Table.Table as Database_Table
 import Standard.Visualization.Table.Visualization
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 polyglot java import java.util.UUID
 

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -9,6 +9,7 @@ import Standard.Database.Data.Table.Table as Database_Table
 import Standard.Visualization.Table.Visualization
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 polyglot java import java.util.UUID
 

--- a/test/Visualization_Tests/src/Visualization_Spec.enso
+++ b/test/Visualization_Tests/src/Visualization_Spec.enso
@@ -5,6 +5,7 @@ import Standard.Examples
 import Standard.Visualization
 
 from Standard.Test import Test
+import Standard.Test.Main as Test_Module
 
 import Standard.Visualization.File_Upload.File_Being_Uploaded
 

--- a/test/Visualization_Tests/src/Visualization_Spec.enso
+++ b/test/Visualization_Tests/src/Visualization_Spec.enso
@@ -5,7 +5,7 @@ import Standard.Examples
 import Standard.Visualization
 
 from Standard.Test import Test
-import Standard.Test.Main as Test_Module
+import Standard.Test.Extensions
 
 import Standard.Visualization.File_Upload.File_Being_Uploaded
 


### PR DESCRIPTION
Previously, a qualified import would always bring extension methods into the scope. This is because extensions methods weren't taking into account the qualifiers at all and imported scope was blindly added to the existing module scope.

For example, given a module with an extension method in one module (`A.enso`)
```
type A
    X
    Y
...
Integer.foo self a = ....
```
we weren't consistent with how extension method `foo` could be brought into the scope.
All of
- `import project.A`
- `import project.A.A`
- `from project.A import all`
- `from project.A.A import X, Y`

would bring it into the scope. 

Now, only
- `import project.A`
- `from project.A import all`

would.

The change limits that by taking into account import qualifiers of the types that are being brought and creating a copy of the original `ModuleScope`.

This meant that in pretty much every test file of our testsuite we had to import `Test.Extensions` module.
This fixes problem 2) in https://www.pivotaltracker.com/n/projects/2539304/stories/183833055

### Important Notes

Note that one cannot
```
import Standard.Table as Table_Module
```
because of the 2-component name restriction that gets desugared to `Standard.Table.Main` and we have to write
```
import Standard.Table.Main as Table_Module
```
in a few places. Once we move `Json.to_table` extension this can be improved.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [ x All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
