### PR TITLE
Implementing transpose and cross_tab for the InMemory table.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,7 @@
 - [Added support for milli and micro seconds, new short form for rename_columns
   and fixed issue with compare_to versus Nothing][3874]
 - [Aligned `Text.match`/`Text.locate` API][3841]
+- [Added `transpose` and `cross_tab` to the In-Memory Table.][3919]
 
 [debug-shortcuts]:
   https://github.com/enso-org/enso/blob/develop/app/gui/docs/product/shortcuts.md#debug
@@ -389,6 +390,7 @@
 [3874]: https://github.com/enso-org/enso/pull/3874
 [3852]: https://github.com/enso-org/enso/pull/3852
 [3841]: https://github.com/enso-org/enso/pull/3841
+[3919]: https://github.com/enso-org/enso/pull/3919
 
 #### Enso Compiler
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -819,6 +819,77 @@ type Table
             on_problems.attach_problems_before problems <|
                 self.updated_context_and_columns new_ctx new_columns
 
+    ## Returns a new table with a chosen subset of columns left unchanged and
+       the other columns pivoted to rows with a single name field and a single
+       value field.
+
+       Arguments:
+       - id_fields: Set of fields to remain as columns. These values will be
+         repeated for each data field that is pivoted.
+       - name_field: The name of the field that will contain the names of the
+         pivoted fields. If this name is already in use, it will be renamed
+         with a numeric suffix.
+       - value_field: The name of the field that will contain the values of the
+         pivoted fields. If this name is already in use, it will be renamed
+         with a numeric suffix.
+       - on_problems: Specifies how to handle problems if they occur, reporting
+         them as warnings by default.
+
+         The following problems can occur:
+         - If a column in columns is not in the input table, a
+           `Missing_Input_Columns`.
+         - If duplicate columns, names or indices are provided, a
+           `Duplicate_Column_Selectors`.
+         - If a column index is out of range, a `Column_Indexes_Out_Of_Range`.
+         - If two distinct indices refer to the same column, an
+           `Input_Indices_Already_Matched`, with the column included the first
+           time it is matched.
+         - If there are no columns to transpose, a `No_Input_Columns`.
+    transpose : Vector Text | Column_Selector -> Text -> Text -> Problem_Behavior -> Table
+    transpose self (id_fields = Column_Selector.By_Name []) (name_field="Name") (value_field="Value") (on_problems = Report_Warning) =
+        ## Avoid unused arguments warning. We cannot rename arguments to `_`,
+           because we need to keep the API consistent with the in-memory table.
+        _ = [id_fields, name_field, value_field, on_problems]
+        msg = "Transposing columns is not supported in database tables, the table has to be materialized first with `read`."
+        Error.throw (Unsupported_Database_Operation_Error_Data msg)
+
+    ## Returns a new table using a chosen field as the column header and then
+       aggregating the rows within each value as specified. Optionally, a set of
+       fields can be used to group the rows.
+
+       Arguments:
+       - group_by: Set of fields to group by. If not provided, a single row will
+         be produced.
+       - name_column: The field to use as the column header. If this field is
+         not found, then each value will be a single column.
+       - values: The aggregation to perform on each set of rows. Can be a single
+         aggregation or a vector of aggregations. Expressions can be used within
+         the aggregation to perform more complicated calculations.
+       - on_problems: Specifies how to handle problems if they occur, reporting
+         them as warnings by default.
+
+         The following problems can occur:
+         - If a column in the input is not in the input table, a
+           `Missing_Input_Columns`.
+         - If a column index is out of range, a `Column_Indexes_Out_Of_Range`.
+         - In `grouping`, if duplicate column names or indices are provided, a
+           `Duplicate_Column_Selectors`.
+         - In `grouping`, If two distinct indices refer to the same column, an
+           `Input_Indices_Already_Matched`, with the column included the first
+           time it is matched.
+         - If grouping on, using as the column name, or computing the `Mode` on
+           a floating point number, a `Floating_Point_Grouping`.
+         - If an aggregation fails, an `Invalid_Aggregation_Method`.
+         - If when concatenating values there is an quoted delimited, an `Unquoted_Delimiter`
+         - If there are more than 10 issues with a single column, an `Additional_Warnings`.
+    cross_tab : Vector Text | Column_Selector -> (Text | Integer | Column) -> Vector Aggregate_Column -> Problem_Behavior -> Table
+    cross_tab self group_by=[] name_column=self.column_names.first values=Aggregate_Column.Count (on_problems=Report_Warning) =
+        ## Avoid unused arguments warning. We cannot rename arguments to `_`,
+           because we need to keep the API consistent with the in-memory table.
+        _ = [group_by, name_column, values, on_problems]
+        msg = "Cross tab of database tables is not supported, the table has to be materialized first with `read`."
+        Error.throw (Unsupported_Database_Operation_Error_Data msg)
+
     ## Parsing values is not supported in database tables, the table has to be
        loaded into memory first with `read`.
     parse_values : Data_Formatter -> (Nothing | Vector Column_Type_Selection) -> Problem_Behavior -> Table

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -37,8 +37,8 @@ type Column
        - name: The name of the column to create.
        - items: The elements to contain in the column.
        - repeats: The number of times to repeat the vector.
-    repeated_from_vector : Text -> Vector -> Integer -> Column
-    repeated_from_vector name items repeats = Column_Data (Java_Column.fromRepeatedItems name items.to_array repeats)
+    from_vector_repeated : Text -> Vector -> Integer -> Column
+    from_vector_repeated name items repeats = Column_Data (Java_Column.fromRepeatedItems name items.to_array repeats)
 
     ## PRIVATE
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -31,6 +31,15 @@ type Column
     from_vector : Text -> Vector -> Column
     from_vector name items = Column_Data (Java_Column.fromItems name items.to_array)
 
+    ## Creates a new column given a name and a vector of elements repeated over and over.
+
+       Arguments:
+       - name: The name of the column to create.
+       - items: The elements to contain in the column.
+       - repeats: The number of times to repeat the vector.
+    repeated_from_vector : Text -> Vector -> Integer -> Column
+    repeated_from_vector name items repeats = Column_Data (Java_Column.fromRepeatedItems name items.to_array repeats)
+
     ## PRIVATE
 
        A representation of a column in a Table.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -492,6 +492,8 @@ type Table
 
        Arguments:
        - columns: Vector of `Aggregate_Column` specifying the aggregated table.
+         Expressions can be used within the aggregate column to perform more
+         complicated calculations.
        - on_problems: Specifies how to handle problems if they occur, reporting
          them as warnings by default.
 
@@ -1188,21 +1190,46 @@ type Table
                 self
             False ->
                 selected_names = Map.from_vector (id_columns.map column-> [column.name, True])
+
                 data = columns_helper.internal_columns.filter column->(selected_names.get_or_else column.name False . not)
+                java_data = data.map .java_column
+
+                java_id = id_columns.map .java_column
+
                 id_columns.each k-> unique.make_unique k.name
-
-                name_column = Column.from_vector_repeated (unique.make_unique name_field) (data.map .name) self.row_count
-                values = Vector.new (self.row_count * count) i->
-                    col = i % count
-                    row = (i - col) / count
-                    data.at col . java_column . getStorage . getItemBoxed row
-                value_column = Column.from_vector (unique.make_unique value_field) values
-
-                Table.new (id_columns + [name_column, value_column])
+                Table.Table_Data (Java_Table.transpose java_id.to_array java_data.to_array (unique.make_unique name_field) (unique.make_unique value_field))
 
         problem_builder.attach_problems_after on_problems result
 
-    ## UNSTABLE
+    ## Returns a new table using a chosen field as the column header and then
+       aggregating the rows within each value as specified. Optionally, a set of
+       fields can be used to group the rows.
+
+       Arguments:
+       - group_by: Set of fields to group by. If not provided, a single row will
+         be produced.
+       - name_column: The field to use as the column header. If this field is
+         not found, then each value will be a single column.
+       - values: The aggregation to perform on each set of rows. Can be a single
+         aggregation or a vector of aggregations. Expressions can be used within
+         the aggregation to perform more complicated calculations.
+       - on_problems: Specifies how to handle problems if they occur, reporting
+         them as warnings by default.
+
+         The following problems can occur:
+         - If a column in the input is not in the input table, a
+           `Missing_Input_Columns`.
+         - If a column index is out of range, a `Column_Indexes_Out_Of_Range`.
+         - In `grouping`, if duplicate column names or indices are provided, a
+           `Duplicate_Column_Selectors`.
+         - In `grouping`, If two distinct indices refer to the same column, an
+           `Input_Indices_Already_Matched`, with the column included the first
+           time it is matched.
+         - If grouping on, using as the column name, or computing the `Mode` on
+           a floating point number, a `Floating_Point_Grouping`.
+         - If an aggregation fails, an `Invalid_Aggregation_Method`.
+         - If when concatenating values there is an quoted delimited, an `Unquoted_Delimiter`
+         - If there are more than 10 issues with a single column, an `Additional_Warnings`.
     cross_tab : Vector Text | Column_Selector -> (Text | Integer | Column) -> Vector Aggregate_Column -> Problem_Behavior -> Table
     cross_tab self group_by=[] name_column=self.column_names.first values=Aggregate_Column.Count (on_problems=Report_Warning) =
         columns_helper = self.columns_helper

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -24,6 +24,7 @@ import project.Internal.Table_Helpers.Table_Column_Helper
 import project.Internal.Aggregate_Column_Helper
 import project.Internal.Parse_Values_Helper
 import project.Internal.Problem_Builder.Problem_Builder
+import project.Internal.Unique_Name_Strategy.Unique_Name_Strategy
 import project.Data.Expression.Expression
 import project.Data.Expression.Expression_Error
 
@@ -1144,6 +1145,80 @@ type Table
             java_tables = Vector.new (other.length + 1) i->(if i==0 then self else other.at i).java_table
             Table.Table_Data (Java_Table.concat java_tables.to_array)
         Table.Table_Data other_java_table -> Table.Table_Data (Java_Table.concat [self.java_table, other_java_table].to_array)
+
+    ## Returns a new table with a chosen subset of columns left unchanged and
+       the other columns pivoted to rows with a single name field and a single
+       value field.
+
+       Arguments:
+       - id_fields: Set of fields to remain as columns. These values will be
+         repeated for each data field that is pivoted.
+       - name_field: The name of the field that will contain the names of the
+         pivoted fields. If this name is already in use, it will be renamed
+         with a numeric suffix.
+       - value_field: The name of the field that will contain the values of the
+         pivoted fields. If this name is already in use, it will be renamed
+         with a numeric suffix.
+       - on_problems: Specifies how to handle problems if they occur, reporting
+         them as warnings by default.
+
+         The following problems can occur:
+         - If a column in columns is not in the input table, a
+           `Missing_Input_Columns`.
+         - If duplicate columns, names or indices are provided, a
+           `Duplicate_Column_Selectors`.
+         - If a column index is out of range, a `Column_Indexes_Out_Of_Range`.
+         - If two distinct indices refer to the same column, an
+           `Input_Indices_Already_Matched`, with the column included the first
+           time it is matched.
+         - If there are no columns to transpose, a `No_Input_Columns`.
+    transpose : Vector Text | Column_Selector -> Text -> Text -> Problem_Behavior -> Table
+    transpose self (id_fields = Column_Selector.By_Name []) (name_field="Name") (value_field="Value") (on_problems = Report_Warning) =
+        columns_helper = self.columns_helper
+        unique = Unique_Name_Strategy.new
+        problem_builder = Problem_Builder.new
+
+        id_columns = columns_helper.select_columns_helper id_fields False problem_builder
+        count = self.column_count - id_columns.length
+
+        result = case count == 0 of
+            True ->
+                problem_builder.report_other_warning No_Input_Columns_Selected
+                id_columns.each k-> unique.make_unique k.name
+                self
+            False ->
+                mask = OrderMask.repeatRows self.row_count count
+
+                selected_names = Map.from_vector (id_columns.map column-> [column.name, True])
+
+                data = columns_helper.internal_columns.filter column->(selected_names.get_or_else column.name False . not)
+
+                id_columns.each k-> unique.make_unique k.name
+
+                name_column = Column.repeated_from_vector (unique.make_unique name_field) (data.map .name) self.row_count
+                values = Vector.new (self.row_count * count) i->
+                    col = i % count
+                    row = (i - col) / count
+                    data.at col . java_column . getStorage . getItemBoxed row
+                value_column = Column.from_vector (unique.make_unique value_field) values
+
+                Table.new (id_columns + [name_column, value_column])
+
+        problem_builder.attach_problems_after on_problems result
+
+    ## UNSTABLE
+    cross_tab : Vector Text | Column_Selector -> (Text | Integer | Column) -> Vector Aggregate_Column -> Problem_Behavior -> Table
+    cross_tab self group_by=[] name_column=self.column_names.first values=Aggregate_Column.Count (on_problems=Report_Warning) =
+        columns_helper = self.columns_helper
+        unique = Unique_Name_Strategy.new
+        problem_builder = Problem_Builder.new
+
+        grouping = columns_helper.select_columns_helper group_by True problem_builder . map Aggregate_Column.Group_By
+        values_vector = case values of
+            _ : Vector -> values
+            _ -> [values]
+        full_set = grouping + [Aggregate_Column.Group_By name_column] + values_vector
+        self.aggregate full_set on_problems
 
     ## PRIVATE
        Returns a table with a continuous sub-range of rows taken.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -510,7 +510,7 @@ type Table
          Group by the Key column, count the rows
 
               table.aggregate [Group_By "Key", Count Nothing]
-    aggregate : [Aggregate_Column] -> Problem_Behavior -> Table
+    aggregate : Vector Aggregate_Column -> Problem_Behavior -> Table
     aggregate self columns (on_problems=Report_Warning) =
         validated = Aggregate_Column_Helper.prepare_aggregate_columns columns self
 
@@ -968,7 +968,7 @@ type Table
     evaluate : Text -> Column
     evaluate self expression =
         get_column name = self.at name
-        make_constant value = Column.from_vector (UUID.randomUUID.to_text) (Vector.new self.row_count _->value)
+        make_constant value = Column.from_vector_repeated (UUID.randomUUID.to_text) [value] self.row_count
         Expression.evaluate expression get_column make_constant "Standard.Table.Data.Column" "Column" Column.var_args_functions
 
     ## Returns the vector of columns contained in this table.
@@ -1191,7 +1191,7 @@ type Table
                 data = columns_helper.internal_columns.filter column->(selected_names.get_or_else column.name False . not)
                 id_columns.each k-> unique.make_unique k.name
 
-                name_column = Column.repeated_from_vector (unique.make_unique name_field) (data.map .name) self.row_count
+                name_column = Column.from_vector_repeated (unique.make_unique name_field) (data.map .name) self.row_count
                 values = Vector.new (self.row_count * count) i->
                     col = i % count
                     row = (i - col) / count

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1182,23 +1182,17 @@ type Table
 
         id_columns = columns_helper.select_columns_helper id_fields False problem_builder
         count = self.column_count - id_columns.length
+        if count == 0 then problem_builder.report_other_warning No_Input_Columns_Selected
 
-        result = case count == 0 of
-            True ->
-                problem_builder.report_other_warning No_Input_Columns_Selected
-                id_columns.each k-> unique.make_unique k.name
-                self
-            False ->
-                selected_names = Map.from_vector (id_columns.map column-> [column.name, True])
+        selected_names = Map.from_vector (id_columns.map column-> [column.name, True])
 
-                data = columns_helper.internal_columns.filter column->(selected_names.get_or_else column.name False . not)
-                java_data = data.map .java_column
+        data = columns_helper.internal_columns.filter column->(selected_names.get_or_else column.name False . not)
+        java_data = data.map .java_column
 
-                java_id = id_columns.map .java_column
+        java_id = id_columns.map .java_column
 
-                id_columns.each k-> unique.make_unique k.name
-                Table.Table_Data (Java_Table.transpose java_id.to_array java_data.to_array (unique.make_unique name_field) (unique.make_unique value_field))
-
+        id_columns.each k-> unique.make_unique k.name
+        result = Table.Table_Data (Java_Table.transpose java_id.to_array java_data.to_array (unique.make_unique name_field) (unique.make_unique value_field))
         problem_builder.attach_problems_after on_problems result
 
     ## Returns a new table using a chosen field as the column header and then

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1224,7 +1224,7 @@ type Table
         validated_values = resolved_values.filter c->((c!=Nothing) && (is_group_by c).not)
 
         on_problems.attach_problems_before (problem_builder.build_problemset) <| Illegal_Argument_Error.handle_java_exception <|
-            java_key_columns = (grouping + matched_name).map .java_column
+            java_key_columns = grouping.map .java_column
             index  = self.java_table.indexFromColumns java_key_columns.to_array Comparator.new
 
             name_mapper = if validated_values.length == 1 then (_ -> "") else
@@ -1240,7 +1240,7 @@ type Table
                     group_by = grouping.map g->(Aggregate_Column_Helper.java_aggregator g.name (Aggregate_Column.Group_By g))
                     index.makeTable (group_by + data_columns).to_array
                 False ->
-                    Nothing
+                    index.makeCrossTabTable java_key_columns.to_array matched_name.first.java_column data_columns.to_array
 
             on_problems.attach_problems_after (Table.Table_Data result) <|
                 problems = result.getProblems

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1187,12 +1187,8 @@ type Table
                 id_columns.each k-> unique.make_unique k.name
                 self
             False ->
-                mask = OrderMask.repeatRows self.row_count count
-
                 selected_names = Map.from_vector (id_columns.map column-> [column.name, True])
-
                 data = columns_helper.internal_columns.filter column->(selected_names.get_or_else column.name False . not)
-
                 id_columns.each k-> unique.make_unique k.name
 
                 name_column = Column.repeated_from_vector (unique.make_unique name_field) (data.map .name) self.row_count
@@ -1210,15 +1206,45 @@ type Table
     cross_tab : Vector Text | Column_Selector -> (Text | Integer | Column) -> Vector Aggregate_Column -> Problem_Behavior -> Table
     cross_tab self group_by=[] name_column=self.column_names.first values=Aggregate_Column.Count (on_problems=Report_Warning) =
         columns_helper = self.columns_helper
-        unique = Unique_Name_Strategy.new
         problem_builder = Problem_Builder.new
 
-        grouping = columns_helper.select_columns_helper group_by True problem_builder . map Aggregate_Column.Group_By
+        ## validate the name and group_by columns
+        matched_name = columns_helper.select_columns_helper [name_column] True problem_builder
+        grouping = columns_helper.select_columns_helper group_by True problem_builder
+
+        ## Validate the values
         values_vector = case values of
             _ : Vector -> values
             _ -> [values]
-        full_set = grouping + [Aggregate_Column.Group_By name_column] + values_vector
-        self.aggregate full_set on_problems
+        resolved_values = values_vector.map (Aggregate_Column_Helper.resolve_aggregate self problem_builder)
+        is_group_by c = case c of
+            Aggregate_Column.Group_By _ _ -> True
+            _ -> False
+        if resolved_values.any is_group_by then problem_builder.report_other_warning (Illegal_Argument_Error_Data "Cannot use group_by for a cross_tab value.")
+        validated_values = resolved_values.filter c->((c!=Nothing) && (is_group_by c).not)
+
+        on_problems.attach_problems_before (problem_builder.build_problemset) <| Illegal_Argument_Error.handle_java_exception <|
+            java_key_columns = (grouping + matched_name).map .java_column
+            index  = self.java_table.indexFromColumns java_key_columns.to_array Comparator.new
+
+            name_mapper = if validated_values.length == 1 then (_ -> "") else
+                all_same = Aggregate_Column_Helper.all_same_column validated_values
+                c -> Aggregate_Column_Helper.default_aggregate_column_name c all_same
+
+            data_columns = validated_values.map c->
+                    col_name = c.new_name.if_nothing (name_mapper c)
+                    Aggregate_Column_Helper.java_aggregator col_name c
+
+            result = case matched_name.is_empty of
+                True ->
+                    group_by = grouping.map g->(Aggregate_Column_Helper.java_aggregator g.name (Aggregate_Column.Group_By g))
+                    index.makeTable (group_by + data_columns).to_array
+                False ->
+                    Nothing
+
+            on_problems.attach_problems_after (Table.Table_Data result) <|
+                problems = result.getProblems
+                Aggregate_Column_Helper.parse_aggregated_problems problems
 
     ## PRIVATE
        Returns a table with a continuous sub-range of rows taken.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1248,13 +1248,14 @@ type Table
             java_key_columns = grouping.map .java_column
             index  = self.java_table.indexFromColumns java_key_columns.to_array Comparator.new
 
-            name_mapper = if validated_values.length == 1 then (_ -> "") else
-                all_same = Aggregate_Column_Helper.all_same_column validated_values
-                c -> Aggregate_Column_Helper.default_aggregate_column_name c all_same
+            name_mapper = if matched_name.is_empty then Aggregate_Column_Helper.default_aggregate_column_name else
+                if validated_values.length == 1 then (_ -> "") else
+                    all_same = Aggregate_Column_Helper.all_same_column validated_values
+                    c -> Aggregate_Column_Helper.default_aggregate_column_name c all_same
 
             data_columns = validated_values.map c->
-                    col_name = c.new_name.if_nothing (name_mapper c)
-                    Aggregate_Column_Helper.java_aggregator col_name c
+                col_name = c.new_name.if_nothing (name_mapper c)
+                Aggregate_Column_Helper.java_aggregator col_name c
 
             result = case matched_name.is_empty of
                 True ->

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Aggregate_Column_Helper.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Aggregate_Column_Helper.enso
@@ -89,16 +89,30 @@ prepare_aggregate_columns aggregates table =
 
    Assumes that the `Aggregate_Column` is resolved. You may need to transform it
    with `resolve_aggregate` first.
-default_aggregate_column_name aggregate_column =
+default_aggregate_column_name aggregate_column include_column=True =
     case aggregate_column of
         Group_By c _ -> c.name
         Count _ -> "Count"
         Count_Distinct columns _ _ ->
             "Count Distinct " + (columns.map .name . join " ")
-        Percentile p c _ -> ((p*100).floor.to_text + "%-ile ") + c.name
+        Percentile p c _ -> ((p*100).floor.to_text + "%-ile ") + (if include_column then c.name else "")
         _ ->
             prefix = Meta.get_simple_type_name aggregate_column . replace "_" " "
-            prefix + " " + aggregate_column.column.name
+            c = aggregate_column.column
+            prefix + " " + (if include_column then c.name else "")
+
+## Utility function to check if all same column
+all_same_column : Vector Aggregate_Column -> Boolean
+all_same_column aggregates =
+    is_not_count c = case c of
+        Count _ -> False
+        Count_Distinct _ _ _ -> False
+        _ -> True
+    without_count = aggregates.filter is_not_count
+
+    if without_count.length < 2 then True else
+        column = without_count.first.column.name
+        without_count.all c->(c.column.name == column)
 
 ## PRIVATE
    Returns a copy of this aggregate where all column descriptors (names,

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -196,7 +196,7 @@ type Table_Column_Helper
             if matched_columns.length == 1 then matched_columns.first else
                 if matched_columns.length != 0 then Panic.throw (Illegal_State_Error_Data "A single exact match should never match more than one column. Perhaps the table breaks the invariant of unique column names?") else
                     expression = (self.table.evaluate selector).catch Any _->Nothing
-                    if expression != Nothing then expression else
+                    if Nothing != expression then expression else
                         problem_builder.report_missing_input_columns [selector]
                         Nothing
         _ : Integer -> case is_index_valid self.internal_columns.length selector of

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/object/Builder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/object/Builder.java
@@ -4,6 +4,20 @@ import org.enso.table.data.column.storage.Storage;
 
 /** A builder for creating columns dynamically. */
 public abstract class Builder {
+  public static Builder getForType(int type, int size) {
+    return switch (type) {
+      case Storage.Type.OBJECT -> new ObjectBuilder(size);
+      case Storage.Type.LONG -> NumericBuilder.createLongBuilder(size);
+      case Storage.Type.DOUBLE -> NumericBuilder.createDoubleBuilder(size);
+      case Storage.Type.STRING -> new StringBuilder(size);
+      case Storage.Type.BOOL -> new BoolBuilder();
+      case Storage.Type.DATE -> new DateBuilder(size);
+      case Storage.Type.TIME_OF_DAY -> new TimeOfDayBuilder(size);
+      case Storage.Type.DATE_TIME -> new DateTimeBuilder(size);
+      default -> new InferredBuilder(size);
+    };
+  }
+
   /**
    * Append a new item to this builder, assuming that it has enough allocated space.
    *

--- a/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueIndex.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueIndex.java
@@ -1,17 +1,18 @@
 package org.enso.table.data.index;
 
-import java.util.*;
-import java.util.function.IntFunction;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.enso.table.aggregations.Aggregator;
-import org.enso.table.data.column.builder.object.*;
 import org.enso.table.data.column.builder.object.StringBuilder;
+import org.enso.table.data.column.builder.object.*;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.table.Column;
 import org.enso.table.data.table.Table;
 import org.enso.table.data.table.problems.AggregatedProblems;
 import org.enso.table.data.table.problems.FloatingPointGrouping;
+
+import java.util.*;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class MultiValueIndex {
   private final int keyColumnsLength;
@@ -91,6 +92,10 @@ public class MultiValueIndex {
             .mapToObj(i -> new Column(columns[i].getName(), storage[i].seal()))
             .toArray(Column[]::new),
         merged);
+  }
+
+  public Table makeCrossTabTable(Column[] groupingColumns, Column nameColumn, Aggregator aggregates) {
+    return null;
   }
 
   public int[] makeOrderMap(int rowCount) {

--- a/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueIndex.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueIndex.java
@@ -1,7 +1,6 @@
 package org.enso.table.data.index;
 
 import org.enso.table.aggregations.Aggregator;
-import org.enso.table.data.column.builder.object.StringBuilder;
 import org.enso.table.data.column.builder.object.*;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.table.Column;
@@ -65,7 +64,7 @@ public class MultiValueIndex {
     boolean emptyScenario = size == 0 & keyColumnsLength == 0;
     Builder[] storage =
         Arrays.stream(columns)
-            .map(c -> getBuilderForType(c.getType(), emptyScenario ? 1 : size))
+            .map(c -> Builder.getForType(c.getType(), emptyScenario ? 1 : size))
             .toArray(Builder[]::new);
 
     if (emptyScenario) {
@@ -104,10 +103,10 @@ public class MultiValueIndex {
 
     // Create the storage
     Builder[] storage = new Builder[columnCount];
-    IntStream.range(0, groupingColumns.length).forEach(i -> storage[i] = getBuilderForType(groupingColumns[i].getStorage().getType(), size));
+    IntStream.range(0, groupingColumns.length).forEach(i -> storage[i] = Builder.getForType(groupingColumns[i].getStorage().getType(), size));
     IntStream.range(0, nameIndex.locs.size()).forEach(i -> {
       int offset = groupingColumns.length + i * aggregates.length;
-      IntStream.range(0, aggregates.length).forEach(j -> storage[offset + j] = getBuilderForType(aggregates[j].getType(), size));
+      IntStream.range(0, aggregates.length).forEach(j -> storage[offset + j] = Builder.getForType(aggregates[j].getType(), size));
     });
 
     // Fill the storage
@@ -171,19 +170,5 @@ public class MultiValueIndex {
     }
 
     return output;
-  }
-
-  private static Builder getBuilderForType(int type, int size) {
-    return switch (type) {
-      case Storage.Type.OBJECT -> new ObjectBuilder(size);
-      case Storage.Type.LONG -> NumericBuilder.createLongBuilder(size);
-      case Storage.Type.DOUBLE -> NumericBuilder.createDoubleBuilder(size);
-      case Storage.Type.STRING -> new StringBuilder(size);
-      case Storage.Type.BOOL -> new BoolBuilder();
-      case Storage.Type.DATE -> new DateBuilder(size);
-      case Storage.Type.TIME_OF_DAY -> new TimeOfDayBuilder(size);
-      case Storage.Type.DATE_TIME -> new DateTimeBuilder(size);
-      default -> new InferredBuilder(size);
-    };
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/mask/OrderMask.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/mask/OrderMask.java
@@ -2,16 +2,6 @@ package org.enso.table.data.mask;
 
 /** Describes a storage reordering operator. */
 public class OrderMask {
-  public static OrderMask repeatRows(int rowCount, int repeats) {
-    int[] result = new int[rowCount * repeats];
-    for (int row = 0; row < rowCount; row++) {
-      for (int repeat = 0; repeat < repeats; repeat++) {
-        result[row * repeats + repeat] = row;
-      }
-    }
-    return new OrderMask(result);
-  }
-
   private final int[] positions;
 
   /**

--- a/std-bits/table/src/main/java/org/enso/table/data/mask/OrderMask.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/mask/OrderMask.java
@@ -2,6 +2,16 @@ package org.enso.table.data.mask;
 
 /** Describes a storage reordering operator. */
 public class OrderMask {
+  public static OrderMask repeatRows(int rowCount, int repeats) {
+    int[] result = new int[rowCount * repeats];
+    for (int row = 0; row < rowCount; row++) {
+      for (int repeat = 0; repeat < repeats; repeat++) {
+        result[row * repeats + repeat] = row;
+      }
+    }
+    return new OrderMask(result);
+  }
+
   private final int[] positions;
 
   /**

--- a/std-bits/table/src/main/java/org/enso/table/data/table/Column.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/Column.java
@@ -117,10 +117,23 @@ public class Column {
    * @return a column with given name and items
    */
   public static Column fromItems(String name, List<Value> items) {
-    InferredBuilder builder = new InferredBuilder(items.size());
-    for (Value item : items) {
-      Object converted = Polyglot_Utils.convertPolyglotValue(item);
-      builder.appendNoGrow(converted);
+    return fromRepeatedItems(name, items, 1);
+  }
+
+  /**
+   * Creates a new column with given name and elements.
+   *
+   * @param name the name to use
+   * @param items the items contained in the column
+   * @return a column with given name and items
+   */
+  public static Column fromRepeatedItems(String name, List<Value> items, int repeat) {
+    InferredBuilder builder = new InferredBuilder(items.size() * repeat);
+    for (int i = 0; i < repeat; i++) {
+      for (Value item : items) {
+        Object converted = Polyglot_Utils.convertPolyglotValue(item);
+        builder.appendNoGrow(converted);
+      }
     }
     var storage = builder.seal();
     return new Column(name, new DefaultIndex(items.size()), storage);

--- a/std-bits/table/src/main/java/org/enso/table/data/table/Table.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/Table.java
@@ -2,7 +2,9 @@ package org.enso.table.data.table;
 
 import org.enso.base.Text_Utils;
 import org.enso.base.text.TextFoldingStrategy;
+import org.enso.table.data.column.builder.object.Builder;
 import org.enso.table.data.column.builder.object.InferredBuilder;
+import org.enso.table.data.column.builder.object.StringBuilder;
 import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.index.DefaultIndex;
@@ -18,6 +20,7 @@ import org.enso.table.operations.Distinct;
 
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /** A representation of a table structure. */
 public class Table {
@@ -379,6 +382,45 @@ public class Table {
       this.name = name;
       this.builder = new InferredBuilder(size);
     }
+  }
+
+
+  /**
+   * Transpose tables.
+   *
+   * @param id_columns the columns to use as the id values in the output.
+   * @param to_transpose the columns to transpose.
+   * @param name_field the name of the Name field in the output.
+   * @param value_field the name of the Value field in the output.
+   * @return a table result from transposing the specified columns.
+   */
+  public static Table transpose(Column[] id_columns, Column[] to_transpose, String name_field, String value_field) {
+    int size = id_columns.length > 0 ? id_columns[0].getSize() : to_transpose[0].getSize();
+    int new_count = size * to_transpose.length;
+
+    // Create Storage
+    Builder[] storage = new Builder[id_columns.length + 2];
+    IntStream.range(0, id_columns.length).forEach(i -> storage[i] = Builder.getForType(id_columns[i].getStorage().getType(), new_count));
+    storage[id_columns.length] = new StringBuilder(new_count);
+    storage[id_columns.length + 1] = new InferredBuilder(new_count);
+
+    // Load Data
+    for (int row = 0; row < size; row++) {
+      for (Column column : to_transpose) {
+        for (int i = 0; i < id_columns.length; i++) {
+          storage[i].append(id_columns[i].getStorage().getItemBoxed(row));
+        }
+        storage[id_columns.length].append(column.getName());
+        storage[id_columns.length + 1].append(column.getStorage().getItemBoxed(row));
+      }
+    }
+
+    // Create Table
+    Column[] new_columns = new Column[id_columns.length + 2];
+    IntStream.range(0, id_columns.length).forEach(i -> new_columns[i] = new Column(id_columns[i].getName(), storage[i].seal()));
+    new_columns[id_columns.length] = new Column(name_field, storage[id_columns.length].seal());
+    new_columns[id_columns.length + 1] = new Column(value_field, storage[id_columns.length + 1].seal());
+    return new Table(new_columns);
   }
 
   /**

--- a/test/Table_Tests/src/Table_Spec.enso
+++ b/test/Table_Tests/src/Table_Spec.enso
@@ -1115,6 +1115,18 @@ spec =
             t1.at "Name" . to_vector . should_equal ["Value", "Another", "Yet Another", "Value", "Another", "Yet Another", "Value", "Another", "Yet Another"]
             t1.at "Value" . to_vector . should_equal [1, 10, Nothing, 2, Nothing, "Hello", 3, 20, "World"]
 
+        Test.specify "should allow all id fields with warning or error" <|
+            t = Table.new [["Key", ["x", "y", "z"]], ["Value", [1, 2, 3]], ["Another", [10, Nothing, 20]], ["Yet Another", [Nothing, "Hello", "World"]]]
+            t1 = t.transpose t.column_names
+            t1.row_count . should_equal 3
+            t1.column_count . should_equal 6
+            t1.at "Key" . to_vector . should_equal ["x", "y", "z"]
+            t1.at "Value" . to_vector . should_equal [1, 2, 3]
+            t1.at "Name" . to_vector . should_equal [Nothing, Nothing, Nothing]
+            t1.at "Value_1" . to_vector . should_equal [Nothing, Nothing, Nothing]
+
+            # ToDo: Verify the warnings and error handling.
+
 main = Test_Suite.run_main spec
 
 ## JS indexes months form 0, so we need to subtract 1.

--- a/test/Table_Tests/src/Table_Spec.enso
+++ b/test/Table_Tests/src/Table_Spec.enso
@@ -936,6 +936,7 @@ spec =
             r = t.distinct on_problems=Report_Error
             r.at "A" . to_vector . should_equal ["a", "b", "b"]
             r.at "B" . to_vector . should_equal [2, 1, 2]
+
     Test.group "[In-Memory] Table.filter" <|
         Test.specify "by a custom predicate" <|
             t = Table.new [["ix", [1, 2, 3, 4, 5]], ["X", [5, 0, 4, 5, 1]]]
@@ -1087,6 +1088,32 @@ spec =
 
             check_timing "dates" <|
                 t.filter date_col (Filter_Condition.Is_In dates_vec) . at "X" . to_vector . should_equal expected_vector
+
+    Test.group "[In-Memory] Table.transpose" <|
+        Test.specify "should transpose all columns by default" <|
+            t = Table.new [["Key", ["x", "y", "z"]], ["Value", [1, 2, 3]], ["Another", [10, Nothing, 20]], ["Yet Another", [Nothing, "Hello", "World"]]]
+            t1 = t.transpose
+            t1.row_count . should_equal 12
+            t1.column_count . should_equal 2
+            t1.at "Name" . to_vector . should_equal ["Key", "Value", "Another", "Yet Another", "Key", "Value", "Another", "Yet Another", "Key", "Value", "Another", "Yet Another"]
+            t1.at "Value" . to_vector . should_equal ["x", 1, 10, Nothing, "y", 2, Nothing, "Hello", "z", 3, 20, "World"]
+
+        Test.specify "should allow custom names" <|
+            t = Table.new [["Key", ["x", "y", "z"]], ["Value", [1, 2, 3]], ["Another", [10, Nothing, 20]], ["Yet Another", [Nothing, "Hello", "World"]]]
+            t1 = t.transpose name_field="Key" value_field="Object"
+            t1.row_count . should_equal 12
+            t1.column_count . should_equal 2
+            t1.at "Key" . to_vector . should_equal ["Key", "Value", "Another", "Yet Another", "Key", "Value", "Another", "Yet Another", "Key", "Value", "Another", "Yet Another"]
+            t1.at "Object" . to_vector . should_equal ["x", 1, 10, Nothing, "y", 2, Nothing, "Hello", "z", 3, 20, "World"]
+
+        Test.specify "should allow id fields" <|
+            t = Table.new [["Key", ["x", "y", "z"]], ["Value", [1, 2, 3]], ["Another", [10, Nothing, 20]], ["Yet Another", [Nothing, "Hello", "World"]]]
+            t1 = t.transpose ["Key"]
+            t1.row_count . should_equal 9
+            t1.column_count . should_equal 3
+            t1.at "Key" . to_vector . should_equal ["x", "x", "x", "y", "y", "y", "z", "z", "z"]
+            t1.at "Name" . to_vector . should_equal ["Value", "Another", "Yet Another", "Value", "Another", "Yet Another", "Value", "Another", "Yet Another"]
+            t1.at "Value" . to_vector . should_equal [1, 10, Nothing, 2, Nothing, "Hello", 3, 20, "World"]
 
 main = Test_Suite.run_main spec
 

--- a/test/Table_Tests/src/Table_Spec.enso
+++ b/test/Table_Tests/src/Table_Spec.enso
@@ -1177,12 +1177,9 @@ spec =
         Test.specify "should aggregate if name_field not found" <|
             t = Table.new [["Key", ["x", "x", "x", "x", "y", "y", "y", "z", "z"]], ["Value", [1, 2, 3, 4, 5, 6, 7, 8, 9]]]
             t1 = t.cross_tab [] "Name"
-            t1.row_count . should_equal 3
-            t1.column_count . should_equal 6
-            t1.at "Key" . to_vector . should_equal ["x", "y", "z"]
-            t1.at "Value" . to_vector . should_equal [1, 2, 3]
-            t1.at "Name" . to_vector . should_equal [Nothing, Nothing, Nothing]
-            t1.at "Value_1" . to_vector . should_equal [Nothing, Nothing, Nothing]
+            t1.row_count . should_equal 1
+            t1.column_count . should_equal 1
+            t1.at "Count" . to_vector . should_equal [9]
 
             # ToDo: Verify the warnings and error handling within cross_tab.
 

--- a/test/Table_Tests/src/Table_Spec.enso
+++ b/test/Table_Tests/src/Table_Spec.enso
@@ -1125,7 +1125,66 @@ spec =
             t1.at "Name" . to_vector . should_equal [Nothing, Nothing, Nothing]
             t1.at "Value_1" . to_vector . should_equal [Nothing, Nothing, Nothing]
 
-            # ToDo: Verify the warnings and error handling.
+            # ToDo: Verify the warnings and error handling within transpose.
+
+    Test.group "[In-Memory] Table.cross_tab" <|
+        Test.specify "should cross_tab counts by default using first column as names" <|
+            t = Table.new [["Key", ["x", "x", "x", "x", "y", "y", "y", "z", "z"]], ["Value", [1, 2, 3, 4, 5, 6, 7, 8, 9]]]
+            t1 = t.cross_tab
+            t1.row_count . should_equal 1
+            t1.column_count . should_equal 3
+            t1.at "x" . to_vector . should_equal [4]
+            t1.at "y" . to_vector . should_equal [3]
+            t1.at "z" . to_vector . should_equal [2]
+
+        Test.specify "should allow a different aggregate" <|
+            t = Table.new [["Key", ["x", "x", "x", "x", "y", "y", "y", "z", "z"]], ["Value", [1, 2, 3, 4, 5, 6, 7, 8, 9]]]
+            t1 = t.cross_tab values=[Sum "Value"]
+            t1.row_count . should_equal 1
+            t1.column_count . should_equal 3
+            t1.at "x" . to_vector . should_equal [10]
+            t1.at "y" . to_vector . should_equal [18]
+            t1.at "z" . to_vector . should_equal [17]
+
+        Test.specify "should allow a custom expression for the aggregate" <|
+            t = Table.new [["Key", ["x", "x", "x", "x", "y", "y", "y", "z", "z"]], ["Value", [1, 2, 3, 4, 5, 6, 7, 8, 9]]]
+            t1 = t.cross_tab values=[Sum "[Value]*[Value]"]
+            t1.row_count . should_equal 1
+            t1.column_count . should_equal 3
+            t1.at "x" . to_vector . should_equal [30]
+            t1.at "y" . to_vector . should_equal [110]
+            t1.at "z" . to_vector . should_equal [145]
+
+        Test.specify "should allow a chosen column" <|
+            t = Table.new [["Group", ["A","B","A","B","A","B","A","B","A"]], ["Species", ["x", "x", "x", "x", "y", "y", "y", "z", "z"]], ["Value", [1, 2, 3, 4, 5, 6, 7, 8, 9]]]
+            t1 = t.cross_tab [] "Species"
+            t1.row_count . should_equal 1
+            t1.column_count . should_equal 3
+            t1.at "x" . to_vector . should_equal [4]
+            t1.at "y" . to_vector . should_equal [3]
+            t1.at "z" . to_vector . should_equal [2]
+
+        Test.specify "should allow a grouping" <|
+            t = Table.new [["Group", ["A","B","A","B","A","B","A","B","A"]], ["Key", ["x", "x", "x", "x", "y", "y", "y", "z", "z"]], ["Value", [1, 2, 3, 4, 5, 6, 7, 8, 9]]]
+            t1 = t.cross_tab ["Group"] "Key"
+            t1.row_count . should_equal 2
+            t1.column_count . should_equal 4
+            t1.at "Group" . to_vector . should_equal ["A", "B"]
+            t1.at "x" . to_vector . should_equal [2, 2]
+            t1.at "y" . to_vector . should_equal [2, 1]
+            t1.at "z" . to_vector . should_equal [1, 1]
+
+        Test.specify "should aggregate if name_field not found" <|
+            t = Table.new [["Key", ["x", "x", "x", "x", "y", "y", "y", "z", "z"]], ["Value", [1, 2, 3, 4, 5, 6, 7, 8, 9]]]
+            t1 = t.cross_tab [] "Name"
+            t1.row_count . should_equal 3
+            t1.column_count . should_equal 6
+            t1.at "Key" . to_vector . should_equal ["x", "y", "z"]
+            t1.at "Value" . to_vector . should_equal [1, 2, 3]
+            t1.at "Name" . to_vector . should_equal [Nothing, Nothing, Nothing]
+            t1.at "Value_1" . to_vector . should_equal [Nothing, Nothing, Nothing]
+
+            # ToDo: Verify the warnings and error handling within cross_tab.
 
 main = Test_Suite.run_main spec
 


### PR DESCRIPTION
### Pull Request Description

- Adds transpose and cross_tab to the In-Memory table.
- Cross Tab is built on top of aggregate and hence allows for expressions and has same error trapping as in aggregate.

### Important Notes

Only basic tests have been implemented. Error and warning tests will be added as a follow up task.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
