### PR TITLE
Catch Panic and Error from Atom.to_text and yield detailed error message

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/List.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/List.enso
@@ -404,10 +404,10 @@ type List
 
     to_text : Text
     to_text self =
-        go l t = case l of
-            Nil -> t + "Nil"
-            Cons x xs -> @Tail_Call go xs (t + "Cons " + x.to_text + " ")
-        go self ""
+        go l t e = case l of
+            Nil -> t + "Nil" + e
+            Cons x xs -> @Tail_Call go xs (t + "(Cons " + x.to_text + " ") (")" + e)
+        go self "" ""
 
 ## UNSTABLE
 

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/ReplTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/ReplTest.scala
@@ -99,10 +99,10 @@ class ReplTest
           result.toString shouldEqual "2"
         }
         inside(executor.evaluate("B.Bar 1")) { case Right(result) =>
-          result.toString shouldEqual "Bar 1"
+          result.toString shouldEqual "Error in method `to_text` of [Bar 1]: Expected Text but got 42"
         }
         inside(executor.evaluate("C.Baz 1")) { case Right(result) =>
-          result.toString shouldEqual "Baz 1"
+          result.toString shouldEqual "Error in method `to_text` of [Baz 1]: Expected Text but got C.to_text[Test:18-40]"
         }
         inside(executor.evaluate("Pattern.compile 'foo'")) {
           case Right(result) =>

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/Atom.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/Atom.java
@@ -208,19 +208,16 @@ public final class Atom implements TruffleObject {
       if (warnings.hasWarnings(result)) {
         result = warnings.removeWarnings(result);
       }
-      if (result instanceof DataflowError) {
+      if (TypesGen.isDataflowError(result)) {
         msg = this.toString("Error in method `to_text` of [", 10, "]: ", result);
+      } else if (TypesGen.isText(result)) {
+        return TypesGen.asText(result);
       } else {
-        return TypesGen.expectText(result);
+        msg = this.toString("Error in method `to_text` of [", 10, "]: Expected Text but got ", result);
       }
-    } catch (AbstractTruffleException panic) {
+    } catch (AbstractTruffleException | UnsupportedMessageException | ArityException | UnknownIdentifierException | UnsupportedTypeException panic) {
       handleError.enter();
       msg = this.toString("Panic in method `to_text` of [", 10, "]: ", panic);
-    } catch (
-      UnexpectedResultException | UnsupportedMessageException | ArityException | UnknownIdentifierException | UnsupportedTypeException e
-    ) {
-      handleError.enter();
-      msg = this.toString("Error in method `to_text` of [", 10, "]: Expected Text but got ", result);
     }
     return Text.create(msg);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/Atom.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/Atom.java
@@ -107,6 +107,8 @@ public final class Atom implements TruffleObject {
       var errorMessage = InteropLibrary.getUncached().toDisplayString(obj);
       if (errorMessage != null) {
         sb.append(errorMessage);
+      } else {
+        sb.append("Nothing");
       }
     }
     return sb.toString();

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/Atom.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/Atom.java
@@ -4,6 +4,7 @@ package org.enso.interpreter.runtime.callable.atom;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.exception.AbstractTruffleException;
 import com.oracle.truffle.api.interop.*;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
@@ -183,6 +184,7 @@ public final class Atom implements TruffleObject {
     try {
       return TypesGen.expectText(atoms.invokeMember(this, "to_text"));
     } catch (UnsupportedMessageException
+        | AbstractTruffleException
         | ArityException
         | UnknownIdentifierException
         | UnsupportedTypeException

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/ListTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/ListTest.java
@@ -144,6 +144,18 @@ public class ListTest {
     assertLength("Generated all", size, list);
     var str = asText.execute(list);
     assertTrue("It is a string", str.isString());
+
+    String s = str.asString();
+    int open = 0;
+    int close = 0;
+    for (int i = 0; i < s.length(); i++) {
+      switch (s.charAt(i)) {
+        case '(' -> open++;
+        case ')' -> close++;
+      }
+    }
+    assertEquals("Correct number of opening braces", size, open);
+    assertEquals("Correct number of closing braces", size, close);
   }
 
   private Value evalCode(final String code, final String methodName) throws URISyntaxException {

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/PolyglotErrorTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/PolyglotErrorTest.java
@@ -1,0 +1,105 @@
+package org.enso.interpreter.test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Paths;
+import java.util.Map;
+import org.enso.polyglot.RuntimeOptions;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Language;
+import org.graalvm.polyglot.Source;
+import org.graalvm.polyglot.Value;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PolyglotErrorTest {
+  private Context ctx;
+  private Value panic;
+
+  public static String bar(Object o) {
+    return "[[" + o + "]]";
+  }
+
+  @Before
+  public void prepareCtx() throws Exception {
+    this.ctx = Context.newBuilder()
+      .allowExperimentalOptions(true)
+      .allowIO(true)
+      .allowAllAccess(true)
+      .logHandler(new ByteArrayOutputStream())
+      .option(
+        RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
+        Paths.get("../../distribution/component").toFile().getAbsolutePath()
+      ).build();
+    final Map<String, Language> langs = ctx.getEngine().getLanguages();
+    assertNotNull("Enso found: " + langs, langs.get("enso"));
+
+    var code = """
+    import Standard.Base.Panic.Panic
+    import Standard.Base.Error.Error
+    import Standard.Base.Error.Illegal_State.Illegal_State
+    polyglot java import org.enso.interpreter.test.PolyglotErrorTest
+
+    type TypeCa
+        Ca x
+
+        to_text : Text
+        to_text self = "<<Ca "+self.x.to_text+">>"
+
+    type TypeCb
+        Cb x
+
+        to_text : Text
+        to_text self = Error.throw (Illegal_State.Error "B")
+
+    type TypeCc
+        Cc x
+
+        to_text : Text
+        to_text self = Panic.throw (Illegal_State.Error "C")
+
+    panic x = case x of
+        1 -> panic1
+        2 -> panic2
+        _ -> panic3
+
+    panic1 = PolyglotErrorTest.bar (TypeCa.Ca 'x')
+
+    panic2 =
+        PolyglotErrorTest.bar (TypeCb.Cb 'y') . catch err->
+            "{Error: "+err.to_text+"}"
+
+    panic3 =
+        Panic.catch Illegal_State (PolyglotErrorTest.bar (TypeCc.Cc 'z')) caught_panic->
+            "{Panic: "+caught_panic.payload.to_text+"}"
+    """;
+    var src = Source.newBuilder("enso", code, "test.enso").build();
+    var module = ctx.eval(src);
+
+    this.panic = module.invokeMember("eval_expression", "panic");
+    assertTrue("It is a function", this.panic.canExecute());
+  }
+
+  @Test
+  public void panic1() {
+    var v = panic.execute(1);
+    assertTrue("Is string", v.isString());
+    assertEquals("[[<<Ca x>>]]", v.asString());
+  }
+
+  @Test
+  public void panic2() {
+    var v = panic.execute(2);
+    assertTrue("Is string", v.isString());
+    assertEquals("[[Cb y]]", v.asString());
+  }
+
+  @Test
+  public void panic3() {
+    var v = panic.execute(3);
+    assertTrue("Is string", v.isString());
+    assertEquals("[[Cc z]]", v.asString());
+  }
+}

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/PolyglotErrorTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/PolyglotErrorTest.java
@@ -41,6 +41,7 @@ public class PolyglotErrorTest {
     import Standard.Base.Error.Error
     import Standard.Base.Error.Illegal_State.Illegal_State
     import Standard.Base.Nothing.Nothing
+    import Standard.Base.Warning.Warning
     polyglot java import org.enso.interpreter.test.PolyglotErrorTest
 
     type TypeCa
@@ -66,12 +67,18 @@ public class PolyglotErrorTest {
 
         to_text self = 42
 
+    type TypeCe
+        Ce x
+
+        to_text self = Warning.attach "Some random warning" self.x
 
     panic x = case x of
         1 -> panic1
         2 -> panic2
         3 -> panic3
-        _ -> panic4
+        4 -> panic4
+        5 -> panic5
+        _ -> panic6
 
     panic1 = PolyglotErrorTest.bar (TypeCa.Ca 'x')
 
@@ -84,6 +91,9 @@ public class PolyglotErrorTest {
             "{Panic: "+caught_panic.payload.to_text+"}"
 
     panic4 = PolyglotErrorTest.bar (TypeCd.Cd Nothing)
+
+    panic5 = PolyglotErrorTest.bar (TypeCe.Ce "Foo")
+    panic6 = PolyglotErrorTest.bar (TypeCe.Ce 44)
     """;
     var src = Source.newBuilder("enso", code, "test.enso").build();
     var module = ctx.eval(src);
@@ -118,5 +128,19 @@ public class PolyglotErrorTest {
     var v = panic.execute(4);
     assertTrue("Is string", v.isString());
     assertEquals("[[Error in method `to_text` of [Cd Nothing]: Expected Text but got 42]]", v.asString());
+  }
+
+  @Test
+  public void panic5() {
+    var v = panic.execute(5);
+    assertTrue("Is string", v.isString());
+    assertEquals("[[Foo]]", v.asString());
+  }
+
+  @Test
+  public void panic6() {
+    var v = panic.execute(6);
+    assertTrue("Is string", v.isString());
+    assertEquals("[[Error in method `to_text` of [Ce 44]: Expected Text but got 44]]", v.asString());
   }
 }

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/PolyglotErrorTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/PolyglotErrorTest.java
@@ -40,6 +40,7 @@ public class PolyglotErrorTest {
     import Standard.Base.Panic.Panic
     import Standard.Base.Error.Error
     import Standard.Base.Error.Illegal_State.Illegal_State
+    import Standard.Base.Nothing.Nothing
     polyglot java import org.enso.interpreter.test.PolyglotErrorTest
 
     type TypeCa
@@ -60,10 +61,17 @@ public class PolyglotErrorTest {
         to_text : Text
         to_text self = Panic.throw (Illegal_State.Error "C")
 
+    type TypeCd
+        Cd x
+
+        to_text self = 42
+
+
     panic x = case x of
         1 -> panic1
         2 -> panic2
-        _ -> panic3
+        3 -> panic3
+        _ -> panic4
 
     panic1 = PolyglotErrorTest.bar (TypeCa.Ca 'x')
 
@@ -74,6 +82,8 @@ public class PolyglotErrorTest {
     panic3 =
         Panic.catch Illegal_State (PolyglotErrorTest.bar (TypeCc.Cc 'z')) caught_panic->
             "{Panic: "+caught_panic.payload.to_text+"}"
+
+    panic4 = PolyglotErrorTest.bar (TypeCd.Cd Nothing)
     """;
     var src = Source.newBuilder("enso", code, "test.enso").build();
     var module = ctx.eval(src);
@@ -101,5 +111,12 @@ public class PolyglotErrorTest {
     var v = panic.execute(3);
     assertTrue("Is string", v.isString());
     assertEquals("[[Panic in method `to_text` of [Cc z]: (Illegal_State.Error 'C' Nothing)]]", v.asString());
+  }
+
+  @Test
+  public void panic4() {
+    var v = panic.execute(4);
+    assertTrue("Is string", v.isString());
+    assertEquals("[[Error in method `to_text` of [Cd Nothing]: Expected Text but got 42]]", v.asString());
   }
 }

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/PolyglotErrorTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/PolyglotErrorTest.java
@@ -93,13 +93,13 @@ public class PolyglotErrorTest {
   public void panic2() {
     var v = panic.execute(2);
     assertTrue("Is string", v.isString());
-    assertEquals("[[Cb y]]", v.asString());
+    assertEquals("[[Error in method `to_text` of [Cb y]: (Error: (Illegal_State.Error 'B' Nothing))]]", v.asString());
   }
 
   @Test
   public void panic3() {
     var v = panic.execute(3);
     assertTrue("Is string", v.isString());
-    assertEquals("[[Cc z]]", v.asString());
+    assertEquals("[[Panic in method `to_text` of [Cc z]: (Illegal_State.Error 'C' Nothing)]]", v.asString());
   }
 }


### PR DESCRIPTION
### Pull Request Description

Don't propagate errors from `toDisplayString` - construct an error message with `Atom.toString`. 

### Important Notes

> currently a failure in to_text is swallowed by `toString` and we cannot detect that something went wrong during the serialization

Not sure how satisfying the solution is, but the error swallowing happens in Truffle and there is little to do with it. We can just catch the error ourselves and produce some meaningful string.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
