### PR TITLE
Don't include type in tagValues

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
@@ -540,13 +540,20 @@ final class SuggestionBuilder[A: IndexedSource](
       hasDefault   = varg.defaultValue.isDefined,
       defaultValue = varg.defaultValue.flatMap(buildDefaultValue),
       tagValues = targ match {
-        case s: TypeArg.Sum => Some(pluckVariants(s))
-        case _              => None
+        case s: TypeArg.Sum => {
+          val tagValues = pluckVariants(s)
+          if (tagValues.nonEmpty) {
+            Some(tagValues)
+          } else {
+            None
+          }
+        }
+        case _ => None
       }
     )
 
   private def pluckVariants(arg: TypeArg): Seq[String] = arg match {
-    case TypeArg.Sum(Some(n), List()) => Seq(n.toString)
+    case TypeArg.Sum(Some(_), List()) => Seq()
     case TypeArg.Sum(_, variants)     => variants.flatMap(pluckVariants)
     case TypeArg.Value(n)             => Seq(n.toString)
     case _                            => Seq()

--- a/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
@@ -553,10 +553,10 @@ final class SuggestionBuilder[A: IndexedSource](
     )
 
   private def pluckVariants(arg: TypeArg): Seq[String] = arg match {
-    case TypeArg.Sum(Some(_), List()) => Seq()
-    case TypeArg.Sum(_, variants)     => variants.flatMap(pluckVariants)
-    case TypeArg.Value(n)             => Seq(n.toString)
-    case _                            => Seq()
+    case TypeArg.Sum(_, List())   => Seq()
+    case TypeArg.Sum(_, variants) => variants.flatMap(pluckVariants)
+    case TypeArg.Value(n)         => Seq(n.toString)
+    case _                        => Seq()
   }
 
   /** Build the name of type argument.

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
@@ -607,7 +607,6 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
                   Some(
                     Seq(
                       "Number",
-                      "Unnamed.Test.Other_Atom",
                       "Unnamed.Test.Variant_1",
                       "Unnamed.Test.Variant_2"
                     )
@@ -692,7 +691,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
                   false,
                   false,
                   None,
-                  Some(List("Unnamed.Test.A"))
+                  None
                 )
               ),
               selfType      = "Unnamed.Test",
@@ -1112,7 +1111,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
                         false,
                         false,
                         None,
-                        Some(List("Unnamed.Test.A"))
+                        None
                       )
                   ),
                   returnType = "Unnamed.Test.A",
@@ -2302,6 +2301,29 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
       fooArg.tagValues shouldEqual Some(
         List("Unnamed.Test.Variant_A", "Unnamed.Test.Variant_B")
       )
+    }
+
+    "parse Text.trim properly" in {
+      val code =
+        """|import Standard.Base.Data.Text.Text
+           |
+           |Text.trim : (Location.Start | Location.End | Location.Both) -> (Text | (Text -> Boolean)) -> Text
+           |Text.trim self where=Location.Both what=_.is_whitespace = self
+           |""".stripMargin
+      val module      = code.preprocessModule
+      val suggestions = build(code, module)
+      val method = suggestions.collectFirst {
+        case s: Suggestion.Method if s.name == "trim" => s
+      }
+      method.get.arguments.size shouldEqual 3
+      val arg1 = method.get.arguments(1)
+      arg1.reprType shouldEqual "Location.Start | Location.End | Location.Both"
+      arg1.tagValues shouldEqual Some(
+        List("Location.Start", "Location.End", "Location.Both")
+      )
+      val arg2 = method.get.arguments(2)
+      arg2.reprType shouldEqual "Standard.Base.Data.Text.Text | (Standard.Base.Data.Text.Text -> Boolean)"
+      arg2.tagValues shouldEqual None
     }
   }
 


### PR DESCRIPTION
### Pull Request Description

`Text.trim` `what` argument offered `Text` in `tagValues` - that's wrong. Using the `Text` type isn't allowed value for `Text` 

### Important Notes

I had to update three other tests to match the new behavior.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
