### PR TITLE
Prune unused ids from metadata on loading file

### DIFF
--- a/app/gui/language/parser/src/api.rs
+++ b/app/gui/language/parser/src/api.rs
@@ -8,6 +8,7 @@ use enso_text::unit::*;
 use ast::id_map::JsonIdMap;
 use ast::HasIdMap;
 use ast::HasRepr;
+use ast::IdMap;
 use enso_text::Range;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
@@ -29,10 +30,28 @@ pub use ast::Ast;
 
 // === Metadata ===
 
+/// Remove node IDs not present in the id map from the metadata.
+///
+/// See [`PruneUnusedIds::prune_unused_ids`] method documentation.
+pub trait PruneUnusedIds {
+    /// Remove node IDs not present in the id map from the metadata.
+    ///
+    /// The IDE loses track of the IDs stored in the metadata section when the user is editing a
+    /// project in the external editor. It means that the size of the metadata will constantly grow,
+    /// and IDE won't ever remove the obsolete nodes from the metadata. This method is called while
+    /// deserializing the [`ParsedSourceFile`] structure and allows to prune of unused ids from the
+    /// metadata section.
+    ///
+    /// As [`ParsedSourceFile`] is parametrized with a generic `Metadata`, this is a separate trait
+    /// that should be implemented for all `Metadata` types.
+    fn prune_unused_ids(&mut self, _id_map: &IdMap) {}
+}
+
 /// Things that are metadata.
-pub trait Metadata: Default + Serialize + DeserializeOwned {}
+pub trait Metadata: Default + Serialize + DeserializeOwned + PruneUnusedIds {}
 
 /// Raw metadata.
+impl PruneUnusedIds for serde_json::Value {}
 impl Metadata for serde_json::Value {}
 
 
@@ -149,13 +168,31 @@ impl SourceFile {
 
 /// Parsed file / module with metadata.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
-pub struct ParsedSourceFile<Metadata> {
+#[serde(bound = "M: Metadata")]
+#[serde(from = "ParsedSourceFileWithUnusedIds<M>")]
+pub struct ParsedSourceFile<M> {
     /// Ast representation.
     pub ast:      ast::known::Module,
     /// Raw metadata in json.
-    #[serde(bound(deserialize = "Metadata:Default+DeserializeOwned"))]
-    #[serde(deserialize_with = "enso_prelude::deserialize_or_default")]
-    pub metadata: Metadata,
+    pub metadata: M,
+}
+
+/// Helper for deserialization. `metadata` is filled with `default()` value if not present.
+///
+/// [`PruneUnusedIds::prune_unused_ids`] is called on deserialization.
+#[derive(Deserialize)]
+struct ParsedSourceFileWithUnusedIds<Metadata> {
+    ast:      ast::known::Module,
+    metadata: Option<Metadata>,
+}
+
+impl<M: Metadata> From<ParsedSourceFileWithUnusedIds<M>> for ParsedSourceFile<M> {
+    fn from(file: ParsedSourceFileWithUnusedIds<M>) -> Self {
+        let ast = file.ast;
+        let mut metadata = file.metadata.unwrap_or_default();
+        metadata.prune_unused_ids(&ast.id_map());
+        Self { ast, metadata }
+    }
 }
 
 impl<M: Metadata> TryFrom<&ParsedSourceFile<M>> for String {
@@ -270,6 +307,7 @@ mod test {
         foo: usize,
     }
 
+    impl PruneUnusedIds for Metadata {}
     impl crate::api::Metadata for Metadata {}
 
     #[test]

--- a/app/gui/language/parser/src/wsclient.rs
+++ b/app/gui/language/parser/src/wsclient.rs
@@ -10,7 +10,6 @@ use crate::api::ParsedSourceFile;
 
 use ast::id_map::JsonIdMap;
 use ast::IdMap;
-use serde::de::DeserializeOwned;
 use std::fmt::Formatter;
 use websocket::stream::sync::TcpStream;
 use websocket::ClientBuilder;
@@ -102,10 +101,10 @@ pub enum Request {
 
 /// All responses that Parser Service might reply with.
 #[derive(Debug, serde::Deserialize)]
-pub enum Response<Metadata> {
-    #[serde(bound(deserialize = "Metadata:Default+DeserializeOwned"))]
+pub enum Response<M> {
+    #[serde(bound(deserialize = "M: Metadata"))]
     Success {
-        module: ParsedSourceFile<Metadata>,
+        module: ParsedSourceFile<M>,
     },
     Error {
         message: String,

--- a/app/gui/language/parser/tests/parsing.rs
+++ b/app/gui/language/parser/tests/parsing.rs
@@ -10,6 +10,7 @@ use parser_scala::prelude::*;
 use ast::test_utils::expect_shape;
 use parser_scala::api::Metadata;
 use parser_scala::api::ParsedSourceFile;
+use parser_scala::api::PruneUnusedIds;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
@@ -60,6 +61,7 @@ fn roundtrip_program(program: &str) {
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 struct FauxMetadata<T>(T);
 
+impl<T> PruneUnusedIds for FauxMetadata<T> {}
 impl<T: Default + Serialize + DeserializeOwned> Metadata for FauxMetadata<T> {}
 
 

--- a/app/gui/src/model/module.rs
+++ b/app/gui/src/model/module.rs
@@ -791,17 +791,18 @@ pub mod test {
     fn outdated_metadata_parses() {
         // Metadata here will fail to serialize because `File` is not a valid qualified name.
         // Expected behavior is that invalid metadata parts will be filled with defaults.
-        let code = r#"main = 5
+        let code = r#"import Standard.Visualization
+main = 5
 
 
 #### METADATA ####
-[]
-{"ide":{"node":{"bd891b65-4c2f-4c05-bc3b-6077b4417cc1":{"position":{"vector":[-75.5,52]},"intended_method":{"module":"Base.System.File","defined_on_type":"File","name":"read"}}}}}"#;
+[[{"index":{"value":7},"size":{"value":8}},"04f2bbe4-6291-4bad-961c-146228f3aee4"],[{"index":{"value":15},"size":{"value":1}},"20f4e5e3-3ab4-4c68-ae7a-d261d3f23af0"],[{"index":{"value":16},"size":{"value":13}},"746b453a-3fed-4128-86ce-a3853ef684b0"],[{"index":{"value":0},"size":{"value":29}},"aead2cca-c429-47f2-85ef-fe090433990b"],[{"index":{"value":30},"size":{"value":4}},"063ab796-e79b-4037-bf94-1f24c9545b9a"],[{"index":{"value":35},"size":{"value":1}},"4b4992bd-7d8e-401b-aebf-42b30a4a5cae"],[{"index":{"value":37},"size":{"value":1}},"1d6660c6-a70b-4eeb-b5f7-82f05a51df25"],[{"index":{"value":30},"size":{"value":8}},"ad5b88bf-0cdb-4eba-90fe-07afc37e3953"],[{"index":{"value":0},"size":{"value":39}},"602dfcea-2321-48fa-95b1-1f58fb028099"]]
+{"ide":{"node":{"1d6660c6-a70b-4eeb-b5f7-82f05a51df25":{"position":{"vector":[-75.5,52]},"intended_method":{"module":"Base.System.File","defined_on_type":"File","name":"read"}}}}}"#;
         let result = Parser::new_or_panic().parse_with_metadata::<Metadata>(code.into());
         let file = result.unwrap();
-        assert_eq!(file.ast.repr(), "main = 5");
+        assert_eq!(file.ast.repr(), "import Standard.Visualization\nmain = 5");
         assert_eq!(file.metadata.ide.node.len(), 1);
-        let id = ast::Id::from_str("bd891b65-4c2f-4c05-bc3b-6077b4417cc1").unwrap();
+        let id = ast::Id::from_str("1d6660c6-a70b-4eeb-b5f7-82f05a51df25").unwrap();
         let node = file.metadata.ide.node.get(&id).unwrap();
         assert_eq!(node.position, Some(Position::new(-75.5, 52.0)));
         assert_eq!(node.intended_method, None);

--- a/app/gui/src/model/module.rs
+++ b/app/gui/src/model/module.rs
@@ -787,7 +787,6 @@ pub mod test {
         assert_eq!(qualified.to_string(), "n.P.Foo.Bar");
     }
 
-    /// Test that the format of metadata did not change.
     #[wasm_bindgen_test]
     fn outdated_metadata_parses() {
         // Metadata here will fail to serialize because `File` is not a valid qualified name.
@@ -796,7 +795,7 @@ pub mod test {
 
 
 #### METADATA ####
-[[{"index":{"value":5},"size":{"value":8}},"bd891b65-4c2f-4c05-bc3b-6077b4417cc1"]]
+[]
 {"ide":{"node":{"bd891b65-4c2f-4c05-bc3b-6077b4417cc1":{"position":{"vector":[-75.5,52]},"intended_method":{"module":"Base.System.File","defined_on_type":"File","name":"read"}}}}}"#;
         let result = Parser::new_or_panic().parse_with_metadata::<Metadata>(code.into());
         let file = result.unwrap();
@@ -806,26 +805,6 @@ pub mod test {
         let node = file.metadata.ide.node.get(&id).unwrap();
         assert_eq!(node.position, Some(Position::new(-75.5, 52.0)));
         assert_eq!(node.intended_method, None);
-    }
-
-    /// Test that nodes with IDs not present in the idmap are removed on loading.
-    #[wasm_bindgen_test]
-    fn unused_ids_are_removed() {
-        let code = r#"main = 5
-
-
-#### METADATA ####
-[[{"index":{"value":5},"size":{"value":8}},"bd891b65-4c2f-4c05-bc3b-6077b4417cc1"],[{"index":{"value":13},"size":{"value":1}},"b07eaee6-4bce-4e5e-8b02-5ab38a9c2225"]]
-{"ide":{"node":{"bd891b65-4c2f-4c05-bc3b-6077b4417cc1":{"position":{"vector":[-75.5,52]},"intended_method":{"module":"Base.System.File","defined_on_type":"File","name":"read"}},"785c052b-da86-473c-a52e-928501f54715":{"position":{"vector":[-100.0,80.0]},"intended_method":null,"uploading_file":null,"selected":false,"visualization":null}}}}"#;
-        let result = Parser::new_or_panic().parse_with_metadata::<Metadata>(code.into());
-        let file = result.unwrap();
-        assert_eq!(file.ast.repr(), "main = 5");
-        assert_eq!(file.metadata.ide.node.len(), 1);
-        let present_id = ast::Id::from_str("bd891b65-4c2f-4c05-bc3b-6077b4417cc1").unwrap();
-        let node = file.metadata.ide.node.get(&present_id).unwrap();
-        assert_eq!(node.position, Some(Position::new(-75.5, 52.0)));
-        assert_eq!(node.intended_method, None);
-        let missing_id = ast::Id::from_str("785c052b-da86-473c-a52e-928501f54715").unwrap();
-        assert!(file.metadata.ide.node.get(&missing_id).is_none());
+        assert_eq!(file.metadata.rest, serde_json::Value::Object(default()));
     }
 }

--- a/app/gui/src/model/module.rs
+++ b/app/gui/src/model/module.rs
@@ -787,6 +787,7 @@ pub mod test {
         assert_eq!(qualified.to_string(), "n.P.Foo.Bar");
     }
 
+    /// Test that the format of metadata did not change.
     #[wasm_bindgen_test]
     fn outdated_metadata_parses() {
         // Metadata here will fail to serialize because `File` is not a valid qualified name.
@@ -795,7 +796,7 @@ pub mod test {
 
 
 #### METADATA ####
-[]
+[[{"index":{"value":5},"size":{"value":8}},"bd891b65-4c2f-4c05-bc3b-6077b4417cc1"]]
 {"ide":{"node":{"bd891b65-4c2f-4c05-bc3b-6077b4417cc1":{"position":{"vector":[-75.5,52]},"intended_method":{"module":"Base.System.File","defined_on_type":"File","name":"read"}}}}}"#;
         let result = Parser::new_or_panic().parse_with_metadata::<Metadata>(code.into());
         let file = result.unwrap();
@@ -805,6 +806,26 @@ pub mod test {
         let node = file.metadata.ide.node.get(&id).unwrap();
         assert_eq!(node.position, Some(Position::new(-75.5, 52.0)));
         assert_eq!(node.intended_method, None);
-        assert_eq!(file.metadata.rest, serde_json::Value::Object(default()));
+    }
+
+    /// Test that nodes with IDs not present in the idmap are removed on loading.
+    #[wasm_bindgen_test]
+    fn unused_ids_are_removed() {
+        let code = r#"main = 5
+
+
+#### METADATA ####
+[[{"index":{"value":5},"size":{"value":8}},"bd891b65-4c2f-4c05-bc3b-6077b4417cc1"],[{"index":{"value":13},"size":{"value":1}},"b07eaee6-4bce-4e5e-8b02-5ab38a9c2225"]]
+{"ide":{"node":{"bd891b65-4c2f-4c05-bc3b-6077b4417cc1":{"position":{"vector":[-75.5,52]},"intended_method":{"module":"Base.System.File","defined_on_type":"File","name":"read"}},"785c052b-da86-473c-a52e-928501f54715":{"position":{"vector":[-100.0,80.0]},"intended_method":null,"uploading_file":null,"selected":false,"visualization":null}}}}"#;
+        let result = Parser::new_or_panic().parse_with_metadata::<Metadata>(code.into());
+        let file = result.unwrap();
+        assert_eq!(file.ast.repr(), "main = 5");
+        assert_eq!(file.metadata.ide.node.len(), 1);
+        let present_id = ast::Id::from_str("bd891b65-4c2f-4c05-bc3b-6077b4417cc1").unwrap();
+        let node = file.metadata.ide.node.get(&present_id).unwrap();
+        assert_eq!(node.position, Some(Position::new(-75.5, 52.0)));
+        assert_eq!(node.intended_method, None);
+        let missing_id = ast::Id::from_str("785c052b-da86-473c-a52e-928501f54715").unwrap();
+        assert!(file.metadata.ide.node.get(&missing_id).is_none());
     }
 }


### PR DESCRIPTION
### Pull Request Description

This PR fixes a bug reported in [Task](https://www.pivotaltracker.com/story/show/184159167).

To reproduce the issue, one can do the following steps:
1. Create a new project in the IDE.
2. Check the metadata section in the `Main.enso` file – `IdeMetadata` (a JSON object starting with `"ide":`) contains info for two nodes.
3. Edit the project in the external editor. For example, replace the expression of the second node.
4. Open a project in the IDE and observe the metadata. Now `IdeMetadata` contains three nodes – one unmodified, one added, and one no longer present. It leads to constantly growing metadata if you use an external editor.

This PR fixes the issue by pruning unused node metadata on loading.

No visual changes to the IDE were made.

### Important Notes

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
