### PR TITLE
fix visualization debug scene

### DIFF
--- a/app/gui/view/debug_scene/visualization/src/lib.rs
+++ b/app/gui/view/debug_scene/visualization/src/lib.rs
@@ -119,6 +119,7 @@ fn init(app: &Application) {
         .expect("Couldn't find Graph class.");
     let visualization = vis_class.new_instance(app).expect("Couldn't create visualiser.");
     visualization.activate.emit(());
+    scene.add_child(&visualization);
 
     let network = enso_frp::Network::new("VisualizationExample");
     enso_frp::extend! { network
@@ -137,7 +138,6 @@ fn init(app: &Application) {
             let data = generate_data(
                 (time_info.since_animation_loop_started.unchecked_raw() / 1000.0).into(),
             );
-            let data = Rc::new(data);
             let content = serde_json::to_value(data).unwrap();
             let data = Data::from(content);
 
@@ -146,6 +146,7 @@ fn init(app: &Application) {
             // Temporary code removing the web-loader instance.
             // To be changed in the future.
             if was_rendered && !loader_hidden {
+                visualization.set_size.emit(Vector2(300.0, 300.0));
                 web::document
                     .get_element_by_id("loader")
                     .map(|t| t.parent_node().map(|p| p.remove_child(&t).unwrap()));


### PR DESCRIPTION
### Pull Request Description

Fixes #5553

Found a fix during triage, as I tried to reproduce the issue. For some reason the visualization UI component was never attached to the scene, and its size was never set. Adding that fixed the issue immediately.

<img width="287" alt="image" src="https://user-images.githubusercontent.com/919491/217581444-4d6463cd-ff7f-4292-9355-edee15221e40.png">


### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
