### PR TITLE
Switch WASM tests to Firefox

### DIFF
--- a/build/build/src/project/wasm.rs
+++ b/build/build/src/project/wasm.rs
@@ -442,9 +442,9 @@ impl Wasm {
                 env::WASM_BINDGEN_TEST_TIMEOUT,
                 wasm_timeout.map(|d| d.as_secs()).as_ref(),
             )?
-            .arg("test")
+            .test()
             .apply_opt(headless.then_some(&Headless))
-            .apply(&Chrome)
+            .apply(&test::BROWSER_FOR_WASM_TESTS)
             .arg("integration-test")
             .arg("--profile=integration-test")
             .args(additional_options)

--- a/build/build/src/project/wasm/test.rs
+++ b/build/build/src/project/wasm/test.rs
@@ -102,7 +102,7 @@ pub async fn test_all(repo_root: PathBuf) -> Result {
                 .current_dir(&repo_root)
                 .arg("test")
                 .arg("--headless")
-                .arg("--chrome")
+                .arg("--firefox")
                 .env("WASM_BINDGEN_TEST_TIMEOUT", "300")
                 // .args(&wasm_pack_args)
                 .arg(member.strip_prefix(&repo_root).unwrap())

--- a/build/build/src/project/wasm/test.rs
+++ b/build/build/src/project/wasm/test.rs
@@ -2,21 +2,26 @@ use crate::project::*;
 
 use anyhow::Context;
 use ide_ci::programs::cargo;
+use ide_ci::programs::wasm_pack;
 use ide_ci::programs::WasmPack;
 
-
+/// Flag that tells wasm-pack which browser should be used to run tests.
+///
+/// We use here Firefox rather than Chrome, because it is more stable. Chrome for some reason has
+/// been randomly failing tests, both locally and on CI.
+pub const BROWSER_FOR_WASM_TESTS: wasm_pack::TestFlags = wasm_pack::TestFlags::Firefox;
 
 /// List of crates that should not be tested by wasm-pack test.
-const PACKAGE_BLACKLIST: [&str; 1] = ["integration-test"];
+pub const PACKAGE_BLACKLIST: [&str; 1] = ["integration-test"];
 
 /// Attributes that denote WASM tests.
-const WASM_TEST_ATTRIBUTES: [&str; 2] = ["#[wasm_bindgen_test]", "#[wasm_bindgen_test(async)]"];
+pub const WASM_TEST_ATTRIBUTES: [&str; 2] = ["#[wasm_bindgen_test]", "#[wasm_bindgen_test(async)]"];
 
 /// Subdirectories in the crate directory that contain sources for the crate.
-const SOURCE_SUBDIRECTORIES: [&str; 4] = ["src", "benches", "examples", "tests"];
+pub const SOURCE_SUBDIRECTORIES: [&str; 4] = ["src", "benches", "examples", "tests"];
 
 /// Lists members of given Cargo.toml workspace.
-fn get_all_crates(repo_root: impl AsRef<Path>) -> Result<Vec<PathBuf>> {
+pub fn get_all_crates(repo_root: impl AsRef<Path>) -> Result<Vec<PathBuf>> {
     let pattern = repo_root.as_ref().join("**/Cargo.toml");
     let all_paths =
         glob::glob(pattern.as_str()).context(format!("Globbing {} failed", pattern.display()))?;
@@ -32,12 +37,12 @@ fn get_all_crates(repo_root: impl AsRef<Path>) -> Result<Vec<PathBuf>> {
 }
 
 ///  Check if the given line of source code is an attribute denoting wasm test.
-fn is_wasm_test_attribute(line: &str) -> bool {
+pub fn is_wasm_test_attribute(line: &str) -> bool {
     WASM_TEST_ATTRIBUTES.contains(&line.trim())
 }
 
 /// Check if the given workspace member contains any wasm tests in the sources.
-fn has_wasm_tests(member: &Path) -> bool {
+pub fn has_wasm_tests(member: &Path) -> bool {
     if let Some(member) = member.to_str() {
         // We go over selected subdirectories only to avoid entering into sources of other crates
         // that are nested within this crate subtree.
@@ -61,26 +66,26 @@ fn has_wasm_tests(member: &Path) -> bool {
 }
 
 /// Parses file under given path as TOML value.
-fn parse_toml(path: impl AsRef<Path>) -> toml::Value {
+pub fn parse_toml(path: impl AsRef<Path>) -> toml::Value {
     let path = path.as_ref();
     let data = ide_ci::fs::read_to_string(path).unwrap();
     data.parse().unwrap()
 }
 
 /// Checks if the given member is blacklisted from running the tests.
-fn blacklisted(memeber: &Path) -> bool {
+pub fn blacklisted(memeber: &Path) -> bool {
     PACKAGE_BLACKLIST.iter().any(|blacklisted| memeber.ends_with(blacklisted))
 }
 
 /// Checks if given workspace member is a proc-macro crate.
-fn is_proc_macro_crate(member: &Path) -> bool {
+pub fn is_proc_macro_crate(member: &Path) -> bool {
     let cargo_toml_path = member.join("Cargo.toml");
     let cargo_toml_root = parse_toml(cargo_toml_path);
     get_proc_macro(cargo_toml_root).contains(&true)
 }
 
 /// Retrieve a `lib.proc-macro` field from Cargo.toml
-fn get_proc_macro(cargo_toml: toml::Value) -> Option<bool> {
+pub fn get_proc_macro(cargo_toml: toml::Value) -> Option<bool> {
     cargo_toml.get("lib")?.get("proc-macro")?.as_bool()
 }
 
@@ -100,12 +105,18 @@ pub async fn test_all(repo_root: PathBuf) -> Result {
             WasmPack
                 .cmd()?
                 .current_dir(&repo_root)
-                .arg("test")
-                .arg("--headless")
-                .arg("--firefox")
+                .test()
+                .apply(&wasm_pack::TestFlags::Headless)
+                .apply(&BROWSER_FOR_WASM_TESTS)
                 .env("WASM_BINDGEN_TEST_TIMEOUT", "300")
                 // .args(&wasm_pack_args)
-                .arg(member.strip_prefix(&repo_root).unwrap())
+                .arg(member.strip_prefix(&repo_root).with_context(|| {
+                    format!(
+                        "Failed to strip prefix {} from {}. Is the test part of the repository?",
+                        repo_root.display(),
+                        member.display()
+                    )
+                })?)
                 .apply(&cargo::Color::Always)
                 .run_ok()
                 .await?;
@@ -115,35 +126,3 @@ pub async fn test_all(repo_root: PathBuf) -> Result {
     }
     Ok(())
 }
-
-// /// Call wasm-pack test for each workspace member
-// ///
-// /// This function reads workspace members list from `Cargo.toml` in current directory, and call
-// /// `wasm-pack test` each member. All script arguments are passed to `wasm-pack` process.
-// fn main() {
-//     let wasm_pack_args = std::env::args().skip(1).collect::<Vec<_>>();
-//     let all_members = get_all_crates();
-//
-//     for member in all_members {
-//         let member_str = member.to_string_lossy();
-//         if blacklisted(&member) {
-//             println!("Skipping blacklisted crate {}", member_str);
-//         } else if is_proc_macro_crate(&member) {
-//             println!("Skipping proc-macro crate {}", member_str);
-//         } else if has_wasm_tests(&member) {
-//             println!("Running tests for {}", member_str);
-//             let mut command = std::process::Command::new("wasm-pack");
-//             command.arg("test").args(&wasm_pack_args).arg(&member);
-//             println!("{:?}", command);
-//             let status = command.status().unwrap();
-//             if !status.success() {
-//                 panic!("Process for {} failed!{}", member_str, match status.code() {
-//                     Some(code) => format!(" Code: {}", code),
-//                     None => String::new(),
-//                 });
-//             }
-//         } else {
-//             println!("No wasm tests in {}", member_str);
-//         }
-//     }
-// }


### PR DESCRIPTION
### Pull Request Description
My experiments have shown that running wasm tests using chromedriver randomly fails. However, so far I haven't observed such an issue with Firefox.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
