### PR TITLE
enable node labels by default and keep their position up to date

### DIFF
--- a/app/gui/view/graph-editor/src/component/node/output/area.rs
+++ b/app/gui/view/graph-editor/src/component/node/output/area.rs
@@ -240,7 +240,6 @@ impl Model {
     fn set_label(&self, content: impl Into<String>) {
         let str = if ARGS.node_labels.unwrap_or(true) { content.into() } else { default() };
         self.label.set_content(str);
-        self.label.set_x(-self.label.width.value() - input::area::TEXT_OFFSET);
     }
 
     /// Update expression type for the particular `ast::Id`.
@@ -482,6 +481,9 @@ impl Area {
             frp.source.port_size_multiplier <+ hysteretic_transition.value;
             eval frp.set_size ((t) model.set_size(*t));
             frp.source.size <+ frp.set_size;
+
+            expr_label_x <- model.label.width.map(|width| -width - input::area::TEXT_OFFSET);
+            eval expr_label_x ((x) model.label.set_x(*x));
 
             frp.source.type_label_visibility <+ frp.set_type_label_visibility;
 

--- a/app/ide-desktop/lib/content/src/index.ts
+++ b/app/ide-desktop/lib/content/src/index.ts
@@ -769,7 +769,7 @@ class Config {
     public use_loader: boolean = true
     public wasm_url: string = '/assets/ide.wasm'
     public wasm_glue_url: string = '/assets/wasm_imports.js'
-    public node_labels: boolean = false
+    public node_labels: boolean = true
     public crash_report_host: string = defaultLogServerHost
     public data_gathering: boolean = true
     public is_in_cloud: boolean = false


### PR DESCRIPTION
### Pull Request Description

Fixes https://www.pivotaltracker.com/n/projects/2539304/stories/183899185
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

![image](https://user-images.githubusercontent.com/919491/204636854-77f0a860-1cdb-4b0f-a925-292afbaa874a.png)
Screenshot taken while holding ctrl, so all labels are visible.

### Important Notes

The node labels config option default switched to true. The fact that this is configurable can potentially explain why it was rougly working for some people, but not other. Apart from that, the labels position update is also now fixed, so it is properly drawn next to the node.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
