### PR TITLE
AST support for new annotation syntax

### DIFF
--- a/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
@@ -275,7 +275,7 @@ final class TreeToIr {
         yield cons(binding, appendTo);
       }
 
-      case Tree.Annotated anno -> {
+      case Tree.AnnotatedBuiltin anno -> {
         var annotation = new IR$Name$Annotation("@" + anno.getAnnotation().codeRepr(), getIdentifiedLocation(anno), meta(), diag());
         yield translateModuleSymbol(anno.getExpression(), cons(annotation, appendTo));
       }
@@ -381,7 +381,7 @@ final class TreeToIr {
         var irDoc = translateComment(doc, doc.getDocumentation());
         yield translateTypeBodyExpression(doc.getExpression(), cons(irDoc, appendTo));
       }
-      case Tree.Annotated anno -> {
+      case Tree.AnnotatedBuiltin anno -> {
         var ir = new IR$Name$Annotation("@" + anno.getAnnotation().codeRepr(), getIdentifiedLocation(anno), meta(), diag());
         var annotation = translateAnnotation(ir, anno.getExpression(), nil());
         yield cons(annotation, appendTo);
@@ -909,7 +909,7 @@ final class TreeToIr {
       }
       case Tree.TemplateFunction templ -> translateExpression(templ.getAst(), false);
       case Tree.Wildcard wild -> new IR$Name$Blank(getIdentifiedLocation(wild), meta(), diag());
-      case Tree.Annotated anno -> {
+      case Tree.AnnotatedBuiltin anno -> {
         var ir = new IR$Name$Annotation("@" + anno.getAnnotation().codeRepr(), getIdentifiedLocation(anno), meta(), diag());
         yield translateAnnotation(ir, anno.getExpression(), nil());
       }
@@ -964,7 +964,7 @@ final class TreeToIr {
         case Tree.UnaryOprApp app -> app.getRhs();
         case Tree.OprSectionBoundary section -> section.getAst();
         case Tree.TemplateFunction function -> function.getAst();
-        case Tree.Annotated annotated -> annotated.getExpression();
+        case Tree.AnnotatedBuiltin annotated -> annotated.getExpression();
         case Tree.Documented documented -> documented.getExpression();
         case Tree.Assignment assignment -> assignment.getExpr();
         case Tree.TypeAnnotated annotated -> annotated.getExpression();

--- a/engine/runtime/src/test/java/org/enso/compiler/EnsoCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/EnsoCompilerTest.java
@@ -605,7 +605,7 @@ public class EnsoCompilerTest {
   public void testNotAnOperator() throws Exception {
     parseTest("""
     main =
-        x = Panic.catch Any @ caught_panic-> caught_panic.payload
+        x = Panic.catch_primitive @ caught_panic-> caught_panic.payload
         x.to_text
     """);
   }

--- a/engine/runtime/src/test/java/org/enso/compiler/EnsoCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/EnsoCompilerTest.java
@@ -605,7 +605,7 @@ public class EnsoCompilerTest {
   public void testNotAnOperator() throws Exception {
     parseTest("""
     main =
-        x = Panic.catch_primitive @ caught_panic-> caught_panic.payload
+        x = Panic.catch Any @ caught_panic-> caught_panic.payload
         x.to_text
     """);
   }

--- a/lib/rust/parser/debug/tests/parse.rs
+++ b/lib/rust/parser/debug/tests/parse.rs
@@ -1212,22 +1212,23 @@ fn trailing_whitespace() {
 
 #[test]
 fn annotation_syntax() {
-    #[rustfmt::skip]
-    let cases = [
-        ("foo@bar", block![(OprApp (Ident foo) (Ok "@") (Ident bar))]),
-        ("foo @ bar", block![(OprApp (Ident foo) (Ok "@") (Ident bar))]),
-        ("@Bar", block![(Annotated "@" Bar #() ())]),
-    ];
-    cases.into_iter().for_each(|(code, expected)| test(code, expected));
+    test!("foo@bar", (OprApp (Ident foo) (Ok "@") (Ident bar)));
+    test!("foo @ bar", (OprApp (Ident foo) (Ok "@") (Ident bar)));
+    test!("@Bar", (AnnotatedBuiltin "@" Bar #() ()));
+}
+
+#[test]
+fn at_operator() {
+    test!("Panic.catch Any @ caught_panic-> caught_panic.payload", ());
 }
 
 #[test]
 fn inline_annotations() {
     #[rustfmt::skip]
     let cases = [
-        ("@Tail_Call go t", block![(Annotated "@" Tail_Call #() (App (Ident go) (Ident t)))]),
+        ("@Tail_Call go t", block![(AnnotatedBuiltin "@" Tail_Call #() (App (Ident go) (Ident t)))]),
         ("@Tail_Call go\n a\n b", block![
-            (Annotated "@" Tail_Call #()
+            (AnnotatedBuiltin "@" Tail_Call #()
              (ArgumentBlockApplication (Ident go) #((Ident a) (Ident b))))]),
     ];
     cases.into_iter().for_each(|(code, expected)| test(code, expected));
@@ -1236,7 +1237,7 @@ fn inline_annotations() {
 #[test]
 fn multiline_annotations() {
     test!("@Builtin_Type\ntype Date",
-        (Annotated "@" Builtin_Type #(()) (TypeDef type Date #() #())));
+        (AnnotatedBuiltin "@" Builtin_Type #(()) (TypeDef type Date #() #())));
 }
 
 

--- a/lib/rust/parser/debug/tests/parse.rs
+++ b/lib/rust/parser/debug/tests/parse.rs
@@ -1211,31 +1211,35 @@ fn trailing_whitespace() {
 // === Annotations ===
 
 #[test]
-fn annotation_syntax() {
+fn at_operator() {
     test!("foo@bar", (OprApp (Ident foo) (Ok "@") (Ident bar)));
     test!("foo @ bar", (OprApp (Ident foo) (Ok "@") (Ident bar)));
-    test!("@Bar", (AnnotatedBuiltin "@" Bar #() ()));
+}
+
+
+#[test]
+fn attributes() {
+    test!("@on_problems P.g\nTable.select_columns : Text -> Table",
+        (Annotated "@" on_problems
+         (OprApp (Ident P) (Ok ".") (Ident g))
+         #(())
+         (TypeSignature (OprApp (Ident Table) (Ok ".") (Ident select_columns))
+                        ":"
+                        (OprApp (Ident Text) (Ok "->") (Ident Table)))));
+    test!("@a z\n@b\nx", (Annotated "@" a (Ident z) #(()) (Annotated "@" b () #(()) (Ident x))));
+    test!("@a\n@b\nx", (Annotated "@" a () #(()) (Annotated "@" b () #(()) (Ident x))));
 }
 
 #[test]
-fn at_operator() {
-    test!("Panic.catch Any @ caught_panic-> caught_panic.payload", ());
+fn inline_builtin_annotations() {
+    test!("@Tail_Call go t", (AnnotatedBuiltin "@" Tail_Call #() (App (Ident go) (Ident t))));
+    test!("@Tail_Call go\n a\n b",
+        (AnnotatedBuiltin "@" Tail_Call #()
+         (ArgumentBlockApplication (Ident go) #((Ident a) (Ident b)))));
 }
 
 #[test]
-fn inline_annotations() {
-    #[rustfmt::skip]
-    let cases = [
-        ("@Tail_Call go t", block![(AnnotatedBuiltin "@" Tail_Call #() (App (Ident go) (Ident t)))]),
-        ("@Tail_Call go\n a\n b", block![
-            (AnnotatedBuiltin "@" Tail_Call #()
-             (ArgumentBlockApplication (Ident go) #((Ident a) (Ident b))))]),
-    ];
-    cases.into_iter().for_each(|(code, expected)| test(code, expected));
-}
-
-#[test]
-fn multiline_annotations() {
+fn multiline_builtin_annotations() {
     test!("@Builtin_Type\ntype Date",
         (AnnotatedBuiltin "@" Builtin_Type #(()) (TypeDef type Date #() #())));
 }

--- a/lib/rust/parser/src/syntax/tree.rs
+++ b/lib/rust/parser/src/syntax/tree.rs
@@ -316,6 +316,18 @@ macro_rules! with_ast_definition { ($f:ident ($($args:tt)*)) => { $f! { $($args)
             pub rest:  Vec<OperatorDelimitedTree<'s>>,
             pub right: token::CloseSymbol<'s>,
         },
+        /// An expression preceded by an annotation. For example:
+        /// ```enso
+        /// @on_problems Problem_Behavior.get_widget_attribute
+        /// Table.select_columns : Vector Text | Column_Selector -> Boolean -> Problem_Behavior -> Table
+        /// ```
+        Annotated {
+            pub token:      token::Operator<'s>,
+            pub annotation: token::Ident<'s>,
+            pub argument:   Option<Tree<'s>>,
+            pub newlines:   Vec<token::Newline<'s>>,
+            pub expression: Option<Tree<'s>>,
+        },
         /// An expression preceded by a special built-in annotation, e.g. `@Tail_Call foo 4`.
         AnnotatedBuiltin {
             pub token:      token::Operator<'s>,
@@ -796,12 +808,12 @@ pub fn apply<'s>(mut func: Tree<'s>, mut arg: Tree<'s>) -> Tree<'s> {
             func_.fractional_digits = mem::take(fractional_digits);
             func
         }
-        (Variant::AnnotatedBuiltin(func_ @ AnnotatedBuiltin { expression: None, .. }), _) => {
-            func_.expression = arg.into();
+        (Variant::Annotated(func_ @ Annotated { argument: None, .. }), _) => {
+            func_.argument = maybe_apply(mem::take(&mut func_.argument), arg).into();
             func
         }
-        (Variant::AnnotatedBuiltin(AnnotatedBuiltin { expression: Some(expression), .. }), _) => {
-            *expression = apply(mem::take(expression), arg);
+        (Variant::AnnotatedBuiltin(func_), _) => {
+            func_.expression = maybe_apply(mem::take(&mut func_.expression), arg).into();
             func
         }
         (Variant::OprApp(OprApp { lhs: Some(_), opr: Ok(_), rhs }),
@@ -850,6 +862,13 @@ pub fn apply<'s>(mut func: Tree<'s>, mut arg: Tree<'s>) -> Tree<'s> {
             Tree::default_app(func, token)
         }
         _ => Tree::app(func, arg)
+    }
+}
+
+fn maybe_apply<'s>(f: Option<Tree<'s>>, x: Tree<'s>) -> Tree<'s> {
+    match f {
+        Some(f) => apply(f, x),
+        None => x,
     }
 }
 
@@ -941,7 +960,10 @@ pub fn apply_operator<'s>(
 pub fn apply_unary_operator<'s>(opr: token::Operator<'s>, rhs: Option<Tree<'s>>) -> Tree<'s> {
     if opr.properties.is_annotation()
             && let Some(Tree { variant: box Variant::Ident(Ident { token }), .. }) = rhs {
-        Tree::annotated_builtin(opr, token, vec![], None)
+        match token.is_type {
+            true => Tree::annotated_builtin(opr, token, vec![], None),
+            false => Tree::annotated(opr, token, None, vec![], None),
+        }
     } else {
         Tree::unary_opr_app(opr, rhs)
     }

--- a/lib/rust/parser/src/syntax/tree.rs
+++ b/lib/rust/parser/src/syntax/tree.rs
@@ -316,8 +316,8 @@ macro_rules! with_ast_definition { ($f:ident ($($args:tt)*)) => { $f! { $($args)
             pub rest:  Vec<OperatorDelimitedTree<'s>>,
             pub right: token::CloseSymbol<'s>,
         },
-        /// An expression preceded by an annotation, e.g. `@Builtin_Method foo`.
-        Annotated {
+        /// An expression preceded by a special built-in annotation, e.g. `@Tail_Call foo 4`.
+        AnnotatedBuiltin {
             pub token:      token::Operator<'s>,
             pub annotation: token::Ident<'s>,
             pub newlines:   Vec<token::Newline<'s>>,
@@ -796,11 +796,11 @@ pub fn apply<'s>(mut func: Tree<'s>, mut arg: Tree<'s>) -> Tree<'s> {
             func_.fractional_digits = mem::take(fractional_digits);
             func
         }
-        (Variant::Annotated(func_ @ Annotated { expression: None, .. }), _) => {
+        (Variant::AnnotatedBuiltin(func_ @ AnnotatedBuiltin { expression: None, .. }), _) => {
             func_.expression = arg.into();
             func
         }
-        (Variant::Annotated(Annotated { expression: Some(expression), .. }), _) => {
+        (Variant::AnnotatedBuiltin(AnnotatedBuiltin { expression: Some(expression), .. }), _) => {
             *expression = apply(mem::take(expression), arg);
             func
         }
@@ -941,7 +941,7 @@ pub fn apply_operator<'s>(
 pub fn apply_unary_operator<'s>(opr: token::Operator<'s>, rhs: Option<Tree<'s>>) -> Tree<'s> {
     if opr.properties.is_annotation()
             && let Some(Tree { variant: box Variant::Ident(Ident { token }), .. }) = rhs {
-        Tree::annotated(opr, token, vec![], None)
+        Tree::annotated_builtin(opr, token, vec![], None)
     } else {
         Tree::unary_opr_app(opr, rhs)
     }

--- a/lib/rust/parser/src/syntax/tree/block.rs
+++ b/lib/rust/parser/src/syntax/tree/block.rs
@@ -58,7 +58,7 @@ pub fn body_from_lines<'s>(lines: impl IntoIterator<Item = Line<'s>>) -> Tree<'s
         let mut statement = line.map_expression(expression_to_statement);
         if let Some(Tree {
             variant:
-                box Variant::Annotated(Annotated { newlines, expression, .. })
+                box Variant::AnnotatedBuiltin(AnnotatedBuiltin { newlines, expression, .. })
                 | box Variant::Documented(Documented {
                     documentation: DocComment { newlines, .. },
                     expression,

--- a/lib/rust/parser/src/syntax/tree/block.rs
+++ b/lib/rust/parser/src/syntax/tree/block.rs
@@ -47,37 +47,111 @@ impl<'s> span::Builder<'s> for Line<'s> {
 // === Body Block ===
 // ==================
 
-/// Build a body block from a sequence of lines; this involves reinterpreting the input expressions
-/// in statement context (i.e. expressions at the top-level of the block that involve the `=`
-/// operator will be reinterpreted as function/variable bindings).
+/// Build a body block from a sequence of lines; this includes:
+/// - Reinterpret the input expressions in statement context (i.e. expressions at the top-level of
+///   the block that involve the `=` operator will be reinterpreted as function/variable bindings).
+/// - Combine sibling lines in case of multi-line statements, such as annotated statements and
+///   documented statements.
 pub fn body_from_lines<'s>(lines: impl IntoIterator<Item = Line<'s>>) -> Tree<'s> {
     use crate::expression_to_statement;
-    let mut lines = lines.into_iter();
+    let lines = lines.into_iter();
     let mut statements = Vec::with_capacity(lines.size_hint().0);
-    while let Some(line) = lines.next() {
-        let mut statement = line.map_expression(expression_to_statement);
-        if let Some(Tree {
-            variant:
-                box Variant::AnnotatedBuiltin(AnnotatedBuiltin { newlines, expression, .. })
-                | box Variant::Documented(Documented {
-                    documentation: DocComment { newlines, .. },
-                    expression,
-                    ..
-                }),
-            ..
-        }) = &mut statement.expression
-        {
-            while expression.is_none() &&
-            let Some(line) = lines.next()
-            {
-                let statement = line.map_expression(expression_to_statement);
-                newlines.push(statement.newline);
-                *expression = statement.expression;
+    let mut prefixes: Vec<Prefix> = Vec::new();
+    let mut newline = None;
+    for line in lines {
+        match prefixes.last_mut() {
+            Some(prefix) => prefix.newlines().push(line.newline),
+            None =>
+                if let Some(empty_line) = newline.replace(line.newline) {
+                    statements.push(empty_line.into());
+                },
+        };
+        if let Some(expression) = line.expression {
+            match Prefix::try_from(expression_to_statement(expression)) {
+                Ok(prefix) => prefixes.push(prefix),
+                Err(mut statement) => {
+                    for prefix in prefixes.drain(..).rev() {
+                        statement = prefix.apply_to(statement);
+                    }
+                    let newline = newline.take().unwrap();
+                    statements.push(Line { newline, expression: Some(statement) });
+                }
             }
         }
-        statements.push(statement);
+    }
+    if let Some(prefix) = prefixes.pop() {
+        let mut statement = prefix.into();
+        for prefix in prefixes.drain(..).rev() {
+            statement = prefix.apply_to(statement);
+        }
+        let newline = newline.take().unwrap();
+        statements.push(Line { newline, expression: Some(statement) });
+    }
+    if let Some(line) = newline {
+        match prefixes.last_mut() {
+            Some(prefix) => prefix.newlines().push(line),
+            None => statements.push(line.into()),
+        }
     }
     Tree::body_block(statements)
+}
+
+
+// === Prefix-list representation ===
+
+/// Representation used to build multi-line statements.
+enum Prefix<'s> {
+    Annotation { node: Annotated<'s>, span: Span<'s> },
+    BuiltinAnnotation { node: AnnotatedBuiltin<'s>, span: Span<'s> },
+    Documentation { node: Documented<'s>, span: Span<'s> },
+}
+
+impl<'s> TryFrom<Tree<'s>> for Prefix<'s> {
+    type Error = Tree<'s>;
+    fn try_from(tree: Tree<'s>) -> Result<Self, Self::Error> {
+        match tree.variant {
+            box Variant::Annotated(node) => Ok(Prefix::Annotation { node, span: tree.span }),
+            box Variant::AnnotatedBuiltin(node @ AnnotatedBuiltin { expression: None, .. }) =>
+                Ok(Prefix::BuiltinAnnotation { node, span: tree.span }),
+            box Variant::Documented(node) => Ok(Prefix::Documentation { node, span: tree.span }),
+            _ => Err(tree),
+        }
+    }
+}
+
+impl<'s> Prefix<'s> {
+    fn newlines(&mut self) -> &mut Vec<token::Newline<'s>> {
+        match self {
+            Prefix::Annotation { node: Annotated { newlines, .. }, .. }
+            | Prefix::BuiltinAnnotation { node: AnnotatedBuiltin { newlines, .. }, .. }
+            | Prefix::Documentation {
+                node: Documented { documentation: DocComment { newlines, .. }, .. },
+                ..
+            } => newlines,
+        }
+    }
+
+    fn apply_to(mut self, expression: Tree<'s>) -> Tree<'s> {
+        *(match &mut self {
+            Prefix::Annotation { node, .. } => &mut node.expression,
+            Prefix::BuiltinAnnotation { node, .. } => &mut node.expression,
+            Prefix::Documentation { node, .. } => &mut node.expression,
+        }) = Some(expression);
+        self.into()
+    }
+}
+
+impl<'s> From<Prefix<'s>> for Tree<'s> {
+    fn from(prefix: Prefix<'s>) -> Self {
+        match prefix {
+            Prefix::Annotation { node, span } =>
+                Tree { variant: Box::new(Variant::Annotated(node)), span },
+            Prefix::BuiltinAnnotation { node, span } =>
+                Tree { variant: Box::new(Variant::AnnotatedBuiltin(node)), span },
+            Prefix::Documentation { node, span } =>
+                Tree { variant: Box::new(Variant::Documented(node)), span },
+        }
+    }
 }
 
 


### PR DESCRIPTION
### Pull Request Description

Implement new annotation syntax.

See: https://www.pivotaltracker.com/story/show/184132200

### Important Notes

- This includes only AST/parser frontend support; the new `Annotated` type needs to be handled in `TreeToIr`.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
