### PR TITLE
Small tweak to convert Date and Time objects to strings in Table viz.

### DIFF
--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -179,13 +179,35 @@ class TableVisualization extends Visualization {
                 if (content instanceof Object) {
                     const type = content.type
                     if (type === 'Date') {
-                        to_render = new Date(content.year, content.month, content.day).toISOString().substring(0, 10)
+                        to_render = new Date(content.year, content.month, content.day)
+                            .toISOString()
+                            .substring(0, 10)
                     } else if (type === 'Time_Of_Day') {
-                        const js_date = new Date(0, 0, 0, content.hour, content.minute, content.second, content.nanosecond / 1000000)
-                        to_render = js_date.toTimeString().substring(0, 8) + (js_date.getMilliseconds() == 0 ? '' : '.' + js_date.getMilliseconds())
+                        const js_date = new Date(
+                            0,
+                            0,
+                            0,
+                            content.hour,
+                            content.minute,
+                            content.second,
+                            content.nanosecond / 1000000
+                        )
+                        to_render =
+                            js_date.toTimeString().substring(0, 8) +
+                            (js_date.getMilliseconds() === 0 ? '' : '.' + js_date.getMilliseconds())
                     } else if (type === 'Date_Time') {
-                        const js_date = new Date(content.year, content.month, content.day, content.hour, content.minute, content.second, content.nanosecond / 1000000)
-                        to_render = js_date.toISOString().substring(0, 19).replace('T', ' ') + (js_date.getMilliseconds() == 0 ? '' : '.' + js_date.getMilliseconds())
+                        const js_date = new Date(
+                            content.year,
+                            content.month,
+                            content.day,
+                            content.hour,
+                            content.minute,
+                            content.second,
+                            content.nanosecond / 1000000
+                        )
+                        to_render =
+                            js_date.toISOString().substring(0, 19).replace('T', ' ') +
+                            (js_date.getMilliseconds() === 0 ? '' : '.' + js_date.getMilliseconds())
                     }
                 }
                 result += '<td class="plaintext">' + to_render + '</td>'

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -175,7 +175,20 @@ class TableVisualization extends Visualization {
                 result += '<th>' + content + '</th>'
             }
             function addCell(content) {
-                result += '<td class="plaintext">' + content + '</td>'
+                let to_render = content
+                if (content instanceof Object) {
+                    const type = content.type
+                    if (type === 'Date') {
+                        to_render = new Date(content.year, content.month, content.day).toISOString().substring(0, 10)
+                    } else if (type === 'Time_Of_Day') {
+                        const js_date = new Date(0, 0, 0, content.hour, content.minute, content.second, content.nanosecond / 1000000)
+                        to_render = js_date.toTimeString().substring(0, 8) + (js_date.getMilliseconds() == 0 ? '' : '.' + js_date.getMilliseconds())
+                    } else if (type === 'Date_Time') {
+                        const js_date = new Date(content.year, content.month, content.day, content.hour, content.minute, content.second, content.nanosecond / 1000000)
+                        to_render = js_date.toISOString().substring(0, 19).replace('T', ' ') + (js_date.getMilliseconds() == 0 ? '' : '.' + js_date.getMilliseconds())
+                    }
+                }
+                result += '<td class="plaintext">' + to_render + '</td>'
             }
             result += '<tr>'
             parsedData.indices_header.forEach(addHeader)


### PR DESCRIPTION
### Pull Request Description

Currently, Date, Time_Of_Day and Date_Time are rendered as `[Object object]` in the table.
![image](https://user-images.githubusercontent.com/4699705/206166467-a08c8a78-af63-4b2e-93d7-4f4d4190f117.png)

This makes them render in simple text format.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
