### PR TITLE
Recover from serialization failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -558,6 +558,7 @@
 - [Convert large longs to doubles, safely, for host calls][4099]
 - [Profile engine startup][4110]
 - [Report type of polyglot values][4111]
+- [Engine can now recover from serialization failures][5591]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -650,6 +651,7 @@
 [4099]: https://github.com/enso-org/enso/pull/4099
 [4110]: https://github.com/enso-org/enso/pull/4110
 [4111]: https://github.com/enso-org/enso/pull/4111
+[5591]: https://github.com/enso-org/enso/pull/5591
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
@@ -289,11 +289,20 @@ class SerializationManager(compiler: Compiler) {
       case e: NotSerializableException =>
         logger.log(
           Level.SEVERE,
-          s"Could not serialize module [$name]."
+          s"Could not serialize module [$name].",
+          e
         )
         throw e
+      case e: Throwable =>
+        logger.log(
+          Level.SEVERE,
+          s"Serialization of module `$name` failed: ${e.getMessage}`",
+          e
+        )
+        throw e
+    } finally {
+      finishSerializing(name)
     }
-    finishSerializing(name)
   }
 
   /** Sets the module described by `name` as serializing.


### PR DESCRIPTION
### Pull Request Description

An exception encountered during serialization prevents engine from continuing because it enters an infinite loop(!).

### Important Notes

The aim of this PR is to make it possible for engine to recover from the serialization failures. Any failure would mean that we enter an infinite loop in deserialization which is in turn waiting for the serialization to finish (which will never happen).
In this particular case FQNs are [referencing concrete modules](https://github.com/enso-org/enso/issues/5037). A separate PR will address that.

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
