### PR TITLE
Make font size in the documentation panel smaller

### DIFF
--- a/app/gui/view/documentation/src/html.rs
+++ b/app/gui/view/documentation/src/html.rs
@@ -43,7 +43,7 @@ const ICON_SVG_XMLNS: &str = "http://www.w3.org/2000/svg";
 /// A single icon used in headers. `content` is an SVG code of the icon's content _without_ the
 /// surrounding `<svg>` tags.
 fn svg_icon(content: &'static str) -> impl Render {
-    let class = "w-5 h-5 fill-none flex-shrink-0 mt-0.5";
+    let class = "w-[12px] h-[12px] fill-none flex-shrink-0 mt-0.5";
     owned_html! {
         svg(class=class, viewBox=ICON_VIEWBOX, xmlns=ICON_SVG_XMLNS) {
             :Raw(content)
@@ -484,7 +484,7 @@ fn local_synopsis<'a>(synopsis: &'a Synopsis) -> Box<dyn Render + 'a> {
 /// class.
 fn docs_content(content: impl Render) -> impl Render {
     owned_html! {
-        div(class="enso-docs text-docsText bg-docsBackground pl-4 pr-2") {
+        div(class="enso-docs text-docsText text-base bg-docsBackground pl-4 pr-2") {
             : &content;
         }
     }
@@ -492,7 +492,7 @@ fn docs_content(content: impl Render) -> impl Render {
 
 fn section_content(content: impl Render) -> impl Render {
     owned_html! {
-        div(class="pl-7") {
+        div(class="pl-5") {
             : &content;
         }
     }
@@ -626,7 +626,7 @@ pub fn caption_html() -> String {
     owned_html! {
         div(class="bg-captionBackground rounded-t-[14px] w-full h-full flex \
                    items-center justify-center") {
-            div(class="text-xs text-white") {
+            div(class="text-base text-white") {
                 : "Hovered item preview. Press the right mouse button to lock it.";
             }
         }

--- a/app/gui/view/documentation/tailwind.config.js
+++ b/app/gui/view/documentation/tailwind.config.js
@@ -2,6 +2,12 @@
 module.exports = {
     content: ['src/**/*.rs'],
     theme: {
+        fontSize: {
+            base: '11.5px',
+            lg: '13px',
+            xl: '15px',
+            '2xl': '17px',
+        },
         extend: {
             colors: {
                 typeName: '#9640da',


### PR DESCRIPTION
### Pull Request Description

Closes #5653 

Make the font size in the documentation panel smaller, the same size as component browser entries.

<img width="1301" alt="Screenshot 2023-02-14 at 14 23 51" src="https://user-images.githubusercontent.com/6566674/218712728-1f233ebb-7b17-4f6d-92e3-2e60def626d3.png">
<img width="890" alt="Screenshot 2023-02-14 at 14 36 55" src="https://user-images.githubusercontent.com/6566674/218712753-72d1cd49-14f7-46c0-a5f5-f56f568219a5.png">

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
