### PR TITLE
Fix bug with Delimited_Format web reader.

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
@@ -26,9 +26,10 @@ format_types = Vector.from_polyglot_array (FileFormatSPI.get_types False)
    Gets the first format not returning Nothing from the callback
 get_format : Function -> Any | Nothing
 get_format callback =
+    types = format_types
     reader idx =
-        if idx >= format_types.length then Nothing else
-            format = callback (format_types.at idx)
+        if idx >= types.length then Nothing else
+            format = callback (types.at idx)
             if format.is_nothing.not then format else
                 @Tail_Call reader (idx + 1)
     reader 0

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Delimited/Delimited_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Delimited/Delimited_Format.enso
@@ -66,7 +66,7 @@ type Delimited_Format
         parts = content_type.split ";" . map .trim
 
         charset_part = parts.find if_missing=Nothing (x-> x.starts_with "charset=")
-        encoding = if charset_part.if_nothing then Encoding.utf_8 else
+        encoding = if charset_part.is_nothing then Encoding.utf_8 else
             parsed = Encoding.from_name (charset_part.drop 8)
             if parsed.is_error then Encoding.utf_8 else parsed
 


### PR DESCRIPTION
Also cache types to stop calling over and over.

### Pull Request Description

- Mistake using `if_nothing` not `is_nothing`.
- Cache the File_Format types to save calling over and over.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
