### PR TITLE
Use a custom directory for VCS repo metadata

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -105,7 +105,9 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: LogLevel) {
   val fileSystem: FileSystem = new FileSystem
   log.trace("Created file system [{}].", fileSystem)
 
-  val git = Git.withEmptyUserConfig()
+  val git = Git.withEmptyUserConfig(
+    Some(languageServerConfig.vcsManager.dataDirectory)
+  )
   log.trace("Created git [{}].", git)
 
   implicit val versionCalculator: ContentBasedVersioning =

--- a/engine/language-server/src/main/scala/org/enso/languageserver/data/Config.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/data/Config.scala
@@ -5,8 +5,7 @@ import org.enso.languageserver.filemanager.ContentRootWithFile
 import org.enso.logger.masking.{MaskingUtils, ToLogString}
 
 import java.io.File
-import java.nio.file.Files
-
+import java.nio.file.{Files, Path}
 import scala.concurrent.duration._
 
 /** Configuration of the path watcher.
@@ -58,7 +57,10 @@ object FileManagerConfig {
   *
   * @param timeout vcs operation timeout
   */
-case class VcsManagerConfig(timeout: FiniteDuration)
+case class VcsManagerConfig(timeout: FiniteDuration) {
+  val dataDirectory: Path =
+    Path.of(ProjectDirectoriesConfig.DataDirectory)
+}
 
 /** Configuration of the execution context.
   *

--- a/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/Git.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/Git.scala
@@ -70,11 +70,12 @@ private class Git(ensoDataDirectory: Option[Path]) extends VcsApi[BlockingIO] {
         .call()
 
       ensoDataDirectory.foreach { _ =>
-        // JGit **always** creates a .git file pointing to gitdir path.
-        // The file may be confusing to the users and unnecessary for
-        // VCS since all commands include repo path explicitly.
+        // When `gitDir` is set, JGit **always** creates a .git file (not a directory!) that points at the real
+        // directory that has the repository.
+        // The presence of the `.git` file is unnecessary and may be confusing to the users;
+        // all operations specify explicitly the location of Git metadata directory.
         val dotGit = root.resolve(".git").toFile
-        if (dotGit.exists()) {
+        if (dotGit.exists() && dotGit.isFile) {
           dotGit.delete()
         }
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/Git.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/Git.scala
@@ -7,7 +7,6 @@ import org.eclipse.jgit.api.{Git => JGit}
 import org.eclipse.jgit.api.ResetCommand.ResetType
 import org.eclipse.jgit.api.errors.RefNotFoundException
 import org.eclipse.jgit.errors.{
-  EntryExistsException,
   IncorrectObjectTypeException,
   InvalidObjectIdException,
   MissingObjectException,
@@ -70,7 +69,7 @@ private class Git(ensoDataDirectory: Option[Path]) extends VcsApi[BlockingIO] {
         .setBare(false)
         .call()
 
-      ensoDataDirectory.foreach { path =>
+      ensoDataDirectory.foreach { _ =>
         // JGit **always** creates a .git file pointing to gitdir path.
         // The file may be confusing to the users and unnecessary for
         // VCS since all commands include repo path explicitly.
@@ -79,13 +78,10 @@ private class Git(ensoDataDirectory: Option[Path]) extends VcsApi[BlockingIO] {
           dotGit.delete()
         }
 
-        if (path.toFile.exists()) {
-          throw new EntryExistsException(path.toString)
-        }
         // Exclude <enso-data>/.git
         jgit
           .reset()
-          .addPath(path.resolve(VcsApi.DefaultRepoDir).toString)
+          .addPath(gitDir.toString)
           .call()
       }
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/VcsApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/VcsApi.scala
@@ -64,6 +64,10 @@ abstract class VcsApi[F[_, _]] {
   ): F[VcsFailure, List[RepoCommit]]
 }
 
+object VcsApi {
+  val DefaultRepoDir = ".git"
+}
+
 /** `RepoStatus` encapsulates the current state of the project under VCS.
   *
   * @param isDirty `true`, if there are any unsaved changes to the project, `false` otherwise

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
@@ -170,7 +170,9 @@ class BaseServerTest
     val vcsManager = system.actorOf(
       VcsManager.props(
         config.vcsManager,
-        Git.withEmptyUserConfig(),
+        Git.withEmptyUserConfig(
+          Some(config.vcsManager.dataDirectory)
+        ),
         contentRootManagerWrapper,
         zioExec
       ),


### PR DESCRIPTION
### Pull Request Description

Rather than hard-coding `.git` in the root of the project, VCS should save data into Enso's data directory (i.e. `.enso`).
This change reshuffles initialization and configuration to store Git VCS metadata by default at `.enso/.git`.
This is follow up to https://github.com/enso-org/enso/pull/3851

### Important Notes

Apparently a custom Git directory in JGit means that it always creates a `.git` **file** with `gitdir` pointing to the custom location.
This is not necessary in our case since all our commands provide that explicitly.
That is why `init` operation removes `.git` file, which may seem a bit counter-intuitive.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
