### PR TITLE
Visualization of DataflowError

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/job/VisualizationResult.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/job/VisualizationResult.java
@@ -4,6 +4,7 @@ import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import java.nio.charset.StandardCharsets;
 import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.error.WithWarnings;
 
 public final class VisualizationResult {
@@ -22,6 +23,9 @@ public final class VisualizationResult {
     }
     if (value instanceof WithWarnings warn) {
       return visualizationResultToBytes(warn.getValue());
+    }
+    if (value instanceof DataflowError err) {
+      return visualizationResultToBytes(err.toString());
     }
     var iop = InteropLibrary.getUncached();
     if (iop.isString(value)) {

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -527,7 +527,7 @@ object ProgramExecutionSupport {
   ): Either[VisualisationException, Array[Byte]] = {
     Option(VisualizationResult.visualizationResultToBytes(value)).toRight(
       new VisualisationException(
-        s"Cannot encode ${value.getClass} to byte array."
+        s"Cannot encode ${value.getClass} to byte array"
       )
     )
   }


### PR DESCRIPTION
Don't complain when trying to visualize DataflowError. We can easily extract the underlying payload message instead.

`Visualisation evaluation failed: Cannot encode class org.enso.interpreter.runtime.error.DataflowError to byte array..` pops up rather frequently in the logs.