### PR TITLE
enso4igv can open engine/language-server & co. projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -498,6 +498,7 @@ lazy val logger = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
   .in(file("lib/scala/logger"))
   .settings(
+    frgaalJavaCompilerSetting,
     version := "0.1",
     libraryDependencies ++= scalaCompiler
   )
@@ -509,6 +510,7 @@ lazy val flexer = crossProject(JVMPlatform, JSPlatform)
   .in(file("lib/scala/flexer"))
   .dependsOn(logger)
   .settings(
+    frgaalJavaCompilerSetting,
     version := "0.1",
     resolvers ++= Resolver.sonatypeOssRepos("releases"),
     libraryDependencies ++= scalaCompiler ++ Seq(
@@ -642,6 +644,7 @@ lazy val `docs-generator` = (project in file("lib/scala/docs-generator"))
   .dependsOn(`version-output`)
   .configs(Benchmark)
   .settings(
+    frgaalJavaCompilerSetting,
     libraryDependencies ++= Seq(
       "commons-cli" % "commons-cli" % commonsCliVersion
     ),
@@ -664,6 +667,7 @@ lazy val `text-buffer` = project
   .in(file("lib/scala/text-buffer"))
   .configs(Test)
   .settings(
+    frgaalJavaCompilerSetting,
     libraryDependencies ++= Seq(
       "org.typelevel"   %% "cats-core"      % catsVersion,
       "org.bouncycastle" % "bcpkix-jdk15on" % bcpkixJdk15Version,
@@ -771,6 +775,7 @@ lazy val graph = (project in file("lib/scala/graph/"))
   .dependsOn(logger.jvm)
   .configs(Test)
   .settings(
+    frgaalJavaCompilerSetting,
     version := "0.1",
     resolvers ++= (
       Resolver.sonatypeOssRepos("releases") ++
@@ -806,6 +811,7 @@ lazy val `akka-native` = project
   .in(file("lib/scala/akka-native"))
   .configs(Test)
   .settings(
+    frgaalJavaCompilerSetting,
     version := "0.1",
     libraryDependencies ++= Seq(
       akkaActor
@@ -818,6 +824,7 @@ lazy val `profiling-utils` = project
   .in(file("lib/scala/profiling-utils"))
   .configs(Test)
   .settings(
+    frgaalJavaCompilerSetting,
     version := "0.1",
     libraryDependencies ++= Seq(
       "org.netbeans.api" % "org-netbeans-modules-sampler" % netbeansApiVersion
@@ -840,6 +847,7 @@ lazy val `logging-utils` = project
   .in(file("lib/scala/logging-utils"))
   .configs(Test)
   .settings(
+    frgaalJavaCompilerSetting,
     version := "0.1",
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % scalatestVersion % Test
@@ -875,6 +883,7 @@ lazy val `logging-service` = project
 lazy val `logging-truffle-connector` = project
   .in(file("lib/scala/logging-truffle-connector"))
   .settings(
+    frgaalJavaCompilerSetting,
     version := "0.1",
     libraryDependencies ++= Seq(
       "org.slf4j"           % "slf4j-api"   % slf4jVersion,
@@ -888,6 +897,7 @@ lazy val cli = project
   .in(file("lib/scala/cli"))
   .configs(Test)
   .settings(
+    frgaalJavaCompilerSetting,
     version := "0.1",
     libraryDependencies ++= circe ++ Seq(
       "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion,
@@ -916,6 +926,7 @@ lazy val `version-output` = (project in file("lib/scala/version-output"))
     version := "0.1"
   )
   .settings(
+    frgaalJavaCompilerSetting,
     Compile / sourceGenerators += Def.task {
       val file = (Compile / sourceManaged).value / "buildinfo" / "Info.scala"
       BuildInfo
@@ -936,6 +947,7 @@ lazy val `project-manager` = (project in file("lib/scala/project-manager"))
     (Compile / mainClass) := Some("org.enso.projectmanager.boot.ProjectManager")
   )
   .settings(
+    frgaalJavaCompilerSetting,
     (Compile / run / fork) := true,
     (Test / fork) := true,
     (Compile / run / connectInput) := true,
@@ -1031,6 +1043,7 @@ lazy val `project-manager` = (project in file("lib/scala/project-manager"))
 lazy val `json-rpc-server` = project
   .in(file("lib/scala/json-rpc-server"))
   .settings(
+    frgaalJavaCompilerSetting,
     libraryDependencies ++= akka ++ akkaTest,
     libraryDependencies ++= circe,
     libraryDependencies ++= Seq(
@@ -1058,6 +1071,7 @@ lazy val `json-rpc-server-test` = project
 lazy val testkit = project
   .in(file("lib/scala/testkit"))
   .settings(
+    frgaalJavaCompilerSetting,
     libraryDependencies ++= Seq(
       "org.apache.commons" % "commons-lang3" % commonsLangVersion,
       "commons-io"         % "commons-io"    % commonsIoVersion,
@@ -1069,6 +1083,7 @@ lazy val searcher = project
   .in(file("lib/scala/searcher"))
   .configs(Test)
   .settings(
+    frgaalJavaCompilerSetting,
     libraryDependencies ++= jmh ++ Seq(
       "com.typesafe.slick" %% "slick"           % slickVersion,
       "org.xerial"          % "sqlite-jdbc"     % sqliteVersion,
@@ -1635,6 +1650,7 @@ lazy val `runtime-with-polyglot` =
 lazy val `engine-runner` = project
   .in(file("engine/runner"))
   .settings(
+    frgaalJavaCompilerSetting,
     javaOptions ++= {
       // Note [Classpath Separation]
       val runtimeClasspath =
@@ -1793,6 +1809,7 @@ lazy val `distribution-manager` = project
   .in(file("lib/scala/distribution-manager"))
   .configs(Test)
   .settings(
+    frgaalJavaCompilerSetting,
     resolvers += Resolver.bintrayRepo("gn0s1s", "releases"),
     libraryDependencies ++= Seq(
       "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion,
@@ -1810,6 +1827,7 @@ lazy val editions = project
   .in(file("lib/scala/editions"))
   .configs(Test)
   .settings(
+    frgaalJavaCompilerSetting,
     resolvers += Resolver.bintrayRepo("gn0s1s", "releases"),
     libraryDependencies ++= Seq(
       "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion,
@@ -1838,6 +1856,7 @@ lazy val editions = project
 
 lazy val downloader = (project in file("lib/scala/downloader"))
   .settings(
+    frgaalJavaCompilerSetting,
     version := "0.1",
     libraryDependencies ++= circe ++ Seq(
       "com.typesafe.scala-logging" %% "scala-logging"    % scalaLoggingVersion,
@@ -1856,6 +1875,7 @@ lazy val `edition-updater` = project
   .in(file("lib/scala/edition-updater"))
   .configs(Test)
   .settings(
+    frgaalJavaCompilerSetting,
     Test / test := (Test / test).tag(simpleLibraryServerTag).value,
     libraryDependencies ++= Seq(
       "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion,
@@ -1869,6 +1889,9 @@ lazy val `edition-updater` = project
 
 lazy val `edition-uploader` = project
   .in(file("lib/scala/edition-uploader"))
+  .settings(
+    frgaalJavaCompilerSetting
+  )
   .dependsOn(editions)
   .dependsOn(`version-output`)
 
@@ -1876,6 +1899,7 @@ lazy val `library-manager` = project
   .in(file("lib/scala/library-manager"))
   .configs(Test)
   .settings(
+    frgaalJavaCompilerSetting,
     libraryDependencies ++= Seq(
       "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion,
       "org.scalatest"              %% "scalatest"     % scalatestVersion % Test
@@ -1893,6 +1917,7 @@ lazy val `library-manager-test` = project
   .in(file("lib/scala/library-manager-test"))
   .configs(Test)
   .settings(
+    frgaalJavaCompilerSetting,
     Test / test := (Test / test).tag(simpleLibraryServerTag).value,
     libraryDependencies ++= Seq(
       "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion,
@@ -1907,6 +1932,7 @@ lazy val `connected-lock-manager` = project
   .in(file("lib/scala/connected-lock-manager"))
   .configs(Test)
   .settings(
+    frgaalJavaCompilerSetting,
     libraryDependencies ++= Seq(
       "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion,
       akkaActor,
@@ -1922,6 +1948,7 @@ lazy val `runtime-version-manager` = project
   .in(file("lib/scala/runtime-version-manager"))
   .configs(Test)
   .settings(
+    frgaalJavaCompilerSetting,
     resolvers += Resolver.bintrayRepo("gn0s1s", "releases"),
     libraryDependencies ++= Seq(
       "com.typesafe.scala-logging" %% "scala-logging"    % scalaLoggingVersion,
@@ -1944,6 +1971,7 @@ lazy val `runtime-version-manager-test` = project
   .in(file("lib/scala/runtime-version-manager-test"))
   .configs(Test)
   .settings(
+    frgaalJavaCompilerSetting,
     libraryDependencies ++= Seq(
       "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion,
       "org.scalatest"              %% "scalatest"     % scalatestVersion,
@@ -1965,6 +1993,7 @@ lazy val `runtime-version-manager-test` = project
 lazy val `locking-test-helper` = project
   .in(file("lib/scala/locking-test-helper"))
   .settings(
+    frgaalJavaCompilerSetting,
     assembly / test := {},
     assembly / assemblyOutputPath := file("locking-test-helper.jar")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1163,6 +1163,7 @@ lazy val `polyglot-api` = project
 
 lazy val `language-server` = (project in file("engine/language-server"))
   .settings(
+    frgaalJavaCompilerSetting,
     libraryDependencies ++= akka ++ circe ++ Seq(
       "com.typesafe.scala-logging" %% "scala-logging"        % scalaLoggingVersion,
       "io.circe"                   %% "circe-generic-extras" % circeGenericExtrasVersion,

--- a/engine/language-server/src/main/java/org/enso/languageserver/package-info.java
+++ b/engine/language-server/src/main/java/org/enso/languageserver/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.languageserver;

--- a/engine/runner/src/main/java/org/enso/runner/package-info.java
+++ b/engine/runner/src/main/java/org/enso/runner/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.runner;

--- a/lib/scala/akka-native/src/main/java/org/enso/nativeimage/workarounds/package-info.java
+++ b/lib/scala/akka-native/src/main/java/org/enso/nativeimage/workarounds/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.nativeimage.workarounds;

--- a/lib/scala/cli/src/main/java/org/enso/cli/internal/package-info.java
+++ b/lib/scala/cli/src/main/java/org/enso/cli/internal/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.cli.internal;

--- a/lib/scala/connected-lock-manager/src/main/java/org/enso/lockmanager/server/package-info.java
+++ b/lib/scala/connected-lock-manager/src/main/java/org/enso/lockmanager/server/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.lockmanager.server;

--- a/lib/scala/distribution-manager/src/main/java/org/enso/distribution/package-info.java
+++ b/lib/scala/distribution-manager/src/main/java/org/enso/distribution/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.distribution;

--- a/lib/scala/docs-generator/src/bench/java/org/enso/docs/generator/package-info.java
+++ b/lib/scala/docs-generator/src/bench/java/org/enso/docs/generator/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.docs.generator;

--- a/lib/scala/downloader/src/main/java/org/enso/downloader/archive/internal/package-info.java
+++ b/lib/scala/downloader/src/main/java/org/enso/downloader/archive/internal/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.downloader.archive.internal;

--- a/lib/scala/edition-updater/src/main/java/org/enso/editions/updater/package-info.java
+++ b/lib/scala/edition-updater/src/main/java/org/enso/editions/updater/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.editions.updater;

--- a/lib/scala/edition-uploader/src/main/java/org/enso/build/editionuploader/package-info.java
+++ b/lib/scala/edition-uploader/src/main/java/org/enso/build/editionuploader/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.build.editionuploader;

--- a/lib/scala/editions/src/main/java/org/enso/editions/package-info.java
+++ b/lib/scala/editions/src/main/java/org/enso/editions/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.editions;

--- a/lib/scala/flexer/src/main/java/org/enso/flexer/package-info.java
+++ b/lib/scala/flexer/src/main/java/org/enso/flexer/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.flexer;

--- a/lib/scala/graph/src/main/java/org/enso/graph/definition/package-info.java
+++ b/lib/scala/graph/src/main/java/org/enso/graph/definition/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.graph.definition;

--- a/lib/scala/json-rpc-server-test/src/main/java/org/enso/jsonrpc/test/package-info.java
+++ b/lib/scala/json-rpc-server-test/src/main/java/org/enso/jsonrpc/test/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.jsonrpc.test;

--- a/lib/scala/library-manager-test/src/main/java/org/enso/librarymanager/published/repository/package-info.java
+++ b/lib/scala/library-manager-test/src/main/java/org/enso/librarymanager/published/repository/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.librarymanager.published.repository;

--- a/lib/scala/library-manager/src/main/java/org/enso/editions/package-info.java
+++ b/lib/scala/library-manager/src/main/java/org/enso/editions/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.editions;

--- a/lib/scala/locking-test-helper/src/main/java/org/enso/runtimeversionmanager/test/package-info.java
+++ b/lib/scala/locking-test-helper/src/main/java/org/enso/runtimeversionmanager/test/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.runtimeversionmanager.test;

--- a/lib/scala/logger/src/main/java/org/enso/package-info.java
+++ b/lib/scala/logger/src/main/java/org/enso/package-info.java
@@ -1,0 +1,1 @@
+package org.enso;

--- a/lib/scala/logging-service/src/main/java/org/enso/logger/akka/package-info.java
+++ b/lib/scala/logging-service/src/main/java/org/enso/logger/akka/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.logger.akka;

--- a/lib/scala/logging-truffle-connector/src/main/java/org/enso/truffleloggerwrapper/package-info.java
+++ b/lib/scala/logging-truffle-connector/src/main/java/org/enso/truffleloggerwrapper/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.truffleloggerwrapper;

--- a/lib/scala/logging-utils/src/main/java/org/enso/logger/masking/package-info.java
+++ b/lib/scala/logging-utils/src/main/java/org/enso/logger/masking/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.logger.masking;

--- a/lib/scala/profiling-utils/src/main/java/org/enso/profiling/package-info.java
+++ b/lib/scala/profiling-utils/src/main/java/org/enso/profiling/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.profiling;

--- a/lib/scala/project-manager/src/main/java/org/enso/projectmanager/event/package-info.java
+++ b/lib/scala/project-manager/src/main/java/org/enso/projectmanager/event/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.projectmanager.event;

--- a/lib/scala/runtime-version-manager-test/src/main/java/org/enso/runtimeversionmanager/test/package-info.java
+++ b/lib/scala/runtime-version-manager-test/src/main/java/org/enso/runtimeversionmanager/test/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.runtimeversionmanager.test;

--- a/lib/scala/runtime-version-manager/src/main/java/org/enso/runtimeversionmanager/package-info.java
+++ b/lib/scala/runtime-version-manager/src/main/java/org/enso/runtimeversionmanager/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.runtimeversionmanager;

--- a/lib/scala/searcher/src/bench/java/org/enso/searcher/sql/package-info.java
+++ b/lib/scala/searcher/src/bench/java/org/enso/searcher/sql/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.searcher.sql;

--- a/lib/scala/testkit/src/main/java/org/enso/testkit/package-info.java
+++ b/lib/scala/testkit/src/main/java/org/enso/testkit/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.testkit;

--- a/lib/scala/text-buffer/src/main/java/org/enso/text/package-info.java
+++ b/lib/scala/text-buffer/src/main/java/org/enso/text/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.text;

--- a/lib/scala/version-output/src/main/java/org/enso/version/package-info.java
+++ b/lib/scala/version-output/src/main/java/org/enso/version/package-info.java
@@ -1,0 +1,1 @@
+package org.enso.version;

--- a/tools/enso4igv/pom.xml
+++ b/tools/enso4igv/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>enso4igv</artifactId>
     <packaging>nbm</packaging>
     <name>Enso Language Support for NetBeans &amp; Ideal Graph Visualizer</name>
-    <version>1.11-SNAPSHOT</version>
+    <version>1.12-NAPSHOT</version>
     <build>
         <plugins>
             <plugin>

--- a/tools/enso4igv/pom.xml
+++ b/tools/enso4igv/pom.xml
@@ -51,6 +51,11 @@
                     </compilerArgs>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.15</version>
+            </plugin>
         </plugins>
     </build>
     <dependencies>
@@ -180,6 +185,20 @@
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-api-debugger</artifactId>
             <version>${netbeans.version}</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-netbeans-modules-nbjunit</artifactId>
+            <version>${netbeans.version}</version>
+            <scope>test</scope>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.modules</groupId>
+            <artifactId>org-netbeans-modules-projectapi-nb</artifactId>
+            <version>${netbeans.version}</version>
+            <scope>test</scope>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoLogicalView.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoLogicalView.java
@@ -6,6 +6,7 @@ import javax.swing.Action;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import org.enso.tools.enso4igv.EnsoSbtClassPathProvider.EnsoSources;
+import org.enso.tools.enso4igv.EnsoSbtClassPathProvider.OtherEnsoSources;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.api.project.SourceGroup;
@@ -94,12 +95,7 @@ final class EnsoLogicalView implements LogicalViewProvider  {
         @Override
         protected boolean createKeys(List<SourceGroup> toPopulate) {
             var arr = Arrays.asList(ProjectUtils.getSources(prj).getSourceGroups(null));
-            var enso = NbCollections.checkedListByCopy(arr, EnsoSources.class, true);
-            for (var e : enso) {
-                toPopulate.add(e);
-            }
-            for (var e : enso) {
-            }
+            toPopulate.addAll(arr);
             return true;
         }
 
@@ -111,9 +107,6 @@ final class EnsoLogicalView implements LogicalViewProvider  {
         @Override
         public void stateChanged(ChangeEvent e) {
             refresh(false);
-        }
-
-        record Entry(String prefix, FileObject root) {
         }
     }
 }

--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoSbtClassPathProvider.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoSbtClassPathProvider.java
@@ -39,7 +39,7 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
     private static final String SOURCE = "classpath/source";
     private static final String COMPILE = "classpath/compile";
     private final EnsoSbtProject project;
-    private final EnsoSources[] sources;
+    private final SourceGroup[] sources;
 
     EnsoSbtClassPathProvider(EnsoSbtProject prj) {
         this.project = prj;
@@ -48,8 +48,8 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
 
     @Override
     public ClassPath findClassPath(FileObject file, String type) {
-        for (var i : sources) {
-            if (i.controlsSource(file)) {
+        for (var g : sources) {
+            if (g instanceof EnsoSources i && i.controlsSource(file)) {
                 return switch (type) {
                     case SOURCE -> i.srcCp;
                     case COMPILE -> i.cp;
@@ -63,22 +63,26 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
 
     @Override
     public void projectOpened() {
-        for (var i : sources) {
-            GlobalPathRegistry.getDefault().register(COMPILE, new ClassPath[] { i.cp });
-            GlobalPathRegistry.getDefault().register(SOURCE, new ClassPath[] { i.srcCp });
+        for (var g : sources) {
+            if (g instanceof EnsoSources i) {
+                GlobalPathRegistry.getDefault().register(COMPILE, new ClassPath[] { i.cp });
+                GlobalPathRegistry.getDefault().register(SOURCE, new ClassPath[] { i.srcCp });
+            }
         }
     }
 
     @Override
     public void projectClosed() {
-        for (var i : sources) {
-            GlobalPathRegistry.getDefault().unregister(COMPILE, new ClassPath[] { i.cp });
-            GlobalPathRegistry.getDefault().unregister(SOURCE, new ClassPath[] { i.srcCp });
+        for (var g : sources) {
+            if (g instanceof EnsoSources i) {
+                GlobalPathRegistry.getDefault().unregister(COMPILE, new ClassPath[] { i.cp });
+                GlobalPathRegistry.getDefault().unregister(SOURCE, new ClassPath[] { i.srcCp });
+            }
         }
     }
 
-    private static EnsoSources[] computeSbtClassPath(EnsoSbtProject prj) {
-        var sources = new ArrayList<EnsoSources>();
+    private static SourceGroup[] computeSbtClassPath(EnsoSbtProject prj) {
+        var sources = new ArrayList<SourceGroup>();
         var platform = JavaPlatform.getDefault();
         var roots = new LinkedHashSet<>();
         var generatedSources = new LinkedHashSet<>();
@@ -181,7 +185,21 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
                 }
             }
         }
-        return sources.toArray(new EnsoSources[0]);
+        if (prj.getProjectDirectory().getFileObject("src") instanceof FileObject src && src.isFolder()) {
+            for (var kind : src.getChildren()) {
+              TYPE: for (var type : kind.getChildren()) {
+                    for (var e : sources) {
+                      if (e.getRootFolder().equals(type)) {
+                        continue TYPE;
+                      }
+                    }
+
+                    var s = new OtherEnsoSources(kind.getNameExt(), type);
+                    sources.add(s);
+                }
+            }
+        }
+        return sources.toArray(new SourceGroup[0]);
     }
 
     private static FileObject findProjectFileObject(EnsoSbtProject prj, String path) {
@@ -197,8 +215,8 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
 
     @Override
     public SourceLevelQueryImplementation2.Result getSourceLevel(FileObject fo) {
-        for (var i : sources) {
-            if (i.controlsSource(fo)) {
+        for (var g : sources) {
+            if (g instanceof EnsoSources i && i.controlsSource(fo)) {
                 return new SourceLevelQueryImplementation2.Result() {
                     @Override
                     public String getSourceLevel() {
@@ -220,8 +238,8 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
 
     @Override
     public CompilerOptionsQueryImplementation.Result getOptions(FileObject fo) {
-        for (var i : sources) {
-            if (i.controlsSource(fo)) {
+        for (var g : sources) {
+            if (g instanceof EnsoSources i && i.controlsSource(fo)) {
                 return new CompilerOptionsQueryImplementation.Result() {
                     @Override
                     public List<? extends String> getArguments() {
@@ -264,10 +282,10 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
     @Override
     public EnsoSources findBinaryRoots2(URL url) {
         var fo = URLMapper.findFileObject(url);
-        for (var i : sources) {
-          if (i.outputsTo(fo) || i.controlsSource(fo)) {
-            return i;
-          }
+        for (var g : sources) {
+            if (g instanceof EnsoSources i && (i.outputsTo(fo) || i.controlsSource(fo))) {
+                return i;
+            }
         }
         return null;
     }
@@ -292,8 +310,8 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
         if (fo == null) {
             return null;
         }
-        for (var i : sources) {
-            if (i.outputsTo(fo) || i.controlsSource(fo)) {
+        for (var g : sources) {
+            if (g instanceof EnsoSources i && (i.outputsTo(fo) || i.controlsSource(fo))) {
                 return new SourceForBinaryQueryImplementation2.Result() {
                     @Override
                     public boolean preferSources() {
@@ -345,7 +363,7 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
 
         @Override
         public String getDisplayName() {
-            return getName();
+            return "Java " + source + " " + getName();
         }
 
         @Override
@@ -385,6 +403,41 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
 
         public String toString() {
             return "EnsoSources[name=" + getName() + ",root=" + getRootFolder() + ",output=" + output() + "]";
+        }
+    }
+
+    record OtherEnsoSources(String kind, FileObject root) implements SourceGroup {
+        @Override
+        public FileObject getRootFolder() {
+            return root;
+        }
+
+        @Override
+        public String getName() {
+            return kind + "/" + root.getNameExt();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return getName();
+        }
+
+        @Override
+        public Icon getIcon(boolean bln) {
+            return null;
+        }
+
+        @Override
+        public boolean contains(FileObject fo) {
+            return FileUtil.isParentOf(root, fo);
+        }
+
+        @Override
+        public void addPropertyChangeListener(PropertyChangeListener pl) {
+        }
+
+        @Override
+        public void removePropertyChangeListener(PropertyChangeListener pl) {
         }
     }
 }

--- a/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/EnsoSbtProjectTest.java
+++ b/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/EnsoSbtProjectTest.java
@@ -2,6 +2,7 @@ package org.enso.tools.enso4igv;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.Sources;
 import org.netbeans.junit.NbTestCase;
@@ -18,23 +19,23 @@ public class EnsoSbtProjectTest extends NbTestCase {
   protected void setUp() throws Exception {
     clearWorkDir();
   }
-  
+
   public void testLanguageServerProject() throws Exception {
     FileObject root = setLanguageServerProjectUp();
-    
+
     var prj = ProjectManager.getDefault().findProject(root);
     assertNotNull("Project found", prj);
     assertEquals("Right type", EnsoSbtProject.class, prj.getClass());
-    
+
     var s = prj.getLookup().lookup(Sources.class);
     assertNotNull("Sources found", s);
-    
+
     var genericGroups = s.getSourceGroups(Sources.TYPE_GENERIC);
     assertEquals("One", 1, genericGroups.length);
     assertEquals("One at root", root, genericGroups[0].getRootFolder());
 
     var javaGroups = s.getSourceGroups("java");
-    assertEquals("Javish", 1, javaGroups.length);
+    assertEquals("1 bench, 2 tests, 4 main: " + Arrays.toString(javaGroups), 7, javaGroups.length);
   }
 
   private static FileObject setLanguageServerProjectUp() throws IOException {
@@ -44,8 +45,8 @@ public class EnsoSbtProjectTest extends NbTestCase {
     var srcBench = src.createFolder("bench");
     var srcBenchScala = srcBench.createFolder("scala");
     var srcTest = src.createFolder("test");
-    var srcTestScala = src.createFolder("scala");
-    var srcTestResources = src.createFolder("resources");
+    var srcTestScala = srcTest.createFolder("scala");
+    var srcTestResources = srcTest.createFolder("resources");
     var srcMain = src.createFolder("main");
     var srcMainJava = srcMain.createFolder("java");
     var srcMainResources = srcMain.createFolder("resources");

--- a/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/EnsoSbtProjectTest.java
+++ b/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/EnsoSbtProjectTest.java
@@ -1,0 +1,77 @@
+package org.enso.tools.enso4igv;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.api.project.Sources;
+import org.netbeans.junit.NbTestCase;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+public class EnsoSbtProjectTest extends NbTestCase {
+
+  public EnsoSbtProjectTest(String name) {
+    super(name);
+  }
+
+  @Override
+  protected void setUp() throws Exception {
+    clearWorkDir();
+  }
+  
+  public void testLanguageServerProject() throws Exception {
+    FileObject root = setLanguageServerProjectUp();
+    
+    var prj = ProjectManager.getDefault().findProject(root);
+    assertNotNull("Project found", prj);
+    assertEquals("Right type", EnsoSbtProject.class, prj.getClass());
+    
+    var s = prj.getLookup().lookup(Sources.class);
+    assertNotNull("Sources found", s);
+    
+    var genericGroups = s.getSourceGroups(Sources.TYPE_GENERIC);
+    assertEquals("One", 1, genericGroups.length);
+    assertEquals("One at root", root, genericGroups[0].getRootFolder());
+
+    var javaGroups = s.getSourceGroups("java");
+    assertEquals("Javish", 1, javaGroups.length);
+  }
+
+  private static FileObject setLanguageServerProjectUp() throws IOException {
+    var fs = FileUtil.createMemoryFileSystem();
+    var root = fs.getRoot().createFolder("langsrv");
+    var src = root.createFolder("src");
+    var srcBench = src.createFolder("bench");
+    var srcBenchScala = srcBench.createFolder("scala");
+    var srcTest = src.createFolder("test");
+    var srcTestScala = src.createFolder("scala");
+    var srcTestResources = src.createFolder("resources");
+    var srcMain = src.createFolder("main");
+    var srcMainJava = srcMain.createFolder("java");
+    var srcMainResources = srcMain.createFolder("resources");
+    var srcMainScala = srcMain.createFolder("scala");
+    var srcMainSchema = srcMain.createFolder("schema");
+    var ensoSources = root.createData(".enso-sources");
+    try (var os = root.createAndOpen(".enso-sources-classes")) {
+      var txt = """
+      java.home=/graalvm-ce-java11-22.3.0
+      target=11
+      output=./target/scala-2.13/classes
+      input=./src/main/java
+      generated=./target/scala-2.13/src_managed/main
+      options.9=./target/scala-2.13/classes
+      options.8=-classpath
+      options.7=--enable-preview
+      options.6=19
+      options.5=-source
+      options.4=-Xlint\\:unchecked
+      options.3=-g
+      options.2=-deprecation
+      options.1=UTF-8
+      options.0=-encoding
+      """;
+      os.write(txt.getBytes(StandardCharsets.UTF_8));
+    }
+    return root;
+  }
+}


### PR DESCRIPTION
### Pull Request Description

In order to investigate `engine/language-server` project, I need to be able to open its sources in IGV and NetBeans.

### Important Notes

By adding some Java source (this time `package-info.java`) and compiling with our Frgaal compiler the necessary `.enso-sources*` files are generated for `engine/language-server` and then the `enso4igv` plugin can open them and properly understand their compile settings.

![Logical View of language-server project](https://user-images.githubusercontent.com/26887752/215472696-ec9801f3-4692-4bdb-be92-c4d2ab552e60.png)

In addition to that this PR enhances the _"logical view"_ presentation of the project by including all source roots found under `src/*/*`.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
