### PR TITLE
Fix separate compilation for ConstantsGen

### DIFF
--- a/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/TypeProcessor.java
+++ b/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/TypeProcessor.java
@@ -136,15 +136,21 @@ public class TypeProcessor extends BuiltinsMetadataProcessor<TypeProcessor.TypeM
           .values()
           .forEach(
               entry ->
-                entry.stdlibName().ifPresent(n ->
-                        out.println(
-                        "    public static final String "
-                                + entry.ensoName().toUpperCase()
-                                + " = \""
-                                + n
-                                + "\";")
-                )
-          );
+                entry.stdlibName().ifPresent(n -> {
+                  out.println(
+                          "  public static final String "
+                                  + entry.ensoName().toUpperCase()
+                                  + " = \""
+                                  + n
+                                  + "\";");
+                  out.println(
+                          "  public static final String "
+                                  + entry.ensoName().toUpperCase() + "_BUILTIN"
+                                  + " = \""
+                                  + n
+                                  + "\";");
+                        })
+                );
 
       out.println();
       out.println("}");

--- a/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/TypeProcessor.java
+++ b/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/TypeProcessor.java
@@ -115,19 +115,7 @@ public class TypeProcessor extends BuiltinsMetadataProcessor<TypeProcessor.TypeM
         for (Map.Entry<String, BuiltinTypeConstr> entry : builtinTypes.get(f).entrySet()) {
           BuiltinTypeConstr constr = entry.getValue();
           if (!constr.getFullName().isEmpty()) {
-            out.println(
-                "  public static final String "
-                    + entry.getKey().toUpperCase()
-                    + " = \""
-                    + constr.getFullName()
-                    + "\";");
-
-            out.println(
-                    "  public static final String "
-                            + entry.getKey().toUpperCase() + "_BUILTIN"
-                            + " = "
-                            + toBuiltinName(constr.getFullName())
-                            + ";");
+            generateEntry(entry.getKey().toUpperCase(), constr.getFullName(), out);
           }
         }
       }
@@ -136,25 +124,27 @@ public class TypeProcessor extends BuiltinsMetadataProcessor<TypeProcessor.TypeM
           .values()
           .forEach(
               entry ->
-                entry.stdlibName().ifPresent(n -> {
-                  out.println(
-                          "  public static final String "
-                                  + entry.ensoName().toUpperCase()
-                                  + " = \""
-                                  + n
-                                  + "\";");
-                  out.println(
-                          "  public static final String "
-                                  + entry.ensoName().toUpperCase() + "_BUILTIN"
-                                  + " = \""
-                                  + n
-                                  + "\";");
-                        })
-                );
+                entry.stdlibName().ifPresent(n -> generateEntry(entry.ensoName().toUpperCase(), n, out))
+          );
 
       out.println();
       out.println("}");
     }
+  }
+
+  public void generateEntry(String name, String value, PrintWriter out) {
+    out.println(
+            "  public static final String "
+                    + name
+                    + " = \""
+                    + value
+                    + "\";");
+    out.println(
+            "  public static final String "
+                    + name + "_BUILTIN"
+                    + " = "
+                    + toBuiltinName(value)
+                    + ";");
   }
 
   private String toBuiltinName(String name) {


### PR DESCRIPTION
### Pull Request Description

A combination of commands triggered separate compilation that only recompiled part of builtins. A mechanism that workaround annotation processor's problems with separate compilation was updated to include changes from https://github.com/enso-org/enso/pull/4111. This was pretty tough to find given the rather unusual circumstances in CI.

### Important Notes

This eliminates the _random_ failures in CI related to separate compilation.
To reproduce a specific set of steps has to be executed:
```
sbt> all buildEngineDistribution engine-runner/assembly runtime/Benchmark/compile language-server/Benchmark/compile searcher/Benchmark/compile
(exit sbt)
sbt> test
```

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
