### PR TITLE
Fix serialization of NPE in logger

### DIFF
--- a/lib/scala/logging-service/src/test/scala/org/enso/loggingservice/internal/DefaultLogMessageRendererSpec.scala
+++ b/lib/scala/logging-service/src/test/scala/org/enso/loggingservice/internal/DefaultLogMessageRendererSpec.scala
@@ -1,0 +1,33 @@
+package org.enso.loggingservice.internal
+
+import org.enso.loggingservice.LogLevel
+import org.enso.loggingservice.internal.protocol.{
+  SerializedException,
+  WSLogMessage
+}
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class DefaultLogMessageRendererSpec
+    extends AnyWordSpec
+    with Matchers
+    with OptionValues {
+
+  "DefaultLogMessageRenderer" should {
+    "render NullPointerException" in {
+      val renderer = new DefaultLogMessageRenderer(printExceptions = true)
+      val ts       = Instant.now().truncatedTo(ChronoUnit.MILLIS)
+
+      val exception =
+        SerializedException.fromException(new NullPointerException)
+      val message =
+        WSLogMessage(LogLevel.Trace, ts, "group", "message", Some(exception))
+
+      noException should be thrownBy renderer.render(message)
+    }
+  }
+}

--- a/lib/scala/logging-service/src/test/scala/org/enso/loggingservice/internal/SerializedExceptionSpec.scala
+++ b/lib/scala/logging-service/src/test/scala/org/enso/loggingservice/internal/SerializedExceptionSpec.scala
@@ -10,6 +10,7 @@ class SerializedExceptionSpec
     extends AnyWordSpec
     with Matchers
     with OptionValues {
+
   "SerializedException" should {
     "serialize and deserialize with nested causes" in {
       val cause = SerializedException(
@@ -25,13 +26,23 @@ class SerializedExceptionSpec
           SerializedException.TraceElement("e2", "loc2"),
           SerializedException.TraceElement("e3", "loc3")
         ),
-        cause = cause
+        cause
       )
 
       exception.asJson
         .as[SerializedException]
         .toOption
         .value shouldEqual exception
+    }
+
+    "be created from NullPointerException" in {
+      val exception = new NullPointerException()
+      val result    = SerializedException.fromException(exception)
+
+      result.name shouldEqual exception.getClass.getName
+      result.message shouldEqual None
+      result.cause shouldEqual None
+      result.stackTrace shouldBe Symbol("nonEmpty")
     }
   }
 }

--- a/lib/scala/logging-service/src/test/scala/org/enso/loggingservice/internal/WSLogMessageSpec.scala
+++ b/lib/scala/logging-service/src/test/scala/org/enso/loggingservice/internal/WSLogMessageSpec.scala
@@ -14,17 +14,31 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class WSLogMessageSpec extends AnyWordSpec with Matchers with OptionValues {
+
   "WSLogMessage" should {
     "serialize and deserialize to the same thing" in {
       val ts = Instant.now().truncatedTo(ChronoUnit.MILLIS)
 
       val message1 = WSLogMessage(LogLevel.Trace, ts, "group", "message", None)
       message1.asJson.as[WSLogMessage].toOption.value shouldEqual message1
+      noException should be thrownBy message1.asJson.noSpaces
 
-      val exception = SerializedException("name", "message", Seq(), None)
+      val exception = SerializedException("name", "message", Seq())
       val message2 =
         WSLogMessage(LogLevel.Trace, ts, "group", "message", Some(exception))
       message2.asJson.as[WSLogMessage].toOption.value shouldEqual message2
+      noException should be thrownBy message2.asJson.noSpaces
+    }
+
+    "serialize NullPointerException" in {
+      val ts = Instant.now().truncatedTo(ChronoUnit.MILLIS)
+
+      val exception =
+        SerializedException.fromException(new NullPointerException)
+      val message =
+        WSLogMessage(LogLevel.Trace, ts, "group", "message", Some(exception))
+      message.asJson.as[WSLogMessage].toOption.value shouldEqual message
+      noException should be thrownBy message.asJson.noSpaces
     }
   }
 }


### PR DESCRIPTION
### Pull Request Description

Fixes an error when the logger processes NPE:
```
[internal-logger-error] One of the printers failed to write a message: java.lang.NullPointerException
```

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] ~If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.~
