### PR TITLE
Remove `Column` type from Aggregate_Column, simplify Column_Selector, some new `File_Format`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,6 +305,7 @@
   simpler API.][4078]
 - [Updated `Table.set` to new API. New `Column.parse` function and added case
   sensitivity to `Filter_Condition` and column functions.][4097]
+- [Updated column selector APIs and new `Excel_Workbook` type.][5646]
 
 [debug-shortcuts]:
   https://github.com/enso-org/enso/blob/develop/app/gui/docs/product/shortcuts.md#debug
@@ -470,6 +471,7 @@
 [4097]: https://github.com/enso-org/enso/pull/4097
 [4120]: https://github.com/enso-org/enso/pull/4120
 [4072]: https://github.com/enso-org/enso/pull/4072
+[5646]: https://github.com/enso-org/enso/pull/5646
 
 #### Enso Compiler
 

--- a/build.sbt
+++ b/build.sbt
@@ -2125,12 +2125,13 @@ lazy val `std-database` = project
     Compile / packageBin / artifactPath :=
       `database-polyglot-root` / "std-database.jar",
     libraryDependencies ++= Seq(
-      "org.xerial"          % "sqlite-jdbc"           % "3.36.0.3",
-      "org.postgresql"      % "postgresql"            % "42.4.0",
-      "com.amazon.redshift" % "redshift-jdbc42"       % "2.1.0.9",
-      "com.amazonaws"       % "aws-java-sdk-core"     % "1.12.273",
-      "com.amazonaws"       % "aws-java-sdk-redshift" % "1.12.273",
-      "com.amazonaws"       % "aws-java-sdk-sts"      % "1.12.273"
+      "org.netbeans.api"    % "org-openide-util-lookup" % netbeansApiVersion % "provided",
+      "org.xerial"          % "sqlite-jdbc"             % "3.36.0.3",
+      "org.postgresql"      % "postgresql"              % "42.4.0",
+      "com.amazon.redshift" % "redshift-jdbc42"         % "2.1.0.9",
+      "com.amazonaws"       % "aws-java-sdk-core"       % "1.12.273",
+      "com.amazonaws"       % "aws-java-sdk-redshift"   % "1.12.273",
+      "com.amazonaws"       % "aws-java-sdk-sts"        % "1.12.273"
     ),
     Compile / packageBin := Def.task {
       val result = (Compile / packageBin).value
@@ -2144,6 +2145,7 @@ lazy val `std-database` = project
       result
     }.value
   )
+  .dependsOn(`std-base` % "provided")
 
 /* Note [Native Image Workaround for GraalVM 20.2]
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/build.sbt
+++ b/build.sbt
@@ -2078,6 +2078,7 @@ lazy val `std-image` = project
     Compile / packageBin / artifactPath :=
       `image-polyglot-root` / "std-image.jar",
     libraryDependencies ++= Seq(
+      "org.netbeans.api" % "org-openide-util-lookup" % netbeansApiVersion % "provided",
       "org.openpnp" % "opencv" % "4.5.1-2"
     ),
     Compile / packageBin := Def.task {
@@ -2092,6 +2093,7 @@ lazy val `std-image` = project
       result
     }.value
   )
+  .dependsOn(`std-base` % "provided")
 
 lazy val `std-google-api` = project
   .in(file("std-bits") / "google-api")

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
@@ -46,6 +46,17 @@ type Widget
        - allow_custom: Allow the user to enter a value not in the list?
     Single_Choice values:(Vector Choice) label:(Nothing | Text)=Nothing display:Display=Display.When_Modified allow_custom:Boolean=True
 
+    ## Describes a list editor widget producing a Vector.
+       Items can be dragged around to change the order, or dragged out to be deleted from the Vector.
+
+       Fields:
+       - item_editor: The widget to use for editing the items.
+       - item_default: The default value for new items inserted when the user clicks the `+` button.
+       - label: The placeholder text value.
+         By default, the parameter name is used.
+       - display: The display mode for the parameter.
+    Vector_Editor item_editor:Widget item_default:Text label:(Nothing | Text)=Nothing display:Display=Display.When_Modified
+
     ## Describes a multi value widget.
     Multiple_Choice values:(Vector Choice) label:(Nothing | Text)=Nothing display:Display=Display.When_Modified quote_values:Boolean=False
 
@@ -60,10 +71,6 @@ type Widget
 
     ## Describes a text widget.
     Text_Input label:(Nothing | Text)=Nothing display:Display=Display.When_Modified quote_values:Boolean=True suggestions:(Vector Text)=[]
-
-
-    ## Describes a list editor widget.
-    Vector_Editor item_editor:Widget values:((Vector Choice) | Nothing)=Nothing label:(Nothing | Text)=Nothing display:Display=Display.When_Modified
 
     ## Describes a folder chooser.
     Folder_Browse label:(Nothing | Text)=Nothing display:Display=Display.When_Modified

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Error.Illegal_State.Illegal_State
 
-from Standard.Table import Column_Selector, Column_Name_Mapping
+from Standard.Table import Column_Name_Mapping
 import Standard.Table.Data.Table.Table as Materialized_Table
 
 import project.Data.SQL_Query.SQL_Query
@@ -105,7 +105,7 @@ type Connection
 
             renamed = table.rename_columns (Column_Name_Mapping.By_Name name_map)
             if all_fields then renamed else
-                renamed.select_columns (Column_Selector.By_Name ["Database", "Schema", "Name", "Type", "Description"])
+                renamed.select_columns ["Database", "Schema", "Name", "Type", "Description"]
 
     ## Set up a query returning a Table object, which can be used to work with data within the database or load it into memory.
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Format.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Format.enso
@@ -6,25 +6,25 @@ import project.Connection.SQLite_Options.SQLite_Options
 
 ## Read the file to a `SQLite_Connection` from a db or sqlite file
 type SQLite_Format
-    ## The DB file to read from
-    For_File file:File
+    ## Read SQLite files
+    For_File
 
     ## If the File_Format supports reading from the file, return a configured instance.
     for_file : File -> SQLite_Format | Nothing
     for_file file =
         case file.extension of
-            ".db" -> SQLite_Format.For_File file
-            ".sqlite" -> SQLite_Format.For_File file
+            ".db" -> SQLite_Format.For_File
+            ".sqlite" -> SQLite_Format.For_File
             _ -> Nothing
 
     ## If the File_Format supports reading from the web response, return a configured instance.
-    for_web : Text -> URI -> Excel_Format | Nothing
+    for_web : Text -> URI -> SQLite_Format | Nothing
     for_web _ _ =
-        ## Currently not loading Excel files automatically as these need to be loaded as a connection.
+        ## Currently not loading SQLite files automatically.
         Nothing
 
     ## Implements the `File.read` for this `File_Format`
     read : File -> Problem_Behavior -> Any
     read self file on_problems =
         _ = [on_problems]
-        Database.connect (SQLite_Options.SQLite self.file)
+        Database.connect (SQLite_Options.SQLite file)

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Format.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Format.enso
@@ -1,0 +1,30 @@
+from Standard.Base import all
+import Standard.Base.Error.Illegal_Argument.Illegal_Argument
+
+import project.Connection.Database
+import project.Connection.SQLite_Options.SQLite_Options
+
+## Read the file to a `SQLite_Connection` from a db or sqlite file
+type SQLite_Format
+    ## The DB file to read from
+    For_File file:File
+
+    ## If the File_Format supports reading from the file, return a configured instance.
+    for_file : File -> SQLite_Format | Nothing
+    for_file file =
+        case file.extension of
+            ".db" -> SQLite_Format.For_File file
+            ".sqlite" -> SQLite_Format.For_File file
+            _ -> Nothing
+
+    ## If the File_Format supports reading from the web response, return a configured instance.
+    for_web : Text -> URI -> Excel_Format | Nothing
+    for_web _ _ =
+        ## Currently not loading Excel files automatically as these need to be loaded as a connection.
+        Nothing
+
+    ## Implements the `File.read` for this `File_Format`
+    read : File -> Problem_Behavior -> Any
+    read self file on_problems =
+        _ = [on_problems]
+        Database.connect (SQLite_Options.SQLite self.file)

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Format.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Format.enso
@@ -4,7 +4,7 @@ import Standard.Base.Error.Illegal_Argument.Illegal_Argument
 import project.Connection.Database
 import project.Connection.SQLite_Options.SQLite_Options
 
-## Read the file to a `SQLite_Connection` from a db or sqlite file
+## Read the file to a `SQLite_Connection` from a `.db` or `.sqlite` file
 type SQLite_Format
     ## Read SQLite files
     For_File

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -119,7 +119,7 @@ type Table
             _ -> Error.throw (Illegal_Argument.Error "expected 'selector' to be either a Text or an Integer, but got "+(Meta.get_simple_type_name selector)+".")
         if internal_column.is_nothing then if_missing else self.make_column internal_column
 
-    ## Gets the first column
+    ## Gets the first column.
     first_column : Column ! Index_Out_Of_Bounds
     first_column self = self.at 0
 
@@ -129,7 +129,7 @@ type Table
 
     ## Gets the last column
     last_column : Column ! Index_Out_Of_Bounds
-    last_column self = self.at (self.column_count - 1)
+    last_column self = self.at -1
 
     ## Returns the number of columns in the table.
     column_count : Integer

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -140,7 +140,8 @@ type Table
        dropped from the output.
 
        Arguments:
-       - columns: Column selection criteria or vector of column names.
+       - columns: Column selection criteria - a single instance or Vector of
+         names, indexes or `Column_Selector`.
        - reorder: By default, or if set to `False`, columns in the output will
          be in the same order as in the input table. If `True`, the order in the
          output table will match the order in the columns list. If a column is
@@ -186,7 +187,7 @@ type Table
              table.select_columns [-1, 0, 1] reorder=True
 
        Icon: select_column
-    select_columns : Vector (Integer | Text | Column_Selector) -> Boolean -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
+    select_columns : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Boolean -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
     select_columns self (columns = [0]) (reorder = False) (error_on_missing_columns = True) (on_problems = Report_Warning) =
         new_columns = self.columns_helper.select_columns selector=columns reorder=reorder error_on_missing_columns=error_on_missing_columns on_problems=on_problems
         self.updated_columns new_columns
@@ -197,7 +198,8 @@ type Table
        input.
 
        Arguments:
-       - columns: Column selection criteria or vector of column names to remove.
+       - columns: Column selection criteria - a single instance or Vector of
+         names, indexes or `Column_Selector`, which are to be removed.
        - error_on_missing_columns: Specifies if a missing input column should
          result in an error regardless of the `on_problems` settings. Defaults
          to `False`.
@@ -237,7 +239,7 @@ type Table
          Remove the first two columns and the last column.
 
              table.remove_columns [-1, 0, 1]
-    remove_columns : Vector (Integer | Text | Column_Selector) -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
+    remove_columns : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
     remove_columns self (columns = [0]) (error_on_missing_columns = False) (on_problems = Report_Warning) =
         new_columns = self.columns_helper.remove_columns selector=columns error_on_missing_columns=error_on_missing_columns on_problems=on_problems
         self.updated_columns new_columns
@@ -246,8 +248,9 @@ type Table
        either the start or the end in the specified order.
 
        Arguments:
-       - columns: Column selection criteria or vector of column names which
-         should be reordered and specifying their order.
+       - columns: Column selection criteria - a single instance or Vector of
+         names, indexes or `Column_Selector`, which should be reordered and
+         specifying their order.
        - position: Specifies how to place the selected columns in relation to
          the remaining columns which were not matched by `columns` (if any).
        - error_on_missing_columns: Specifies if a missing input column should
@@ -291,7 +294,7 @@ type Table
          Move the first column to back.
 
              table.reorder_columns [0] position=Position.After_Other_Columns
-    reorder_columns : Vector (Integer | Text | Column_Selector) -> Position -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Column_Indexes_Out_Of_Range
+    reorder_columns : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Position -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Column_Indexes_Out_Of_Range
     reorder_columns self (columns = [0]) (position = Position.Before_Other_Columns) (error_on_missing_columns = False) (on_problems = Report_Warning) =
         new_columns = self.columns_helper.reorder_columns selector=columns position=position error_on_missing_columns on_problems=on_problems
         self.updated_columns new_columns
@@ -813,7 +816,7 @@ type Table
          - If floating points values are present in the distinct columns, a
            `Floating_Point_Equality` is reported according to the `on_problems`
            setting.
-    distinct : Vector (Integer | Text | Column_Selector) -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | No_Input_Columns_Selected | Floating_Point_Equality
+    distinct : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | No_Input_Columns_Selected | Floating_Point_Equality
     distinct self columns=self.column_names case_sensitivity=Case_Sensitivity.Default error_on_missing_columns=True on_problems=Report_Warning =
         key_columns = self.columns_helper.select_columns selector=columns reorder=True error_on_missing_columns=error_on_missing_columns on_problems=on_problems . catch No_Output_Columns _->
             Error.throw No_Input_Columns_Selected
@@ -1219,7 +1222,7 @@ type Table
          - If any column names in the new table are clashing, a
            `Duplicate_Output_Column_Names` is reported according to the
            `on_problems` setting.
-    transpose :  Vector (Integer | Text | Column_Selector) -> Text -> Text -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range | Duplicate_Output_Column_Names
+    transpose :  Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Text -> Text -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range | Duplicate_Output_Column_Names
     transpose self id_fields=[] (name_field="Name") (value_field="Value") (error_on_missing_columns=True) (on_problems = Report_Warning) =
         ## Avoid unused arguments warning. We cannot rename arguments to `_`,
            because we need to keep the API consistent with the in-memory table.
@@ -1261,7 +1264,7 @@ type Table
              an `Unquoted_Delimiter`
            - If there are more than 10 issues with a single column,
              an `Additional_Warnings`.
-    cross_tab : Text | Integer | Vector (Integer | Text | Column_Selector) -> (Text | Integer | Column) -> Vector Aggregate_Column -> Problem_Behavior -> Table ! Missing_Input_Columns | Column_Indexes_Out_Of_Range | Invalid_Aggregate_Column | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings
+    cross_tab : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> (Text | Integer | Column) -> Vector Aggregate_Column -> Problem_Behavior -> Table ! Missing_Input_Columns | Column_Indexes_Out_Of_Range | Invalid_Aggregate_Column | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings
     cross_tab self group_by=[] name_column=self.column_names.first values=Aggregate_Column.Count (on_problems=Report_Warning) =
         ## Avoid unused arguments warning. We cannot rename arguments to `_`,
            because we need to keep the API consistent with the in-memory table.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -952,7 +952,7 @@ type Table
          table. This applies only if the order of the rows was specified (for
          example, by sorting the table; in-memory tables will keep the memory
          layout order while for database tables the order may be unspecified).
-    cross_join : Table -> Integer | Nothing -> Table
+    cross_join : Table -> Integer | Nothing -> Text -> Problem_Behavior -> Table
     cross_join self right right_row_limit=100 right_prefix="Right_" on_problems=Report_Warning =
         _ = [right, right_row_limit, right_prefix, on_problems]
         Error.throw (Unsupported_Database_Operation.Error "Table.cross_join is not implemented yet for the Database backends.")

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -179,7 +179,7 @@ type Table
        > Example
          Select columns matching a regular expression.
 
-             table.select_columns (Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True)
+             table.select_columns [Column_Selector.By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True, Column_Selector.By_Name "b.*" Case_Sensitivity.Insensitive use_regex=True]
 
        > Example
          Select the first two columns and the last column, moving the last one to front.
@@ -233,7 +233,7 @@ type Table
        > Example
          Remove columns matching a regular expression.
 
-             table.remove_columns (Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True)
+             table.remove_columns [Column_Selector.By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True, Column_Selector.By_Name "b.*" Case_Sensitivity.Insensitive use_regex=True]
 
        > Example
          Remove the first two columns and the last column.
@@ -283,7 +283,7 @@ type Table
        > Example
          Move columns matching a regular expression to front, keeping columns matching "foo.+" before columns matching "b.*".
 
-             table.reorder_columns (Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True)
+             table.reorder_columns [Column_Selector.By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True, Column_Selector.By_Name "b.*" Case_Sensitivity.Insensitive use_regex=True]
 
        > Example
          Swap the first two columns.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -157,7 +157,7 @@ type Table
        > Example
          Select columns by name.
 
-             table.select_columns (Column_Selector.By_Name ["bar", "foo"])
+             table.select_columns ["bar", "foo"]
 
        > Example
          Select columns using names passed as a Vector.
@@ -167,16 +167,16 @@ type Table
        > Example
          Select columns matching a regular expression.
 
-             table.select_columns (Column_Selector.By_Name ["foo.+", "b.*"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Insensitive))
+             table.select_columns [Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True]
 
        > Example
          Select the first two columns and the last column, moving the last one to front.
 
-             table.select_columns (Column_Selector.By_Index [-1, 0, 1]) reorder=True
+             table.select_columns [-1, 0, 1] reorder=True
 
        Icon: select_column
-    select_columns : Vector Text | Column_Selector -> Boolean -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
-    select_columns self (columns = Column_Selector.By_Index [0]) (reorder = False) (error_on_missing_columns = True) (on_problems = Report_Warning) =
+    select_columns : Vector (Integer | Text | Column_Selector) -> Boolean -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
+    select_columns self (columns = [0]) (reorder = False) (error_on_missing_columns = True) (on_problems = Report_Warning) =
         new_columns = self.columns_helper.select_columns selector=columns reorder=reorder error_on_missing_columns=error_on_missing_columns on_problems=on_problems
         self.updated_columns new_columns
 
@@ -210,7 +210,7 @@ type Table
        > Example
          Remove columns with given names.
 
-             table.remove_columns (Column_Selector.By_Name ["bar", "foo"])
+             table.remove_columns ["bar", "foo"]
 
        > Example
          Remove columns using names passed as a Vector.
@@ -220,15 +220,14 @@ type Table
        > Example
          Remove columns matching a regular expression.
 
-             table.remove_columns (Column_Selector.By_Name ["foo.+", "b.*"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Insensitive))
+             table.remove_columns [Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True]
 
        > Example
          Remove the first two columns and the last column.
 
-             table.remove_columns (Column_Selector.By_Index [-1, 0, 1])
-
-    remove_columns : Vector Text | Column_Selector -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
-    remove_columns self (columns = Column_Selector.By_Index [0]) (error_on_missing_columns = False) (on_problems = Report_Warning) =
+             table.remove_columns [-1, 0, 1]
+    remove_columns : Vector (Integer | Text | Column_Selector) -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
+    remove_columns self (columns = [0]) (error_on_missing_columns = False) (on_problems = Report_Warning) =
         new_columns = self.columns_helper.remove_columns selector=columns error_on_missing_columns=error_on_missing_columns on_problems=on_problems
         self.updated_columns new_columns
 
@@ -260,30 +259,29 @@ type Table
        > Example
          Move a column with a specified name to back.
 
-             table.reorder_columns (By_Name ["foo"]) position=After_Other_Columns
+             table.reorder_columns ["foo"] position=Position.After_Other_Columns
 
        > Example
          Move columns using names passed as a Vector.
 
-             table.reorder_columns ["bar", "foo"] position=After_Other_Columns
+             table.reorder_columns ["bar", "foo"] position=Position.After_Other_Columns
 
        > Example
          Move columns matching a regular expression to front, keeping columns matching "foo.+" before columns matching "b.*".
 
-             table.reorder_columns (By_Name ["foo.+", "b.*"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Insensitive))
+             table.reorder_columns [Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True]
 
        > Example
          Swap the first two columns.
 
-             table.reorder_columns (Column_Selector.By_Index [1, 0]) position=Before_Other_Columns
+             table.reorder_columns [1, 0]
 
        > Example
          Move the first column to back.
 
-             table.reorder_columns (Column_Selector.By_Index [0]) position=After_Other_Columns
-
-    reorder_columns : Vector Text | Column_Selector -> Position -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Column_Indexes_Out_Of_Range
-    reorder_columns self (columns = Column_Selector.By_Index [0]) (position = Position.Before_Other_Columns) (error_on_missing_columns = False) (on_problems = Report_Warning) =
+             table.reorder_columns [0] position=Position.After_Other_Columns
+    reorder_columns : Vector (Integer | Text | Column_Selector) -> Position -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Column_Indexes_Out_Of_Range
+    reorder_columns self (columns = [0]) (position = Position.Before_Other_Columns) (error_on_missing_columns = False) (on_problems = Report_Warning) =
         new_columns = self.columns_helper.reorder_columns selector=columns position=position error_on_missing_columns on_problems=on_problems
         self.updated_columns new_columns
 
@@ -804,8 +802,8 @@ type Table
          - If floating points values are present in the distinct columns, a
            `Floating_Point_Equality` is reported according to the `on_problems`
            setting.
-    distinct : Vector Text | Column_Selector -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | No_Input_Columns_Selected | Floating_Point_Equality
-    distinct self (columns = Column_Selector.By_Name (self.columns.map .name)) case_sensitivity=Case_Sensitivity.Default error_on_missing_columns=True on_problems=Report_Warning =
+    distinct : Vector (Integer | Text | Column_Selector) -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | No_Input_Columns_Selected | Floating_Point_Equality
+    distinct self columns=self.column_names case_sensitivity=Case_Sensitivity.Default error_on_missing_columns=True on_problems=Report_Warning =
         key_columns = self.columns_helper.select_columns selector=columns reorder=True error_on_missing_columns=error_on_missing_columns on_problems=on_problems . catch No_Output_Columns _->
             Error.throw No_Input_Columns_Selected
         problem_builder = Problem_Builder.new
@@ -1210,8 +1208,8 @@ type Table
          - If any column names in the new table are clashing, a
            `Duplicate_Output_Column_Names` is reported according to the
            `on_problems` setting.
-    transpose : Vector Text | Column_Selector -> Text -> Text -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range | Duplicate_Output_Column_Names
-    transpose self (id_fields = Column_Selector.By_Name []) (name_field="Name") (value_field="Value") (error_on_missing_columns=True) (on_problems = Report_Warning) =
+    transpose :  Vector (Integer | Text | Column_Selector) -> Text -> Text -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range | Duplicate_Output_Column_Names
+    transpose self id_fields=[] (name_field="Name") (value_field="Value") (error_on_missing_columns=True) (on_problems = Report_Warning) =
         ## Avoid unused arguments warning. We cannot rename arguments to `_`,
            because we need to keep the API consistent with the in-memory table.
         _ = [id_fields, name_field, value_field, error_on_missing_columns, on_problems]
@@ -1252,7 +1250,7 @@ type Table
              an `Unquoted_Delimiter`
            - If there are more than 10 issues with a single column,
              an `Additional_Warnings`.
-    cross_tab : Text | Vector Text | Column_Selector -> (Text | Integer | Column) -> Vector Aggregate_Column -> Problem_Behavior -> Table ! Missing_Input_Columns | Column_Indexes_Out_Of_Range | Invalid_Aggregate_Column | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings
+    cross_tab : Text | Integer | Vector (Integer | Text | Column_Selector) -> (Text | Integer | Column) -> Vector Aggregate_Column -> Problem_Behavior -> Table ! Missing_Input_Columns | Column_Indexes_Out_Of_Range | Invalid_Aggregate_Column | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings
     cross_tab self group_by=[] name_column=self.column_names.first values=Aggregate_Column.Count (on_problems=Report_Warning) =
         ## Avoid unused arguments warning. We cannot rename arguments to `_`,
            because we need to keep the API consistent with the in-memory table.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -179,7 +179,7 @@ type Table
        > Example
          Select columns matching a regular expression.
 
-             table.select_columns [Column_Selector.By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True, Column_Selector.By_Name "b.*" Case_Sensitivity.Insensitive use_regex=True]
+             table.select_columns (Column_Selector.By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True)
 
        > Example
          Select the first two columns and the last column, moving the last one to front.
@@ -233,7 +233,7 @@ type Table
        > Example
          Remove columns matching a regular expression.
 
-             table.remove_columns [Column_Selector.By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True, Column_Selector.By_Name "b.*" Case_Sensitivity.Insensitive use_regex=True]
+             table.remove_columns (Column_Selector.By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True)
 
        > Example
          Remove the first two columns and the last column.
@@ -283,7 +283,7 @@ type Table
        > Example
          Move columns matching a regular expression to front, keeping columns matching "foo.+" before columns matching "b.*".
 
-             table.reorder_columns [Column_Selector.By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True, Column_Selector.By_Name "b.*" Case_Sensitivity.Insensitive use_regex=True]
+             table.reorder_columns (Column_Selector.By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True)
 
        > Example
          Swap the first two columns.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -189,7 +189,7 @@ type Table
        Icon: select_column
     select_columns : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Boolean -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
     select_columns self (columns = [0]) (reorder = False) (error_on_missing_columns = True) (on_problems = Report_Warning) =
-        new_columns = self.columns_helper.select_columns selector=columns reorder=reorder error_on_missing_columns=error_on_missing_columns on_problems=on_problems
+        new_columns = self.columns_helper.select_columns selectors=columns reorder=reorder error_on_missing_columns=error_on_missing_columns on_problems=on_problems
         self.updated_columns new_columns
 
     ## Returns a new table with the chosen set of columns, as specified by the
@@ -241,7 +241,7 @@ type Table
              table.remove_columns [-1, 0, 1]
     remove_columns : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
     remove_columns self (columns = [0]) (error_on_missing_columns = False) (on_problems = Report_Warning) =
-        new_columns = self.columns_helper.remove_columns selector=columns error_on_missing_columns=error_on_missing_columns on_problems=on_problems
+        new_columns = self.columns_helper.remove_columns selectors=columns error_on_missing_columns=error_on_missing_columns on_problems=on_problems
         self.updated_columns new_columns
 
     ## Returns a new table with the specified selection of columns moved to
@@ -296,7 +296,7 @@ type Table
              table.reorder_columns [0] position=Position.After_Other_Columns
     reorder_columns : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Position -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Column_Indexes_Out_Of_Range
     reorder_columns self (columns = [0]) (position = Position.Before_Other_Columns) (error_on_missing_columns = False) (on_problems = Report_Warning) =
-        new_columns = self.columns_helper.reorder_columns selector=columns position=position error_on_missing_columns on_problems=on_problems
+        new_columns = self.columns_helper.reorder_columns selectors=columns position=position error_on_missing_columns on_problems=on_problems
         self.updated_columns new_columns
 
     ## Returns a new table with the columns sorted by name according to the
@@ -818,7 +818,7 @@ type Table
            setting.
     distinct : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | No_Input_Columns_Selected | Floating_Point_Equality
     distinct self columns=self.column_names case_sensitivity=Case_Sensitivity.Default error_on_missing_columns=True on_problems=Report_Warning =
-        key_columns = self.columns_helper.select_columns selector=columns reorder=True error_on_missing_columns=error_on_missing_columns on_problems=on_problems . catch No_Output_Columns _->
+        key_columns = self.columns_helper.select_columns selectors=columns reorder=True error_on_missing_columns=error_on_missing_columns on_problems=on_problems . catch No_Output_Columns _->
             Error.throw No_Input_Columns_Selected
         problem_builder = Problem_Builder.new
         new_table = self.connection.dialect.prepare_distinct self key_columns case_sensitivity problem_builder

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -50,7 +50,6 @@ polyglot java import java.util.UUID
 
 ## Represents a column-oriented table data structure backed by a database.
 type Table
-
     ## PRIVATE
 
        Represents a column-oriented table data structure backed by a database.
@@ -119,6 +118,18 @@ type Table
             _ : Text -> self.internal_columns.find (p -> p.name == selector) if_missing=Nothing
             _ -> Error.throw (Illegal_Argument.Error "expected 'selector' to be either a Text or an Integer, but got "+(Meta.get_simple_type_name selector)+".")
         if internal_column.is_nothing then if_missing else self.make_column internal_column
+
+    ## Gets the first column
+    first_column : Column ! Index_Out_Of_Bounds
+    first_column self = self.at 0
+
+    ## Gets the second column
+    second_column : Column ! Index_Out_Of_Bounds
+    second_column self = self.at 1
+
+    ## Gets the last column
+    last_column : Column ! Index_Out_Of_Bounds
+    last_column self = self.at (self.column_count - 1)
 
     ## Returns the number of columns in the table.
     column_count : Integer

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -179,7 +179,7 @@ type Table
        > Example
          Select columns matching a regular expression.
 
-             table.select_columns [Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True]
+             table.select_columns (Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True)
 
        > Example
          Select the first two columns and the last column, moving the last one to front.
@@ -233,7 +233,7 @@ type Table
        > Example
          Remove columns matching a regular expression.
 
-             table.remove_columns [Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True]
+             table.remove_columns (Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True)
 
        > Example
          Remove the first two columns and the last column.
@@ -283,7 +283,7 @@ type Table
        > Example
          Move columns matching a regular expression to front, keeping columns matching "foo.+" before columns matching "b.*".
 
-             table.reorder_columns [Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True]
+             table.reorder_columns (Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True)
 
        > Example
          Swap the first two columns.

--- a/distribution/lib/Standard/Image/0.0.0-dev/src/Image_File_Format.enso
+++ b/distribution/lib/Standard/Image/0.0.0-dev/src/Image_File_Format.enso
@@ -1,0 +1,29 @@
+from Standard.Base import all
+import Standard.Base.Error.Illegal_Argument.Illegal_Argument
+
+import project.Data.Image.Image
+
+supported = [".bmp", ".dib", ".jpeg", ".jpg", ".jpe", ".jp2", ".png", ".webp", ".pbm", ".pgm", ".ppm", ".pxm", ".pnm", ".pfm", ".sr", ".ras", ".tiff", ".tif", ".exr", ".hdr", ".pic"]
+
+## Read the file to a `SQLite_Connection` from a db or sqlite file
+type Image_File_Format
+    ## File_Format to read Image files
+    For_File
+
+    ## If the File_Format supports reading from the file, return a configured instance.
+    for_file : File -> Image_File_Format | Nothing
+    for_file file =
+        extension = file.extension
+        if supported.contains extension then Image_File_Format.For_File else Nothing
+
+    ## If the File_Format supports reading from the web response, return a configured instance.
+    for_web : Text -> URI -> Image_File_Format | Nothing
+    for_web _ _ =
+        ## Currently not loading Excel files automatically as these need to be loaded as a connection.
+        Nothing
+
+    ## Implements the `File.read` for this `File_Format`
+    read : File -> Problem_Behavior -> Any
+    read self file on_problems =
+        _ = [on_problems]
+        Image.read file

--- a/distribution/lib/Standard/Image/0.0.0-dev/src/Image_File_Format.enso
+++ b/distribution/lib/Standard/Image/0.0.0-dev/src/Image_File_Format.enso
@@ -5,7 +5,7 @@ import project.Data.Image.Image
 
 supported = [".bmp", ".dib", ".jpeg", ".jpg", ".jpe", ".jp2", ".png", ".webp", ".pbm", ".pgm", ".ppm", ".pxm", ".pnm", ".pfm", ".sr", ".ras", ".tiff", ".tif", ".exr", ".hdr", ".pic"]
 
-## Read the file to a `SQLite_Connection` from a db or sqlite file
+## Read the file to a `Image` from a supported file format.
 type Image_File_Format
     ## File_Format to read Image files
     For_File
@@ -19,7 +19,7 @@ type Image_File_Format
     ## If the File_Format supports reading from the web response, return a configured instance.
     for_web : Text -> URI -> Image_File_Format | Nothing
     for_web _ _ =
-        ## Currently not loading Excel files automatically as these need to be loaded as a connection.
+        ## Currently not loading Image files automatically. This should be supported later.
         Nothing
 
     ## Implements the `File.read` for this `File_Format`

--- a/distribution/lib/Standard/Image/0.0.0-dev/src/Image_File_Format.enso
+++ b/distribution/lib/Standard/Image/0.0.0-dev/src/Image_File_Format.enso
@@ -3,6 +3,7 @@ import Standard.Base.Error.Illegal_Argument.Illegal_Argument
 
 import project.Data.Image.Image
 
+## List comes from org.opencv.imgcodecs.Imgcodecs#imread doc comment.
 supported = [".bmp", ".dib", ".jpeg", ".jpg", ".jpe", ".jp2", ".png", ".webp", ".pbm", ".pgm", ".ppm", ".pxm", ".pnm", ".pfm", ".sr", ".ras", ".tiff", ".tif", ".exr", ".hdr", ".pic"]
 
 ## Read the file to a `Image` from a supported file format.

--- a/distribution/lib/Standard/Searcher/0.0.0-dev/src/Data_Science/Preparation.enso
+++ b/distribution/lib/Standard/Searcher/0.0.0-dev/src/Data_Science/Preparation.enso
@@ -11,10 +11,9 @@
      Get the item name and price columns from the shop inventory.
 
          import Standard.Examples
-         from Standard.Table.Data.Column_Selector import By_Name
 
          example_select =
-             Examples.inventory_table.select_columns (By_Name ["item_name", "price"])
+             Examples.inventory_table.select_columns ["item_name", "price"]
 
    > Example
      Remove any rows that contain missing values from the table.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Aggregate_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Aggregate_Column.enso
@@ -31,7 +31,7 @@ type Aggregate_Column
          multiple selection.
        - new_name: name of new column.
        - ignore_nothing: if all values are Nothing won't be included.
-    Count_Distinct (columns:(Text|Integer|Vector (Integer|Text| Column_Selector))=0) (new_name:Text|Nothing=Nothing) (ignore_nothing:Boolean=False)
+    Count_Distinct (columns:(Text | Integer | Vector (Integer|Text|Column_Selector))=0) (new_name:Text|Nothing=Nothing) (ignore_nothing:Boolean=False)
 
     ## ALIAS Count_Not_Null
 
@@ -148,7 +148,7 @@ type Aggregate_Column
          not missing value returned.
        - order_by: required for database tables. Specifies how to order the
          results within the group.
-    First (column:Text|Integer=0) (new_name:Text|Nothing=Nothing) (ignore_nothing:Boolean=True) (order_by:Text | Sort_Column | Vector (Text | Sort_Column) | Nothing=Nothing)
+    First (column:Text|Integer=0) (new_name:Text|Nothing=Nothing) (ignore_nothing:Boolean=True) (order_by:(Text | Sort_Column | Vector (Text | Sort_Column) | Nothing)=Nothing)
 
     ## Creates a new column with the last value in each group. If no rows,
        evaluates to `Nothing`.
@@ -161,7 +161,7 @@ type Aggregate_Column
          not missing value returned.
        - order_by: required for database tables. Specifies how to order the
          results within the group.
-    Last (column:Text|Integer=0) (new_name:Text|Nothing=Nothing) (ignore_nothing:Boolean=True) (order_by:Text | Sort_Column | Vector (Text | Sort_Column) | Nothing=Nothing)
+    Last (column:Text|Integer=0) (new_name:Text|Nothing=Nothing) (ignore_nothing:Boolean=True) (order_by:(Text | Sort_Column | Vector (Text | Sort_Column) | Nothing)=Nothing)
 
     ## Creates a new column with the maximum value in each group. If no rows,
        evaluates to `Nothing`.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Aggregate_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Aggregate_Column.enso
@@ -31,7 +31,7 @@ type Aggregate_Column
          multiple selection.
        - new_name: name of new column.
        - ignore_nothing: if all values are Nothing won't be included.
-    Count_Distinct (columns:(Text | Integer | Vector (Integer|Text|Column_Selector))=0) (new_name:Text|Nothing=Nothing) (ignore_nothing:Boolean=False)
+    Count_Distinct (columns:(Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector))=0) (new_name:Text|Nothing=Nothing) (ignore_nothing:Boolean=False)
 
     ## ALIAS Count_Not_Null
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Aggregate_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Aggregate_Column.enso
@@ -1,33 +1,37 @@
 from Standard.Base import all
 
-import project.Data.Column.Column
 import project.Data.Column_Selector.Column_Selector
 import project.Data.Sort_Column.Sort_Column
 
 ## Defines an Aggregate Column
 type Aggregate_Column
-    ## Group By
-    Group_By (column:Column|Text|Integer) (new_name:Text|Nothing=Nothing)
+    ## Specifies a column to group the rows by.
+
+       Arguments:
+       - column: the column (specified by name, expression or index) to group
+         by.
+       - new_name: name of new column.
+    Group_By (column:Text|Integer) (new_name:Text|Nothing=Nothing)
 
     ## Creates a new column with the row count of each group. If no rows,
        evaluates to 0.
 
        Arguments:
-       - name: name of new column.
+       - new_name: name of new column.
     Count (new_name:Text|Nothing=Nothing)
 
     ## Creates a new column with the count of unique items in the selected
        column(s) within each group. If no rows, evaluates to 0.
 
        Arguments:
-       - columns: either a single or set of columns (specified by name, index or
-         Column object) to count across. The aggregation may also be computed
-         over an expression evaluated on the Table, if provided instead of a
+       - columns: either a single or set of columns (specified by name or
+         index) to count across. The aggregation may also be computed over
+         an expression evaluated on the Table, if provided instead of a
          single column name. Currently expressions are not supported with
          multiple selection.
-       - name: name of new column.
+       - new_name: name of new column.
        - ignore_nothing: if all values are Nothing won't be included.
-    Count_Distinct (columns:Column|Text|Integer|Column_Selector=0) (new_name:Text|Nothing=Nothing) (ignore_nothing:Boolean=False)
+    Count_Distinct (columns:(Text|Integer|Vector (Integer|Text| Column_Selector))=0) (new_name:Text|Nothing=Nothing) (ignore_nothing:Boolean=False)
 
     ## ALIAS Count_Not_Null
 
@@ -35,10 +39,9 @@ type Aggregate_Column
        specified column within each group. If no rows, evaluates to 0.
 
        Arguments:
-       - columns: column (specified by name, expression, index or Column object)
-         to count.
-       - name: name of new column.
-    Count_Not_Nothing (column:Column|Text|Integer=0) (new_name:Text|Nothing=Nothing)
+       - column: the column (specified by name, expression or index) to count.
+       - new_name: name of new column.
+    Count_Not_Nothing (column:Text|Integer=0) (new_name:Text|Nothing=Nothing)
 
     ## ALIAS Count_Null, Count_Missing
 
@@ -46,158 +49,152 @@ type Aggregate_Column
        specified column within each group. If no rows, evaluates to 0.
 
        Arguments:
-       - column: column (specified by name, expression, index or Column object)
-         to count.
-       - name: name of new column.
-    Count_Nothing (column:Column|Text|Integer=0) (new_name:Text|Nothing=Nothing)
+       - column: the column (specified by name, expression or index) to count.
+       - new_name: name of new column.
+    Count_Nothing (column:Text|Integer=0) (new_name:Text|Nothing=Nothing)
 
     ## Creates a new column with the count of not `Nothing` (null) and non-empty
        ("") values of the column within each group. If no rows, evaluates to 0.
 
        Arguments:
-       - column: column (specified by name, expression, index or Column object)
-         to count.
-       - name: name of new column.
-    Count_Not_Empty (column:Column|Text|Integer=0) (new_name:Text|Nothing=Nothing)
+       - column: the column (specified by name, expression or index) to count.
+       - new_name: name of new column.
+    Count_Not_Empty (column:Text|Integer=0) (new_name:Text|Nothing=Nothing)
 
     ## Creates a new column with the count of `Nothing` (null) or empty ("")
        text values of the column within each group. If no rows, evaluates to 0.
 
        Arguments:
-       - column: column (specified by name, expression, index or Column object)
-         to count.
-       - name: name of new column.
-    Count_Empty (column:Column|Text|Integer=0) (new_name:Text|Nothing=Nothing)
+       - column: the column (specified by name, expression or index) to count.
+       - new_name: name of new column.
+    Count_Empty (column:Text|Integer=0) (new_name:Text|Nothing=Nothing)
 
     ## Creates a new column with the sum of values (ignoring missing values) of
        the column within each group. If no rows, evaluates to `Nothing`.
 
        Arguments:
-       - column: column (specified by name, expression, index or Column object)
-         to total.
-       - name: name of new column.
-    Sum (column:Column|Text|Integer=0) (new_name:Text|Nothing=Nothing)
+       - column: the column (specified by name, expression or index) to total.
+       - new_name: name of new column.
+    Sum (column:Text|Integer=0) (new_name:Text|Nothing=Nothing)
 
     ## Creates a new column with the mean of values (ignoring missing values) of
        the column within each group. If no rows, evaluates to `Nothing`.
 
        Arguments:
-       - column: column (specified by name, expression, index or Column object)
-         to average.
-       - name: name of new column.
-    Average (column:Column|Text|Integer=0) (new_name:Text|Nothing=Nothing)
+       - column: the column (specified by name, expression or index) to average.
+       - new_name: name of new column.
+    Average (column:Text|Integer=0) (new_name:Text|Nothing=Nothing)
 
     ## Creates a new column with the median of values (ignoring missing values)
        of the column within each group. If no rows, evaluates to `Nothing`.
 
        Arguments:
-       - column: column (specified by name, expression, index or Column object)
-         to calculate median on.
-       - name: name of new column.
-    Median (column:Column|Text|Integer=0) (new_name:Text|Nothing=Nothing)
+       - column: column (specified by name, expression or index) to calculate
+         median on.
+       - new_name: name of new column.
+    Median (column:Text|Integer=0) (new_name:Text|Nothing=Nothing)
 
     ## Creates a new column with the median of values (ignoring missing values)
        of the column within each group. If no rows, evaluates to `Nothing`.
 
        Arguments:
        - percentile: Percentage to compute from 0-1 inclusive.
-       - column: column (specified by name, expression, index or Column object)
-         to compute percentile.
-       - name: name of new column.
-    Percentile (percentile:Decimal=0.5) (column:Column|Text|Integer=0) (new_name:Text|Nothing=Nothing)
+       - column: column (specified by name, expression or index) to compute
+         percentile.
+       - new_name: name of new column.
+    Percentile (percentile:Decimal=0.5) (column:Text|Integer=0) (new_name:Text|Nothing=Nothing)
 
     ## Creates a new column with the mode of values (ignoring missing values)
        of the column within each group. If no rows, evaluates to `Nothing`.
 
        Arguments:
-       - column: column (specified by name, expression, index or Column object)
-         to find the most common value.
-       - name: name of new column.
-    Mode (column:Column|Text|Integer=0) (new_name:Text|Nothing=Nothing)
+       - column: column (specified by name, expression or index) to find the
+         most common value.
+       - new_name: name of new column.
+    Mode (column:Text|Integer=0) (new_name:Text|Nothing=Nothing)
 
     ## Creates a new column with the standard deviation of values (ignoring
        missing values) of the column within each group. If no rows, evaluates to
        `Nothing`.
 
        Arguments:
-       - column: column (specified by name, expression, index or Column object)
-         to compute standard deviation.
-       - name: name of new column.
+       - column: column (specified by name, expression or index) to compute
+         standard deviation.
+       - new_name: name of new column.
        - population: specifies if group is a sample or the population
-    Standard_Deviation (column:Column|Text|Integer=0) (new_name:Text|Nothing=Nothing) (population:Boolean=False)
+    Standard_Deviation (column:Text|Integer=0) (new_name:Text|Nothing=Nothing) (population:Boolean=False)
 
     ## Creates a new column with the values concatenated together. `Nothing`
        values will become an empty string. If no rows, evaluates to `Nothing`.
 
        Arguments:
-       - column: column (specified by name, expression, index or Column object)
-         to concatenate values.
-       - name: name of new column.
+       - column: column (specified by name, expression or index) to concatenate.
+       - new_name: name of new column.
        - separator: added between each value.
        - prefix: added at the start of the result.
        - suffix: added at the end of the result.
        - quote_char: character used to quote the values if the value is `Empty`
          or contains the separator.
-    Concatenate (column:Column|Text|Integer=0) (new_name:Text|Nothing=Nothing) (separator:Text="") (prefix:Text="") (suffix:Text="") (quote_char:Text="")
+    Concatenate (column:Text|Integer=0) (new_name:Text|Nothing=Nothing) (separator:Text="") (prefix:Text="") (suffix:Text="") (quote_char:Text="")
 
     ## Creates a new column with the first value in each group. If no rows,
        evaluates to `Nothing`.
 
        Arguments:
-       - column: column (specified by name, expression, index or Column object)
-         to find first group entry.
-       - name: name of new column.
+       - column: column (specified by name, expression or index) to find first
+         group entry.
+       - new_name: name of new column.
        - ignore_nothing: if `True`, then missing values are ignored and first
          not missing value returned.
        - order_by: required for database tables. Specifies how to order the
          results within the group.
-    First (column:Column|Text|Integer=0) (new_name:Text|Nothing=Nothing) (ignore_nothing:Boolean=True) (order_by:Sort_Column|Nothing=Nothing)
+    First (column:Text|Integer=0) (new_name:Text|Nothing=Nothing) (ignore_nothing:Boolean=True) (order_by:Text | Sort_Column | Vector (Text | Sort_Column) | Nothing=Nothing)
 
     ## Creates a new column with the last value in each group. If no rows,
        evaluates to `Nothing`.
 
        Arguments:
-       - column: column (specified by name, expression, index or Column object)
-         to find last group entry.
-       - name: name of new column.
+       - column: column (specified by name, expression or index) to find last
+         group entry.
+       - new_name: name of new column.
        - ignore_nothing: if `True`, then missing values are ignored and last
          not missing value returned.
        - order_by: required for database tables. Specifies how to order the
          results within the group.
-    Last (column:Column|Text|Integer=0) (new_name:Text|Nothing=Nothing) (ignore_nothing:Boolean=True) (order_by:Sort_Column|Nothing=Nothing)
+    Last (column:Text|Integer=0) (new_name:Text|Nothing=Nothing) (ignore_nothing:Boolean=True) (order_by:Text | Sort_Column | Vector (Text | Sort_Column) | Nothing=Nothing)
 
     ## Creates a new column with the maximum value in each group. If no rows,
        evaluates to `Nothing`.
 
        Arguments:
-       - column: column (specified by name, expression, index or Column object)
-         to find maximum.
-       - name: name of new column.
-    Maximum (column:Column|Text|Integer=0) (new_name:Text|Nothing=Nothing)
+       - column: column (specified by name, expression or index) to find the
+         group maximum.
+       - new_name: name of new column.
+    Maximum (column:Text|Integer=0) (new_name:Text|Nothing=Nothing)
 
     ## Creates a new column with the maximum value in each group. If no rows,
        evaluates to `Nothing`.
 
        Arguments:
-       - column: column (specified by name, expression, index or Column object)
-         to find minimum.
-       - name: name of new column.
-    Minimum (column:Column|Text|Integer=0) (new_name:Text|Nothing=Nothing)
+       - column: column (specified by name, expression or index) to find the
+         group minimum.
+       - new_name: name of new column.
+    Minimum (column:Text|Integer=0) (new_name:Text|Nothing=Nothing)
 
     ## Creates a new column with the shortest text in each group. If no rows,
        evaluates to `Nothing`.
 
        Arguments:
-       - column: column (specified by name, expression, index or Column object)
-         to find shortest value.
-       - name: name of new column.
-    Shortest (column:Column|Text|Integer=0) (new_name:Text|Nothing=Nothing)
+       - column: column (specified by name, expression or index) to find the
+         group shortest value.
+       - new_name: name of new column.
+    Shortest (column:Text|Integer=0) (new_name:Text|Nothing=Nothing)
 
     ## Creates a new column with the longest text in each group. If no rows,
        evaluates to `Nothing`.
 
        Arguments:
-       - column: column (specified by name, expression, index or Column object)
-         to find longest value.
-       - name: name of new column.
-    Longest (column:Column|Text|Integer=0) (new_name:Text|Nothing=Nothing)
+       - column: column (specified by name, expression or index) to find the
+         group longest value.
+       - new_name: name of new column.
+    Longest (column:Text|Integer=0) (new_name:Text|Nothing=Nothing)

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column_Selector.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column_Selector.enso
@@ -3,20 +3,12 @@ from Standard.Base import all
 ## Specifies a selection of columns from the table on which an operation is
    going to be performed.
 type Column_Selector
-
     ## Selects columns based on their names.
 
-       The `matcher` can be used to specify if the names should be matched
-       exactly or should be treated as regular expressions. It also allows to
-       specify if the matching should be case-sensitive.
-    By_Name (names : Vector Text) (matcher : Matcher = Text_Matcher.Case_Sensitive)
-
-    ## Selects columns by their index.
-
-       The index of the first column in the table is 0. If the provided index is
-       negative, it counts from the end of the table (e.g. -1 refers to the last
-       column in the table).
-    By_Index (indexes : Vector Integer)
+       It can do regex-based and case insensitive matching if requested.
+       It is possible for it to match multiple columns, in which case all the
+       matched ones will be included in the same relative order as in the table.
+    By_Name name:Text case_sensitivity:Case_Sensitivity=Case_Sensitivity.Insensitive use_regex:Boolean=False
 
     ## ALIAS dropna
        ALIAS drop_missing_columns

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Row.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Row.enso
@@ -13,8 +13,19 @@ type Row
     length self = self.table.columns.length
 
     ## Gets the value of the specified column.
+
+       Arguments:
+       - column: The name or index of the column being looked up.
     at : (Integer | Text) -> Any
     at self column = self.table.at column . at self.index
+
+    ## Gets the value of the specified column.
+
+       Arguments:
+       - column: The name or index of the column being looked up.
+       - if_missing: The value to use if the column isn't present.
+    get : (Integer | Text) -> Any -> Any
+    get self column ~if_missing=Nothing= self.table.at column . get self.index if_missing
 
     ## Gets the row as a Vector.
     to_vector : Vector

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Row.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Row.enso
@@ -25,7 +25,7 @@ type Row
        - column: The name or index of the column being looked up.
        - if_missing: The value to use if the column isn't present.
     get : (Integer | Text) -> Any -> Any
-    get self column ~if_missing=Nothing= self.table.at column . get self.index if_missing
+    get self column ~if_missing=Nothing = self.table.at column . get self.index if_missing
 
     ## Gets the row as a Vector.
     to_vector : Vector

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Row.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Row.enso
@@ -25,7 +25,9 @@ type Row
        - column: The name or index of the column being looked up.
        - if_missing: The value to use if the column isn't present.
     get : (Integer | Text) -> Any -> Any
-    get self column ~if_missing=Nothing = self.table.at column . get self.index if_missing
+    get self column ~if_missing=Nothing =
+        table_column = self.table.get column
+        if table_column.is_nothing then if_missing else table_column.at self.index
 
     ## Gets the row as a Vector.
     to_vector : Vector

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -303,7 +303,7 @@ type Table
        Icon: select_column
     select_columns :  Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Boolean -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
     select_columns self columns=[0] (reorder = False) (error_on_missing_columns = True) (on_problems = Report_Warning) =
-        new_columns = self.columns_helper.select_columns selector=columns reorder=reorder error_on_missing_columns=error_on_missing_columns on_problems=on_problems
+        new_columns = self.columns_helper.select_columns selectors=columns reorder=reorder error_on_missing_columns=error_on_missing_columns on_problems=on_problems
         Table.new new_columns
 
     ## Returns a new table with the chosen set of columns, as specified by the
@@ -356,7 +356,7 @@ type Table
 
     remove_columns :  Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
     remove_columns self (columns=[0]) (error_on_missing_columns = False) (on_problems = Report_Warning) =
-        new_columns = self.columns_helper.remove_columns selector=columns error_on_missing_columns=error_on_missing_columns on_problems=on_problems
+        new_columns = self.columns_helper.remove_columns selectors=columns error_on_missing_columns=error_on_missing_columns on_problems=on_problems
         Table.new new_columns
 
     ## Returns a new table with the specified selection of columns moved to
@@ -412,7 +412,7 @@ type Table
 
     reorder_columns : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Position -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Column_Indexes_Out_Of_Range
     reorder_columns self (columns = [0]) (position = Position.Before_Other_Columns) (error_on_missing_columns = False) (on_problems = Report_Warning) =
-        new_columns = self.columns_helper.reorder_columns selector=columns position=position error_on_missing_columns=error_on_missing_columns on_problems=on_problems
+        new_columns = self.columns_helper.reorder_columns selectors=columns position=position error_on_missing_columns=error_on_missing_columns on_problems=on_problems
         Table.new new_columns
 
     ## Returns a new table with the columns sorted by name according to the
@@ -717,9 +717,9 @@ type Table
          - If floating points values are present in the distinct columns, a
            `Floating_Point_Equality` is reported according to the `on_problems`
            setting.
-    distinct : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | No_Input_Columns_Selected | Floating_Point_Grouping
+    distinct : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | No_Input_Columns_Selected | Floating_Point_Equality
     distinct self (columns = self.column_names) case_sensitivity=Case_Sensitivity.Default error_on_missing_columns=True on_problems=Report_Warning =
-        key_columns = self.columns_helper.select_columns selector=columns reorder=True error_on_missing_columns=error_on_missing_columns on_problems=on_problems . catch No_Output_Columns _->
+        key_columns = self.columns_helper.select_columns selectors=columns reorder=True error_on_missing_columns=error_on_missing_columns on_problems=on_problems . catch No_Output_Columns _->
             Error.throw No_Input_Columns_Selected
         java_columns = key_columns.map .java_column
         text_folding_strategy = Case_Sensitivity.folding_strategy case_sensitivity

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -293,7 +293,7 @@ type Table
        > Example
          Select columns matching a regular expression.
 
-             table.select_columns [Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True]
+             table.select_columns (Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True)
 
        > Example
          Select the first two columns and the last column, moving the last one to front.
@@ -347,7 +347,7 @@ type Table
        > Example
          Remove columns matching a regular expression.
 
-             table.remove_columns [Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True]
+             table.remove_columns (Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True)
 
        > Example
          Remove the first two columns and the last column.
@@ -398,7 +398,7 @@ type Table
        > Example
          Move columns matching a regular expression to front, keeping columns matching "foo.+" before columns matching "b.*".
 
-             table.reorder_columns [Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True]
+             table.reorder_columns (Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True)
 
        > Example
          Swap the first two columns.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -232,7 +232,7 @@ type Table
             _ -> Error.throw (Illegal_Argument.Error "expected 'selector' to be either a Text or an Integer, but got "+(Meta.get_simple_type_name selector)+".")
         if java_column.is_nothing then if_missing else Column.Value java_column
 
-    ## Gets the first column
+    ## Gets the first column.
     first_column : Column ! Index_Out_Of_Bounds
     first_column self = self.at 0
 
@@ -242,7 +242,7 @@ type Table
 
     ## Gets the last column
     last_column : Column ! Index_Out_Of_Bounds
-    last_column self = self.at (self.column_count - 1)
+    last_column self = self.at -1
 
     ## Returns the number of columns in the table.
     column_count : Integer

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -270,7 +270,7 @@ type Table
        > Example
          Select columns by name.
 
-             table.select_columns (Column_Selector.By_Name ["bar", "foo"])
+             table.select_columns ["bar", "foo"]
 
        > Example
          Select columns using names passed as a Vector.
@@ -280,16 +280,16 @@ type Table
        > Example
          Select columns matching a regular expression.
 
-             table.select_columns (Column_Selector.By_Name ["foo.+", "b.*"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Insensitive))
+             table.select_columns [Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True]
 
        > Example
          Select the first two columns and the last column, moving the last one to front.
 
-             table.select_columns (Column_Selector.By_Index [-1, 0, 1]) reorder=True
+             table.select_columns [-1, 0, 1] reorder=True
 
        Icon: select_column
-    select_columns : Vector Text | Column_Selector -> Boolean -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
-    select_columns self (columns = Column_Selector.By_Index [0]) (reorder = False) (error_on_missing_columns = True) (on_problems = Report_Warning) =
+    select_columns :  Vector (Integer | Text | Column_Selector) -> Boolean -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
+    select_columns self columns=[0] (reorder = False) (error_on_missing_columns = True) (on_problems = Report_Warning) =
         new_columns = self.columns_helper.select_columns selector=columns reorder=reorder error_on_missing_columns=error_on_missing_columns on_problems=on_problems
         Table.new new_columns
 
@@ -323,7 +323,7 @@ type Table
        > Example
          Remove columns with given names.
 
-             table.remove_columns (Column_Selector.By_Name ["bar", "foo"])
+             table.remove_columns ["bar", "foo"]
 
        > Example
          Remove columns using names passed as a Vector.
@@ -333,15 +333,15 @@ type Table
        > Example
          Remove columns matching a regular expression.
 
-             table.remove_columns (Column_Selector.By_Name ["foo.+", "b.*"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Insensitive))
+             table.remove_columns [Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True]
 
        > Example
          Remove the first two columns and the last column.
 
-             table.remove_columns (Column_Selector.By_Index [-1, 0, 1])
+             table.remove_columns [-1, 0, 1]
 
-    remove_columns : Vector Text | Column_Selector -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
-    remove_columns self (columns = Column_Selector.By_Index [0]) (error_on_missing_columns = False) (on_problems = Report_Warning) =
+    remove_columns :  Vector (Integer | Text | Column_Selector) -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
+    remove_columns self (columns=[0]) (error_on_missing_columns = False) (on_problems = Report_Warning) =
         new_columns = self.columns_helper.remove_columns selector=columns error_on_missing_columns=error_on_missing_columns on_problems=on_problems
         Table.new new_columns
 
@@ -373,30 +373,30 @@ type Table
        > Example
          Move a column with a specified name to back.
 
-             table.reorder_columns (Column_Selector.By_Name ["foo"]) position=After_Other_Columns
+             table.reorder_columns ["foo"] position=Position.After_Other_Columns
 
        > Example
          Move columns using names passed as a Vector.
 
-             table.reorder_columns ["bar", "foo"] position=After_Other_Columns
+             table.reorder_columns ["bar", "foo"] position=Position.After_Other_Columns
 
        > Example
          Move columns matching a regular expression to front, keeping columns matching "foo.+" before columns matching "b.*".
 
-             table.reorder_columns (Column_Selector.By_Name ["foo.+", "b.*"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Insensitive))
+             table.reorder_columns [Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True]
 
        > Example
          Swap the first two columns.
 
-             table.reorder_columns (Column_Selector.By_Index [1, 0]) position=Before_Other_Columns
+             table.reorder_columns [1, 0] position=Position.Before_Other_Columns
 
        > Example
          Move the first column to back.
 
-             table.reorder_columns (Column_Selector.By_Index [0]) position=After_Other_Columns
+             table.reorder_columns [0] position=Position.After_Other_Columns
 
-    reorder_columns : Vector Text | Column_Selector -> Position -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Column_Indexes_Out_Of_Range
-    reorder_columns self (columns = Column_Selector.By_Index [0]) (position = Position.Before_Other_Columns) (error_on_missing_columns = False) (on_problems = Report_Warning) =
+    reorder_columns : Vector (Integer | Text | Column_Selector) -> Position -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Column_Indexes_Out_Of_Range
+    reorder_columns self (columns = [0]) (position = Position.Before_Other_Columns) (error_on_missing_columns = False) (on_problems = Report_Warning) =
         new_columns = self.columns_helper.reorder_columns selector=columns position=position error_on_missing_columns=error_on_missing_columns on_problems=on_problems
         Table.new new_columns
 
@@ -702,8 +702,8 @@ type Table
          - If floating points values are present in the distinct columns, a
            `Floating_Point_Equality` is reported according to the `on_problems`
            setting.
-    distinct : Vector Text | Column_Selector -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | No_Input_Columns_Selected | Floating_Point_Equality
-    distinct self (columns = Column_Selector.By_Name (self.columns.map .name)) case_sensitivity=Case_Sensitivity.Default error_on_missing_columns=True on_problems=Report_Warning =
+    distinct :  Vector (Integer | Text | Column_Selector) -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | No_Input_Columns_Selected | Floating_Point_Grouping
+    distinct self (columns = self.column_names) case_sensitivity=Case_Sensitivity.Default error_on_missing_columns=True on_problems=Report_Warning =
         key_columns = self.columns_helper.select_columns selector=columns reorder=True error_on_missing_columns=error_on_missing_columns on_problems=on_problems . catch No_Output_Columns _->
             Error.throw No_Input_Columns_Selected
         java_columns = key_columns.map .java_column
@@ -820,21 +820,17 @@ type Table
        > Example
          Remove leading and trailing spaces from cells in multiple columns.
 
-             table.replace_text (Column_Selector.By_Name ["foo", "bar"]) "^\s*(.*?)\s*$" "$1" matcher=Regex_Matcher.Value
+             table.replace_text By_Name ["foo", "bar"] "^\s*(.*?)\s*$" "$1" matcher=Regex_Matcher.Value
 
        > Example
          Replace texts in quotes with parentheses in column at index 1.
 
              table.replace_text 1 '"(.*?)"' '($1)' matcher=Regex_Matcher.Value
-    replace_text : (Text | Integer | Column_Selector) -> Text -> Text -> Matching_Mode.First | Matching_Mode.Last | Regex_Mode -> (Text_Matcher | Regex_Matcher) -> Problem_Behavior -> Table
-    replace_text self columns=(Column_Selector.By_Index [0]) term="" new_text="" mode=Regex_Mode.All matcher=Text_Matcher.Case_Sensitive on_problems=Problem_Behavior.Report_Warning = if term.is_empty then self else
+    replace_text :  Vector (Integer | Text | Column_Selector) -> Text -> Text -> Matching_Mode.First | Matching_Mode.Last | Regex_Mode -> (Text_Matcher | Regex_Matcher) -> Problem_Behavior -> Table
+    replace_text self columns=[0] term="" new_text="" mode=Regex_Mode.All matcher=Text_Matcher.Case_Sensitive on_problems=Problem_Behavior.Report_Warning = if term.is_empty then self else
         problem_builder = Problem_Builder.new
 
-        selector = case columns of
-            _ : Column_Selector -> columns
-            name : Text -> Column_Selector.By_Name [name]
-            index : Integer -> Column_Selector.By_Index [index]
-        selection = self.columns_helper.select_columns_helper selector reorder=False problem_builder
+        selection = self.columns_helper.select_columns_helper columns reorder=False problem_builder
         selected_names = Map.from_vector (selection.map column-> [column.name, True])
 
         map_preserve_name column f = column.map f . rename column.name
@@ -1511,8 +1507,8 @@ type Table
          - If any column names in the new table are clashing, a
            `Duplicate_Output_Column_Names` is reported according to the
            `on_problems` setting.
-    transpose : Text | Vector Text | Column_Selector -> Text -> Text -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range | Duplicate_Output_Column_Names
-    transpose self (id_fields = Column_Selector.By_Name []) (name_field="Name") (value_field="Value") (error_on_missing_columns=True) (on_problems = Report_Warning) =
+    transpose : Text |  Vector (Integer | Text | Column_Selector) -> Text -> Text -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range | Duplicate_Output_Column_Names
+    transpose self (id_fields = []) (name_field="Name") (value_field="Value") (error_on_missing_columns=True) (on_problems = Report_Warning) =
         columns_helper = self.columns_helper
         unique = Unique_Name_Strategy.new
         problem_builder = Problem_Builder.new error_on_missing_columns=error_on_missing_columns
@@ -1566,15 +1562,16 @@ type Table
              an `Unquoted_Delimiter`
            - If there are more than 10 issues with a single column,
              an `Additional_Warnings`.
-    cross_tab : Text | Vector Text | Column_Selector -> (Text | Integer) -> Vector Aggregate_Column -> Problem_Behavior -> Table ! Missing_Input_Columns | Column_Indexes_Out_Of_Range | Invalid_Aggregate_Column | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings
+    cross_tab : Text |  Vector (Integer | Text | Column_Selector) -> (Text | Integer) -> Vector Aggregate_Column -> Problem_Behavior -> Table ! Missing_Input_Columns | Column_Indexes_Out_Of_Range | Invalid_Aggregate_Column | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings
     cross_tab self group_by=[] name_column=self.column_names.first values=Aggregate_Column.Count (on_problems=Report_Warning) =
         columns_helper = self.columns_helper
         problem_builder = Problem_Builder.new error_on_missing_columns=True
 
         ## validate the name and group_by columns
         name_column_selector = case name_column of
-            ix : Integer -> Column_Selector.By_Index [ix]
-            name : Text -> Column_Selector.By_Name [name]
+            ix : Integer -> [ix]
+            name : Text -> [name]
+            _ -> Error.throw (Illegal_Argument.Error "name_column must be a column index or name.")
         matched_name = columns_helper.select_columns_helper name_column_selector True problem_builder
         grouping = columns_helper.select_columns_helper group_by True problem_builder
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1253,7 +1253,7 @@ type Table
          table. This applies only if the order of the rows was specified (for
          example, by sorting the table; in-memory tables will keep the memory
          layout order while for database tables the order may be unspecified).
-    cross_join : Table -> Integer | Nothing -> Table
+    cross_join : Table -> Integer | Nothing -> Text -> Problem_Behavior -> Table
     cross_join self right right_row_limit=100 right_prefix="Right_" on_problems=Report_Warning =
         if check_table "right" right then
             limit_problems = case right_row_limit.is_nothing.not && (right.row_count > right_row_limit) of

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -293,7 +293,7 @@ type Table
        > Example
          Select columns matching a regular expression.
 
-             table.select_columns [Column_Selector.By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True, Column_Selector.By_Name "b.*" Case_Sensitivity.Insensitive use_regex=True]
+             table.select_columns (Column_Selector.By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True)
 
        > Example
          Select the first two columns and the last column, moving the last one to front.
@@ -347,7 +347,7 @@ type Table
        > Example
          Remove columns matching a regular expression.
 
-             table.remove_columns [Column_Selector.By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True, Column_Selector.By_Name "b.*" Case_Sensitivity.Insensitive use_regex=True]
+             table.remove_columns (Column_Selector.By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True)
 
        > Example
          Remove the first two columns and the last column.
@@ -398,7 +398,7 @@ type Table
        > Example
          Move columns matching a regular expression to front, keeping columns matching "foo.+" before columns matching "b.*".
 
-             table.reorder_columns [Column_Selector.By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True, Column_Selector.By_Name "b.*" Case_Sensitivity.Insensitive use_regex=True]
+             table.reorder_columns (Column_Selector.By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True)
 
        > Example
          Swap the first two columns.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -232,6 +232,18 @@ type Table
             _ -> Error.throw (Illegal_Argument.Error "expected 'selector' to be either a Text or an Integer, but got "+(Meta.get_simple_type_name selector)+".")
         if java_column.is_nothing then if_missing else Column.Value java_column
 
+    ## Gets the first column
+    first_column : Column ! Index_Out_Of_Bounds
+    first_column self = self.at 0
+
+    ## Gets the second column
+    second_column : Column ! Index_Out_Of_Bounds
+    second_column self = self.at 1
+
+    ## Gets the last column
+    last_column : Column ! Index_Out_Of_Bounds
+    last_column self = self.at (self.column_count - 1)
+
     ## Returns the number of columns in the table.
     column_count : Integer
     column_count self = self.java_table.getColumns.length

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -293,7 +293,7 @@ type Table
        > Example
          Select columns matching a regular expression.
 
-             table.select_columns (Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True)
+             table.select_columns [Column_Selector.By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True, Column_Selector.By_Name "b.*" Case_Sensitivity.Insensitive use_regex=True]
 
        > Example
          Select the first two columns and the last column, moving the last one to front.
@@ -347,7 +347,7 @@ type Table
        > Example
          Remove columns matching a regular expression.
 
-             table.remove_columns (Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True)
+             table.remove_columns [Column_Selector.By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True, Column_Selector.By_Name "b.*" Case_Sensitivity.Insensitive use_regex=True]
 
        > Example
          Remove the first two columns and the last column.
@@ -398,7 +398,7 @@ type Table
        > Example
          Move columns matching a regular expression to front, keeping columns matching "foo.+" before columns matching "b.*".
 
-             table.reorder_columns (Column_Selector.By_Name ["foo.+", "b.*"] Case_Sensitivity.Insensitive use_regex=True)
+             table.reorder_columns [Column_Selector.By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True, Column_Selector.By_Name "b.*" Case_Sensitivity.Insensitive use_regex=True]
 
        > Example
          Swap the first two columns.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -253,7 +253,8 @@ type Table
        dropped from the output.
 
        Arguments:
-       - columns: Column selection criteria or vector of column names.
+       - columns: Column selection criteria - a single instance or Vector of
+         names, indexes or `Column_Selector`.
        - reorder: By default, or if set to `False`, columns in the output will
          be in the same order as in the input table. If `True`, the order in the
          output table will match the order in the columns list. If a column is
@@ -300,7 +301,7 @@ type Table
              table.select_columns [-1, 0, 1] reorder=True
 
        Icon: select_column
-    select_columns :  Vector (Integer | Text | Column_Selector) -> Boolean -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
+    select_columns :  Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Boolean -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
     select_columns self columns=[0] (reorder = False) (error_on_missing_columns = True) (on_problems = Report_Warning) =
         new_columns = self.columns_helper.select_columns selector=columns reorder=reorder error_on_missing_columns=error_on_missing_columns on_problems=on_problems
         Table.new new_columns
@@ -311,7 +312,8 @@ type Table
        input.
 
        Arguments:
-       - columns: Column selection criteria or vector of column names to remove.
+       - columns: Column selection criteria - a single instance or Vector of
+         names, indexes or `Column_Selector`, which are to be removed.
        - error_on_missing_columns: Specifies if a missing input column should
          result in an error regardless of the `on_problems` settings. Defaults
          to `False`.
@@ -352,7 +354,7 @@ type Table
 
              table.remove_columns [-1, 0, 1]
 
-    remove_columns :  Vector (Integer | Text | Column_Selector) -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
+    remove_columns :  Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range
     remove_columns self (columns=[0]) (error_on_missing_columns = False) (on_problems = Report_Warning) =
         new_columns = self.columns_helper.remove_columns selector=columns error_on_missing_columns=error_on_missing_columns on_problems=on_problems
         Table.new new_columns
@@ -361,8 +363,9 @@ type Table
        either the start or the end in the specified order.
 
        Arguments:
-       - columns: Column selection criteria or vector of column names which
-         should be reordered and specifying their order.
+       - columns: Column selection criteria - a single instance or Vector of
+         names, indexes or `Column_Selector`, which should be reordered and
+         specifying their order.
        - position: Specifies how to place the selected columns in relation to
          the remaining columns which were not matched by `columns` (if any).
        - error_on_missing_columns: Specifies if a missing input column should
@@ -407,7 +410,7 @@ type Table
 
              table.reorder_columns [0] position=Position.After_Other_Columns
 
-    reorder_columns : Vector (Integer | Text | Column_Selector) -> Position -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Column_Indexes_Out_Of_Range
+    reorder_columns : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Position -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Column_Indexes_Out_Of_Range
     reorder_columns self (columns = [0]) (position = Position.Before_Other_Columns) (error_on_missing_columns = False) (on_problems = Report_Warning) =
         new_columns = self.columns_helper.reorder_columns selector=columns position=position error_on_missing_columns=error_on_missing_columns on_problems=on_problems
         Table.new new_columns
@@ -714,7 +717,7 @@ type Table
          - If floating points values are present in the distinct columns, a
            `Floating_Point_Equality` is reported according to the `on_problems`
            setting.
-    distinct :  Vector (Integer | Text | Column_Selector) -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | No_Input_Columns_Selected | Floating_Point_Grouping
+    distinct : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | No_Input_Columns_Selected | Floating_Point_Grouping
     distinct self (columns = self.column_names) case_sensitivity=Case_Sensitivity.Default error_on_missing_columns=True on_problems=Report_Warning =
         key_columns = self.columns_helper.select_columns selector=columns reorder=True error_on_missing_columns=error_on_missing_columns on_problems=on_problems . catch No_Output_Columns _->
             Error.throw No_Input_Columns_Selected
@@ -838,7 +841,7 @@ type Table
          Replace texts in quotes with parentheses in column at index 1.
 
              table.replace_text 1 '"(.*?)"' '($1)' matcher=Regex_Matcher.Value
-    replace_text :  Vector (Integer | Text | Column_Selector) -> Text -> Text -> Matching_Mode.First | Matching_Mode.Last | Regex_Mode -> (Text_Matcher | Regex_Matcher) -> Problem_Behavior -> Table
+    replace_text : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Text -> Text -> Matching_Mode.First | Matching_Mode.Last | Regex_Mode -> (Text_Matcher | Regex_Matcher) -> Problem_Behavior -> Table
     replace_text self columns=[0] term="" new_text="" mode=Regex_Mode.All matcher=Text_Matcher.Case_Sensitive on_problems=Problem_Behavior.Report_Warning = if term.is_empty then self else
         problem_builder = Problem_Builder.new
 
@@ -1519,7 +1522,7 @@ type Table
          - If any column names in the new table are clashing, a
            `Duplicate_Output_Column_Names` is reported according to the
            `on_problems` setting.
-    transpose : Text |  Vector (Integer | Text | Column_Selector) -> Text -> Text -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range | Duplicate_Output_Column_Names
+    transpose : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Text -> Text -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Column_Indexes_Out_Of_Range | Duplicate_Output_Column_Names
     transpose self (id_fields = []) (name_field="Name") (value_field="Value") (error_on_missing_columns=True) (on_problems = Report_Warning) =
         columns_helper = self.columns_helper
         unique = Unique_Name_Strategy.new
@@ -1574,7 +1577,7 @@ type Table
              an `Unquoted_Delimiter`
            - If there are more than 10 issues with a single column,
              an `Additional_Warnings`.
-    cross_tab : Text |  Vector (Integer | Text | Column_Selector) -> (Text | Integer) -> Vector Aggregate_Column -> Problem_Behavior -> Table ! Missing_Input_Columns | Column_Indexes_Out_Of_Range | Invalid_Aggregate_Column | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings
+    cross_tab : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> (Text | Integer) -> Vector Aggregate_Column -> Problem_Behavior -> Table ! Missing_Input_Columns | Column_Indexes_Out_Of_Range | Invalid_Aggregate_Column | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings
     cross_tab self group_by=[] name_column=self.column_names.first values=Aggregate_Column.Count (on_problems=Report_Warning) =
         columns_helper = self.columns_helper
         problem_builder = Problem_Builder.new error_on_missing_columns=True

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Format.enso
@@ -9,7 +9,7 @@ import project.Excel.Excel_Writer
 
 ## PRIVATE
    Resolve the xls_format setting to a boolean.
-should_treat_as_xls_format : (Boolean|Infer) -> File -> Boolean | Illegal_Argument
+should_treat_as_xls_format : (Boolean|Infer) -> File -> Boolean ! Illegal_Argument
 should_treat_as_xls_format xls_format file =
     if xls_format != Infer then xls_format else
         case file.extension of

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Format.enso
@@ -4,6 +4,7 @@ import Standard.Base.Error.Illegal_Argument.Illegal_Argument
 import project.Data.Table.Table
 import project.Data.Match_Columns.Match_Columns
 import project.Excel.Excel_Reader
+import project.Excel.Excel_Workbook.Excel_Workbook
 import project.Excel.Excel_Section.Excel_Section
 import project.Excel.Excel_Writer
 
@@ -19,7 +20,6 @@ should_treat_as_xls_format xls_format file =
             ".xlt" -> True
             _ -> Error.throw (Illegal_Argument.Error ("Unknown file extension for Excel file (" + file.extension + ")"))
 
-
 ## Read the file to a `Table` from an Excel file
 type Excel_Format
     ## Read Excels files into a Table or Vector.
@@ -27,6 +27,7 @@ type Excel_Format
        Arguments:
        - section: The `Excel_Section` to read from the workbook.
          This can be one of:
+         - `Workbook` - open the workbook as a connection.
          - `Sheet_Names` - outputs a `Vector` of sheet names.
          - `Range_Names` - outputs a `Vector` of range names.
          - `Worksheet` - outputs a `Table` containing the specified sheet.
@@ -40,7 +41,7 @@ type Excel_Format
          If set to `True`, the file is read as an Excel 95-2003 format.
          If set to `False`, the file is read as an Excel 2007+ format.
          `Infer` will attempt to deduce this from the extension of the filename.
-    Excel (section:Excel_Section=Excel_Section.Worksheet) (headers:(Boolean|Infer)=Infer) (xls_format:(Boolean|Infer)=Infer)
+    Excel (section:Excel_Section=Excel_Section.Workbook) (headers:(Boolean|Infer)=Infer) (xls_format:(Boolean|Infer)=Infer)
 
     ## If the File_Format supports reading from the file, return a configured instance.
     for_file : File -> Excel_Format | Nothing
@@ -59,7 +60,9 @@ type Excel_Format
     read : File -> Problem_Behavior -> Any
     read self file on_problems =
         format = should_treat_as_xls_format self.xls_format file
-        Excel_Reader.read_file file self.section self.headers on_problems format
+        case self.section of
+            Excel_Section.Workbook -> Excel_Workbook.Value file format self.headers
+            _ -> Excel_Reader.read_file file self.section self.headers on_problems format
 
     ## Implements the `Table.write` for this `File_Format`.
     write_table : File -> Table -> Existing_File_Behavior -> Match_Columns -> Problem_Behavior -> Nothing
@@ -67,6 +70,9 @@ type Excel_Format
         format = should_treat_as_xls_format self.xls_format file
 
         case self.section of
+            Excel_Section.Workbook ->
+                if file.exists then Error.throw (Illegal_Argument.Error "Workbook cannot be used for `write`.") else
+                    self.write_table file (Excel_Workbook.Worksheet "Sheet1") on_existing_file match_columns on_problems
             Excel_Section.Sheet_Names -> Error.throw (Illegal_Argument.Error "Sheet_Names cannot be used for `write`.")
             Excel_Section.Range_Names -> Error.throw (Illegal_Argument.Error "Range_Names cannot be used for `write`.")
             _ -> Excel_Writer.write_file file table on_existing_file self.section self.headers match_columns on_problems format

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Format.enso
@@ -76,7 +76,7 @@ type Excel_Format
                 sheet_name = if file.exists.not then "Sheet1" else
                     names = Excel_Reader.read_file file Excel_Section.Sheet_Names False on_problems format
                     name_map = Map.from_vector (names.map n-> [n, 1])
-                    idx = 1.up_to 256 . find n-> name_map.contains_key ("Sheet" + n.to_text)
+                    idx = 1.up_to 256 . find n-> (name_map.contains_key ("Sheet" + n.to_text) . not)
                     "Sheet" + idx.to_text
                 Excel_Writer.write_file file table on_existing_file (Excel_Section.Worksheet sheet_name) True match_columns on_problems format
             _ -> Excel_Writer.write_file file table on_existing_file self.section self.headers match_columns on_problems format

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Format.enso
@@ -65,6 +65,23 @@ type Excel_Format
             _ -> Excel_Reader.read_file file self.section self.headers on_problems format
 
     ## Implements the `Table.write` for this `File_Format`.
+
+       Depending on the `section` will control where to write.
+       - If `Excel_Section.Workbook` (the default), the `table` will be written
+         to a new sheet in the workbook named `Sheet<n>` where n is the first
+         integer >1 that is not already used as a sheet name. If too many sheets
+         are present an `Illegal_Argument` error will be thrown.
+       - If `Excel_Section.Worksheet`, the `table` will be written to the
+         specified sheet (either adding or replacing).
+       - If `Excel_Section.Cell_Range`, the `table` will be written to the
+         specified range.
+
+        Arguments:
+        - file: The file to write to.
+        - table: The table to write.
+        - on_existing_file: What to do if the file already exists.
+        - match_columns: How to match columns between the table and the file.
+        - on_problems: What to do if there are problems reading the file.
     write_table : File -> Table -> Existing_File_Behavior -> Match_Columns -> Problem_Behavior -> Nothing
     write_table self file table on_existing_file match_columns on_problems =
         format = should_treat_as_xls_format self.xls_format file
@@ -75,8 +92,9 @@ type Excel_Format
             Excel_Section.Workbook ->
                 sheet_name = if file.exists.not then "Sheet1" else
                     names = Excel_Reader.read_file file Excel_Section.Sheet_Names False on_problems format
-                    name_map = Map.from_vector (names.map n-> [n, 1])
-                    idx = 1.up_to 256 . find n-> (name_map.contains_key ("Sheet" + n.to_text) . not)
-                    "Sheet" + idx.to_text
+                    if names.length == 255 then Error.throw (Illegal_Argument.Error "Too many sheets in workbook.") else
+                        name_map = Map.from_vector (names.map n-> [n, 1])
+                        idx = 1.up_to 256 . find n-> (name_map.contains_key ("Sheet" + n.to_text) . not)
+                        "Sheet" + idx.to_text
                 Excel_Writer.write_file file table on_existing_file (Excel_Section.Worksheet sheet_name) True match_columns on_problems format
             _ -> Excel_Writer.write_file file table on_existing_file self.section self.headers match_columns on_problems format

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Format.enso
@@ -70,9 +70,13 @@ type Excel_Format
         format = should_treat_as_xls_format self.xls_format file
 
         case self.section of
-            Excel_Section.Workbook ->
-                if file.exists then Error.throw (Illegal_Argument.Error "Workbook cannot be used for `write`.") else
-                    self.write_table file (Excel_Workbook.Worksheet "Sheet1") on_existing_file match_columns on_problems
             Excel_Section.Sheet_Names -> Error.throw (Illegal_Argument.Error "Sheet_Names cannot be used for `write`.")
             Excel_Section.Range_Names -> Error.throw (Illegal_Argument.Error "Range_Names cannot be used for `write`.")
+            Excel_Section.Workbook ->
+                sheet_name = if file.exists.not then "Sheet1" else
+                    names = Excel_Reader.read_file file Excel_Section.Sheet_Names False on_problems format
+                    name_map = Map.from_vector (names.map n-> [n, 1])
+                    idx = 1.up_to 256 . find n-> name_map.contains_key ("Sheet" + n.to_text)
+                    "Sheet" + idx.to_text
+                Excel_Writer.write_file file table on_existing_file (Excel_Section.Worksheet sheet_name) True match_columns on_problems format
             _ -> Excel_Writer.write_file file table on_existing_file self.section self.headers match_columns on_problems format

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Format.enso
@@ -61,7 +61,7 @@ type Excel_Format
     read self file on_problems =
         format = should_treat_as_xls_format self.xls_format file
         case self.section of
-            Excel_Section.Workbook -> Excel_Workbook.Value file format self.headers
+            Excel_Section.Workbook -> Excel_Workbook.new file format self.headers
             _ -> Excel_Reader.read_file file self.section self.headers on_problems format
 
     ## Implements the `Table.write` for this `File_Format`.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Reader.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Reader.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Error.File_Error.File_Error
+import Standard.Base.Error.Illegal_Argument.Illegal_Argument
 import Standard.Base.System.File.Input_Stream
 
 import project.Data.Table.Table
@@ -64,6 +65,7 @@ handle_reader file reader =
 read_file : File -> Excel_Section -> (Boolean|Infer) -> Problem_Behavior -> Boolean -> (Table | Vector)
 read_file file section headers on_problems xls_format=False =
     reader stream = case section of
+        Excel_Section.Workbook -> Error.throw (Illegal_Argument.Error "Cannot read an entire workbook.")
         Excel_Section.Sheet_Names -> Vector.from_polyglot_array (ExcelReader.readSheetNames stream xls_format)
         Excel_Section.Range_Names -> Vector.from_polyglot_array (ExcelReader.readRangeNames stream xls_format)
         Excel_Section.Worksheet sheet skip_rows row_limit ->

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Section.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Section.enso
@@ -3,6 +3,9 @@ from Standard.Base import all
 import project.Excel.Excel_Range.Excel_Range
 
 type Excel_Section
+    ## Opens the Workbook as a Connection.
+    Workbook
+
     ## Gets a list of sheets within a workbook.
     Sheet_Names
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Workbook.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Workbook.enso
@@ -1,0 +1,96 @@
+from Standard.Base import all
+import Standard.Base.Error.Illegal_Argument.Illegal_Argument
+
+from Standard.Base.Metadata.Widget import Single_Choice
+from Standard.Base.Metadata.Choice import Option
+import Standard.Base.Metadata.Display
+
+import project.Data.Table.Table
+import project.Excel.Excel_Reader
+import project.Excel.Excel_Section.Excel_Section
+
+type Excel_Workbook
+    Value file:File|Text xls_format:Boolean headers:(Boolean|Infer)=Infer
+
+    ## Returns the list of databases (or catalogs) for the connection.
+    databases : Nothing
+    databases self = Nothing
+
+    ## Returns the name of the current database (or catalog).
+    database : Text
+    database self = self.file.normalize.path
+
+    ## Returns a new Connection with the specified database set as default.
+
+       Arguments:
+        - database: The name of the database to connect to.
+    @database (Single_Choice display=Display.Always values=[Option 'Nothing'])
+    set_database : Text -> Excel_Workbook ! Illegal_Argument
+    set_database self database =
+        if database == self.database then self else
+            file = File.new database
+            if file.exists then Excel_Workbook.Value file self.xls_format else
+                Error.throw (Illegal_Argument.Error "The specified file does not exist.")
+
+    ## Returns the list of schemas for the connection within the current database (or catalog).
+    schemas : Vector (Text | Nothing)
+    schemas self = [Nothing]
+
+    ## Returns the name of the current schema.
+    schema : Text | Nothing
+    schema self = Nothing
+
+    ## Returns a new Connection with the specified schema set as default.
+
+       Arguments:
+        - schema: The name of the schema to connect to.
+    @schema (Single_Choice display=Display.Always values=[Option 'Nothing'])
+    set_schema : Text | Nothing -> Excel_Workbook ! Illegal_Argument
+    set_schema self schema =
+        if schema == self.schema then self else
+            Error.throw (Illegal_Argument.Error "Changing schema is not supported.")
+
+    ## Gets a list of the table types
+    table_types : Vector Text
+    table_types self = ['Worksheet', 'Named Range']
+
+    ## Returns a materialised Table of all the matching views and tables.
+
+       Arguments:
+       - name_like: The table name pattern to search for. Support SQL wildcards (`%`, `_`).
+       - database: The database name to search in (default is current database).
+       - schema: The schema name to search in (defaults to current schema).
+       - types: The table types to search for. The list of values can be obtained using the `table_types` method.
+       - all_fields: Return all the fields in the metadata table.
+    @types (self-> Single_Choice values=(self.table_types.map t-> Option t t.pretty))
+    tables : Text -> Text -> Text -> Vector -> Boolean -> Table
+    tables self name_like=Nothing database=self.database schema=self.schema types=Nothing all_fields=False =
+        sheets_raw = Excel_Reader.read_file self.file Excel_Section.Sheet_Names self.headers Report_Warning self.xls_format
+        sheets = sheets_raw.map s-> [s, 'Worksheet', self.database, Nothing]
+
+        range_names_raw = Excel_Reader.read_file self.file Excel_Section.Range_Names self.headers Report_Warning self.xls_format
+        ranges = range_names_raw.map r-> [r, 'Named Range', self.database, Nothing]
+
+        rows = sheets + ranges
+        Table.from_rows ['Name', 'Type', 'Database', 'Schema'] rows
+
+    ## Set up a query returning a Table object, which can be used to work with data within the database or load it into memory.
+
+       Arguments:
+       - query: sheet name, range name or address to read from the workbook.
+       - alias: optionally specify a friendly alias for the query (unused).
+    @query (self-> Single_Choice display=Display.Always values=(self.tables.at "Name" . to_vector . map t-> Option t t.pretty))
+    query : Text -> Text -> Table
+    query self query alias="" =
+        _ = [alias]
+        self.read query
+
+    ## Execute the query and load the results into memory as a Table.
+
+       Arguments:
+       - query: sheet name, range name or address to read from the workbook.
+       - limit: the maximum number of rows to return.
+    @query (self-> Single_Choice display=Display.Always values=(self.tables.at "Name" . to_vector . map t-> Option t t.pretty))
+    read : Text -> Integer | Nothing -> Table
+    read self query limit=Nothing =
+        Excel_Reader.read_file self.file (Excel_Section.Cell_Range query 0 limit) self.headers Report_Warning self.xls_format

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Workbook.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Workbook.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base.Error.File_Error.File_Error
 import Standard.Base.Error.Illegal_Argument.Illegal_Argument
 from Standard.Base.Data.Filter_Condition import sql_like_to_regex
 
@@ -7,11 +8,31 @@ from Standard.Base.Metadata.Choice import Option
 import Standard.Base.Metadata.Display
 
 import project.Data.Table.Table
+import project.Excel.Excel_Range.Excel_Range
 import project.Excel.Excel_Reader
-import project.Excel.Excel_Section.Excel_Section
+
+polyglot java import org.enso.table.read.ExcelReader
+polyglot java import org.apache.poi.ss.usermodel.Workbook
 
 type Excel_Workbook
-    Value file:File|Text xls_format:Boolean headers:(Boolean|Infer)=Infer
+    ## Load a File as an Excel_Workbook.
+
+       Arguments:
+       - file: The file to load.
+       - xls_format: Whether to use the old XLS format (default is XLSX).
+       - headers: Whether to use the first row as headers (default is to infer).
+    new : File | Text -> Boolean -> Boolean | Infer -> Excel_Workbook
+    new file xls_format=False headers=Infer =
+        file_obj = File.new file . normalize
+        File_Error.handle_java_exceptions file_obj <|
+            file_obj.with_input_stream [File_Access.Read] stream->
+                stream.with_java_stream java_stream->
+                    workbook = ExcelReader.readWorkbook java_stream xls_format
+                    Excel_Workbook.Value workbook file_obj xls_format headers
+
+    ## PRIVATE
+       Creates an Excel_Workbook connection.
+    Value workbook:Workbook file:File xls_format:Boolean headers:(Boolean|Infer)
 
     ## Returns the list of databases (or catalogs) for the connection.
     databases : Nothing
@@ -19,7 +40,7 @@ type Excel_Workbook
 
     ## Returns the name of the current database (or catalog).
     database : Text
-    database self = self.file.normalize.path
+    database self = self.file.path
 
     ## Returns a new Connection with the specified database set as default.
 
@@ -30,8 +51,8 @@ type Excel_Workbook
     set_database self database =
         if database == self.database then self else
             file = File.new database
-            if file.exists then Excel_Workbook.Value file self.xls_format else
-                Error.throw (Illegal_Argument.Error "The specified file does not exist.")
+            if file.exists && file.is_directory.not then Excel_Workbook.new file self.xls_format self.headers else
+                Error.throw (Illegal_Argument.Error "The specified file ('"+file.path+"') does not exist.")
 
     ## Returns the list of schemas for the connection within the current database (or catalog).
     schemas : Vector (Text | Nothing)
@@ -51,6 +72,22 @@ type Excel_Workbook
         if schema == self.schema then self else
             Error.throw (Illegal_Argument.Error "Changing schema is not supported.")
 
+    ## Gets the number of sheets
+    sheet_count : Integer
+    sheet_count self = self.workbook.getNumberOfSheets
+
+    ## Gets the names of all the sheets
+    sheet_names : Vector Text
+    sheet_names self = Vector.from_polyglot_array (ExcelReader.readSheetNames self.workbook)
+
+    ## Gets the number of named ranges
+    named_ranges_count : Integer
+    named_ranges_count self = self.workbook.getNumberOfNames
+
+    ## Gets the names of all the named ranges
+    named_ranges : Vector Text
+    named_ranges self = Vector.from_polyglot_array (ExcelReader.readRangeNames self.workbook)
+
     ## Gets a list of the table types
     table_types : Vector Text
     table_types self = ['Worksheet', 'Named Range']
@@ -67,15 +104,9 @@ type Excel_Workbook
     tables : Text -> Text -> Text -> Vector -> Boolean -> Table
     tables self name_like=Nothing database=self.database schema=self.schema types=Nothing all_fields=False =
         _ = [all_fields]
-        rows = if (schema != Nothing) then [] else
-            file = File.new database
-
-            sheets_raw = Excel_Reader.read_file file Excel_Section.Sheet_Names self.headers Report_Warning self.xls_format
-            sheets = if types=Nothing || types.contains "Worksheet" then sheets_raw.map s-> [s, 'Worksheet', database, Nothing] else []
-
-            range_names_raw = Excel_Reader.read_file file Excel_Section.Range_Names self.headers Report_Warning self.xls_format
-            ranges = if types=Nothing || types.contains "Named Range" then range_names_raw.map r-> [r, 'Named Range', database, Nothing] else []
-
+        rows = if schema != Nothing then [] else
+            sheets = if types==Nothing || types.contains "Worksheet" then self.sheet_names.map s-> [s, 'Worksheet', database, Nothing] else []
+            ranges = if types==Nothing || types.contains "Named Range" then self.named_ranges.map r-> [r, 'Named Range', database, Nothing] else []
             sheets + ranges
 
         filtered = if name_like == Nothing then rows else
@@ -103,4 +134,7 @@ type Excel_Workbook
     @query (self-> Single_Choice display=Display.Always values=(self.tables.at "Name" . to_vector . map t-> Option t t.pretty))
     read : Text -> Integer | Nothing -> Table
     read self query limit=Nothing =
-        Excel_Reader.read_file self.file (Excel_Section.Cell_Range query 0 limit) self.headers Report_Warning self.xls_format
+        java_headers = Excel_Reader.make_java_headers self.headers
+        Excel_Reader.prepare_reader_table Report_Warning <| case query of
+            _ : Excel_Range -> ExcelReader.readRange self.workbook query.java_range java_headers 0 limit
+            _ : Text -> ExcelReader.readRangeByName self.workbook query java_headers 0 limit

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Workbook.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Workbook.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Error.Illegal_Argument.Illegal_Argument
+from Standard.Base.Data.Filter_Condition import sql_like_to_regex
 
 from Standard.Base.Metadata.Widget import Single_Choice
 from Standard.Base.Metadata.Choice import Option
@@ -65,14 +66,23 @@ type Excel_Workbook
     @types (self-> Single_Choice values=(self.table_types.map t-> Option t t.pretty))
     tables : Text -> Text -> Text -> Vector -> Boolean -> Table
     tables self name_like=Nothing database=self.database schema=self.schema types=Nothing all_fields=False =
-        sheets_raw = Excel_Reader.read_file self.file Excel_Section.Sheet_Names self.headers Report_Warning self.xls_format
-        sheets = sheets_raw.map s-> [s, 'Worksheet', self.database, Nothing]
+        _ = [all_fields]
+        rows = if (schema != Nothing) then [] else
+            file = File.new database
 
-        range_names_raw = Excel_Reader.read_file self.file Excel_Section.Range_Names self.headers Report_Warning self.xls_format
-        ranges = range_names_raw.map r-> [r, 'Named Range', self.database, Nothing]
+            sheets_raw = Excel_Reader.read_file file Excel_Section.Sheet_Names self.headers Report_Warning self.xls_format
+            sheets = if types=Nothing || types.contains "Worksheet" then sheets_raw.map s-> [s, 'Worksheet', database, Nothing] else []
 
-        rows = sheets + ranges
-        Table.from_rows ['Name', 'Type', 'Database', 'Schema'] rows
+            range_names_raw = Excel_Reader.read_file file Excel_Section.Range_Names self.headers Report_Warning self.xls_format
+            ranges = if types=Nothing || types.contains "Named Range" then range_names_raw.map r-> [r, 'Named Range', database, Nothing] else []
+
+            sheets + ranges
+
+        filtered = if name_like == Nothing then rows else
+            regex = sql_like_to_regex name_like
+            rows.filter r-> regex.matches r.first
+
+        Table.from_rows ['Name', 'Type', 'Database', 'Schema'] filtered
 
     ## Set up a query returning a Table object, which can be used to work with data within the database or load it into memory.
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Workbook.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Workbook.enso
@@ -15,7 +15,7 @@ polyglot java import org.enso.table.read.ExcelReader
 polyglot java import org.apache.poi.ss.usermodel.Workbook
 
 type Excel_Workbook
-    ## Load a File as an Excel_Workbook.
+    ## Load a File as a connection to an Excel workbook.
 
        Arguments:
        - file: The file to load.
@@ -72,23 +72,23 @@ type Excel_Workbook
         if schema == self.schema then self else
             Error.throw (Illegal_Argument.Error "Changing schema is not supported.")
 
-    ## Gets the number of sheets
+    ## Gets the number of sheets.
     sheet_count : Integer
     sheet_count self = self.workbook.getNumberOfSheets
 
-    ## Gets the names of all the sheets
+    ## Gets the names of all the sheets.
     sheet_names : Vector Text
     sheet_names self = Vector.from_polyglot_array (ExcelReader.readSheetNames self.workbook)
 
-    ## Gets the number of named ranges
+    ## Gets the number of named ranges.
     named_ranges_count : Integer
     named_ranges_count self = self.workbook.getNumberOfNames
 
-    ## Gets the names of all the named ranges
+    ## Gets the names of all the named ranges.
     named_ranges : Vector Text
     named_ranges self = Vector.from_polyglot_array (ExcelReader.readRangeNames self.workbook)
 
-    ## Gets a list of the table types
+    ## Gets a list of the table types.
     table_types : Vector Text
     table_types self = ['Worksheet', 'Named Range']
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Aggregate_Column_Helper.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Aggregate_Column_Helper.enso
@@ -142,12 +142,12 @@ resolve_aggregate table problem_builder aggregate_column =
     table_columns = table.columns
     columns_helper = table.columns_helper
 
-    resolve : (Integer|Text|Column) -> Column ! Internal_Missing_Column_Error
+    resolve : (Integer|Text) -> Column ! Internal_Missing_Column_Error
     resolve c =
         res = columns_helper.resolve_column_or_expression c problem_builder
         res.if_nothing (Error.throw Internal_Missing_Column_Error)
 
-    resolve_selector_to_vector : Column_Selector -> [Column] ! Internal_Missing_Column_Error
+    resolve_selector_to_vector : Text | Integer |  Vector (Integer | Text | Column_Selector) -> Vector Column ! Internal_Missing_Column_Error
     resolve_selector_to_vector selector =
         resolved = columns_helper.select_columns_helper selector reorder=True problem_builder
         if resolved.is_empty then Error.throw Internal_Missing_Column_Error else resolved

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Aggregate_Column_Helper.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Aggregate_Column_Helper.enso
@@ -147,7 +147,7 @@ resolve_aggregate table problem_builder aggregate_column =
         res = columns_helper.resolve_column_or_expression c problem_builder
         res.if_nothing (Error.throw Internal_Missing_Column_Error)
 
-    resolve_selector_to_vector : Text | Integer |  Vector (Integer | Text | Column_Selector) -> Vector Column ! Internal_Missing_Column_Error
+    resolve_selector_to_vector : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Vector Column ! Internal_Missing_Column_Error
     resolve_selector_to_vector selector =
         resolved = columns_helper.select_columns_helper selector reorder=True problem_builder
         if resolved.is_empty then Error.throw Internal_Missing_Column_Error else resolved
@@ -164,9 +164,7 @@ resolve_aggregate table problem_builder aggregate_column =
         Group_By c new_name -> Group_By (resolve c) new_name
         Count new_name -> Count new_name
         Count_Distinct c new_name ignore_nothing ->
-            new_c = case c of
-                _ : Column_Selector -> resolve_selector_to_vector c
-                _ -> [resolve c]
+            new_c = resolve_selector_to_vector c
             Count_Distinct new_c new_name ignore_nothing
         Count_Not_Nothing c new_name -> Count_Not_Nothing (resolve c) new_name
         Count_Nothing c new_name -> Count_Nothing (resolve c) new_name

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -150,7 +150,7 @@ type Table_Column_Helper
     select_columns_helper self selectors reorder problem_builder =
         resolve_selector selector = case selector of
             name : Text -> resolve_selector (Column_Selector.By_Name name Case_Sensitivity.Sensitive False)
-            ix : Integer -> if is_index_valid self.internal_columns.length ix then self.internal_columns.at ix else
+            ix : Integer -> if is_index_valid self.internal_columns.length ix then [self.internal_columns.at ix] else
                 problem_builder.report_oob_indices [ix]
                 []
             Column_Selector.By_Name name case_sensitivity use_regex ->
@@ -197,7 +197,7 @@ type Table_Column_Helper
             _ : Vector -> selectors
             _ -> [selectors]
         selected_columns = vector.map resolve_selector . flatten
-        if reorder.not then selected_columns . distinct on=_.name else
+        if reorder.not then selected_columns.distinct on=_.name else
             map = Map.from_vector (selected_columns.map column-> [column.name, True])
             self.internal_columns.filter column-> map.contains_key column.name
 
@@ -398,7 +398,7 @@ select_indices_preserving_order vector indices =
    Checks if the given index is in the valid range for the provided vector.
 is_index_valid : Integer -> Integer -> Boolean
 is_index_valid length ix =
-    ix>=-length && ix<length
+    (ix >= -length) && (ix<length)
 
 ## PRIVATE
    A helper method to match columns by name

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -197,8 +197,8 @@ type Table_Column_Helper
             _ : Vector -> selectors
             _ -> [selectors]
         selected_columns = vector.map resolve_selector . flatten
-        if reorder.not then selected_columns.distinct on=_.name else
-            map = Map.from_vector (selected_columns.map column-> [column.name, True])
+        if reorder then selected_columns.distinct on=_.name else
+            map = Map.from_vector (selected_columns.map column-> [column.name, True]) allow_duplicates=True
             self.internal_columns.filter column-> map.contains_key column.name
 
     ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -158,40 +158,7 @@ type Table_Column_Helper
                 if matches.is_empty then problem_builder.report_missing_input_columns [name]
                 matches
             Column_Selector.Blank_Columns when_any treat_nans_as_blank ->
-                blanks = self.internal_columns.map_with_index ix-> internal_column->
-                    column = self.make_column internal_column
-                    blank_indicator = column.is_blank treat_nans_as_blank
-                    blank_indicator.iif 1 0 . rename "blanks_"+ix.to_text
-
-                ## We cannot just use a custom_column in the aggregate because of
-                   how the column selector works. We may need to revisit this. For
-                   now we need to use tricks like that:
-
-                   To be backend agnostic, we cannot create a new table with the
-                   columns above. Instead, we add our blank columns to the table
-                   and then remove any other columns we. We do not have to deal
-                   with name conflicts, as adding a new column with a clashing
-                   name does not affect the old column or derived columns.
-                table_with_blank_indicators = blanks.fold self.table table-> blanks_col-> table.set blanks_col
-                just_indicators = table_with_blank_indicators.select_columns (blanks.map .name) on_problems=Problem_Behavior.Report_Error
-
-                # Maximum is equivalent to Exists and Minimum is equivalent to Forall.
-                col_aggregate = if when_any then Maximum _ else Minimum _
-                aggregates = blanks.map blanks_col-> col_aggregate blanks_col.name
-
-                aggregate_result = just_indicators.aggregate aggregates on_problems=Problem_Behavior.Report_Error
-                materialized_result = self.materialize <| aggregate_result.catch Any error->
-                    msg = "Unexpected dataflow error has been thrown in an `select_columns_helper`. This is a bug in the Table library. The unexpected error was: "+error.to_display_text
-                    Panic.throw (Illegal_State.Error message=msg cause=error)
-
-                counts = materialized_result.rows.first
-                self.internal_columns.filter_with_index i-> _->
-                    case counts.at i of
-                        ## No rows in input, so treating as blank by convention.
-                        Nothing -> True
-                        1 -> True
-                        0 -> False
-                        _ -> Panic.throw (Illegal_State.Error "Unexpected result. Perhaps an implementation bug of Column_Selector.Blank_Columns.")
+                get_blank_columns when_any treat_nans_as_blank self.internal_columns self.make_column self.table self.materialize
 
         vector = case selectors of
             _ : Vector -> selectors
@@ -485,3 +452,42 @@ unify_result_type_for_union column_set all_tables allow_type_widening problem_bu
                     got_type = first_wrong_column.value_type
                     problem_builder.report_other_warning (Column_Type_Mismatch.Error column_set.name first_type got_type)
                     Nothing
+
+## PRIVATE
+   A helper method that gets the columns from the provided table that are
+   complete blank or have some blanks.
+get_blank_columns when_any treat_nans_as_blank internal_columns make_column table materialize =
+    blanks = internal_columns.map_with_index ix-> internal_column->
+        column = make_column internal_column
+        blank_indicator = column.is_blank treat_nans_as_blank
+        blank_indicator.iif 1 0 . rename "blanks_"+ix.to_text
+
+    ## We cannot just use a custom_column in the aggregate because of
+       how the column selector works. We may need to revisit this. For
+       now we need to use tricks like that:
+
+       To be backend agnostic, we cannot create a new table with the
+       columns above. Instead, we add our blank columns to the table
+       and then remove any other columns we. We do not have to deal
+       with name conflicts, as adding a new column with a clashing
+       name does not affect the old column or derived columns.
+    table_with_blank_indicators = blanks.fold table table-> blanks_col-> table.set blanks_col
+    just_indicators = table_with_blank_indicators.select_columns (blanks.map .name) on_problems=Problem_Behavior.Report_Error
+
+    # Maximum is equivalent to Exists and Minimum is equivalent to Forall.
+    col_aggregate = if when_any then Maximum _ else Minimum _
+    aggregates = blanks.map blanks_col-> col_aggregate blanks_col.name
+
+    aggregate_result = just_indicators.aggregate aggregates on_problems=Problem_Behavior.Report_Error
+    materialized_result = materialize <| aggregate_result.catch Any error->
+        msg = "Unexpected dataflow error has been thrown in an `select_columns_helper`. This is a bug in the Table library. The unexpected error was: "+error.to_display_text
+        Panic.throw (Illegal_State.Error message=msg cause=error)
+
+    counts = materialized_result.rows.first
+    internal_columns.filter_with_index i-> _->
+        case counts.at i of
+            ## No rows in input, so treating as blank by convention.
+            Nothing -> True
+            1 -> True
+            0 -> False
+            _ -> Panic.throw (Illegal_State.Error "Unexpected result. Perhaps an implementation bug of Column_Selector.Blank_Columns.")

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -143,22 +143,27 @@ type Table_Column_Helper
          criterion on the list. If a single criterion's group has more than one
          element, their relative order is the same as in the input.
        - problem_builder: Encapsulates the aggregation of encountered problems.
-    select_columns_helper : Text | Vector | Column_Selector -> Boolean -> Problem_Builder -> Vector
+    select_columns_helper : Text | Integer |  Vector (Integer | Text | Column_Selector) -> Boolean -> Problem_Builder -> Vector
     select_columns_helper self selector reorder problem_builder = case selector of
-        _ : Text ->
-            self.select_columns_helper (Column_Selector.By_Name [selector]) reorder problem_builder
+        _ : Text -> self.select_columns_helper [selector] reorder problem_builder
+        _ : Integer -> self.select_columns_helper [selector] reorder problem_builder
         _ : Vector ->
-            self.select_columns_helper (Column_Selector.By_Name selector) reorder problem_builder
-        Column_Selector.By_Name names matcher ->
-            valid_names = validate_unique names (_->Nothing)
-            Matching.match_criteria_callback matcher self.internal_columns valid_names reorder=reorder name_mapper=(_.name) problem_callback=problem_builder.report_missing_input_columns
-        Column_Selector.By_Index indices ->
+
+            unique_names = validate_unique (selector.filter t-> t.is_a Text) _->Nothing
+
+
+
             good_indices = validate_indices self.internal_columns.length indices problem_builder . map .first
             case reorder of
                 True ->
                     select_indices_reordering self.internal_columns good_indices
                 False ->
                     select_indices_preserving_order self.internal_columns good_indices
+
+            self.select_columns_helper (Column_Selector.By_Name selector) reorder problem_builder
+        Column_Selector.By_Name names case_sensitivity use_regex ->
+            valid_names = validate_unique names (_->Nothing)
+            Matching.match_criteria_callback matcher self.internal_columns valid_names reorder=reorder name_mapper=(_.name) problem_callback=problem_builder.report_missing_input_columns
         Column_Selector.Blank_Columns when_any treat_nans_as_blank -> if self.internal_columns.is_empty then [] else
             blanks = self.internal_columns.map_with_index ix-> internal_column->
                 column = self.make_column internal_column
@@ -209,7 +214,7 @@ type Table_Column_Helper
 
        It may allow selection of columns by index, name or computing a derived
        expression.
-    resolve_column_or_expression : (Integer | Text | Column) -> Problem_Builder -> Any | Nothing
+    resolve_column_or_expression : (Integer | Text) -> Problem_Builder -> Any | Nothing
     resolve_column_or_expression self selector problem_builder = case selector of
         _ : Text ->
             matched_columns = self.internal_columns.filter column->(column.name==selector)
@@ -224,9 +229,6 @@ type Table_Column_Helper
             False ->
                 problem_builder.report_oob_indices [selector]
                 Nothing
-        ## A wildcard to match any backend's column.
-        _ ->
-            self.resolve_column_or_expression selector.name problem_builder=problem_builder
 
 ## PRIVATE
    A helper function encapsulating shared code for `rename_columns`

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -132,7 +132,8 @@ type Table_Column_Helper
        provided selection criteria.
 
        Arguments:
-       - selector: Column selection criteria or vector of column names.
+       - selectors: Vector of names, indexes of `Column_Selector`s or a single
+         instance.
        - reorder: Specifies whether to reorder the matched columns according to
          the order of the selection criteria.
          If `False`, the matched entries are returned in the same order as in
@@ -143,71 +144,60 @@ type Table_Column_Helper
          criterion on the list. If a single criterion's group has more than one
          element, their relative order is the same as in the input.
        - problem_builder: Encapsulates the aggregation of encountered problems.
-    select_columns_helper : Text | Integer |  Vector (Integer | Text | Column_Selector) -> Boolean -> Problem_Builder -> Vector
-    select_columns_helper self selector reorder problem_builder = case selector of
-        _ : Text -> self.select_columns_helper [selector] reorder problem_builder
-        _ : Integer -> self.select_columns_helper [selector] reorder problem_builder
-        _ : Vector ->
+    select_columns_helper : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Boolean -> Problem_Builder -> Vector
+    select_columns_helper self selectors reorder problem_builder =
+        resolve_selector selector = case selector of
+            name : Text -> resolve_selector (Column_Selector.By_Name name Case_Sensitivity.Sensitive False)
+            ix : Integer -> if is_index_valid self.internal_columns.length ix then self.internal_columns.at ix else
+                problem_builder.report_oob_indices [ix]
+                []
+            Column_Selector.By_Name name case_sensitivity use_regex ->
+                matches = match_columns name case_sensitivity use_regex self.internal_columns
+                if matches.is_empty then problem_builder.report_missing_input_columns [name]
+                matches
+            Column_Selector.Blank_Columns when_any treat_nans_as_blank ->
+                blanks = self.internal_columns.map_with_index ix-> internal_column->
+                    column = self.make_column internal_column
+                    blank_indicator = column.is_blank treat_nans_as_blank
+                    blank_indicator.iif 1 0 . rename "blanks_"+ix.to_text
 
-            unique_names = validate_unique (selector.filter t-> t.is_a Text) _->Nothing
+                ## We cannot just use a custom_column in the aggregate because of
+                   how the column selector works. We may need to revisit this. For
+                   now we need to use tricks like that:
 
+                   To be backend agnostic, we cannot create a new table with the
+                   columns above. Instead, we add our blank columns to the table
+                   and then remove any other columns we. We do not have to deal
+                   with name conflicts, as adding a new column with a clashing
+                   name does not affect the old column or derived columns.
+                table_with_blank_indicators = blanks.fold self.table table-> blanks_col-> table.set blanks_col
+                just_indicators = table_with_blank_indicators.select_columns (blanks.map .name) on_problems=Problem_Behavior.Report_Error
 
+                # Maximum is equivalent to Exists and Minimum is equivalent to Forall.
+                col_aggregate = if when_any then Maximum _ else Minimum _
+                aggregates = blanks.map blanks_col-> col_aggregate blanks_col.name
 
-            good_indices = validate_indices self.internal_columns.length indices problem_builder . map .first
-            case reorder of
-                True ->
-                    select_indices_reordering self.internal_columns good_indices
-                False ->
-                    select_indices_preserving_order self.internal_columns good_indices
+                aggregate_result = just_indicators.aggregate aggregates on_problems=Problem_Behavior.Report_Error
+                materialized_result = self.materialize <| aggregate_result.catch Any error->
+                    msg = "Unexpected dataflow error has been thrown in an `select_columns_helper`. This is a bug in the Table library. The unexpected error was: "+error.to_display_text
+                    Panic.throw (Illegal_State.Error message=msg cause=error)
 
-            self.select_columns_helper (Column_Selector.By_Name selector) reorder problem_builder
-        Column_Selector.By_Name names case_sensitivity use_regex ->
-            valid_names = validate_unique names (_->Nothing)
-            Matching.match_criteria_callback matcher self.internal_columns valid_names reorder=reorder name_mapper=(_.name) problem_callback=problem_builder.report_missing_input_columns
-        Column_Selector.Blank_Columns when_any treat_nans_as_blank -> if self.internal_columns.is_empty then [] else
-            blanks = self.internal_columns.map_with_index ix-> internal_column->
-                column = self.make_column internal_column
-                blank_indicator = column.is_blank treat_nans_as_blank
-                blank_indicator.iif 1 0 . rename "blanks_"+ix.to_text
-            ## We cannot just use a custom_column in the aggregate because of
-               how the column selector works. We may need to revisit this. For
-               now we need to use tricks like that:
+                counts = materialized_result.rows.first
+                self.internal_columns.filter_with_index i-> _->
+                    case counts.at i of
+                        ## No rows in input, so treating as blank by convention.
+                        Nothing -> True
+                        1 -> True
+                        0 -> False
+                        _ -> Panic.throw (Illegal_State.Error "Unexpected result. Perhaps an implementation bug of Column_Selector.Blank_Columns.")
 
-               To be backend agnostic, we cannot create a new table with the
-               columns above just out of thin air (actually we may want to allow
-               this in the future if all columns come from the same context, but
-               currently it's not possible). Instead, we add our blank columns
-               to the current table and then remove any other columns we are not
-               interested in. Note that we do not have to care about potential
-               name conflicts, as we are dropping any other columns anyway, and
-               adding a new column with a clashing name will not affect any
-               other columns computed from the old column with that name.
-            table_with_blank_indicators = blanks.fold self.table table-> blanks_col->
-                table.set blanks_col
-            just_indicators = table_with_blank_indicators.select_columns (blanks.map .name) on_problems=Problem_Behavior.Report_Error
-            # Maximum is equivalent to Exists and Minimum is equivalent to Forall.
-            col_aggregate = if when_any then Maximum _ else Minimum _
-            aggregates = blanks.map blanks_col-> col_aggregate blanks_col.name
-
-            aggregate_result = just_indicators.aggregate aggregates on_problems=Problem_Behavior.Report_Error
-            materialized_result = self.materialize <| aggregate_result.catch Any error->
-                msg = "Unexpected dataflow error has been thrown in an `select_columns_helper`. This is a bug in the Table library. The unexpected error was: "+error.to_display_text
-                Panic.throw (Illegal_State.Error message=msg cause=error)
-
-            counts = materialized_result.rows.first
-
-            ## The `reorder` argument has no meaning for Blank_Columns selector
-               - either way all blank columns are selected in the order that
-               they are in the Table.
-            self.internal_columns.filter_with_index i-> _->
-                case counts.at i of
-                    ## Nothing is returned if there were no rows, in that case
-                       we treat the column as blank by convention, regardless of
-                       `when_any`.
-                    Nothing -> True
-                    1 -> True
-                    0 -> False
-                    _ -> Panic.throw (Illegal_State.Error "Unexpected result. Perhaps an implementation bug of Column_Selector.Blank_Columns.")
+        vector = case selectors of
+            _ : Vector -> selectors
+            _ -> [selectors]
+        selected_columns = vector.map resolve_selector . flatten
+        if reorder.not then selected_columns . distinct on=_.name else
+            map = Map.from_vector (selected_columns.map column-> [column.name, True])
+            self.internal_columns.filter column-> map.contains_key column.name
 
     ## PRIVATE
        A helper function which selects a single column from the table.
@@ -292,7 +282,7 @@ rename_columns internal_columns mapping error_on_missing_columns on_problems =
 
             index_mapping = inbound_selectors.fold Map.empty acc-> selector->
                 ix = selector.first
-                resolved_ix = resolve_index col_count ix
+                resolved_ix = if ix < 0 then ix + col_count else ix
 
                 matches = acc.get resolved_ix []
                 acc.insert resolved_ix matches+[selector]
@@ -403,67 +393,21 @@ select_indices_preserving_order vector indices =
         indices_to_keep.get ix False
 
 ## PRIVATE
-   Returns the actual position in the array that the index points to.
-
-   It resolves negative indices to regular indices.
-
-   If the negative index is sufficiently large, a negative result can still be
-   returned. This function does not ensure that the resulting indices are within
-   bounds.
-resolve_index : Integer -> Integer -> Integer
-resolve_index length ix =
-    if ix < 0 then length+ix else ix
-
-## PRIVATE
    Checks if the given index is in the valid range for the provided vector.
 is_index_valid : Integer -> Integer -> Boolean
 is_index_valid length ix =
-    actual_ix = resolve_index length ix
-    actual_ix>=0 && actual_ix<length
+    ix>=-length && ix<length
 
 ## PRIVATE
-   Validates a Vector of indices returning `good_indices` and reporting any
-   encountered problems.
-
-   Arguments:
-   - length:
-   - indices:
-   - problem_builder:
-   - on: a mapping from a possibly complex index selector into an integer index
-     associated with it. Used if the selector contains additional metadata. The
-     default one is an identity mapping for when the selector is just an
-     integer.
-validate_indices : Integer -> Vector -> Problem_Builder -> (Any -> Integer) -> Vector
-validate_indices length indices problem_builder on=(x->x) =
-    partitioned_indices = indices.partition (is_index_valid length << on)
-    inbound_indices = partitioned_indices.first
-    oob_indices = partitioned_indices.second
-    problem_builder.report_oob_indices (oob_indices.map on)
-
-    uniques = validate_unique inbound_indices (_->Nothing) on=on
-
-    resolver = ix->(resolve_index length (on ix))
-    alias_uniques = validate_unique uniques (_->Nothing) on=resolver
-    good_indices = alias_uniques.map i->[resolver i, i]
-    good_indices
-
-## PRIVATE
-   Splits a vector into elements which are distinct and the duplicates.
-   Duplicates are wrapped as an error
-validate_unique : Vector -> (Vector -> Vector) -> (Any -> Any) -> Vector
-validate_unique vector problem_callback on=(x->x) =
-    acc = vector.fold [Map.empty, Vector.new_builder, Vector.new_builder] acc-> item->
-        existing = acc.at 0
-        key = on item
-        already_present = existing.get key False
-        case already_present of
-            True -> [existing, acc.at 1, acc.at 2 . append item]
-            False -> [existing.insert key True, acc.at 1 . append item, acc.at 2]
-
-    duplicates = acc.at 2 . to_vector
-    if duplicates.not_empty then problem_callback duplicates
-
-    acc.at 1 . to_vector
+   A helper method to match columns by name
+match_columns : Text -> Case_Sensitivity -> Boolean -> Vector -> Vector
+match_columns name case_sensitivity use_regex columns =
+    matcher = if use_regex then Regex_Matcher.Value case_sensitivity=case_sensitivity else
+        case case_sensitivity of
+            Case_Sensitivity.Default -> Text_Matcher.Case_Sensitive
+            Case_Sensitivity.Sensitive -> Text_Matcher.Case_Sensitive
+            Case_Sensitivity.Insensitive locale -> Text_Matcher.Case_Insensitive locale=locale
+    columns.filter c-> matcher.match_single_criterion c.name name
 
 ## PRIVATE
    A helper type used by transform helpers.
@@ -479,26 +423,13 @@ prepare_order_by internal_columns column_selectors problem_builder =
         Sort_Column.Name name direction ->
             resolve_selector (Sort_Column.Select_By_Name name direction Case_Sensitivity.Sensitive use_regex=False)
         Sort_Column.Index ix _ ->
-            actual_index = if ix < 0 then internal_columns.length+ix else ix
-            case (actual_index >= 0) && (actual_index < internal_columns.length) of
-                True -> [Column_Transform_Element.Value (internal_columns.at actual_index) selector]
-                False ->
-                    problem_builder.report_oob_indices [ix]
-                    []
+            if is_index_valid internal_columns.length ix then [Column_Transform_Element.Value (internal_columns.at ix) selector] else
+                problem_builder.report_oob_indices [ix]
+                []
         Sort_Column.Select_By_Name name _ case_sensitivity use_regex ->
-            matcher = case use_regex of
-                True -> Regex_Matcher.Value case_sensitivity=case_sensitivity
-                False -> case case_sensitivity of
-                    Case_Sensitivity.Default -> Text_Matcher.Case_Sensitive
-                    Case_Sensitivity.Sensitive -> Text_Matcher.Case_Sensitive
-                    Case_Sensitivity.Insensitive locale ->
-                        Text_Matcher.Case_Insensitive locale=locale
-            matches = internal_columns.filter c->
-                matcher.match_single_criterion c.name name
-            if matches.is_empty then
-                problem_builder.report_missing_input_columns [name]
-            matches.map c->
-                Column_Transform_Element.Value c selector
+            matches = match_columns name case_sensitivity use_regex internal_columns
+            if matches.is_empty then problem_builder.report_missing_input_columns [name]
+            matches.map c-> Column_Transform_Element.Value c selector
     selectors_vec = case column_selectors of
         _ : Vector -> column_selectors
         _ -> [column_selectors]
@@ -506,95 +437,6 @@ prepare_order_by internal_columns column_selectors problem_builder =
     if selected_elements.is_empty then
         problem_builder.report_other_warning No_Input_Columns_Selected
     selected_elements
-
-## PRIVATE
-   A helper function which can be used by methods that select a subset of
-   columns and need to keep some metadata coming from the selector associated
-   with each column.
-
-   The returned columns are in the same order as the original selectors that
-   matched them. A single selector may match multiple columns - in such case
-   these columns are all placed in the place belonging to that selector and they
-   keep their relative order from the table. If a column is matched by multiple
-   selectors, it only appears once in the result - in the place associated with
-   the first selector that matched it. Currently, the function does not warn
-   about such duplicated matches.
-
-   Arguments:
-   - internal_columns: A list of all columns in a table.
-   - name_selectors: A vector of selectors which contain a column name and
-     optionally some metadata.
-   - matcher: Specifies the strategy of matching names.
-   - problem_builder: Encapsulates the aggregation of encountered problems.
-   - name_extractor: A function which extracts the column name from the selector.
-select_columns_by_name : Vector -> Vector -> Text_Matcher -> Problem_Builder -> (Any -> Text) -> Boolean -> Vector
-select_columns_by_name internal_columns name_selectors matcher problem_builder name_extractor =
-    case Matching.make_match_matrix matcher objects=internal_columns criteria=name_selectors object_name_mapper=(_.name) criterion_mapper=name_extractor of
-        ## We do the pattern match to ensure that any dataflow errors in
-           `match_matrix` are correctly propagated. Without it, due to the
-           imperative Vector Builder and `each` method, the dataflow errors
-           would get swallowed.
-        match_matrix ->
-            problem_builder.report_missing_input_columns match_matrix.unmatched_criteria
-            results = Vector.new_builder
-            internal_columns.each_with_index i-> column->
-                matching_selector_indices = match_matrix.criteria_indices_matching_object i
-                if matching_selector_indices.not_empty then
-                    associated_selector_index = matching_selector_indices.first
-                    associated_selector = name_selectors.at associated_selector_index
-                    element = Column_Transform_Element.Value column associated_selector
-                    results.append (Pair.new element [associated_selector_index, i])
-            # We sort the results by the associated selector index, breaking ties by the column index.
-            sorted = results.to_vector.sort on=(_.second) by=Vector_Lexicographic_Order.compare
-            sorted.map .first
-
-## PRIVATE
-   A helper function which can be used by methods that select a subset of
-   columns and need to keep some metadata coming from the selector associated
-   with each column.
-
-   The returned columns are in the same order as the original selectors that
-   matched them. A single selector may match multiple columns - in such case
-   these columns are all placed in the place belonging to that selector and they
-   keep their relative order from the table. If a column is matched by multiple
-   selectors a warning is raised and it only appears once in the result - in the
-   place associated with the first selector that matched it.
-
-   Arguments:
-   - internal_columns: A list of all columns in a table.
-   - index_selectors: A vector of selectors which contain a column index and
-     optionally some metadata.
-   - problem_builder: Encapsulates the aggregation of encountered problems.
-select_columns_by_index : Vector -> Vector -> Problem_Builder -> (Any -> Integer) -> Vector
-select_columns_by_index internal_columns index_selectors problem_builder index_extractor =
-    good_selectors = validate_indices internal_columns.length index_selectors problem_builder index_extractor
-    good_selectors.map pair->
-        Column_Transform_Element.Value (internal_columns.at pair.first) pair.second
-
-## PRIVATE
-   A helper function which can be used by methods that select a subset of
-   columns and need to keep some metadata coming from the selector associated
-   with each column.
-
-   The returned columns are in the same order as the original selectors that
-   matched them. A single selector may match multiple columns - in such case
-   these columns are all placed in the place belonging to that selector and they
-   keep their relative order from the table. If a column is matched by multiple
-   selectors a warning is raised and it only appears once in the result - in the
-   place associated with the first selector that matched it.
-
-   Arguments:
-   - internal_columns: A list of all columns in a table.
-   - column_selectors: A vector of column selectors which contain a column whose
-     name should be used as a reference to select the corresponding column in
-     the given table. The selectors may also optionally contain some metadata.
-   - problem_builder: Encapsulates the aggregation of encountered problems.
-select_columns_by_column_reference : Vector -> Vector -> Problem_Builder -> (Any -> Integer) -> Vector
-select_columns_by_column_reference internal_columns column_selectors problem_builder column_extractor =
-    name_extractor = selector->
-        column = column_extractor selector
-        column.name
-    select_columns_by_name internal_columns column_selectors Text_Matcher.Case_Sensitive problem_builder name_extractor
 
 ## PRIVATE
    A helper method gathering the common logic for constructing expressions that

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -42,7 +42,8 @@ type Table_Column_Helper
        resulting list of columns.
 
        Arguments:
-       - selector: Column selection criteria or vector of column names.
+       - selectors: Single instance or a Vector of names, indexes or
+         `Column_Selector`s.
        - reorder: Specifies whether to reorder the matched columns according to
          the order of the selection criteria.
          If `False`, the matched entries are returned in the same order as in
@@ -58,10 +59,10 @@ type Table_Column_Helper
          operation. By default, a warning is issued, but the operation proceeds.
          If set to `Report_Error`, the operation fails with a dataflow error.
          If set to `Ignore`, the operation proceeds without errors or warnings.
-    select_columns : Vector | Column_Selector -> Boolean -> Boolean -> Problem_Behavior -> Vector
-    select_columns self selector reorder error_on_missing_columns on_problems =
+    select_columns : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Boolean -> Boolean -> Problem_Behavior -> Vector
+    select_columns self selectors reorder error_on_missing_columns on_problems =
         problem_builder = Problem_Builder.new error_on_missing_columns=error_on_missing_columns
-        result = self.select_columns_helper selector reorder problem_builder
+        result = self.select_columns_helper selectors reorder problem_builder
         problem_builder.attach_problems_before on_problems <|
             if result.is_empty then Error.throw No_Output_Columns else result
 
@@ -75,17 +76,18 @@ type Table_Column_Helper
        of columns.
 
        Arguments:
-       - selector: Column selection criteria or vector of column names.
+       - selectors: Single instance or a Vector of names, indexes or
+         `Column_Selector`s.
        - error_on_missing_columns: Specifies if missing columns should be raised
          as error regardless of `on_problems`.
        - on_problems: Specifies the behavior when a problem occurs during the
          operation. By default, a warning is issued, but the operation proceeds.
          If set to `Report_Error`, the operation fails with a dataflow error.
          If set to `Ignore`, the operation proceeds without errors or warnings.
-    remove_columns : Vector | Column_Selector -> Boolean -> Problem_Behavior -> Vector
-    remove_columns self selector error_on_missing_columns on_problems =
+    remove_columns : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Boolean -> Problem_Behavior -> Vector
+    remove_columns self selectors error_on_missing_columns on_problems =
         problem_builder = Problem_Builder.new error_on_missing_columns=error_on_missing_columns
-        selection = self.select_columns_helper selector reorder=False problem_builder
+        selection = self.select_columns_helper selectors reorder=False problem_builder
         selected_names = Map.from_vector (selection.map column-> [column.name, True])
         result = self.internal_columns.filter column->
             should_be_removed = selected_names.get column.name False
@@ -103,8 +105,8 @@ type Table_Column_Helper
        of columns.
 
        Arguments:
-       - selector: A selector specifying which columns should be moved and the
-         order in which they should appear in the result.
+       - selectors: Single instance or a Vector of names, indexes or
+         `Column_Selector`s.
        - position: Specifies how to place the selected columns in relation to
          the columns which were not matched by the `selector` (if any).
        - error_on_missing_columns: Specifies if missing columns should be raised
@@ -113,10 +115,10 @@ type Table_Column_Helper
          operation. By default, a warning is issued, but the operation proceeds.
          If set to `Report_Error`, the operation fails with a dataflow error.
          If set to `Ignore`, the operation proceeds without errors or warnings.
-    reorder_columns : Vector | Column_Selector -> Position -> Boolean -> Problem_Behavior -> Vector
-    reorder_columns self selector position error_on_missing_columns on_problems =
+    reorder_columns : Text | Integer | Column_Selector | Vector (Integer | Text | Column_Selector) -> Position -> Boolean -> Problem_Behavior -> Vector
+    reorder_columns self selectors position error_on_missing_columns on_problems =
         problem_builder = Problem_Builder.new error_on_missing_columns=error_on_missing_columns
-        selection = self.select_columns_helper selector reorder=True problem_builder
+        selection = self.select_columns_helper selectors reorder=True problem_builder
         problem_builder.attach_problems_before on_problems <|
             selected_names = Map.from_vector (selection.map column-> [column.name, True])
             other_columns = self.internal_columns.filter column->
@@ -132,8 +134,8 @@ type Table_Column_Helper
        provided selection criteria.
 
        Arguments:
-       - selectors: Vector of names, indexes of `Column_Selector`s or a single
-         instance.
+       - selectors: Single instance or a Vector of names, indexes or
+         `Column_Selector`s.
        - reorder: Specifies whether to reorder the matched columns according to
          the order of the selection criteria.
          If `False`, the matched entries are returned in the same order as in

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
@@ -21,6 +21,7 @@ import project.Delimited.Quote_Style.Quote_Style
 import project.Excel.Excel_Format.Excel_Format
 import project.Excel.Excel_Range.Excel_Range
 import project.Excel.Excel_Section.Excel_Section
+import project.Excel.Excel_Workbook.Excel_Workbook
 
 export project.Data.Aggregate_Column.Aggregate_Column
 export project.Data.Column.Column
@@ -43,6 +44,7 @@ export project.Delimited.Quote_Style.Quote_Style
 export project.Excel.Excel_Format.Excel_Format
 export project.Excel.Excel_Range.Excel_Range
 export project.Excel.Excel_Section.Excel_Section
+export project.Excel.Excel_Workbook.Excel_Workbook
 
 from project.Delimited.Delimited_Format.Delimited_Format import Delimited
 from project.Excel.Excel_Format.Excel_Format import Excel

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -5,8 +5,6 @@ import Standard.Table.Data.Column.Column as Dataframe_Column
 import Standard.Database.Data.Table.Table as Database_Table
 import Standard.Database.Data.Column.Column as Database_Column
 
-import Standard.Table.Data.Column_Selector.Column_Selector
-
 import project.Helpers
 
 # TODO add an initial offset to fully support lazy visualizations

--- a/std-bits/database/src/main/java/org/enso/database/SQLiteFormatSPI.java
+++ b/std-bits/database/src/main/java/org/enso/database/SQLiteFormatSPI.java
@@ -1,0 +1,16 @@
+package org.enso.database;
+
+import org.enso.base.file_format.FileFormatSPI;
+
+@org.openide.util.lookup.ServiceProvider(service = FileFormatSPI.class)
+public class SQLiteFormatSPI extends FileFormatSPI {
+    @Override
+    protected String getModuleName() {
+        return "Standard.Database.Connection.SQLite_Format";
+    }
+
+    @Override
+    protected String getTypeName() {
+        return "SQLite_Format";
+    }
+}

--- a/std-bits/database/src/main/java/org/enso/database/SQLiteFormatSPI.java
+++ b/std-bits/database/src/main/java/org/enso/database/SQLiteFormatSPI.java
@@ -4,13 +4,13 @@ import org.enso.base.file_format.FileFormatSPI;
 
 @org.openide.util.lookup.ServiceProvider(service = FileFormatSPI.class)
 public class SQLiteFormatSPI extends FileFormatSPI {
-    @Override
-    protected String getModuleName() {
-        return "Standard.Database.Connection.SQLite_Format";
-    }
+  @Override
+  protected String getModuleName() {
+    return "Standard.Database.Connection.SQLite_Format";
+  }
 
-    @Override
-    protected String getTypeName() {
-        return "SQLite_Format";
-    }
+  @Override
+  protected String getTypeName() {
+    return "SQLite_Format";
+  }
 }

--- a/std-bits/image/src/main/java/org/enso/image/ImageFormatSPI.java
+++ b/std-bits/image/src/main/java/org/enso/image/ImageFormatSPI.java
@@ -1,0 +1,17 @@
+package org.enso.image;
+
+import org.enso.base.file_format.FileFormatSPI;
+
+@org.openide.util.lookup.ServiceProvider(service = FileFormatSPI.class)
+
+public class ImageFormatSPI extends FileFormatSPI {
+    @Override
+    protected String getModuleName() {
+        return "Standard.Image.Image_File_Format";
+    }
+
+    @Override
+    protected String getTypeName() {
+        return "Image_File_Format";
+    }
+}

--- a/std-bits/image/src/main/java/org/enso/image/ImageFormatSPI.java
+++ b/std-bits/image/src/main/java/org/enso/image/ImageFormatSPI.java
@@ -3,15 +3,14 @@ package org.enso.image;
 import org.enso.base.file_format.FileFormatSPI;
 
 @org.openide.util.lookup.ServiceProvider(service = FileFormatSPI.class)
-
 public class ImageFormatSPI extends FileFormatSPI {
-    @Override
-    protected String getModuleName() {
-        return "Standard.Image.Image_File_Format";
-    }
+  @Override
+  protected String getModuleName() {
+    return "Standard.Image.Image_File_Format";
+  }
 
-    @Override
-    protected String getTypeName() {
-        return "Image_File_Format";
-    }
+  @Override
+  protected String getTypeName() {
+    return "Image_File_Format";
+  }
 }

--- a/std-bits/table/src/main/java/org/enso/table/read/ExcelReader.java
+++ b/std-bits/table/src/main/java/org/enso/table/read/ExcelReader.java
@@ -155,6 +155,17 @@ public class ExcelReader {
       throws IOException, InvalidLocationException {
     Workbook workbook = getWorkbook(stream, xls_format);
 
+    int sheetIndex = workbook.getSheetIndex(rangeNameOrAddress);
+    if (sheetIndex != -1) {
+        return readTable(
+            workbook,
+            sheetIndex,
+            null,
+            headers,
+            skip_rows,
+            row_limit == null ? Integer.MAX_VALUE : row_limit);
+    }
+
     Name name = workbook.getName(rangeNameOrAddress);
 
     ExcelRange excelRange;

--- a/std-bits/table/src/main/java/org/enso/table/read/ExcelReader.java
+++ b/std-bits/table/src/main/java/org/enso/table/read/ExcelReader.java
@@ -34,7 +34,7 @@ public class ExcelReader {
    * @param stream an {@link InputStream} allowing to read the XLS(X) file contents.
    * @param xls_format specifies whether the file is in Excel Binary Format (95-2003 format).
    * @return a {@link Workbook} containing the specified data.
-   * @throws IOException
+   * @throws IOException - when the input stream cannot be read.
    */
   public static Workbook readWorkbook(InputStream stream, boolean xls_format) throws IOException {
     return getWorkbook(stream, xls_format);
@@ -58,7 +58,6 @@ public class ExcelReader {
    *
    * @param workbook a {@link Workbook} to read the sheet names from.
    * @return a String[] containing the sheet names.
-   * @throws IOException when the input stream cannot be read.
    */
   public static String[] readSheetNames(Workbook workbook) {
     int sheetCount = workbook.getNumberOfSheets();
@@ -87,13 +86,10 @@ public class ExcelReader {
    *
    * @param workbook a {@link Workbook} to read the sheet names from.
    * @return a String[] containing the range names.
-   * @throws IOException when the input stream cannot be read.
    */
   public static String[] readRangeNames(Workbook workbook) {
     var names = workbook.getAllNames();
-    return names.stream()
-            .map(Name::getNameName)
-            .toArray(String[]::new);
+    return names.stream().map(Name::getNameName).toArray(String[]::new);
   }
 
   /**
@@ -170,8 +166,8 @@ public class ExcelReader {
   }
 
   /**
-   * Reads a range by sheet name, named range or address for the specified
-   * XLSX/XLS file into a table.
+   * Reads a range by sheet name, named range or address for the specified XLSX/XLS file into a
+   * table.
    *
    * @param stream an {@link InputStream} allowing to read the XLSX file contents.
    * @param rangeNameOrAddress sheet name, range name or address to read.
@@ -192,17 +188,11 @@ public class ExcelReader {
       boolean xls_format)
       throws IOException, InvalidLocationException {
     Workbook workbook = getWorkbook(stream, xls_format);
-    return readRangeByName(
-        workbook,
-        rangeNameOrAddress,
-        headers,
-        skip_rows,
-        row_limit);
+    return readRangeByName(workbook, rangeNameOrAddress, headers, skip_rows, row_limit);
   }
 
   /**
-   * Reads a range by sheet name, named range or address for the workbook into a
-   * table.
+   * Reads a range by sheet name, named range or address for the workbook into a table.
    *
    * @param workbook a {@link Workbook} to read from.
    * @param rangeNameOrAddress sheet name, range name or address to read.
@@ -210,25 +200,24 @@ public class ExcelReader {
    * @param skip_rows skip rows from the top of the range.
    * @param row_limit maximum number of rows to read.
    * @return a {@link Table} containing the specified data.
-   * @throws IOException when the input stream cannot be read.
    * @throws InvalidLocationException when the range name or address is not found.
    */
   public static WithProblems<Table> readRangeByName(
-          Workbook workbook,
-          String rangeNameOrAddress,
-          ExcelHeaders.HeaderBehavior headers,
-          int skip_rows,
-          Integer row_limit)
-          throws IOException, InvalidLocationException {
+      Workbook workbook,
+      String rangeNameOrAddress,
+      ExcelHeaders.HeaderBehavior headers,
+      int skip_rows,
+      Integer row_limit)
+      throws InvalidLocationException {
     int sheetIndex = workbook.getSheetIndex(rangeNameOrAddress);
     if (sheetIndex != -1) {
-        return readTable(
-            workbook,
-            sheetIndex,
-            null,
-            headers,
-            skip_rows,
-            row_limit == null ? Integer.MAX_VALUE : row_limit);
+      return readTable(
+          workbook,
+          sheetIndex,
+          null,
+          headers,
+          skip_rows,
+          row_limit == null ? Integer.MAX_VALUE : row_limit);
     }
 
     Name name = workbook.getName(rangeNameOrAddress);

--- a/std-bits/table/src/main/java/org/enso/table/read/ExcelReader.java
+++ b/std-bits/table/src/main/java/org/enso/table/read/ExcelReader.java
@@ -29,15 +29,38 @@ import java.util.stream.IntStream;
 /** A table reader for MS Excel files. */
 public class ExcelReader {
   /**
+   * Loads a workbook (either XLSX or XLS format from the specified input stream.
+   *
+   * @param stream an {@link InputStream} allowing to read the XLS(X) file contents.
+   * @param xls_format specifies whether the file is in Excel Binary Format (95-2003 format).
+   * @return a {@link Workbook} containing the specified data.
+   * @throws IOException
+   */
+  public static Workbook readWorkbook(InputStream stream, boolean xls_format) throws IOException {
+    return getWorkbook(stream, xls_format);
+  }
+
+  /**
    * Reads a list of sheet names for the specified XLSX/XLS file into an array.
    *
-   * @param stream an {@link InputStream} allowing to read the XLSX file contents.
+   * @param stream an {@link InputStream} allowing to read the XLS(X) file contents.
    * @param xls_format specifies whether the file is in Excel Binary Format (95-2003 format).
    * @return a String[] containing the sheet names.
    * @throws IOException when the input stream cannot be read.
    */
   public static String[] readSheetNames(InputStream stream, boolean xls_format) throws IOException {
     Workbook workbook = getWorkbook(stream, xls_format);
+    return readSheetNames(workbook);
+  }
+
+  /**
+   * Reads a list of sheet names from a workbook into an array.
+   *
+   * @param workbook a {@link Workbook} to read the sheet names from.
+   * @return a String[] containing the sheet names.
+   * @throws IOException when the input stream cannot be read.
+   */
+  public static String[] readSheetNames(Workbook workbook) {
     int sheetCount = workbook.getNumberOfSheets();
     var output = new String[sheetCount];
     for (int i = 0; i < sheetCount; i++) {
@@ -55,9 +78,22 @@ public class ExcelReader {
    * @throws IOException when the input stream cannot be read.
    */
   public static String[] readRangeNames(InputStream stream, boolean xls_format) throws IOException {
-    return getWorkbook(stream, xls_format).getAllNames().stream()
-        .map(Name::getNameName)
-        .toArray(String[]::new);
+    Workbook workbook = getWorkbook(stream, xls_format);
+    return readRangeNames(workbook);
+  }
+
+  /**
+   * Reads a list of range names for the specified XLSX/XLS file into an array.
+   *
+   * @param workbook a {@link Workbook} to read the sheet names from.
+   * @return a String[] containing the range names.
+   * @throws IOException when the input stream cannot be read.
+   */
+  public static String[] readRangeNames(Workbook workbook) {
+    var names = workbook.getAllNames();
+    return names.stream()
+            .map(Name::getNameName)
+            .toArray(String[]::new);
   }
 
   /**
@@ -134,10 +170,12 @@ public class ExcelReader {
   }
 
   /**
-   * Reads a range by name or address for the specified XLSX/XLS file into a table.
+   * Reads a range by sheet name, named range or address for the specified
+   * XLSX/XLS file into a table.
    *
    * @param stream an {@link InputStream} allowing to read the XLSX file contents.
-   * @param rangeNameOrAddress name or address of the range to read.
+   * @param rangeNameOrAddress sheet name, range name or address to read.
+   * @param headers specifies whether the first row should be used as headers.
    * @param skip_rows skip rows from the top of the range.
    * @param row_limit maximum number of rows to read.
    * @param xls_format specifies whether the file is in Excel Binary Format (95-2003 format).
@@ -154,7 +192,34 @@ public class ExcelReader {
       boolean xls_format)
       throws IOException, InvalidLocationException {
     Workbook workbook = getWorkbook(stream, xls_format);
+    return readRangeByName(
+        workbook,
+        rangeNameOrAddress,
+        headers,
+        skip_rows,
+        row_limit);
+  }
 
+  /**
+   * Reads a range by sheet name, named range or address for the workbook into a
+   * table.
+   *
+   * @param workbook a {@link Workbook} to read from.
+   * @param rangeNameOrAddress sheet name, range name or address to read.
+   * @param headers specifies whether the first row should be used as headers.
+   * @param skip_rows skip rows from the top of the range.
+   * @param row_limit maximum number of rows to read.
+   * @return a {@link Table} containing the specified data.
+   * @throws IOException when the input stream cannot be read.
+   * @throws InvalidLocationException when the range name or address is not found.
+   */
+  public static WithProblems<Table> readRangeByName(
+          Workbook workbook,
+          String rangeNameOrAddress,
+          ExcelHeaders.HeaderBehavior headers,
+          int skip_rows,
+          Integer row_limit)
+          throws IOException, InvalidLocationException {
     int sheetIndex = workbook.getSheetIndex(rangeNameOrAddress);
     if (sheetIndex != -1) {
         return readTable(

--- a/test/Benchmarks/src/Table/Aggregate.enso
+++ b/test/Benchmarks/src/Table/Aggregate.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
 
-from Standard.Table import Table, Column_Selector
+from Standard.Table import Table
 from Standard.Table.Data.Aggregate_Column.Aggregate_Column import all
 
 from Standard.Test import Bench, Faker

--- a/test/Image_Tests/src/Image_Read_Spec.enso
+++ b/test/Image_Tests/src/Image_Read_Spec.enso
@@ -10,7 +10,8 @@ import Standard.Test.Extensions
 polyglot java import java.lang.System as Java_System
 
 fetch addr file =
-    Process.run "curl" [addr, "--silent", "--output", file.path]
+    if file.exists then Exit_Code.Success else
+        Process.run "curl" [addr, "--silent", "--output", file.path]
 
 spec =
     rgba_addr = "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Hue_alpha_falloff.png/320px-Hue_alpha_falloff.png"

--- a/test/Image_Tests/src/Image_Read_Spec.enso
+++ b/test/Image_Tests/src/Image_Read_Spec.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 import Standard.Base.Error.File_Error.File_Error
 
 from Standard.Image import Image, Read_Flag, Write_Flag
+import Standard.Image.Image_File_Format.Image_File_Format
 
 from Standard.Test import Test, Test_Suite
 import Standard.Test.Extensions
@@ -12,18 +13,13 @@ fetch addr file =
     Process.run "curl" [addr, "--silent", "--output", file.path]
 
 spec =
-    is_ci = Java_System.getenv "CI" == "true"
     rgba_addr = "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Hue_alpha_falloff.png/320px-Hue_alpha_falloff.png"
     rgba_file = enso_project.root / "rgba.png"
-    pending = case is_ci of
-        True ->
-            case fetch rgba_addr rgba_file of
-                Exit_Code.Failure _ ->
-                    "The Image.Read spec was not able to fetch the file from " + rgba_addr
-                Exit_Code.Success ->
-                    Nothing
-        False ->
-            "The Image.Read spec only run when the `CI` environment variable is set to true"
+    pending = case fetch rgba_addr rgba_file of
+        Exit_Code.Failure _ ->
+            "The Image.Read spec was not able to fetch the file from " + rgba_addr
+        Exit_Code.Success ->
+            Nothing
 
     Test.group "Image.read" pending=pending <|
         Test.specify "should return error when read failed" <|
@@ -60,5 +56,17 @@ spec =
             out_file = enso_project.root / "out.jpeg"
             flags = [Write_Flag.JPEG_Quality 75, Write_Flag.JPEG_Optimize, Write_Flag.JPEG_Progressive]
             Image.read rgba_file . write out_file flags . should_equal Nothing
+
+    Test.group "Image File_Format" <|
+        Test.specify "should recognise image files" <|
+            Auto_Detect.get_format (enso_project.data / "data.jpg") . should_be_a Image_File_Format
+            Auto_Detect.get_format (enso_project.data / "data.png") . should_be_a Image_File_Format
+            Auto_Detect.get_format (enso_project.data / "data.bmp") . should_be_a Image_File_Format
+
+        Test.specify "should allow reading an Image" <|
+            img = Data.read rgba_file
+            img.rows.should_equal 160
+            img.columns.should_equal 320
+            img.channels.should_equal 3
 
 main = Test_Suite.run_main spec

--- a/test/Table_Tests/src/Common_Table_Operations/Aggregate_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Aggregate_Spec.enso
@@ -76,7 +76,7 @@ spec setup =
             materialized.columns.at 2 . at 0 . should_equal 2
 
         Test.specify "should be able to count distinct values over multiple columns" (pending = resolve_pending test_selection.multi_distinct) <|
-            grouped = table.aggregate [Count_Distinct (By_Name ["Index", "Flag"])]
+            grouped = table.aggregate [Count_Distinct ["Index", "Flag"]]
             materialized = materialize grouped
             grouped.row_count . should_equal 1
             materialized.column_count . should_equal 1
@@ -451,7 +451,7 @@ spec setup =
             materialized.columns.at 3 . at idx . should_equal 2
 
         Test.specify "should be able to count distinct values over multiple columns" (pending = resolve_pending test_selection.multi_distinct) <|
-            grouped = table.aggregate [Group_By "Index", Count_Distinct (By_Name ["Index", "Flag"])]
+            grouped = table.aggregate [Group_By "Index", Count_Distinct ["Index", "Flag"]]
             materialized = materialize grouped
             grouped.row_count . should_equal 10
             materialized.column_count . should_equal 2
@@ -644,7 +644,7 @@ spec setup =
             materialized.columns.at 3 . at idx . should_equal 1
 
         Test.specify "should be able to count distinct values over multiple columns" (pending = resolve_pending test_selection.multi_distinct) <|
-            grouped = table.aggregate [Group_By "Index", Count_Distinct (By_Name ["Index", "Flag"]), Group_By "Flag"]
+            grouped = table.aggregate [Group_By "Index", Count_Distinct ["Index", "Flag"], Group_By "Flag"]
             materialized = materialize grouped
             grouped.row_count . should_equal 20
             materialized.column_count . should_equal 3
@@ -911,14 +911,14 @@ spec setup =
         Test.specify "should correctly count all-null keys in multi-column mode" (pending = resolve_pending test_selection.multi_distinct) <|
             table = table_builder [["A", ["foo", "foo", Nothing, Nothing, Nothing]], ["B", ["baz", Nothing, Nothing, Nothing, "baz"]], ["C", [1, 2, 3, Nothing, 5]]]
 
-            r2 = table.aggregate [Count_Distinct (By_Name ["A", "B"]) (ignore_nothing=False)]
+            r2 = table.aggregate [Count_Distinct ["A", "B"] (ignore_nothing=False)]
             r2.row_count.should_equal 1
             m2 = materialize r2
             m2.column_count.should_equal 1
             m2.columns.first.name . should_equal "Count Distinct A B"
             m2.columns.first.to_vector . should_equal [4]
 
-            r1 = table.aggregate [Count_Distinct (By_Name ["A", "B"]) (ignore_nothing=True)]
+            r1 = table.aggregate [Count_Distinct ["A", "B"] (ignore_nothing=True)]
             r1.row_count.should_equal 1
             m1 = materialize r1
             m1.column_count.should_equal 1
@@ -1302,7 +1302,7 @@ spec setup =
             Problems.test_problem_handling action problems tester
 
         Test.specify "should allow partial matches on Count_Distinct" <|
-            action = table.aggregate [Count_Distinct (By_Name ["Missing", "Value"])] on_problems=_
+            action = table.aggregate [Count_Distinct ["Missing", "Value"]] on_problems=_
             problems = [Missing_Input_Columns.Error ["Missing"]]
             tester = expect_column_names ["Count Distinct Value"]
             Problems.test_problem_handling action problems tester
@@ -1464,4 +1464,4 @@ spec setup =
                 Test.specify "with Count_Distinct on multiple fields" <|
                     table = table_builder [["X", [1,2,3]], ["Y", ["a", "bb", "ccc"]]]
                     expect_sum_and_unsupported_errors 1 <|
-                        table.aggregate [Sum "X", Count_Distinct (By_Name ["X", "Y"])]
+                        table.aggregate [Sum "X", Count_Distinct ["X", "Y"]]

--- a/test/Table_Tests/src/Common_Table_Operations/Aggregate_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Aggregate_Spec.enso
@@ -1,8 +1,7 @@
 from Standard.Base import all hiding First, Last
 
-from Standard.Table import Table, Sort_Column, Column_Selector
+from Standard.Table import Table, Sort_Column
 from Standard.Table.Data.Aggregate_Column.Aggregate_Column import all
-from Standard.Table.Data.Column_Selector.Column_Selector import By_Name
 import Standard.Table.Data.Expression.Expression_Error
 from Standard.Table.Errors import all
 
@@ -1309,7 +1308,7 @@ spec setup =
             Problems.test_problem_handling action problems tester
 
         Test.specify "should ignore Count_Distinct if no columns matched" <|
-            action = table.aggregate [Count_Distinct (Column_Selector.By_Index [-100]), Count] on_problems=_
+            action = table.aggregate [Count_Distinct [-100], Count] on_problems=_
             problems = [Column_Indexes_Out_Of_Range.Error [-100]]
             tester = expect_column_names ["Count"]
             Problems.test_problem_handling action problems tester

--- a/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
@@ -49,6 +49,18 @@ spec setup =
             column_3.name . should_equal "abcd123"
             column_3.to_vector . should_equal [19, 20, 21]
 
+            column_4 = table.first_column
+            column_4.name . should_equal "foo"
+            column_4.to_vector . should_equal [1, 2, 3]
+
+            column_5 = table.second_column
+            column_5.name . should_equal "bar"
+            column_5.to_vector . should_equal [4, 5, 6]
+
+            column_6 = table.last_column
+            column_6.name . should_equal "abcd123"
+            column_6.to_vector . should_equal [19, 20, 21]
+
             table.at 100 . should_fail_with Index_Out_Of_Bounds.Error
 
         Test.specify "should fail with Type Error is not an Integer or Text" <|
@@ -167,12 +179,25 @@ spec setup =
             first_row.at "Y" . should_equal 5
             first_row.at "Z" . should_equal "A"
 
+            first_row.get "X" . should_equal 1
+            first_row.get "Y" . should_equal 5
+            first_row.get "Z" . should_equal "A"
+            first_row.get "T" . should_equal Nothing
+            first_row.get "T" "???" . should_equal "???"
+
             last_row = rows.at -1
             last_row . length . should_equal 3
             last_row.at 0 . should_equal 4
             last_row.at 1 . should_equal 8
             last_row.at 2 . should_equal "D"
             last_row.at -1 . should_equal "D"
+
+            last_row.get 0 . should_equal 4
+            last_row.get 1 . should_equal 8
+            last_row.get 2 . should_equal "D"
+            last_row.get -1 . should_equal "D"
+            last_row.get 3 . should_equal Nothing
+            last_row.get 3 "???" . should_equal "???"
 
             rows.map .to_vector . should_equal [[1, 5, "A"], [2, 6, "B"], [3, 7, "C"], [4, 8, "D"]]
 

--- a/test/Table_Tests/src/Common_Table_Operations/Cross_Tab_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Cross_Tab_Spec.enso
@@ -1,7 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Error.Illegal_Argument.Illegal_Argument
 
-from Standard.Table import Column_Selector
 from Standard.Table.Data.Aggregate_Column.Aggregate_Column import Average, Count, Group_By, Sum
 import Standard.Table.Data.Expression.Expression_Error
 from Standard.Table.Errors import all
@@ -105,7 +104,7 @@ spec setup =
             err1.should_fail_with Missing_Input_Columns
             err1.catch.criteria . should_equal ["Nonexistent Group", "OTHER"]
 
-            err2 = table2.cross_tab (Column_Selector.By_Index [0, 42]) "Key"
+            err2 = table2.cross_tab [0, 42] "Key"
             err2.should_fail_with Column_Indexes_Out_Of_Range
             err2.catch.indexes . should_equal [42]
 

--- a/test/Table_Tests/src/Common_Table_Operations/Distinct_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Distinct_Spec.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
 
-from Standard.Table import Column_Selector, Sort_Column
+from Standard.Table import Sort_Column
 from Standard.Table.Errors import all
 
 from Standard.Test import Test, Problems
@@ -28,7 +28,7 @@ spec setup =
             c = ["C", [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]]
             t = table_builder [a, b, c]
 
-            r1 = t.distinct (Column_Selector.By_Name ["A"]) on_problems=Report_Error |> materialize
+            r1 = t.distinct ["A"] on_problems=Report_Error |> materialize
             r1.at "A" . to_vector . should_equal ["a"]
             r1.at "B" . to_vector . should_equal [1]
             r1.at "C" . to_vector . should_equal [0.1]
@@ -55,10 +55,10 @@ spec setup =
         Test.specify "should allow to control case-sensitivity of keys" <|
             x = ["X", ['A', 'a', 'enso', 'Enso', 'A']]
             t1 = table_builder [x]
-            d1 = t1.distinct (Column_Selector.By_Name ["X"]) on_problems=Report_Error |> materialize |> _.order_by ["X"]
+            d1 = t1.distinct ["X"] on_problems=Report_Error |> materialize |> _.order_by ["X"]
             d1.at "X" . to_vector . should_equal ['A', 'Enso', 'a', 'enso']
 
-            d2 = t1.distinct (Column_Selector.By_Name ["X"]) case_sensitivity=Case_Sensitivity.Insensitive on_problems=Report_Error |> materialize |> _.order_by ["X"]
+            d2 = t1.distinct ["X"] case_sensitivity=Case_Sensitivity.Insensitive on_problems=Report_Error |> materialize |> _.order_by ["X"]
             v = d2.at "X" . to_vector
             v.length . should_equal 2
             v.filter (_.equals_ignore_case "enso") . length . should_equal 1
@@ -99,11 +99,11 @@ spec setup =
                 t2.should_fail_with Missing_Input_Columns
                 t2.catch . should_equal (Missing_Input_Columns.Error ["Y", "Z"])
 
-                t3 = t1.distinct (Column_Selector.By_Name ["X", "Y"]) on_problems=pb
+                t3 = t1.distinct ["X", "Y"] on_problems=pb
                 t3.should_fail_with Missing_Input_Columns
                 t3.catch . should_equal (Missing_Input_Columns.Error ["Y"])
 
-                t4 = t1.distinct (Column_Selector.By_Index [0, 42]) on_problems=pb
+                t4 = t1.distinct [0, 42] on_problems=pb
                 t4.should_fail_with Column_Indexes_Out_Of_Range
                 t4.catch . should_equal (Column_Indexes_Out_Of_Range.Error [42])
 
@@ -117,13 +117,13 @@ spec setup =
             t7 = t1.distinct ["Y", "Z"] error_on_missing_columns=False on_problems=Problem_Behavior.Report_Warning
             t7.should_fail_with No_Input_Columns_Selected
 
-            action2 = t1.distinct (Column_Selector.By_Name ["X", "Y"]) error_on_missing_columns=False on_problems=_
+            action2 = t1.distinct ["X", "Y"] error_on_missing_columns=False on_problems=_
             tester2 table =
                 table.at "X" . to_vector . should_equal [1, 2, 3]
             problems2 = [Missing_Input_Columns.Error ["Y"]]
             Problems.test_problem_handling action2 problems2 tester2
 
-            action3 = t1.distinct (Column_Selector.By_Index [0, 42]) error_on_missing_columns=False on_problems=_
+            action3 = t1.distinct [0, 42] error_on_missing_columns=False on_problems=_
             tester3 table =
                 table.at "X" . to_vector . should_equal [1, 2, 3]
             problems3 = [Column_Indexes_Out_Of_Range.Error [42]]

--- a/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base.Error.Common.Arithmetic_Error
 import Standard.Base.Error.Illegal_State.Illegal_State
 
-from Standard.Table import Table, Column, Sort_Column, Column_Selector, Aggregate_Column
+from Standard.Table import Table, Column, Sort_Column, Aggregate_Column
 from Standard.Table.Errors import Floating_Point_Equality, Additional_Warnings
 import Standard.Table.Data.Expression.Expression_Error
 

--- a/test/Table_Tests/src/Common_Table_Operations/Join/Join_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Join/Join_Spec.enso
@@ -589,7 +589,7 @@ spec setup =
             tc = table_builder [["id_a", [0, 1]], ["id_b", [0, 2]]]
 
             res = (tc.join ta on=(Join_Condition.Equals "id_a" "id")) . join tb on=(Join_Condition.Equals "id_b" "id") right_prefix="b_"
-            sel = res.select_columns (Column_Selector.By_Name ["name", "b_name"])
+            sel = res.select_columns ["name", "b_name"]
             r = materialize sel . order_by "name" . rows . map .to_vector
             r.length . should_equal 2
             r.at 0 . should_equal ["Foo", "Y"]

--- a/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
@@ -47,6 +47,10 @@ spec setup =
         Test.specify "should allow negative indices" <|
             expect_column_names ["foo", "bar", "foo_2"] <| table.select_columns [-3, 0, 1]
 
+        Test.specify "should allow mixed names and indexes" <|
+            expect_column_names ["foo", "bar", "foo_2"] <| table.select_columns [-3, "bar", 0]
+            expect_column_names ["foo_2", "bar", "foo"] <| table.select_columns [-3, "bar", 0] reorder=True
+
         if test_selection.supports_case_sensitive_columns then
             Test.specify "should correctly handle exact matches matching multiple names due to case insensitivity" <|
                 table =
@@ -116,6 +120,15 @@ spec setup =
             err = table.select_columns selector on_problems=Problem_Behavior.Ignore
             err.should_fail_with Missing_Input_Columns
             err.catch.criteria . should_equal ["hmm", weird_name]
+
+        Test.specify "should correctly handle problems in mixed case" <|
+            err = table.select_columns ["foo", "hmm", 99] on_problems=Problem_Behavior.Ignore
+            err.should_fail_with Missing_Input_Columns
+            err.catch.criteria . should_equal ["hmm"]
+
+            err_2 = table.select_columns [99, "foo", "hmm"] on_problems=Problem_Behavior.Ignore
+            err.should_fail_with Missing_Input_Columns
+            err.catch.criteria . should_equal ["hmm"]
 
         Test.specify "should correctly handle problems: no columns in the output" <|
             [Problem_Behavior.Ignore, Problem_Behavior.Report_Warning, Problem_Behavior.Report_Error].each pb->

--- a/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
@@ -50,6 +50,8 @@ spec setup =
         Test.specify "should allow mixed names and indexes" <|
             expect_column_names ["foo", "bar", "foo_2"] <| table.select_columns [-3, "bar", 0]
             expect_column_names ["foo_2", "bar", "foo"] <| table.select_columns [-3, "bar", 0] reorder=True
+            expect_column_names ["foo", "bar", "foo_1", "foo_2", "abcd123"] <| table.select_columns [-1, "bar", By_Name "foo.*" Case_Sensitivity.Sensitive use_regex=True]
+            expect_column_names ["foo", "foo_1", "foo_2", "bar", "abcd123"] <| table.select_columns [By_Name "foo.*" Case_Sensitivity.Sensitive use_regex=True, "bar", "foo", -1] reorder=True
 
         if test_selection.supports_case_sensitive_columns then
             Test.specify "should correctly handle exact matches matching multiple names due to case insensitivity" <|

--- a/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 from Standard.Table import Column_Name_Mapping, Position
-from Standard.Table.Data.Column_Selector.Column_Selector import By_Name, By_Index
+from Standard.Table.Data.Column_Selector.Column_Selector import By_Name
 from Standard.Table.Errors import all
 
 from Standard.Test import Test, Problems
@@ -27,26 +27,25 @@ spec setup =
 
     Test.group prefix+"Table.select_columns" <|
         Test.specify "should work as shown in the doc examples" <|
-            expect_column_names ["foo", "bar"] <| table.select_columns (By_Name ["bar", "foo"])
-            expect_column_names ["foo", "bar"] <| table.select_columns (["bar", "foo"])
-            expect_column_names ["bar", "Baz", "foo_1", "foo_2"] <| table.select_columns (By_Name ["foo.+", "b.*"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Insensitive))
-            expect_column_names ["abcd123", "foo", "bar"] <| table.select_columns (By_Index [-1, 0, 1]) reorder=True
+            expect_column_names ["foo", "bar"] <| table.select_columns ["bar", "foo"]
+            expect_column_names ["bar", "Baz", "foo_1", "foo_2"] <| table.select_columns [By_Name "foo.+" use_regex=True, By_Name "b.*" use_regex=True]
+            expect_column_names ["abcd123", "foo", "bar"] <| table.select_columns [-1, 0, 1] reorder=True
 
         Test.specify "should allow to reorder columns if asked to" <|
-            table_2 = table.select_columns (By_Name ["bar", "foo"]) reorder=True
+            table_2 = table.select_columns ["bar", "foo"] reorder=True
             expect_column_names ["bar", "foo"] table_2
             table_2 . at "bar" . to_vector . should_equal [4,5,6]
             table_2 . at "foo" . to_vector . should_equal [1,2,3]
 
         Test.specify "should correctly handle regex matching" <|
-            expect_column_names ["foo"] <| table.select_columns (By_Name ["foo"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Sensitive))
-            expect_column_names ["ab.+123", "abcd123"] <| table.select_columns (By_Name ["a.*"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Sensitive))
-            expect_column_names ["ab.+123", "abcd123"] <| table.select_columns (By_Name ["ab.+123"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Sensitive))
-            expect_column_names ["ab.+123"] <| table.select_columns (By_Name ["ab.+123"])
-            expect_column_names ["abcd123"] <| table.select_columns (By_Name ["abcd123"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Sensitive))
+            expect_column_names ["foo"] <| table.select_columns [By_Name "foo" Case_Sensitivity.Sensitive use_regex=True]
+            expect_column_names ["ab.+123", "abcd123"] <| table.select_columns [By_Name "a.*" Case_Sensitivity.Sensitive use_regex=True]
+            expect_column_names ["ab.+123", "abcd123"] <| table.select_columns [By_Name "ab.+123" Case_Sensitivity.Sensitive use_regex=True]
+            expect_column_names ["ab.+123"] <| table.select_columns ["ab.+123"]
+            expect_column_names ["abcd123"] <| table.select_columns [By_Name "abcd123" Case_Sensitivity.Sensitive use_regex=True]
 
         Test.specify "should allow negative indices" <|
-            expect_column_names ["foo", "bar", "foo_2"] <| table.select_columns (By_Index [-3, 0, 1])
+            expect_column_names ["foo", "bar", "foo_2"] <| table.select_columns [-3, 0, 1]
 
         if test_selection.supports_case_sensitive_columns then
             Test.specify "should correctly handle exact matches matching multiple names due to case insensitivity" <|
@@ -55,14 +54,14 @@ spec setup =
                     col2 = ["bar", [4,5,6]]
                     col3 = ["Bar", [7,8,9]]
                     table_builder [col1, col2, col3]
-                expect_column_names ["bar", "Bar"] <| table.select_columns (By_Name ["bar"] Text_Matcher.Case_Insensitive)
+                expect_column_names ["bar", "Bar"] <| table.select_columns [By_Name "bar"]
 
         Test.specify "should correctly handle regexes matching multiple names" <|
-            expect_column_names ["foo", "bar", "foo_1", "foo_2"] <| table.select_columns (By_Name ["b.*", "f.+"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Sensitive))
-            expect_column_names ["bar", "foo", "foo_1", "foo_2"] <| table.select_columns (By_Name ["b.*", "f.+"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Sensitive)) reorder=True
+            expect_column_names ["foo", "bar", "foo_1", "foo_2"] <| table.select_columns [By_Name "b.*" Case_Sensitivity.Sensitive use_regex=True, By_Name "f.+" Case_Sensitivity.Sensitive use_regex=True]
+            expect_column_names ["bar", "foo", "foo_1", "foo_2"] <| table.select_columns [By_Name "b.*" Case_Sensitivity.Sensitive use_regex=True, By_Name "f.+" Case_Sensitivity.Sensitive use_regex=True]
 
         Test.specify "should correctly handle problems: out of bounds indices" <|
-            selector = By_Index [1, 0, 100, -200, 300]
+            selector = [1, 0, 100, -200, 300]
             action = table.select_columns selector error_on_missing_columns=False on_problems=_
             tester = expect_column_names ["foo", "bar"]
             problems = [Column_Indexes_Out_Of_Range.Error [100, -200, 300]]
@@ -72,43 +71,43 @@ spec setup =
             err.should_fail_with Column_Indexes_Out_Of_Range
 
         Test.specify "should correctly handle edge-cases: duplicate indices" <|
-            selector = By_Index [0, 0, 0]
+            selector = [0, 0, 0]
             t = table.select_columns selector on_problems=Problem_Behavior.Report_Error
             expect_column_names ["foo"] t
 
             expect_column_names ["foo", "bar"] <|
-                table.select_columns (By_Index [0, 1, 0])
+                table.select_columns [0, 1, 0]
 
         Test.specify "should correctly handle edge-cases: aliased indices" <|
-            selector = By_Index [0, -6, 1, -7]
+            selector = [0, -6, 1, -7]
             t = table.select_columns selector on_problems=Problem_Behavior.Report_Error
             expect_column_names ["foo", "bar"] t
 
         Test.specify "should correctly handle edge-cases: duplicate names" <|
-            selector = By_Name ["foo", "foo"]
+            selector = ["foo", "foo"]
             t = table.select_columns selector on_problems=Problem_Behavior.Report_Error
             expect_column_names ["foo"] t
 
             expect_column_names ["foo", "bar"] <|
-                table.select_columns (By_Name ["foo", "bar", "foo", "foo", "bar"]) reorder=True
+                table.select_columns ["foo", "bar", "foo", "foo", "bar"] reorder=True
 
             expect_column_names ["bar", "foo"] <|
-                table.select_columns (By_Name ["bar", "foo", "bar", "foo", "foo", "bar"]) reorder=True
+                table.select_columns ["bar", "foo", "bar", "foo", "foo", "bar"] reorder=True
 
             expect_column_names ["foo", "bar"] <|
-                table.select_columns (By_Name ["bar", "foo", "foo", "bar"]) reorder=False
+                table.select_columns ["bar", "foo", "foo", "bar"] reorder=False
 
         Test.specify "should correctly handle edge-cases: duplicate matches due to case insensitivity" <|
-            selector = By_Name ["FOO", "foo"] Text_Matcher.Case_Insensitive
+            selector = [By_Name "FOO", By_Name "foo"]
             t = table.select_columns selector on_problems=Problem_Behavior.Report_Error
             expect_column_names ["foo"] t
 
             expect_column_names ["bar", "foo"] <|
-                table.select_columns (By_Name ["BAR", "foo", "bar"] Text_Matcher.Case_Insensitive) reorder=True
+                table.select_columns [By_Name "BAR", By_Name "foo", By_Name "bar"] reorder=True
 
         Test.specify "should correctly handle problems: unmatched names" <|
             weird_name = '.*?-!@#!"'
-            selector = By_Name ["foo", "hmm", weird_name]
+            selector = ["foo", "hmm", weird_name]
             action = table.select_columns selector error_on_missing_columns=False on_problems=_
             tester = expect_column_names ["foo"]
             problems = [Missing_Input_Columns.Error ["hmm", weird_name]]
@@ -120,30 +119,29 @@ spec setup =
 
         Test.specify "should correctly handle problems: no columns in the output" <|
             [Problem_Behavior.Ignore, Problem_Behavior.Report_Warning, Problem_Behavior.Report_Error].each pb->
-                t = table.select_columns (By_Index []) on_problems=pb
+                t = table.select_columns [] on_problems=pb
                 t.should_fail_with No_Output_Columns
 
-            table.select_columns (By_Name ["hmmm"]) . should_fail_with Missing_Input_Columns
-            table.select_columns (By_Name ["hmmm"]) error_on_missing_columns=False . should_fail_with No_Output_Columns
+            table.select_columns ["hmmm"] . should_fail_with Missing_Input_Columns
+            table.select_columns ["hmmm"] error_on_missing_columns=False . should_fail_with No_Output_Columns
 
     Test.group prefix+"Table.remove_columns" <|
         Test.specify "should work as shown in the doc examples" <|
-            expect_column_names ["Baz", "foo_1", "foo_2", "ab.+123", "abcd123"] <| table.remove_columns (By_Name ["bar", "foo"])
             expect_column_names ["Baz", "foo_1", "foo_2", "ab.+123", "abcd123"] <| table.remove_columns ["bar", "foo"]
-            expect_column_names ["foo", "ab.+123", "abcd123"] <| table.remove_columns (By_Name ["foo.+", "b.*"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Insensitive))
-            expect_column_names ["Baz", "foo_1", "foo_2", "ab.+123"] <| table.remove_columns (By_Index [-1, 0, 1])
+            expect_column_names ["foo", "ab.+123", "abcd123"] <| table.remove_columns [By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True, By_Name "b.*" Case_Sensitivity.Insensitive use_regex=True]
+            expect_column_names ["Baz", "foo_1", "foo_2", "ab.+123"] <| table.remove_columns [-1, 0, 1]
 
         Test.specify "should correctly handle regex matching" <|
             last_ones = table.columns.drop 1 . map .name
-            expect_column_names last_ones <| table.remove_columns (By_Name ["foo"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Sensitive))
+            expect_column_names last_ones <| table.remove_columns [By_Name "foo" Case_Sensitivity.Sensitive use_regex=True]
             first_ones = ["foo", "bar", "Baz", "foo_1", "foo_2"]
-            expect_column_names first_ones <| table.remove_columns (By_Name ["a.*"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Sensitive))
-            expect_column_names first_ones <| table.remove_columns (By_Name ["ab.+123"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Sensitive))
-            expect_column_names first_ones+["abcd123"] <| table.remove_columns (By_Name ["ab.+123"])
-            expect_column_names first_ones+["ab.+123"] <| table.remove_columns (By_Name ["abcd123"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Sensitive))
+            expect_column_names first_ones <| table.remove_columns [By_Name "a.*" Case_Sensitivity.Sensitive use_regex=True]
+            expect_column_names first_ones <| table.remove_columns [By_Name "ab.+123" Case_Sensitivity.Sensitive use_regex=True]
+            expect_column_names first_ones+["abcd123"] <| table.remove_columns [By_Name "ab.+123"]
+            expect_column_names first_ones+["ab.+123"] <| table.remove_columns [By_Name "abcd123" Case_Sensitivity.Sensitive use_regex=True]
 
         Test.specify "should allow negative indices" <|
-            expect_column_names ["Baz", "foo_1", "ab.+123"] <| table.remove_columns (By_Index [-1, -3, 0, 1])
+            expect_column_names ["Baz", "foo_1", "ab.+123"] <| table.remove_columns [-1, -3, 0, 1]
 
         if test_selection.supports_case_sensitive_columns then
             Test.specify "should correctly handle exact matches matching multiple names due to case insensitivity" <|
@@ -152,13 +150,13 @@ spec setup =
                     col2 = ["bar", [4,5,6]]
                     col3 = ["Bar", [7,8,9]]
                     table_builder [col1, col2, col3]
-                expect_column_names ["foo"] <| table.remove_columns (By_Name ["bar"] Text_Matcher.Case_Insensitive)
+                expect_column_names ["foo"] <| table.remove_columns (By_Name "bar")
 
         Test.specify "should correctly handle regexes matching multiple names" <|
-            expect_column_names ["Baz", "ab.+123", "abcd123"] <| table.remove_columns (By_Name ["b.*", "f.+"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Sensitive))
+            expect_column_names ["Baz", "ab.+123", "abcd123"] <| table.remove_columns [By_Name "f.+" Case_Sensitivity.Sensitive use_regex=True, By_Name "b.*" Case_Sensitivity.Sensitive use_regex=True]
 
         Test.specify "should correctly handle problems: out of bounds indices" <|
-            selector = By_Index [1, 0, 100, -200, 300]
+            selector = [1, 0, 100, -200, 300]
             action = table.remove_columns selector on_problems=_
             tester = expect_column_names ["Baz", "foo_1", "foo_2", "ab.+123", "abcd123"]
             problems = [Column_Indexes_Out_Of_Range.Error [100, -200, 300]]
@@ -168,28 +166,28 @@ spec setup =
             err.should_fail_with Column_Indexes_Out_Of_Range
 
         Test.specify "should correctly handle edge-cases: duplicate indices" <|
-            selector = By_Index [0, 0, 0]
+            selector = [0, 0, 0]
             t = table.remove_columns selector on_problems=Problem_Behavior.Report_Error
             expect_column_names ["bar", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123"] t
 
         Test.specify "should correctly handle edge-cases: aliased indices" <|
-            selector = By_Index [0, -7, -6, 1]
+            selector = [0, -7, -6, 1]
             t = table.remove_columns selector on_problems=Problem_Behavior.Report_Error
             expect_column_names ["Baz", "foo_1", "foo_2", "ab.+123", "abcd123"]  t
 
         Test.specify "should correctly handle edge-cases: duplicate names" <|
-            selector = By_Name ["foo", "foo"]
+            selector = ["foo", "foo"]
             t = table.remove_columns selector on_problems=Problem_Behavior.Report_Error
             expect_column_names ["bar", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123"] t
 
         Test.specify "should correctly handle edge-cases: duplicate matches due to case insensitivity" <|
-            selector = By_Name ["FOO", "foo"] Text_Matcher.Case_Insensitive
+            selector = [By_Name "FOO", By_Name "foo"]
             t = table.remove_columns selector on_problems=Problem_Behavior.Report_Error
             expect_column_names ["bar", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123"] t
 
         Test.specify "should correctly handle problems: unmatched names" <|
             weird_name = '.*?-!@#!"'
-            selector = By_Name ["foo", "hmm", weird_name]
+            selector = ["foo", "hmm", weird_name]
             action = table.remove_columns selector on_problems=_
             tester = expect_column_names ["bar", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123"]
             problems = [Missing_Input_Columns.Error ["hmm", weird_name]]
@@ -200,32 +198,32 @@ spec setup =
 
         Test.specify "should correctly handle problems: no columns in the output" <|
             [Problem_Behavior.Ignore, Problem_Behavior.Report_Warning, Problem_Behavior.Report_Error].each pb->
-                selector = By_Name [".*"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Sensitive)
+                selector = [By_Name ".*" Case_Sensitivity.Sensitive use_regex=True]
                 t = table.remove_columns selector on_problems=pb
                 t.should_fail_with No_Output_Columns
 
-            selector_2 = By_Name [".*", "hmmm"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Sensitive)
+            selector_2 = [By_Name ".*" Case_Sensitivity.Sensitive use_regex=True, By_Name "hmmm" Case_Sensitivity.Sensitive use_regex=True]
             t1 = table.remove_columns selector_2
             t1.should_fail_with No_Output_Columns
 
     Test.group prefix+"Table.reorder_columns" <|
         Test.specify "should work as shown in the doc examples" <|
-            expect_column_names ["bar", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123", "foo"] <| table.reorder_columns (By_Name ["foo"]) Position.After_Other_Columns
+            expect_column_names ["bar", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123", "foo"] <| table.reorder_columns "foo" Position.After_Other_Columns
             expect_column_names ["Baz", "foo_1", "foo_2", "ab.+123", "abcd123", "foo", "bar"] <| table.reorder_columns ["foo", "bar"] Position.After_Other_Columns
-            expect_column_names ["foo_1", "foo_2", "bar", "Baz", "foo", "ab.+123", "abcd123"] <| table.reorder_columns (By_Name ["foo.+", "b.*"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Insensitive))
-            expect_column_names ["bar", "foo", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123"] <| table.reorder_columns (By_Index [1, 0]) Position.Before_Other_Columns
-            expect_column_names ["bar", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123", "foo"] <| table.reorder_columns (By_Index [0]) Position.After_Other_Columns
+            expect_column_names ["foo_1", "foo_2", "bar", "Baz", "foo", "ab.+123", "abcd123"] <| table.reorder_columns [By_Name "foo.+" Case_Sensitivity.Insensitive use_regex=True, By_Name "b.*" Case_Sensitivity.Insensitive use_regex=True]
+            expect_column_names ["bar", "foo", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123"] <| table.reorder_columns [1, 0] Position.Before_Other_Columns
+            expect_column_names ["bar", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123", "foo"] <| table.reorder_columns [0] Position.After_Other_Columns
 
         Test.specify "should correctly handle regex matching" <|
-            expect_column_names ["bar", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123", "foo"] <| table.reorder_columns (By_Name ["foo"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Sensitive)) Position.After_Other_Columns
+            expect_column_names ["bar", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123", "foo"] <| table.reorder_columns [By_Name "foo" Case_Sensitivity.Sensitive use_regex=True] Position.After_Other_Columns
             rest = ["foo", "bar", "Baz", "foo_1", "foo_2"]
-            expect_column_names ["ab.+123", "abcd123"]+rest <| table.reorder_columns (By_Name ["a.*"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Sensitive))
-            expect_column_names ["ab.+123", "abcd123"]+rest <| table.reorder_columns (By_Name ["ab.+123"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Sensitive))
-            expect_column_names ["ab.+123"]+rest+["abcd123"] <| table.reorder_columns (By_Name ["ab.+123"])
-            expect_column_names ["abcd123"]+rest+["ab.+123"] <| table.reorder_columns (By_Name ["abcd123"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Sensitive))
+            expect_column_names ["ab.+123", "abcd123"]+rest <| table.reorder_columns [By_Name "a.*" Case_Sensitivity.Sensitive use_regex=True]
+            expect_column_names ["ab.+123", "abcd123"]+rest <| table.reorder_columns [By_Name "ab.+123" Case_Sensitivity.Sensitive use_regex=True]
+            expect_column_names ["ab.+123"]+rest+["abcd123"] <| table.reorder_columns ["ab.+123"]
+            expect_column_names ["abcd123"]+rest+["ab.+123"] <| table.reorder_columns [By_Name "abcd123" Case_Sensitivity.Sensitive use_regex=True]
 
         Test.specify "should allow negative indices" <|
-            expect_column_names ["abcd123", "foo_2", "foo", "bar", "Baz", "foo_1", "ab.+123"] <| table.reorder_columns (By_Index [-1, -3, 0, 1])
+            expect_column_names ["abcd123", "foo_2", "foo", "bar", "Baz", "foo_1", "ab.+123"] <| table.reorder_columns [-1, -3, 0, 1]
 
         if test_selection.supports_case_sensitive_columns then
             Test.specify "should correctly handle exact matches matching multiple names due to case insensitivity" <|
@@ -234,13 +232,13 @@ spec setup =
                     col2 = ["bar", [4,5,6]]
                     col3 = ["Bar", [7,8,9]]
                     table_builder [col1, col2, col3]
-                expect_column_names ["bar", "Bar", "foo"] <| table.reorder_columns (By_Name ["bar"] Text_Matcher.Case_Insensitive)
+                expect_column_names ["bar", "Bar", "foo"] <| table.reorder_columns [By_Name "bar"]
 
         Test.specify "should correctly handle regexes matching multiple names" <|
-            expect_column_names ["bar", "foo", "foo_1", "foo_2", "Baz", "ab.+123", "abcd123"] <| table.reorder_columns (By_Name ["b.*", "f.+"] (Regex_Matcher.Value case_sensitivity=Case_Sensitivity.Sensitive))
+            expect_column_names ["bar", "foo", "foo_1", "foo_2", "Baz", "ab.+123", "abcd123"] <| table.reorder_columns [By_Name "b.*" Case_Sensitivity.Sensitive use_regex=True, By_Name "f.+" Case_Sensitivity.Sensitive use_regex=True]
 
         Test.specify "should correctly handle problems: out of bounds indices" <|
-            selector = By_Index [1, 0, 100, -200, 300]
+            selector = [1, 0, 100, -200, 300]
             action = table.reorder_columns selector on_problems=_
             tester = expect_column_names ["bar", "foo", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123"]
             problems = [Column_Indexes_Out_Of_Range.Error [100, -200, 300]]
@@ -250,23 +248,23 @@ spec setup =
             err.should_fail_with Column_Indexes_Out_Of_Range
 
         Test.specify "should correctly handle edge-cases: duplicate indices" <|
-            selector = By_Index [0, 0, 0]
+            selector = [0, 0, 0]
             t = table.reorder_columns selector Position.After_Other_Columns on_problems=Problem_Behavior.Report_Error
             expect_column_names ["bar", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123", "foo"] t
 
         Test.specify "should correctly handle edge-cases: aliased indices" <|
-            selector = By_Index [0, -7, -6, 1]
+            selector = [0, -7, -6, 1]
             t = table.reorder_columns selector Position.After_Other_Columns on_problems=Problem_Behavior.Report_Error
             expect_column_names ["Baz", "foo_1", "foo_2", "ab.+123", "abcd123", "foo", "bar"] t
 
         Test.specify "should correctly handle edge-cases: duplicate names" <|
-            selector = By_Name ["foo", "foo"]
+            selector = ["foo", "foo"]
             t = table.reorder_columns selector Position.After_Other_Columns on_problems=Problem_Behavior.Report_Error
             expect_column_names ["bar", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123", "foo"] t
 
         Test.specify "should correctly handle problems: unmatched names" <|
             weird_name = '.*?-!@#!"'
-            selector = By_Name ["foo", "hmm", weird_name]
+            selector = ["foo", "hmm", weird_name]
             action = table.reorder_columns selector Position.After_Other_Columns on_problems=_
             tester = expect_column_names ["bar", "Baz", "foo_1", "foo_2", "ab.+123", "abcd123", "foo"]
             problems = [Missing_Input_Columns.Error ["hmm", weird_name]]

--- a/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
@@ -58,7 +58,7 @@ spec setup =
 
         Test.specify "should correctly handle regexes matching multiple names" <|
             expect_column_names ["foo", "bar", "foo_1", "foo_2"] <| table.select_columns [By_Name "b.*" Case_Sensitivity.Sensitive use_regex=True, By_Name "f.+" Case_Sensitivity.Sensitive use_regex=True]
-            expect_column_names ["bar", "foo", "foo_1", "foo_2"] <| table.select_columns [By_Name "b.*" Case_Sensitivity.Sensitive use_regex=True, By_Name "f.+" Case_Sensitivity.Sensitive use_regex=True]
+            expect_column_names ["bar", "foo", "foo_1", "foo_2"] <| table.select_columns [By_Name "b.*" Case_Sensitivity.Sensitive use_regex=True, By_Name "f.+" Case_Sensitivity.Sensitive use_regex=True] reorder=True
 
         Test.specify "should correctly handle problems: out of bounds indices" <|
             selector = [1, 0, 100, -200, 300]

--- a/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
@@ -127,8 +127,8 @@ spec setup =
             err.catch.criteria . should_equal ["hmm"]
 
             err_2 = table.select_columns [99, "foo", "hmm"] on_problems=Problem_Behavior.Ignore
-            err.should_fail_with Missing_Input_Columns
-            err.catch.criteria . should_equal ["hmm"]
+            err_2.should_fail_with Missing_Input_Columns
+            err_2.catch.criteria . should_equal ["hmm"]
 
         Test.specify "should correctly handle problems: no columns in the output" <|
             [Problem_Behavior.Ignore, Problem_Behavior.Report_Warning, Problem_Behavior.Report_Error].each pb->

--- a/test/Table_Tests/src/Common_Table_Operations/Transpose_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Transpose_Spec.enso
@@ -1,6 +1,5 @@
 from Standard.Base import all
 
-from Standard.Table import Column_Selector
 from Standard.Table.Errors import all
 
 from Standard.Test import Test, Problems
@@ -51,7 +50,7 @@ spec setup =
 
         Test.specify "should allow fields selected by index" <|
             t = table_builder [["Key", ["x", "y", "z"]], ["Value", [1, 2, 3]], ["Another", [10, Nothing, 20]], ["Yet Another", [Nothing, "Hello", "World"]]]
-            t1 = t.transpose (Column_Selector.By_Index [0, -1])
+            t1 = t.transpose [0, -1]
             t1.column_names . should_equal ["Key", "Yet Another", "Name", "Value"]
             t1.row_count . should_equal 6
             t1.at "Key" . to_vector . should_equal ["x", "x", "y", "y", "z", "z"]
@@ -78,7 +77,7 @@ spec setup =
             err1.should_fail_with Missing_Input_Columns
             err1.catch.criteria . should_equal ["Missing", "Missing_2"]
 
-            err2 = t1.transpose (Column_Selector.By_Index [0, -1, 42, -100])
+            err2 = t1.transpose [0, -1, 42, -100]
             err2.should_fail_with Column_Indexes_Out_Of_Range
             err2.catch.indexes . should_equal [42, -100]
 
@@ -88,7 +87,7 @@ spec setup =
             problems1 = [Missing_Input_Columns.Error ["Missing", "Missing_2"]]
             Problems.test_problem_handling action1 problems1 tester1
 
-            action2 = t1.transpose (Column_Selector.By_Index [0, -1, 42, -100]) error_on_missing_columns=False on_problems=_
+            action2 = t1.transpose [0, -1, 42, -100] error_on_missing_columns=False on_problems=_
             tester2 table =
                 table.column_names . should_equal ["Key", "Another", "Name", "Value"]
             problems2 = [Column_Indexes_Out_Of_Range.Error [42, -100]]

--- a/test/Table_Tests/src/Database/Codegen_Spec.enso
+++ b/test/Table_Tests/src/Database/Codegen_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Error.Illegal_State.Illegal_State
 
-from Standard.Table import Sort_Column, Column_Selector, Join_Condition
+from Standard.Table import Sort_Column
 from Standard.Table.Data.Aggregate_Column.Aggregate_Column import all
 from Standard.Table.Errors import No_Input_Columns_Selected, Missing_Input_Columns, No_Such_Column
 
@@ -45,7 +45,7 @@ spec =
     Test.group "[Codegen] Basic Select" <|
         Test.specify "should select columns from a table" <|
             t1.to_sql.prepare . should_equal ['SELECT "T1"."A" AS "A", "T1"."B" AS "B", "T1"."C" AS "C" FROM "T1" AS "T1"', []]
-            t2 = t1.select_columns (Column_Selector.By_Name ["C", "B", "undefined"]) reorder=True error_on_missing_columns=False
+            t2 = t1.select_columns ["C", "B", "undefined"] reorder=True error_on_missing_columns=False
             t2.to_sql.prepare . should_equal ['SELECT "T1"."C" AS "C", "T1"."B" AS "B" FROM "T1" AS "T1"', []]
 
             foo = t1.at "A" . rename "FOO"

--- a/test/Table_Tests/src/Database/Common_Spec.enso
+++ b/test/Table_Tests/src/Database/Common_Spec.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
 
-from Standard.Table import Table, Sort_Column, Column_Selector
+from Standard.Table import Table, Sort_Column
 from Standard.Table.Data.Aggregate_Column.Aggregate_Column import all
 from Standard.Table.Errors import No_Input_Columns_Selected, Missing_Input_Columns
 

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -4,6 +4,7 @@ import Standard.Base.Runtime.Ref.Ref
 from Standard.Table import Table
 
 from Standard.Database import Database, SQLite, In_Memory, SQL_Query
+import Standard.Database.Connection.SQLite_Format.SQLite_Format
 from Standard.Database.Errors import SQL_Error
 
 from Standard.Test import Test, Test_Suite
@@ -145,5 +146,26 @@ spec =
     file.delete
 
     sqlite_spec (Database.connect (SQLite In_Memory)) "[SQLite Memory] "
+
+    Test.group "SQLite_Format should allow connecting to SQLite files" <|
+        file.delete_if_exists
+
+        connection = Database.connect (SQLite file)
+        connection.execute_update 'CREATE TABLE "Dummy" ("strs" VARCHAR, "ints" INTEGER, "bools" BOOLEAN, "reals" REAL)'
+        connection.close
+
+        Test.specify "should recognise a db file" <|
+            Auto_Detect.get_format (enso_project.data / "data.db") . should_be_a SQLite_Format
+
+        Test.specify "should recognise a sqlite file" <|
+            Auto_Detect.get_format (enso_project.data / "data.sqlite") . should_be_a SQLite_Format
+
+        Test.specify "should connect to a db file" <|
+            connection = Data.read file
+            tables = connection.tables
+            tables.row_count . should_not_equal 0
+            connection.close
+
+        file.delete_if_exists
 
 main = Test_Suite.run_main spec

--- a/test/Table_Tests/src/IO/Csv_Spec.enso
+++ b/test/Table_Tests/src/IO/Csv_Spec.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
 
-from Standard.Table import Table, Column, Delimited, Column_Selector
+from Standard.Table import Table, Column, Delimited
 import Standard.Table.Main as Table_Module
 
 from Standard.Test import Test, Test_Suite
@@ -37,7 +37,7 @@ spec =
             c_6 = ["Column_6", ['1', '2', '3', '4', '5', '6.25', '7', 'osiem']]
 
             expected = Table.new [c_1, c_3, c_4, c_5, c_6]
-            varied_column.select_columns (Column_Selector.By_Index [0, 2, 3, 4, 5]) . should_equal expected
+            varied_column.select_columns [0, 2, 3, 4, 5] . should_equal expected
 
         Test.specify "should handle duplicated columns" <|
             csv = """

--- a/test/Table_Tests/src/IO/Excel_Spec.enso
+++ b/test/Table_Tests/src/IO/Excel_Spec.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base.Error.File_Error.File_Error
 import Standard.Base.Error.Illegal_Argument.Illegal_Argument
 
-from Standard.Table import Table, Match_Columns, Column_Name_Mapping, Excel, Excel_Range, Data_Formatter, Sheet_Names, Range_Names, Worksheet, Cell_Range, Delimited
+from Standard.Table import Table, Match_Columns, Column_Name_Mapping, Excel, Excel_Range, Data_Formatter, Sheet_Names, Range_Names, Worksheet, Cell_Range, Delimited, Excel_Workbook
 
 from Standard.Table.Errors import Invalid_Output_Column_Names, Duplicate_Output_Column_Names, Invalid_Location, Range_Exceeded, Existing_Data, Column_Count_Mismatch, Column_Name_Mismatch, Empty_Sheet_Error
 
@@ -13,10 +13,14 @@ import Standard.Examples
 
 import project.Util
 
-spec_fmt header file read_method =
+spec_fmt header file read_method sheet_count=5 =
     Test.group header <|
+        Test.specify "should read a workbook in" <|
+            wb = read_method file
+            wb.sheet_count . should_equal sheet_count
+
         Test.specify "should read the specified sheet by index and use correct headers" <|
-            t = read_method file
+            t = read_method file (Excel (Worksheet 1))
             t.columns.map .name . should_equal ['Name', 'Quantity', 'Price']
             t.at 'Name' . to_vector . should_equal ['blouse', 't-shirt', 'trousers', 'shoes', 'skirt', 'dress']
             t.at 'Quantity' . to_vector . should_equal [10, 20, Nothing, 30, Nothing, 5]
@@ -458,6 +462,9 @@ spec =
     xls_sheet = enso_project.data / "TestSheetOld.xls"
     xls_path = xls_sheet.path
 
+    sheet_names = ["Sheet1", "Another", "NoHeaders", "Random"]
+    range_names = ["myData"]
+
     col_a = ["Test", "Here", "Is", "Data"]
     col_b = [1, 2, 3, 4]
     col_c = [Date.new 2022 06 12, Date.new 2022 10 20, Date.new 2022 07 30, Date.new 2022 10 15]
@@ -477,32 +484,55 @@ spec =
         if count > 3 then check_column (table.at "D") col_d
         if count > 4 then check_column (table.at "E") col_e
 
-    Test.group "Read XLSX / XLS Files" <|
-        Test.specify "should let you read the first sheet with Auto_Detect" <|
-            check_table <| xlsx_sheet.read
-            check_table <| Data.read xlsx_sheet
-            check_table <| Data.read xlsx_path
-            check_table <| xls_sheet.read
-            check_table <| Data.read xls_sheet
-            check_table <| Data.read xls_path
+    check_workbook workbook sheets=sheet_names.length ranges=range_names.length =
+        workbook.is_a Excel_Workbook . should_be_true
+        workbook.sheet_count . should_equal sheets
+        workbook.named_ranges_count . should_equal ranges
 
-        Test.specify "should let you read the first sheet with Excel" <|
-            check_table <| xlsx_sheet.read Excel
-            check_table <| Data.read xlsx_sheet Excel
-            check_table <| Data.read xlsx_path Excel
-            check_table <| xls_sheet.read Excel
-            check_table <| Data.read xls_sheet Excel
-            check_table <| Data.read xls_path Excel
+    Test.group "Read XLSX / XLS Files" <|
+        Test.specify "should let you read the workbook with Auto_Detect" <|
+            check_workbook <| xlsx_sheet.read
+            check_workbook <| Data.read xlsx_sheet
+            check_workbook <| Data.read xlsx_path
+
+            check_workbook <| xls_sheet.read
+            check_workbook <| Data.read xls_sheet
+            check_workbook <| Data.read xls_path
+
+        Test.specify "should let you read the workbook with Excel" <|
+            check_workbook <| xlsx_sheet.read Excel
+            check_workbook <| Data.read xlsx_sheet Excel
+            check_workbook <| Data.read xlsx_path Excel
+
+            check_workbook <| xls_sheet.read Excel
+            check_workbook <| Data.read xls_sheet Excel
+            check_workbook <| Data.read xls_path Excel
+
+        Test.specify "workbook should look like a database connection" <|
+            workbook = xlsx_sheet.read
+
+            workbook.database . should_equal xlsx_sheet.normalize.path
+            workbook.schema . should_equal Nothing
+
+            workbook.table_types . should_equal ['Worksheet', 'Named Range']
+
+            workbook.tables.row_count . should_equal (sheet_names.length + range_names.length)
+            workbook.tables types=["Worksheet"] . row_count . should_equal sheet_names.length
+            workbook.tables types=["Named Range"] . row_count . should_equal range_names.length
+            workbook.tables types=["XXX"] . row_count . should_equal 0
+
+            workbook.tables "%not%" . row_count . should_equal 1
+            workbook.tables "%not%" . at 'Name' . to_vector . should_equal ["Another"]
 
         Test.specify "should let you read the sheet names" <|
-            sheet_names = ["Sheet1", "Another", "NoHeaders", "Random"]
             xlsx_sheet.read (Excel Sheet_Names) . should_equal sheet_names
             xls_sheet.read (Excel Sheet_Names) . should_equal sheet_names
+            xlsx_sheet.read . sheet_names . should_equal sheet_names
 
         Test.specify "should let you read the range names" <|
-            range_names = ["myData"]
             xlsx_sheet.read (Excel Range_Names) . should_equal range_names
             xls_sheet.read (Excel Range_Names) . should_equal range_names
+            xlsx_sheet.read . named_ranges . should_equal range_names
 
         Test.specify "should let you read by sheet index" <|
             table = xlsx_sheet.read (Excel (Worksheet 1))
@@ -520,6 +550,9 @@ spec =
             table_2.row_count . should_equal col_a.length
             check_table table_2
 
+            table_3 = xlsx_sheet.read . read "Sheet1"
+            check_table table_3
+
         Test.specify "should let you read XLS by sheet index" <|
             table = xls_sheet.read (Excel (Worksheet 1))
             check_table table
@@ -532,6 +565,9 @@ spec =
             table = xls_sheet.read (Excel (Worksheet "Sheet1"))
             check_table table
 
+            table_2 = xls_sheet.read . read "Sheet1"
+            check_table table_2
+
         Test.specify "should let you read by range" <|
             table = xlsx_sheet.read (Excel (Cell_Range "Sheet1!A:C"))
             check_table table 3
@@ -543,10 +579,17 @@ spec =
             check_table <| xlsx_sheet.read (Excel (Cell_Range "Sheet1!10:13"))
             check_table count=3 <| xlsx_sheet.read (Excel (Cell_Range "Sheet1!A10:C13"))
 
+            check_table <| xlsx_sheet.read . read "Sheet1!10:13"
+            check_table count=3 <| xlsx_sheet.read . read "Sheet1!A10:C13"
+
         Test.specify "should let you read by range name" <|
             table = xlsx_sheet.read (Excel (Cell_Range "myData"))
             table.row_count . should_equal col_a.length
             check_table table 3
+
+            table_2 = xlsx_sheet.read . read "myData"
+            table_2.row_count . should_equal col_a.length
+            check_table table_2 3
 
         Test.specify "should let you restrict number of rows read and skip rows" <|
             table = xlsx_sheet.read (Excel (Worksheet "Sheet1"))

--- a/test/Table_Tests/src/IO/Excel_Spec.enso
+++ b/test/Table_Tests/src/IO/Excel_Spec.enso
@@ -78,14 +78,28 @@ spec_write suffix test_sheet_name =
             out.delete_if_exists
             table.write out on_problems=Report_Error . should_succeed
             written = out.read
-            written.should_equal table
+            written.sheet_count . should_equal 1
+            written.sheet_names . should_equal ['Sheet1']
+            written.read 'Sheet1' . should_equal table
             out.delete_if_exists
 
         Test.specify 'should write a table to non-existent file in append mode as a new sheet with headers' <|
             out.delete_if_exists
             table.write out on_existing_file=Existing_File_Behavior.Append on_problems=Report_Error . should_succeed
             written = out.read
-            written.should_equal table
+            written.sheet_count . should_equal 1
+            written.sheet_names . should_equal ['Sheet1']
+            written.read 'Sheet1' . should_equal table
+            out.delete_if_exists
+
+        Test.specify 'should write a table to existing file as a new sheet with headers' <|
+            out.delete_if_exists
+            table.write out on_problems=Report_Error . should_succeed
+            table.write out on_problems=Report_Error . should_succeed
+            written = out.read
+            written.sheet_count . should_equal 2
+            written.sheet_names . should_equal ['Sheet1', 'Sheet2']
+            written.read 'Sheet2' . should_equal table
             out.delete_if_exists
 
         Test.specify 'should write a table to existing file in overwrite mode as a new sheet with headers' <|
@@ -177,7 +191,9 @@ spec_write suffix test_sheet_name =
             out.delete_if_exists
             table.write out (Excel (Worksheet "Sheet1") headers=False) on_problems=Report_Error . should_succeed
             written = out.read
-            written.should_equal (table.rename_columns (Column_Name_Mapping.By_Position ['A', 'B', 'C', 'D', 'E', 'F']))
+            written.sheet_count . should_equal 1
+            written.sheet_names . should_equal ['Sheet1']
+            written.read 'Sheet1' . should_equal (table.rename_columns (Column_Name_Mapping.By_Position ['A', 'B', 'C', 'D', 'E', 'F']))
             out.delete_if_exists
 
         Test.specify 'should be able to append to a sheet by name' <|

--- a/test/Table_Tests/src/IO/Excel_Spec.enso
+++ b/test/Table_Tests/src/IO/Excel_Spec.enso
@@ -533,6 +533,8 @@ spec =
             workbook.table_types . should_equal ['Worksheet', 'Named Range']
 
             workbook.tables.row_count . should_equal (sheet_names.length + range_names.length)
+            workbook.tables.at "Name" . to_vector . should_contain_the_same_elements_as (sheet_names + range_names)
+
             workbook.tables types=["Worksheet"] . row_count . should_equal sheet_names.length
             workbook.tables types=["Named Range"] . row_count . should_equal range_names.length
             workbook.tables types=["XXX"] . row_count . should_equal 0

--- a/test/Table_Tests/src/IO/Excel_Spec.enso
+++ b/test/Table_Tests/src/IO/Excel_Spec.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base.Error.File_Error.File_Error
 import Standard.Base.Error.Illegal_Argument.Illegal_Argument
 
-from Standard.Table import Table, Match_Columns, Column_Name_Mapping, Excel, Excel_Range, Data_Formatter, Sheet_Names, Range_Names, Worksheet, Cell_Range, Delimited, Column_Selector
+from Standard.Table import Table, Match_Columns, Column_Name_Mapping, Excel, Excel_Range, Data_Formatter, Sheet_Names, Range_Names, Worksheet, Cell_Range, Delimited
 
 from Standard.Table.Errors import Invalid_Output_Column_Names, Duplicate_Output_Column_Names, Invalid_Location, Range_Exceeded, Existing_Data, Column_Count_Mismatch, Column_Name_Mismatch, Empty_Sheet_Error
 
@@ -68,7 +68,7 @@ spec_write suffix test_sheet_name =
         out_bak = enso_project.data / ('out.' + suffix + '.bak')
         table = enso_project.data/'varied_column.csv' . read
         clothes = enso_project.data/'clothes.csv' . read
-        sub_clothes = clothes.select_columns (Column_Selector.By_Index [0, 1])
+        sub_clothes = clothes.select_columns [0, 1]
 
         Test.specify 'should write a table to non-existent file as a new sheet with headers' <|
             out.delete_if_exists
@@ -182,7 +182,7 @@ spec_write suffix test_sheet_name =
             extra_another = Table.new [['AA', ['d', 'e']], ['BB',[4, 5]], ['CC',[True, False]], ['DD', ['2022-01-20', '2022-01-21']]]
             expected = Table.new [['AA', ['a','b','c','d', 'e']], ['BB',[1,2,3,4,5]], ['CC',[True, False, False, True, False]]]
             extra_another.write out (Excel (Worksheet "Another")) on_existing_file=Existing_File_Behavior.Append on_problems=Report_Error . should_succeed
-            written = out.read (Excel (Worksheet "Another")) . select_columns (Column_Selector.By_Index [0, 1, 2])
+            written = out.read (Excel (Worksheet "Another")) . select_columns [0, 1, 2]
             written.should_equal expected
             out.delete_if_exists
 
@@ -192,7 +192,7 @@ spec_write suffix test_sheet_name =
             extra_another = Table.new [['A', ['d', 'e']], ['B',[4, 5]], ['C',[True, False]], ['D', ['2022-01-20', '2022-01-21']]]
             expected = Table.new [['AA', ['a','b','c','d', 'e']], ['BB',[1,2,3,4,5]], ['CC',[True, False, False, True, False]]]
             extra_another.write out (Excel (Worksheet "Another")) on_existing_file=Existing_File_Behavior.Append match_columns=Match_Columns.By_Position on_problems=Report_Error . should_succeed
-            written = out.read (Excel (Worksheet "Another")) . select_columns (Column_Selector.By_Index [0, 1, 2])
+            written = out.read (Excel (Worksheet "Another")) . select_columns [0, 1, 2]
             written.should_equal expected
             out.delete_if_exists
 
@@ -202,7 +202,7 @@ spec_write suffix test_sheet_name =
             extra_another = Table.new [['CC',[True, False]], ['BB',[4, 5]], ['AA', ['d', 'e']], ['DD', ['2022-01-20', '2022-01-21']]]
             expected = Table.new [['AA', ['a','b','c','d', 'e']], ['BB',[1,2,3,4,5]], ['CC',[True, False, False, True, False]]]
             extra_another.write out (Excel (Worksheet "Another")) on_existing_file=Existing_File_Behavior.Append on_problems=Report_Error . should_succeed
-            written = out.read (Excel (Worksheet "Another")) . select_columns (Column_Selector.By_Index [0, 1, 2])
+            written = out.read (Excel (Worksheet "Another")) . select_columns [0, 1, 2]
             written.should_equal expected
             out.delete_if_exists
 
@@ -212,7 +212,7 @@ spec_write suffix test_sheet_name =
             extra_another = Table.new [['AA', ['d', 'e']], ['BB',[4, 5]], ['CC',[True, False]], ['DD', ['2022-01-20', '2022-01-21']]]
             expected = Table.new [['AA', ['a','b','c','d', 'e']], ['BB',[1,2,3,4,5]], ['CC',[True, False, False, True, False]]]
             extra_another.write out (Excel (Cell_Range "Another!A1")) on_existing_file=Existing_File_Behavior.Append on_problems=Report_Error . should_succeed
-            written = out.read (Excel (Worksheet "Another")) . select_columns (Column_Selector.By_Index [0, 1, 2])
+            written = out.read (Excel (Worksheet "Another")) . select_columns [0, 1, 2]
             written.should_equal expected
             out.delete_if_exists
 
@@ -222,7 +222,7 @@ spec_write suffix test_sheet_name =
             extra_another = Table.new [['A', ['d', 'e']], ['B',[4, 5]], ['C',[True, False]], ['D', ['2022-01-20', '2022-01-21']]]
             expected = Table.new [['AA', ['a','b','c','d', 'e']], ['BB',[1,2,3,4,5]], ['CC',[True, False, False, True, False]]]
             extra_another.write out (Excel (Cell_Range "Another!A1")) on_existing_file=Existing_File_Behavior.Append match_columns=Match_Columns.By_Position on_problems=Report_Error . should_succeed
-            written = out.read (Excel (Worksheet "Another")) . select_columns (Column_Selector.By_Index [0, 1, 2])
+            written = out.read (Excel (Worksheet "Another")) . select_columns [0, 1, 2]
             written.should_equal expected
             out.delete_if_exists
 
@@ -232,7 +232,7 @@ spec_write suffix test_sheet_name =
             extra_another = Table.new [['CC',[True, False]], ['BB',[4, 5]], ['AA', ['d', 'e']], ['DD', ['2022-01-20', '2022-01-21']]]
             expected = Table.new [['AA', ['a','b','c','d', 'e']], ['BB',[1,2,3,4,5]], ['CC',[True, False, False, True, False]]]
             extra_another.write out (Excel (Cell_Range "Another!A1")) on_existing_file=Existing_File_Behavior.Append on_problems=Report_Error . should_succeed
-            written = out.read (Excel (Worksheet "Another")) . select_columns (Column_Selector.By_Index [0, 1, 2])
+            written = out.read (Excel (Worksheet "Another")) . select_columns [0, 1, 2]
             written.should_equal expected
             out.delete_if_exists
 
@@ -242,7 +242,7 @@ spec_write suffix test_sheet_name =
             extra_another = Table.new [['AA', ['d', 'e']], ['BB', [4, 5]], ['CC', [True, False]], ['DD', ['2022-01-20', '2022-01-21']]]
             expected = Table.new [['AA', ['a', 'b', 'c', 'd', 'e']], ['BB', [1, 2, 3, 4, 5]], ['CC', [True, False, False, True, False]]]
             extra_another.write out (Excel (Cell_Range "Another!A1:D6")) on_existing_file=Existing_File_Behavior.Append on_problems=Report_Error . should_succeed
-            written = out.read (Excel (Worksheet "Another")) . select_columns (Column_Selector.By_Index [0, 1, 2])
+            written = out.read (Excel (Worksheet "Another")) . select_columns [0, 1, 2]
             written.should_equal expected
             out.delete_if_exists
 
@@ -252,7 +252,7 @@ spec_write suffix test_sheet_name =
             extra_another = Table.new [['A', ['d', 'e']], ['B',[4, 5]], ['C',[True, False]], ['D', ['2022-01-20', '2022-01-21']]]
             expected = Table.new [['AA', ['a','b','c','d', 'e']], ['BB',[1,2,3,4,5]], ['CC',[True, False, False, True, False]]]
             extra_another.write out (Excel (Cell_Range "Another!A1:D6")) on_existing_file=Existing_File_Behavior.Append match_columns=Match_Columns.By_Position on_problems=Report_Error . should_succeed
-            written = out.read (Excel (Worksheet "Another")) . select_columns (Column_Selector.By_Index [0, 1, 2])
+            written = out.read (Excel (Worksheet "Another")) . select_columns [0, 1, 2]
             written.should_equal expected
             out.delete_if_exists
 
@@ -262,7 +262,7 @@ spec_write suffix test_sheet_name =
             extra_another = Table.new [['AA', ['d', 'e']], ['BB',[4, 5]], ['CC',[True, False]], ['DD', ['2022-01-20', '2022-01-21']]]
             expected = Table.new [['AA', ['f', 'g', 'h', 'd', 'e']], ['BB',[1, 2, 3, 4, 5]], ['CC',[True, False, False, True, False]]]
             extra_another.write out (Excel (Cell_Range "Random!K9")) on_existing_file=Existing_File_Behavior.Append on_problems=Report_Error . should_succeed
-            written = out.read (Excel (Cell_Range "Random!K9")) . select_columns (Column_Selector.By_Index [0, 1, 2])
+            written = out.read (Excel (Cell_Range "Random!K9")) . select_columns [0, 1, 2]
             written.should_equal expected
             out.delete_if_exists
 
@@ -272,7 +272,7 @@ spec_write suffix test_sheet_name =
             extra_another = Table.new [['AA', ['d', 'e']], ['BB',[4, 5]], ['AA_1',[True, False]], ['BB_1', ['2022-01-20', '2022-01-21']]]
             expected = Table.new [['AA', ['f', 'g', 'h', 'd', 'e']], ['BB',[1, 2, 3, 4, 5]], ['AA_1',[True, False, False, True, False]]]
             extra_another.write out (Excel (Cell_Range "Random!S3")) on_existing_file=Existing_File_Behavior.Append on_problems=Report_Error . should_succeed
-            written = out.read (Excel (Cell_Range "Random!S3")) . select_columns (Column_Selector.By_Index [0, 1, 2])
+            written = out.read (Excel (Cell_Range "Random!S3")) . select_columns [0, 1, 2]
             written.should_equal expected
             out.delete_if_exists
 
@@ -282,7 +282,7 @@ spec_write suffix test_sheet_name =
             extra_another = Table.new [['A', ['d', 'e']], ['B',[4, 5]], ['C',[True, False]], ['D', ['2022-01-20', '2022-01-21']]]
             expected = Table.new [['AA', ['f', 'g', 'h', 'd', 'e']], ['BB',[1, 2, 3, 4, 5]], ['CC',[True, False, False, True, False]]]
             extra_another.write out (Excel (Cell_Range "Random!K9")) on_existing_file=Existing_File_Behavior.Append match_columns=Match_Columns.By_Position on_problems=Report_Error . should_succeed
-            written = out.read (Excel (Cell_Range "Random!K9")) . select_columns (Column_Selector.By_Index [0, 1, 2])
+            written = out.read (Excel (Cell_Range "Random!K9")) . select_columns [0, 1, 2]
             written.should_equal expected
             out.delete_if_exists
 
@@ -292,7 +292,7 @@ spec_write suffix test_sheet_name =
             extra_another = Table.new [['CC',[True, False]], ['BB',[4, 5]], ['AA', ['d', 'e']], ['DD', ['2022-01-20', '2022-01-21']]]
             expected = Table.new [['AA', ['a','b','c','d', 'e']], ['BB',[1,2,3,4,5]], ['CC',[True, False, False, True, False]]]
             extra_another.write out (Excel (Cell_Range "Another!A1:D6")) on_existing_file=Existing_File_Behavior.Append on_problems=Report_Error . should_succeed
-            written = out.read (Excel (Worksheet "Another")) . select_columns (Column_Selector.By_Index [0, 1, 2])
+            written = out.read (Excel (Worksheet "Another")) . select_columns [0, 1, 2]
             written.should_equal expected
             out.delete_if_exists
 

--- a/test/Table_Tests/src/In_Memory/Aggregate_Column_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Aggregate_Column_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all hiding First, Last
 import Standard.Base.Error.Illegal_Argument.Illegal_Argument
 
-from Standard.Table import Table, Column_Selector
+from Standard.Table import Table
 from Standard.Table.Data.Aggregate_Column.Aggregate_Column import all
 
 import Standard.Table.Internal.Aggregate_Column_Helper
@@ -151,9 +151,9 @@ spec = Test.group "Aggregate Columns" <|
         test_aggregator simple_table (Count_Distinct float_col test_name ignore_nothing=True) test_name 4
 
     Test.specify "should be able to count distinct items on a multiple sets of values" <|
-        test_aggregator simple_table (Count_Distinct (Column_Selector.By_Index [0, 1])) "Count Distinct count is_valid" 5
-        test_aggregator simple_table (Count_Distinct (Column_Selector.By_Name ["is_valid", "float"])) "Count Distinct is_valid float" 5
-        test_aggregator simple_table (Count_Distinct (Column_Selector.By_Name ["is_valid", "float"]) ignore_nothing=True) "Count Distinct is_valid float" 4
+        test_aggregator simple_table (Count_Distinct [0, 1]) "Count Distinct count is_valid" 5
+        test_aggregator simple_table (Count_Distinct ["is_valid", "float"]) "Count Distinct is_valid float" 5
+        test_aggregator simple_table (Count_Distinct ["is_valid", "float"] ignore_nothing=True) "Count Distinct is_valid float" 4
 
     Test.specify "should be able to get the minimum of a set of values" <|
         test_aggregator simple_table (Minimum -2) "Minimum float" 1

--- a/test/Table_Tests/src/In_Memory/Aggregate_Column_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Aggregate_Column_Spec.enso
@@ -12,10 +12,6 @@ import Standard.Test.Extensions
 
 spec = Test.group "Aggregate Columns" <|
     simple_table = Table.new [["count", [1, 2, Nothing, 3, Nothing]], ["is_valid", [Nothing, False, True, False, Nothing]], ["float", [3.4, 1, 5.6, 2.1, Nothing]], ["text", ["A", "", Nothing, "B,C", Nothing]]]
-    text_col = simple_table.at "text"
-    bool_col = simple_table.at "is_valid"
-    float_col = simple_table.at "float"
-    int_col = simple_table.at "count"
     empty_table  = Table.new [["count", []], ["is_valid", []], ["text", []]]
 
     test_name = "Test Column"
@@ -47,108 +43,93 @@ spec = Test.group "Aggregate Columns" <|
         test_aggregator simple_table (Count_Nothing 0) "Count Nothing count" 2
         test_aggregator simple_table (Count_Nothing 0 test_name) test_name 2
         test_aggregator simple_table (Count_Nothing "text" test_name) test_name 2
-        test_aggregator simple_table (Count_Nothing text_col test_name) test_name 2
         test_aggregator empty_table (Count_Nothing 0 test_name) test_name empty_table.row_count
 
     Test.specify "should be able to count non missing values in a set" <|
         test_aggregator simple_table (Count_Not_Nothing 0) "Count Not Nothing count" 3
         test_aggregator simple_table (Count_Not_Nothing 0 test_name) test_name 3
         test_aggregator simple_table (Count_Not_Nothing "text" test_name) test_name 3
-        test_aggregator simple_table (Count_Not_Nothing text_col test_name) test_name 3
         test_aggregator empty_table (Count_Not_Nothing 0 test_name) test_name empty_table.row_count
 
     Test.specify "should be able to count empties in a set of Texts" <|
         test_aggregator simple_table (Count_Empty -1) "Count Empty text" 3
         test_aggregator simple_table (Count_Empty -1 test_name) test_name 3
         test_aggregator simple_table (Count_Empty "text" test_name) test_name 3
-        test_aggregator simple_table (Count_Empty text_col test_name) test_name 3
         test_aggregator empty_table (Count_Empty 0 test_name) test_name empty_table.row_count
 
     Test.specify "should be able to count non empties in a set of Texts" <|
         test_aggregator simple_table (Count_Not_Empty -1) "Count Not Empty text" 2
         test_aggregator simple_table (Count_Not_Empty -1 test_name) test_name 2
         test_aggregator simple_table (Count_Not_Empty "text" test_name) test_name 2
-        test_aggregator simple_table (Count_Not_Empty text_col test_name) test_name 2
         test_aggregator empty_table (Count_Not_Empty 0 test_name) test_name empty_table.row_count
 
     Test.specify "should be able to total a set of values" <|
         test_aggregator simple_table (Sum -2) "Sum float" 12.1
         test_aggregator simple_table (Sum -2 test_name) test_name 12.1
         test_aggregator simple_table (Sum "float" test_name) test_name 12.1
-        test_aggregator simple_table (Sum float_col test_name) test_name 12.1
         test_aggregator empty_table (Sum 0 test_name) test_name Nothing
 
     Test.specify "should be able to average a set of values" <|
         test_aggregator simple_table (Average -2) "Average float" 3.025 0.000001
         test_aggregator simple_table (Average -2 test_name) test_name 3.025 0.000001
         test_aggregator simple_table (Average "float" test_name) test_name 3.025 0.000001
-        test_aggregator simple_table (Average float_col test_name) test_name 3.025 0.000001
         test_aggregator empty_table (Average 0 test_name) test_name Nothing
 
     Test.specify "should be able to compute standard deviation a set of values" <|
         test_aggregator simple_table (Standard_Deviation -2) "Standard Deviation float" 1.977161 0.000001
         test_aggregator simple_table (Standard_Deviation -2 test_name) test_name 1.977161 0.000001
         test_aggregator simple_table (Standard_Deviation "float" test_name) test_name 1.977161 0.000001
-        test_aggregator simple_table (Standard_Deviation float_col test_name) test_name 1.977161 0.000001
         test_aggregator empty_table (Standard_Deviation 0 test_name) test_name Nothing
 
     Test.specify "should be able to compute standard deviation of a population a set of values" <|
         test_aggregator simple_table (Standard_Deviation -2 population=True) "Standard Deviation float" 1.712271 0.000001
         test_aggregator simple_table (Standard_Deviation -2 test_name population=True) test_name 1.712271 0.000001
         test_aggregator simple_table (Standard_Deviation "float" test_name population=True) test_name 1.712271 0.000001
-        test_aggregator simple_table (Standard_Deviation float_col test_name population=True) test_name 1.712271 0.000001
         test_aggregator empty_table (Standard_Deviation 0 test_name population=True) test_name Nothing
 
     Test.specify "should be able to compute median a set of values" <|
         test_aggregator simple_table (Median -2) "Median float" 2.75 0.000001
         test_aggregator simple_table (Median -2 test_name) test_name 2.75 0.000001
         test_aggregator simple_table (Median "float" test_name) test_name 2.75 0.000001
-        test_aggregator simple_table (Median float_col test_name) test_name 2.75 0.000001
         test_aggregator empty_table (Median 0 test_name) test_name Nothing
 
     Test.specify "should be able to compute first of a set of values including missing" <|
         test_aggregator simple_table (First 1 ignore_nothing=False) "First is_valid" Nothing
         test_aggregator simple_table (First 1 test_name ignore_nothing=False) test_name Nothing
         test_aggregator simple_table (First "is_valid" test_name ignore_nothing=False) test_name Nothing
-        test_aggregator simple_table (First bool_col test_name ignore_nothing=False) test_name Nothing
         test_aggregator empty_table (First 0 test_name ignore_nothing=False) test_name Nothing
 
     Test.specify "should be able to compute first of a set of values excluding missing" <|
         test_aggregator simple_table (First 1) "First is_valid" False
         test_aggregator simple_table (First 1 test_name) test_name False
         test_aggregator simple_table (First "is_valid" test_name) test_name False
-        test_aggregator simple_table (First bool_col test_name) test_name False
         test_aggregator empty_table (First 0 test_name) test_name Nothing
 
     Test.specify "should be able to compute last of a set of values including missing" <|
         test_aggregator simple_table (Last 1 ignore_nothing=False) "Last is_valid" Nothing
         test_aggregator simple_table (Last 1 test_name ignore_nothing=False) test_name Nothing
         test_aggregator simple_table (Last "is_valid" test_name ignore_nothing=False) test_name Nothing
-        test_aggregator simple_table (Last bool_col test_name ignore_nothing=False) test_name Nothing
         test_aggregator empty_table (Last 0 test_name ignore_nothing=False) test_name Nothing
 
     Test.specify "should be able to compute last of a set of values excluding missing" <|
         test_aggregator simple_table (Last 1) "Last is_valid" False
         test_aggregator simple_table (Last 1 test_name) test_name False
         test_aggregator simple_table (Last "is_valid" test_name) test_name False
-        test_aggregator simple_table (Last bool_col test_name) test_name False
         test_aggregator empty_table (Last 0 test_name) test_name Nothing
 
     Test.specify "should be able to concatenate a set of values excluding missing" <|
         test_aggregator simple_table (Concatenate -1 Nothing ',' '[' ']' '"') "Concatenate text" '[A,"",,"B,C",]'
         test_aggregator simple_table (Concatenate -1 test_name) test_name 'AB,C'
         test_aggregator simple_table (Concatenate "text" test_name ',') test_name 'A,,,B,C,'
-        test_aggregator simple_table (Concatenate text_col test_name) test_name 'AB,C'
         test_aggregator empty_table (Concatenate 0 test_name) test_name Nothing
 
     Test.specify "should be able to count distinct items on a single set of values" <|
         test_aggregator simple_table (Count_Distinct 0) "Count Distinct count" 4
         test_aggregator simple_table (Count_Distinct 0 test_name) test_name 4
         test_aggregator simple_table (Count_Distinct "count" test_name) test_name 4
-        test_aggregator simple_table (Count_Distinct int_col test_name) test_name 4
         test_aggregator empty_table (Count_Distinct 0 test_name) test_name 0
-        test_aggregator simple_table (Count_Distinct float_col test_name ignore_nothing=False) test_name 5
-        test_aggregator simple_table (Count_Distinct float_col test_name ignore_nothing=True) test_name 4
+        test_aggregator simple_table (Count_Distinct "float" test_name ignore_nothing=False) test_name 5
+        test_aggregator simple_table (Count_Distinct "float" test_name ignore_nothing=True) test_name 4
 
     Test.specify "should be able to count distinct items on a multiple sets of values" <|
         test_aggregator simple_table (Count_Distinct [0, 1]) "Count Distinct count is_valid" 5
@@ -159,28 +140,24 @@ spec = Test.group "Aggregate Columns" <|
         test_aggregator simple_table (Minimum -2) "Minimum float" 1
         test_aggregator simple_table (Minimum -2 test_name) test_name 1
         test_aggregator simple_table (Minimum "float" test_name) test_name 1
-        test_aggregator simple_table (Minimum float_col test_name) test_name 1
         test_aggregator empty_table (Minimum 0 test_name) test_name Nothing
 
     Test.specify "should be able to get the maximum of a set of values" <|
         test_aggregator simple_table (Maximum -2) "Maximum float" 5.6
         test_aggregator simple_table (Maximum -2 test_name) test_name 5.6
         test_aggregator simple_table (Maximum "float" test_name) test_name 5.6
-        test_aggregator simple_table (Maximum float_col test_name) test_name 5.6
         test_aggregator empty_table (Maximum 0 test_name) test_name Nothing
 
     Test.specify "should be able to get the shortest of a set of texts" <|
         test_aggregator simple_table (Shortest -1) "Shortest text" ""
         test_aggregator simple_table (Shortest -1 test_name) test_name ""
         test_aggregator simple_table (Shortest "text" test_name) test_name ""
-        test_aggregator simple_table (Shortest text_col test_name) test_name ""
         test_aggregator empty_table (Shortest 0 test_name) test_name Nothing
 
     Test.specify "should be able to get the longest of a set of texts" <|
         test_aggregator simple_table (Longest -1) "Longest text" "B,C"
         test_aggregator simple_table (Longest -1 test_name) test_name "B,C"
         test_aggregator simple_table (Longest "text" test_name) test_name "B,C"
-        test_aggregator simple_table (Longest text_col test_name) test_name "B,C"
         test_aggregator empty_table (Longest 0 test_name) test_name Nothing
 
     Test.specify "should be able to get the mode of a set of numbers" <|

--- a/test/Table_Tests/src/In_Memory/Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Spec.enso
@@ -626,7 +626,7 @@ spec =
             texts1 = ["texts1", ["foo", "bar", "baz"]]
             texts2 = ["texts2", ["baz", "quux", "spam"]]
             table = Table.new [bools, texts1, texts2]
-            actual = table.replace_text (Column_Selector.By_Name ["texts1", "texts2"]) "a" "o"
+            actual = table.replace_text ["texts1", "texts2"] "a" "o"
             actual.at "bools"  . to_vector . should_equal [False, False, True]
             actual.at "texts1" . to_vector . should_equal ["foo", "bor", "boz"]
             actual.at "texts2" . to_vector . should_equal ["boz", "quux", "spom"]
@@ -702,7 +702,7 @@ spec =
             c = ["C", [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]]
             t = Table.new [a, b, c]
 
-            r2 = t.distinct (Column_Selector.By_Name ["A", "B"]) on_problems=Report_Error
+            r2 = t.distinct ["A", "B"] on_problems=Report_Error
             r2.at "A" . to_vector . should_equal ["a", "a"]
             r2.at "B" . to_vector . should_equal [1, 2]
             r2.at "C" . to_vector . should_equal [0.1, 0.3]
@@ -711,7 +711,7 @@ spec =
             a = ["A", ["a", Nothing, "b", "a", "b", Nothing, "a", "b"]]
             b = ["B", [1, 2, 3, 4, 5, 6, 7, 8]]
             t = Table.new [a, b]
-            r = t.distinct (Column_Selector.By_Name ["A"]) on_problems=Report_Error
+            r = t.distinct ["A"] on_problems=Report_Error
             r.at "A" . to_vector . should_equal ["a", Nothing, "b"]
             r.at "B" . to_vector . should_equal [1, 2, 3]
 
@@ -723,11 +723,11 @@ spec =
             x = ["X", ['A', 'a', 'enso', 'śledź', 'Enso', 'A', 's\u0301ledz\u0301']]
             y = ["Y", [1, 2, 3, 4, 5, 6, 7]]
             t1 = Table.new [x, y]
-            d1 = t1.distinct (Column_Selector.By_Name ["X"]) on_problems=Report_Error
+            d1 = t1.distinct ["X"] on_problems=Report_Error
             d1.at "X" . to_vector . should_equal ['A', 'a', 'enso', 'śledź', 'Enso']
             d1.at "Y" . to_vector . should_equal [1, 2, 3, 4, 5]
 
-            d2 = t1.distinct (Column_Selector.By_Name ["X"]) case_sensitivity=Case_Sensitivity.Insensitive on_problems=Report_Error
+            d2 = t1.distinct ["X"] case_sensitivity=Case_Sensitivity.Insensitive on_problems=Report_Error
             d2.at "X" . to_vector . should_equal ['A', 'enso', 'śledź']
             d2.at "Y" . to_vector . should_equal [1, 3, 4]
 


### PR DESCRIPTION
### Pull Request Description

- Updated `Widget.Vector_Editor` ready for use by IDE team.
- Added `get` to `Row` to make API more aligned.
- Added `first_column`, `second_column` and `last_column` to `Table` APIs.
- Adjusted `Column_Selector` and associated methods to have simpler API.
- Removed `Column` from `Aggregate_Column` constructors.
- Added new `Excel_Workbook` type and added to `Excel_Section`.
- Added new `SQLiteFormatSPI` and `SQLite_Format`.
- Added new `IamgeFormatSPI` and `Image_Format`.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
