### PR TITLE
Bump supported engine version

### DIFF
--- a/app/gui/config.yaml
+++ b/app/gui/config.yaml
@@ -16,8 +16,8 @@ minimumSupportedVersion": "2.0.0-alpha.6"
 
 # The minimum engine version supported by the application. The projects opened with the older versions
 # will have the "Unsupported engine version" message displayed.
-engineVersionSupported: "2022.1.1-nightly.2022-04-26"
+engineVersionSupported: "2023.1.1-nightly.2023.2.8"
 
 # The minimum language edition supported by the application. It will be displayed as edition user
 # should put in their package.yaml file to have project compatible with the IDE.
-languageEditionSupported: "2022.1.1-nightly.2022-04-26"
+languageEditionSupported: "2023.1.1-nightly.2023.2.8"

--- a/app/gui/config/src/lib.rs
+++ b/app/gui/config/src/lib.rs
@@ -28,7 +28,7 @@ include!(concat!(env!("OUT_DIR"), "/config.rs"));
 pub use generated::*;
 
 pub fn engine_version_requirement() -> semver::VersionReq {
-    semver::VersionReq::parse(&format!("^{engine_version_supported}")).unwrap()
+    semver::VersionReq::parse(&format!(">={engine_version_supported}")).unwrap()
 }
 
 


### PR DESCRIPTION
### Pull Request Description

Bumped supported engine version to the first nightly after last breaking change.

Also made it not being fooled by year change.

### Important Notes

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - ~~[x] Unit tests have been written where possible.~~
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
