### PR TITLE
Make To Text Conversion Identity for Text

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Any.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Any.enso
@@ -39,9 +39,19 @@ type Any
        representation.
 
        > Example
-         Getting a human-readable textual representation of the number 7.
+         Getting a human-readable representation of the number 7.
 
              7.to_text
+    pretty : Text
+    pretty self = @Builtin_Method "Any.pretty"
+
+    ## Generic conversion of an arbitrary Enso value to a corresponding short
+       human-readable representation.
+
+       > Example
+         Getting a short human-readable textual representation of the number 7.
+
+             7.to_display_text
     to_display_text : Text
     to_display_text self = @Builtin_Method "Any.to_display_text"
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text.enso
@@ -149,3 +149,18 @@ type Text
              "aaa".not_empty
     not_empty : Boolean
     not_empty self = self.is_empty.not
+
+    ## ADVANCED
+       PRIVATE
+       UNSTABLE
+
+       Conversion to Text that overrides the default `to_text` behavior.
+    to_text : Text
+    to_text self = Text.from self
+
+## ADVANCED
+   PRIVATE
+   UNSTABLE
+
+   Conversion from Text.
+Text.from (that:Text) = that

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text.enso
@@ -150,17 +150,9 @@ type Text
     not_empty : Boolean
     not_empty self = self.is_empty.not
 
-    ## ADVANCED
-       PRIVATE
+    ## PRIVATE
        UNSTABLE
 
        Conversion to Text that overrides the default `to_text` behavior.
     to_text : Text
-    to_text self = Text.from self
-
-## ADVANCED
-   PRIVATE
-   UNSTABLE
-
-   Conversion from Text.
-Text.from (that:Text) = that
+    to_text self = self

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Delimited/Delimited_Writer.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Delimited/Delimited_Writer.enso
@@ -62,7 +62,7 @@ append_to_file table format file match_columns on_problems =
                 if existing_separator.is_nothing.not && (selected_separator != existing_separator) then
                     Panic.throw <| Illegal_Argument.Error <|
                         # Ensure that these are properly escaped once `to_text` meaning is changed.
-                        "The explicitly provided line endings (" + selected_separator.to_text + ") do not match the line endings in the file (" + existing_separator.to_text + ")."
+                        "The explicitly provided line endings (" + selected_separator.pretty + ") do not match the line endings in the file (" + existing_separator.pretty + ")."
                 other_ending_style.to_text
 
         reordered_java_table = case preexisting_headers of

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyPrettyNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyPrettyNode.java
@@ -1,0 +1,86 @@
+package org.enso.interpreter.node.expression.builtin.text;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.dsl.Fallback;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
+import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.data.text.Text;
+
+@BuiltinMethod(type = "Any", name = "pretty", description = "Generic pretty printing function.")
+public abstract class AnyPrettyNode extends Node {
+  private static final int DISPATCH_CACHE = 3;
+  private @Child InteropLibrary displays =
+      InteropLibrary.getFactory().createDispatched(DISPATCH_CACHE);
+  private @Child InteropLibrary strings =
+      InteropLibrary.getFactory().createDispatched(DISPATCH_CACHE);
+
+  public static AnyPrettyNode build() {
+    return AnyPrettyNodeGen.create();
+  }
+
+  public abstract Text execute(Object self);
+
+  @Specialization
+  Text doAtom(Atom at) {
+    if (at.getFields().length == 0) {
+      return consName(at.getConstructor());
+    } else {
+      return doComplexAtom(at);
+    }
+  }
+
+  @Fallback
+  Text doOther(Object object) {
+    try {
+      return Text.create(showObject(object));
+    } catch (UnsupportedMessageException e) {
+      CompilerDirectives.transferToInterpreter();
+      return Text.create(object.toString());
+    }
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  private Text consName(AtomConstructor constructor) {
+    return Text.create(constructor.getDisplayName());
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  private Text doComplexAtom(Atom atom) {
+    Text res = Text.create("(", consName(atom.getConstructor()));
+    res = Text.create(res, " ");
+    try {
+      res = Text.create(res, showObject(atom.getFields()[0]));
+    } catch (UnsupportedMessageException e) {
+      res = Text.create(res, atom.getFields()[0].toString());
+    }
+    for (int i = 1; i < atom.getFields().length; i++) {
+      res = Text.create(res, " ");
+      try {
+        res = Text.create(res, strings.asString(displays.toDisplayString(atom.getFields()[i])));
+      } catch (UnsupportedMessageException e) {
+        res = Text.create(res, atom.getFields()[i].toString());
+      }
+    }
+    res = Text.create(res, ")");
+    return res;
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  private String showObject(Object child) throws UnsupportedMessageException {
+    if (child == null) {
+      // TODO [RW] This is a temporary workaround to make it possible to display errors related to
+      // https://www.pivotaltracker.com/story/show/181652974
+      // Most likely it should be removed once that is implemented.
+      return "null";
+    } else if (child instanceof Boolean) {
+      return (boolean) child ? "True" : "False";
+    } else {
+      return strings.asString(displays.toDisplayString(child));
+    }
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyPrettyNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyPrettyNode.java
@@ -61,7 +61,7 @@ public abstract class AnyPrettyNode extends Node {
     for (int i = 1; i < atom.getFields().length; i++) {
       res = Text.create(res, " ");
       try {
-        res = Text.create(res, strings.asString(displays.toDisplayString(atom.getFields()[i])));
+        res = Text.create(res, showObject(atom.getFields()[i]));
       } catch (UnsupportedMessageException e) {
         res = Text.create(res, atom.getFields()[i].toString());
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyToTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/AnyToTextNode.java
@@ -61,7 +61,7 @@ public abstract class AnyToTextNode extends Node {
     for (int i = 1; i < atom.getFields().length; i++) {
       res = Text.create(res, " ");
       try {
-        res = Text.create(res, strings.asString(displays.toDisplayString(atom.getFields()[i])));
+        res = Text.create(res, showObject(atom.getFields()[i]));
       } catch (UnsupportedMessageException e) {
         res = Text.create(res, atom.getFields()[i].toString());
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
@@ -200,7 +200,7 @@ public final class Vector implements TruffleObject {
         Object at =
             readArrayElement(
                 i, iop, WarningsLibrary.getUncached(), HostValueToEnsoNode.getUncached());
-        Object str = iop.toDisplayString(at, allowSideEffects);
+        Object str = showObject(iop, allowSideEffects, at);
         if (iop.isString(str)) {
           sb.append(iop.asString(str));
         } else {
@@ -271,5 +271,16 @@ public final class Vector implements TruffleObject {
   @SuppressWarnings("unchecked")
   private static <E extends Exception> E raise(Class<E> clazz, Throwable t) throws E {
     throw (E) t;
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  private Object showObject(InteropLibrary iop, boolean allowSideEffects, Object child) throws UnsupportedMessageException {
+    if (child == null) {
+      return "null";
+    } else if (child instanceof Boolean) {
+      return (boolean) child ? "True" : "False";
+    } else {
+      return iop.toDisplayString(child, allowSideEffects);
+    }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
@@ -274,7 +274,8 @@ public final class Vector implements TruffleObject {
   }
 
   @CompilerDirectives.TruffleBoundary
-  private Object showObject(InteropLibrary iop, boolean allowSideEffects, Object child) throws UnsupportedMessageException {
+  private Object showObject(InteropLibrary iop, boolean allowSideEffects, Object child)
+      throws UnsupportedMessageException {
     if (child == null) {
       return "null";
     } else if (child instanceof Boolean) {

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -71,7 +71,7 @@ sqlite_specific_spec connection =
 
             action = connection.read (SQL_Query.Raw_SQL "SELECT A FROM undefined_table")
             action . should_fail_with SQL_Error.Error
-            action.catch.to_text . should_equal "There was an SQL error: '[SQLITE_ERROR] SQL error or missing database (no such table: undefined_table)'. [Query was: SELECT A FROM undefined_table]"
+            action.catch.to_text . should_equal "There was an SQL error: [SQLITE_ERROR] SQL error or missing database (no such table: undefined_table). [Query was: SELECT A FROM undefined_table]"
 
     Test.group "[SQLite] Metadata" <|
         tinfo = Name_Generator.random_name "Tinfo"

--- a/test/Table_Tests/src/In_Memory/Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Spec.enso
@@ -331,7 +331,7 @@ spec =
             t1 = t.filter_blank_rows when_any=True treat_nans_as_blank=False
             t1.at "X" . to_vector . should_equal [1, 4, 5]
             # Comparing text value because `Number.nan != Number.nan`.
-            t1.at "Y" . to_vector . to_text . should_equal "['A', NaN, 0]"
+            t1.at "Y" . to_vector . to_text . should_equal "[A, NaN, 0]"
             t2 = t.filter_blank_rows when_any=True treat_nans_as_blank=True
             t2.at "X" . to_vector . should_equal [1, 5]
             t2.at "Y" . to_vector . should_equal ['A', 0]
@@ -343,7 +343,7 @@ spec =
         Test.specify "Blank_Columns selector should work for all kinds of methods accepting Column_Selector" <|
             t = Table.new [["X", [1, 2, 3, 4, 5]], ["Y", ["", Nothing, Nothing, Number.nan, ""]]]
             r1 = t.distinct (Column_Selector.Blank_Columns treat_nans_as_blank=True)
-            r1.at "Y" . to_vector . to_text . should_equal "['', Nothing, NaN]"
+            r1.at "Y" . to_vector . to_text . should_equal "[, Nothing, NaN]"
             r1.at "X" . to_vector . should_equal [1, 2, 4]
 
             # TODO this could be moved to Common_Table_Operations once replace_text is implemented for Database too

--- a/test/Tests/src/Data/Text_Spec.enso
+++ b/test/Tests/src/Data/Text_Spec.enso
@@ -251,9 +251,17 @@ spec =
             text_1 = '''
                 foo
                 bar\r\tbaz
-            text_1.to_text.should_equal "'foo\nbar\r\tbaz'"
+            text_1.pretty.should_equal "'foo\nbar\r\tbaz'"
             text_2 = '\n\t\a\b\f\r\v\e\''
-            text_2.to_text.should_equal "'\n\t\a\b\f\r\v\e\''"
+            text_2.pretty.should_equal "'\n\t\a\b\f\r\v\e\''"
+
+        Test.specify "should return text as is when converting to text" <|
+            text_1 = '''
+                foo
+                bar\r\tbaz
+            text_1.to_text.should_equal text_1
+            text_2 = '\n\t\a\b\f\r\v\e\''
+            text_2.to_text.should_equal text_2
 
         Test.specify "should allow taking or dropping every other character" <|
             "ABCDE".take (Every 1) . should_equal "ABCDE"

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -322,7 +322,7 @@ spec = Test.group "Vectors" <|
         [].to_text.should_equal "[]"
         [1,2,3].to_text.should_equal "[1, 2, 3]"
         [Nothing].to_text.should_equal "[Nothing]"
-        ['a'].to_text . should_equal "['a']"
+        ['a'].to_text . should_equal "[a]"
 
     Test.specify "should allow to generate a short text representation for display" <|
         [].short_display_text max_entries=3 . should_equal "[]"

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -670,4 +670,11 @@ spec = Test.group "Vectors" <|
     Test.specify "array1 should be equal to array2" <|
         a1.should_equal a2
 
+    Test.specify "should have a well-defined debug-printing method" <|
+        [].pretty.should_equal "[]"
+        [1,2,3].pretty.should_equal "[1, 2, 3]"
+        [Nothing].pretty.should_equal "[Nothing]"
+        [True, False, 'a'].pretty . should_equal "[True, False, 'a']"
+        [Foo.Value True].pretty . should_equal "[(Foo.Value True)]"
+
 main = Test_Suite.run_main spec

--- a/test/Tests/src/Semantic/Conversion_Spec.enso
+++ b/test/Tests/src/Semantic/Conversion_Spec.enso
@@ -73,7 +73,7 @@ spec =
         Test.specify "should call intrinsic object conversions for unimported constructors" <|
             Vector.from Methods.get_foo . should_equal ["foo"]
         Test.specify "should call extension conversions" <|
-            Text.from Methods.get_bar . should_equal "'bar'"
+            Text.from Methods.get_bar . should_equal "bar"
 
         Test.specify "should fail graciously when there is no conversion" <|
             Panic.recover Any (Foo.from (Quux.Value 10)) . catch Any .to_display_text . should_equal "Could not find a conversion from `Quux.Value` to `Foo`"

--- a/test/Tests/src/Semantic/Error_Spec.enso
+++ b/test/Tests/src/Semantic/Error_Spec.enso
@@ -270,7 +270,7 @@ spec =
                 Panic.catch Text handler=err->"JS string:"+err.payload.to_text <|
                     throw_js_str
 
-            caught_js_str_panic . should_equal "JS string:'foo'"
+            caught_js_str_panic . should_equal "JS string:foo"
 
             caught_js_arr_panic = Panic.catch Any handler=err->"Any:"+err.payload.to_text <|
                 Panic.catch Array handler=err->"JS array:"+err.payload.to_text <|


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

First part of fixing `Text.to_text`. 
- add: `pretty` method for pretty printing.
- update: make `Text.to_text` conversion identity for Text

In the next iterations `to_text` will be gradually replaced with `to Text` conversion once the related issues with conversions are fixed.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] ~If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.~
