### PR TITLE
Workaround the JS serialisation issue for errors.

### DIFF
--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Preprocessor.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Preprocessor.enso
@@ -17,4 +17,7 @@ error_preprocessor x =
         stack_trace = x.get_stack_trace_text.if_nothing "" . split '\n'
         full_message = message + if stack_trace.length > 1 then " (" + stack_trace.at 1 . trim +")" else ""
         JS_Object.from_pairs [['kind', 'Dataflow'], ['message', full_message]] . to_json
-    if result.is_error then result.catch else ok
+
+    ## Workaround so that the JS String is converted to a Text
+       https://www.pivotaltracker.com/story/show/184061302
+    "" + if result.is_error then result.catch else ok


### PR DESCRIPTION
### Pull Request Description

Currently, getting a PolyglotProxy error as a JavaScript string is being passed.
This works around the problem by concatenating an empty string.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
