### PR TITLE
Dump where AvoidIdInstrumentationTag is placed

### DIFF
--- a/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/AvoidIdTagTest.java
+++ b/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/AvoidIdTagTest.java
@@ -1,0 +1,92 @@
+package org.enso.interpreter.test.instrument;
+import com.oracle.truffle.api.debug.Debugger;
+import com.oracle.truffle.api.instrumentation.InstrumentableNode;
+import com.oracle.truffle.api.instrumentation.StandardTags;
+import java.io.OutputStream;
+import java.nio.file.Paths;
+import java.util.Map;
+import org.enso.interpreter.runtime.tag.AvoidIdInstrumentationTag;
+import org.enso.interpreter.runtime.tag.IdentifiedTag;
+import org.enso.interpreter.test.NodeCountingTestInstrument;
+import org.enso.interpreter.test.instrument.RuntimeServerTest.TestContext;
+import org.enso.polyglot.RuntimeOptions;
+import org.enso.polyglot.runtime.Runtime$Api$InitializedNotification;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.Language;
+import org.junit.After;
+import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AvoidIdTagTest {
+
+  private Engine engine;
+  private Context context;
+
+  @Before
+  public void initContext() {
+    engine = Engine.newBuilder()
+        .allowExperimentalOptions(true)
+        .option(
+            RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
+            Paths.get("../../distribution/component").toFile().getAbsolutePath()
+        )
+        .logHandler(OutputStream.nullOutputStream())
+        .build();
+
+    context = Context.newBuilder()
+        .engine(engine)
+        .allowExperimentalOptions(true)
+        .allowIO(true)
+        .allowAllAccess(true)
+        .build();
+
+    Map<String, Language> langs = engine.getLanguages();
+    Assert.assertNotNull("Enso found: " + langs, langs.get("enso"));
+  }
+
+  @After
+  public void disposeContext() {
+    context.close();
+    engine.close();
+  }
+
+  @Test
+  public void instrumentedNodes() {
+    var nodes = engine.getInstruments().get(NodeCountingTestInstrument.INSTRUMENT_ID).lookup(NodeCountingTestInstrument.class);
+    nodes.enable();
+
+    var code = """
+    from Standard.Base import all
+    import Standard.Visualization
+
+    run n = 0.up_to n . map i-> 1.noise * i
+    """;
+
+    var module = context.eval("enso", code);
+    var run = module.invokeMember("eval_expression", "run");
+    var res = run.execute(10000);
+    var found = nodes.assertNewNodes("Give me nodes", 0, 10000);
+
+    for (var nn : found.values()) {
+      for (var n : nn) {
+        var ss = n.getSourceSection();
+        if (ss == null) {
+          continue;
+        }
+        var st = ss.getCharacters().toString();
+        if (st.contains("noise")) {
+          System.err.println("code: " + st + " for node " + n.getClass().getName());
+          if (n instanceof InstrumentableNode in) {
+            System.err.println("  AvoidIdInstrumentationTag: " + in.hasTag(AvoidIdInstrumentationTag.class));
+            System.err.println("  IdentifiedTag: " + in.hasTag(IdentifiedTag.class));
+            System.err.println("  ExpressionTag: " + in.hasTag(StandardTags.ExpressionTag.class));
+          }
+        }
+      }
+    }
+  }
+}

--- a/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/AvoidIdTagTest.java
+++ b/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/AvoidIdTagTest.java
@@ -1,5 +1,4 @@
 package org.enso.interpreter.test.instrument;
-import com.oracle.truffle.api.debug.Debugger;
 import com.oracle.truffle.api.instrumentation.InstrumentableNode;
 import com.oracle.truffle.api.instrumentation.StandardTags;
 import java.io.OutputStream;
@@ -8,16 +7,12 @@ import java.util.Map;
 import org.enso.interpreter.runtime.tag.AvoidIdInstrumentationTag;
 import org.enso.interpreter.runtime.tag.IdentifiedTag;
 import org.enso.interpreter.test.NodeCountingTestInstrument;
-import org.enso.interpreter.test.instrument.RuntimeServerTest.TestContext;
 import org.enso.polyglot.RuntimeOptions;
-import org.enso.polyglot.runtime.Runtime$Api$InitializedNotification;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Engine;
 import org.graalvm.polyglot.Language;
 import org.junit.After;
 import org.junit.Assert;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -78,12 +73,13 @@ public class AvoidIdTagTest {
           continue;
         }
         var st = ss.getCharacters().toString();
-        if (st.contains("noise")) {
+        if (st.contains("noise") && !st.contains("map")) {
           System.err.println("code: " + st + " for node " + n.getClass().getName());
           if (n instanceof InstrumentableNode in) {
             System.err.println("  AvoidIdInstrumentationTag: " + in.hasTag(AvoidIdInstrumentationTag.class));
             System.err.println("  IdentifiedTag: " + in.hasTag(IdentifiedTag.class));
             System.err.println("  ExpressionTag: " + in.hasTag(StandardTags.ExpressionTag.class));
+            System.err.println("  RootNode: " + n.getRootNode());
           }
         }
       }

--- a/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/AvoidIdTagTest.java
+++ b/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/AvoidIdTagTest.java
@@ -4,6 +4,7 @@ import com.oracle.truffle.api.instrumentation.StandardTags;
 import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.util.Map;
+import org.enso.interpreter.node.ClosureRootNode;
 import org.enso.interpreter.runtime.tag.AvoidIdInstrumentationTag;
 import org.enso.interpreter.runtime.tag.IdentifiedTag;
 import org.enso.interpreter.test.NodeCountingTestInstrument;
@@ -80,6 +81,10 @@ public class AvoidIdTagTest {
             System.err.println("  IdentifiedTag: " + in.hasTag(IdentifiedTag.class));
             System.err.println("  ExpressionTag: " + in.hasTag(StandardTags.ExpressionTag.class));
             System.err.println("  RootNode: " + n.getRootNode());
+            if (n.getRootNode() instanceof ClosureRootNode crn) {
+              System.err.println("  crn.subject to instr: " + crn.isSubjectToInstrumentation());
+              System.err.println("  crn.used in bindings: " + crn.isUsedInBinding());
+            }
           }
         }
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/FunctionCallInstrumentationNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/FunctionCallInstrumentationNode.java
@@ -21,6 +21,8 @@ import org.enso.interpreter.runtime.tag.IdentifiedTag;
 
 import java.util.Arrays;
 import java.util.UUID;
+import org.enso.interpreter.node.ClosureRootNode;
+import org.enso.interpreter.runtime.tag.AvoidIdInstrumentationTag;
 
 /**
  * A node used for instrumenting function calls. It does nothing useful from the language
@@ -151,6 +153,9 @@ public class FunctionCallInstrumentationNode extends Node implements Instrumenta
    */
   @Override
   public boolean hasTag(Class<? extends Tag> tag) {
+    if (AvoidIdInstrumentationTag.class == tag) {
+      return getRootNode() instanceof ClosureRootNode c && !c.isSubjectToInstrumentation();
+    }
     return tag == StandardTags.CallTag.class || (tag == IdentifiedTag.class && id != null);
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/function/StatementNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/function/StatementNode.java
@@ -4,7 +4,9 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.StandardTags;
 import com.oracle.truffle.api.instrumentation.Tag;
 import com.oracle.truffle.api.source.SourceSection;
+import org.enso.interpreter.node.ClosureRootNode;
 import org.enso.interpreter.node.ExpressionNode;
+import org.enso.interpreter.runtime.tag.AvoidIdInstrumentationTag;
 
 /**
  * Node tagged with {@link StandardTags.StatementTag}. Inserted by {@link BlockNode} into the AST
@@ -42,6 +44,9 @@ final class StatementNode extends ExpressionNode {
 
   @Override
   public boolean hasTag(Class<? extends Tag> tag) {
+    if (AvoidIdInstrumentationTag.class == tag) {
+      return getRootNode() instanceof ClosureRootNode c && !c.isSubjectToInstrumentation();
+    }
     return StandardTags.StatementTag.class == tag;
   }
 }


### PR DESCRIPTION
### Pull Request Description

Fighting with _too many messages being delivered_ I wrote a test that dumps information about `AvoidIdInstrumentationTag` - every node that has `AvoidIdInstrumentationTag` is excluded from the instrumentation. However, when I look at the output for
```
    from Standard.Base import all
    import Standard.Visualization

    run n = 0.up_to n . map i-> 1.noise * i
```
I see that `1.noise` didn't have the tag. Now there is [AvoidIdInstrumentationTagTest.java](https://github.com/enso-org/enso/pull/3973/files#diff-32cd9240bda2bfe0e5904695ced008daba86fefb3d137ac401997f4265fa50eb) which can be used to collect all programs where _too many messages is being delivered_. Just add a program, identify _isLambda_ and verify all nodes are properly tagged.

### Test Output

```
code: 1.noise for node org.enso.interpreter.node.callable.ApplicationNode
  AvoidIdInstrumentationTag: false
  IdentifiedTag: false
  ExpressionTag: true
  RootNode: <anonymous><arg-0>
  crn.subject to instr: true
  crn.used in bindings: false
code: 1.noise for node org.enso.interpreter.node.callable.FunctionCallInstrumentationNode
  AvoidIdInstrumentationTag: false
  IdentifiedTag: false
  ExpressionTag: false
  RootNode: <anonymous><arg-0>
  crn.subject to instr: true
  crn.used in bindings: false
code: noise for node org.enso.interpreter.node.expression.constant.DynamicSymbolNode
  AvoidIdInstrumentationTag: false
  IdentifiedTag: false
  ExpressionTag: true
  RootNode: <anonymous><arg-0>
  crn.subject to instr: true
  crn.used in bindings: false
```

### Passing thru _subject to instrumentation_

I modified the `IrToTruffle` to pass _subject to instrumentation_ information to _embedded lambdas_ and looks like the scenario reported by @jdunkerley  is working:

![obrazek](https://user-images.githubusercontent.com/26887752/207260515-50c069df-d3aa-4e3a-946d-c35f327f5071.png)

Seven hundred milliseconds is way better than 19s mentioned in the original [bug report](https://www.pivotaltracker.com/n/projects/2539304/stories/184011316).

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
