### PR TITLE
Fix order by Text

### DIFF
--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -410,7 +410,7 @@ prepare_order_by : Vector -> Text | Vector Text | Sort_Column_Selector -> Proble
 prepare_order_by internal_columns column_selectors problem_builder =
     selected_elements = case column_selectors of
         _ : Text ->
-            unified_name_selectors = [Sort_Column.Name unified_name_selectors]
+            unified_name_selectors = [Sort_Column.Name column_selectors]
             select_columns_by_name internal_columns unified_name_selectors Text_Matcher.Case_Sensitive problem_builder name_extractor=(_.name)
         _ : Vector ->
             unified_name_selectors = column_selectors.map (Sort_Column.Name _)

--- a/test/Table_Tests/src/Common_Table_Operations/Order_By_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Order_By_Spec.enso
@@ -35,6 +35,11 @@ spec setup =
             t1.at "alpha" . to_vector . should_equal [0, 1, 2, 3]
             t1.at "gamma" . to_vector . should_equal [4, 3, 2, 1]
 
+        Test.specify "should work with single column name" <|
+            t1 = table.order_by "alpha"
+            t1.at "alpha" . to_vector . should_equal [0, 1, 2, 3]
+            t1.at "gamma" . to_vector . should_equal [4, 3, 2, 1]
+
             t2 = table.order_by (Sort_Column_Selector.By_Index [1, Sort_Column.Index -8 Sort_Direction.Descending])
             t2.at "beta" . to_vector . should_equal ["a", "a", "b", "b"]
             t2.at "gamma" . to_vector . should_equal [3, 1, 4, 2]


### PR DESCRIPTION
### Pull Request Description

Mistake in the definition.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
