### PR TITLE
Windows doesn't like resolving last commit with `refs/heads/master`

### DIFF
--- a/docs/language-server/protocol-language-server.md
+++ b/docs/language-server/protocol-language-server.md
@@ -2755,7 +2755,7 @@ project includes:
 - `dirtty` flag, indicating if any of the project files has been modified, added
   or deleted
 - list of paths to the modified files, if any
-- the metadata of a last save
+- the metadata of a last save, if any
 
 #### Parameters
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/vcs/StatusVcsHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/vcs/StatusVcsHandler.scala
@@ -49,7 +49,11 @@ class StatusVcsHandler(
       replyTo ! ResponseResult(
         StatusVcs,
         id,
-        StatusVcs.Result(isModified, changed, StatusVcs.Save(last._1, last._2))
+        StatusVcs.Result(
+          isModified,
+          changed,
+          last.map(commit => StatusVcs.Save(commit._1, commit._2))
+        )
       )
       cancellable.cancel()
       context.stop(self)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/Git.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/Git.scala
@@ -232,7 +232,7 @@ private class Git(ensoDataDirectory: Option[Path]) extends VcsApi[BlockingIO] {
             val log = logs.next()
             Option(RepoCommit(log.getName, log.getShortMessage()))
           } else None
-        }) getOrElse null
+        })
       RepoStatus(changed.nonEmpty, changedPaths, last)
     }.mapError(errorHandling)
   }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/Git.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/Git.scala
@@ -19,7 +19,7 @@ import org.eclipse.jgit.util.SystemReader
 import org.enso.languageserver.vcsmanager.Git.{
   AuthorEmail,
   AuthorName,
-  MasterRef,
+  HeadRef,
   RepoExists
 }
 
@@ -226,7 +226,7 @@ private class Git(ensoDataDirectory: Option[Path]) extends VcsApi[BlockingIO] {
       val changedPaths = changed.map(name => Path.of(name)).toSet
       val logCmd       = jgit.log()
       val last =
-        Option(repo.resolve(MasterRef)) flatMap (_ => {
+        Option(repo.resolve(HeadRef)) flatMap (_ => {
           val logs = logCmd.setMaxCount(1).call().iterator()
           if (logs.hasNext()) {
             val log = logs.next()
@@ -301,7 +301,7 @@ private class Git(ensoDataDirectory: Option[Path]) extends VcsApi[BlockingIO] {
 }
 
 object Git {
-  private val MasterRef   = "refs/heads/master"
+  private val HeadRef     = "HEAD"
   private val AuthorName  = "Enso VCS"
   private val AuthorEmail = "vcs@enso.io"
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/VcsApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/VcsApi.scala
@@ -72,12 +72,12 @@ object VcsApi {
   *
   * @param isDirty `true`, if there are any unsaved changes to the project, `false` otherwise
   * @param changed list of modified, new or deleted files that have not yet been recorded permanently in VCS
-  * @param lastCommit metadata of the last commit recorder for the project
+  * @param lastCommit optional metadata of the last commit recorder for the project
   */
 case class RepoStatus(
   isDirty: Boolean,
   changed: Set[Path],
-  lastCommit: RepoCommit
+  lastCommit: Option[RepoCommit]
 )
 
 /** Encapsulates metadata of a single commit of the project.

--- a/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/VcsManager.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/VcsManager.scala
@@ -92,7 +92,7 @@ class VcsManager(
               (
                 status.isDirty,
                 status.changed.map(f => Path(repoRoot.rootId, f)).toList,
-                RepoCommit.unapply(status.lastCommit).get
+                status.lastCommit.flatMap(RepoCommit.unapply)
               )
             )
           )

--- a/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/VcsManagerApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/VcsManagerApi.scala
@@ -33,7 +33,11 @@ object VcsManagerApi {
 
   case object StatusVcs extends Method("vcs/status") {
     case class Params(root: Path)
-    case class Result(dirty: Boolean, changed: List[Path], lastSave: Save)
+    case class Result(
+      dirty: Boolean,
+      changed: List[Path],
+      lastSave: Option[Save]
+    )
     case class Save(commitId: String, message: String)
 
     implicit val hasParams = new HasParams[this.type] {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/VcsProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/VcsProtocol.scala
@@ -31,8 +31,8 @@ object VcsProtocol {
   case class StatusRepo(clientId: ClientId, root: Path)
 
   case class StatusRepoResponse(
-    result: Either[VcsFailure, (Boolean, List[Path], (String, String))]
-  ) extends VCSResponse[(Boolean, List[Path], (String, String))]
+    result: Either[VcsFailure, (Boolean, List[Path], Option[(String, String)])]
+  ) extends VCSResponse[(Boolean, List[Path], Option[(String, String)])]
 
   case class ListRepo(clientId: ClientId, root: Path, limit: Option[Int])
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/vcsmanager/GitSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/vcsmanager/GitSpec.scala
@@ -145,7 +145,7 @@ class GitSpec extends AnyWordSpecLike with Matchers with Effects {
       val r = modifiedResultEither1.getOrElse(null)
       r shouldBe an[RepoStatus]
       repoStatusIgnoreSha(r) should equal(
-        RepoStatus(false, Set(), RepoCommit(null, "Initial commit"))
+        RepoStatus(false, Set(), Some(RepoCommit(null, "Initial commit")))
       )
 
       createStubFile(repoPath.resolve("Foo.enso")) should equal(true)
@@ -162,7 +162,7 @@ class GitSpec extends AnyWordSpecLike with Matchers with Effects {
       val r = modifiedResultEither1.getOrElse(null)
       r shouldBe an[RepoStatus]
       repoStatusIgnoreSha(r) should equal(
-        RepoStatus(false, Set(), RepoCommit(null, "Initial commit"))
+        RepoStatus(false, Set(), Some(RepoCommit(null, "Initial commit")))
       )
 
       createStubFile(repoPath.resolve("Foo.enso")) should equal(true)
@@ -177,7 +177,7 @@ class GitSpec extends AnyWordSpecLike with Matchers with Effects {
       repoStatusIgnoreSha(r2) shouldBe RepoStatus(
         false,
         Set(),
-        RepoCommit(null, "New files")
+        Some(RepoCommit(null, "New files"))
       )
     }
 
@@ -200,7 +200,7 @@ class GitSpec extends AnyWordSpecLike with Matchers with Effects {
       repoStatusIgnoreSha(r) shouldBe RepoStatus(
         true,
         Set(fooFile.getFileName),
-        RepoCommit(null, "New files")
+        Some(RepoCommit(null, "New files"))
       )
 
     }
@@ -391,7 +391,7 @@ class GitSpec extends AnyWordSpecLike with Matchers with Effects {
     }
 
     def repoStatusIgnoreSha(r: RepoStatus) = {
-      r.copy(lastCommit = r.lastCommit.copy(commitId = null))
+      r.copy(lastCommit = r.lastCommit.map(_.copy(commitId = null)))
     }
   }
 


### PR DESCRIPTION
### Pull Request Description

Apparently
```
git --git-dir .enso/.vcs log refs/heads/master
fatal: ambiguous argument 'refs/heads/master': unknown revision or path not in the working tree.
```
but
```
git --git-dir .enso/.vcs log HEAD
fatal: ambiguous argument 'refs/heads/master': unknown revision or path not in the working tree.
```
works just fine on Windows.

Added some safeguards to avoid propagating weird errors because of retrieving element from an
empty Option.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
