### PR TITLE
Better handling of negative constants in case_of

### DIFF
--- a/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
@@ -636,6 +636,9 @@ final class TreeToIr {
           case "->" -> {
             // Old-style lambdas; this syntax will be eliminated after the parser transition is complete.
             var arg = app.getLhs();
+            if (arg == null) {
+              yield translateSyntaxError(app, IR$Error$Syntax$UnexpectedExpression$.MODULE$);
+            }
             var isSuspended = new boolean[1];
             if (arg instanceof Tree.UnaryOprApp susApp && "~".equals(susApp.getOpr().codeRepr())) {
                 arg = susApp.getRhs();
@@ -1213,6 +1216,18 @@ final class TreeToIr {
         new IR$Pattern$Literal(translateLiteral(lit), getIdentifiedLocation(lit), meta(), diag());
       case Tree.Number num ->
         new IR$Pattern$Literal((IR.Literal) translateNumber(num), getIdentifiedLocation(num), meta(), diag());
+      case Tree.UnaryOprApp num when num.getOpr().codeRepr().equals("-") -> {
+        var n = (IR$Literal$Number) translateExpression(num.getRhs());
+        var t = n.copy(
+          n.copy$default$1(),
+          "-" + n.copy$default$2(),
+          n.copy$default$3(),
+          n.copy$default$4(),
+          n.copy$default$5(),
+          n.copy$default$6()
+        );
+        yield new IR$Pattern$Literal(t, getIdentifiedLocation(num), meta(), diag());
+      }
       case Tree.TypeAnnotated anno -> {
         var type = buildNameOrQualifiedName(maybeManyParensed(anno.getType()));
         var expr = buildNameOrQualifiedName(maybeManyParensed(anno.getExpression()));

--- a/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
@@ -75,6 +75,16 @@ public class ErrorCompilerTest {
   }
 
   @Test
+  public void badCase4() throws Exception {
+    var ir = parseTest("""
+    main =
+        case value of
+        -1 ->"minus one"
+    """);
+    assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 32, 45);
+  }
+
+  @Test
   public void malformedSequence1() throws Exception {
     var ir = parseTest("(1, )");
     assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression.", 0, 5);

--- a/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
@@ -1,0 +1,49 @@
+package org.enso.compiler;
+
+import java.io.OutputStream;
+import java.nio.file.Paths;
+import org.enso.polyglot.RuntimeOptions;
+import org.graalvm.polyglot.Context;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class ExecCompilerTest {
+  private static Context ctx;
+
+  @BeforeClass
+  public static void initEnsoContext() {
+    ctx = Context.newBuilder()
+        .allowExperimentalOptions(true)
+        .allowIO(true)
+        .option(
+            RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
+            Paths.get("../../distribution/component").toFile().getAbsolutePath()
+        )
+        .logHandler(OutputStream.nullOutputStream())
+        .allowAllAccess(true)
+        .build();
+    assertNotNull("Enso language is supported", ctx.getEngine().getLanguages().get("enso"));
+  }
+
+  @AfterClass
+  public static void closeEnsoContext() throws Exception {
+    ctx.close();
+  }
+
+  @Test
+  public void testCaseOfWithNegativeConstant() throws Exception {
+    var module = ctx.eval("enso", """
+    run value =
+        case value of
+            -1 -> "minus one"
+            _ -> "none"
+    """);
+    var run = module.invokeMember("eval_expression", "run");
+    var minusOne = run.execute(-1);
+    assertEquals("minus one", minusOne.asString());
+    var none = run.execute(33);
+    assertEquals("none", none.asString());
+  }
+}


### PR DESCRIPTION
### Pull Request Description

```
from Standard.Base import all

main = 
    value = 1

    case value of
        1 -> IO.println "one"
        2 -> IO.println "two"
        -1 -> IO.println "minus one"
        _ -> IO.println "other"
```


### Important Notes

Had to write new `ExecCompilerTest` as comparing the AST with old compiler produced miserable results - the old AST wasn't ready for negative constants in `case of` at all.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
