### PR TITLE
Check `cargo` return value to ensure issues are reported back to SBT

### DIFF
--- a/project/LauncherShimsForTest.scala
+++ b/project/LauncherShimsForTest.scala
@@ -10,7 +10,7 @@ object LauncherShimsForTest {
     Def.task {
       val log = state.value.log
       Cargo.run(
-        "build -p launcher-shims",
+        Seq("build", "-p", "launcher-shims"),
         log         = log
       )
     }


### PR DESCRIPTION
### Pull Request Description

Before, any failures of the Rust-side of the parser build would be swallowed by sbt, for example if I add gibberish to the Rust code I will get:
<img width="474" alt="image" src="https://user-images.githubusercontent.com/1436948/217374050-fd9ddaca-136c-459e-932e-c4b9e630d610.png">

This is problematic, because when users are compiling in SBT they may get confusing errors about Java files not being found whereas the true cause is hard to track down because it is somewhere deep in the logs. We've run into this silent failure when setting up SBT builds together with @GregoryTravis today.

I suggest to change it so that once cargo fails, the build is failed with a helpful message - this way it will be easier to track down the issues.

With these changes we get:
<img width="802" alt="image" src="https://user-images.githubusercontent.com/1436948/217374531-707ae348-4c55-4d62-9a86-93850ad8086b.png">


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [X] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
