### PR TITLE
Ensure that warnings are preserved on Nothing values passing back to Enso through polyglot boundary

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -745,20 +745,9 @@ type Output_Stream
            the `?` character.
         replacement_sequence = Encoding_Utils.INVALID_CHARACTER.bytes encoding on_problems=Problem_Behavior.Ignore
         java_charset = encoding.to_java_charset
-        ## This is a workaround due to the fact that this `action` will be
-           called as a callback from a Java method and we have a bug where a
-           `Nothing` returned from such a method will loose its attached
-           warnings. To avoid that, we return a Text value instead. It is then
-           replaced with a `Nothing` on the other side of the call, but making
-           sure that any warnings are inherited.
-           The related bug is tracked at https://github.com/enso-org/enso/issues/5672
-        wrapped_action encoder =
-            result = action encoder
-            Pair.new result Nothing
-        results = Encoding_Utils.with_stream_encoder java_stream java_charset replacement_sequence.to_array wrapped_action
+        results = Encoding_Utils.with_stream_encoder java_stream java_charset replacement_sequence.to_array action
         problems = Vector.from_polyglot_array results.problems . map Encoding_Error.Error
-        unwrapped_result = results.result . first
-        on_problems.attach_problems_after unwrapped_result problems
+        on_problems.attach_problems_after results.result problems
 
 ## An input stream, allowing for interactive reading of contents from an open
    file.

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/syntax/HostValueToEnsoNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/syntax/HostValueToEnsoNode.java
@@ -2,16 +2,11 @@ package org.enso.interpreter.node.expression.builtin.interop.syntax;
 
 import com.oracle.truffle.api.dsl.*;
 import com.oracle.truffle.api.interop.InteropLibrary;
-import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
-import com.oracle.truffle.api.profiles.ConditionProfile;
 import org.enso.interpreter.node.expression.foreign.CoerceNothing;
-import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.data.text.Text;
-import org.enso.interpreter.runtime.error.Warning;
 import org.enso.interpreter.runtime.error.WarningsLibrary;
-import org.enso.interpreter.runtime.error.WithWarnings;
 
 /**
  * Converts a value returned by a polyglot call back to a value that can be further used within Enso
@@ -70,9 +65,8 @@ public abstract class HostValueToEnsoNode extends Node {
       Object o,
       @CachedLibrary(limit = "3") InteropLibrary nulls,
       @CachedLibrary(limit = "3") WarningsLibrary warnings,
-      @Cached ConditionProfile nullWarningProfile) {
-    var nothing = EnsoContext.get(this).getBuiltins().nothing();
-    return CoerceNothing.coerceNothing(o, nothing, warnings, nullWarningProfile);
+      @Cached CoerceNothing coerceNothing) {
+    return coerceNothing.execute(o);
   }
 
   @Fallback

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/syntax/HostValueToEnsoNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/syntax/HostValueToEnsoNode.java
@@ -6,6 +6,7 @@ import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.ConditionProfile;
+import org.enso.interpreter.node.expression.foreign.CoerceNothing;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.error.Warning;
@@ -71,17 +72,7 @@ public abstract class HostValueToEnsoNode extends Node {
       @CachedLibrary(limit = "3") WarningsLibrary warnings,
       @Cached ConditionProfile nullWarningProfile) {
     var nothing = EnsoContext.get(this).getBuiltins().nothing();
-
-    if (nullWarningProfile.profile(warnings.hasWarnings(o))) {
-      try {
-        Warning[] attachedWarnings = warnings.getWarnings(o, null);
-        return new WithWarnings(nothing, attachedWarnings);
-      } catch (UnsupportedMessageException e) {
-        return nothing;
-      }
-    }
-
-    return nothing;
+    return CoerceNothing.coerceNothing(o, nothing, warnings, nullWarningProfile);
   }
 
   @Fallback

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/foreign/CoerceNothing.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/foreign/CoerceNothing.java
@@ -21,7 +21,8 @@ public abstract class CoerceNothing extends Node {
   }
 
   /**
-   * Converts a null polyglot representation into an equivalent Nothing representation in Enso context.
+   * Converts a null polyglot representation into an equivalent Nothing representation in Enso
+   * context.
    *
    * @param value the polyglot value to perform coercion on
    * @return {@code value} coerced to an Enso primitive where applicable

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/foreign/CoerceNothing.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/foreign/CoerceNothing.java
@@ -8,6 +8,7 @@ import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.profiles.ConditionProfile;
 import org.enso.interpreter.runtime.EnsoContext;
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.error.Warning;
 import org.enso.interpreter.runtime.error.WarningsLibrary;
 import org.enso.interpreter.runtime.error.WithWarnings;
@@ -34,17 +35,24 @@ public abstract class CoerceNothing extends Node {
       @CachedLibrary(limit = "1") InteropLibrary interop,
       @CachedLibrary(limit = "3") WarningsLibrary warnings) {
     var nothing = EnsoContext.get(this).getBuiltins().nothing();
+    return coerceNothing(value, nothing, warnings, nullWarningProfile);
+  }
 
-    if (nullWarningProfile.profile(warnings.hasWarnings(value))) {
+  public static Object coerceNothing(
+      Object nullInput,
+      Type nullOutput,
+      WarningsLibrary warningsLibrary,
+      ConditionProfile nullWarningProfile) {
+    if (nullWarningProfile.profile(warningsLibrary.hasWarnings(nullInput))) {
       try {
-        Warning[] attachedWarnings = warnings.getWarnings(value, null);
-        return new WithWarnings(nothing, attachedWarnings);
+        Warning[] attachedWarnings = warningsLibrary.getWarnings(nullInput, null);
+        return new WithWarnings(nullOutput, attachedWarnings);
       } catch (UnsupportedMessageException e) {
-        return nothing;
+        return nullOutput;
       }
     }
 
-    return nothing;
+    return nullOutput;
   }
 
   @Fallback

--- a/std-bits/base/src/main/java/org/enso/base/Encoding_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/Encoding_Utils.java
@@ -3,6 +3,7 @@ package org.enso.base;
 import org.enso.base.encoding.ReportingStreamDecoder;
 import org.enso.base.encoding.ReportingStreamEncoder;
 import org.enso.base.text.ResultWithWarnings;
+import org.graalvm.polyglot.Value;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -167,15 +168,13 @@ public class Encoding_Utils {
    * <p>It returns the result returned from the executed action and any encoding problems that
    * occurred when processing it.
    */
-  public static <R> WithProblems<R, String> with_stream_decoder(
-      InputStream stream, Charset charset, Function<ReportingStreamDecoder, R> action)
+  public static WithProblems<Value, String> with_stream_decoder(
+      InputStream stream, Charset charset, Function<ReportingStreamDecoder, Value> action)
       throws IOException {
-    R result;
+    Value result;
     ReportingStreamDecoder decoder = create_stream_decoder(stream, charset);
-    try {
+    try (decoder) {
       result = action.apply(decoder);
-    } finally {
-      decoder.close();
     }
     return new WithProblems<>(result, decoder.getReportedProblems());
   }
@@ -198,18 +197,16 @@ public class Encoding_Utils {
    * <p>It returns the result returned from the executed action and any encoding problems that
    * occurred when processing it.
    */
-  public static <R> WithProblems<R, String> with_stream_encoder(
+  public static WithProblems<Value, String> with_stream_encoder(
       OutputStream stream,
       Charset charset,
       byte[] replacementSequence,
-      Function<ReportingStreamEncoder, R> action)
+      Function<ReportingStreamEncoder, Value> action)
       throws IOException {
-    R result;
+    Value result;
     ReportingStreamEncoder encoder = create_stream_encoder(stream, charset, replacementSequence);
-    try {
+    try (encoder) {
       result = action.apply(encoder);
-    } finally {
-      encoder.close();
     }
     return new WithProblems<>(result, encoder.getReportedProblems());
   }

--- a/test/Tests/polyglot-sources/enso-test-java-helpers/src/main/java/org/enso/base_test_helpers/CallbackHelper.java
+++ b/test/Tests/polyglot-sources/enso-test-java-helpers/src/main/java/org/enso/base_test_helpers/CallbackHelper.java
@@ -1,0 +1,11 @@
+package org.enso.base_test_helpers;
+
+import org.graalvm.polyglot.Value;
+
+import java.util.function.Function;
+
+public class CallbackHelper {
+  public static Value runCallbackInt(Function<Integer, Value> callback, int x) {
+    return callback.apply(x);
+  }
+}

--- a/test/Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Tests/src/Semantic/Warnings_Spec.enso
@@ -1,6 +1,8 @@
 from Standard.Base import all
 
 polyglot java import java.lang.Long
+polyglot java import java.util.function.Function as Java_Function
+polyglot java import org.enso.base_test_helpers.CallbackHelper
 
 from Standard.Test import Test, Test_Suite
 import Standard.Test.Extensions
@@ -245,5 +247,55 @@ spec = Test.group "Dataflow Warnings" <|
         Warning.get_all r . map .value . should_contain_the_same_elements_as ["b", "a"]
         Warning.get_all a . map .value . should_contain_the_same_elements_as ["a"]
         Warning.get_all b . map .value . should_contain_the_same_elements_as ["b"]
+
+    Test.specify "should be preserved around polyglot calls expecting a Value" <|
+        x = Warning.attach "x" 1
+
+        java_id = Java_Function.identity
+        f x = Warning.attach "f("+x.to_text+")" <| Pair.new "A" x+10
+        ## We compose our Enso functions with Java identity, forcing our methods
+           to be lifted into the Java polyglot world and being used as callbacks
+           from within Java.
+        javaized_f = Java_Function.identity.andThen f
+
+        r1 = java_id.apply x
+        r1.should_equal 1
+        Warning.get_all r1 . map .value . should_contain_the_same_elements_as ["x"]
+
+        r2 = javaized_f.apply x
+        r2.should_equal (Pair.new "A" 11)
+        Warning.get_all r2 . map .value . should_contain_the_same_elements_as ["f(1)", "x"]
+
+        ## The following will not work, as if the polyglot method expects an
+           `Object` it will get converted to a Java 'primitive' losing the
+           attached warnings. The only way to preserve warnings in that case is
+           to explicitly expect a `Value` return type, as in the test below.
+        #g x = Warning.attach "g("+x.to_text+")" x+10
+        #h x = Warning.attach "h("+x.to_text+")" "{x="+x.to_text+"}"
+        #i x = Warning.attach "i("+x.to_text+")" Nothing
+
+    Test.specify "should be preserved around polyglot calls expecting a Value" <|
+        x = Warning.attach "x" 1
+
+        f x = Warning.attach "f("+x.to_text+")" <| Pair.new "A" x+10
+        g x = Warning.attach "g("+x.to_text+")" x+10
+        h x = Warning.attach "h("+x.to_text+")" "{x="+x.to_text+"}"
+        i x = Warning.attach "i("+x.to_text+")" Nothing
+
+        r1 = CallbackHelper.runCallbackInt f x
+        r1.should_equal (Pair.new "A" 11)
+        Warning.get_all r1 . map .value . should_contain_the_same_elements_as ["f(1)", "x"]
+
+        r2 = CallbackHelper.runCallbackInt g x
+        r2.should_equal 11
+        Warning.get_all r2 . map .value . should_contain_the_same_elements_as ["g(1)", "x"]
+
+        r3 = CallbackHelper.runCallbackInt h x
+        r3.should_equal "{x=1}"
+        Warning.get_all r3 . map .value . should_contain_the_same_elements_as ["h(1)", "x"]
+
+        r4 = CallbackHelper.runCallbackInt i x
+        r4.should_equal Nothing
+        Warning.get_all r4 . map .value . should_contain_the_same_elements_as ["i(1)", "x"]
 
 main = Test_Suite.run_main spec

--- a/test/Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Tests/src/Semantic/Warnings_Spec.enso
@@ -248,7 +248,7 @@ spec = Test.group "Dataflow Warnings" <|
         Warning.get_all a . map .value . should_contain_the_same_elements_as ["a"]
         Warning.get_all b . map .value . should_contain_the_same_elements_as ["b"]
 
-    Test.specify "should be preserved around polyglot calls expecting a Value" <|
+    Test.specify "should be preserved around polyglot calls" <|
         x = Warning.attach "x" 1
 
         java_id = Java_Function.identity
@@ -274,7 +274,7 @@ spec = Test.group "Dataflow Warnings" <|
         #h x = Warning.attach "h("+x.to_text+")" "{x="+x.to_text+"}"
         #i x = Warning.attach "i("+x.to_text+")" Nothing
 
-    Test.specify "should be preserved around polyglot calls expecting a Value" <|
+    Test.specify "should be better preserved around polyglot calls expecting a Value" <|
         x = Warning.attach "x" 1
 
         f x = Warning.attach "f("+x.to_text+")" <| Pair.new "A" x+10


### PR DESCRIPTION
### Pull Request Description

Fixes #5672 

### Important Notes

- Added a subproject `enso-test-java-helpers` which allows the in-Enso tests to add Java helpers for testing.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
