### PR TITLE
Make ArrayOverBuffer behave like an Array/Array.sort no longer mutates the Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -498,6 +498,8 @@
 - [IGV can jump to JMH sources & more][4008]
 - [Basic support of VSCode integration][4014]
 - [Sync language server with file system after VCS restore][4020]
+- [`ArrayOverBuffer` behaves like an `Array` and `Array.sort` no longer sorts in
+  place][4022]
 - [Introducing Meta.atom_with_hole][4023]
 - [Report failures in name resolution in type signatures][4030]
 
@@ -581,6 +583,7 @@
 [4008]: https://github.com/enso-org/enso/pull/4008
 [4014]: https://github.com/enso-org/enso/pull/4014
 [4020]: https://github.com/enso-org/enso/pull/4020
+[4022]: https://github.com/enso-org/enso/pull/4022
 [4023]: https://github.com/enso-org/enso/pull/4023
 [4030]: https://github.com/enso-org/enso/pull/4030
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
@@ -134,19 +134,21 @@ type Array
     length : Integer
     length self = @Builtin_Method "Array.length"
 
-    ## Sorts the this array in place.
+    ## ADVANCED
 
-       Arguments:
-       - comparator: A comparison function that takes two elements and returns
-         an Ordering that describes how the first element is ordered with
-         respect to the second.
+      Sorts this array in place.
+
+      Arguments:
+      - comparator: A comparison function that takes two elements and returns
+        an Ordering that describes how the first element is ordered with
+        respect to the second.
 
       > Example
         Sorting an array of numbers.
 
             [1,2,3].to_array.sort
     sort : (Any -> Any -> Ordering) -> Nothing
-    sort self comparator = @Builtin_Method "Array.sort"
+    sort self comparator=(_.compare_to _) = self.sort_builtin comparator
 
     ## Identity.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
@@ -134,9 +134,7 @@ type Array
     length : Integer
     length self = @Builtin_Method "Array.length"
 
-    ## ADVANCED
-
-      Sorts the Array.
+    ## Sorts the Array.
 
       Arguments:
       - comparator: A comparison function that takes two elements and returns

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
@@ -136,7 +136,7 @@ type Array
 
     ## ADVANCED
 
-      Sorts this array in place.
+      Sorts the Array.
 
       Arguments:
       - comparator: A comparison function that takes two elements and returns
@@ -144,11 +144,12 @@ type Array
         respect to the second.
 
       > Example
-        Sorting an array of numbers.
+        Getting a sorted array of numbers.
 
-            [1,2,3].to_array.sort
-    sort : (Any -> Any -> Ordering) -> Nothing
-    sort self comparator=(_.compare_to _) = self.sort_builtin comparator
+            [3,2,1].to_array.sort
+    sort : (Any -> Any -> Ordering) -> Array
+    sort self comparator=(_.compare_to _) =
+        self.sort_builtin comparator
 
     ## Identity.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -871,12 +871,6 @@ type Vector a
              [Pair 1 2, Pair -1 8].sort (_.first) (order = Sort_Direction.Descending)
     sort : (Any -> Any) -> (Any -> Any -> Ordering) -> Sort_Direction -> Vector Any ! Incomparable_Values
     sort self (on = x -> x) (by = (_.compare_to _)) (order = Sort_Direction.Ascending) =
-        ## Prepare the destination array that will underlie the vector. We do
-           not want to sort in place on the original vector, as `sort` is not
-           intended to be mutable.
-        new_vec_arr = Array.new self.length
-        Array.copy self.to_array 0 new_vec_arr 0 self.length
-
         ## As we want to account for both custom projections and custom
            comparisons we need to construct a comparator for internal use that
            does both.
@@ -886,7 +880,7 @@ type Vector a
             comp_descending
 
         Incomparable_Values.handle_errors <|
-            new_vec_arr.sort compare
+            new_vec_arr = self.to_array.sort compare
             Vector.from_polyglot_array new_vec_arr
 
     ## UNSTABLE

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/SortNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/SortNode.java
@@ -66,8 +66,13 @@ public abstract class SortNode extends Node {
     Byte[] tmpArray = ArrayUtils.toObject(self.backingArray());
     runSort(compare, tmpArray);
     byte[] sortedPrimitiveArray = ArrayUtils.toPrimitive(tmpArray);
+    return createArrayOverBuffer(sortedPrimitiveArray);
+  }
+
+  @TruffleBoundary
+  private ArrayOverBuffer createArrayOverBuffer(byte[] arrayOfPrimitives) {
     return ArrayOverBuffer.wrapBuffer(
-        ByteBuffer.wrap(sortedPrimitiveArray, 0, sortedPrimitiveArray.length));
+        ByteBuffer.wrap(arrayOfPrimitives, 0, arrayOfPrimitives.length));
   }
 
   @Specialization(guards = "arrays.hasArrayElements(self)")

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/SortNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/SortNode.java
@@ -27,10 +27,7 @@ import org.enso.interpreter.runtime.data.Array;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.state.State;
 
-@BuiltinMethod(
-    type = "Array",
-    name = "sort_builtin",
-    description = "Returns a sorted array.")
+@BuiltinMethod(type = "Array", name = "sort_builtin", description = "Returns a sorted array.")
 public abstract class SortNode extends Node {
   private @Child CallOptimiserNode callOptimiserNode = SimpleCallOptimiserNode.build();
   private @Child InvalidComparisonNode invalidComparisonNode = InvalidComparisonNode.build();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/SortNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/SortNode.java
@@ -16,7 +16,7 @@ import com.oracle.truffle.api.profiles.BranchProfile;
 import java.util.Arrays;
 import java.util.Comparator;
 
-import org.enso.interpreter.dsl.BuiltinMethod;;
+import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.callable.dispatch.CallOptimiserNode;
 import org.enso.interpreter.node.callable.dispatch.SimpleCallOptimiserNode;
 import org.enso.interpreter.node.expression.builtin.interop.syntax.HostValueToEnsoNode;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/SortNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/mutable/SortNode.java
@@ -30,7 +30,7 @@ import org.enso.interpreter.runtime.state.State;
 @BuiltinMethod(
     type = "Array",
     name = "sort_builtin",
-    description = "Sorts a mutable array in place.")
+    description = "Returns a sorted array.")
 public abstract class SortNode extends Node {
   private @Child CallOptimiserNode callOptimiserNode = SimpleCallOptimiserNode.build();
   private @Child InvalidComparisonNode invalidComparisonNode = InvalidComparisonNode.build();

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArrayOverBuffer.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArrayOverBuffer.java
@@ -1,10 +1,18 @@
 package org.enso.interpreter.runtime.data;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.InvalidArrayIndexException;
 import com.oracle.truffle.api.interop.TruffleObject;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
+import org.enso.interpreter.node.expression.builtin.error.InvalidArrayIndex;
+import org.enso.interpreter.node.expression.builtin.interop.syntax.HostValueToEnsoNode;
+import org.enso.interpreter.runtime.error.WarningsLibrary;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.ByteBuffer;
 
 @ExportLibrary(InteropLibrary.class)
@@ -16,8 +24,12 @@ public final class ArrayOverBuffer implements TruffleObject {
   }
 
   @ExportMessage
-  Object readArrayElement(long index) {
-    return (long) buffer.get(buffer.position() + Math.toIntExact(index));
+  Object readArrayElement(long index) throws InvalidArrayIndexException {
+    try {
+      return (long) buffer.get(buffer.position() + Math.toIntExact(index));
+    } catch (IndexOutOfBoundsException e) {
+      throw InvalidArrayIndexException.create(index);
+    }
   }
 
   @ExportMessage
@@ -37,5 +49,50 @@ public final class ArrayOverBuffer implements TruffleObject {
 
   public static ArrayOverBuffer wrapBuffer(ByteBuffer buffer) {
     return new ArrayOverBuffer(buffer);
+  }
+
+  @ExportMessage
+  String toDisplayString(boolean allowSideEffects) {
+    final InteropLibrary iop = InteropLibrary.getUncached();
+    StringBuilder sb = new StringBuilder();
+    try {
+      sb.append('[');
+      String sep = "";
+      long len = getArraySize();
+      for (long i = 0; i < len; i++) {
+        sb.append(sep);
+
+        Object at = readArrayElement(i);
+        Object str = showObject(iop, allowSideEffects, at);
+        if (iop.isString(str)) {
+          sb.append(iop.asString(str));
+        } else {
+          sb.append("_");
+        }
+        sep = ", ";
+      }
+      sb.append(']');
+    } catch (InvalidArrayIndexException | UnsupportedMessageException ex) {
+      StringWriter w = new StringWriter();
+      ex.printStackTrace(new PrintWriter(w));
+      sb.append("...\n").append(w.toString());
+    }
+    return sb.toString();
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  private Object showObject(InteropLibrary iop, boolean allowSideEffects, Object child)
+      throws UnsupportedMessageException {
+    if (child == null) {
+      return "null";
+    } else if (child instanceof Boolean) {
+      return (boolean) child ? "True" : "False";
+    } else {
+      return iop.toDisplayString(child, allowSideEffects);
+    }
+  }
+
+  public byte[] backingArray() {
+    return buffer.array();
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArrayOverBuffer.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArrayOverBuffer.java
@@ -50,16 +50,4 @@ public final class ArrayOverBuffer implements TruffleObject {
     final InteropLibrary iop = InteropLibrary.getUncached();
     return DisplayArrayUtils.toDisplayString(this, allowSideEffects, iop);
   }
-
-  /**
-   * Retrieves the underlying array of the buffer.
-   *
-   * <p>The returned array should not be further modified.
-   *
-   * @return byte array backing ByteBuffer
-   */
-  @CompilerDirectives.TruffleBoundary
-  public byte[] backingArray() {
-    return buffer.array();
-  }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArrayOverBuffer.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArrayOverBuffer.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.runtime.data;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.InvalidArrayIndexException;
 import com.oracle.truffle.api.interop.TruffleObject;
@@ -57,6 +58,7 @@ public final class ArrayOverBuffer implements TruffleObject {
    *
    * @return byte array backing ByteBuffer
    */
+  @CompilerDirectives.TruffleBoundary
   public byte[] backingArray() {
     return buffer.array();
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArrayOverBuffer.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArrayOverBuffer.java
@@ -1,18 +1,11 @@
 package org.enso.interpreter.runtime.data;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.InvalidArrayIndexException;
 import com.oracle.truffle.api.interop.TruffleObject;
-import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
-import org.enso.interpreter.node.expression.builtin.error.InvalidArrayIndex;
-import org.enso.interpreter.node.expression.builtin.interop.syntax.HostValueToEnsoNode;
-import org.enso.interpreter.runtime.error.WarningsLibrary;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.nio.ByteBuffer;
 
 @ExportLibrary(InteropLibrary.class)
@@ -54,44 +47,16 @@ public final class ArrayOverBuffer implements TruffleObject {
   @ExportMessage
   String toDisplayString(boolean allowSideEffects) {
     final InteropLibrary iop = InteropLibrary.getUncached();
-    StringBuilder sb = new StringBuilder();
-    try {
-      sb.append('[');
-      String sep = "";
-      long len = getArraySize();
-      for (long i = 0; i < len; i++) {
-        sb.append(sep);
-
-        Object at = readArrayElement(i);
-        Object str = showObject(iop, allowSideEffects, at);
-        if (iop.isString(str)) {
-          sb.append(iop.asString(str));
-        } else {
-          sb.append("_");
-        }
-        sep = ", ";
-      }
-      sb.append(']');
-    } catch (InvalidArrayIndexException | UnsupportedMessageException ex) {
-      StringWriter w = new StringWriter();
-      ex.printStackTrace(new PrintWriter(w));
-      sb.append("...\n").append(w.toString());
-    }
-    return sb.toString();
+    return DisplayArrayUtils.toDisplayString(this, allowSideEffects, iop);
   }
 
-  @CompilerDirectives.TruffleBoundary
-  private Object showObject(InteropLibrary iop, boolean allowSideEffects, Object child)
-      throws UnsupportedMessageException {
-    if (child == null) {
-      return "null";
-    } else if (child instanceof Boolean) {
-      return (boolean) child ? "True" : "False";
-    } else {
-      return iop.toDisplayString(child, allowSideEffects);
-    }
-  }
-
+  /**
+   * Retrieves the underlying array of the buffer.
+   *
+   * <p>The returned array should not be further modified.
+   *
+   * @return byte array backing ByteBuffer
+   */
   public byte[] backingArray() {
     return buffer.array();
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/DisplayArrayUtils.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/DisplayArrayUtils.java
@@ -1,0 +1,50 @@
+package org.enso.interpreter.runtime.data;
+
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.InvalidArrayIndexException;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public class DisplayArrayUtils {
+
+  public static String toDisplayString(
+      Object arrayLike, boolean allowSideEffects, InteropLibrary iop) {
+    StringBuilder sb = new StringBuilder();
+    try {
+      sb.append('[');
+      String sep = "";
+      long len = iop.getArraySize(arrayLike);
+      for (long i = 0; i < len; i++) {
+        sb.append(sep);
+
+        Object at = iop.readArrayElement(arrayLike, i);
+        Object str = showObject(iop, allowSideEffects, at);
+        if (iop.isString(str)) {
+          sb.append(iop.asString(str));
+        } else {
+          sb.append("_");
+        }
+        sep = ", ";
+      }
+      sb.append(']');
+    } catch (InvalidArrayIndexException | UnsupportedMessageException ex) {
+      StringWriter w = new StringWriter();
+      ex.printStackTrace(new PrintWriter(w));
+      sb.append("...\n").append(w.toString());
+    }
+    return sb.toString();
+  }
+
+  private static Object showObject(InteropLibrary iop, boolean allowSideEffects, Object child)
+      throws UnsupportedMessageException {
+    if (child == null) {
+      return "null";
+    } else if (child instanceof Boolean) {
+      return (boolean) child ? "True" : "False";
+    } else {
+      return iop.toDisplayString(child, allowSideEffects);
+    }
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/DisplayArrayUtils.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/DisplayArrayUtils.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.runtime.data;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.InvalidArrayIndexException;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
@@ -9,6 +10,7 @@ import java.io.StringWriter;
 
 public class DisplayArrayUtils {
 
+  @CompilerDirectives.TruffleBoundary
   public static String toDisplayString(
       Object arrayLike, boolean allowSideEffects, InteropLibrary iop) {
     StringBuilder sb = new StringBuilder();
@@ -32,7 +34,7 @@ public class DisplayArrayUtils {
     } catch (InvalidArrayIndexException | UnsupportedMessageException ex) {
       StringWriter w = new StringWriter();
       ex.printStackTrace(new PrintWriter(w));
-      sb.append("...\n").append(w.toString());
+      sb.append("...\n").append(w);
     }
     return sb.toString();
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
@@ -11,8 +11,6 @@ import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.dsl.Builtin;
@@ -188,32 +186,7 @@ public final class Vector implements TruffleObject {
   @CompilerDirectives.TruffleBoundary
   String toDisplayString(boolean allowSideEffects) {
     final InteropLibrary iop = InteropLibrary.getUncached();
-    StringBuilder sb = new StringBuilder();
-    try {
-      sb.append('[');
-      String sep = "";
-      long len = length(iop);
-      for (long i = 0; i < len; i++) {
-        sb.append(sep);
-
-        Object at =
-            readArrayElement(
-                i, iop, WarningsLibrary.getUncached(), HostValueToEnsoNode.getUncached());
-        Object str = showObject(iop, allowSideEffects, at);
-        if (iop.isString(str)) {
-          sb.append(iop.asString(str));
-        } else {
-          sb.append("_");
-        }
-        sep = ", ";
-      }
-      sb.append(']');
-    } catch (InvalidArrayIndexException | UnsupportedMessageException ex) {
-      StringWriter w = new StringWriter();
-      ex.printStackTrace(new PrintWriter(w));
-      sb.append("...\n").append(w.toString());
-    }
-    return sb.toString();
+    return DisplayArrayUtils.toDisplayString(this, allowSideEffects, iop);
   }
 
   @ExportMessage
@@ -270,17 +243,5 @@ public final class Vector implements TruffleObject {
   @SuppressWarnings("unchecked")
   private static <E extends Exception> E raise(Class<E> clazz, Throwable t) throws E {
     throw (E) t;
-  }
-
-  @CompilerDirectives.TruffleBoundary
-  private Object showObject(InteropLibrary iop, boolean allowSideEffects, Object child)
-      throws UnsupportedMessageException {
-    if (child == null) {
-      return "null";
-    } else if (child instanceof Boolean) {
-      return (boolean) child ? "True" : "False";
-    } else {
-      return iop.toDisplayString(child, allowSideEffects);
-    }
   }
 }

--- a/test/Tests/src/Data/Array_Spec.enso
+++ b/test/Tests/src/Data/Array_Spec.enso
@@ -43,4 +43,22 @@ spec =
             res = Array.new err
             res . should_fail_with Illegal_State.Error
 
+        Test.specify "should sort in place" <|
+            arr = make_enso_array [3, 1, 2]
+            arr.sort
+            arr . should_equal [1, 2, 3]
+
+    Test.group "ArrayOverBuffer" <|
+        Test.specify "should behave like an Array" <|
+            array_over_buffer = (File.new (enso_project.data / "sample.txt") . read_last_bytes 10).to_array
+
+            case array_over_buffer of
+                _ : Array -> Nothing
+                _ -> Test.fail "Expected ArrayOverBuffer to match on Array type"
+
+            array_over_buffer.to_text . should_equal "[32, 106, 117, 106, 117, 98, 101, 115, 46, 10]"
+            array_over_buffer.sort
+            array_over_buffer.to_text . should_equal "[10, 32, 46, 98, 101, 106, 106, 115, 117, 117]"
+
+
 main = Test_Suite.run_main spec

--- a/test/Tests/src/Data/Array_Spec.enso
+++ b/test/Tests/src/Data/Array_Spec.enso
@@ -50,7 +50,11 @@ spec =
             new_arr . should_equal [1, 2, 3]
 
     Test.group "ArrayOverBuffer" <|
-        Test.specify "should behave like an Array" <|
+        location_pending = case Platform.os of
+            Platform.OS.Windows -> "This test is disabled on Windows."
+            _ -> Nothing
+
+        Test.specify "should behave like an Array" pending=location_pending <|
             array_over_buffer = (File.new (enso_project.data / "sample.txt") . read_last_bytes 10).to_array
 
             case array_over_buffer of

--- a/test/Tests/src/Data/Array_Spec.enso
+++ b/test/Tests/src/Data/Array_Spec.enso
@@ -43,10 +43,11 @@ spec =
             res = Array.new err
             res . should_fail_with Illegal_State.Error
 
-        Test.specify "should sort in place" <|
+        Test.specify "should not sort in place" <|
             arr = make_enso_array [3, 1, 2]
-            arr.sort
-            arr . should_equal [1, 2, 3]
+            new_arr = arr.sort
+            arr . should_equal [3, 1, 2]
+            new_arr . should_equal [1, 2, 3]
 
     Test.group "ArrayOverBuffer" <|
         Test.specify "should behave like an Array" <|
@@ -57,8 +58,9 @@ spec =
                 _ -> Test.fail "Expected ArrayOverBuffer to match on Array type"
 
             array_over_buffer.to_text . should_equal "[32, 106, 117, 106, 117, 98, 101, 115, 46, 10]"
-            array_over_buffer.sort
-            array_over_buffer.to_text . should_equal "[10, 32, 46, 98, 101, 106, 106, 115, 117, 117]"
+            sorted = array_over_buffer.sort
+            array_over_buffer.to_text . should_equal "[32, 106, 117, 106, 117, 98, 101, 115, 46, 10]"
+            sorted.to_text . should_equal "[10, 32, 46, 98, 101, 106, 106, 115, 117, 117]"
 
 
 main = Test_Suite.run_main spec

--- a/test/Tests/src/Semantic/Js_Interop_Spec.enso
+++ b/test/Tests/src/Semantic/Js_Interop_Spec.enso
@@ -47,7 +47,7 @@ foreign js make_array = """
     return [{ x: 10}, {x: 20}, {x: 30}];
 
 foreign js make_simple_array = """
-    return [10, 20, 30];
+    return [30, 10, 20];
 
 foreign js make_str str = """
     return "foo " + str + " bar"
@@ -100,7 +100,11 @@ spec = Test.group "Polyglot JS" <|
         vec = Vector.from_polyglot_array make_array
         vec.map .x . should_equal [10, 20, 30]
         vec2 = Vector.from_polyglot_array make_simple_array
-        vec2.to_array.at 0 . should_equal 10
+        vec2.to_array.at 0 . should_equal 30
+        arr = make_simple_array
+        new_arr = arr.sort
+        arr . should_equal [30, 10, 20]
+        new_arr . should_equal [10, 20, 30]
 
     Test.specify "should correctly marshall strings" <|
         str = make_str "x" + " baz"

--- a/test/Tests/src/Semantic/Js_Interop_Spec.enso
+++ b/test/Tests/src/Semantic/Js_Interop_Spec.enso
@@ -106,6 +106,11 @@ spec = Test.group "Polyglot JS" <|
         arr . should_equal [30, 10, 20]
         new_arr . should_equal [10, 20, 30]
 
+        arr_2 = make_simple_array
+        sorted_2 = arr_2.sort
+        arr_2 . should_equal [30, 10, 20]
+        sorted_2 . should_equal [10, 20, 30]
+
     Test.specify "should correctly marshall strings" <|
         str = make_str "x" + " baz"
         str.should_equal "foo x bar baz"

--- a/test/Tests/src/Semantic/Python_Interop_Spec.enso
+++ b/test/Tests/src/Semantic/Python_Interop_Spec.enso
@@ -47,6 +47,9 @@ foreign python make_array = """
             return self.x < guess
     return [My(30), My(10), My(20)]
 
+foreign python make_num_array = """
+    return [30, 10, 20]
+
 foreign python make_str str = """
     return ("foo " + str + " bar")
 
@@ -93,6 +96,11 @@ spec =
             sorted = arr.sort
             arr . should_equal [30, 10, 20]
             sorted . should_equal [10, 20, 30]
+
+            arr_2 = make_num_array
+            sorted_2 = arr_2.sort
+            arr_2 . should_equal [30, 10, 20]
+            sorted_2 . should_equal [10, 20, 30]
 
 
         Test.specify "should correctly marshall strings" <|

--- a/test/Tests/src/Semantic/Python_Interop_Spec.enso
+++ b/test/Tests/src/Semantic/Python_Interop_Spec.enso
@@ -45,7 +45,7 @@ foreign python make_array = """
             self.x = x
         def compare(self, guess):
             return self.x < guess
-    return [My(10), My(20), My(30)]
+    return [My(30), My(10), My(20)]
 
 foreign python make_str str = """
     return ("foo " + str + " bar")
@@ -87,7 +87,13 @@ spec =
 
         Test.specify "should expose array interfaces for Python arrays" <|
             vec = Vector.from_polyglot_array make_array
-            vec.map .x . should_equal [10, 20, 30]
+            vec.map .x . should_equal [30, 10, 20]
+
+            arr = vec.map .x . to_array
+            sorted = arr.sort
+            arr . should_equal [30, 10, 20]
+            sorted . should_equal [10, 20, 30]
+
 
         Test.specify "should correctly marshall strings" <|
             str = make_str "x" + " baz"

--- a/test/Tests/src/Semantic/R_Interop_Spec.enso
+++ b/test/Tests/src/Semantic/R_Interop_Spec.enso
@@ -31,7 +31,7 @@ foreign r make_object = """
     list(x=x, y=FALSE, compare=function(guess) x < guess)
 
 foreign r make_array = """
-    list(list(x=10), list(x=20), list(x=30))
+    list(list(x=30), list(x=10), list(x=20))
 
 foreign r make_str str = """
     paste("foo", str, "bar", sep=" ")
@@ -73,7 +73,12 @@ spec =
 
         Test.specify "should expose array interfaces for R arrays" <|
             vec = Vector.from_polyglot_array make_array
-            vec.map .x . should_equal [10, 20, 30]
+            vec.map .x . should_equal [30, 10, 20]
+
+            arr = vec.map .x . to_array
+            sorted = arr.sort
+            arr . should_equal [30, 10, 20]
+            sorted . should_equal [10, 20, 30]
 
         Test.specify "should correctly marshall strings" <|
             str = make_str "x" + " baz"

--- a/test/Tests/src/Semantic/R_Interop_Spec.enso
+++ b/test/Tests/src/Semantic/R_Interop_Spec.enso
@@ -33,6 +33,9 @@ foreign r make_object = """
 foreign r make_array = """
     list(list(x=30), list(x=10), list(x=20))
 
+foreign r make_num_array = """
+    list(30, 10, 20)
+
 foreign r make_str str = """
     paste("foo", str, "bar", sep=" ")
 
@@ -79,6 +82,11 @@ spec =
             sorted = arr.sort
             arr . should_equal [30, 10, 20]
             sorted . should_equal [10, 20, 30]
+
+            arr_2 = make_num_array
+            sorted_2 = arr_2.sort
+            arr_2 . should_equal [30, 10, 20]
+            sorted_2 . should_equal [10, 20, 30]
 
         Test.specify "should correctly marshall strings" <|
             str = make_str "x" + " baz"


### PR DESCRIPTION
### Pull Request Description

Most of the problems with accessing `ArrayOverBuffer` have been resolved by using `CoerceArrayNode` (https://github.com/enso-org/enso/pull/3817). In `Array.sort` we still however specialized on Array which wasn't compatible with `ArrayOverBuffer`. Similarly sorting JS or Python arrays wouldn't work.

Added a specialization to `Array.sort` to deal with that case. A generic specialization (with `hasArrayElements`) not only handles `ArrayOverBuffer` but also polyglot arrays coming from JS or Python. We could have an additional specialization for `ArrayOverBuffer` only (removed in the last commit) that returns `ArrayOverBuffer` rather than `Array` although that adds additional complexity which so far is unnecessary.

Also fixed an example in `Array.enso` by providing a default argument.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
