### PR TITLE
Avoid warnings about colliding filenames

### DIFF
--- a/lib/rust/config-reader/Cargo.toml
+++ b/lib/rust/config-reader/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Enso Team <contact@enso.org>"]
 edition = "2021"
 
 [lib]
-crate-type = ["rlib", "cdylib"]
+crate-type = ["rlib"]
 
 [dependencies]
 serde = { version = "1.0" }

--- a/lib/rust/macro-utils/Cargo.toml
+++ b/lib/rust/macro-utils/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools::procedural-macro-helpers"]
 publish = true
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["rlib"]
 
 [dependencies]
 proc-macro2 = "1.0"


### PR DESCRIPTION
### Pull Request Description
When running `cargo test` a number of warnings about colliding filenames were issues. I've fixed that by removing `cdylib` from some crates that don't really needed that.

I also suppose it might be a cause of some CI failures that we observed when building shapely macros.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
