### PR TITLE
Create static wrappers for builtin types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -546,6 +546,7 @@
 - [Add Meta.get_annotation method][4049]
 - [Resolve Fully Qualified Names][4056]
 - [Optimize Atom storage layouts][3862]
+- [Make instance methods callable like statics for builtin types][4077]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -632,8 +633,9 @@
 [4023]: https://github.com/enso-org/enso/pull/4023
 [4030]: https://github.com/enso-org/enso/pull/4030
 [4048]: https://github.com/enso-org/enso/pull/4048
-[4056]: https://github.com/enso-org/enso/pull/4049
+[4049]: https://github.com/enso-org/enso/pull/4049
 [4056]: https://github.com/enso-org/enso/pull/4056
+[4077]: https://github.com/enso-org/enso/pull/4077
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/Any.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/Any.java
@@ -11,6 +11,6 @@ public class Any extends Builtin {
 
   @Override
   protected boolean containsValues() {
-    return false;
+    return true;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
@@ -178,10 +178,6 @@ public class Builtins {
             LoadedBuiltinMethod value = entry.getValue();
             Optional<BuiltinFunction> fun = value.toFunction(language, false);
             fun.ifPresent(f -> scope.registerMethod(tpe, entry.getKey(), f.getFunction()));
-            if (!value.isStatic()) {
-              Optional<BuiltinFunction> fun2 = value.toFunction(language, true);
-              fun2.ifPresent(f -> scope.registerMethod(tpe, entry.getKey() + "_static", f.getFunction()));
-            }
           }
         });
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
@@ -175,8 +175,13 @@ public class Builtins {
         methods.entrySet().stream().forEach(entry -> {
           Type tpe = entry.getValue().isAutoRegister ? (!entry.getValue().isStatic() ? type : type.getEigentype()) : null;
           if (tpe != null) {
-            Optional<BuiltinFunction> fun = entry.getValue().toFunction(language);
+            LoadedBuiltinMethod value = entry.getValue();
+            Optional<BuiltinFunction> fun = value.toFunction(language, false);
             fun.ifPresent(f -> scope.registerMethod(tpe, entry.getKey(), f.getFunction()));
+            if (!value.isStatic()) {
+              Optional<BuiltinFunction> fun2 = value.toFunction(language, true);
+              fun2.ifPresent(f -> scope.registerMethod(tpe, entry.getKey() + "_static", f.getFunction()));
+            }
           }
         });
       }
@@ -360,7 +365,7 @@ public class Builtins {
                     @SuppressWarnings("unchecked")
                     Class<BuiltinRootNode> clazz =
                             (Class<BuiltinRootNode>) Class.forName(builtinMeta[1]);
-                    Method meth = clazz.getMethod("makeFunction", EnsoLanguage.class);
+                    Method meth = clazz.getMethod("makeFunction", EnsoLanguage.class, boolean.class);
                     LoadedBuiltinMethod meta = new LoadedBuiltinMethod(meth, isStatic, isAutoRegister);
                     return new AbstractMap.SimpleEntry<String, LoadedBuiltinMethod>(builtinMeta[0], meta);
                   } catch (ClassNotFoundException | NoSuchMethodException e) {
@@ -380,17 +385,17 @@ public class Builtins {
    * @return A non-empty function under the given name, if it exists. An empty value if no such
    *     builtin method was ever registerd
    */
-  public Optional<BuiltinFunction> getBuiltinFunction(String type, String methodName, EnsoLanguage language) {
+  public Optional<BuiltinFunction> getBuiltinFunction(String type, String methodName, EnsoLanguage language, boolean isStaticInstance) {
     // TODO: move away from String mapping once Builtins is gone
     Map<String, LoadedBuiltinMethod> atomNodes = builtinMethodNodes.get(type);
     if (atomNodes == null) return Optional.empty();
     LoadedBuiltinMethod builtin = atomNodes.get(methodName);
     if (builtin == null) return Optional.empty();
-    return builtin.toFunction(language);
+    return builtin.toFunction(language, isStaticInstance);
   }
 
   public Optional<BuiltinFunction> getBuiltinFunction(Type type, String methodName, EnsoLanguage language) {
-    return getBuiltinFunction(type.getName(), methodName, language);
+    return getBuiltinFunction(type.getName(), methodName, language, false);
   }
 
   public <T extends Builtin> T getBuiltinType(Class<T> clazz) {
@@ -618,9 +623,9 @@ public class Builtins {
   }
 
   private record LoadedBuiltinMethod(Method meth, boolean isStatic, boolean isAutoRegister) {
-    Optional<BuiltinFunction> toFunction(EnsoLanguage language) {
+    Optional<BuiltinFunction> toFunction(EnsoLanguage language, boolean isStaticInstance) {
       try {
-        return Optional.ofNullable((Function) meth.invoke(null, language)).map(f-> new BuiltinFunction(f, isAutoRegister));
+        return Optional.ofNullable((Function) meth.invoke(null, language, isStaticInstance)).map(f-> new BuiltinFunction(f, isAutoRegister));
       } catch (Exception e) {
         e.printStackTrace();
         return Optional.empty();

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -379,14 +379,19 @@ class IrToTruffle(
         )
 
         val function = methodDef.body match {
-          case fn: IR.Function if isBuiltinMethod(fn.body) =>
+          case fn: IR.Function
+              if isBuiltinMethod(
+                fn.body
+              ) =>
             // For builtin types that own the builtin method we only check that
             // the method has been registered during the initialization of builtins
             // and not attempt to register it in the scope (can't redefined methods).
             // For non-builtin types (or modules) that own the builtin method
             // we have to look up the function and register it in the scope.
-            val x              = methodDef.body.asInstanceOf[IR.Function.Lambda].body
-            val fullMethodName = x.asInstanceOf[IR.Literal.Text]
+            val fullMethodName = methodDef.body
+              .asInstanceOf[IR.Function.Lambda]
+              .body
+              .asInstanceOf[IR.Literal.Text]
 
             val builtinNameElements = fullMethodName.text.split('.')
             if (builtinNameElements.length != 2) {
@@ -397,8 +402,15 @@ class IrToTruffle(
             val methodName      = builtinNameElements(1)
             val methodOwnerName = builtinNameElements(0)
 
+            val staticWrapper = methodDef.isStaticWrapperForInstanceMethod
+
             val builtinFunction = context.getBuiltins
-              .getBuiltinFunction(methodOwnerName, methodName, language)
+              .getBuiltinFunction(
+                methodOwnerName,
+                methodName,
+                language,
+                staticWrapper
+              )
             builtinFunction.toScala
               .map(Some(_))
               .toRight(
@@ -407,18 +419,41 @@ class IrToTruffle(
                 )
               )
               .left
-              .flatMap(l =>
+              .flatMap { l =>
                 // Builtin Types Number and Integer have methods only for documentation purposes
-                if (
-                  cons == context.getBuiltins.number().getNumber ||
-                  cons == context.getBuiltins.number().getInteger
-                ) Right(None)
+                val number = context.getBuiltins.number()
+                val ok =
+                  staticWrapper && (cons == number.getNumber.getEigentype || cons == number.getInteger.getEigentype) ||
+                  !staticWrapper && (cons == number.getNumber             || cons == number.getInteger)
+                if (ok) Right(None)
                 else Left(l)
-              )
+              }
               .map(fOpt =>
                 // Register builtin iff it has not been automatically registered at an early stage
-                // of builtins initialization.
-                fOpt.filter(m => !m.isAutoRegister).map(m => m.getFunction)
+                // of builtins initialization or if it is a static wrapper.
+                fOpt
+                  .filter(m => !m.isAutoRegister() || staticWrapper)
+                  .map { m =>
+                    if (staticWrapper) {
+                      // Static wrappers differ in the number of arguments by 1.
+                      // Therefore we cannot simply get the registered function.
+                      // BuiltinRootNode.execute will infer the right order of arguments.
+                      val bodyBuilder =
+                        new expressionProcessor.BuildFunctionBody(
+                          fn.arguments,
+                          fn.body,
+                          effectContext,
+                          true
+                        )
+                      new RuntimeFunction(
+                        m.getFunction.getCallTarget,
+                        null,
+                        new FunctionSchema(new Array[RuntimeAnnotation](0), bodyBuilder.args(): _*)
+                      )
+                    } else {
+                      m.getFunction
+                    }
+                  }
               )
           case fn: IR.Function =>
             val bodyBuilder =

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -379,15 +379,13 @@ class IrToTruffle(
         )
 
         val function = methodDef.body match {
-          case fn: IR.Function
-              if isBuiltinMethod(
-                fn.body
-              ) =>
+          case fn: IR.Function if isBuiltinMethod(fn.body) =>
             // For builtin types that own the builtin method we only check that
             // the method has been registered during the initialization of builtins
             // and not attempt to register it in the scope (can't redefined methods).
             // For non-builtin types (or modules) that own the builtin method
             // we have to look up the function and register it in the scope.
+            // Static wrappers for instance methods have to be registered always.
             val fullMethodName = methodDef.body
               .asInstanceOf[IR.Function.Lambda]
               .body

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -446,7 +446,10 @@ class IrToTruffle(
                       new RuntimeFunction(
                         m.getFunction.getCallTarget,
                         null,
-                        new FunctionSchema(new Array[RuntimeAnnotation](0), bodyBuilder.args(): _*)
+                        new FunctionSchema(
+                          new Array[RuntimeAnnotation](0),
+                          bodyBuilder.args(): _*
+                        )
                       )
                     } else {
                       m.getFunction

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/MethodsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/MethodsTest.scala
@@ -186,6 +186,24 @@ class MethodsTest extends InterpreterTest {
       )
     }
 
+    "be callable on builtin types when non-static, with additional self arg" in {
+      val code =
+        """import Standard.Base.IO
+          |import Standard.Base.Data.Array.Array
+          |import Standard.Base.Data.Text.Text
+          |
+          |main =
+          |    a = Array.new_1 1
+          |    t_1 = "foo"
+          |    t_2 = "bar"
+          |
+          |    IO.println (Array.length a)
+          |    IO.println (Text.+ t_1 t_2)
+          |""".stripMargin
+      eval(code)
+      consumeOut.shouldEqual(List("1", "foobar"))
+    }
+
     "not be callable on instances when static" in {
       val code =
         """
@@ -200,5 +218,18 @@ class MethodsTest extends InterpreterTest {
         code
       ) should have message "Method `new` of Mk_Foo could not be found."
     }
+
+    "not be callable on Nothing when non-static" in {
+      val code =
+        """
+          |import Standard.Base.Nothing.Nothing
+          |
+          |main = Nothing.is_nothing Nothing
+          |""".stripMargin
+      the[InterpreterException] thrownBy eval(
+        code
+      ) should have message "Type error: expected a function, but got True."
+    }
+
   }
 }

--- a/test/Tests/src/Semantic/Error_Spec.enso
+++ b/test/Tests/src/Semantic/Error_Spec.enso
@@ -66,7 +66,7 @@ spec =
 
         Test.specify "should implement to_text" <|
             Error.throw Nothing . to_text . should_equal "(Error: Nothing)"
-            Error.to_text . should_equal "Error"
+            Error.to_text Error . should_equal "Error"
 
         Test.specify "should be able to be mapped" <|
             error = Error.throw 42

--- a/test/Tests/src/Semantic/Error_Spec.enso
+++ b/test/Tests/src/Semantic/Error_Spec.enso
@@ -67,6 +67,9 @@ spec =
         Test.specify "should implement to_text" <|
             Error.throw Nothing . to_text . should_equal "(Error: Nothing)"
             Error.to_text Error . should_equal "Error"
+            case (Error.to_text) of
+                _ : Function -> Nothing
+                _ -> Test.fail "Expected the expression to be of Function type"
 
         Test.specify "should be able to be mapped" <|
             error = Error.throw 42

--- a/test/Tests/src/Semantic/Java_Interop_Spec.enso
+++ b/test/Tests/src/Semantic/Java_Interop_Spec.enso
@@ -13,7 +13,7 @@ polyglot java import java.util.ArrayList
 polyglot java import java.time.LocalDate
 polyglot java import java.time.LocalTime
 
-Any.test_me x = x.is_nothing
+Any.test_me self x = x.is_nothing
 
 spec =
     Test.group "Java FFI" <|

--- a/test/Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Tests/src/Semantic/Warnings_Spec.enso
@@ -65,7 +65,7 @@ map_odd_warnings_and_errors value =
 throw_a_bar =
     Panic.throw "bar"
 
-Any.is_static_nothing x = x.is_nothing
+Any.is_static_nothing self x = x.is_nothing
 
 spec = Test.group "Dataflow Warnings" <|
     Test.specify "should allow to attach multiple warnings and read them back" <|

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Nothing.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Nothing.enso
@@ -1,2 +1,5 @@
+from project.Data.Boolean.Boolean import True
+
 @Builtin_Type
 type Nothing
+    is_nothing self = True


### PR DESCRIPTION
### Pull Request Description

https://github.com/enso-org/enso/pull/3764 introduced static wrappers for instance methods. Except it had a limitation to only be allowed for types with at least a single constructor.
That excluded builtin types as well which, by default, don't have them. This limitation is problematic for Array/Vector consolidation and makes builtin types somehow second-citizens.

This change lifts the limitation for builtin types only. Note that we do want to share the implementation of the generated builtin methods. At the same time due to the additional argument we have to adjust the starting index of the arguments.
This change avoids messing with the existing dispatch logic, to avoid unnecessary complexity.

As a result it is now possible to call builtin types' instance methods, statically:
```
  arr = Array.new_1 42
  Array.length arr
```
That would previously lead to missing method exception in runtime.

### Important Notes

The only exception is `Nothing`. Primarily because it requires `Nothing` to have a proper eigentype (`Nothing.type`) which would messed up a lot of existing logic for no obvious benefit (no more calling of `foo=Nothing` in parameters being one example).

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
