### PR TITLE
Fix vcs-restore edit notification

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
@@ -267,9 +267,10 @@ class CollaborativeBuffer(
       // Notify *all* clients about the new buffer
       // This also ensures that the client that requested the restore operation
       // also gets a notification.
+      val edits = List(TextEdit(oldBuffer.fullRange, file.content))
       val change = FileEdit(
         path,
-        List(TextEdit(oldBuffer.fullRange, file.content)),
+        edits,
         oldBuffer.version.toHexString,
         buffer.version.toHexString
       )
@@ -277,7 +278,7 @@ class CollaborativeBuffer(
         Api.SetModuleSourcesNotification(file.path, file.content)
       )
       runtimeConnector ! Api.Request(
-        Api.EditFileNotification(file.path, Seq(), execute = true)
+        Api.EditFileNotification(file.path, edits, execute = true)
       )
       clients.values.foreach { _.rpcController ! TextDidChange(List(change)) }
       unstashAll()

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
@@ -667,7 +667,7 @@ class CollaborativeBuffer(
       Right(OpenFileResult(buffer, Some(cap)))
     )
     runtimeConnector ! Api.Request(
-      Api.SetModuleSourcesNotification(file.path, file.content)
+      Api.OpenFileNotification(file.path, file.content)
     )
     context.become(
       collaborativeEditing(

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
@@ -275,9 +275,6 @@ class CollaborativeBuffer(
         buffer.version.toHexString
       )
       runtimeConnector ! Api.Request(
-        Api.SetModuleSourcesNotification(file.path, file.content)
-      )
-      runtimeConnector ! Api.Request(
         Api.EditFileNotification(file.path, edits, execute = true)
       )
       clients.values.foreach { _.rpcController ! TextDidChange(List(change)) }

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/FileNotificationsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/FileNotificationsTest.scala
@@ -88,7 +88,7 @@ class FileNotificationsTest extends BaseServerTest with FlakySpec {
       // 4
       runtimeConnectorProbe.expectMsg(
         Api.Request(
-          Api.SetModuleSourcesNotification(file("foo.txt"), "123456789")
+          Api.OpenFileNotification(file("foo.txt"), "123456789")
         )
       )
 

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -94,7 +94,7 @@ object Runtime {
         name  = "getComponentGroupsResponse"
       ),
       new JsonSubTypes.Type(
-        value = classOf[Api.SetModuleSourcesNotification],
+        value = classOf[Api.OpenFileNotification],
         name  = "setModuleSourcesNotification"
       ),
       new JsonSubTypes.Type(
@@ -1301,12 +1301,12 @@ object Runtime {
       */
     final case class InvalidStackItemError(contextId: ContextId) extends Error
 
-    /** A notification sent to the server about setting module's sources to literal contents.
+    /** A notification sent to the server about opening a file.
       *
       * @param path the file being moved to memory.
       * @param contents the current module's contents.
       */
-    final case class SetModuleSourcesNotification(
+    final case class OpenFileNotification(
       path: File,
       contents: String
     ) extends ApiRequest
@@ -1314,7 +1314,7 @@ object Runtime {
 
       /** @inheritdoc */
       override def toLogString(shouldMask: Boolean): String =
-        "SetModuleSourcesNotification(" +
+        "OpenFileNotification(" +
         s"path=${MaskedPath(path.toPath).toLogString(shouldMask)}," +
         s"contents=${MaskedString(contents).toLogString(shouldMask)}," +
         ")"

--- a/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/IncrementalUpdatesTest.java
+++ b/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/IncrementalUpdatesTest.java
@@ -24,7 +24,7 @@ import org.enso.polyglot.runtime.Runtime$Api$PushContextResponse;
 import org.enso.polyglot.runtime.Runtime$Api$Request;
 import org.enso.polyglot.runtime.Runtime$Api$Response;
 import org.enso.polyglot.runtime.Runtime$Api$SetExpressionValueNotification;
-import org.enso.polyglot.runtime.Runtime$Api$SetModuleSourcesNotification;
+import org.enso.polyglot.runtime.Runtime$Api$OpenFileNotification;
 import org.enso.polyglot.runtime.Runtime$Api$StackItem$ExplicitCall;
 import org.enso.polyglot.runtime.Runtime$Api$StackItem$LocalCall;
 import org.enso.text.editing.model;
@@ -196,7 +196,7 @@ public class IncrementalUpdatesTest {
     );
     // Open the new file
     context.send(
-      Request(new Runtime$Api$SetModuleSourcesNotification(mainFile, contents))
+      Request(new Runtime$Api$OpenFileNotification(mainFile, contents))
     );
     assertTrue("No reply", context.receiveNone().isEmpty());
 

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/BuiltinTypesTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/BuiltinTypesTest.scala
@@ -111,7 +111,7 @@ class BuiltinTypesTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
@@ -121,7 +121,7 @@ class RuntimeAsyncCommandsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -182,7 +182,7 @@ class RuntimeAsyncCommandsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeComponentsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeComponentsTest.scala
@@ -222,7 +222,7 @@ class RuntimeComponentsTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveOne shouldEqual None
 
@@ -316,7 +316,7 @@ class RuntimeComponentsTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveOne shouldEqual None
 

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
@@ -135,7 +135,7 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -221,7 +221,7 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -302,7 +302,7 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -371,7 +371,7 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -456,7 +456,7 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -532,7 +532,7 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -686,7 +686,7 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -781,7 +781,7 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -872,7 +872,7 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -977,7 +977,7 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1098,7 +1098,7 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1226,7 +1226,7 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1340,7 +1340,7 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1441,7 +1441,7 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
@@ -119,7 +119,7 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -166,7 +166,7 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -219,7 +219,7 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -281,7 +281,7 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -343,7 +343,7 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -402,7 +402,7 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -459,7 +459,7 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -517,7 +517,7 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -584,7 +584,7 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -646,7 +646,7 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -705,7 +705,7 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -767,7 +767,7 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -827,7 +827,7 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -885,7 +885,7 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -956,7 +956,7 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -346,7 +346,7 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -453,7 +453,7 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -507,7 +507,7 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -608,10 +608,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
-    context.send(Api.Request(Api.SetModuleSourcesNotification(aFile, aCode)))
+    context.send(Api.Request(Api.OpenFileNotification(aFile, aCode)))
     context.receiveNone shouldEqual None
 
     // push main
@@ -692,7 +692,7 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -751,7 +751,7 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -812,7 +812,7 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -875,7 +875,7 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -934,7 +934,7 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1002,7 +1002,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1123,7 +1123,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1216,7 +1216,7 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1298,7 +1298,7 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1392,7 +1392,7 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1633,7 +1633,7 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1841,7 +1841,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1893,7 +1893,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1938,7 +1938,7 @@ class RuntimeServerTest
     val mainFile = context.writeMain(code)
 
     // Set sources for the module
-    context.send(Api.Request(Api.SetModuleSourcesNotification(mainFile, code)))
+    context.send(Api.Request(Api.OpenFileNotification(mainFile, code)))
     context.receiveNone shouldEqual None
     context.consumeOut shouldEqual List()
 
@@ -2008,7 +2008,7 @@ class RuntimeServerTest
     val mainFile = context.writeMain(code)
 
     // Set sources for the module
-    context.send(Api.Request(Api.SetModuleSourcesNotification(mainFile, code)))
+    context.send(Api.Request(Api.OpenFileNotification(mainFile, code)))
     context.receiveNone shouldEqual None
     context.consumeOut shouldEqual List()
 
@@ -2046,7 +2046,7 @@ class RuntimeServerTest
     )
 
     // Re-open the the file and apply the same operation
-    context.send(Api.Request(Api.SetModuleSourcesNotification(mainFile, code)))
+    context.send(Api.Request(Api.OpenFileNotification(mainFile, code)))
     context.receiveNone shouldEqual None
     context.consumeOut shouldEqual List()
 
@@ -2089,7 +2089,7 @@ class RuntimeServerTest
     val mainFile = context.writeMain(code)
 
     // Set sources for the module
-    context.send(Api.Request(Api.SetModuleSourcesNotification(mainFile, code)))
+    context.send(Api.Request(Api.OpenFileNotification(mainFile, code)))
     context.receiveNone shouldEqual None
 
     // Push new item on the stack to trigger the re-execution
@@ -2151,7 +2151,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, context.Main.code))
+      Api.Request(Api.OpenFileNotification(mainFile, context.Main.code))
     )
     context.receiveNone shouldEqual None
 
@@ -2229,7 +2229,7 @@ class RuntimeServerTest
     val mainFile = context.writeMain(code)
 
     // Set sources for the module
-    context.send(Api.Request(Api.SetModuleSourcesNotification(mainFile, code)))
+    context.send(Api.Request(Api.OpenFileNotification(mainFile, code)))
     context.receiveNone shouldEqual None
     context.consumeOut shouldEqual List()
 
@@ -2324,7 +2324,7 @@ class RuntimeServerTest
     val mainFile = context.writeMain(code)
 
     // Set sources for the module
-    context.send(Api.Request(Api.SetModuleSourcesNotification(mainFile, code)))
+    context.send(Api.Request(Api.OpenFileNotification(mainFile, code)))
     context.receiveNone shouldEqual None
     context.consumeOut shouldEqual List()
 
@@ -2400,7 +2400,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -2446,7 +2446,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -2509,7 +2509,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
 
     context.receiveNone shouldEqual None
@@ -2564,7 +2564,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
 
     context.receiveNone shouldEqual None
@@ -2608,7 +2608,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -2659,7 +2659,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -2717,7 +2717,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -2785,7 +2785,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -2861,7 +2861,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -2939,7 +2939,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -3017,7 +3017,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -3110,7 +3110,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -3169,7 +3169,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -3227,7 +3227,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -3292,7 +3292,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -3359,7 +3359,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -3419,7 +3419,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -3469,7 +3469,7 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -3517,7 +3517,7 @@ class RuntimeServerTest
     // open file
     context.send(
       Api.Request(
-        Api.SetModuleSourcesNotification(mainFile, contents)
+        Api.OpenFileNotification(mainFile, contents)
       )
     )
     context.receiveNone shouldEqual None
@@ -3640,7 +3640,7 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -3729,7 +3729,7 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -3805,7 +3805,7 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -3862,7 +3862,7 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeStdlibTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeStdlibTest.scala
@@ -218,7 +218,7 @@ class RuntimeStdlibTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveOne shouldEqual None
 

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
@@ -119,7 +119,7 @@ class RuntimeSuggestionUpdatesTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, code))
+      Api.Request(Api.OpenFileNotification(mainFile, code))
     )
     context.receiveNone shouldEqual None
 
@@ -746,7 +746,7 @@ class RuntimeSuggestionUpdatesTest
 
     // open file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -927,11 +927,11 @@ class RuntimeSuggestionUpdatesTest
 
     // open files
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, mainCode))
+      Api.Request(Api.OpenFileNotification(mainFile, mainCode))
     )
     context.receiveNone shouldEqual None
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(aFile, aCode))
+      Api.Request(Api.OpenFileNotification(aFile, aCode))
     )
     context.receiveNone shouldEqual None
 

--- a/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -275,7 +275,7 @@ class RuntimeVisualizationsTest
 
     context.send(
       Api.Request(
-        Api.SetModuleSourcesNotification(
+        Api.OpenFileNotification(
           visualisationFile,
           context.Visualisation.code
         )
@@ -294,7 +294,7 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -393,7 +393,7 @@ class RuntimeVisualizationsTest
 
     context.send(
       Api.Request(
-        Api.SetModuleSourcesNotification(
+        Api.OpenFileNotification(
           visualisationFile,
           context.Visualisation.code
         )
@@ -412,7 +412,7 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -530,7 +530,7 @@ class RuntimeVisualizationsTest
     // open files
     context.send(
       Api.Request(
-        Api.SetModuleSourcesNotification(
+        Api.OpenFileNotification(
           visualisationFile,
           context.Visualisation.code
         )
@@ -538,7 +538,7 @@ class RuntimeVisualizationsTest
     )
     context.receiveNone shouldEqual None
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -657,7 +657,7 @@ class RuntimeVisualizationsTest
     // open files
     context.send(
       Api.Request(
-        Api.SetModuleSourcesNotification(
+        Api.OpenFileNotification(
           visualisationFile,
           context.Visualisation.code
         )
@@ -665,7 +665,7 @@ class RuntimeVisualizationsTest
     )
     context.receiveNone shouldEqual None
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -784,7 +784,7 @@ class RuntimeVisualizationsTest
     // open files
     context.send(
       Api.Request(
-        Api.SetModuleSourcesNotification(
+        Api.OpenFileNotification(
           visualisationFile,
           context.Visualisation.code
         )
@@ -792,7 +792,7 @@ class RuntimeVisualizationsTest
     )
     context.receiveNone shouldEqual None
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -987,12 +987,12 @@ class RuntimeVisualizationsTest
 
     // open files
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
     context.send(
       Api.Request(
-        Api.SetModuleSourcesNotification(
+        Api.OpenFileNotification(
           visualisationFile,
           context.Visualisation.code
         )
@@ -1114,12 +1114,12 @@ class RuntimeVisualizationsTest
 
     // open files
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
     context.send(
       Api.Request(
-        Api.SetModuleSourcesNotification(
+        Api.OpenFileNotification(
           visualisationFile,
           context.Visualisation.code
         )
@@ -1259,7 +1259,7 @@ class RuntimeVisualizationsTest
     // open files
     context.send(
       Api.Request(
-        Api.SetModuleSourcesNotification(
+        Api.OpenFileNotification(
           visualisationFile,
           context.Visualisation.code
         )
@@ -1267,7 +1267,7 @@ class RuntimeVisualizationsTest
     )
     context.receiveNone shouldEqual None
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1366,12 +1366,12 @@ class RuntimeVisualizationsTest
 
     // open files
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
     context.send(
       Api.Request(
-        Api.SetModuleSourcesNotification(
+        Api.OpenFileNotification(
           visualisationFile,
           context.Visualisation.code
         )
@@ -1515,7 +1515,7 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1579,7 +1579,7 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1674,7 +1674,7 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1752,7 +1752,7 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1844,7 +1844,7 @@ class RuntimeVisualizationsTest
 
     context.send(
       Api.Request(
-        Api.SetModuleSourcesNotification(
+        Api.OpenFileNotification(
           visualisationFile,
           visualisationCode
         )
@@ -1863,7 +1863,7 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -1972,7 +1972,7 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -2062,7 +2062,7 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -2176,7 +2176,7 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -2275,7 +2275,7 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -2353,7 +2353,7 @@ class RuntimeVisualizationsTest
 
     context.send(
       Api.Request(
-        Api.SetModuleSourcesNotification(
+        Api.OpenFileNotification(
           visualisationFile,
           context.Visualisation.code
         )
@@ -2372,7 +2372,7 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -2479,7 +2479,7 @@ class RuntimeVisualizationsTest
 
     context.send(
       Api.Request(
-        Api.SetModuleSourcesNotification(
+        Api.OpenFileNotification(
           visualisationFile,
           context.AnnotatedVisualisation.code
         )
@@ -2498,7 +2498,7 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -2651,7 +2651,7 @@ class RuntimeVisualizationsTest
 
     context.send(
       Api.Request(
-        Api.SetModuleSourcesNotification(
+        Api.OpenFileNotification(
           visualisationFile,
           context.AnnotatedVisualisation.code
         )
@@ -2670,7 +2670,7 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -2830,7 +2830,7 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -2927,7 +2927,7 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -3021,7 +3021,7 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 
@@ -3136,7 +3136,7 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.SetModuleSourcesNotification(mainFile, contents))
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
     )
     context.receiveNone shouldEqual None
 

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/CommandFactory.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/CommandFactory.scala
@@ -46,8 +46,8 @@ object CommandFactory {
       case payload: Api.RenameProject =>
         new RenameProjectCmd(request.requestId, payload)
 
-      case payload: Api.SetModuleSourcesNotification =>
-        new SetModuleSourcesCmd(payload)
+      case payload: Api.OpenFileNotification =>
+        new OpenFileCmd(payload)
       case payload: Api.CloseFileNotification => new CloseFileCmd(payload)
       case payload: Api.EditFileNotification  => new EditFileCmd(payload)
       case payload: Api.SetExpressionValueNotification =>

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/OpenFileCmd.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/OpenFileCmd.scala
@@ -9,8 +9,7 @@ import scala.concurrent.{ExecutionContext, Future}
   *
   * @param request a request for a service
   */
-class OpenFileCmd(request: Api.OpenFileNotification)
-    extends Command(None) {
+class OpenFileCmd(request: Api.OpenFileNotification) extends Command(None) {
 
   /** @inheritdoc */
   override def execute(implicit

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/OpenFileCmd.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/OpenFileCmd.scala
@@ -5,11 +5,11 @@ import org.enso.polyglot.runtime.Runtime.Api
 
 import scala.concurrent.{ExecutionContext, Future}
 
-/** A command that sets sources for the module..
+/** A command that opens a file.
   *
   * @param request a request for a service
   */
-class SetModuleSourcesCmd(request: Api.SetModuleSourcesNotification)
+class OpenFileCmd(request: Api.OpenFileNotification)
     extends Command(None) {
 
   /** @inheritdoc */


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Changelog:
- fix: vcs/restore sends proper text edit
- refactor: restore original `OpenFileNotification` name

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] ~If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.~
