### PR TITLE
Speeding up Array_Proxy.from_proxy_object twice

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array_Proxy.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array_Proxy.enso
@@ -33,4 +33,4 @@ type Array_Proxy
        methods.
     from_proxy_object : Any -> Array
     from_proxy_object proxy =
-        Array_Proxy.new proxy.length proxy.at
+        Array_Proxy.new proxy.length (i -> proxy.at i)

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/SrcUtil.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/SrcUtil.java
@@ -1,0 +1,21 @@
+package org.enso.interpreter.bench.benchmarks.semantic;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import org.graalvm.polyglot.Source;
+
+final class SrcUtil {
+  private SrcUtil() {
+  }
+
+  static Source source(String benchmarkName, String code) throws IOException {
+    var d = new File(new File(new File("."), "target"), "bench-data");
+    d.mkdirs();
+    var f = new File(d, benchmarkName + ".enso");
+    try ( var w = new FileWriter(f)) {
+      w.write(code);
+    }
+    return Source.newBuilder("enso", f).build();
+  }
+}

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/VectorBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/VectorBenchmarks.java
@@ -1,15 +1,12 @@
     package org.enso.interpreter.bench.benchmarks.semantic;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileWriter;
 import java.nio.file.Paths;
 import java.util.AbstractList;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Engine;
-import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -51,6 +48,7 @@ public class VectorBenchmarks {
       .allowAllAccess(true)
       .build();
 
+    var benchmarkName = params.getBenchmark().replaceFirst(".*\\.", "");
     var code = """
         import Standard.Base.Data.Vector.Vector
         import Standard.Base.Data.Array_Proxy.Array_Proxy
@@ -81,7 +79,8 @@ public class VectorBenchmarks {
         create_array_proxy vec =
           Array_Proxy.from_proxy_object vec
         """;
-    var module = ctx.eval("enso", code);
+
+    var module = ctx.eval(SrcUtil.source(benchmarkName, code));
 
     this.self = module.invokeMember("get_associated_type");
     Function<String,Value> getMethod = (name) -> module.invokeMember("get_method", self, name);
@@ -89,7 +88,7 @@ public class VectorBenchmarks {
     var length = 1000;
     Value vec = getMethod.apply("fibarr").execute(self, length, Integer.MAX_VALUE);
 
-    switch (params.getBenchmark().replaceFirst(".*\\.", "")) {
+    switch (benchmarkName) {
       case "averageOverVector": {
         this.arrayOfFibNumbers = vec;
         break;


### PR DESCRIPTION
### Pull Request Description

Using lambda instead of higher order function.

### Important Notes

Running:
```
sbt:runtime> benchOnly VectorBenchmarks.averageOverArrayProxy
```
speeds up from `0.038 ms/op` to `0.016 ms/op` on my computer. Which seems good enough.

### Checklist

- All code has been tested:
  - [x] Benchmark is improved
