### PR TITLE
Adjusting annotations to use Widget types properly.

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Filter_Condition.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Filter_Condition.enso
@@ -204,7 +204,7 @@ type Filter_Condition
     ## PRIVATE
        Gets a widget set up for a Filter_Condition.
     default_widget =
-        names = ["Equal", "Not_Equal", "Is_In", "Not_In", "Is_True", "Is_False", "Is_Nothing", "Not_Nothing", "Is_Empty", "Not_Empty", "Less", "Equal_Or_Less", "Greater", "Equal_Or_Greater", "Between", "Starts_With", "Ends_With", "Contains", "Not_Contains", "Like", "Not_Like"]
+        names = ["Equal", "Not Equal", "Is In", "Not In", "Is True", "Is False", "Is Nothing", "Not Nothing", "Is Empty", "Not Empty", "Less", "Equal Or Less", "Greater", "Equal Or Greater", "Between", "Starts With", "Ends With", "Contains", "Not Contains", "Like", "Not Like"]
         values = ["(Filter_Condition.Equal _)", "(Filter_Condition.Not_Equal _)", "(Filter_Condition.Is_In _)", "(Filter_Condition.Not_In _)", "Filter_Condition.Is_True", "Filter_Condition.Is_False", "Filter_Condition.Is_Nothing", "Filter_Condition.Not_Nothing", "Filter_Condition.Is_Empty", "Filter_Condition.Not_Empty", "(Filter_Condition.Less _)", "(Filter_Condition.Equal_Or_Less _)", "(Filter_Condition.Greater _)", "(Filter_Condition.Equal_Or_Greater _)", "(Filter_Condition.Between _ _)", "(Filter_Condition.Starts_With _)", "(Filter_Condition.Ends_With _)", "(Filter_Condition.Contains _)", "(Filter_Condition.Not_Contains _)", "(Filter_Condition.Like _)", "(Filter_Condition.Not_Like _)"]
         options = names.zip values . map p-> Option p.first p.second
         Single_Choice values=options display=Display.Always

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Filter_Condition.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Filter_Condition.enso
@@ -9,6 +9,7 @@ import project.Nothing.Nothing
 from project.Data.Boolean import all
 
 from project.Metadata.Widget import Single_Choice
+from project.Metadata.Choice import Option
 import project.Metadata.Display
 
 polyglot java import org.enso.base.Regex_Utils
@@ -202,10 +203,11 @@ type Filter_Condition
 
     ## PRIVATE
        Gets a widget set up for a Filter_Condition.
-    widget_for_filter_condition =
-        ## values = ["(Filter_Condition.Equal to=_)", "(Filter_Condition.Not_Equal to=_)", "(Filter_Condition.Is_In values=_)", "(Filter_Condition.Not_In values=_)", "Filter_Condition.Is_True", "Filter_Condition.Is_False", "Filter_Condition.Is_Nothing", "Filter_Condition.Not_Nothing", "Filter_Condition.Is_Empty", "Filter_Condition.Not_Empty", "(Filter_Condition.Less than=_)", "(Filter_Condition.Equal_Or_Less than=_)", "(Filter_Condition.Greater than=_)", "(Filter_Condition.Equal_Or_Greater than=_)", "(Filter_Condition.Between lower=_ upper=_)", "(Filter_Condition.Starts_With prefix=_)", "(Filter_Condition.Ends_With suffix=_)", "(Filter_Condition.Contains substring=_)", "(Filter_Condition.Not_Contains substring=_)", "(Filter_Condition.Like pattern=_)", "(Filter_Condition.Not_Like pattern=_)"]
+    default_widget =
+        names = ["Equal", "Not_Equal", "Is_In", "Not_In", "Is_True", "Is_False", "Is_Nothing", "Not_Nothing", "Is_Empty", "Not_Empty", "Less", "Equal_Or_Less", "Greater", "Equal_Or_Greater", "Between", "Starts_With", "Ends_With", "Contains", "Not_Contains", "Like", "Not_Like"]
         values = ["(Filter_Condition.Equal _)", "(Filter_Condition.Not_Equal _)", "(Filter_Condition.Is_In _)", "(Filter_Condition.Not_In _)", "Filter_Condition.Is_True", "Filter_Condition.Is_False", "Filter_Condition.Is_Nothing", "Filter_Condition.Not_Nothing", "Filter_Condition.Is_Empty", "Filter_Condition.Not_Empty", "(Filter_Condition.Less _)", "(Filter_Condition.Equal_Or_Less _)", "(Filter_Condition.Greater _)", "(Filter_Condition.Equal_Or_Greater _)", "(Filter_Condition.Between _ _)", "(Filter_Condition.Starts_With _)", "(Filter_Condition.Ends_With _)", "(Filter_Condition.Contains _)", "(Filter_Condition.Not_Contains _)", "(Filter_Condition.Like _)", "(Filter_Condition.Not_Like _)"]
-        Single_Choice values display=Display.Always
+        options = names.zip values . map p-> Option p.first p.second
+        Single_Choice values=options display=Display.Always
 
 ## PRIVATE
 sql_like_to_regex sql_pattern =

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json.enso
@@ -19,6 +19,10 @@ import project.Nothing.Nothing
 import project.Panic.Panic
 import project.Warning.Warning
 
+from project.Metadata.Widget import Single_Choice
+from project.Metadata.Choice import Option
+import project.Metadata.Display
+
 from project.Data.Boolean import Boolean, True, False
 
 ## Methods for serializing from and to JSON.
@@ -125,6 +129,7 @@ type JS_Object
        Arguments:
        - key: The key to get.
        - if_missing: The value to return if the key is not found.
+    @key make_field_name_selector
     get : Text -> Any -> JS_Object | Boolean | Number | Nothing | Text | Vector
     get self key ~if_missing=Nothing =
         if (has_property self.js_object key) . not then if_missing else
@@ -136,6 +141,7 @@ type JS_Object
 
        Arguments:
        - key: The key to get.
+    @key make_field_name_selector
     at : Text -> JS_Object | Boolean | Number | Nothing | Text | Vector ! No_Such_Key
     at self key = self.get key (Error.throw (No_Such_Key.Error self key))
 
@@ -246,6 +252,12 @@ make_javascript enso_object =
             _ : Vector -> enso_object.map make_javascript
             _ : Array -> Vector.from_polyglot_array enso_object . map make_javascript
             _ -> enso_object
+
+## PRIVATE
+   Make a field name selector
+make_field_name_selector : JS_Object -> Single_Choice
+make_field_name_selector js_object display=Display.Always =
+    Single_Choice display=display values=(js_object.field_names.map n->(Option n n.pretty))
 
 foreign js new_object = """
     return {}

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Error/Problem_Behavior.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Error/Problem_Behavior.enso
@@ -145,7 +145,7 @@ type Problem_Behavior
         Report_Error -> result
 
     ## PRIVATE
-       Gets a widget set up for a Filter_Condition.
+       Gets a widget set up for a `Problem_Behavior`.
     default_widget =
         values = ["Report_Error", "Report_Warning", "Ignore"]
         Single_Choice (values.map n-> Option n) display=Display.Expanded_Only

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Error/Problem_Behavior.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Error/Problem_Behavior.enso
@@ -3,6 +3,10 @@ import project.Data.Vector.Vector
 import project.Error.Error
 import project.Warning.Warning
 
+from project.Metadata.Widget import Single_Choice
+from project.Metadata.Choice import Option
+import project.Metadata.Display
+
 from project.Error.Problem_Behavior.Problem_Behavior import all
 
 ## Specifies how to handle problems.
@@ -139,3 +143,9 @@ type Problem_Behavior
         Ignore -> fallback
         Report_Warning -> Warning.attach error fallback
         Report_Error -> result
+
+    ## PRIVATE
+       Gets a widget set up for a Filter_Condition.
+    default_widget =
+        values = ["Report_Error", "Report_Warning", "Ignore"]
+        Single_Choice (values.map n-> Option n) display=Display.Expanded_Only

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
@@ -28,12 +28,12 @@ type Choice
     ## Describes an entry in a Single_Choice or Multiple_Choice widget.
 
        Fields:
-       - value: The code to insert for the entry.
-       - label: The text to display for the entry. By default, the `value` is used.
+       - label: The text to display for the entry.
+       - value: The code to insert for the entry. By default, the `label` is used.
        - parameters: A list of parameters for the arguments for the `value`.
          This provides the structure needed for nested widgets.
        - icon: The icon to display for the entry. By default, no icon is used.
-    Option value:Text label:Text=value parameters:(Vector (Pair Text Widget))=[] icon:Text=""
+    Option label:Text value:Text=label parameters:(Vector (Pair Text Widget))=[] icon:Text=""
 
 type Widget
     ## Describes a single value widget (dropdown).

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
@@ -40,8 +40,6 @@ type Widget
 
        Fields:
        - values: A list of choices to display.
-         If a `Text` value is used, it is treated as `Option value:Text`.
-         The visualization module will convert Text to Option automatically, IDE only recieves Choice structures.
        - label: The placeholder text value.
          By default, the parameter name is used.
        - display: The display mode for the parameter.
@@ -49,7 +47,7 @@ type Widget
     Single_Choice values:(Vector Choice) label:(Nothing | Text)=Nothing display:Display=Display.When_Modified allow_custom:Boolean=True
 
     ## Describes a multi value widget.
-    Multiple_Choice values:(Vector (Choice | Text)) label:(Nothing | Text)=Nothing display:Display=Display.When_Modified quote_values:Boolean=False
+    Multiple_Choice values:(Vector Choice) label:(Nothing | Text)=Nothing display:Display=Display.When_Modified quote_values:Boolean=False
 
     ## Describe a code parameter.
     Code_Input label:(Nothing | Text)=Nothing display:Display=Display.When_Modified
@@ -65,7 +63,7 @@ type Widget
 
 
     ## Describes a list editor widget.
-    Vector_Editor item_editor:Widget values:((Vector (Choice | Text)) | Nothing)=Nothing label:(Nothing | Text)=Nothing display:Display=Display.When_Modified
+    Vector_Editor item_editor:Widget values:((Vector Choice) | Nothing)=Nothing label:(Nothing | Text)=Nothing display:Display=Display.When_Modified
 
     ## Describes a folder chooser.
     Folder_Browse label:(Nothing | Text)=Nothing display:Display=Display.When_Modified

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
@@ -17,6 +17,13 @@ type Display
     ## Parameter is only shown on the expanded view.
     Expanded_Only
 
+type File_Action
+    ## The File or Folder is for reading from.
+    Open
+
+    ## The File or Folder is for writing to.
+    Save
+
 type Choice
     ## Describes an entry in a Single_Choice or Multiple_Choice widget.
 
@@ -28,15 +35,22 @@ type Choice
        - icon: The icon to display for the entry. By default, no icon is used.
     Option value:Text label:Text=value parameters:(Vector (Pair Text Widget))=[] icon:Text=""
 
-type File_Action
-    ## The File or Folder is for reading from.
-    Open
-
-    ## The File or Folder is for writing to.
-    Save
-
-
 type Widget
+    ## Describes a single value widget (dropdown).
+
+       Fields:
+       - values: A list of choices to display.
+         If a `Text` value is used, it is treated as `Option value:Text`.
+         The visualization module will convert Text to Option automatically, IDE only recieves Choice structures.
+       - label: The placeholder text value.
+         By default, the parameter name is used.
+       - display: The display mode for the parameter.
+       - allow_custom: Allow the user to enter a value not in the list?
+    Single_Choice values:(Vector Choice) label:(Nothing | Text)=Nothing display:Display=Display.When_Modified allow_custom:Boolean=True
+
+    ## Describes a multi value widget.
+    Multiple_Choice values:(Vector (Choice | Text)) label:(Nothing | Text)=Nothing display:Display=Display.When_Modified quote_values:Boolean=False
+
     ## Describe a code parameter.
     Code_Input label:(Nothing | Text)=Nothing display:Display=Display.When_Modified
 
@@ -49,20 +63,6 @@ type Widget
     ## Describes a text widget.
     Text_Input label:(Nothing | Text)=Nothing display:Display=Display.When_Modified quote_values:Boolean=True suggestions:(Vector Text)=[]
 
-    ## Describes a single value widget (drowdown).
-
-       Fields:
-       - values: A list of choices to display.
-         If a `Text` value is used, it is treated as `Option value:Text`.
-       - label: The text to display for the widget.
-         By default, the parameter name is used.
-       - display: The display mode for the parameter.
-       - quote_values: Should the values be quoted automatically?
-       - allow_custom: Allow the user to enter a value not in the list?
-    Single_Choice values:(Vector (Choice | Text)) label:(Nothing | Text)=Nothing display:Display=Display.When_Modified quote_values:Boolean=False allow_custom:Boolean=True
-
-    ## Describes a multi value widget.
-    Multiple_Choice values:(Vector (Choice | Text)) label:(Nothing | Text)=Nothing display:Display=Display.When_Modified quote_values:Boolean=False
 
     ## Describes a list editor widget.
     Vector_Editor item_editor:Widget values:((Vector (Choice | Text)) | Nothing)=Nothing label:(Nothing | Text)=Nothing display:Display=Display.When_Modified

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -25,6 +25,10 @@ import project.System.File.File_Permissions.File_Permissions
 
 from project.Data.Boolean import Boolean, True, False
 
+from project.Metadata.Widget import Single_Choice
+from project.Metadata.Choice import Option
+import project.Metadata.Display
+
 polyglot java import org.enso.base.Encoding_Utils
 polyglot java import org.enso.base.encoding.ReportingStreamDecoder
 polyglot java import org.enso.base.encoding.ReportingStreamEncoder
@@ -241,6 +245,7 @@ type File
              import Standard.Examples
 
              example_append = Examples.data_dir / "scratch_file"
+    @subpath get_child_widget
     / : (Text | File) -> File
     / self subpath = self.resolve subpath
 
@@ -262,6 +267,7 @@ type File
              import Standard.Examples
 
              example_append = Examples.data_dir.join ["2022", "10", "31", "scratch_file"]
+    @subpaths get_child_widget
     join : (Text | File | Vector) -> File
     join self subpaths = case subpaths of
         _ : Vector -> (subpaths.fold self c->p-> c / p) . normalize
@@ -918,3 +924,12 @@ get_cwd = @Builtin_Method "File.get_cwd"
    - path: The path to obtain a file at.
 get_file : Text -> File
 get_file path = @Builtin_Method "File.get_file"
+
+## PRIVATE
+get_child_widget : File -> Widget
+get_child_widget file =
+    if file.exists.not then Nothing else
+        if file.is_directory.not then Nothing else
+            children = file.list
+            options = children.map c-> Option c.name c.name.pretty
+            Single_Choice values=options display=Display.Always

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -25,7 +25,7 @@ import project.System.File.File_Permissions.File_Permissions
 
 from project.Data.Boolean import Boolean, True, False
 
-from project.Metadata.Widget import Single_Choice
+import project.Metadata.Widget
 from project.Metadata.Choice import Option
 import project.Metadata.Display
 
@@ -932,4 +932,4 @@ get_child_widget file =
         if file.is_directory.not then Nothing else
             children = file.list
             options = children.map c-> Option c.name c.name.pretty
-            Single_Choice values=options display=Display.Always
+            Widget.Single_Choice values=options display=Display.Always

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
@@ -7,6 +7,7 @@ import Standard.Table.Data.Value_Type.Value_Type
 import Standard.Table.Data.Column.Column as Materialized_Column
 import Standard.Table.Data.Column_Type_Selection.Auto
 import Standard.Table.Data.Value_Type.Value_Type
+import Standard.Table.Internal.Widget_Helpers
 
 import project.Data.SQL_Statement.SQL_Statement
 import project.Data.SQL_Type.SQL_Type
@@ -822,7 +823,7 @@ type Column
              import Standard.Examples
 
              example_contains = Examples.text_column_1.parse Boolean 'Yes|No'
-    @type (Single_Choice ['Auto','Integer','Decimal','Date','Date_Time','Time_Of_Day','Boolean'] display=Display.Always)
+    @type Widget_Helpers.parse_type_selector
     parse : (Auto|Integer|Decimal|Date|Date_Time|Time_Of_Day|Boolean) -> Text | Nothing -> Problem_Behavior -> Column
     parse self type=Auto format=Nothing on_problems=Report_Warning =
         _ = [type, format, on_problems]

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -8,11 +8,7 @@ import Standard.Base.Error.Illegal_State.Illegal_State
 import Standard.Base.Error.Incomparable_Values.Incomparable_Values
 import Standard.Base.Error.Unimplemented.Unimplemented
 
-from Standard.Base.Metadata.Widget import Single_Choice
-import Standard.Base.Metadata.Display
-
-from Standard.Table import Auto_Detect, Aggregate_Column, Data_Formatter, Column_Name_Mapping, Column_Selector, Sort_Column_Selector, Sort_Column, Match_Columns, Position, Set_Mode
-from Standard.Table import Auto_Detect, Aggregate_Column, Data_Formatter, Column_Name_Mapping, Column_Selector, Sort_Column, Match_Columns, Position
+from Standard.Table import Auto_Detect, Aggregate_Column, Data_Formatter, Column_Name_Mapping, Column_Selector, Sort_Column, Match_Columns, Position, Set_Mode
 import Standard.Table.Data.Column_Type_Selection.Column_Type_Selection
 import Standard.Table.Data.Expression.Expression
 import Standard.Table.Data.Expression.Expression_Error
@@ -22,11 +18,12 @@ import Standard.Table.Data.Report_Unmatched.Report_Unmatched
 import Standard.Table.Data.Row.Row
 import Standard.Table.Data.Table.Table as Materialized_Table
 import Standard.Table.Data.Value_Type.Value_Type
+import Standard.Table.Internal.Aggregate_Column_Helper
 import Standard.Table.Internal.Java_Exports
 import Standard.Table.Internal.Table_Helpers
 import Standard.Table.Internal.Table_Helpers.Table_Column_Helper
 import Standard.Table.Internal.Problem_Builder.Problem_Builder
-import Standard.Table.Internal.Aggregate_Column_Helper
+import Standard.Table.Internal.Widget_Helpers
 from Standard.Table.Data.Column import get_item_string
 from Standard.Table.Data.Table import print_table
 from Standard.Table.Internal.Filter_Condition_Helpers import make_filter_column
@@ -103,7 +100,7 @@ type Table
 
        Arguments:
        - selector: The name or index of the column to get.
-    @selector (self-> Single_Choice display=Display.Always values=(self.column_names.map .pretty))
+    @selector Widget_Helpers.make_column_name_selector
     at : Text | Integer -> Column ! No_Such_Column | Index_Out_Of_Bounds
     at self selector=0 = case selector of
         _ : Integer -> self.make_column (self.internal_columns.at selector)
@@ -114,7 +111,7 @@ type Table
        Arguments:
        - selector: The name or index of the column being looked up.
        - if_missing: The value to use if the selector isn't present.
-    @selector (self-> Single_Choice display=Display.Always values=(self.column_names.map .pretty))
+    @selector Widget_Helpers.make_column_name_selector
     get : Text | Integer -> Any -> Column | Any
     get self selector=0 ~if_missing=Nothing =
         internal_column = case selector of
@@ -437,7 +434,8 @@ type Table
          Select people celebrating a jubilee.
 
              people.filter "age" (age -> (age%10 == 0))
-    @column (self-> Single_Choice display=Display.Always values=(self.column_names.map .pretty))
+    @column Widget_Helpers.make_column_name_selector
+    @filter Filter_Condition.default_widget
     filter : (Column | Text | Integer) -> (Filter_Condition|(Any->Boolean)) -> Table ! No_Such_Column | Index_Out_Of_Bounds | Invalid_Value_Type
     filter self column filter=Filter_Condition.Is_True = case column of
        _ : Column ->
@@ -581,7 +579,7 @@ type Table
                  double_inventory = table.at "total_stock" * 2
                  table.set double_inventory new_name="total_stock"
                  table.set "2 * [total_stock]" new_name="total_stock_expr"
-    set : Text -> Column | Text -> Table ! Unsupported_Name | Existing_Column | Missing_Column
+    set : Column | Text -> Text | Nothing -> Table ! Unsupported_Name | Existing_Column | Missing_Column
     set self column new_name=Nothing set_mode=Set_Mode.Add_Or_Update =
         resolved = case column of
             _ : Text -> self.compute column
@@ -822,7 +820,8 @@ type Table
          allows to join the two tables on equality of corresponding columns with
          the same name. So `table.join other on=["A", "B"]` is a shorthand for:
              table.join other on=[Join_Condition.Equals "A" "A", Join_Condition.Equals "B" "B"]
-    @join_kind (Single_Choice ["Join_Kind.Inner", "Join_Kind.Left_Outer", "Join_Kind.Right_Outer", "Join_Kind.Full", "Join_Kind.Left_Exclusive", "Join_Kind.Right_Exclusive"]])
+    @join_kind Widget_Helpers.join_kind_selector
+    @on Widget_Helpers.make_column_name_selector
     join : Table -> Join_Kind -> Join_Condition | Text | Vector (Join_Condition | Text) -> Text -> Problem_Behavior -> Table
     join self right join_kind=Join_Kind.Inner on=[Join_Condition.Equals 0 0] right_prefix="Right_" on_problems=Report_Warning =
         can_proceed = if Table_Helpers.is_table right . not then Error.throw (Type_Error.Error Table right "right") else

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 import Standard.Base.Error.Illegal_State.Illegal_State
 
 from Standard.Base.Metadata.Widget import Single_Choice
+from Standard.Base.Metadata.Choice import Option
 import Standard.Base.Metadata.Display
 
 import Standard.Table.Data.Table.Table as Materialized_Table
@@ -51,7 +52,7 @@ type Postgres_Connection
 
        Arguments:
         - database: The name of the database to connect to.
-    @database (self-> Single_Choice display=Display.Always values=(self.databases . map .pretty))
+    @database (self-> Single_Choice display=Display.Always values=(self.databases . map d-> Option d d.pretty))
     set_database : Text -> Connection ! SQL_Error
     set_database self database =
         if database == self.database then self else
@@ -69,7 +70,7 @@ type Postgres_Connection
 
        Arguments:
         - schema: The name of the schema to connect to.
-    @schema (self-> Single_Choice display=Display.Always values=(self.schemas . map .pretty))
+    @schema (self-> Single_Choice display=Display.Always values=(self.schemas . map s-> Option s s.pretty))
     set_schema : Text -> Connection ! SQL_Error
     set_schema self schema =
         if schema == self.schema then self else
@@ -87,7 +88,7 @@ type Postgres_Connection
        - schema: The schema name to search in (defaults to current schema).
        - types: The table types to search for. The list of values can be obtained using the `table_types` method.
        - all_fields: Return all the fields in the metadata table.
-    @types (self-> Single_Choice values=(self.table_types.map .pretty))
+    @types (self-> Single_Choice values=(self.table_types.map t-> Option t t.pretty))
     tables : Text -> Text -> Text -> Vector -> Boolean -> Materialized_Table
     tables self name_like=Nothing database=self.database schema=self.schema types=Nothing all_fields=False =
         self.connection.tables name_like database schema types all_fields
@@ -98,7 +99,7 @@ type Postgres_Connection
        - query: name of the table or sql statement to query.
          If supplied as `Text`, the name is checked against the `tables` list to determine if it is a table or a query.
        - alias: optionally specify a friendly alias for the query.
-    @query (self-> Single_Choice display=Display.Always values=(self.tables.at "Name" . to_vector . map .pretty))
+    @query (self-> Single_Choice display=Display.Always values=(self.tables.at "Name" . to_vector . map t-> Option t t.pretty))
     query : Text | SQL_Query -> Text -> Database_Table
     query self query alias="" = self.connection.query query alias
 
@@ -108,7 +109,7 @@ type Postgres_Connection
        - query: name of the table or sql statement to query.
          If supplied as `Text`, the name is checked against the `tables` list to determine if it is a table or a query.
        - limit: the maximum number of rows to return.
-    @query (self-> Single_Choice display=Display.Always values=(self.tables.at "Name" . to_vector . map .pretty))
+    @query (self-> Single_Choice display=Display.Always values=(self.tables.at "Name" . to_vector . map t-> Option t t.pretty))
     read : Text | SQL_Query -> Integer | Nothing -> Materialized_Table
     read self query limit=Nothing = self.connection.read query limit
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 import Standard.Base.Error.Illegal_State.Illegal_State
 
 from Standard.Base.Metadata.Widget import Single_Choice
+from Standard.Base.Metadata.Choice import Option
 import Standard.Base.Metadata.Display
 
 import Standard.Table.Data.Table.Table as Materialized_Table
@@ -44,7 +45,7 @@ type SQLite_Connection
 
        Arguments:
         - database: The name of the database to connect to.
-    @database (Single_Choice display=Display.Always values=['Nothing'])
+    @database (Single_Choice display=Display.Always values=[Option 'Nothing'])
     set_database : Text -> Connection ! SQL_Error
     set_database self database =
         if database == self.database then self else
@@ -62,7 +63,7 @@ type SQLite_Connection
 
        Arguments:
         - schema: The name of the schema to connect to.
-    @schema (Single_Choice display=Display.Always values=['Nothing'])
+    @schema (Single_Choice display=Display.Always values=[Option 'Nothing'])
     set_schema : Text -> Connection ! SQL_Error
     set_schema self schema =
         if schema == self.schema then self else
@@ -80,7 +81,7 @@ type SQLite_Connection
        - schema: The schema name to search in (defaults to current schema).
        - types: The table types to search for. The list of values can be obtained using the `table_types` method.
        - all_fields: Return all the fields in the metadata table.
-    @types (self-> Single_Choice values=(self.table_types.map .pretty))
+    @types (self-> Single_Choice values=(self.table_types.map t-> Option t t.pretty))
     tables : Text -> Text -> Text -> Vector -> Boolean -> Materialized_Table
     tables self name_like=Nothing database=self.database schema=self.schema types=Nothing all_fields=False =
         self.connection.tables name_like database schema types all_fields
@@ -91,7 +92,7 @@ type SQLite_Connection
        - query: name of the table or sql statement to query.
          If supplied as `Text`, the name is checked against the `tables` list to determine if it is a table or a query.
        - alias: optionally specify a friendly alias for the query.
-    @query (self-> Single_Choice display=Display.Always values=(self.tables.at "Name" . to_vector . map .pretty))
+    @query (self-> Single_Choice display=Display.Always values=(self.tables.at "Name" . to_vector . map t-> Option t t.pretty))
     query : Text | SQL_Query -> Text -> Database_Table
     query self query alias="" = self.connection.query query alias
 
@@ -101,7 +102,7 @@ type SQLite_Connection
        - query: name of the table or sql statement to query.
          If supplied as `Text`, the name is checked against the `tables` list to determine if it is a table or a query.
        - limit: the maximum number of rows to return.
-    @query (self-> Single_Choice display=Display.Always values=(self.tables.at "Name" . to_vector . map .pretty))
+    @query (self-> Single_Choice display=Display.Always values=(self.tables.at "Name" . to_vector . map t-> Option t t.pretty))
     read : Text | SQL_Query -> Integer | Nothing -> Materialized_Table
     read self query limit=Nothing = self.connection.read query limit
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -7,15 +7,13 @@ import Standard.Base.Error.Illegal_State.Illegal_State
 
 import Standard.Base.Data.Index_Sub_Range as Index_Sub_Range_Module
 
-from Standard.Base.Metadata.Widget import Single_Choice
-import Standard.Base.Metadata.Display
-
 import project.Data.Column_Type_Selection.Auto
 import project.Data.Data_Formatter.Data_Formatter
 import project.Data.Storage.Storage
 import project.Data.Table.Table
 import project.Data.Value_Type.Value_Type
 import project.Internal.Parse_Values_Helper
+import project.Internal.Widget_Helpers
 
 from project.Data.Table import print_table
 from project.Errors import No_Index_Set_Error
@@ -900,7 +898,7 @@ type Column
              import Standard.Examples
 
              example_contains = Examples.text_column_1.parse Boolean 'Yes|No'
-    @type (Single_Choice ['Auto','Integer','Decimal','Date','Date_Time','Time_Of_Day','Boolean'] display=Display.Always)
+    @type Widget_Helpers.parse_type_selector
     parse : (Auto|Integer|Decimal|Date|Date_Time|Time_Of_Day|Boolean) -> Text | Nothing -> Problem_Behavior -> Column
     parse self type=Auto format=Nothing on_problems=Report_Warning =
         ensure_type ~fn = if [Auto, Integer, Decimal, Date, Date_Time, Time_Of_Day, Boolean].index_of type == Nothing then Error.throw (Illegal_Argument.Error "Unsupported target type "+type.to_text+".") else fn

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -1063,7 +1063,11 @@ type Column
         if valid_index.not then Error.throw (Index_Out_Of_Bounds.Error index self.length) else
             storage = self.java_column.getStorage
             if storage.isNa index then Nothing else
-                storage.getItem index
+                case storage.getItem index of
+                    d : Date -> Date.new d.year d.month d.day
+                    dt : Date_Time -> Date_Time.new dt.year dt.month dt.day dt.hour dt.minute dt.second 0 0 dt.nanosecond dt.time_zone
+                    t : Time_Of_Day -> Time_Of_Day.new t.hour t.minute t.second t.nanosecond
+                    x -> x
 
     ## UNSTABLE
 
@@ -1085,7 +1089,14 @@ type Column
 
              example_to_vector = Examples.integer_column.to_vector
     to_vector : Vector
-    to_vector self = Vector.from_polyglot_array self.java_column.getStorage.toList
+    to_vector self =
+        pg_array = self.java_column.getStorage.toList
+        get i = case pg_array.get i of
+            d : Date -> Date.new d.year d.month d.day
+            dt : Date_Time -> Date_Time.new dt.year dt.month dt.day dt.hour dt.minute dt.second 0 0 dt.nanosecond dt.time_zone
+            t : Time_Of_Day -> Time_Of_Day.new t.hour t.minute t.second t.nanosecond
+            x -> x
+        Vector.from_polyglot_array (Array_Proxy.new pg_array.length get)
 
     ## Returns the underlying storage type of this column.
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -1061,11 +1061,7 @@ type Column
         if valid_index.not then Error.throw (Index_Out_Of_Bounds.Error index self.length) else
             storage = self.java_column.getStorage
             if storage.isNa index then Nothing else
-                case storage.getItem index of
-                    d : Date -> Date.new d.year d.month d.day
-                    dt : Date_Time -> Date_Time.new dt.year dt.month dt.day dt.hour dt.minute dt.second 0 0 dt.nanosecond dt.time_zone
-                    t : Time_Of_Day -> Time_Of_Day.new t.hour t.minute t.second t.nanosecond
-                    x -> x
+                storage.getItem index
 
     ## UNSTABLE
 
@@ -1087,14 +1083,7 @@ type Column
 
              example_to_vector = Examples.integer_column.to_vector
     to_vector : Vector
-    to_vector self =
-        pg_array = self.java_column.getStorage.toList
-        get i = case pg_array.get i of
-            d : Date -> Date.new d.year d.month d.day
-            dt : Date_Time -> Date_Time.new dt.year dt.month dt.day dt.hour dt.minute dt.second 0 0 dt.nanosecond dt.time_zone
-            t : Time_Of_Day -> Time_Of_Day.new t.hour t.minute t.second t.nanosecond
-            x -> x
-        Vector.from_polyglot_array (Array_Proxy.new pg_array.length get)
+    to_vector self = Vector.from_polyglot_array self.java_column.getStorage.toList
 
     ## Returns the underlying storage type of this column.
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -10,9 +10,6 @@ import Standard.Base.Error.Illegal_Argument.Illegal_Argument
 import Standard.Base.Error.Incomparable_Values.Incomparable_Values
 import Standard.Base.Error.Unimplemented.Unimplemented
 
-from Standard.Base.Metadata.Widget import Single_Choice
-import Standard.Base.Metadata.Display
-
 import project.Data.Aggregate_Column.Aggregate_Column
 import project.Data.Column.Column
 import project.Data.Column as Column_Module
@@ -38,6 +35,7 @@ import project.Internal.Problem_Builder.Problem_Builder
 import project.Internal.Table_Helpers
 import project.Internal.Table_Helpers.Table_Column_Helper
 import project.Internal.Unique_Name_Strategy.Unique_Name_Strategy
+import project.Internal.Widget_Helpers
 import project.Data.Expression.Expression
 import project.Data.Expression.Expression_Error
 import project.Delimited.Delimited_Format.Delimited_Format
@@ -198,7 +196,7 @@ type Table
              import Standard.Examples
 
              example_at = Examples.inventory_table.at -1
-    @selector (self-> Single_Choice display=Display.Always values=(self.column_names.map .pretty))
+    @selector Widget_Helpers.make_column_name_selector
     at : Text | Integer -> Column ! No_Such_Column | Index_Out_Of_Bounds
     at self selector=0 = case selector of
         _ : Integer ->
@@ -225,7 +223,7 @@ type Table
              import Standard.Examples
 
              example_at = Examples.inventory_table.get -1
-    @selector (self-> Single_Choice display=Display.Always values=(self.column_names.map .pretty))
+    @selector Widget_Helpers.make_column_name_selector
     get : Text | Integer -> Any -> Column | Any
     get self selector=0 ~if_missing=Nothing =
         java_column = case selector of
@@ -901,9 +899,8 @@ type Table
          Select people celebrating a jubilee.
 
              people.filter "age" (age -> (age%10 == 0))
-    @column (self-> Single_Choice display=Display.Always values=(self.column_names.map .pretty))
-    @filter Filter_Condition.widget_for_filter_condition
-    @on_problems (Single_Choice ["Report_Error", "Report_Warning", "Ignore"] display=Display.Expanded_Only)
+    @column Widget_Helpers.make_column_name_selector
+    @filter Filter_Condition.default_widget
     filter : (Column | Text | Integer) -> (Filter_Condition|(Any->Boolean)) -> Table ! No_Such_Column | Index_Out_Of_Bounds | Invalid_Value_Type
     filter self column filter=(Filter_Condition.Is_True) = case column of
         _ : Column ->
@@ -1021,7 +1018,7 @@ type Table
                  double_inventory = table.at "total_stock" * 2
                  table.set double_inventory new_name="total_stock"
                  table.set "2 * [total_stock]" new_name="total_stock_expr"
-    set : Text -> Column | Text -> Table ! Existing_Column | Missing_Column
+    set : Column | Text -> Text | Nothing -> Table ! Existing_Column | Missing_Column
     set self column new_name=Nothing set_mode=Set_Mode.Add_Or_Update =
         resolved = case column of
             _ : Text -> self.compute column
@@ -1142,7 +1139,8 @@ type Table
          allows to join the two tables on equality of corresponding columns with
          the same name. So `table.join other on=["A", "B"]` is a shorthand for:
              table.join other on=[Join_Condition.Equals "A" "A", Join_Condition.Equals "B" "B"]
-    @join_kind (Single_Choice ["Join_Kind.Inner", "Join_Kind.Left_Outer", "Join_Kind.Right_Outer", "Join_Kind.Full", "Join_Kind.Left_Exclusive", "Join_Kind.Right_Exclusive"]])
+    @join_kind Widget_Helpers.join_kind_selector
+    @on Widget_Helpers.make_column_name_selector
     join : Table -> Join_Kind -> Join_Condition | Text | Vector (Join_Condition | Text) -> Text -> Problem_Behavior -> Table
     join self right join_kind=Join_Kind.Inner on=[Join_Condition.Equals 0 0] right_prefix="Right_" on_problems=Report_Warning =
         if check_table "right" right then

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
@@ -16,7 +16,7 @@ make_column_name_selector table display=Display.Always =
    Selector for type argument on `Column.parse`.
 parse_type_selector : Single_Choice
 parse_type_selector =
-    choice = ['Auto','Integer','Decimal','Date','Date_Time','Time_Of_Day','Boolean']
+    choice = ['Auto', 'Integer', 'Decimal', 'Date', 'Date_Time', 'Time_Of_Day', 'Boolean']
     Single_Choice display=Display.Always values=(choice.map n->(Option n))
 
 ## PRIVATE
@@ -24,6 +24,6 @@ parse_type_selector =
 join_kind_selector : Single_Choice
 join_kind_selector =
     choice = ['Join_Kind.Inner','Join_Kind.Left_Outer','Join_Kind.Right_Outer','Join_Kind.Full','Join_Kind.Left_Exclusive','Join_Kind.Right_Exclusive']
-    names = ['Inner','Left Outer','Right Outer','Full','Left Exclusive','Right Exclusive']
-    options = choice.zip names . map pair-> Option pair.first pair.second
+    names = ['Inner', 'Left Outer', 'Right Outer', 'Full', 'Left Exclusive', 'Right Exclusive']
+    options = names.zip choice . map pair-> Option pair.first pair.second
     Single_Choice display=Display.Always values=options

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
@@ -1,0 +1,29 @@
+from Standard.Base import all
+
+from Standard.Base.Metadata.Widget import Single_Choice
+from Standard.Base.Metadata.Choice import Option
+import Standard.Base.Metadata.Display
+
+from project.Data.Table import Table
+
+## PRIVATE
+   Make a column name selector.
+make_column_name_selector : Table -> Single_Choice
+make_column_name_selector table display=Display.Always =
+    Single_Choice display=display values=(table.column_names.map n->(Option n n.pretty))
+
+## PRIVATE
+   Selector for type argument on `Column.parse`.
+parse_type_selector : Single_Choice
+parse_type_selector =
+    choice = ['Auto','Integer','Decimal','Date','Date_Time','Time_Of_Day','Boolean']
+    Single_Choice display=Display.Always values=(choice.map n->(Option n))
+
+## PRIVATE
+   Selector for type argument on `Column.parse`.
+join_kind_selector : Single_Choice
+join_kind_selector =
+    choice = ['Join_Kind.Inner','Join_Kind.Left_Outer','Join_Kind.Right_Outer','Join_Kind.Full','Join_Kind.Left_Exclusive','Join_Kind.Right_Exclusive']
+    names = ['Inner','Left Outer','Right Outer','Full','Left Exclusive','Right Exclusive']
+    options = choice.zip names . map pair-> Option pair.first pair.second
+    Single_Choice display=Display.Always values=options

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Widgets.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Widgets.enso
@@ -8,6 +8,27 @@ get_full_annotations_json : Any -> Text -> Vector Text -> Text
 get_full_annotations_json value call_name argument_names =
     read_annotation argument =
         annotation = Meta.get_annotation value call_name argument
+        widget = case annotation of
+            _ : Function -> annotation value
+            _ -> annotation
+
+        js_widget = widget.to_js_object
+        if js_widget.get "values" . is_nothing then js_widget else
+            js_codes = js_widget.get "values" . map (_.get "value")
+            fields = js_widget.field_names
+            values = fields.map f-> if f=="values" then js_codes else js_widget.get f
+            JS_Object.from_pairs (fields.zip values)
+    annotations = argument_names.map (arg -> [arg, read_annotation arg])
+    annotations.to_json
+
+## PRIVATE
+   Basic preprocessor for widgets metadata visualization.
+
+   Returns full annotation data for all requested arguments.
+get_widget_json : Any -> Text -> Vector Text -> Text
+get_widget_json value call_name argument_names =
+    read_annotation argument =
+        annotation = Meta.get_annotation value call_name argument
         case annotation of
             _ : Function -> annotation value
             _ -> annotation

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Widgets.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Widgets.enso
@@ -3,7 +3,8 @@ from Standard.Base import all
 ## PRIVATE
    Basic preprocessor for widgets metadata visualization.
 
-   Returns full annotation data for all requested arguments.
+   Returns simplified annotation data for all requested arguments.
+   Values are replaced with just Text of the code.
 get_full_annotations_json : Any -> Text -> Vector Text -> Text
 get_full_annotations_json value call_name argument_names =
     read_annotation argument =

--- a/engine/runtime/src/test/java/org/enso/compiler/ParseStdLibTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ParseStdLibTest.java
@@ -169,7 +169,8 @@ public final class ParseStdLibTest extends TestCase {
             "Data/Value_Type.enso",
             "Data/Vector.enso",
             "Network/HTTP/HTTP_Status_Code.enso",
-            "Internal/Base_Generator.enso"));
+            "Internal/Base_Generator.enso",
+            "System/File.enso"));
   }
 
   private static boolean isKnownToWork(String name) {


### PR DESCRIPTION
### Pull Request Description

Closes #5038 

- Use the proper widget structure.
- Provide new method `get_widget_json` with whole structure, but keep `get_full_annotations_json` in old form.
- Start to get to some reusable functions.
- Added widget to JS_Object field selections.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
