### PR TITLE
Mocking values for Table.at selector field

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Meta.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Meta.enso
@@ -1,9 +1,11 @@
 import project.Any.Any
+import project.Nothing.Nothing
 import project.Data.Array.Array
 import project.Data.Numbers.Decimal
 import project.Data.Numbers.Integer
 import project.Data.Numbers.Number
 import project.Data.Text.Text
+import project.Data.Text.Extensions
 import project.Data.Time.Date_Time.Date_Time
 import project.Data.Time.Date.Date
 import project.Data.Time.Duration.Duration
@@ -287,6 +289,22 @@ meta value = if is_atom value then Atom.Value value else
             if is_unresolved_symbol value then Unresolved_Symbol.Value value else
                 if is_error value then Error.Value value.catch else
                     Primitive.Value value
+
+## Given a type object, method name and parameter name, return the associated Attribute if it exists.
+
+   Attributes:
+   - target: The value or type to get the attribute from.
+   - method_name: The name of the method to get the attribute for.
+   - parameter_name: The name of the parameter to get the attribute for.
+Meta.get_annotation : Any -> Text -> Text -> Any | Nothing
+Meta.get_annotation target method_name parameter_name =
+    mock_table = if (target.to_text.contains "org.enso.table.data.table.Table@").not then Nothing else case method_name of
+        "at" -> case parameter_name of
+            "selector" -> target.columns.map .name
+            _ -> Nothing
+        _ -> Nothing
+
+    mock_table
 
 ## UNSTABLE
    ADVANCED

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Meta.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Meta.enso
@@ -17,6 +17,9 @@ import project.Polyglot.Java
 import project.Error.Error as Base_Error
 import project.Polyglot.Polyglot as Base_Polyglot
 
+import project.Metadata.Display
+import project.Metadata.Widget
+
 from project.Data.Boolean import Boolean, True, False
 
 type Atom
@@ -300,7 +303,8 @@ Meta.get_annotation : Any -> Text -> Text -> Any | Nothing
 Meta.get_annotation target method_name parameter_name =
     mock_table = if (target.to_text.contains "org.enso.table.data.table.Table@").not then Nothing else case method_name of
         "at" -> case parameter_name of
-            "selector" -> target.columns.map .name
+            "selector" ->
+                Widget.Single_Choice display=Display.Always values=(target.columns.map .name)
             _ -> Nothing
         _ -> Nothing
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
@@ -1,0 +1,57 @@
+import project.Data.Numbers.Integer
+import project.Data.Numbers.Number
+import project.Data.Pair.Pair
+import project.Data.Text.Text
+import project.Data.Vector.Vector
+import project.Nothing.Nothing
+
+from project.Data.Boolean import Boolean, True, False
+
+type Display
+    ## Parameter is always shown on the collapsed view.
+    Always
+
+    ## Parameter is shown on the collapsed view if not the default value.
+    When_Modified
+
+    ## Parameter is only shown on the expanded view.
+    Expanded_Only
+
+type Parameter_Type
+    Parameter value:Text label:Text=code parameters:(Vector Widget)=[] icon:Text=""
+
+
+type File_Action
+    ## The File or Folder is for reading from.
+    Open
+
+    ## The File or Folder is for writing to.
+    Save
+
+type Widget
+    ## Describe a code parameter.
+    Code_Input label:(Nothing|Text)=Nothing display:Display=Display.When_Modified
+
+    ## Describe a boolean parameter.
+    Boolean_Input label:Nothing|Text=Nothing display:Display=Display.When_Modified
+
+    ## Describe a numeric parameter.
+    Numeric_Input label:Nothing|Text=Nothing display:Display=Display.When_Modified minimum:Integer|Nothing=Nothing maximum:Integer|Nothing=Nothing step:Number=1 decimal_places:Integer=0 allow_outside:Boolean=True
+
+    ## Describes a text widget.
+    Text_Input label:Nothing|Text=Nothing display:Display=Display.When_Modified quote_values:Boolean=True suggestions:(Vector Text)=[]
+
+    ## Describes a single value widget.
+    Single_Choice values:(Vector Parameter) label:Nothing|Text=Nothing display:Display=Display.When_Modified quote_values:Boolean=False allow_custom:Boolean=True
+
+    ## Describes a multi value widget.
+    Multiple_Choice values:(Vector Parameter) label:Nothing|Text=Nothing display:Display=Display.When_Modified quote_values:Boolean=False
+
+    ## Describes a list editor widget.
+    Vector_Editor item_editor:Widget values:((Vector Parameter)|Nothing)=Nothing label:Nothing|Text=Nothing display:Display=Display.When_Modified
+
+    ## Describes a folder chooser.
+    Folder_Browse label:Nothing|Text=Nothing display:Display=Display.When_Modified
+
+    ## Describes a file chooser.
+    File_Browse label:Nothing|Text=Nothing display:Display=Display.When_Modified action:File_Action=File_Action.Open file_types:(Vector Pair)=[Pair "All Files" "*.*"]

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
@@ -18,7 +18,7 @@ type Display
     Expanded_Only
 
 type Parameter_Type
-    Parameter value:Text label:Text=code parameters:(Vector Widget)=[] icon:Text=""
+    Parameter value:Text label:Text="code" parameters:(Vector Widget)=[] icon:Text=""
 
 
 type File_Action

--- a/test/Table_Tests/src/In_Memory/Main.enso
+++ b/test/Table_Tests/src/In_Memory/Main.enso
@@ -4,6 +4,7 @@ from Standard.Test import Test_Suite
 
 import project.In_Memory.Aggregate_Column_Spec
 import project.In_Memory.Column_Spec
+import project.In_Memory.Meta_Table_Spec
 import project.In_Memory.Table_Spec
 import project.In_Memory.Table_Date_Spec
 import project.In_Memory.Table_Date_Time_Spec
@@ -18,5 +19,6 @@ spec =
     Table_Time_Of_Day_Spec.spec
     Aggregate_Column_Spec.spec
     Unique_Naming_Strategy_Spec.spec
+    Meta_Table_Spec.spec
 
 main = Test_Suite.run_main spec

--- a/test/Table_Tests/src/In_Memory/Meta_Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Meta_Table_Spec.enso
@@ -11,6 +11,8 @@ from Standard.Table.Data.Storage import Storage
 import Standard.Table.Data.Value_Type.Value_Type
 from Standard.Table.Errors import Invalid_Output_Column_Names, Duplicate_Output_Column_Names, No_Input_Columns_Selected, Missing_Input_Columns, No_Such_Column, Floating_Point_Grouping, Invalid_Value_Type
 
+import Standard.Base.Metadata.Widget
+import Standard.Base.Metadata.Display
 import Standard.Visualization
 
 from Standard.Database import Database, SQLite, In_Memory
@@ -28,7 +30,14 @@ spec =
             texts = ["texts", ["foo", "foo", "bar", "baz", "spam"]]
             table = Table.new [bools, texts]
             dynamic_drop_down = Meta.get_annotation table "at" "selector"
-            dynamic_drop_down . should_equal [ "bools", "texts" ]
+            case dynamic_drop_down of
+                Widget.Single_Choice arr n a b1 b2 ->
+                    arr . should_equal [ "bools", "texts" ]
+                    n . should_equal Nothing
+                    a . should_equal Display.Always
+                    b1 . should_equal False
+                    b2 . should_equal True
+                _ -> Test.fail "Unexpected type returned " + dynamic_drop_down.to_text
 
         Test.specify "find bools and two texts" <|
             bools = ["bools", [False, False, True]]
@@ -36,6 +45,13 @@ spec =
             texts2 = ["texts2", ["baz", "quux", "spam"]]
             table = Table.new [bools, texts1, texts2]
             dynamic_drop_down = Meta.get_annotation table "at" "selector"
-            dynamic_drop_down . should_equal [ "bools", "texts1", "texts2" ]
+            case dynamic_drop_down of
+                Widget.Single_Choice arr n a b1 b2 ->
+                    arr . should_equal [ "bools", "texts1", "texts2" ]
+                    n . should_equal Nothing
+                    a . should_equal Display.Always
+                    b1 . should_equal False
+                    b2 . should_equal True
+                _ -> Test.fail "Unexpected type returned " + dynamic_drop_down.to_text
 
 main = Test_Suite.run_main spec

--- a/test/Table_Tests/src/In_Memory/Meta_Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Meta_Table_Spec.enso
@@ -28,7 +28,7 @@ spec =
             texts = ["texts", ["foo", "foo", "bar", "baz", "spam"]]
             table = Table.new [bools, texts]
             dynamic_drop_down = Meta.get_annotation table "at" "selector"
-            [ "bools", "texts" ] . should_equal dynamic_drop_down
+            dynamic_drop_down . should_equal [ "bools", "texts" ]
 
         Test.specify "find bools and two texts" <|
             bools = ["bools", [False, False, True]]

--- a/test/Table_Tests/src/In_Memory/Meta_Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Meta_Table_Spec.enso
@@ -36,6 +36,6 @@ spec =
             texts2 = ["texts2", ["baz", "quux", "spam"]]
             table = Table.new [bools, texts1, texts2]
             dynamic_drop_down = Meta.get_annotation table "at" "selector"
-            [ "bools", "texts1", "texts2" ] . should_equal dynamic_drop_down
+            dynamic_drop_down . should_equal [ "bools", "texts1", "texts2" ]
 
 main = Test_Suite.run_main spec

--- a/test/Table_Tests/src/In_Memory/Meta_Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Meta_Table_Spec.enso
@@ -1,0 +1,41 @@
+from Standard.Base import all
+import Standard.Base.Error.Common.Type_Error
+import Standard.Base.Error.Illegal_Argument.Illegal_Argument
+import Standard.Base.Error.Incomparable_Values.Incomparable_Values
+
+from Standard.Table import Table, Column, Sort_Column, Column_Selector, Sort_Column_Selector, Aggregate_Column
+import Standard.Table.Main as Table_Module
+from Standard.Table.Data.Aggregate_Column.Aggregate_Column import all hiding First, Last
+from Standard.Table.Data.Table import Empty_Error
+from Standard.Table.Data.Storage import Storage
+import Standard.Table.Data.Value_Type.Value_Type
+from Standard.Table.Errors import Invalid_Output_Column_Names, Duplicate_Output_Column_Names, No_Input_Columns_Selected, Missing_Input_Columns, No_Such_Column, Floating_Point_Grouping, Invalid_Value_Type
+
+import Standard.Visualization
+
+from Standard.Database import Database, SQLite, In_Memory
+
+from Standard.Test import Test, Test_Suite, Problems
+import Standard.Test.Extensions
+
+import project.Common_Table_Operations
+from project.Util import all
+
+spec =
+    Test.group "Meta.get_annotation for table at selector" <|
+        Test.specify "find bools and texts" <|
+            bools = ["bools", [False, False, True, True, False]]
+            texts = ["texts", ["foo", "foo", "bar", "baz", "spam"]]
+            table = Table.new [bools, texts]
+            dynamic_drop_down = Meta.get_annotation table "at" "selector"
+            [ "bools", "texts" ] . should_equal dynamic_drop_down
+
+        Test.specify "find bools and two texts" <|
+            bools = ["bools", [False, False, True]]
+            texts1 = ["texts1", ["foo", "bar", "baz"]]
+            texts2 = ["texts2", ["baz", "quux", "spam"]]
+            table = Table.new [bools, texts1, texts2]
+            dynamic_drop_down = Meta.get_annotation table "at" "selector"
+            [ "bools", "texts1", "texts2" ] . should_equal dynamic_drop_down
+
+main = Test_Suite.run_main spec


### PR DESCRIPTION
### Pull Request Description

The _"dynamic dropdowns"_ design [ten lines above](https://github.com/enso-org/design/blob/main/epics/widgets/drop-downs/dynamic-widgets.md#initial-functions) expects `Meta.get_annotation` function to query dynamic drop down values for various method parameters. Later an example for`Table.at selector` parameter is given. This PR turns that example is a _mock implementation_. Build as:
```
enso$ ./run backend sbt
sbt:enso> buildEngineDistribution
```
and then test as:
```
enso$ ./built-distribution/enso-engine-*/enso-*/bin/enso --run test/Table_Tests/src/In_Memory/Meta_Table_Spec.enso --in-project test/Table_Tests/
Meta.get_annotation for table at selector:  [2/2, 202ms]
    - find bools and texts [191ms]
    - find bools and two texts [11ms]
2 tests succeeded.
0 tests failed.
0 tests skipped.
```
The IDE shall then be able to invoke this method the same way it invokes [visualizations](https://github.com/enso-org/enso/blob/develop/app/gui/docs/product/visualizations.md). 

### Important Notes

James, please help me verify that the mock implementation follows your design.

This PR is unlikely to ever get merged as the mock implementation will be replaced by a real one. The only useful stuff to merge is `Meta_Table_Spec` - that shall remain valid even in the future.

### Checklist

Please include the following checklist in your PR:

- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
