### PR TITLE
Efficient joining for Equals and Equals_Ignore_Case using a hashmap

### DIFF
--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Join_Condition.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Join_Condition.enso
@@ -2,15 +2,15 @@ from Standard.Base import all
 
 type Join_Condition
     ## Specifies a join condition that correlates rows from the two tables if
-       the element from the `left_column` of the left table is equal to the
-       element from the `right_column` of the right table.
+       the element from the `left` of the left table is equal to the element
+       from the `right` of the right table.
 
        Missing values are treated as equal to each other.
 
        Arguments:
-        - left_column: A name or index of a column in the left table.
-        - right_column: A name or index of a column in the right table.
-    Equals (left_column : Text | Integer) (right_column : Text | Integer)
+        - left: A name or index of a column in the left table.
+        - right: A name or index of a column in the right table.
+    Equals (left : Text | Integer) (right : Text | Integer = left)
 
     ## Specifies a join condition that correlates rows from the two tables if
        the element from the `left` column of the left table is equal to the

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -73,7 +73,11 @@ type Table
             case c of
                 _ : Vector -> Column.from_vector (c.at 0) (c.at 1) . java_column
                 Column.Value java_col -> java_col
-        Table.Value (Java_Table.new cols.to_array)
+        # TODO enable this once we stop returning tables without columns
+        # if cols.is_empty then Error.throw (Illegal_Argument.Error "Cannot create a table with no columns.") else
+        if (cols.all c-> c.getSize == cols.first.getSize).not then Error.throw (Illegal_Argument.Error "All columns must have the same row count.") else
+            if cols.distinct .getName . length != cols.length then Error.throw (Illegal_Argument.Error "Column names must be distinct.") else
+                Table.Value (Java_Table.new cols.to_array)
 
     ## Creates a new table from a vector of column names and a vector of vectors
        specifying row contents.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -518,7 +518,7 @@ type Table
 
         on_problems.attach_problems_before validated.problems <| Illegal_Argument.handle_java_exception <|
             java_key_columns = validated.key_columns.map .java_column
-            index = self.java_table.indexFromColumns java_key_columns.to_array Comparator.new
+            index = self.java_table.indexFromColumns java_key_columns.to_array
 
             new_columns = validated.valid_columns.map c->(Aggregate_Column_Helper.java_aggregator c.first c.second)
 
@@ -1297,7 +1297,7 @@ type Table
 
         on_problems.attach_problems_before (problem_builder.build_problemset) <| Illegal_Argument.handle_java_exception <|
             java_key_columns = grouping.map .java_column
-            index  = self.java_table.indexFromColumns java_key_columns.to_array Comparator.new
+            index  = self.java_table.indexFromColumns java_key_columns.to_array
 
             name_mapper = if matched_name.is_empty then Aggregate_Column_Helper.default_aggregate_column_name else
                 if validated_values.length == 1 then (_ -> "") else

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Aggregate_Column_Helper.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Aggregate_Column_Helper.enso
@@ -195,7 +195,7 @@ java_aggregator name column =
         Count _ -> CountAggregator.new name
         Count_Distinct columns _ ignore_nothing ->
             resolved = columns.map .java_column
-            CountDistinctAggregator.new name resolved.to_array ignore_nothing Comparator.new
+            CountDistinctAggregator.new name resolved.to_array ignore_nothing
         Count_Not_Nothing c _ -> CountNothingAggregator.new name c.java_column False
         Count_Nothing c _ -> CountNothingAggregator.new name c.java_column True
         Count_Not_Empty c _ -> CountEmptyAggregator.new name c.java_column False

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Join_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Join_Helpers.enso
@@ -40,6 +40,7 @@ type Join_Condition_Resolver
         conditions_vector = case conditions of
             _ : Vector -> conditions
             single_condition : Join_Condition -> [single_condition]
+            single_condition : Text -> [single_condition]
         handle_equals left_selector right_selector =
             left = resolve_left left_selector
             right = resolve_right right_selector

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Test_Reporter.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Test_Reporter.enso
@@ -24,6 +24,16 @@ wrap_junit_testsuites config builder ~action =
     result
 
 ## PRIVATE
+use_ansi_colors : Boolean
+use_ansi_colors = Environment.get "ENSO_TEST_ANSI_COLORS" . is_nothing . not
+
+## PRIVATE
+failure_message : Text
+failure_message =
+    fail = 'FAILED'
+    if use_ansi_colors then '\u001b[31;1m'+fail+'\u001b[0m' else fail
+
+## PRIVATE
    Prints a report on the tests to standard output.
 print_report : Test -> Suite_Config -> (StringBuilder|Nothing) -> Nothing
 print_report spec config builder =
@@ -71,7 +81,7 @@ print_report spec config builder =
                     if config.print_only_failures.not then
                         IO.println ("    - " + behavior.name + " " + make_behavior_description behavior)
                 Test_Result.Failure msg details ->
-                    IO.println ("    - [FAILED] " + behavior.name + " " + make_behavior_description behavior)
+                    IO.println ("    - ["+failure_message+"] " + behavior.name + " " + make_behavior_description behavior)
                     IO.println ("        Reason: " + msg)
                     if details.is_nothing.not then
                         IO.println details

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CatchTypeBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CatchTypeBranchNode.java
@@ -1,6 +1,7 @@
 package org.enso.interpreter.node.controlflow.caseexpr;
 
 import com.oracle.truffle.api.RootCallTarget;
+import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.InteropLibrary;
@@ -61,7 +62,7 @@ public abstract class CatchTypeBranchNode extends BranchNode {
     return isArrayType;
   }
 
-  @Specialization
+  @Fallback
   public void doValue(VirtualFrame frame, Object state, Object target) {
     Object typeOfTarget = typeOfNode.execute(target);
     boolean test = isSameObject.execute(expectedType, typeOfTarget);

--- a/std-bits/base/src/main/java/org/enso/base/polyglot/NumericConverter.java
+++ b/std-bits/base/src/main/java/org/enso/base/polyglot/NumericConverter.java
@@ -48,10 +48,13 @@ public class NumericConverter {
 
   /** Returns true if the object is any supported number. */
   public static boolean isCoercibleToDouble(Object o) {
+    return isDecimalLike(o)|| isCoercibleToLong(o);
+  }
+
+  public static boolean isDecimalLike(Object o) {
     return o instanceof Double
         || o instanceof BigDecimal
-        || o instanceof Float
-        || isCoercibleToLong(o);
+        || o instanceof Float;
   }
 
   /**

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Aggregator.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Aggregator.java
@@ -65,38 +65,4 @@ public abstract class Aggregator {
     }
     problems.add(problem);
   }
-
-  protected static Long CastToLong(Object value) {
-    if (value instanceof Long) {
-      return (Long) value;
-    } else if (value instanceof Integer) {
-      return ((Integer) value).longValue();
-    } else if (value instanceof Byte) {
-      return ((Byte) value).longValue();
-    } else if (value instanceof Float && ((Float) value) % 1 == 0) {
-      // Only return if an integer stored as a float ( % 1 == 0)
-      return ((Float) value).longValue();
-    } else if (value instanceof Double && ((Double) value) % 1 == 0) {
-      // Only return if an integer stored as a double ( % 1 == 0)
-      return ((Double) value).longValue();
-    }
-
-    return null;
-  }
-
-  protected static Double CastToDouble(Object value) {
-    if (value instanceof Long) {
-      return ((Long) value).doubleValue();
-    } else if (value instanceof Integer) {
-      return ((Integer) value).doubleValue();
-    } else if (value instanceof Byte) {
-      return ((Byte) value).doubleValue();
-    } else if (value instanceof Float) {
-      return ((Float) value).doubleValue();
-    } else if (value instanceof Double) {
-      return ((Double) value);
-    }
-
-    return null;
-  }
 }

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/CountDistinct.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/CountDistinct.java
@@ -32,7 +32,8 @@ public class CountDistinct extends Aggregator {
     super(name, Storage.Type.LONG);
     this.storage = Arrays.stream(columns).map(Column::getStorage).toArray(Storage[]::new);
     this.ignoreAllNull = ignoreAllNull;
-    textFoldingStrategy = ConstantList.make(TextFoldingStrategy.unicodeNormalizedFold, storage.length);
+    textFoldingStrategy =
+        ConstantList.make(TextFoldingStrategy.unicodeNormalizedFold, storage.length);
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/CountDistinct.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/CountDistinct.java
@@ -1,9 +1,11 @@
 package org.enso.table.aggregations;
 
+import org.enso.base.text.TextFoldingStrategy;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.index.UnorderedMultiValueKey;
 import org.enso.table.data.table.Column;
 import org.enso.table.data.table.problems.FloatingPointGrouping;
+import org.enso.table.util.ConstantList;
 
 import java.util.Arrays;
 import java.util.Comparator;
@@ -16,7 +18,7 @@ import java.util.List;
  */
 public class CountDistinct extends Aggregator {
   private final Storage<?>[] storage;
-  private final Comparator<Object> objectComparator;
+  private final List<TextFoldingStrategy> textFoldingStrategy;
   private final boolean ignoreAllNull;
 
   /**
@@ -26,19 +28,18 @@ public class CountDistinct extends Aggregator {
    * @param columns input columns
    * @param ignoreAllNull if true ignore then all values are null
    */
-  public CountDistinct(
-      String name, Column[] columns, boolean ignoreAllNull, Comparator<Object> objectComparator) {
+  public CountDistinct(String name, Column[] columns, boolean ignoreAllNull) {
     super(name, Storage.Type.LONG);
     this.storage = Arrays.stream(columns).map(Column::getStorage).toArray(Storage[]::new);
     this.ignoreAllNull = ignoreAllNull;
-    this.objectComparator = objectComparator;
+    textFoldingStrategy = ConstantList.make(TextFoldingStrategy.unicodeNormalizedFold, storage.length);
   }
 
   @Override
   public Object aggregate(List<Integer> indexes) {
     HashSet<UnorderedMultiValueKey> set = new HashSet<>();
     for (int row : indexes) {
-      UnorderedMultiValueKey key = new UnorderedMultiValueKey(storage, row);
+      UnorderedMultiValueKey key = new UnorderedMultiValueKey(storage, row, textFoldingStrategy);
       if (key.hasFloatValues()) {
         this.addProblem(new FloatingPointGrouping(this.getName(), row));
       }

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Mean.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Mean.java
@@ -1,5 +1,6 @@
 package org.enso.table.aggregations;
 
+import org.enso.base.polyglot.NumericConverter;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.table.Column;
 import org.enso.table.data.table.problems.InvalidAggregation;
@@ -31,7 +32,7 @@ public class Mean extends Aggregator {
     for (int row : indexes) {
       Object value = storage.getItemBoxed(row);
       if (value != null) {
-        Double dValue = CastToDouble(value);
+        Double dValue = NumericConverter.tryConvertingToDouble(value);
         if (dValue == null) {
           this.addProblem(
               new InvalidAggregation(this.getName(), row, "Cannot convert to a number."));

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Mode.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Mode.java
@@ -1,5 +1,6 @@
 package org.enso.table.aggregations;
 
+import org.enso.base.polyglot.NumericConverter;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.table.Column;
 import org.enso.table.data.table.problems.FloatingPointGrouping;
@@ -26,9 +27,9 @@ public class Mode extends Aggregator {
       Object value = storage.getItemBoxed(row);
       if (value != null) {
         // Merge all numbers onto a Long if possible or a Double if needed
-        Long lValue = CastToLong(value);
+        Long lValue = NumericConverter.tryConvertingToLong(value);
         if (lValue == null) {
-          Double dValue = CastToDouble(value);
+          Double dValue = NumericConverter.tryConvertingToDouble(value);
           if (dValue != null) {
             this.addProblem(new FloatingPointGrouping(this.getName(), row));
             value = dValue;

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Percentile.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Percentile.java
@@ -1,5 +1,6 @@
 package org.enso.table.aggregations;
 
+import org.enso.base.polyglot.NumericConverter;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.table.Column;
 import org.enso.table.data.table.problems.InvalidAggregation;
@@ -27,7 +28,7 @@ public class Percentile extends Aggregator {
     for (int row : indexes) {
       Object value = storage.getItemBoxed(row);
       if (value != null) {
-        Double dValue = CastToDouble(value);
+        Double dValue = NumericConverter.tryConvertingToDouble(value);
 
         if (dValue == null) {
           this.addProblem(

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/StandardDeviation.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/StandardDeviation.java
@@ -1,5 +1,6 @@
 package org.enso.table.aggregations;
 
+import org.enso.base.polyglot.NumericConverter;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.table.Column;
 import org.enso.table.data.table.problems.InvalidAggregation;
@@ -35,7 +36,7 @@ public class StandardDeviation extends Aggregator {
     for (int row : indexes) {
       Object value = storage.getItemBoxed(row);
       if (value != null) {
-        Double dValue = CastToDouble(value);
+        Double dValue = NumericConverter.tryConvertingToDouble(value);
         if (dValue == null) {
           this.addProblem(
               new InvalidAggregation(this.getName(), row, "Cannot convert to a number."));

--- a/std-bits/table/src/main/java/org/enso/table/aggregations/Sum.java
+++ b/std-bits/table/src/main/java/org/enso/table/aggregations/Sum.java
@@ -1,5 +1,6 @@
 package org.enso.table.aggregations;
 
+import org.enso.base.polyglot.NumericConverter;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.table.Column;
 import org.enso.table.data.table.problems.InvalidAggregation;
@@ -25,13 +26,13 @@ public class Sum extends Aggregator {
           current = 0L;
         }
 
-        Long lCurrent = CastToLong(current);
-        Long lValue = CastToLong(value);
+        Long lCurrent = NumericConverter.tryConvertingToLong(current);
+        Long lValue = NumericConverter.tryConvertingToLong(value);
         if (lCurrent != null && lValue != null) {
           current = lCurrent + lValue;
         } else {
-          Double dCurrent = CastToDouble(current);
-          Double dValue = CastToDouble(value);
+          Double dCurrent = NumericConverter.tryConvertingToDouble(current);
+          Double dValue = NumericConverter.tryConvertingToDouble(value);
           if (dCurrent != null && dValue != null) {
             current = dCurrent + dValue;
           } else {

--- a/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueIndex.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueIndex.java
@@ -75,7 +75,7 @@ public class MultiValueIndex<KeyType extends MultiValueKeyBase> {
     final int length = columns.length;
     final int size = locs.size();
 
-    boolean emptyScenario = size == 0 & keyColumnsLength == 0;
+    boolean emptyScenario = size == 0 && keyColumnsLength == 0;
     Builder[] storage =
         Arrays.stream(columns)
             .map(c -> Builder.getForType(c.getType(), emptyScenario ? 1 : size))

--- a/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueIndex.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueIndex.java
@@ -20,29 +20,38 @@ public class MultiValueIndex<KeyType extends MultiValueKeyBase> {
   private final Map<KeyType, List<Integer>> locs;
   private final AggregatedProblems problems;
 
-  public static MultiValueIndex<OrderedMultiValueKey> makeOrderedIndex(Column[] keyColumns, int tableSize, int[] ordering, Comparator<Object> objectComparator) {
+  public static MultiValueIndex<OrderedMultiValueKey> makeOrderedIndex(
+      Column[] keyColumns, int tableSize, int[] ordering, Comparator<Object> objectComparator) {
     TreeMap<OrderedMultiValueKey, List<Integer>> locs = new TreeMap<>();
-    final Storage<?>[] storage = Arrays.stream(keyColumns).map(Column::getStorage).toArray(Storage[]::new);
+    final Storage<?>[] storage =
+        Arrays.stream(keyColumns).map(Column::getStorage).toArray(Storage[]::new);
     IntFunction<OrderedMultiValueKey> keyFactory =
-      i -> new OrderedMultiValueKey(storage, i, ordering, objectComparator);
+        i -> new OrderedMultiValueKey(storage, i, ordering, objectComparator);
     return new MultiValueIndex<>(keyColumns, tableSize, locs, keyFactory);
   }
 
-  public static MultiValueIndex<UnorderedMultiValueKey> makeUnorderedIndex(Column[] keyColumns, int tableSize, List<TextFoldingStrategy> textFoldingStrategies) {
+  public static MultiValueIndex<UnorderedMultiValueKey> makeUnorderedIndex(
+      Column[] keyColumns, int tableSize, List<TextFoldingStrategy> textFoldingStrategies) {
     HashMap<UnorderedMultiValueKey, List<Integer>> locs = new HashMap<>();
-    final Storage<?>[] storage = Arrays.stream(keyColumns).map(Column::getStorage).toArray(Storage[]::new);
+    final Storage<?>[] storage =
+        Arrays.stream(keyColumns).map(Column::getStorage).toArray(Storage[]::new);
     IntFunction<UnorderedMultiValueKey> keyFactory =
-      i -> new UnorderedMultiValueKey(storage, i, textFoldingStrategies);
+        i -> new UnorderedMultiValueKey(storage, i, textFoldingStrategies);
     return new MultiValueIndex<>(keyColumns, tableSize, locs, keyFactory);
   }
 
-  public static MultiValueIndex<UnorderedMultiValueKey> makeUnorderedIndex(Column[] keyColumns, int tableSize, TextFoldingStrategy commonTextFoldingStrategy) {
-    List<TextFoldingStrategy> strategies = ConstantList.make(commonTextFoldingStrategy, keyColumns.length);
+  public static MultiValueIndex<UnorderedMultiValueKey> makeUnorderedIndex(
+      Column[] keyColumns, int tableSize, TextFoldingStrategy commonTextFoldingStrategy) {
+    List<TextFoldingStrategy> strategies =
+        ConstantList.make(commonTextFoldingStrategy, keyColumns.length);
     return makeUnorderedIndex(keyColumns, tableSize, strategies);
   }
 
   private MultiValueIndex(
-      Column[] keyColumns, int tableSize, Map<KeyType, List<Integer>> initialLocs, IntFunction<KeyType> keyFactory) {
+      Column[] keyColumns,
+      int tableSize,
+      Map<KeyType, List<Integer>> initialLocs,
+      IntFunction<KeyType> keyFactory) {
     this.keyColumnsLength = keyColumns.length;
     this.problems = new AggregatedProblems();
     this.locs = initialLocs;
@@ -114,7 +123,10 @@ public class MultiValueIndex<KeyType extends MultiValueKeyBase> {
     final int size = locs.size();
 
     var nameIndex =
-        MultiValueIndex.makeUnorderedIndex(new Column[] {nameColumn}, nameColumn.getSize(), TextFoldingStrategy.unicodeNormalizedFold);
+        MultiValueIndex.makeUnorderedIndex(
+            new Column[] {nameColumn},
+            nameColumn.getSize(),
+            TextFoldingStrategy.unicodeNormalizedFold);
     final int columnCount = groupingColumns.length + nameIndex.locs.size() * aggregates.length;
 
     // Create the storage

--- a/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueIndex.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueIndex.java
@@ -1,5 +1,6 @@
 package org.enso.table.data.index;
 
+import org.enso.base.text.TextFoldingStrategy;
 import org.enso.table.aggregations.Aggregator;
 import org.enso.table.data.column.builder.object.*;
 import org.enso.table.data.column.storage.Storage;
@@ -7,43 +8,50 @@ import org.enso.table.data.table.Column;
 import org.enso.table.data.table.Table;
 import org.enso.table.data.table.problems.AggregatedProblems;
 import org.enso.table.data.table.problems.FloatingPointGrouping;
+import org.enso.table.util.ConstantList;
 
 import java.util.*;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-public class MultiValueIndex {
+public class MultiValueIndex<KeyType extends MultiValueKeyBase> {
   private final int keyColumnsLength;
-  private final Map<MultiValueKeyBase, List<Integer>> locs;
+  private final Map<KeyType, List<Integer>> locs;
   private final AggregatedProblems problems;
-  private final Comparator<Object> comparator;
 
-  public MultiValueIndex(Column[] keyColumns, int tableSize, Comparator<Object> objectComparator) {
-    this(keyColumns, tableSize, null, objectComparator);
+  public static MultiValueIndex<OrderedMultiValueKey> makeOrderedIndex(Column[] keyColumns, int tableSize, int[] ordering, Comparator<Object> objectComparator) {
+    TreeMap<OrderedMultiValueKey, List<Integer>> locs = new TreeMap<>();
+    final Storage<?>[] storage = Arrays.stream(keyColumns).map(Column::getStorage).toArray(Storage[]::new);
+    IntFunction<OrderedMultiValueKey> keyFactory =
+      i -> new OrderedMultiValueKey(storage, i, ordering, objectComparator);
+    return new MultiValueIndex<>(keyColumns, tableSize, locs, keyFactory);
   }
 
-  public MultiValueIndex(
-      Column[] keyColumns, int tableSize, int[] ordering, Comparator<Object> objectComparator) {
+  public static MultiValueIndex<UnorderedMultiValueKey> makeUnorderedIndex(Column[] keyColumns, int tableSize, List<TextFoldingStrategy> textFoldingStrategies) {
+    HashMap<UnorderedMultiValueKey, List<Integer>> locs = new HashMap<>();
+    final Storage<?>[] storage = Arrays.stream(keyColumns).map(Column::getStorage).toArray(Storage[]::new);
+    IntFunction<UnorderedMultiValueKey> keyFactory =
+      i -> new UnorderedMultiValueKey(storage, i, textFoldingStrategies);
+    return new MultiValueIndex<>(keyColumns, tableSize, locs, keyFactory);
+  }
+
+  public static MultiValueIndex<UnorderedMultiValueKey> makeUnorderedIndex(Column[] keyColumns, int tableSize, TextFoldingStrategy commonTextFoldingStrategy) {
+    List<TextFoldingStrategy> strategies = ConstantList.make(commonTextFoldingStrategy, keyColumns.length);
+    return makeUnorderedIndex(keyColumns, tableSize, strategies);
+  }
+
+  private MultiValueIndex(
+      Column[] keyColumns, int tableSize, Map<KeyType, List<Integer>> initialLocs, IntFunction<KeyType> keyFactory) {
     this.keyColumnsLength = keyColumns.length;
-    this.comparator = objectComparator;
     this.problems = new AggregatedProblems();
-
-    boolean isOrdered = ordering != null;
-    this.locs = isOrdered ? new TreeMap<>() : new HashMap<>();
-
-    Storage<?>[] storage =
-        Arrays.stream(keyColumns).map(Column::getStorage).toArray(Storage[]::new);
-    IntFunction<MultiValueKeyBase> keyFactory =
-        isOrdered
-            ? i -> new OrderedMultiValueKey(storage, i, ordering, objectComparator)
-            : i -> new UnorderedMultiValueKey(storage, i);
+    this.locs = initialLocs;
 
     if (keyColumns.length != 0) {
       int size = keyColumns[0].getSize();
 
       for (int i = 0; i < size; i++) {
-        MultiValueKeyBase key = keyFactory.apply(i);
+        KeyType key = keyFactory.apply(i);
 
         if (key.hasFloatValues()) {
           final int row = i;
@@ -106,7 +114,7 @@ public class MultiValueIndex {
     final int size = locs.size();
 
     var nameIndex =
-        new MultiValueIndex(new Column[] {nameColumn}, nameColumn.getSize(), null, this.comparator);
+        MultiValueIndex.makeUnorderedIndex(new Column[] {nameColumn}, nameColumn.getSize(), TextFoldingStrategy.unicodeNormalizedFold);
     final int columnCount = groupingColumns.length + nameIndex.locs.size() * aggregates.length;
 
     // Create the storage
@@ -196,15 +204,15 @@ public class MultiValueIndex {
     return output;
   }
 
-  public Set<MultiValueKeyBase> keys() {
+  public Set<KeyType> keys() {
     return locs.keySet();
   }
 
-  public boolean contains(MultiValueKeyBase key) {
+  public boolean contains(KeyType key) {
     return this.locs.containsKey(key);
   }
 
-  public List<Integer> get(MultiValueKeyBase key) {
+  public List<Integer> get(KeyType key) {
     return this.locs.get(key);
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueKeyBase.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueKeyBase.java
@@ -32,8 +32,8 @@ public abstract class MultiValueKeyBase {
 
   /** Checks if all cells in the current row are missing. */
   public boolean areAllNull() {
-    for (Storage<?> value : storages) {
-      if (!value.isNa(rowIndex)) {
+    for (Storage<?> storage : storages) {
+      if (!storage.isNa(rowIndex)) {
         return false;
       }
     }

--- a/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueKeyBase.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/MultiValueKeyBase.java
@@ -1,5 +1,6 @@
 package org.enso.table.data.index;
 
+import org.enso.base.polyglot.NumericConverter;
 import org.enso.table.data.column.storage.Storage;
 
 import java.util.ArrayList;
@@ -52,14 +53,10 @@ public abstract class MultiValueKeyBase {
     return hasFloatValues;
   }
 
-  protected boolean isFloatingPoint(Object value) {
-    return value instanceof Double || value instanceof Float;
-  }
-
   private boolean findFloats() {
     for (int i = 0; i < storages.length; i++) {
       Object value = this.get(i);
-      if (isFloatingPoint(value)) {
+      if (NumericConverter.isDecimalLike(value)) {
         return true;
       }
     }
@@ -74,7 +71,7 @@ public abstract class MultiValueKeyBase {
     List<Integer> result = new ArrayList<>();
     for (int i = 0; i < storages.length; i++) {
       Object value = this.get(i);
-      if (isFloatingPoint(value)) {
+      if (NumericConverter.isDecimalLike(value)) {
         result.add(i);
       }
     }

--- a/std-bits/table/src/main/java/org/enso/table/data/index/UnorderedMultiValueKey.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/UnorderedMultiValueKey.java
@@ -6,6 +6,9 @@ import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.enso.base.polyglot.NumericConverter;
 import org.enso.base.text.TextFoldingStrategy;
@@ -34,10 +37,11 @@ public class UnorderedMultiValueKey extends MultiValueKeyBase {
     for (int i = 0; i < storages.length; i++) {
       h = 31 * h;
 
-      Object foldedValue = getObjectFolded(i);
-      if (foldedValue != null) {
-        hasFloatValues = hasFloatValues || NumericConverter.isDecimalLike(foldedValue);
-        h += foldedValue.hashCode();
+      Object value = this.get(i);
+      if (value != null) {
+        hasFloatValues = hasFloatValues || NumericConverter.isDecimalLike(value);
+        Object folded = foldObject(value, textFoldingStrategy.get(i));
+        h += folded.hashCode();
       }
     }
 
@@ -116,8 +120,8 @@ public class UnorderedMultiValueKey extends MultiValueKeyBase {
     if (storages.length != that.storages.length) return false;
     if (hashCodeValue != that.hashCodeValue) return false;
     for (int i = 0; i < storages.length; i++) {
-      Object thisFolded = getObjectFolded(i);
-      Object thatFolded = getObjectFolded(i);
+      Object thisFolded = this.getObjectFolded(i);
+      Object thatFolded = that.getObjectFolded(i);
       if (!Objects.equals(thisFolded, thatFolded)) {
         return false;
       }
@@ -129,5 +133,15 @@ public class UnorderedMultiValueKey extends MultiValueKeyBase {
   @Override
   public int hashCode() {
     return this.hashCodeValue;
+  }
+
+  @Override
+  public String toString() {
+    return "UnorderedMultiValueKey{"
+        + "hashCode="
+        + hashCodeValue
+        + ", values="
+        + IntStream.range(0, storages.length).mapToObj(i -> String.valueOf(this.get(i))).collect(Collectors.joining(", "))
+        + '}';
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/index/UnorderedMultiValueKey.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/UnorderedMultiValueKey.java
@@ -3,13 +3,10 @@ package org.enso.table.data.index;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
 import org.enso.base.polyglot.NumericConverter;
 import org.enso.base.text.TextFoldingStrategy;
 import org.enso.table.data.column.storage.Storage;
@@ -76,11 +73,15 @@ public class UnorderedMultiValueKey extends MultiValueKeyBase {
       return value;
     }
 
-    if (value instanceof LocalDate || value instanceof LocalTime || value instanceof ZonedDateTime) {
+    if (value instanceof LocalDate
+        || value instanceof LocalTime
+        || value instanceof ZonedDateTime) {
       return value;
     }
 
-    throw new IllegalArgumentException("Custom objects in UnorderedMultiValueKey are currently not supported due to lack of hashing support.");
+    throw new IllegalArgumentException(
+        "Custom objects in UnorderedMultiValueKey are currently not supported due to lack of"
+            + " hashing support.");
   }
 
   /**
@@ -91,7 +92,7 @@ public class UnorderedMultiValueKey extends MultiValueKeyBase {
    * Double} unless they represent a whole integer in which case they are also coerced to {@code
    * Long}, to ensure the Enso property that {@code 2 == 2.0}.
    *
-   * Returns {@code null} if the value was not a numeric value.
+   * <p>Returns {@code null} if the value was not a numeric value.
    */
   protected static Object foldNumeric(Object value) {
     if (value instanceof Long) {
@@ -141,7 +142,9 @@ public class UnorderedMultiValueKey extends MultiValueKeyBase {
         + "hashCode="
         + hashCodeValue
         + ", values="
-        + IntStream.range(0, storages.length).mapToObj(i -> String.valueOf(this.get(i))).collect(Collectors.joining(", "))
+        + IntStream.range(0, storages.length)
+            .mapToObj(i -> String.valueOf(this.get(i)))
+            .collect(Collectors.joining(", "))
         + '}';
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/index/UnorderedMultiValueKey.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/index/UnorderedMultiValueKey.java
@@ -5,6 +5,7 @@ import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 
+import org.enso.base.polyglot.NumericConverter;
 import org.enso.base.text.TextFoldingStrategy;
 import org.enso.table.data.column.storage.Storage;
 
@@ -37,7 +38,7 @@ public class UnorderedMultiValueKey extends MultiValueKeyBase {
 
       Object value = this.get(i);
       if (value != null) {
-        hasFloatValues = hasFloatValues || isFloatingPoint(value);
+        hasFloatValues = hasFloatValues || NumericConverter.isDecimalLike(value);
         Object folded = foldObject(value);
         h += folded.hashCode();
       }

--- a/std-bits/table/src/main/java/org/enso/table/data/table/Table.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/Table.java
@@ -221,11 +221,10 @@ public class Table {
    * Creates an index for this table by using values from the specified columns.
    *
    * @param columns set of columns to use as an Index
-   * @param objectComparator Object comparator allowing calling back to `compare_to` when needed.
    * @return a table indexed by the proper column
    */
-  public MultiValueIndex indexFromColumns(Column[] columns, Comparator<Object> objectComparator) {
-    return new MultiValueIndex(columns, this.rowCount(), objectComparator);
+  public MultiValueIndex<?> indexFromColumns(Column[] columns) {
+    return MultiValueIndex.makeUnorderedIndex(columns, this.rowCount(), TextFoldingStrategy.unicodeNormalizedFold);
   }
 
   /**
@@ -237,7 +236,7 @@ public class Table {
    */
   public Table orderBy(Column[] columns, Long[] directions, Comparator<Object> objectComparator) {
     int[] directionInts = Arrays.stream(directions).mapToInt(Long::intValue).toArray();
-    MultiValueIndex index = new MultiValueIndex(columns, this.rowCount(), directionInts, objectComparator);
+    MultiValueIndex<?> index = MultiValueIndex.makeOrderedIndex(columns, this.rowCount(), directionInts, objectComparator);
     OrderMask mask = new OrderMask(index.makeOrderMap(this.rowCount()));
     return this.applyMask(mask);
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/table/Table.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/Table.java
@@ -294,9 +294,7 @@ public class Table {
     JoinResult joinResult = null;
     // Only compute the join if there are any results to be returned.
     if (keepLeftUnmatched || keepMatched || keepRightUnmatched) {
-      // TODO We'll want a mixed strategy doing Index for supported conditions and then scanning on subgroups. For now Index works only for the simple happy path.
-      boolean allCanUseIndex = conditions.stream().allMatch(IndexJoin::isSupported);
-      JoinStrategy strategy = allCanUseIndex ? new IndexJoin(objectComparator) : new ScanJoin(objectComparator, equalityFallback);
+      JoinStrategy strategy = new IndexJoin(objectComparator, equalityFallback);
       joinResult = strategy.join(this, right, conditions);
     }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/table/join/IndexJoin.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/join/IndexJoin.java
@@ -1,5 +1,10 @@
 package org.enso.table.data.table.join;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 import org.enso.base.text.TextFoldingStrategy;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.index.MultiValueIndex;
@@ -10,91 +15,101 @@ import org.enso.table.data.table.join.scan.MatcherFactory;
 import org.enso.table.data.table.problems.AggregatedProblems;
 import org.graalvm.collections.Pair;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.function.BiFunction;
-import java.util.stream.Collectors;
-
 public class IndexJoin implements JoinStrategy {
-    private final Comparator<Object> objectComparator;
-    private final BiFunction<Object, Object, Boolean> equalityFallback;
+  private final Comparator<Object> objectComparator;
+  private final BiFunction<Object, Object, Boolean> equalityFallback;
 
-    public IndexJoin(Comparator<Object> objectComparator, BiFunction<Object, Object, Boolean> equalityFallback) {
-        this.objectComparator = objectComparator;
-        this.equalityFallback = equalityFallback;
-    }
+  public IndexJoin(
+      Comparator<Object> objectComparator, BiFunction<Object, Object, Boolean> equalityFallback) {
+    this.objectComparator = objectComparator;
+    this.equalityFallback = equalityFallback;
+  }
 
-    private record HashEqualityCondition(Column left, Column right, TextFoldingStrategy textFoldingStrategy) {}
+  private record HashEqualityCondition(
+      Column left, Column right, TextFoldingStrategy textFoldingStrategy) {}
 
-    @Override
-    public JoinResult join(Table left, Table right, List<JoinCondition> conditions) {
-        List<HashEqualityCondition> equalConditions = conditions.stream()
-                .filter(IndexJoin::isSupported)
-                .map(IndexJoin::makeHashEqualityCondition)
-                .collect(Collectors.toList());
+  @Override
+  public JoinResult join(Table left, Table right, List<JoinCondition> conditions) {
+    List<HashEqualityCondition> equalConditions =
+        conditions.stream()
+            .filter(IndexJoin::isSupported)
+            .map(IndexJoin::makeHashEqualityCondition)
+            .collect(Collectors.toList());
 
-        var remainingConditions = conditions.stream()
-            .filter(c -> !isSupported(c)).collect(Collectors.toList());
+    var remainingConditions =
+        conditions.stream().filter(c -> !isSupported(c)).collect(Collectors.toList());
 
-        var leftEquals = equalConditions.stream().map(HashEqualityCondition::left).toArray(Column[]::new);
-        var rightEquals = equalConditions.stream().map(HashEqualityCondition::right).toArray(Column[]::new);
-        var textFoldingStrategies = equalConditions.stream().map(HashEqualityCondition::textFoldingStrategy).collect(Collectors.toList());
+    var leftEquals =
+        equalConditions.stream().map(HashEqualityCondition::left).toArray(Column[]::new);
+    var rightEquals =
+        equalConditions.stream().map(HashEqualityCondition::right).toArray(Column[]::new);
+    var textFoldingStrategies =
+        equalConditions.stream()
+            .map(HashEqualityCondition::textFoldingStrategy)
+            .collect(Collectors.toList());
 
-        var leftIndex = MultiValueIndex.makeUnorderedIndex(leftEquals, left.rowCount(), textFoldingStrategies);
-        var rightIndex = MultiValueIndex.makeUnorderedIndex(rightEquals, right.rowCount(), textFoldingStrategies);
+    var leftIndex =
+        MultiValueIndex.makeUnorderedIndex(leftEquals, left.rowCount(), textFoldingStrategies);
+    var rightIndex =
+        MultiValueIndex.makeUnorderedIndex(rightEquals, right.rowCount(), textFoldingStrategies);
 
-        MatcherFactory factory = new MatcherFactory(objectComparator, equalityFallback);
-        Matcher remainingMatcher = factory.create(remainingConditions);
+    MatcherFactory factory = new MatcherFactory(objectComparator, equalityFallback);
+    Matcher remainingMatcher = factory.create(remainingConditions);
 
-        List<Pair<Integer, Integer>> matches = new ArrayList<>();
-        for (var leftKey : leftIndex.keys()) {
-            if (rightIndex.contains(leftKey)) {
-                for (var leftRow : leftIndex.get(leftKey)) {
-                    for (var rightRow : rightIndex.get(leftKey)) {
-                        if (remainingMatcher.matches(leftRow, rightRow)) {
-                            matches.add(Pair.create(leftRow, rightRow));
-                        }
-                    }
-                }
+    List<Pair<Integer, Integer>> matches = new ArrayList<>();
+    for (var leftKey : leftIndex.keys()) {
+      if (rightIndex.contains(leftKey)) {
+        for (var leftRow : leftIndex.get(leftKey)) {
+          for (var rightRow : rightIndex.get(leftKey)) {
+            if (remainingMatcher.matches(leftRow, rightRow)) {
+              matches.add(Pair.create(leftRow, rightRow));
             }
+          }
         }
-
-        AggregatedProblems problems = AggregatedProblems.merge(new AggregatedProblems[]{
-            leftIndex.getProblems(),
-            rightIndex.getProblems(),
-            remainingMatcher.getProblems()
-        });
-        return new JoinResult(matches, problems);
+      }
     }
 
-    private static boolean isSupported(JoinCondition condition) {
-        switch (condition) {
-            case Equals eq -> {
-                return isBuiltinType(eq.left().getStorage()) && isBuiltinType(eq.right().getStorage());
-            }
-            case EqualsIgnoreCase ignored -> {
-                return true;
-            }
-            default -> {
-                return false;
-            }
-        }
-    }
+    AggregatedProblems problems =
+        AggregatedProblems.merge(
+            new AggregatedProblems[] {
+              leftIndex.getProblems(), rightIndex.getProblems(), remainingMatcher.getProblems()
+            });
+    return new JoinResult(matches, problems);
+  }
 
-    private static HashEqualityCondition makeHashEqualityCondition(JoinCondition eq) {
-        switch (eq) {
-            case Equals e -> {
-                return new HashEqualityCondition(e.left(), e.right(), TextFoldingStrategy.unicodeNormalizedFold);
-            }
-            case EqualsIgnoreCase e -> {
-                return new HashEqualityCondition(e.left(), e.right(), TextFoldingStrategy.caseInsensitiveFold(e.locale()));
-            }
-            default -> throw new IllegalStateException("Impossible: trying to convert condition " + eq + " to a HashEqualityCondition, but it should not be marked as supported. This is a bug in the Table library.");
-        }
+  private static boolean isSupported(JoinCondition condition) {
+    switch (condition) {
+      case Equals eq -> {
+        return isBuiltinType(eq.left().getStorage()) && isBuiltinType(eq.right().getStorage());
+      }
+      case EqualsIgnoreCase ignored -> {
+        return true;
+      }
+      default -> {
+        return false;
+      }
     }
+  }
 
-    private static boolean isBuiltinType(Storage<?> storage) {
-        return storage.getType() != Storage.Type.OBJECT;
+  private static HashEqualityCondition makeHashEqualityCondition(JoinCondition eq) {
+    switch (eq) {
+      case Equals e -> {
+        return new HashEqualityCondition(
+            e.left(), e.right(), TextFoldingStrategy.unicodeNormalizedFold);
+      }
+      case EqualsIgnoreCase e -> {
+        return new HashEqualityCondition(
+            e.left(), e.right(), TextFoldingStrategy.caseInsensitiveFold(e.locale()));
+      }
+      default -> throw new IllegalStateException(
+          "Impossible: trying to convert condition "
+              + eq
+              + " to a HashEqualityCondition, but it should not be marked as supported. This is a"
+              + " bug in the Table library.");
     }
+  }
+
+  private static boolean isBuiltinType(Storage<?> storage) {
+    return storage.getType() != Storage.Type.OBJECT;
+  }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/table/join/IndexJoin.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/join/IndexJoin.java
@@ -4,43 +4,56 @@ import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.index.MultiValueIndex;
 import org.enso.table.data.table.Column;
 import org.enso.table.data.table.Table;
+import org.enso.table.data.table.join.scan.Matcher;
+import org.enso.table.data.table.join.scan.MatcherFactory;
 import org.enso.table.data.table.problems.AggregatedProblems;
 import org.graalvm.collections.Pair;
 
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 public class IndexJoin implements JoinStrategy {
-    private final Comparator<Object> comparator;
+    private final Comparator<Object> objectComparator;
+    private final BiFunction<Object, Object, Boolean> equalityFallback;
 
-    public IndexJoin(Comparator<Object> comparator) {
-        this.comparator = comparator;
+    public IndexJoin(Comparator<Object> objectComparator, BiFunction<Object, Object, Boolean> equalityFallback) {
+        this.objectComparator = objectComparator;
+        this.equalityFallback = equalityFallback;
     }
 
     @Override
     public JoinResult join(Table left, Table right, List<JoinCondition> conditions) {
         var equalConditions = conditions.stream()
+                .filter(IndexJoin::isSupported)
+                // TODO equals Ignore case support needed too
                 .map(c -> c instanceof Equals e ? e : null)
-                .filter(c -> c != null)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
-        if (equalConditions.size() != conditions.size()) {
-            throw new IllegalArgumentException("Currently conditions other than Equals are not supported in index-joins.");
-        }
+
+        var remainingConditions = conditions.stream()
+            .filter(c -> !isSupported(c)).collect(Collectors.toList());
 
         var leftEquals = equalConditions.stream().map(Equals::left).toArray(Column[]::new);
-        var leftIndex = new MultiValueIndex(leftEquals, left.rowCount(), comparator);
+        var leftIndex = new MultiValueIndex(leftEquals, left.rowCount(), objectComparator);
 
         var rightEquals = equalConditions.stream().map(Equals::right).toArray(Column[]::new);
-        var rightIndex = new MultiValueIndex(rightEquals, right.rowCount(), comparator);
+        var rightIndex = new MultiValueIndex(rightEquals, right.rowCount(), objectComparator);
+
+        MatcherFactory factory = new MatcherFactory(objectComparator, equalityFallback);
+        Matcher remainingMatcher = factory.create(remainingConditions);
 
         List<Pair<Integer, Integer>> matches = new ArrayList<>();
         for (var leftKey : leftIndex.keys()) {
             if (rightIndex.contains(leftKey)) {
                 for (var leftRow : leftIndex.get(leftKey)) {
                     for (var rightRow : rightIndex.get(leftKey)) {
-                        matches.add(Pair.create(leftRow, rightRow));
+                        if (remainingMatcher.matches(leftRow, rightRow)) {
+                            matches.add(Pair.create(leftRow, rightRow));
+                        }
                     }
                 }
             }
@@ -48,12 +61,13 @@ public class IndexJoin implements JoinStrategy {
 
         AggregatedProblems problems = AggregatedProblems.merge(new AggregatedProblems[]{
             leftIndex.getProblems(),
-            rightIndex.getProblems()
+            rightIndex.getProblems(),
+            remainingMatcher.getProblems()
         });
         return new JoinResult(matches, problems);
     }
 
-    public static boolean isSupported(JoinCondition condition) {
+    private static boolean isSupported(JoinCondition condition) {
         if (condition instanceof Equals eq) {
             // Currently hashing works only for builtin types.
             return isBuiltinType(eq.left().getStorage()) && isBuiltinType(eq.right().getStorage());

--- a/std-bits/table/src/main/java/org/enso/table/data/table/join/scan/MatcherFactory.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/join/scan/MatcherFactory.java
@@ -1,5 +1,10 @@
 package org.enso.table.data.table.join.scan;
 
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 import org.enso.base.Text_Utils;
 import org.enso.base.polyglot.NumericConverter;
 import org.enso.table.data.column.storage.Storage;
@@ -11,17 +16,12 @@ import org.enso.table.data.table.join.JoinCondition;
 import org.enso.table.data.table.problems.AggregatedProblems;
 import org.enso.table.data.table.problems.FloatingPointGrouping;
 
-import java.util.Comparator;
-import java.util.Locale;
-import java.util.List;
-import java.util.function.BiFunction;
-import java.util.stream.Collectors;
-
 public class MatcherFactory {
   private final Comparator<Object> objectComparator;
   private final BiFunction<Object, Object, Boolean> equalityFallback;
 
-  public MatcherFactory(Comparator<Object> objectComparator, BiFunction<Object, Object, Boolean> equalityFallback) {
+  public MatcherFactory(
+      Comparator<Object> objectComparator, BiFunction<Object, Object, Boolean> equalityFallback) {
     this.objectComparator = objectComparator;
     this.equalityFallback = equalityFallback;
   }
@@ -31,7 +31,8 @@ public class MatcherFactory {
       case Equals eq -> new EqualsMatcher(eq, equalityFallback);
       case EqualsIgnoreCase eq -> new EqualsIgnoreCaseMatcher(eq);
       case Between between -> new BetweenMatcher(between, objectComparator);
-      default -> throw new UnsupportedOperationException("Unsupported join condition: " + condition);
+      default -> throw new UnsupportedOperationException(
+          "Unsupported join condition: " + condition);
     };
   }
 
@@ -98,7 +99,8 @@ public class MatcherFactory {
         problems.add(new FloatingPointGrouping(rightColumnName, right));
       }
 
-      // We could do a fast-path for some known primitive types, but it doesn't matter as it will be replaced with hashing soon anyway.
+      // We could do a fast-path for some known primitive types, but it doesn't matter as it will be
+      // replaced with hashing soon anyway.
       return equalityFallback.apply(leftValue, rightValue);
     }
 
@@ -113,6 +115,7 @@ public class MatcherFactory {
     private final StringStorage rightStorage;
 
     private final Locale locale;
+
     public EqualsIgnoreCaseMatcher(EqualsIgnoreCase eq) {
       if (eq.left().getStorage() instanceof StringStorage leftStrings) {
         leftStorage = leftStrings;
@@ -152,6 +155,7 @@ public class MatcherFactory {
     private final Storage<?> leftStorage;
     private final Storage<?> rightLowerStorage;
     private final Storage<?> rightUpperStorage;
+
     public BetweenMatcher(Between between, Comparator<Object> objectComparator) {
       this.objectComparator = objectComparator;
       leftStorage = between.left().getStorage();
@@ -165,13 +169,16 @@ public class MatcherFactory {
       Object rightLowerValue = rightLowerStorage.getItemBoxed(right);
       Object rightUpperValue = rightUpperStorage.getItemBoxed(right);
 
-      // If any value is missing, such a pair of rows is never correlated with Between as we assume the ordering is not well-defined for missing values.
+      // If any value is missing, such a pair of rows is never correlated with Between as we assume
+      // the ordering is not well-defined for missing values.
       if (leftValue == null || rightLowerValue == null || rightUpperValue == null) {
         return false;
       }
 
-      // We could do a fast-path for some known primitive types, but it doesn't matter as it should be replaced with sorting optimization soon(ish).
-      return objectComparator.compare(leftValue, rightLowerValue) >= 0 && objectComparator.compare(leftValue, rightUpperValue) <= 0;
+      // We could do a fast-path for some known primitive types, but it doesn't matter as it should
+      // be replaced with sorting optimization soon(ish).
+      return objectComparator.compare(leftValue, rightLowerValue) >= 0
+          && objectComparator.compare(leftValue, rightUpperValue) <= 0;
     }
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/table/join/scan/MatcherFactory.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/join/scan/MatcherFactory.java
@@ -57,11 +57,11 @@ public class MatcherFactory {
       Object leftValue = leftStorage.getItemBoxed(left);
       Object rightValue = rightStorage.getItemBoxed(right);
 
-      if (NumericConverter.isCoercibleToDouble(leftValue)) {
+      if (NumericConverter.isDecimalLike(leftValue)) {
         problems.add(new FloatingPointGrouping(leftColumnName, left));
       }
 
-      if (NumericConverter.isCoercibleToDouble(rightValue)) {
+      if (NumericConverter.isDecimalLike(rightValue)) {
         problems.add(new FloatingPointGrouping(rightColumnName, right));
       }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/table/join/scan/ScanJoin.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/join/scan/ScanJoin.java
@@ -34,10 +34,10 @@ public class ScanJoin implements JoinStrategy {
     for (int l = 0; l < ls; ++l) {
       for (int r = 0; r < rs; ++r) {
         boolean match = true;
-        for (Matcher matcher : matchers) {
+        checkMatch: for (Matcher matcher : matchers) {
           if (!matcher.matches(l, r)) {
             match = false;
-            break;
+            break checkMatch;
           }
         }
 

--- a/std-bits/table/src/main/java/org/enso/table/data/table/join/scan/ScanJoin.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/join/scan/ScanJoin.java
@@ -1,15 +1,12 @@
 package org.enso.table.data.table.join.scan;
 
-import org.enso.table.data.table.Table;
-import org.enso.table.data.table.join.*;
-import org.enso.table.data.table.problems.AggregatedProblems;
-import org.graalvm.collections.Pair;
-
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.BiFunction;
-import java.util.stream.Collectors;
+import org.enso.table.data.table.Table;
+import org.enso.table.data.table.join.*;
+import org.graalvm.collections.Pair;
 
 public class ScanJoin implements JoinStrategy {
 

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/FloatingPointGrouping.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/FloatingPointGrouping.java
@@ -12,12 +12,8 @@ public class FloatingPointGrouping extends ColumnAggregatedProblems {
 
   @Override
   public boolean merge(ColumnAggregatedProblems another) {
-    if (another instanceof FloatingPointGrouping
-        && this.getColumnName().equals(another.getColumnName())) {
-      this.rows.addAll(another.rows);
-      return true;
-    }
-
-    return false;
+    // We purposefully ignore merging `rows` because we do not use these on the result anyway.
+    return another instanceof FloatingPointGrouping
+        && this.getColumnName().equals(another.getColumnName());
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/operations/Distinct.java
+++ b/std-bits/table/src/main/java/org/enso/table/operations/Distinct.java
@@ -9,6 +9,7 @@ import org.enso.table.data.index.UnorderedMultiValueKey;
 import org.enso.table.data.table.Column;
 import org.enso.table.data.table.problems.AggregatedProblems;
 import org.enso.table.data.table.problems.FloatingPointGrouping;
+import org.enso.table.util.ConstantList;
 
 public class Distinct {
   /** Creates a row mask containing only the first row from sets of rows grouped by key columns. */
@@ -23,8 +24,9 @@ public class Distinct {
       int size = keyColumns[0].getSize();
       Storage<?>[] storage =
           Arrays.stream(keyColumns).map(Column::getStorage).toArray(Storage[]::new);
+      List<TextFoldingStrategy> strategies = ConstantList.make(textFoldingStrategy, storage.length);
       for (int i = 0; i < size; i++) {
-        UnorderedMultiValueKey key = new UnorderedMultiValueKey(storage, i, textFoldingStrategy);
+        UnorderedMultiValueKey key = new UnorderedMultiValueKey(storage, i, strategies);
 
         if (key.hasFloatValues()) {
           problems.add(new FloatingPointGrouping("Distinct", i));

--- a/std-bits/table/src/main/java/org/enso/table/util/ConstantList.java
+++ b/std-bits/table/src/main/java/org/enso/table/util/ConstantList.java
@@ -1,0 +1,32 @@
+package org.enso.table.util;
+
+import java.util.AbstractList;
+
+public class ConstantList<E> extends AbstractList<E> {
+
+  private final E element;
+  private final int size;
+
+  public static <T> ConstantList<T> make(T element, int size) {
+    return new ConstantList<>(element, size);
+  }
+
+  protected ConstantList(E element, int size) {
+    this.element = element;
+    this.size = size;
+  }
+
+  @Override
+  public E get(int index) {
+    if (index < 0 || index >= size) {
+      throw new IndexOutOfBoundsException(index);
+    }
+
+    return element;
+  }
+
+  @Override
+  public int size() {
+    return size;
+  }
+}

--- a/test/Table_Tests/src/Common_Table_Operations/Aggregate_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Aggregate_Spec.enso
@@ -1137,6 +1137,18 @@ spec setup =
             materialized.columns.at 0 . name . should_equal "B"
             materialized.columns.at 0 . to_vector . should_equal [2, 3, 2]
 
+        if setup.test_selection.supports_unicode_normalization then
+            Test.specify "should correctly handle Unicode normalization within grouping" <|
+                table = table_builder [["A", ['s', 's\u0301', 'ś', 's\u0301']], ["B", [1, 2, 4, 8]]]
+                grouped = table.aggregate [Group_By "A", Sum "B"]
+                grouped.row_count . should_equal 2
+                materialized = materialize grouped . order_by ["A"]
+                materialized.column_count . should_equal 2
+                materialized.columns.at 0 . name . should_equal "A"
+                materialized.columns.at 0 . to_vector . should_equal ['s', 'ś']
+                materialized.columns.at 1 . name . should_equal "Sum B"
+                materialized.columns.at 1 . to_vector . should_equal [1, 14]
+
         if test_selection.date_support then
             Test.specify "should allow grouping by dates" <|
                 dates = ["Date", [Date.new 1997, Date.new 2000 2 2, Date.new 2022 12 31, Date.new 2000 2 2, Date.new 1997]]

--- a/test/Table_Tests/src/Common_Table_Operations/Join_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Join_Spec.enso
@@ -359,7 +359,7 @@ spec setup =
             r1.at "Y" . to_vector . should_equal [0, 1, 1, 2, 3, 3]
             r1.at "Z" . to_vector . should_equal [10, 20, 30, 10, 20, 30]
 
-        Test.specify "should correctly handle nulls in between conditions" <|
+        Test.specify "should correctly handle nulls in Between conditions" <|
             t1 = table_builder [["X", [1, Nothing, 2, Nothing]], ["Y", [0, 1, 2, 3]]]
             t2 = table_builder [["l", [Nothing, 0, 1]], ["u", [100, 10, Nothing]], ["Z", [10, 20, 30]]]
 
@@ -401,18 +401,106 @@ spec setup =
             t1.join t2 on=["X", error] . should_fail_with Illegal_State.Error
 
         # TODO see if it makes sense to keep these tests for Databases. It could be a good idea to double-check that our resulting queries execute efficiently, but connection overhead may make the test unstable - to be seen!
-        n = 10000
-        Test.specify "should efficiently compute equality joins" pending="TODO" <|
-            t1 = table_builder [["X", 0.up_to n . to_vector], ["Y", [0.up_to n . map (_ % 2)]]]
+        n = 5000 # TODO I probably want 20k here after all, but for testing its easier to have a smaller value
+        Test.specify "should efficiently compute equality joins" <|
+            vec = 0.up_to n . to_vector
+            vec2 = 1.up_to n+1 . to_vector
+            t1 = table_builder [["X", vec], ["Y", 0.up_to n . map (_ % 2)]]
             t2 = table_builder [["B", [0, 1]]]
-            t3 = table_builder [["X", 0.up_to n . to_vector . reverse], ["Y", [1.up_to n+1 . to_vector]]]
+            t3 = table_builder [["X", vec.reverse], ["Z", vec2]]
 
             r1 = Duration.time_execution <|
                 materialize <| t1.join t2 on=(Join_Condition.Equals "Y" "B")
-            IO.println r1
 
-        Test.specify "should efficiently compute case-insensitive equality joins" pending="TODO" <|
-            Nothing
+            r2 = Duration.time_execution <|
+                materialize <| t1.join t3 on="X"
+            t4 = r2.second . order_by ["X"]
+            t4.at "X" . to_vector . should_equal <| vec
+            t4.at "Z" . to_vector . should_equal <| vec2.reverse
 
-        Test.specify "should efficiently compute equality joins mixed with others" pending="TODO" <|
-            Nothing
+            expected_max_time_ms = r1.first.total_milliseconds * 5 + 100
+            runtime_ms = r2.first.total_milliseconds
+            if runtime_ms > expected_max_time_ms then
+                Test.fail "Expected a join of "+n.to_text+"x"+n.to_text+" with linear result size to be efficient, but it took "+runtime_ms.to_text+"ms while a join of 2x"+n.to_text+" with the same result size took "+expected_max_time_ms.to_text+"ms."
+
+        Test.specify "should efficiently compute equality joins mixed with other secondary conditions" <|
+            vec = 0.up_to n . to_vector
+            vec2 = 1.up_to n+1 . to_vector
+            t1 = table_builder [["X", vec], ["Y", 0.up_to n . map (_ % 2)], ["A", Vector.fill n "a"], ["B", Vector.fill n 9]]
+            t2 = table_builder [["B", [0, 1]], ["A", ["A", "A"]], ["l", [0, 0]], ["u", [20, 20]]]
+            t3 = table_builder [["X", vec.reverse], ["Z", vec2], ["A", Vector.fill n "a"], ["l", Vector.fill n 0], ["u", Vector.fill n 20]]
+
+            secondary_conditions = [Join_Condition.Equals_Ignore_Case "A", Join_Condition.Between "B" "l" "u"]
+
+            r1 = Duration.time_execution <|
+                materialize <| t1.join t2 on=secondary_conditions+[Join_Condition.Equals "Y" "B"]
+
+            r2 = Duration.time_execution <|
+                materialize <| t1.join t3 on=secondary_conditions+[Join_Condition.Equals "X" "X"]
+            t4 = r2.second . order_by ["X"]
+            t4.at "X" . to_vector . should_equal <| vec
+            t4.at "Z" . to_vector . should_equal <| vec2.reverse
+
+            expected_max_time_ms = r1.first.total_milliseconds * 5 + 100
+            runtime_ms = r2.first.total_milliseconds
+            if runtime_ms > expected_max_time_ms then
+                Test.fail "Expected a join of "+n.to_text+"x"+n.to_text+" with linear result size to be efficient, but it took "+runtime_ms.to_text+"ms while a join of 2x"+n.to_text+" with the same result size took "+expected_max_time_ms.to_text+"ms."
+
+        Test.specify "should efficiently compute case-insensitive equality joins" <|
+            unique_text_for_number prefix i =
+                suffix = Text.from_utf_8 [97 + i%20]
+                "a" + i.to_text + "-" + suffix
+            lowers = 0.up_to n . map (unique_text_for_number "a")
+            uppers = 0.up_to n . map (unique_text_for_number "A")
+            t1 = table_builder [["X", lowers], ["Y", 0.up_to n . map i-> if i%2 == 0 then "a" else "b"], ["A", Vector.fill n 44], ["B", Vector.fill n 9], ["N", 0.up_to n . to_vector]]
+            t2 = table_builder [["B", ["A", "B", "a"]], ["A", [44, 44, 44]], ["l", [0, 0, 0]], ["u", [20, 20, 20]]]
+            t3 = table_builder [["X", uppers.reverse], ["Z", 1.up_to n+1 . to_vector], ["A", Vector.fill n 44], ["l", Vector.fill n 0], ["u", Vector.fill n 20]]
+
+            secondary_conditions = [Join_Condition.Equals "A", Join_Condition.Between "B" "l" "u"]
+
+            r1 = Duration.time_execution <|
+                materialize <| t1.join t2 on=[Join_Condition.Equals_Ignore_Case "Y" "B"]+secondary_conditions
+            r1.second.row_count . should_equal (n + n/2)
+
+            r2 = Duration.time_execution <|
+                materialize <| t1.join t3 on=[Join_Condition.Equals_Ignore_Case "X" "X"]+secondary_conditions
+            t4 = r2.second . order_by "N"
+            t4.row_count . should_equal n
+            t4.at "X" . to_vector . should_equal lowers
+            t4.at "X_1" . to_vector . should_equal uppers
+            t4.at "Z" . to_vector . should_equal <| 1.up_to n+1 . to_vector . reverse
+
+            expected_max_time_ms = r1.first.total_milliseconds * 5 + 100
+            runtime_ms = r2.first.total_milliseconds
+            if runtime_ms > expected_max_time_ms then
+                Test.fail "Expected a join of "+n.to_text+"x"+n.to_text+" with linear result size to be efficient, but it took "+runtime_ms.to_text+"ms while a join of 3x"+n.to_text+" with the same result size took "+expected_max_time_ms.to_text+"ms."
+
+        Test.specify "should efficiently compute Between joins" pending="TODO in task https://www.pivotaltracker.com/story/show/183913337" <|
+            xs = 0.up_to n . map x-> x * 20
+            ls = 0.up_to n . map x-> x * 20 - 20
+            us = 0.up_to n . map x-> x * 20 + 5
+            t1 = table_builder [["X", xs], ["A", Vector.fill n "a"], ["B", Vector.fill n 44]]
+            # We set up the ranges so that each entry of `t1` will match 2, apart from the first entry matched only once.
+            t2 = table_builder [["l", [0, 10]], ["u", [20 * n, 20 * n + 100]], ["A", ["a", "A"]], ["B", [44, 44]]]
+            # Here also, each range from `t3` will match 2 entries of `t1`, apart from the first one.
+            t3 = table_builder [["l", ls], ["u", us], ["A", Vector.fill n "A"], ["B", Vector.fill n 44]]
+
+            conditions = [Join_Condition.Equals_Ignore_Case "A", Join_Condition.Between "X" "l" "u", Join_Condition.Equals "B"]
+
+            r1 = Duration.time_execution <|
+                materialize <| t1.join t2 on=conditions
+            r1.second.row_count . should_equal (2*n - 1)
+
+            r2 = Duration.time_execution <|
+                materialize <| t1.join t3 on=conditions
+            t4 = r2.second . order_by ["X", "l"]
+            t4.row_count . should_equal (2*n - 1)
+
+            t4.at "X" . to_vector . should_equal ((xs.flat_map x-> [x, x]) . drop (Last 1))
+            t4.at "l" . to_vector . should_equal (ls.zip (ls.drop 1) . flatten)+[ls.last]
+
+            expected_max_time_ms = r1.first.total_milliseconds * 5 + 100
+            runtime_ms = r2.first.total_milliseconds
+            if runtime_ms > expected_max_time_ms then
+                Test.fail "Expected a join of "+n.to_text+"x"+n.to_text+" with linear result size to be efficient, but it took "+runtime_ms.to_text+"ms while a join of 2x"+n.to_text+" with the same result size took "+expected_max_time_ms.to_text+"ms."
+

--- a/test/Table_Tests/src/Common_Table_Operations/Join_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Join_Spec.enso
@@ -26,6 +26,7 @@ main = run_default_backend spec
 spec setup =
     prefix = setup.prefix
     table_builder = setup.table_builder
+    materialize = setup.materialize
     join_pending = if prefix.contains "In-Memory" then Nothing else "New Joining API is not supported by the database backends yet."
     Test.group prefix+"Table.join" pending=join_pending <|
         t1 = table_builder [["X", [1, 2, 3]], ["Y", [4, 5, 6]]]
@@ -34,28 +35,28 @@ spec setup =
 
             t3 = t1.join t2
             expect_column_names ["X", "Y", "Z", "W"] t3
-            t4 = t3.order_by ["X", "W"] # TODO materialize for DB
+            t4 = t3 |> materialize |> _.order_by ["X", "W"]
             t4.at "X" . to_vector . should_equal [2, 2, 3]
             t4.at "Z" . to_vector . should_equal [2, 2, 3]
             t4.at "Y" . to_vector . should_equal [5, 5, 6]
             t4.at "W" . to_vector . should_equal [4, 6, 5]
 
         Test.specify "should allow to perform all kinds of joins" <|
-            t3 = t1.join t2 join_kind=Join_Kind.Full . order_by ["X", "W"]
+            t3 = t1.join t2 join_kind=Join_Kind.Full |> materialize |> _.order_by ["X", "W"]
             expect_column_names ["X", "Y", "Z", "W"] t3
             t3.at "X" . to_vector . should_equal [Nothing, 1, 2, 2, 3]
             t3.at "Y" . to_vector . should_equal [Nothing, 4, 5, 5, 6]
             t3.at "Z" . to_vector . should_equal [4, Nothing, 2, 2, 3]
             t3.at "W" . to_vector . should_equal [7, Nothing, 4, 6, 5]
 
-            t4 = t1.join t2 join_kind=Join_Kind.Left_Outer . order_by ["X", "W"]
+            t4 = t1.join t2 join_kind=Join_Kind.Left_Outer |> materialize |> _.order_by ["X", "W"]
             expect_column_names ["X", "Y", "Z", "W"] t4
             t4.at "X" . to_vector . should_equal [1, 2, 2, 3]
             t4.at "Y" . to_vector . should_equal [4, 5, 5, 6]
             t4.at "Z" . to_vector . should_equal [Nothing, 2, 2, 3]
             t4.at "W" . to_vector . should_equal [Nothing, 4, 6, 5]
 
-            t5 = t1.join t2 join_kind=Join_Kind.Right_Outer . order_by ["X", "W"]
+            t5 = t1.join t2 join_kind=Join_Kind.Right_Outer |> materialize |> _.order_by ["X", "W"]
             expect_column_names ["X", "Y", "Z", "W"] t5
             t5.at "X" . to_vector . should_equal [Nothing, 2, 2, 3]
             t5.at "Y" . to_vector . should_equal [Nothing, 5, 5, 6]
@@ -63,12 +64,12 @@ spec setup =
             t5.at "W" . to_vector . should_equal [7, 4, 6, 5]
 
         Test.specify "should allow to perform anti-joins" <|
-            t6 = t1.join t2 join_kind=Join_Kind.Left_Exclusive . order_by ["X"]
+            t6 = t1.join t2 join_kind=Join_Kind.Left_Exclusive |> materialize |> _.order_by ["X"]
             t6.columns.map .name . should_equal ["X", "Y"]
             t6.at "X" . to_vector . should_equal [1]
             t6.at "Y" . to_vector . should_equal [4]
 
-            t7 = t1.join t2 join_kind=Join_Kind.Right_Exclusive . order_by ["Z"]
+            t7 = t1.join t2 join_kind=Join_Kind.Right_Exclusive |> materialize |> _.order_by ["Z"]
             t7.columns.map .name . should_equal ["Z", "W"]
             t7.at "Z" . to_vector . should_equal [4]
             t7.at "W" . to_vector . should_equal [7]
@@ -85,11 +86,11 @@ spec setup =
 
         Test.specify "should allow to join on equality of multiple columns and drop redundant columns" <|
             conditions = [Join_Condition.Equals "Y" "Y", Join_Condition.Equals "X" "X"]
-            r = t3.join t4 on=conditions . order_by ["X", "Y", "Z", "Z_1"]
+            r = t3.join t4 on=conditions |> materialize |> _.order_by ["X", "Y", "Z", "Z_1"]
             check_xy_joined r
 
         Test.specify "should support same-name column join shorthand" <|
-            r = t3.join t4 on=["X", "Y"] . order_by ["X", "Y", "Z", "Z_1"]
+            r = t3.join t4 on=["X", "Y"] |> materialize |> _.order_by ["X", "Y", "Z", "Z_1"]
             check_xy_joined r
 
         Test.specify "should allow to join on text equality ignoring case" <|
@@ -102,7 +103,7 @@ spec setup =
             r1 . at "Y" . to_vector . should_equal [1]
             r1 . at "Z" . to_vector . should_equal [2]
 
-            r2 = t1.join t2 on=(Join_Condition.Equals_Ignore_Case "X") . order_by ["Z"]
+            r2 = t1.join t2 on=(Join_Condition.Equals_Ignore_Case "X") |> materialize |> _.order_by ["Z"]
             # TODO rename to Right_X
             expect_column_names ["X", "Y", "X_1", "Z"] r2
             r2 . at "X" . to_vector . should_equal ["a", "a", "B"]
@@ -121,7 +122,7 @@ spec setup =
                 r1 . at "Y" . to_vector . should_equal [1]
                 r1 . at "Z" . to_vector . should_equal [3]
 
-                r2 = t1.join t2 on=(Join_Condition.Equals_Ignore_Case "X") . order_by ["Y"]
+                r2 = t1.join t2 on=(Join_Condition.Equals_Ignore_Case "X") |> materialize |> _.order_by ["Y"]
                 # TODO rename to Right_X
                 expect_column_names ["X", "Y", "X_1", "Z"] r2
                 r2 . at "X" . to_vector . should_equal ['s\u0301', 'S\u0301']
@@ -145,7 +146,7 @@ spec setup =
                 t1 = table_builder [["X", [My_Type.Value 1 2, My_Type.Value 2 3]], ["Y", [1, 2]]]
                 t2 = table_builder [["X", [My_Type.Value 5 0, My_Type.Value 2 1]], ["Z", [10, 20]]]
 
-                r1 = t1.join t2 . order_by ["Y"]
+                r1 = t1.join t2 |> materialize |> _.order_by ["Y"]
                 expect_column_names ["X", "Y", "Z"] r1
                 r1 . at "X" . to_vector . should_equal [My_Type.Value 1 2, My_Type.Value 2 3]
                 ## We don't keep the other column, because the values in both
@@ -160,7 +161,7 @@ spec setup =
             t1 = table_builder [["X", [1, 10, 12]], ["Y", [1, 2, 3]]]
             t2 = table_builder [["lower", [1, 10, 8, 12]], ["upper", [1, 12, 30, 0]], ["Z", [1, 2, 3, 4]]]
 
-            r1 = t1.join t2 on=(Join_Condition.Between "X" "lower" "upper") . order_by ["X", "Z"]
+            r1 = t1.join t2 on=(Join_Condition.Between "X" "lower" "upper") |> materialize |> _.order_by ["X", "Z"]
             expect_column_names ["X", "Y", "lower", "upper", "Z"] r1
             r1 . at "X" . to_vector . should_equal     [1, 10, 10, 12, 12]
             r1 . at "Y" . to_vector . should_equal     [1, 2,  2,  3,  3]
@@ -172,7 +173,7 @@ spec setup =
             t1 = table_builder [["X", ["a", "b", "c"]], ["Y", [1, 2, 3]]]
             t2 = table_builder [["lower", ["a", "b"]], ["upper", ["a", "ccc"]], ["Z", [10, 20]]]
 
-            r1 = t1.join t2 on=(Join_Condition.Between "X" "lower" "upper") . order_by ["X", "Z"]
+            r1 = t1.join t2 on=(Join_Condition.Between "X" "lower" "upper") |> materialize |> _.order_by ["X", "Z"]
             expect_column_names ["X", "Y", "lower", "upper", "Z"] r1
             r1 . at "X" . to_vector . should_equal     ["a", "b",   "c"]
             r1 . at "Y" . to_vector . should_equal     [1,    2,     3]
@@ -185,7 +186,7 @@ spec setup =
                 t1 = table_builder [["X", ['s\u0301', 's']], ["Y", [1, 2]]]
                 t2 = table_builder [["lower", ['s', 'ś']], ["upper", ['sa', 'ś']], ["Z", [10, 20]]]
 
-                r1 = t1.join t2 on=(Join_Condition.Between "X" "lower" "upper") . order_by ["Y"]
+                r1 = t1.join t2 on=(Join_Condition.Between "X" "lower" "upper") |> materialize |> _.order_by ["Y"]
                 expect_column_names ["X", "Y", "lower", "upper", "Z"] r1
                 r1 . at "X" . to_vector . should_equal     ['s\u0301', 's']
                 r1 . at "Y" . to_vector . should_equal     [1, 2]
@@ -198,7 +199,7 @@ spec setup =
                 t1 = table_builder [["X", [My_Type.Value 20 30, My_Type.Value 1 2]], ["Y", [1, 2]]]
                 t2 = table_builder [["lower", [My_Type.Value 3 0, My_Type.Value 10 10]], ["upper", [My_Type.Value 2 1, My_Type.Value 100 0]], ["Z", [10, 20]]]
 
-                r1 = t1.join t2 on=(Join_Condition.Between "X" "lower" "upper") . order_by ["Z"]
+                r1 = t1.join t2 on=(Join_Condition.Between "X" "lower" "upper") |> materialize |> _.order_by ["Z"]
                 expect_column_names ["X", "Y", "lower", "upper", "Z"] r1
                 r1 . at "X" . to_vector . to_text . should_equal "[(My_Type.Value 1 2), (My_Type.Value 20 30)]"
                 r1 . at "Y" . to_vector . should_equal [2, 1]
@@ -210,7 +211,7 @@ spec setup =
             t1 = table_builder [["X", [1, 12, 12, 0]], ["Y", [1, 2, 3, 4]], ["Z", ["a", "A", "a", "ą"]], ["W", [1, 2, 3, 4]]]
             t2 = table_builder [["X", [12, 12, 1]], ["l", [0, 100, 100]], ["u", [10, 100, 100]], ["Z", ["A", "A", "A"]], ["W'", [10, 20, 30]]]
 
-            r1 = t1.join t2 on=[Join_Condition.Between "Y" "l" "u", Join_Condition.Equals_Ignore_Case "Z" "Z", Join_Condition.Equals "X" "X"] . order_by ["Y"]
+            r1 = t1.join t2 on=[Join_Condition.Between "Y" "l" "u", Join_Condition.Equals_Ignore_Case "Z" "Z", Join_Condition.Equals "X" "X"] |> materialize |> _.order_by ["Y"]
             expect_column_names ["X", "Y", "Z", "W", "l", "u", "Z_1", "W'"] r1
             r1.at "X" . to_vector . should_equal [12, 12]
             r1.at "Y" . to_vector . should_equal [2, 3]
@@ -222,13 +223,13 @@ spec setup =
             r1.at "W'" . to_vector . should_equal [10, 10]
 
         Test.specify "should work fine if the same condition is specified multiple times" <|
-            r = t3.join t4 on=["X", "X", "Y", "X", "Y"] . order_by ["X", "Y", "Z", "Z_1"]
+            r = t3.join t4 on=["X", "X", "Y", "X", "Y"] |> materialize |> _.order_by ["X", "Y", "Z", "Z_1"]
             check_xy_joined r
 
             t5 = table_builder [["X", [1, 10, 12]], ["Y", [1, 2, 3]]]
             t6 = table_builder [["lower", [1, 10, 8, 12]], ["upper", [1, 12, 30, 0]], ["Z", [1, 2, 3, 4]]]
 
-            r1 = t5.join t6 on=[Join_Condition.Between "X" "lower" "upper", Join_Condition.Between "X" "lower" "upper", Join_Condition.Between "X" "lower" "upper"] . order_by ["X", "Z"]
+            r1 = t5.join t6 on=[Join_Condition.Between "X" "lower" "upper", Join_Condition.Between "X" "lower" "upper", Join_Condition.Between "X" "lower" "upper"] |> materialize |> _.order_by ["X", "Z"]
             r1 . at "X" . to_vector . should_equal     [1, 10, 10, 12, 12]
             r1 . at "Y" . to_vector . should_equal     [1, 2,  2,  3,  3]
             r1 . at "Z" . to_vector . should_equal     [1, 2,  3,  2,  3]
@@ -236,7 +237,7 @@ spec setup =
             t7 = table_builder [["X", ["a", "B"]], ["Y", [1, 2]]]
             t8 = table_builder [["X", ["A", "a", "b"]], ["Z", [1, 2, 3]]]
 
-            r2 = t7.join t8 on=[Join_Condition.Equals_Ignore_Case "X", Join_Condition.Equals_Ignore_Case "X", Join_Condition.Equals_Ignore_Case "X" "X"] . order_by ["Z"]
+            r2 = t7.join t8 on=[Join_Condition.Equals_Ignore_Case "X", Join_Condition.Equals_Ignore_Case "X", Join_Condition.Equals_Ignore_Case "X" "X"] |> materialize |> _.order_by ["Z"]
             r2 . at "X" . to_vector . should_equal ["a", "a", "B"]
             r2 . at "X_1" . to_vector . should_equal ["A", "a", "b"]
             r2 . at "Z" . to_vector . should_equal [1, 2, 3]
@@ -341,7 +342,7 @@ spec setup =
             t1 = table_builder [["X", ["A", Nothing, "a", Nothing, "ą"]], ["Y", [0, 1, 2, 3, 4]]]
             t2 = table_builder [["X", ["a", Nothing, Nothing]], ["Z", [10, 20, 30]]]
 
-            r1 = t1.join t2 . order_by ["Y"]
+            r1 = t1.join t2 |> materialize |> _.order_by ["Y"]
             expect_column_names ["X", "Y", "Z"] r1
             r1.at "X" . to_vector . should_equal [Nothing, Nothing, "a", Nothing, Nothing]
             r1.at "Y" . to_vector . should_equal [1, 1, 2, 3, 3]
@@ -351,7 +352,7 @@ spec setup =
             t1 = table_builder [["X", ["A", Nothing, "a", Nothing, "ą"]], ["Y", [0, 1, 2, 3, 4]]]
             t2 = table_builder [["X", ["a", Nothing, Nothing]], ["Z", [10, 20, 30]]]
 
-            r1 = t1.join t2 on=(Join_Condition.Equals_Ignore_Case "X") . order_by ["Y"]
+            r1 = t1.join t2 on=(Join_Condition.Equals_Ignore_Case "X") |> materialize |> _.order_by ["Y"]
             expect_column_names ["X", "Y", "X_1", "Z"] r1
             r1.at "X" . to_vector . should_equal ["A", Nothing, Nothing, "a", Nothing, Nothing]
             r1.at "X_1" . to_vector . should_equal ["a", Nothing, Nothing, "a", Nothing, Nothing]
@@ -362,7 +363,7 @@ spec setup =
             t1 = table_builder [["X", [1, Nothing, 2, Nothing]], ["Y", [0, 1, 2, 3]]]
             t2 = table_builder [["l", [Nothing, 0, 1]], ["u", [100, 10, Nothing]], ["Z", [10, 20, 30]]]
 
-            r1 = t1.join t2 on=(Join_Condition.Between "X" "l" "u") . order_by ["Y"]
+            r1 = t1.join t2 on=(Join_Condition.Between "X" "l" "u") |> materialize |> _.order_by ["Y"]
             expect_column_names ["X", "Y", "l", "u", "Z"] r1
             r1.at "X" . to_vector . should_equal [1, 2]
             r1.at "Y" . to_vector . should_equal [0, 2]
@@ -375,7 +376,7 @@ spec setup =
             t2 = table_builder [["X", [2, 1]], ["Y", [2, 2]]]
 
             # TODO this should be Right_X, Right_Y instead of X_1, Y_1 once implemented properly
-            t3 = t1.join t2 on=(Join_Condition.Equals "X" "Y") . order_by ["X_1"]
+            t3 = t1.join t2 on=(Join_Condition.Equals "X" "Y") |> materialize |> _.order_by ["X_1"]
             expect_column_names ["X", "Y", "X_1", "Y_1"] t3
             t3.at "X" . to_vector . should_equal [2, 2]
             t3.at "Y_1" . to_vector . should_equal [2, 2]
@@ -398,3 +399,20 @@ spec setup =
             error = Error.throw (Illegal_State.Error "FOO")
             t1.join error . should_fail_with Illegal_State.Error
             t1.join t2 on=["X", error] . should_fail_with Illegal_State.Error
+
+        # TODO see if it makes sense to keep these tests for Databases. It could be a good idea to double-check that our resulting queries execute efficiently, but connection overhead may make the test unstable - to be seen!
+        n = 10000
+        Test.specify "should efficiently compute equality joins" pending="TODO" <|
+            t1 = table_builder [["X", 0.up_to n . to_vector], ["Y", [0.up_to n . map (_ % 2)]]]
+            t2 = table_builder [["B", [0, 1]]]
+            t3 = table_builder [["X", 0.up_to n . to_vector . reverse], ["Y", [1.up_to n+1 . to_vector]]]
+
+            r1 = Duration.time_execution <|
+                materialize <| t1.join t2 on=(Join_Condition.Equals "Y" "B")
+            IO.println r1
+
+        Test.specify "should efficiently compute case-insensitive equality joins" pending="TODO" <|
+            Nothing
+
+        Test.specify "should efficiently compute equality joins mixed with others" pending="TODO" <|
+            Nothing

--- a/test/Table_Tests/src/Common_Table_Operations/Join_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Join_Spec.enso
@@ -449,7 +449,7 @@ spec setup =
         Test.specify "should efficiently compute case-insensitive equality joins" <|
             unique_text_for_number prefix i =
                 suffix = Text.from_utf_8 [97 + i%20]
-                "a" + i.to_text + "-" + suffix
+                prefix + i.to_text + "-" + suffix
             lowers = 0.up_to n . map (unique_text_for_number "a")
             uppers = 0.up_to n . map (unique_text_for_number "A")
             t1 = table_builder [["X", lowers], ["Y", 0.up_to n . map i-> if i%2 == 0 then "a" else "b"], ["A", Vector.fill n 44], ["B", Vector.fill n 9], ["N", 0.up_to n . to_vector]]
@@ -504,3 +504,6 @@ spec setup =
             if runtime_ms > expected_max_time_ms then
                 Test.fail "Expected a join of "+n.to_text+"x"+n.to_text+" with linear result size to be efficient, but it took "+runtime_ms.to_text+"ms while a join of 2x"+n.to_text+" with the same result size took "+expected_max_time_ms.to_text+"ms."
 
+        # TODO
+        Test.specify "should efficiently compute mixed joins where all kinds of conditions have big intersection sizes" <|
+            Nothing

--- a/test/Table_Tests/src/Common_Table_Operations/Util.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Util.enso
@@ -3,7 +3,7 @@ from Standard.Base import all
 import Standard.Test
 from Standard.Test import Test_Suite
 
-import project.In_Memory.Table_Spec as In_Memory_Table_Spec
+import project.In_Memory.Common_Spec as In_Memory_Table_Spec
 
 expect_column_names names table =
     table.columns . map .name . should_equal names frames_to_skip=2

--- a/test/Table_Tests/src/In_Memory/Common_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Common_Spec.enso
@@ -1,0 +1,23 @@
+from Standard.Base import all
+
+from Standard.Table import Table
+
+from Standard.Test import Test_Suite
+
+import project.Common_Table_Operations
+
+run_common_spec spec =
+    selection = Common_Table_Operations.Main.Test_Selection.Config supports_case_sensitive_columns=True order_by=True natural_ordering=True case_insensitive_ordering=True order_by_unicode_normalization_by_default=True supports_unicode_normalization=True
+    aggregate_selection = Common_Table_Operations.Aggregate_Spec.Test_Selection.Config
+
+    table = (enso_project.data / "data.csv") . read
+    empty_table = Table.new <| table.columns.map c->[c.name, []]
+    materialize = x->x
+
+    setup = Common_Table_Operations.Main.Test_Setup.Config "[In-Memory] " table empty_table Table.new materialize is_database=False test_selection=selection aggregate_test_selection=aggregate_selection
+    spec setup
+
+spec =
+    run_common_spec Common_Table_Operations.Main.spec
+
+main = Test_Suite.run_main spec

--- a/test/Table_Tests/src/In_Memory/Main.enso
+++ b/test/Table_Tests/src/In_Memory/Main.enso
@@ -4,6 +4,7 @@ from Standard.Test import Test_Suite
 
 import project.In_Memory.Aggregate_Column_Spec
 import project.In_Memory.Column_Spec
+import project.In_Memory.Common_Spec
 import project.In_Memory.Table_Spec
 import project.In_Memory.Table_Date_Spec
 import project.In_Memory.Table_Date_Time_Spec
@@ -13,6 +14,7 @@ import project.In_Memory.Unique_Naming_Strategy_Spec
 spec =
     Table_Spec.spec
     Column_Spec.spec
+    Common_Spec.spec
     Table_Date_Spec.spec
     Table_Date_Time_Spec.spec
     Table_Time_Of_Day_Spec.spec

--- a/test/Table_Tests/src/In_Memory/Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Spec.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base.Error.Common.Index_Out_Of_Bounds
 import Standard.Base.Error.Common.Type_Error
 import Standard.Base.Error.Illegal_Argument.Illegal_Argument
 import Standard.Base.Error.Incomparable_Values.Incomparable_Values
@@ -18,7 +19,6 @@ from Standard.Database import Database, SQLite, In_Memory
 from Standard.Test import Test, Test_Suite, Problems
 import Standard.Test.Extensions
 
-import project.Common_Table_Operations
 from project.Util import all
 
 type My
@@ -34,8 +34,6 @@ type My
         My.Data x1 y1 -> My.Data y1 x1
 
 spec =
-    run_common_spec Common_Table_Operations.Main.spec
-
     make_varied_type_table =
         strs = ["strs", ["a", "b", "c", Nothing]]
         ints = ["ints", [Nothing, 1, 2, 4]]
@@ -52,14 +50,41 @@ spec =
         Table.new [strs, ints, doubles, doubles_and_ints, custom_objects, dates, times, datetimes, mixed, mixed_dates, just_nulls]
     varied_type_table = make_varied_type_table
 
-    Test.group 'Construction' <|
-        Test.specify 'should allow creating a table from rows' <|
+    Test.group "Construction" <|
+        Test.specify "should allow creating a table from rows" <|
             header = ['foo', 'bar']
             rows = [[1, False], [2, True], [3, False]]
             r = Table.from_rows header rows
+            r.row_count.should_equal 3
+            r.at "foo" . to_vector . should_equal [1, 2, 3]
+            r.at "bar" . to_vector . should_equal [False, True, False]
 
-            r.at 'foo' . to_vector . should_equal [1, 2, 3]
-            r.at 'bar' . to_vector . should_equal [False, True, False]
+            r2 = Table.from_rows header []
+            r2.row_count . should_equal 0
+            r2.at "foo" . to_vector . should_equal []
+            r2.at "bar" . to_vector . should_equal []
+
+        Test.specify "should allow creating a table from columns" <|
+            r = Table.new [["foo", [1, 2, 3]], ["bar", [False, True, False]]]
+            r.row_count.should_equal 3
+            r.at "foo" . to_vector . should_equal [1, 2, 3]
+            r.at "bar" . to_vector . should_equal [False, True, False]
+
+            r2 = Table.new [["foo", []], ["bar", []]]
+            r2.row_count . should_equal 0
+            r2.at "foo" . to_vector . should_equal []
+            r2.at "bar" . to_vector . should_equal []
+
+        Test.specify "should handle error scenarios gracefully" <|
+            Table.new [["X", [1,2,3]], ["Y", [4]]] . should_fail_with Illegal_Argument.Error
+            Table.new [["X", [1]], ["X", [2]]] . should_fail_with Illegal_Argument.Error
+
+            Table.from_rows ["X", "X"] [] . should_fail_with Illegal_Argument.Error
+            Table.from_rows ["X", "Y"] [[1,2], [1]] . should_fail_with Index_Out_Of_Bounds.Error
+
+        Test.specify "should handle error scenarios gracefully (merge with above once enabled)" pending="To be enabled after errors refactor where instead of returning a table with no columns we throw an error." <|
+            Table.new [] . should_fail_with Illegal_Argument.Error
+            Table.from_rows [] [] . should_fail_with Illegal_Argument.Error
 
         Test.specify "should correctly infer storage types" <|
             varied_type_table.at "strs" . storage_type . should_equal Storage.Text
@@ -678,7 +703,7 @@ spec =
             Problems.assume_no_problems actual
 
         Test.specify "should support regex replacement" <|
-            bools = ["bools", [False, False, True, True, False]]
+            bools = ["bools", [False, False, True, True]]
             texts = ["texts", ["foo", "bar", "baz", "spam"]]
             table = Table.new [bools, texts]
             actual = table.replace_text "texts" "(a|o)" "$1e" matcher=Regex_Matcher.Value
@@ -1092,17 +1117,6 @@ spec =
             r = t.join db_table
             r.should_fail_with Illegal_Argument.Error
             r.catch.message . contains "cross-backend" . should_be_true
-
-run_common_spec spec =
-    selection = Common_Table_Operations.Main.Test_Selection.Config supports_case_sensitive_columns=True order_by=True natural_ordering=True case_insensitive_ordering=True order_by_unicode_normalization_by_default=True supports_unicode_normalization=True
-    aggregate_selection = Common_Table_Operations.Aggregate_Spec.Test_Selection.Config
-
-    table = (enso_project.data / "data.csv") . read
-    empty_table = Table.new <| table.columns.map c->[c.name, []]
-    materialize = x->x
-
-    setup = Common_Table_Operations.Main.Test_Setup.Config "[In-Memory] " table empty_table Table.new materialize is_database=False test_selection=selection aggregate_test_selection=aggregate_selection
-    spec setup
 
 main = Test_Suite.run_main spec
 

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -603,6 +603,7 @@ spec = Test.group "Vectors" <|
     Test.specify "should return a vector containing only unique elements" <|
         [1, 3, 1, 2, 2, 1].distinct . should_equal [1, 3, 2]
         ["a", "a", "a"].distinct . should_equal ["a"]
+        ['ś', 's', 's\u0301'].distinct . should_equal ['ś', 's']
         [1, 1.0, 2, 2.0].distinct . should_equal [1, 2]
         [].distinct . should_equal []
 

--- a/test/Tests/src/Semantic/Case_Spec.enso
+++ b/test/Tests/src/Semantic/Case_Spec.enso
@@ -10,7 +10,6 @@ polyglot java import java.util.AbstractList
 polyglot java import java.util.ArrayList
 polyglot java import java.util.List as JList
 
-
 from Standard.Test import Test, Test_Suite
 import Standard.Test.Extensions
 
@@ -262,6 +261,14 @@ spec = Test.group "Pattern Matches" <|
             ArrayList -> Nothing
             Class -> Test.fail "Expected to match on a polyglot symbol."
             _ -> Test.fail "Expected to match on a polyglot symbol."
+
+        # Tests a bug where array matching a polyglot Object[] array would fail if the same branch mis-matched earlier.
+        foo x = case x of
+            _ : Array -> "array"
+            _ : Text -> "text"
+        v = ["X", list.toArray]
+        u = v.map foo
+        u.should_equal ["text", "array"]
 
     Test.specify "should correctly pattern match on supertype" <|
         case 1 of


### PR DESCRIPTION
### Pull Request Description

- Implemented https://www.pivotaltracker.com/story/show/183913276
- Refactored MultiValueIndex and MultiValueKeys to be more type-safe and more direct about using ordered or unordered maps.
- Added performance tests ensuring we use an efficient algorithm for the joins (the tests will fail for a full O(N*M) scan).
- Removed some duplicate code in the Table library.
- Added optional coloring of test results in terminal to make failures easier to spot.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
