### PR TITLE
ExpressionNodes are only wrapped in the presence of Chrome inspector

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/ExpressionNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/ExpressionNode.java
@@ -20,6 +20,7 @@ import com.oracle.truffle.api.nodes.UnexpectedResultException;
 import com.oracle.truffle.api.source.SourceSection;
 import java.util.UUID;
 import org.enso.interpreter.instrument.HostObjectDebugWrapper;
+import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
@@ -223,7 +224,12 @@ public abstract class ExpressionNode extends BaseNode implements InstrumentableN
    */
   @OutgoingConverter
   public Object wrapHostObjects(Object retValue) {
-    return HostObjectDebugWrapper.wrapHostValues(retValue, InteropLibrary.getUncached());
+    // Wrap only if chrome inspector is attached.
+    if (EnsoContext.get(this).getChromeInspectorNotAttached().isValid()) {
+      return retValue;
+    } else {
+      return HostObjectDebugWrapper.wrapHostValues(retValue, InteropLibrary.getUncached());
+    }
   }
 
   @ExportMessage

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -1,6 +1,8 @@
 package org.enso.interpreter.runtime;
 
+import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.TruffleFile;
 import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.TruffleLanguage.Env;
@@ -67,6 +69,9 @@ public class EnsoContext {
   private final DistributionManager distributionManager;
   private final LockManager lockManager;
   private final AtomicLong clock = new AtomicLong();
+
+  private final Assumption chromeInspectorNotAttached =
+      Truffle.getRuntime().createAssumption("chromeInspectorNotAttached");
 
   private final Shape rootStateShape = Shape.newBuilder().layout(State.Container.class).build();
   private final IOPermissions rootIOPermissions;
@@ -201,6 +206,11 @@ public class EnsoContext {
    */
   public final Compiler getCompiler() {
     return compiler;
+  }
+
+  /** Returns an {@link Assumption} that Chrome inspector is not attached to this context. */
+  public Assumption getChromeInspectorNotAttached() {
+    return chromeInspectorNotAttached;
   }
 
   /**


### PR DESCRIPTION
### Pull Request Description

Fixes bug in visualization of host polyglot values - `ExpressionNode` is only wrapped once Chrome inspector instrument is attached to the context. With this fix, when chromeinspector is attached (`enso --run --inspect ...`), all the host values are reinterpreted as text - the assumption is invalidated. But when running as language server, nothing is wrapped.

### Important Notes


### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
