### PR TITLE
Custom type conversion to double from large long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -547,6 +547,7 @@
 - [Resolve Fully Qualified Names][4056]
 - [Optimize Atom storage layouts][3862]
 - [Make instance methods callable like statics for builtin types][4077]
+- [Convert large longs to doubles, safely, for host calls][4099]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -636,6 +637,7 @@
 [4049]: https://github.com/enso-org/enso/pull/4049
 [4056]: https://github.com/enso-org/enso/pull/4056
 [4077]: https://github.com/enso-org/enso/pull/4077
+[4099]: https://github.com/enso-org/enso/pull/4099
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -43,7 +43,7 @@ import org.enso.librarymanager.published.PublishedLibraryCache
 import org.enso.lockmanager.server.LockManagerService
 import org.enso.logger.masking.Masking
 import org.enso.loggingservice.{JavaLoggingLogHandler, LogLevel}
-import org.enso.polyglot.{RuntimeOptions, RuntimeServerInfo}
+import org.enso.polyglot.{HostAccessFactory, RuntimeOptions, RuntimeServerInfo}
 import org.enso.searcher.sql.{SqlDatabase, SqlSuggestionsRepo, SqlVersionsRepo}
 import org.enso.text.{ContentBasedVersioning, Sha3_224VersionCalculator}
 import org.graalvm.polyglot.Context
@@ -270,6 +270,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: LogLevel) {
   val context = Context
     .newBuilder()
     .allowAllAccess(true)
+    .allowHostAccess(new HostAccessFactory().allWithTypeMapping())
     .allowExperimentalOptions(true)
     .option(RuntimeServerInfo.ENABLE_OPTION, "true")
     .option(RuntimeOptions.INTERACTIVE_MODE, "true")

--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/CompilerBasedDependencyExtractor.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/CompilerBasedDependencyExtractor.scala
@@ -5,7 +5,7 @@ import org.enso.libraryupload.DependencyExtractor
 import org.enso.loggingservice.{JavaLoggingLogHandler, LogLevel}
 import org.enso.pkg.Package
 import org.enso.pkg.SourceFile
-import org.enso.polyglot.{PolyglotContext, RuntimeOptions}
+import org.enso.polyglot.{HostAccessFactory, PolyglotContext, RuntimeOptions}
 import org.graalvm.polyglot.Context
 
 import java.io.File
@@ -55,6 +55,7 @@ class CompilerBasedDependencyExtractor(logLevel: LogLevel)
       .newBuilder()
       .allowExperimentalOptions(true)
       .allowAllAccess(true)
+      .allowHostAccess(new HostAccessFactory().allWithTypeMapping())
       .option(RuntimeOptions.PROJECT_ROOT, pkg.root.getCanonicalPath)
       .option("js.foreign-object-prototype", "true")
       .option(

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/HostAccessFactory.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/HostAccessFactory.java
@@ -1,0 +1,35 @@
+package org.enso.polyglot;
+
+import org.graalvm.polyglot.HostAccess;
+
+/** Utility class for creating HostAccess object. */
+public class HostAccessFactory {
+
+  // Copied from com.oracle.truffle.api.interop.NumberUtils
+  // since the latter is inaccessible
+  private static final long LONG_MAX_SAFE_DOUBLE = 9007199254740991L; // 2 ** 53 - 1
+
+  public HostAccess allWithTypeMapping() {
+    return HostAccess.newBuilder()
+        .allowPublicAccess(true)
+        .allowAllImplementations(true)
+        .allowAllClassImplementations(true)
+        .allowArrayAccess(true)
+        .allowListAccess(true)
+        .allowBufferAccess(true)
+        .allowIterableAccess(true)
+        .allowIteratorAccess(true)
+        .allowMapAccess(true)
+        .allowAccessInheritance(true)
+        .targetTypeMapping(
+            Long.class,
+            Double.class,
+            (v) -> v != null && !longInSafeDoubleRange(v, LONG_MAX_SAFE_DOUBLE),
+            (v) -> Double.longBitsToDouble(v))
+        .build();
+  }
+
+  private boolean longInSafeDoubleRange(Long v, Long max) {
+    return v >= -max && v <= max;
+  }
+}

--- a/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
@@ -5,7 +5,7 @@ import org.enso.polyglot.debugger.{
   DebugServerInfo,
   DebuggerSessionManagerEndpoint
 }
-import org.enso.polyglot.{PolyglotContext, RuntimeOptions}
+import org.enso.polyglot.{HostAccessFactory, PolyglotContext, RuntimeOptions}
 import org.graalvm.polyglot.Context
 
 import java.io.{InputStream, OutputStream}
@@ -46,6 +46,7 @@ class ContextFactory {
       .newBuilder()
       .allowExperimentalOptions(true)
       .allowAllAccess(true)
+      .allowHostAccess(new HostAccessFactory().allWithTypeMapping())
       .option(RuntimeOptions.PROJECT_ROOT, projectRoot)
       .option(RuntimeOptions.STRICT_ERRORS, strictErrors.toString)
       .option(RuntimeOptions.WAIT_FOR_PENDING_SERIALIZATION_JOBS, "true")

--- a/test/Tests/src/Semantic/Java_Interop_Spec.enso
+++ b/test/Tests/src/Semantic/Java_Interop_Spec.enso
@@ -12,6 +12,7 @@ polyglot java import java.lang.StringBuilder as Java_String_Builder
 polyglot java import java.util.ArrayList
 polyglot java import java.time.LocalDate
 polyglot java import java.time.LocalTime
+polyglot java import org.enso.base.statistics.Moments
 
 Any.test_me self x = x.is_nothing
 
@@ -42,6 +43,12 @@ spec =
         Test.specify "should invoke static methods" <|
             x = Integer.valueOf 1
             x.test_me x . should_equal False
+
+    Test.group "Numeric values" <|
+        Test.specify "can be passed in host calls without lossy coercion exception" <|
+            large_long = 6907338656278321365
+            moments = Moments.new 1
+            moments.add large_long
 
     Test.group "Java/Enso Date" <|
         Test.specify "Java date has Enso properties" <|


### PR DESCRIPTION
### Pull Request Description

When a large long would be passed to a host call expecting a double, it would crash with a
```
Cannot convert '<some long>'(language: Java, type: java.lang.Long) to Java type 'double': Invalid or lossy primitive coercion
```

That is unlikely to be expected by users. It also came up in the Statistics examples during Sum. One could workaround it by forcing the conversion manually with `.to_decimal` but it is not a permanent solution.

Instead this change adds a custom type mapping from Long to Double that will do it behind the scenes with no user interaction. The mapping kicks in only for really large longs.

### Important Notes

Note that the _safe_ range is hardcoded in Truffle and it is not accessible in enso packages. Therefore a simple c&p for that max safe long value was necessary.

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
