### PR TITLE
Simplify compilation of nested patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -494,6 +494,7 @@
 - [Add executionContext/interrupt API command][3952]
 - [Any.== is a builtin method][3956]
 - [Simplify exception handling for polyglot exceptions][3981]
+- [Simplify compilation of nested patterns][4005]
 - [IGV can jump to JMH sources & more][4008]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
@@ -572,6 +573,7 @@
 [3952]: https://github.com/enso-org/enso/pull/3952
 [3956]: https://github.com/enso-org/enso/pull/3956
 [3981]: https://github.com/enso-org/enso/pull/3981
+[4005]: https://github.com/enso-org/enso/pull/4005
 [4008]: https://github.com/enso-org/enso/pull/4008
 
 # Enso 2.0.0-alpha.18 (2021-10-12)

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/NestedPatternCompilationBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/NestedPatternCompilationBenchmarks.java
@@ -1,0 +1,93 @@
+package org.enso.interpreter.bench.benchmarks.semantic;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.AbstractList;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Blackhole;
+
+
+@BenchmarkMode(Mode.AverageTime)
+@Fork(1)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class NestedPatternCompilationBenchmarks {
+    private Value self;
+    private String benchmarkName;
+    private String code;
+    private Context ctx;
+
+    @Setup
+    public void initializeBenchmark(BenchmarkParams params) throws Exception {
+        ctx = Context.newBuilder()
+                .allowExperimentalOptions(true)
+                .allowIO(true)
+                .allowAllAccess(true)
+                .logHandler(new ByteArrayOutputStream())
+                .option(
+                        "enso.languageHomeOverride",
+                        Paths.get("../../distribution/component").toFile().getAbsolutePath()
+                ).build();
+
+        benchmarkName = params.getBenchmark().replaceFirst(".*\\.", "");
+        code = """
+            type List
+                Cons a b
+                Nil
+
+            test x =
+                case x of
+                    List.Nil -> 0
+                    List.Cons a List.Nil -> a
+                    List.Cons a (List.Cons b List.Nil) -> a+b
+                    List.Cons a (List.Cons b (List.Cons c List.Nil)) -> a+b+c
+                    List.Cons a (List.Cons b (List.Cons c (List.Cons d List.Nil))) -> a+b+c+d
+                    List.Cons a (List.Cons b (List.Cons c (List.Cons d (List.Cons e List.Nil)))) ->a+b+c+d+e
+                    List.Cons a (List.Cons b (List.Cons c (List.Cons d (List.Cons e (List.Cons f List.Nil))))) -> a+b+c+d+e+f
+
+            list_of_6 =
+                List.Cons 1 (List.Cons 2 (List.Cons 3 (List.Cons 4 (List.Cons 5 (List.Cons 6 List.Nil)))))
+        """;
+    }
+
+    @Benchmark
+    public void sumList(Blackhole hole) throws IOException {
+        // Compilation is included in the benchmark on purpose
+        var module = ctx.eval(SrcUtil.source(benchmarkName, code));
+
+        this.self = module.invokeMember("get_associated_type");
+        Function<String,Value> getMethod = (name) -> module.invokeMember("get_method", self, name);
+
+        var list = getMethod.apply("list_of_6").execute(self);
+        var result = getMethod.apply("test").execute(self, list);
+
+        if (!result.fitsInDouble()) {
+            throw new AssertionError("Shall be a double: " + result);
+        }
+        var calculated = (long) result.asDouble();
+        var expected = 21;
+        if (calculated != expected) {
+            throw new AssertionError("Expected " + expected + " from sum but got " + calculated);
+        }
+        hole.consume(result);
+    }
+
+}
+

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/NestedPatternCompilationBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/NestedPatternCompilationBenchmarks.java
@@ -59,7 +59,7 @@ public class NestedPatternCompilationBenchmarks {
                     List.Cons a (List.Cons b List.Nil) -> a+b
                     List.Cons a (List.Cons b (List.Cons c List.Nil)) -> a+b+c
                     List.Cons a (List.Cons b (List.Cons c (List.Cons d List.Nil))) -> a+b+c+d
-                    List.Cons a (List.Cons b (List.Cons c (List.Cons d (List.Cons e List.Nil)))) ->a+b+c+d+e
+                    List.Cons a (List.Cons b (List.Cons c (List.Cons d (List.Cons e List.Nil)))) -> a+b+c+d+e
                     List.Cons a (List.Cons b (List.Cons c (List.Cons d (List.Cons e (List.Cons f List.Nil))))) -> a+b+c+d+e+f
 
             list_of_6 =

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/BooleanBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/BooleanBranchNode.java
@@ -13,8 +13,8 @@ public abstract class BooleanBranchNode extends BranchNode {
   private final boolean matched;
   private final ConditionProfile profile = ConditionProfile.createCountingProfile();
 
-  BooleanBranchNode(boolean matched, RootCallTarget branch) {
-    super(branch);
+  BooleanBranchNode(boolean matched, RootCallTarget branch, boolean terminalBranch) {
+    super(branch, terminalBranch);
     this.matched = matched;
   }
 
@@ -25,8 +25,9 @@ public abstract class BooleanBranchNode extends BranchNode {
    * @param branch the expression to be executed if (@code matcher} matches
    * @return a node for matching in a case expression
    */
-  public static BooleanBranchNode build(boolean matched, RootCallTarget branch) {
-    return BooleanBranchNodeGen.create(matched, branch);
+  public static BooleanBranchNode build(
+      boolean matched, RootCallTarget branch, boolean terminalBranch) {
+    return BooleanBranchNodeGen.create(matched, branch, terminalBranch);
   }
 
   @Specialization

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/BranchResult.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/BranchResult.java
@@ -1,0 +1,30 @@
+package org.enso.interpreter.node.controlflow.caseexpr;
+
+import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.runtime.EnsoContext;
+
+public class BranchResult {
+  private final boolean matched;
+  private final Object result;
+
+  public BranchResult(boolean matched, Object result) {
+    this.matched = matched;
+    this.result = result;
+  }
+
+  public static BranchResult failure(Node node) {
+    return new BranchResult(false, EnsoContext.get(node).getBuiltins().nothing());
+  }
+
+  public static BranchResult success(Object result) {
+    return new BranchResult(true, result);
+  }
+
+  public boolean isMatched() {
+    return matched;
+  }
+
+  public Object getResult() {
+    return result;
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/BranchResult.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/BranchResult.java
@@ -3,14 +3,7 @@ package org.enso.interpreter.node.controlflow.caseexpr;
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.runtime.EnsoContext;
 
-public class BranchResult {
-  private final boolean matched;
-  private final Object result;
-
-  public BranchResult(boolean matched, Object result) {
-    this.matched = matched;
-    this.result = result;
-  }
+public record BranchResult(boolean isMatched, Object result) {
 
   public static BranchResult failure(Node node) {
     return new BranchResult(false, EnsoContext.get(node).getBuiltins().nothing());
@@ -20,11 +13,4 @@ public class BranchResult {
     return new BranchResult(true, result);
   }
 
-  public boolean isMatched() {
-    return matched;
-  }
-
-  public Object getResult() {
-    return result;
-  }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/BranchSelectedException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/BranchSelectedException.java
@@ -6,14 +6,16 @@ import com.oracle.truffle.api.nodes.NodeInfo;
 /** This exception is used to signal when a certain branch in a case expression has been taken. */
 @NodeInfo(shortName = "BranchSelect", description = "Signals that a case branch has been selected")
 public class BranchSelectedException extends ControlFlowException {
-  private final Object result;
+  private final BranchResult result;
 
   /**
-   * Creates a new exception instance.
+   * Creates a new exception instance. The result is wrapped in `CaseResult` to indiciate if the
+   * result represents a failed nested branch or actually a complete and successful execution of a
+   * (potentially nested) branch.
    *
    * @param result the result of executing the branch this is thrown from
    */
-  public BranchSelectedException(Object result) {
+  public BranchSelectedException(BranchResult result) {
     this.result = result;
   }
 
@@ -22,7 +24,7 @@ public class BranchSelectedException extends ControlFlowException {
    *
    * @return the result of executing the case branch from which this is thrown
    */
-  public Object getResult() {
+  public BranchResult getBranchResult() {
     return result;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CaseNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CaseNode.java
@@ -119,7 +119,7 @@ public abstract class CaseNode extends ExpressionNode {
       }
     } catch (BranchSelectedException e) {
       // Note [Branch Selection Control Flow]
-      return isNested ? e.getBranchResult() : e.getBranchResult().getResult();
+      return isNested ? e.getBranchResult() : e.getBranchResult().result();
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CaseNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CaseNode.java
@@ -8,10 +8,10 @@ import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.NodeInfo;
+import com.oracle.truffle.api.profiles.ConditionProfile;
 import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.function.Function;
-import org.enso.interpreter.runtime.data.ArrayRope;
 import org.enso.interpreter.runtime.error.*;
 import org.enso.interpreter.runtime.state.State;
 import org.enso.interpreter.runtime.type.TypesGen;
@@ -28,9 +28,13 @@ import org.enso.interpreter.runtime.type.TypesGen;
 public abstract class CaseNode extends ExpressionNode {
 
   @Children private final BranchNode[] cases;
+  private final boolean isNested;
 
-  CaseNode(BranchNode[] cases) {
+  private final ConditionProfile fallthroughProfile = ConditionProfile.createCountingProfile();
+
+  CaseNode(boolean isNested, BranchNode[] cases) {
     this.cases = cases;
+    this.isNested = isNested;
   }
 
   /**
@@ -38,10 +42,12 @@ public abstract class CaseNode extends ExpressionNode {
    *
    * @param scrutinee the value being scrutinised
    * @param cases the case branches
+   * @param isNested if true, the flag indicates that the case node represents a nested pattern. If
+   *     false, the case node represents a top-level case involving potentially nested patterns.
    * @return a node representing a pattern match
    */
-  public static CaseNode build(ExpressionNode scrutinee, BranchNode[] cases) {
-    return CaseNodeGen.create(cases, scrutinee);
+  public static CaseNode build(ExpressionNode scrutinee, BranchNode[] cases, boolean isNested) {
+    return CaseNodeGen.create(isNested, cases, scrutinee);
   }
 
   /**
@@ -104,12 +110,16 @@ public abstract class CaseNode extends ExpressionNode {
       for (BranchNode branchNode : cases) {
         branchNode.execute(frame, state, object);
       }
-      CompilerDirectives.transferToInterpreter();
-      throw new PanicException(
-          EnsoContext.get(this).getBuiltins().error().makeInexhaustivePatternMatch(object), this);
+      if (fallthroughProfile.profile(isNested)) {
+        return BranchResult.failure(this);
+      } else {
+        CompilerDirectives.transferToInterpreter();
+        throw new PanicException(
+            EnsoContext.get(this).getBuiltins().error().makeInexhaustivePatternMatch(object), this);
+      }
     } catch (BranchSelectedException e) {
       // Note [Branch Selection Control Flow]
-      return e.getResult();
+      return isNested ? e.getBranchResult() : e.getBranchResult().getResult();
     }
   }
 
@@ -132,5 +142,13 @@ public abstract class CaseNode extends ExpressionNode {
    *
    * The main alternative to this was desugaring to a nested-if, which would've been significantly
    * harder to maintain, and also resulted in significantly higher code complexity.
+   *
+   * Note that the CaseNode may return either a BranchResult or it's underlying value.
+   * This depends on whether the current CaseNode has been constructed as part of the desugaring phase
+   * for nested patterns.
+   * Case expressions that are synthetic, correspond to nested patterns and must propagate additional
+   * information about the state of the match. That way, in the case of a failure in a deeply
+   * nested case, other branches of the original case expression are tried.
+   * `isNested` check ensures that `CaseResult` never leaks outside the CaseNode/BranchNode hierarchy.
    */
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CatchAllBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CatchAllBranchNode.java
@@ -13,8 +13,8 @@ import com.oracle.truffle.api.nodes.NodeInfo;
     description = "An explicit catch-all branch in a case expression")
 public class CatchAllBranchNode extends BranchNode {
 
-  private CatchAllBranchNode(RootCallTarget functionNode) {
-    super(functionNode);
+  private CatchAllBranchNode(RootCallTarget functionNode, boolean terminalBranch) {
+    super(functionNode, terminalBranch);
   }
 
   /**
@@ -23,8 +23,8 @@ public class CatchAllBranchNode extends BranchNode {
    * @param functionNode the function to execute in this case
    * @return a catch-all node
    */
-  public static CatchAllBranchNode build(RootCallTarget functionNode) {
-    return new CatchAllBranchNode(functionNode);
+  public static CatchAllBranchNode build(RootCallTarget functionNode, boolean terminalBranch) {
+    return new CatchAllBranchNode(functionNode, terminalBranch);
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CatchTypeBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CatchTypeBranchNode.java
@@ -15,8 +15,8 @@ public class CatchTypeBranchNode extends BranchNode {
   private @Child IsValueOfTypeNode isValueOfTypeNode = IsValueOfTypeNode.build();
   private final ConditionProfile profile = ConditionProfile.createCountingProfile();
 
-  CatchTypeBranchNode(Type tpe, RootCallTarget functionNode) {
-    super(functionNode);
+  CatchTypeBranchNode(Type tpe, RootCallTarget functionNode, boolean terminalBranch) {
+    super(functionNode, terminalBranch);
     this.expectedType = tpe;
   }
 
@@ -27,8 +27,9 @@ public class CatchTypeBranchNode extends BranchNode {
    * @param functionNode the function to execute in this case
    * @return a catch-all node
    */
-  public static CatchTypeBranchNode build(Type tpe, RootCallTarget functionNode) {
-    return new CatchTypeBranchNode(tpe, functionNode);
+  public static CatchTypeBranchNode build(
+      Type tpe, RootCallTarget functionNode, boolean terminalBranch) {
+    return new CatchTypeBranchNode(tpe, functionNode, terminalBranch);
   }
 
   public void execute(VirtualFrame frame, Object state, Object value) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/ConstructorBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/ConstructorBranchNode.java
@@ -15,8 +15,8 @@ public abstract class ConstructorBranchNode extends BranchNode {
   private final AtomConstructor matcher;
   private final ConditionProfile profile = ConditionProfile.createCountingProfile();
 
-  ConstructorBranchNode(AtomConstructor matcher, RootCallTarget branch) {
-    super(branch);
+  ConstructorBranchNode(AtomConstructor matcher, RootCallTarget branch, boolean terminalBranch) {
+    super(branch, terminalBranch);
     this.matcher = matcher;
   }
 
@@ -27,8 +27,9 @@ public abstract class ConstructorBranchNode extends BranchNode {
    * @param branch the expression to be executed if (@code matcher} matches
    * @return a node for matching in a case expression
    */
-  public static ConstructorBranchNode build(AtomConstructor matcher, RootCallTarget branch) {
-    return ConstructorBranchNodeGen.create(matcher, branch);
+  public static ConstructorBranchNode build(
+      AtomConstructor matcher, RootCallTarget branch, boolean terminalBranch) {
+    return ConstructorBranchNodeGen.create(matcher, branch, terminalBranch);
   }
 
   @Specialization

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/NumericLiteralBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/NumericLiteralBranchNode.java
@@ -17,21 +17,24 @@ public abstract class NumericLiteralBranchNode extends BranchNode {
 
   private final ConditionProfile numProfile = ConditionProfile.createCountingProfile();
 
-  NumericLiteralBranchNode(Object literal, RootCallTarget branch) {
-    super(branch);
+  NumericLiteralBranchNode(Object literal, RootCallTarget branch, boolean terminalBranch) {
+    super(branch, terminalBranch);
     this.literal = literal;
   }
 
-  public static NumericLiteralBranchNode build(long literal, RootCallTarget branch) {
-    return NumericLiteralBranchNodeGen.create(literal, branch);
+  public static NumericLiteralBranchNode build(
+      long literal, RootCallTarget branch, boolean terminalBranch) {
+    return NumericLiteralBranchNodeGen.create(literal, branch, terminalBranch);
   }
 
-  public static NumericLiteralBranchNode build(double literal, RootCallTarget branch) {
-    return NumericLiteralBranchNodeGen.create(literal, branch);
+  public static NumericLiteralBranchNode build(
+      double literal, RootCallTarget branch, boolean terminalBranch) {
+    return NumericLiteralBranchNodeGen.create(literal, branch, terminalBranch);
   }
 
-  public static NumericLiteralBranchNode build(BigInteger literal, RootCallTarget branch) {
-    return NumericLiteralBranchNodeGen.create(literal, branch);
+  public static NumericLiteralBranchNode build(
+      BigInteger literal, RootCallTarget branch, boolean terminalBranch) {
+    return NumericLiteralBranchNodeGen.create(literal, branch, terminalBranch);
   }
 
   @Specialization(guards = "interop.isNumber(target)")

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/ObjectEqualityBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/ObjectEqualityBranchNode.java
@@ -10,13 +10,13 @@ public class ObjectEqualityBranchNode extends BranchNode {
   private @Child IsSameObjectNode isSameObject = IsSameObjectNode.build();
   private final ConditionProfile profile = ConditionProfile.createCountingProfile();
 
-  public static BranchNode build(RootCallTarget branch, Object expected) {
-    return new ObjectEqualityBranchNode(branch, expected);
+  private ObjectEqualityBranchNode(RootCallTarget branch, Object expected, boolean terminalBranch) {
+    super(branch, terminalBranch);
+    this.expected = expected;
   }
 
-  private ObjectEqualityBranchNode(RootCallTarget branch, Object expected) {
-    super(branch);
-    this.expected = expected;
+  public static BranchNode build(RootCallTarget branch, Object expected, boolean terminalBranch) {
+    return new ObjectEqualityBranchNode(branch, expected, terminalBranch);
   }
 
   @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/PolyglotBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/PolyglotBranchNode.java
@@ -15,8 +15,8 @@ public abstract class PolyglotBranchNode extends BranchNode {
   private final ConditionProfile constructorProfile = ConditionProfile.createCountingProfile();
   private final ConditionProfile polyglotProfile = ConditionProfile.createCountingProfile();
 
-  PolyglotBranchNode(Type polyglot, RootCallTarget branch) {
-    super(branch);
+  PolyglotBranchNode(Type polyglot, RootCallTarget branch, boolean terminalBranch) {
+    super(branch, terminalBranch);
     this.polyglot = polyglot;
   }
 
@@ -27,8 +27,9 @@ public abstract class PolyglotBranchNode extends BranchNode {
    * @param branch the code to execute
    * @return an integer branch node
    */
-  public static PolyglotBranchNode build(Type polyglot, RootCallTarget branch) {
-    return PolyglotBranchNodeGen.create(polyglot, branch);
+  public static PolyglotBranchNode build(
+      Type polyglot, RootCallTarget branch, boolean terminalBranch) {
+    return PolyglotBranchNodeGen.create(polyglot, branch, terminalBranch);
   }
 
   @Specialization

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/PolyglotSymbolTypeBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/PolyglotSymbolTypeBranchNode.java
@@ -26,8 +26,9 @@ public abstract class PolyglotSymbolTypeBranchNode extends BranchNode {
   private final ConditionProfile profile = ConditionProfile.createCountingProfile();
   private final ConditionProfile subtypeProfile = ConditionProfile.createCountingProfile();
 
-  PolyglotSymbolTypeBranchNode(Object polyglotSymbol, RootCallTarget functionNode) {
-    super(functionNode);
+  PolyglotSymbolTypeBranchNode(
+      Object polyglotSymbol, RootCallTarget functionNode, boolean terminalBranch) {
+    super(functionNode, terminalBranch);
     this.polyglotSymbol = polyglotSymbol;
   }
 
@@ -39,8 +40,8 @@ public abstract class PolyglotSymbolTypeBranchNode extends BranchNode {
    * @return a catch-all node
    */
   public static PolyglotSymbolTypeBranchNode build(
-      Object polyglotSymbol, RootCallTarget functionNode) {
-    return PolyglotSymbolTypeBranchNodeGen.create(polyglotSymbol, functionNode);
+      Object polyglotSymbol, RootCallTarget functionNode, boolean terminalBranch) {
+    return PolyglotSymbolTypeBranchNodeGen.create(polyglotSymbol, functionNode, terminalBranch);
   }
 
   @Specialization

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/StringLiteralBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/StringLiteralBranchNode.java
@@ -19,13 +19,14 @@ public abstract class StringLiteralBranchNode extends BranchNode {
 
   private final ConditionProfile textProfile = ConditionProfile.createCountingProfile();
 
-  StringLiteralBranchNode(String literal, RootCallTarget branch) {
-    super(branch);
+  StringLiteralBranchNode(String literal, RootCallTarget branch, boolean terminalBranch) {
+    super(branch, terminalBranch);
     this.literal = literal;
   }
 
-  public static StringLiteralBranchNode build(String literal, RootCallTarget branch) {
-    return StringLiteralBranchNodeGen.create(literal, branch);
+  public static StringLiteralBranchNode build(
+      String literal, RootCallTarget branch, boolean terminalBranch) {
+    return StringLiteralBranchNodeGen.create(literal, branch, terminalBranch);
   }
 
   @Specialization

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
@@ -665,7 +665,7 @@ case object AliasAnalysis extends IRPass {
     parentScope: Scope
   ): IR.Case = {
     ir match {
-      case caseExpr @ IR.Case.Expr(scrutinee, branches, _, _, _) =>
+      case caseExpr @ IR.Case.Expr(scrutinee, branches, _, _, _, _) =>
         caseExpr
           .copy(
             scrutinee = analyseExpression(scrutinee, graph, parentScope),

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
@@ -574,12 +574,12 @@ case object DataflowAnalysis extends IRPass {
     */
   def analyseCase(cse: IR.Case, info: DependencyInfo): IR.Case = {
     cse match {
-      case expr @ IR.Case.Expr(scrutinee, branches, _, _, _) =>
+      case expr: IR.Case.Expr =>
         val exprDep  = asStatic(expr)
-        val scrutDep = asStatic(scrutinee)
+        val scrutDep = asStatic(expr.scrutinee)
         info.dependents.updateAt(scrutDep, Set(exprDep))
         info.dependencies.updateAt(exprDep, Set(scrutDep))
-        branches.foreach(branch => {
+        expr.branches.foreach(branch => {
           val branchDep = asStatic(branch)
           info.dependents.updateAt(branchDep, Set(exprDep))
           info.dependencies.updateAt(exprDep, Set(branchDep))
@@ -587,8 +587,8 @@ case object DataflowAnalysis extends IRPass {
 
         expr
           .copy(
-            scrutinee = analyseExpression(scrutinee, info),
-            branches  = branches.map(analyseCaseBranch(_, info))
+            scrutinee = analyseExpression(expr.scrutinee, info),
+            branches  = expr.branches.map(analyseCaseBranch(_, info))
           )
           .updateMetadata(this -->> info)
       case _: IR.Case.Branch =>

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DemandAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DemandAnalysis.scala
@@ -309,7 +309,7 @@ case object DemandAnalysis extends IRPass {
     isInsideCallArgument: Boolean
   ): IR.Case =
     cse match {
-      case expr @ IR.Case.Expr(scrutinee, branches, _, _, _) =>
+      case expr @ IR.Case.Expr(scrutinee, branches, _, _, _, _) =>
         expr.copy(
           scrutinee = analyseExpression(
             scrutinee,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/TailCall.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/TailCall.scala
@@ -323,7 +323,7 @@ case object TailCall extends IRPass {
     */
   def analyseCase(caseExpr: IR.Case, isInTailPosition: Boolean): IR.Case = {
     caseExpr match {
-      case caseExpr @ IR.Case.Expr(scrutinee, branches, _, _, _) =>
+      case caseExpr @ IR.Case.Expr(scrutinee, branches, _, _, _, _) =>
         caseExpr
           .copy(
             scrutinee = analyseExpression(scrutinee, isInTailPosition = false),

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/NestedPatternMatch.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/NestedPatternMatch.scala
@@ -31,9 +31,6 @@ import scala.annotation.unused
   *   case x of
   *       Cons (Cons a b) y -> case y of
   *           Nil -> a + b
-  *           _ -> case x of
-  *               Cons a Nil -> a
-  *               _ -> 0
   *       Cons a Nil -> a
   *       _ -> 0
   *
@@ -42,12 +39,6 @@ import scala.annotation.unused
   *       Cons w y -> case w of
   *           Cons a b -> case y of
   *               Nil -> a + b
-  *               _ -> case x of
-  *                   Cons a Nil -> a
-  *                   _ -> 0
-  *           _ -> case x of
-  *                   Cons a Nil -> a
-  *                   _ -> 0
   *       Cons a Nil -> a
   *       _ -> 0
   *
@@ -56,24 +47,15 @@ import scala.annotation.unused
   *       Cons w y -> case w of
   *           Cons a b -> case y of
   *               Nil -> a + b
-  *               _ -> case x of
-  *                   Cons a z -> case z of
-  *                       Nil -> a
-  *                       _ -> case x of
-  *                           _ -> 0
-  *                   _ -> 0
-  *           _ -> case x of
-  *                   Cons a z -> case z of
-  *                       Nil -> a
-  *                       _ -> case x of
-  *                           _ -> 0
-  *                   _ -> 0
   *       Cons a z -> case z of
   *           Nil -> a
-  *           _ -> case x of
-  *               _ -> 0
   *       _ -> 0
   * }}}
+  *
+  * Note how the desugaring discards unmatched branches for nested cases.
+  * This is done on purpose to simplify the constructed IR. Rather than
+  * implementing the fallthrough logic using IR, it is done in CaseNode/BranchNode
+  * Truffle nodes directly.
   *
   * This pass requires no configuration.
   *
@@ -178,7 +160,7 @@ case object NestedPatternMatch extends IRPass {
     freshNameSupply: FreshNameSupply
   ): IR.Expression = {
     expr match {
-      case expr @ IR.Case.Expr(scrutinee, branches, _, _, _) =>
+      case expr @ IR.Case.Expr(scrutinee, branches, _, _, _, _) =>
         val scrutineeBindingName = freshNameSupply.newName()
         val scrutineeExpression  = desugarExpression(scrutinee, freshNameSupply)
         val scrutineeBinding =
@@ -186,14 +168,10 @@ case object NestedPatternMatch extends IRPass {
 
         val caseExprScrutinee = scrutineeBindingName.duplicate()
 
-        val processedBranches = branches.zipWithIndex.map { case (branch, ix) =>
-          val remainingBranches = branches.drop(ix + 1).toList
-
+        val processedBranches = branches.zipWithIndex.map { case (branch, _) =>
           desugarCaseBranch(
             branch,
-            caseExprScrutinee,
             branch.location,
-            remainingBranches,
             freshNameSupply
           )
         }
@@ -214,20 +192,15 @@ case object NestedPatternMatch extends IRPass {
   /** Desugars a case branch.
     *
     * @param branch the branch to desugar
-    * @param originalScrutinee the original scrutinee of the pattern match
     * @param topBranchLocation the location of the source branch that is being
     *                           desugared
-    * @param remainingBranches all subsequent branches at the current pattern
-    *                          match level
     * @param freshNameSupply the compiler's supply of fresh names
     * @return `branch`, with any nested patterns desugared
     */
   @scala.annotation.tailrec
   def desugarCaseBranch(
     branch: IR.Case.Branch,
-    originalScrutinee: IR.Expression,
     topBranchLocation: Option[IR.IdentifiedLocation],
-    remainingBranches: List[IR.Case.Branch],
     freshNameSupply: FreshNameSupply
   ): IR.Case.Branch = {
     if (containsNestedPatterns(branch.pattern)) {
@@ -241,7 +214,6 @@ case object NestedPatternMatch extends IRPass {
           val newField = Pattern.Name(newName, None)
           val nestedScrutinee =
             newName.duplicate()
-          newName.duplicate()
 
           val newFields =
             fields.take(nestedPosition) ++ (newField :: fields.drop(
@@ -255,22 +227,20 @@ case object NestedPatternMatch extends IRPass {
           val newExpression = generateNestedCase(
             lastNestedPattern,
             nestedScrutinee,
-            originalScrutinee,
-            branch.expression,
-            remainingBranches
+            branch.expression
           )
 
+          val newPattern1 = newPattern.duplicate()
           val partDesugaredBranch = IR.Case.Branch(
-            pattern    = newPattern.duplicate(),
-            expression = newExpression.duplicate(),
+            pattern        = newPattern1,
+            expression     = newExpression.duplicate(),
+            terminalBranch = false,
             None
           )
 
           desugarCaseBranch(
             partDesugaredBranch,
-            originalScrutinee,
             topBranchLocation,
-            remainingBranches,
             freshNameSupply
           )
         case _: Pattern.Literal =>
@@ -321,41 +291,30 @@ case object NestedPatternMatch extends IRPass {
     * @param pattern the pattern being replaced in the desugaring
     * @param nestedScrutinee the name of the variable replacing `pattern` in the
     *                      branch
-    * @param topLevelScrutineeExpr the scrutinee of the original case expression
     * @param currentBranchExpr the expression executed in the current branch on
     *                          a success
-    * @param remainingBranches the branches to check against on a failure
     * @return a nested case expression of the form above
     */
   def generateNestedCase(
     pattern: Pattern,
     nestedScrutinee: IR.Expression,
-    topLevelScrutineeExpr: IR.Expression,
-    currentBranchExpr: IR.Expression,
-    remainingBranches: List[IR.Case.Branch]
+    currentBranchExpr: IR.Expression
   ): IR.Expression = {
-    val fallbackCase = IR.Case.Expr(
-      topLevelScrutineeExpr.duplicate(),
-      remainingBranches.duplicate(),
-      None
-    )
-
+    val patternDuplicate = pattern.duplicate()
+    val finalTest        = containsNestedPatterns(patternDuplicate)
     val patternBranch =
       IR.Case.Branch(
-        pattern.duplicate(),
+        patternDuplicate,
         currentBranchExpr.duplicate(),
-        None
+        terminalBranch = !finalTest,
+        location       = None
       )
-    val fallbackBranch = IR.Case.Branch(
-      IR.Pattern.Name(IR.Name.Blank(None), None),
-      fallbackCase,
-      None
-    )
 
     IR.Case.Expr(
       nestedScrutinee.duplicate(),
-      List(patternBranch, fallbackBranch),
-      None
+      List(patternBranch),
+      isNested = true,
+      location = None
     )
   }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/NestedPatternMatch.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/NestedPatternMatch.scala
@@ -30,25 +30,25 @@ import scala.annotation.unused
   *   # Desugar Nil in first branch
   *   case x of
   *       Cons (Cons a b) y -> case y of
-  *           Nil -> a + b
+  *           Nil -> a + b ## fallthrough on failed match ##
   *       Cons a Nil -> a
   *       _ -> 0
   *
   *   # Desuar `Cons a b` in the first branch
   *   case x of
   *       Cons w y -> case w of
-  *           Cons a b -> case y of
-  *               Nil -> a + b
+  *           Cons a b -> case y of ## fallthrough on failed match ##
+  *               Nil -> a + b ## fallthrough on failed match ##
   *       Cons a Nil -> a
   *       _ -> 0
   *
   *   # Desugar `Cons a Nil` in the second branch
   *   case x of
   *       Cons w y -> case w of
-  *           Cons a b -> case y of
-  *               Nil -> a + b
+  *           Cons a b -> case y of ## fallthrough on failed match ##
+  *               Nil -> a + b ## fallthrough on failed match ##
   *       Cons a z -> case z of
-  *           Nil -> a
+  *           Nil -> a ## fallthrough on failed match ##
   *       _ -> 0
   * }}}
   *

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/NestedPatternMatch.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/NestedPatternMatch.scala
@@ -30,25 +30,25 @@ import scala.annotation.unused
   *   # Desugar Nil in first branch
   *   case x of
   *       Cons (Cons a b) y -> case y of
-  *           Nil -> a + b ## fallthrough on failed match ##
+  *           Nil -> a + b            ## fallthrough on failed match ##
   *       Cons a Nil -> a
   *       _ -> 0
   *
   *   # Desuar `Cons a b` in the first branch
   *   case x of
   *       Cons w y -> case w of
-  *           Cons a b -> case y of ## fallthrough on failed match ##
-  *               Nil -> a + b ## fallthrough on failed match ##
+  *           Cons a b -> case y of   ## fallthrough on failed match ##
+  *               Nil -> a + b        ## fallthrough on failed match ##
   *       Cons a Nil -> a
   *       _ -> 0
   *
   *   # Desugar `Cons a Nil` in the second branch
   *   case x of
   *       Cons w y -> case w of
-  *           Cons a b -> case y of ## fallthrough on failed match ##
-  *               Nil -> a + b ## fallthrough on failed match ##
+  *           Cons a b -> case y of   ## fallthrough on failed match ##
+  *               Nil -> a + b        ## fallthrough on failed match ##
   *       Cons a z -> case z of
-  *           Nil -> a ## fallthrough on failed match ##
+  *           Nil -> a                ## fallthrough on failed match ##
   *       _ -> 0
   * }}}
   *

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/ShadowedPatternFields.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/ShadowedPatternFields.scala
@@ -104,7 +104,7 @@ case object ShadowedPatternFields extends IRPass {
     */
   def lintCase(cse: IR.Case): IR.Case = {
     cse match {
-      case expr @ IR.Case.Expr(scrutinee, branches, _, _, _) =>
+      case expr @ IR.Case.Expr(scrutinee, branches, _, _, _, _) =>
         expr.copy(
           scrutinee = lintExpression(scrutinee),
           branches  = branches.map(lintCaseBranch)

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/UnusedBindings.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/UnusedBindings.scala
@@ -217,7 +217,7 @@ case object UnusedBindings extends IRPass {
     */
   def lintCase(cse: IR.Case, context: InlineContext): IR.Case = {
     cse match {
-      case expr @ Case.Expr(scrutinee, branches, _, _, _) =>
+      case expr @ Case.Expr(scrutinee, branches, _, _, _, _) =>
         expr.copy(
           scrutinee = runExpression(scrutinee, context),
           branches  = branches.map(lintCaseBranch(_, context))

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/UnreachableMatchBranches.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/UnreachableMatchBranches.scala
@@ -120,7 +120,7 @@ case object UnreachableMatchBranches extends IRPass {
   //noinspection DuplicatedCode
   def optimizeCase(cse: IR.Case): IR.Case = {
     cse match {
-      case expr @ IR.Case.Expr(scrutinee, branches, _, _, _) =>
+      case expr @ IR.Case.Expr(scrutinee, branches, _, _, _, _) =>
         val reachableNonCatchAllBranches = branches.takeWhile(!isCatchAll(_))
         val firstCatchAll                = branches.find(isCatchAll)
         val unreachableBranches =

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/DocumentationComments.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/DocumentationComments.scala
@@ -116,10 +116,10 @@ case object DocumentationComments extends IRPass {
   private def resolveBranches(items: Seq[Branch]): Seq[Branch] = {
     var lastDoc: Option[String] = None
     items.flatMap {
-      case Branch(IR.Pattern.Documentation(doc, _, _, _), _, _, _, _) =>
+      case Branch(IR.Pattern.Documentation(doc, _, _, _), _, _, _, _, _) =>
         lastDoc = Some(doc)
         None
-      case branch @ Branch(pattern, expression, _, _, _) =>
+      case branch @ Branch(pattern, expression, _, _, _, _) =>
         val resolved =
           branch.copy(
             pattern    = pattern.mapExpressions(resolveExpression),

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/IgnoredBindings.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/IgnoredBindings.scala
@@ -286,7 +286,7 @@ case object IgnoredBindings extends IRPass {
     */
   def resolveCase(cse: IR.Case, supply: FreshNameSupply): IR.Case = {
     cse match {
-      case expr @ Case.Expr(scrutinee, branches, _, _, _) =>
+      case expr @ Case.Expr(scrutinee, branches, _, _, _, _) =>
         expr.copy(
           scrutinee = resolveExpression(scrutinee, supply),
           branches  = branches.map(resolveCaseBranch(_, supply))

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/NestedPatternMatchTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/NestedPatternMatchTest.scala
@@ -163,10 +163,9 @@ class NestedPatternMatchTest extends CompilerTest {
         .asInstanceOf[IR.Case.Expr]
 
       nestedCase.scrutinee shouldBe an[IR.Name.Literal]
-      nestedCase.branches.length shouldEqual 2
+      nestedCase.branches.length shouldEqual 1
 
-      val nilBranch      = nestedCase.branches(0)
-      val fallbackBranch = nestedCase.branches(1)
+      val nilBranch = nestedCase.branches(0)
 
       nilBranch.pattern shouldBe a[Pattern.Constructor]
       nilBranch.pattern
@@ -175,19 +174,6 @@ class NestedPatternMatchTest extends CompilerTest {
         .name shouldEqual "Nil"
       nilBranch.expression shouldBe an[IR.Name.Literal]
       nilBranch.expression.asInstanceOf[IR.Name].name shouldEqual "a"
-
-      fallbackBranch.pattern shouldBe a[Pattern.Name]
-      fallbackBranch.pattern
-        .asInstanceOf[Pattern.Name]
-        .name shouldBe an[IR.Name.Blank]
-
-      fallbackBranch.expression shouldBe an[IR.Expression.Block]
-      fallbackBranch.expression
-        .asInstanceOf[IR.Expression.Block]
-        .returnValue
-        .asInstanceOf[IR.Case.Expr]
-        .branches
-        .length shouldEqual 1
     }
 
     "desugar deeply nested patterns to simple patterns" in {
@@ -202,25 +188,18 @@ class NestedPatternMatchTest extends CompilerTest {
         .asInstanceOf[IR.Case.Expr]
 
       nestedCase.scrutinee shouldBe an[IR.Name.Literal]
-      nestedCase.branches.length shouldEqual 2
+      nestedCase.branches.length shouldEqual 1
 
-      val consBranch      = nestedCase.branches(0)
-      val fallbackBranch1 = nestedCase.branches(1)
+      val consBranch = nestedCase.branches(0)
 
       consBranch.expression shouldBe an[IR.Expression.Block]
-      fallbackBranch1.expression shouldBe an[IR.Expression.Block]
 
       val consBranchBody = consBranch.expression
         .asInstanceOf[IR.Expression.Block]
         .returnValue
         .asInstanceOf[IR.Case.Expr]
-      val fallbackBranch1Body =
-        fallbackBranch1.expression
-          .asInstanceOf[IR.Expression.Block]
-          .returnValue
-          .asInstanceOf[IR.Case.Expr]
 
-      consBranchBody.branches.length shouldEqual 2
+      consBranchBody.branches.length shouldEqual 1
       consBranchBody.branches.head.expression shouldBe an[IR.Expression.Block]
       consBranchBody.branches.head.pattern
         .asInstanceOf[Pattern.Constructor]
@@ -228,16 +207,6 @@ class NestedPatternMatchTest extends CompilerTest {
         .name shouldEqual "MyAtom"
       NestedPatternMatch.containsNestedPatterns(
         consBranchBody.branches.head.pattern
-      ) shouldEqual false
-
-      fallbackBranch1Body.branches.length shouldEqual 4
-      fallbackBranch1Body.branches.head.pattern shouldBe a[Pattern.Constructor]
-      fallbackBranch1Body.branches.head.pattern
-        .asInstanceOf[Pattern.Constructor]
-        .constructor
-        .name shouldEqual "Cons"
-      NestedPatternMatch.containsNestedPatterns(
-        fallbackBranch1Body.branches.head.pattern
       ) shouldEqual false
     }
 
@@ -253,25 +222,18 @@ class NestedPatternMatchTest extends CompilerTest {
         .asInstanceOf[IR.Case.Expr]
 
       nestedCase.scrutinee shouldBe an[IR.Name.Literal]
-      nestedCase.branches.length shouldEqual 2
+      nestedCase.branches.length shouldEqual 1
 
-      val consBranch      = nestedCase.branches(0)
-      val fallbackBranch1 = nestedCase.branches(1)
+      val consBranch = nestedCase.branches(0)
 
       consBranch.expression shouldBe an[IR.Expression.Block]
-      fallbackBranch1.expression shouldBe an[IR.Expression.Block]
 
       val consBranchBody = consBranch.expression
         .asInstanceOf[IR.Expression.Block]
         .returnValue
         .asInstanceOf[IR.Case.Expr]
-      val fallbackBranch1Body =
-        fallbackBranch1.expression
-          .asInstanceOf[IR.Expression.Block]
-          .returnValue
-          .asInstanceOf[IR.Case.Expr]
 
-      consBranchBody.branches.length shouldEqual 2
+      consBranchBody.branches.length shouldEqual 1
       consBranchBody.branches.head.expression shouldBe an[IR.Expression.Block]
       consBranchBody.branches.head.pattern
         .asInstanceOf[Pattern.Literal]
@@ -280,16 +242,6 @@ class NestedPatternMatchTest extends CompilerTest {
         .numericValue shouldEqual 1
       NestedPatternMatch.containsNestedPatterns(
         consBranchBody.branches.head.pattern
-      ) shouldEqual false
-
-      fallbackBranch1Body.branches.length shouldEqual 3
-      fallbackBranch1Body.branches.head.pattern shouldBe a[Pattern.Constructor]
-      fallbackBranch1Body.branches.head.pattern
-        .asInstanceOf[Pattern.Constructor]
-        .constructor
-        .name shouldEqual "Cons"
-      NestedPatternMatch.containsNestedPatterns(
-        fallbackBranch1Body.branches.head.pattern
       ) shouldEqual false
     }
 
@@ -307,25 +259,18 @@ class NestedPatternMatchTest extends CompilerTest {
         .asInstanceOf[IR.Case.Expr]
 
       nestedCase.scrutinee shouldBe an[IR.Name.Literal]
-      nestedCase.branches.length shouldEqual 2
+      nestedCase.branches.length shouldEqual 1
 
-      val consBranch      = nestedCase.branches(0)
-      val fallbackBranch1 = nestedCase.branches(1)
+      val consBranch = nestedCase.branches(0)
 
       consBranch.expression shouldBe an[IR.Expression.Block]
-      fallbackBranch1.expression shouldBe an[IR.Expression.Block]
 
       val consBranchBody = consBranch.expression
         .asInstanceOf[IR.Expression.Block]
         .returnValue
         .asInstanceOf[IR.Case.Expr]
-      val fallbackBranch1Body =
-        fallbackBranch1.expression
-          .asInstanceOf[IR.Expression.Block]
-          .returnValue
-          .asInstanceOf[IR.Case.Expr]
 
-      consBranchBody.branches.length shouldEqual 2
+      consBranchBody.branches.length shouldEqual 1
       consBranchBody.branches.head.expression shouldBe an[IR.Expression.Block]
       val tpePattern = consBranchBody.branches.head.pattern
         .asInstanceOf[Pattern.Type]
@@ -339,31 +284,13 @@ class NestedPatternMatchTest extends CompilerTest {
         consBranchBody.branches.head.pattern
       ) shouldEqual false
 
-      consBranchBody.branches(1).pattern shouldBe an[Pattern.Name]
-      consBranchBody
-        .branches(1)
-        .pattern
-        .asInstanceOf[Pattern.Name]
-        .name shouldBe an[IR.Name.Blank]
-
       val consTpeBranchBody = consBranchBody.branches.head.expression
         .asInstanceOf[IR.Expression.Block]
         .returnValue
         .asInstanceOf[IR.Case.Expr]
-      consTpeBranchBody.branches.length shouldEqual 2
+      consTpeBranchBody.branches.length shouldEqual 1
 
       consTpeBranchBody.branches.head.pattern shouldBe an[Pattern.Constructor]
-      consTpeBranchBody.branches(1).pattern shouldBe an[Pattern.Name]
-
-      fallbackBranch1Body.branches.length shouldEqual 2
-      fallbackBranch1Body.branches.head.pattern shouldBe a[Pattern.Constructor]
-      fallbackBranch1Body.branches.head.pattern
-        .asInstanceOf[Pattern.Constructor]
-        .constructor
-        .name shouldEqual "Cons"
-      NestedPatternMatch.containsNestedPatterns(
-        fallbackBranch1Body.branches.head.pattern
-      ) shouldEqual false
     }
 
     "work recursively" in {
@@ -386,7 +313,7 @@ class NestedPatternMatchTest extends CompilerTest {
           .returnValue
           .asInstanceOf[IR.Case.Expr]
 
-      consANilBranch2Expr.branches.length shouldEqual 2
+      consANilBranch2Expr.branches.length shouldEqual 1
       consANilBranch2Expr.branches.head.pattern
         .asInstanceOf[Pattern.Constructor]
         .constructor

--- a/lib/rust/types/src/dim_macros.rs
+++ b/lib/rust/types/src/dim_macros.rs
@@ -1,6 +1,8 @@
 //! Macros allowing generation of swizzling getters and setters.
 //! See the docs of [`build.rs`] and usage places to learn more.
 
+
+
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // THIS IS AN AUTO-GENERATED FILE. DO NOT EDIT IT DIRECTLY!
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/lib/rust/types/src/dim_macros.rs
+++ b/lib/rust/types/src/dim_macros.rs
@@ -1,8 +1,6 @@
 //! Macros allowing generation of swizzling getters and setters.
 //! See the docs of [`build.rs`] and usage places to learn more.
 
-
-
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 // THIS IS AN AUTO-GENERATED FILE. DO NOT EDIT IT DIRECTLY!
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
### Pull Request Description

`NestedPatternMatch` pass desugared complex patterns in a very inefficient way resulting in an exponential generation of the number of `case` IR (and Truffle) nodes. Every failed nested pattern would copy all the remaining patterns of the original case expression, in a desugared form. While the execution itself of such deeply nested `case` expression might not have many problems, the time spent in compilation phases certainly was a blocker.

This change desugars deeply nested into individual cases with a fallthrough logic. However the fallthrough logic is implemented directly in Truffle nodes, rather than via IR. That way we can generate much simpler IR for nested patterns.

Consider a simple case of
```
case x of
    Cons (Cons a b) Nil -> a + b
    Cons a Nil -> a
    _ -> 0
```

Before the change, the compiler would generate rather large IR even for those two patterns:
```
case x of
    Cons w y -> case w of
        Cons a b -> case y of
            Nil -> a + b
            _ -> case x of
                Cons a z -> case z of
                    Nil -> a
                    _ -> case x of
                        _ -> 0
                _ -> 0
        _ -> case x of
            Cons a z -> case z of
                Nil -> a
                _ -> case x of
                    _ -> 0
           _ -> 0
    Cons a z -> case z of
        Nil -> a
        _ -> case x of
            _ -> 0
    _ -> 0
```

Now we generate simple patterns with fallthrough semantics and no catch-all branches:
```
case x of
    Cons w y -> case w of
        Cons a b -> case y of   ## fallthrough on failed match ## 
            Nil -> a + b                ## fallthrough on failed match ## 
    Cons a z -> case z of
        Nil -> a                          ## fallthrough on failed match ## 
    _ -> 0
```


### Important Notes

If you wonder how much does it improve, then @radeusgd's example in https://www.pivotaltracker.com/story/show/183971366/comments/234688327 used to take at least 8 minutes to compile and run.
Now it takes 5 seconds from cold start.

Also, the example in the benchmark includes compilation time on purpose (that was the main culprit of the slowdown).
For the old implementation I had to kill it after 15 minutes as it still wouldn't finish a single compilation.
Now it runs 2 seconds or less.

Bonus points: This PR will also fix problem reported in https://www.pivotaltracker.com/story/show/184071954 (duplicate errors for nested patterns)

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
