### PR TITLE
Fixes for `--wasm-size-limit` option

### DIFF
--- a/build/build/src/project/wasm.rs
+++ b/build/build/src/project/wasm.rs
@@ -333,6 +333,8 @@ impl IsWatchable for Wasm {
             }
             if let Some(wasm_size_limit) = wasm_size_limit {
                 watch_cmd.args(["--wasm-size-limit", wasm_size_limit.to_string().as_str()]);
+            } else {
+                watch_cmd.args(["--wasm-size-limit", "0"]);
             }
 
             // === cargo-watch options ===

--- a/build/cli/src/arg/wasm.rs
+++ b/build/cli/src/arg/wasm.rs
@@ -85,7 +85,11 @@ pub struct BuildInput {
 
     /// Fail the build if compressed WASM exceeds the specified size. Supports format like
     /// "4.06MiB". Pass "0" to disable check.
-    #[clap(long, enso_env(), default_value_if("skip_wasm_opt", Some("true"), Some("0")), maybe_default = DEFAULT_WASM_SIZE_LIMIT.get())]
+    #[clap(long, enso_env(),
+        maybe_default = DEFAULT_WASM_SIZE_LIMIT.get(),
+        default_value_if("skip-wasm-opt", Some("true"), Some("0")),
+        default_value_if("skip-wasm-opt", None, Some("0")),
+    )]
     pub wasm_size_limit: Option<byte_unit::Byte>,
 }
 


### PR DESCRIPTION
### Pull Request Description
It will be properly propagated to `cargo-watch` when set to 0 and will use use 0 as a default if `--skip-wasm-opt` is given.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
