### PR TITLE
Integer.parse and Decimal.parse improvements

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
@@ -985,7 +985,6 @@ type Integer
 
 ## UNSTABLE
 
-
    A syntax error when parsing a double.
 @Builtin_Type
 type Number_Parse_Error

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
@@ -975,7 +975,11 @@ type Integer
 
             Integer.parse "20220216"
     parse : Text -> Text -> Integer ! Parse_Error
-    parse text (radix=10) = Integer.parse_internal text radix
+    parse text (radix=10) = Integer.parse_builtin text radix
+
+    ## PRIVATE
+
+        Internally handles the parsing.
 
     parse_builtin text radix = @Builtin_Method "Integer.parse"
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
@@ -975,13 +975,15 @@ type Integer
 
             Integer.parse "20220216"
     parse : Text -> Text -> Integer ! Parse_Error
-    parse text (radix=10) =
-        Panic.catch NumberFormatException (Long.parseLong text radix) _->
-             Error.throw (Number_Parse_Error.Error text)
+    parse text (radix=10) = Integer.parse_internal text radix
+
+    parse_internal text radix = @Builtin_Method "Integer.parse"
 
 ## UNSTABLE
 
+
    A syntax error when parsing a double.
+@Builtin_Type
 type Number_Parse_Error
     Error text
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
@@ -977,7 +977,7 @@ type Integer
     parse : Text -> Text -> Integer ! Parse_Error
     parse text (radix=10) = Integer.parse_internal text radix
 
-    parse_internal text radix = @Builtin_Method "Integer.parse"
+    parse_builtin text radix = @Builtin_Method "Integer.parse"
 
 ## UNSTABLE
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
@@ -1,6 +1,8 @@
 import project.Data.Json.Json
 import project.Data.Ordering.Ordering
 import project.Data.Text.Text
+import project.Data.Locale.Locale
+import project.Nothing
 
 from project.Data.Boolean import Boolean, True, False
 from project.Error.Common import Panic,Error,Illegal_Argument_Error
@@ -10,6 +12,8 @@ polyglot java import java.lang.Math
 polyglot java import java.lang.String
 polyglot java import java.lang.Long
 polyglot java import java.lang.NumberFormatException
+polyglot java import java.text.NumberFormat
+polyglot java import java.text.ParseException
 
 ## The root type of the Enso numeric hierarchy.
 
@@ -591,14 +595,17 @@ type Decimal
 
        Arguments:
        - text: The text to parse into a decimal.
+       - locale: The locale that specifies the format to use when parsing
 
        > Example
          Parse the text "7.6" into a decimal number.
 
              Decimal.parse "7.6"
-    parse : Text -> Decimal ! Parse_Error
-    parse text =
-        Panic.catch NumberFormatException (Double.parseDouble text) _->
+    parse : Text -> Locale | Nothing -> Decimal ! Parse_Error
+    parse text locale=Nothing = case locale of
+        Nothing -> Panic.catch NumberFormatException (Double.parseDouble text) _->
+            Error.throw (Number_Parse_Error.Error text)
+        Locale.Value java_locale -> Panic.catch ParseException ((NumberFormat.getInstance java_locale).parse text) _->
             Error.throw (Number_Parse_Error.Error text)
 
 ## Integer is the type of integral numbers in Enso. They are of unbounded

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/NumberParseError.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/NumberParseError.java
@@ -1,0 +1,19 @@
+package org.enso.interpreter.node.expression.builtin.error;
+
+import java.util.List;
+
+import org.enso.interpreter.dsl.BuiltinType;
+import org.enso.interpreter.node.expression.builtin.Builtin;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+
+@BuiltinType
+public final class NumberParseError extends Builtin {
+  @Override
+  protected final List<Cons> getDeclaredConstructors() {
+    return List.of(new Cons("Error", "text"));
+  }
+
+  public final Atom newInstance(Object... params) {
+    return getConstructors()[0].newInstance(params);
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/integer/ParseIntegerNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/integer/ParseIntegerNode.java
@@ -1,0 +1,28 @@
+package org.enso.interpreter.node.expression.builtin;
+
+import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.dsl.*;
+import org.enso.interpreter.node.expression.builtin.text.util.ToJavaStringNode;
+import org.enso.interpreter.runtime.Context;
+import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.error.PanicException;
+
+@BuiltinMethod(type = "Integer", name = "parse", description = """
+Parse integer number""", autoRegister = false)
+public final class ParseIntegerNode extends Node {
+  @Node.Child
+  ToJavaStringNode toJavaString = ToJavaStringNode.build();
+
+  Object execute(Text value, long radix) {
+    try {
+      return Long.parseLong(toJavaString.execute(value), Math.toIntExact(radix));
+    } catch (NumberFormatException ex) {
+      var err = Context.get(this).getBuiltins().error();
+      throw new PanicException(
+        err.makeNumberParseError(ex.getMessage()),
+        this
+      );
+    }
+  }
+}
+

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/integer/ParseIntegerNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/integer/ParseIntegerNode.java
@@ -5,7 +5,7 @@ import com.oracle.truffle.api.profiles.BranchProfile;
 import java.math.BigInteger;
 import org.enso.interpreter.dsl.*;
 import org.enso.interpreter.node.expression.builtin.text.util.ToJavaStringNode;
-import org.enso.interpreter.runtime.Context;
+import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.number.EnsoBigInteger;
@@ -31,7 +31,7 @@ public final class ParseIntegerNode extends Node {
         ex = ex2;
       }
       noEx2.enter();
-      var errors = Context.get(this).getBuiltins().error();
+      var errors = EnsoContext.get(this).getBuiltins().error();
       var err = errors.makeNumberParseError(ex.getMessage());
       return DataflowError.withoutTrace(err, this);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/integer/ParseIntegerNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/integer/ParseIntegerNode.java
@@ -1,22 +1,36 @@
 package org.enso.interpreter.node.expression.builtin.number.integer;
 
 import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.profiles.BranchProfile;
+import java.math.BigInteger;
 import org.enso.interpreter.dsl.*;
 import org.enso.interpreter.node.expression.builtin.text.util.ToJavaStringNode;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.error.DataflowError;
+import org.enso.interpreter.runtime.number.EnsoBigInteger;
 
 @BuiltinMethod(type = "Integer", name = "parse", description = """
 Parse integer number""", autoRegister = false)
 public final class ParseIntegerNode extends Node {
   @Node.Child
   ToJavaStringNode toJavaString = ToJavaStringNode.build();
+  private final BranchProfile noEx1 = BranchProfile.create();
+  private final BranchProfile noEx2 = BranchProfile.create();
 
   Object execute(Text value, long radix) {
+    var r = Math.toIntExact(radix);
+    var t = toJavaString.execute(value);
     try {
-      return Long.parseLong(toJavaString.execute(value), Math.toIntExact(radix));
+      return Long.parseLong(t, r);
     } catch (NumberFormatException ex) {
+      noEx1.enter();
+      try {
+        return new EnsoBigInteger(new BigInteger(t, r));
+      } catch (NumberFormatException ex2) {
+        ex = ex2;
+      }
+      noEx2.enter();
       var errors = Context.get(this).getBuiltins().error();
       var err = errors.makeNumberParseError(ex.getMessage());
       return DataflowError.withoutTrace(err, this);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/integer/ParseIntegerNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/integer/ParseIntegerNode.java
@@ -1,11 +1,11 @@
-package org.enso.interpreter.node.expression.builtin;
+package org.enso.interpreter.node.expression.builtin.number.integer;
 
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.dsl.*;
 import org.enso.interpreter.node.expression.builtin.text.util.ToJavaStringNode;
 import org.enso.interpreter.runtime.Context;
 import org.enso.interpreter.runtime.data.text.Text;
-import org.enso.interpreter.runtime.error.PanicException;
+import org.enso.interpreter.runtime.error.DataflowError;
 
 @BuiltinMethod(type = "Integer", name = "parse", description = """
 Parse integer number""", autoRegister = false)
@@ -17,11 +17,9 @@ public final class ParseIntegerNode extends Node {
     try {
       return Long.parseLong(toJavaString.execute(value), Math.toIntExact(radix));
     } catch (NumberFormatException ex) {
-      var err = Context.get(this).getBuiltins().error();
-      throw new PanicException(
-        err.makeNumberParseError(ex.getMessage()),
-        this
-      );
+      var errors = Context.get(this).getBuiltins().error();
+      var err = errors.makeNumberParseError(ex.getMessage());
+      return DataflowError.withoutTrace(err, this);
     }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Error.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Error.java
@@ -35,6 +35,7 @@ public class Error {
   private final NotInvokableError notInvokableError;
   private final InvalidConversionTargetError invalidConversionTargetError;
   private final NoSuchFieldError noSuchFieldError;
+  private final NumberParseError numberParseError;
   private final Panic panic;
   private final CaughtPanic caughtPanic;
   private final ForbiddenOperation forbiddenOperation;
@@ -67,6 +68,7 @@ public class Error {
     notInvokableError = builtins.getBuiltinType(NotInvokableError.class);
     invalidConversionTargetError = builtins.getBuiltinType(InvalidConversionTargetError.class);
     noSuchFieldError = builtins.getBuiltinType(NoSuchFieldError.class);
+    numberParseError = builtins.getBuiltinType(NumberParseError.class);
     panic = builtins.getBuiltinType(Panic.class);
     caughtPanic = builtins.getBuiltinType(CaughtPanic.class);
     forbiddenOperation = builtins.getBuiltinType(ForbiddenOperation.class);
@@ -223,5 +225,9 @@ public class Error {
 
   public ForbiddenOperation getForbiddenOperation() {
     return forbiddenOperation;
+  }
+
+  public Atom makeNumberParseError(String message) {
+    return numberParseError.newInstance(Text.create(message));
   }
 }

--- a/test/Tests/src/Data/Numbers_Spec.enso
+++ b/test/Tests/src/Data/Numbers_Spec.enso
@@ -185,6 +185,11 @@ spec =
             Integer.parse "123A" . should_fail_with Number_Parse_Error.Error
             Integer.parse "aaaa" . should_fail_with Number_Parse_Error.Error
 
+        Test.specify "should parse hundred factorial" <|
+            txt = hundred_factorial.to_text
+            number = Integer.parse txt
+            number . should_equal hundred_factorial
+
         Test.specify "should be able to parse alternate bases" <|
             Integer.parse "1245623" 8 . should_equal 347027
             Integer.parse "-1245623" 8 . should_equal -347027

--- a/test/Tests/src/Data/Numbers_Spec.enso
+++ b/test/Tests/src/Data/Numbers_Spec.enso
@@ -230,6 +230,15 @@ spec =
             Decimal.parse "000000.0001" . should_equal 0.0001
             Decimal.parse "aaaa" . should_fail_with Number_Parse_Error.Error
 
+        Test.specify "parse with locale" <|
+            l = Locale.new "cs"
+            Decimal.parse "32,5" l . should_equal 32.5
+            Decimal.parse "0122,5" l . should_equal 122.5
+            Decimal.parse "-98,5" l . should_equal -98.5
+            Decimal.parse "000000" l . should_equal 0
+            Decimal.parse "000000,0001" l . should_equal 0.0001
+            Decimal.parse "aaaa" l . should_fail_with Number_Parse_Error.Error
+
         Test.specify "decimal should parse hundred factorial well" <|
             txt = hundred_factorial.to_text + ".345"
             decimal = Decimal.parse txt

--- a/test/Tests/src/Data/Numbers_Spec.enso
+++ b/test/Tests/src/Data/Numbers_Spec.enso
@@ -190,6 +190,11 @@ spec =
             number = Integer.parse txt
             number . should_equal hundred_factorial
 
+        Test.specify "should fail on too huge decimal" <|
+            txt = hundred_factorial.to_text + ".345"
+            number = Integer.parse txt
+            number . should_fail_with Number_Parse_Error.Error
+
         Test.specify "should be able to parse alternate bases" <|
             Integer.parse "1245623" 8 . should_equal 347027
             Integer.parse "-1245623" 8 . should_equal -347027
@@ -224,6 +229,12 @@ spec =
             Decimal.parse "000000" . should_equal 0
             Decimal.parse "000000.0001" . should_equal 0.0001
             Decimal.parse "aaaa" . should_fail_with Number_Parse_Error.Error
+
+        Test.specify "decimal should parse hundred factorial well" <|
+            txt = hundred_factorial.to_text + ".345"
+            decimal = Decimal.parse txt
+            is_huge = decimal > (hundred_factorial / 5)
+            is_huge . should_equal True
 
     Test.group "Numbers" <|
 


### PR DESCRIPTION
### Pull Request Description

Converting `Integer.parse` into a builtin and making sure it can parse big values like `100!`. Adding `locale` parameter to `Locale.parse` and making sure it parses `32,5` as `32.5` double in Czech locale.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
