### PR TITLE
Fix Match Scoring Algorithm

### DIFF
--- a/app/gui/src/controller/searcher/component.rs
+++ b/app/gui/src/controller/searcher/component.rs
@@ -433,7 +433,7 @@ pub(crate) mod tests {
             .map(|c| c.match_info.borrow().clone())
             .collect_vec();
         debug!("{match_infos:?}");
-        assert_ids_of_matches_entries(&list.top_modules().next().unwrap()[0], &[2, 4]);
+        assert_ids_of_matches_entries(&list.top_modules().next().unwrap()[0], &[4, 2]);
         assert_ids_of_matches_entries(&list.favorites[0], &[4, 2]);
         assert_ids_of_matches_entries(&list.local_scope, &[2]);
 

--- a/lib/rust/fuzzly/src/metric.rs
+++ b/lib/rust/fuzzly/src/metric.rs
@@ -94,9 +94,9 @@ impl Default for SubsequentLettersBonus {
 }
 
 impl Metric for SubsequentLettersBonus {
-    fn measure_vertex(&self, vertex: subsequence_graph::Vertex, text: &str, _pattern: &str) -> f32 {
+    fn measure_vertex(&self, vertex: subsequence_graph::Vertex, text: &str, pattern: &str) -> f32 {
         let is_first_pattern_char = vertex.layer == 0;
-        let is_last_pattern_char = text.len().checked_sub(1).contains(&vertex.layer);
+        let is_last_pattern_char = pattern.len().checked_sub(1).contains(&vertex.layer);
         let first_char_bonus = if is_first_pattern_char {
             self.base_weight / (vertex.position_in_text as f32 + 1.0) * self.beginning_weight
         } else {

--- a/lib/rust/fuzzly/src/score.rs
+++ b/lib/rust/fuzzly/src/score.rs
@@ -230,6 +230,7 @@ pub fn find_best_subsequence(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::metric;
 
     mod mock_metric {
         use super::*;
@@ -334,5 +335,29 @@ mod test {
         let pattern = "any";
         let text = "";
         assert_eq!(find_best_subsequence(text, pattern, mock_metric::Sum::default()), None);
+    }
+
+    #[test]
+    fn correct_scoring_of_trailing_pattern() {
+        let pattern = "list";
+        let target_text = "File.list";
+        let target_text_2 = "File.list_immediate_children";
+
+        let score1 =
+            find_best_subsequence(target_text, pattern, metric::SubsequentLettersBonus::default())
+                .unwrap()
+                .score;
+        let score2 = find_best_subsequence(
+            target_text_2,
+            pattern,
+            metric::SubsequentLettersBonus::default(),
+        )
+        .unwrap()
+        .score;
+
+        assert!(
+            score1 > score2,
+            "Score of trailing pattern should be higher than score of non-trailing pattern."
+        );
     }
 }


### PR DESCRIPTION


### Pull Request Description

Fixes an error in our scoring algorithm for computing match scores. It now correctly computes scores for patterns that are trailing the target text and ranks patterns at the end of the target text higher than patterns in the middle of the target text. 

Closes  #4965 (for now).
See also Discussion https://github.com/enso-org/enso/discussions/5649


### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
