### PR TITLE
Workaround vcs/restore issues on Windows

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/Git.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/vcsmanager/Git.scala
@@ -38,11 +38,17 @@ private class Git(ensoDataDirectory: Option[Path]) extends VcsApi[BlockingIO] {
 
   private def repository(root: Path): Repository = {
     val builder = new FileRepositoryBuilder()
-    builder
+    val repo = builder
       .setWorkTree(root.toFile)
       .setGitDir(root.resolve(gitDir).toFile)
       .setMustExist(true)
       .build()
+    disableAutoCRLF(repo)
+    repo
+  }
+
+  private def disableAutoCRLF(repo: Repository): Unit = {
+    repo.getConfig.setString("core", null, "autocrlf", "false")
   }
 
   override def init(root: Path): BlockingIO[VcsFailure, Unit] = {
@@ -71,6 +77,7 @@ private class Git(ensoDataDirectory: Option[Path]) extends VcsApi[BlockingIO] {
         .setDirectory(root.toFile)
         .setBare(false)
         .call()
+      disableAutoCRLF(jgit.getRepository)
 
       ensoDataDirectory.foreach { _ =>
         // When `gitDir` is set, JGit **always** creates a .git file (not a directory!) that points at the real


### PR DESCRIPTION
### Pull Request Description

Potential workaround to line endings problems after `vcs/restore` operation is executed.

### Important Notes

Not really able to reproduce the problem myself so this PR has a lot of _leap of faith_ in it.
