### PR TITLE
Nested type declaration shall yield a syntax error

### DIFF
--- a/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
@@ -328,7 +328,10 @@ final class TreeToIr {
     var inputAst = maybeManyParensed(exp);
     return switch (inputAst) {
       case null -> appendTo;
-      case Tree.TypeDef def -> translateModuleSymbol(def, (List) appendTo);
+      case Tree.TypeDef def -> {
+        var ir = translateSyntaxError(def, IR$Error$Syntax$UnexpectedDeclarationInType$.MODULE$);
+        yield cons(ir, appendTo);
+      }
       case Tree.ArgumentBlockApplication app -> appendTo;
       case Tree.TypeSignature sig -> {
         var isMethod = false;

--- a/engine/runtime/src/test/java/org/enso/compiler/EnsoCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/EnsoCompilerTest.java
@@ -366,6 +366,16 @@ public class EnsoCompilerTest {
   }
 
   @Test
+  public void testPanic_184119084() throws Exception {
+    parseTest("""
+    type Foo
+        type Bar
+
+    main = 42
+    """);
+  }
+
+  @Test
   public void testMetadataRaw() throws Exception {
     parseTest("""
     main =


### PR DESCRIPTION
### Pull Request Description

Nested type declaration shall yield a syntax error

### Important Notes

Now the Radek's sample:
```
type Foo
    type Bar

main = 42
```
yields
```bash
$ enso --run test.enso
In module test:
Compiler encountered errors:
test.enso[2:9-2:16]: Unexpected declaration in the body of a type.
Aborting due to 1 errors and 0 warnings.
Execution finished with an error: Compilation aborted due to errors.
```

### Checklist

Please include the following checklist in your PR:

- [x] All code conforms to the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
