### PR TITLE
Schedule initialization of JS context in a separate thread

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -292,6 +292,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: LogLevel) {
       RuntimeServerInfo.JOB_PARALLELISM_OPTION,
       Runtime.getRuntime.availableProcessors().toString
     )
+    .option(RuntimeOptions.PREINITIALIZE, "js")
     .out(stdOut)
     .err(stdErr)
     .in(stdIn)

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
@@ -71,6 +71,10 @@ public class RuntimeOptions {
       OptionDescriptor.newBuilder(EDITION_OVERRIDE_KEY, EDITION_OVERRIDE).build();
 
   public static final String DISABLE_IR_CACHES = optionName("disableIrCaches");
+  public static final String PREINITIALIZE = optionName("preinitialize");
+  public static final OptionKey<String> PREINITIALIZE_KEY = new OptionKey<>("");
+  private static final OptionDescriptor PREINITIALIZE_DESCRIPTOR =
+      OptionDescriptor.newBuilder(PREINITIALIZE_KEY, PREINITIALIZE).build();
   public static final OptionKey<Boolean> DISABLE_IR_CACHES_KEY = new OptionKey<>(false);
   private static final OptionDescriptor DISABLE_IR_CACHES_DESCRIPTOR =
       OptionDescriptor.newBuilder(DISABLE_IR_CACHES_KEY, DISABLE_IR_CACHES).build();
@@ -115,6 +119,7 @@ public class RuntimeOptions {
               EDITION_OVERRIDE_DESCRIPTOR,
               INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION_DESCRIPTOR,
               DISABLE_IR_CACHES_DESCRIPTOR,
+              PREINITIALIZE_DESCRIPTOR,
               WAIT_FOR_PENDING_SERIALIZATION_JOBS_DESCRIPTOR,
               USE_GLOBAL_IR_CACHE_LOCATION_DESCRIPTOR,
               ENABLE_EXECUTION_TIMER_DESCRIPTOR));

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/EpbLanguage.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/EpbLanguage.java
@@ -1,8 +1,8 @@
 package org.enso.interpreter.epb;
 
 import com.oracle.truffle.api.CallTarget;
-import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.TruffleLanguage;
+import java.util.function.Consumer;
 import org.enso.interpreter.epb.node.ContextRewrapNode;
 import org.enso.interpreter.epb.node.ForeignEvalNode;
 
@@ -34,19 +34,23 @@ import org.enso.interpreter.epb.node.ForeignEvalNode;
     characterMimeTypes = {EpbLanguage.MIME},
     internal = true,
     defaultMimeType = EpbLanguage.MIME,
-    contextPolicy = TruffleLanguage.ContextPolicy.SHARED)
+    contextPolicy = TruffleLanguage.ContextPolicy.SHARED,
+    services = Consumer.class)
 public class EpbLanguage extends TruffleLanguage<EpbContext> {
   public static final String ID = "epb";
   public static final String MIME = "application/epb";
 
   @Override
   protected EpbContext createContext(Env env) {
-    return new EpbContext(env);
+    var ctx = new EpbContext(env);
+    Consumer<String> init = ctx::initialize;
+    env.registerService(init);
+    return ctx;
   }
 
   @Override
   protected void initializeContext(EpbContext context) {
-    context.initialize();
+    context.initialize(null);
   }
 
   @Override

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/ForeignEvalNode.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/ForeignEvalNode.java
@@ -3,7 +3,6 @@ package org.enso.interpreter.epb.node;
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.exception.AbstractTruffleException;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.VirtualFrame;

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/runtime/GuardedTruffleContext.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/runtime/GuardedTruffleContext.java
@@ -2,10 +2,12 @@ package org.enso.interpreter.epb.runtime;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.TruffleContext;
+import com.oracle.truffle.api.TruffleLanguage;
 
 import com.oracle.truffle.api.nodes.Node;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 
 /** Wraps a {@link TruffleContext} by providing an optional GIL functionality. */
 public class GuardedTruffleContext {
@@ -25,6 +27,16 @@ public class GuardedTruffleContext {
     } else {
       this.lock = null;
     }
+  }
+
+  /**
+   * Spawns new thread with associated {@code context}
+   *
+   * @param env environment to spawn the thread in
+   * @param run code to execute in given TruffleContext
+   */
+  public Thread createThread(TruffleLanguage.Env env, Consumer<TruffleContext> run) {
+    return env.createThread(() -> run.accept(context), context);
   }
 
   /**

--- a/engine/runtime-with-polyglot/src/test/java/org/enso/interpreter/test/instrument/MockLogHandler.java
+++ b/engine/runtime-with-polyglot/src/test/java/org/enso/interpreter/test/instrument/MockLogHandler.java
@@ -1,0 +1,42 @@
+package org.enso.interpreter.test.instrument;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.SimpleFormatter;
+import static org.junit.Assert.fail;
+
+final class MockLogHandler extends Handler {
+  private final List<LogRecord> logs = new ArrayList<>();
+
+  MockLogHandler() {
+    setLevel(Level.ALL);
+  }
+
+  @Override
+  public synchronized void publish(LogRecord lr) {
+    logs.add(lr);
+  }
+
+  @Override
+  public void flush() {}
+
+  @Override
+  public void close() throws SecurityException {}
+
+  synchronized Object[] assertMessage(String loggerName, String msgPrefix) {
+    var f = new SimpleFormatter();
+    var sb = new StringBuilder();
+    sb.append("Cannot find ").append(msgPrefix).append(" in ").append(loggerName);
+    for (var r : logs) {
+      if (loggerName.equals(r.getLoggerName()) && r.getMessage().startsWith(msgPrefix)) {
+        return r.getParameters();
+      }
+      sb.append("\n").append(f.format(r));
+    }
+    fail(sb.toString());
+    return null;
+  }
+}

--- a/engine/runtime-with-polyglot/src/test/java/org/enso/interpreter/test/instrument/VerifyJavaScriptIsAvailableTest.java
+++ b/engine/runtime-with-polyglot/src/test/java/org/enso/interpreter/test/instrument/VerifyJavaScriptIsAvailableTest.java
@@ -1,41 +1,56 @@
 package org.enso.interpreter.test.instrument;
 
-import java.io.OutputStream;
 import java.nio.file.Paths;
 import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class VerifyJavaScriptIsAvailableTest {
   private static Context ctx;
+  private static MockLogHandler handler;
 
   @BeforeClass
   public static void initEnsoContext() {
+    handler = new MockLogHandler();
     ctx =
         Context.newBuilder()
             .allowExperimentalOptions(true)
             .allowIO(true)
+            .option(RuntimeOptions.PREINITIALIZE, "js")
             .option(
                 RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
                 Paths.get("../../distribution/component").toFile().getAbsolutePath())
-            .logHandler(OutputStream.nullOutputStream())
+            .option("log.level", "FINE")
+            .logHandler(handler)
             .allowAllAccess(true)
             .build();
     assertNotNull("Enso language is supported", ctx.getEngine().getLanguages().get("enso"));
+    var fourtyTwo =
+        ctx.eval("enso", "mul x y = x * y").invokeMember("eval_expression", "mul").execute(6, 7);
+    assertEquals(42, fourtyTwo.asInt());
   }
 
   @AfterClass
   public static void closeEnsoContext() throws Exception {
     ctx.close();
+
+    var args =
+        handler.assertMessage(
+            "epb.org.enso.interpreter.epb.EpbContext", "Done initializing language");
+    assertEquals("js", args[0]);
+    assertEquals(Boolean.TRUE, args[1]);
   }
 
   @Test
   public void javaScriptIsPresent() {
     var js = ctx.getEngine().getLanguages().get("js");
     assertNotNull("JavaScript is available", js);
+    var fourtyTwo = ctx.eval("js", "6 * 7");
+    assertEquals(42, fourtyTwo.asInt());
   }
 
   @Test

--- a/engine/runtime/src/main/java/org/enso/interpreter/EnsoLanguage.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/EnsoLanguage.java
@@ -16,6 +16,7 @@ import java.io.PrintStream;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.enso.compiler.Compiler;
 import org.enso.compiler.context.InlineContext;
@@ -156,8 +157,16 @@ public final class EnsoLanguage extends TruffleLanguage<EnsoContext> {
    * @param context the language context
    */
   @Override
+  @SuppressWarnings("unchecked")
   protected void initializeContext(EnsoContext context) {
     context.initialize();
+    var env = context.getEnvironment();
+    var preinit = env.getOptions().get(RuntimeOptions.PREINITIALIZE_KEY);
+    if (preinit != null && preinit.length() > 0) {
+      var epb = env.getInternalLanguages().get(EpbLanguage.ID);
+      var run = env.lookup(epb, Consumer.class);
+      run.accept(preinit);
+    }
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/instrument/IdExecutionService.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/instrument/IdExecutionService.java
@@ -2,8 +2,6 @@ package org.enso.interpreter.instrument;
 
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.instrumentation.EventBinding;
-import com.oracle.truffle.api.instrumentation.ExecutionEventListener;
-import com.oracle.truffle.api.instrumentation.ExecutionEventNode;
 import com.oracle.truffle.api.instrumentation.ExecutionEventNodeFactory;
 import com.oracle.truffle.api.nodes.RootNode;
 import java.util.Arrays;


### PR DESCRIPTION
### Pull Request Description

Implements the #5643 idea. As soon as `MainModule` creates `Context` for GraalVM execution, it schedules a background task to initialize JavaScript. The initialization finishes sooner than Enso compiler is ready to work, saving time when it is actually needed. 

### Important Notes

Only modifies boot sequence of `MainModule` (used in the IDE) and `VerifyJavaScriptIsAvailableTest` (to verify the _"context passing logic"_ works OK between threads). Regular CLI execution remains unchanged for now assuming batch execution may not need JavaScript in all the cases and if it does the initialization speed isn't that critical.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
