### PR TITLE
Don't export polyglot symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -454,6 +454,7 @@
 - [Add the `Self` keyword referring to current type][3844]
 - [Support VCS for projects in Language Server][3851]
 - [Support multiple exports of the same module][3897]
+- [Don't export polyglot symbols][3915]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -522,6 +523,7 @@
 [3844]: https://github.com/enso-org/enso/pull/3844
 [3851]: https://github.com/enso-org/enso/pull/3851
 [3897]: https://github.com/enso-org/enso/pull/3897
+[3915]: https://github.com/enso-org/enso/pull/3915
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/data/BindingsMap.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/data/BindingsMap.scala
@@ -717,6 +717,8 @@ object BindingsMap {
     def resolvedIn(module: Module): ResolvedName = resolvedIn(
       ModuleReference.Concrete(module)
     )
+    // Determines if this entity can be exported during export resolution pass
+    def canExport: Boolean
   }
 
   /** A representation of a constructor.
@@ -737,19 +739,25 @@ object BindingsMap {
     override val name: String,
     members: Seq[Cons],
     builtinType: Boolean
-  ) extends DefinedEntity
+  ) extends DefinedEntity {
+    override def canExport: Boolean = true
+  }
 
   /** A representation of an imported polyglot symbol.
     *
     * @param name the name of the symbol.
     */
-  case class PolyglotSymbol(override val name: String) extends DefinedEntity
+  case class PolyglotSymbol(override val name: String) extends DefinedEntity {
+    override def canExport: Boolean = false
+  }
 
   /** A representation of a method defined on the current module.
     *
     * @param name the name of the method.
     */
-  case class ModuleMethod(override val name: String) extends DefinedEntity
+  case class ModuleMethod(override val name: String) extends DefinedEntity {
+    override def canExport: Boolean = true
+  }
 
   /** A name resolved to a sum type.
     *

--- a/engine/runtime/src/main/scala/org/enso/compiler/phase/ExportsResolution.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/phase/ExportsResolution.scala
@@ -170,7 +170,9 @@ class ExportsResolution {
     modules.foreach { module =>
       val bindings = getBindings(module)
       val ownEntities =
-        bindings.definedEntities.map(e => (e.name, List(e.resolvedIn(module))))
+        bindings.definedEntities
+          .filter(_.canExport)
+          .map(e => (e.name, List(e.resolvedIn(module))))
       val exportedModules = bindings.resolvedExports.collect {
         case ExportedModule(mod, Some(name), _)
             if mod.module.unsafeAsModule() != module =>

--- a/engine/runtime/src/test/resources/Test_Polyglot_Exports/package.yaml
+++ b/engine/runtime/src/test/resources/Test_Polyglot_Exports/package.yaml
@@ -1,0 +1,6 @@
+name: Test_Polyglot_Exports
+license: APLv2
+enso-version: default
+version: "0.0.1"
+author: "Enso Team <contact@enso.org>"
+maintainer: "Enso Team <contact@enso.org>"

--- a/engine/runtime/src/test/resources/Test_Polyglot_Exports/src/Atom.enso
+++ b/engine/runtime/src/test/resources/Test_Polyglot_Exports/src/Atom.enso
@@ -1,0 +1,3 @@
+polyglot java import java.lang.Long
+
+foo = 42

--- a/engine/runtime/src/test/resources/Test_Polyglot_Exports/src/Main.enso
+++ b/engine/runtime/src/test/resources/Test_Polyglot_Exports/src/Main.enso
@@ -1,0 +1,6 @@
+from Standard.Base import IO
+from project.Atom import all
+
+main =
+    IO.println Long.MAX_VALUE
+    foo

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ImportsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ImportsTest.scala
@@ -123,6 +123,17 @@ class ImportsTest extends PackageTest {
     ) shouldEqual "Hidden 'bar' name of the export module local.Test_Multiple_Conflicting_Exports_2.F1 conflicts with the unqualified export"
   }
 
+  "Polyglot symbols" should "not be exported" in {
+    the[InterpreterException] thrownBy evalTestProject(
+      "Test_Polyglot_Exports"
+    ) should have message "Compilation aborted due to errors."
+    val outLines = consumeOut
+    outLines should have length 3
+    outLines(
+      2
+    ) shouldEqual "Main.enso[5:16-5:19]: The name `Long` could not be found."
+  }
+
   "Constructors" should "be importable" in {
     evalTestProject("Test_Type_Imports").toString shouldEqual "(Some 10)"
   }


### PR DESCRIPTION

### Pull Request Description

By default all polyglot symbols that have been imported were always exported. This means that importing a module that had some polyglot imports brought them into the scope automatically. This didn't follow our desired semantics.

Fixes task 3 in https://www.pivotaltracker.com/story/show/183833055.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
