### PR TITLE
Improvements to VCS setup

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/Git.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/Git.scala
@@ -83,12 +83,12 @@ private class Git(ensoDataDirectory: Option[Path]) extends VcsApi[BlockingIO] {
       }
 
       val isDataDir =
-        (x: Path) => ensoDataDirectory.map(_ == x).getOrElse(false)
+        ensoDataDirectory.contains _
       val filesToAdd =
         listDirectoryFiles(root, Set(gitDir))
           .filterNot(isDataDir)
           .map(ensureUnixPathSeparator)
-      if (!filesToAdd.isEmpty) {
+      if (filesToAdd.nonEmpty) {
         filesToAdd
           .foldLeft(jgit.add()) { case (cmd, filePath) =>
             cmd.addFilepattern(filePath)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/VcsApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/VcsApi.scala
@@ -65,7 +65,7 @@ abstract class VcsApi[F[_, _]] {
 }
 
 object VcsApi {
-  val DefaultRepoDir = ".git"
+  val DefaultRepoDir = ".vcs"
 }
 
 /** `RepoStatus` encapsulates the current state of the project under VCS.

--- a/engine/language-server/src/test/scala/org/enso/languageserver/vcsmanager/GitSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/vcsmanager/GitSpec.scala
@@ -366,8 +366,16 @@ class GitSpec extends AnyWordSpecLike with Matchers with Effects {
 
     def isPathUnderVcs(repo: Repository, relativePath: Path): Boolean = {
       val jgit = new JGit(repo)
-      jgit.log().addPath(relativePath.toString).call().iterator().hasNext
+      jgit
+        .log()
+        .addPath(ensureUnixPathSeparator(relativePath))
+        .call()
+        .iterator()
+        .hasNext
     }
+
+    private def ensureUnixPathSeparator(path: Path): String =
+      path.toString.replaceAll("\\\\", "/")
 
     def hasUntrackedFiles(repoDir: Path): Boolean = {
       hasUntrackedFiles(testRepo(repoDir))

--- a/engine/language-server/src/test/scala/org/enso/languageserver/vcsmanager/GitSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/vcsmanager/GitSpec.scala
@@ -50,6 +50,16 @@ class GitSpec extends AnyWordSpecLike with Matchers with Effects {
         Some(dataDirectory)
       )
 
+      repoPath.resolve(dataDirectory).toFile.mkdir()
+
+      val relativePackageJsonFile = dataDirectory.resolve("project.json")
+      val absolutePackageJsonFie  = repoPath.resolve(relativePackageJsonFile)
+      createStubFile(absolutePackageJsonFie) should equal(true)
+      Files.write(
+        absolutePackageJsonFie,
+        "dummy package json file".getBytes(StandardCharsets.UTF_8)
+      )
+
       val targetRepo =
         repoPath.resolve(dataDirectory).resolve(VcsApi.DefaultRepoDir)
       targetRepo.toFile shouldNot exist
@@ -57,6 +67,18 @@ class GitSpec extends AnyWordSpecLike with Matchers with Effects {
       result.isRight shouldBe true
       targetRepo.toFile should exist
       repoPath.resolve(VcsApi.DefaultRepoDir).toFile shouldNot exist
+      isPathUnderVcs(
+        repoPath.resolve(dataDirectory),
+        dataDirectory
+      ) shouldBe true
+      isPathUnderVcs(
+        repoPath.resolve(dataDirectory),
+        dataDirectory.resolve(VcsApi.DefaultRepoDir)
+      ) shouldBe false
+      isPathUnderVcs(
+        repoPath.resolve(dataDirectory),
+        relativePackageJsonFile
+      ) shouldBe true
     }
   }
 
@@ -336,6 +358,15 @@ class GitSpec extends AnyWordSpecLike with Matchers with Effects {
     def listCommits(repo: Repository): List[RevCommit] = {
       val jgit = new JGit(repo)
       jgit.log().call().asScala.toList
+    }
+
+    def isPathUnderVcs(repo: Path, relativePath: Path): Boolean = {
+      isPathUnderVcs(testRepo(repo), relativePath)
+    }
+
+    def isPathUnderVcs(repo: Repository, relativePath: Path): Boolean = {
+      val jgit = new JGit(repo)
+      jgit.log().addPath(relativePath.toString).call().iterator().hasNext
     }
 
     def hasUntrackedFiles(repoDir: Path): Boolean = {

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/VcsManagerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/VcsManagerTest.scala
@@ -871,7 +871,10 @@ class VcsManagerTest extends BaseServerTest with RetrySpec {
   }
 
   private def ensureUnixPathSeparator(path: Path): String =
-    path.toString.replaceAll("\\\\", "/")
+    ensureUnixPathSeparator(path.toString)
+
+  private def ensureUnixPathSeparator(path: String): String =
+    path.replaceAll("\\\\", "/")
 
   private def repository(path: Path): Repository = {
     val builder = new FileRepositoryBuilder();
@@ -913,11 +916,16 @@ class VcsManagerTest extends BaseServerTest with RetrySpec {
     val jgit   = new JGit(repository(root.toPath))
     val status = jgit.status().call()
     val changed =
-      status.getUntracked().asScala ++ status.getModified().asScala ++ status
-        .getRemoved()
-        .asScala
-    val gitdir = config.vcsManager.dataDirectory.resolve(VcsApi.DefaultRepoDir)
-    changed.toList.filterNot(file => file.startsWith(gitdir.toString)).isEmpty
+      (status.getUntracked().asScala
+      ++ status.getModified().asScala
+      ++ status.getRemoved().asScala)
+    val gitDir = ensureUnixPathSeparator(
+      config.vcsManager.dataDirectory.resolve(VcsApi.DefaultRepoDir)
+    )
+    changed.toList
+      .map(ensureUnixPathSeparator)
+      .filterNot(file => file.startsWith(gitDir))
+      .isEmpty
   }
 
 }

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/VcsManagerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/VcsManagerTest.scala
@@ -8,13 +8,13 @@ import org.eclipse.jgit.revwalk.RevCommit
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import org.enso.languageserver.boot.ProfilingConfig
 import org.enso.languageserver.data._
+import org.enso.languageserver.vcsmanager.VcsApi
 import org.enso.testkit.RetrySpec
 
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
 import java.time.{Clock, LocalDate}
-
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
@@ -35,7 +35,7 @@ class VcsManagerTest extends BaseServerTest with RetrySpec {
   }
 
   "Initializing project" must {
-    "create a repository" taggedAs Retry in {
+    "create a repository" in {
       val client = getInitialisedWsClient()
       client.send(json"""
           { "jsonrpc": "2.0",
@@ -83,7 +83,7 @@ class VcsManagerTest extends BaseServerTest with RetrySpec {
       testContentRoot.file.toPath.resolve(".git").toFile shouldNot exist
       testContentRoot.file.toPath
         .resolve(".enso")
-        .resolve(".git")
+        .resolve(".vcs")
         .toFile should exist
     }
 
@@ -428,14 +428,14 @@ class VcsManagerTest extends BaseServerTest with RetrySpec {
                   "rootId" : $testContentRootId,
                   "segments" : [
                     "src",
-                    "Foo.enso"
+                    "Bar.enso"
                   ]
                 },
                 {
                   "rootId" : $testContentRootId,
                   "segments" : [
                     "src",
-                    "Bar.enso"
+                    "Foo.enso"
                   ]
                 }
               ],
@@ -834,10 +834,13 @@ class VcsManagerTest extends BaseServerTest with RetrySpec {
   }
 
   def withCleanRoot[T](test: WsTestClient => T): T = {
+
     FileUtils.deleteQuietly(testContentRoot.file)
     val path = testContentRoot.file
     val vcsRepoPath =
-      path.toPath.resolve(config.vcsManager.dataDirectory).resolve(".git")
+      path.toPath
+        .resolve(config.vcsManager.dataDirectory)
+        .resolve(VcsApi.DefaultRepoDir)
     val jgit =
       JGit
         .init()
@@ -848,13 +851,13 @@ class VcsManagerTest extends BaseServerTest with RetrySpec {
 
     path.toPath.resolve(".git").toFile.delete() shouldBe true
 
-    Files.write(
-      path.toPath.resolve(".gitignore"),
-      config.vcsManager.dataDirectory.toString.getBytes(StandardCharsets.UTF_8)
-    )
-
     val client = getInitialisedWsClient()
-    jgit.add().addFilepattern(".").call()
+    jgit
+      .add()
+      .addFilepattern(
+        config.vcsManager.dataDirectory.resolve("suggestions.db").toString
+      )
+      .call()
     jgit
       .commit()
       .setAllowEmpty(true)
@@ -869,7 +872,10 @@ class VcsManagerTest extends BaseServerTest with RetrySpec {
     val builder = new FileRepositoryBuilder();
     builder
       .setGitDir(
-        path.resolve(config.vcsManager.dataDirectory).resolve(".git").toFile
+        path
+          .resolve(config.vcsManager.dataDirectory)
+          .resolve(VcsApi.DefaultRepoDir)
+          .toFile
       )
       .setMustExist(true)
       .build()
@@ -901,7 +907,12 @@ class VcsManagerTest extends BaseServerTest with RetrySpec {
   def isClean(root: File): Boolean = {
     val jgit   = new JGit(repository(root.toPath))
     val status = jgit.status().call()
-    status.isClean
+    val changed =
+      status.getUntracked().asScala ++ status.getModified().asScala ++ status
+        .getRemoved()
+        .asScala
+    val gitdir = config.vcsManager.dataDirectory.resolve(VcsApi.DefaultRepoDir)
+    changed.toList.filterNot(file => file.startsWith(gitdir.toString)).isEmpty
   }
 
 }

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/VcsManagerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/VcsManagerTest.scala
@@ -855,7 +855,9 @@ class VcsManagerTest extends BaseServerTest with RetrySpec {
     jgit
       .add()
       .addFilepattern(
-        config.vcsManager.dataDirectory.resolve("suggestions.db").toString
+        ensureUnixPathSeparator(
+          config.vcsManager.dataDirectory.resolve("suggestions.db")
+        )
       )
       .call()
     jgit
@@ -867,6 +869,9 @@ class VcsManagerTest extends BaseServerTest with RetrySpec {
       .call()
     test(client)
   }
+
+  private def ensureUnixPathSeparator(path: Path): String =
+    path.toString.replaceAll("\\\\", "/")
 
   private def repository(path: Path): Repository = {
     val builder = new FileRepositoryBuilder();
@@ -896,7 +901,7 @@ class VcsManagerTest extends BaseServerTest with RetrySpec {
     paths.forall(path =>
       try {
         val relativePath = root.toPath.relativize(path)
-        jgit.add().addFilepattern(relativePath.toString).call()
+        jgit.add().addFilepattern(ensureUnixPathSeparator(relativePath)).call()
         true
       } catch {
         case _: Throwable => false


### PR DESCRIPTION
### Pull Request Description

The presence of `.git` in Enso's data directory (`.enso`), which should be under VCS as well, turned out to be really problematic. Git (and JGit) treat `.enso` as a submodule which prevents as from manual inspection of the repo. Additionally, every commit changed the submodule version, which in turn was reporting invalid/changed status always.

This change renames `.enso/.git` to `.enso/.vcs` which eliminates a lot of problems. Additionally, rather than doing `git add .` we selectively add files to the index, thus preventing most of the issues reported in the ticket.
This change also means that JGit's status needs to filter `.enso/.vcs` as those will be marked as untracked always.

### Important Notes

To manually test the status of the project's repo do
```
git --git-dir .enso/.vcs status
```

### Checklist

Please include the following checklist in your PR:

- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
