### PR TITLE
support custom widget entry labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@
   sign up and sign in for users), via either email/password or GitHub/Google.
 - [New Enso documentation parser][5917]. Smaller and faster; enables planned
   improvements to internal documentation representation.
+- [Added more user-friendly labels to dropdown widgets.][5705]
 
 #### EnsoGL (rendering engine)
 
@@ -530,6 +531,7 @@
 [5850]: https://github.com/enso-org/enso/pull/5850
 [5863]: https://github.com/enso-org/enso/pull/5863
 [5917]: https://github.com/enso-org/enso/pull/5917
+[5705]: https://github.com/enso-org/enso/pull/5705
 
 #### Enso Compiler
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,10 @@
   sign up and sign in for users), via either email/password or GitHub/Google.
 - [New Enso documentation parser][5917]. Smaller and faster; enables planned
   improvements to internal documentation representation.
-- [Added more user-friendly labels to dropdown widgets.][5705]
+- [Dropdown widgets now support custom labels][5705] and automatically generate
+  shortened labels for entries with long module paths. When an option is
+  selected from the dropdown, the necessary module imports are inserted,
+  eliminating the need for fully qualified names.
 
 #### EnsoGL (rendering engine)
 

--- a/app/gui/controller/double-representation/src/alias_analysis.rs
+++ b/app/gui/controller/double-representation/src/alias_analysis.rs
@@ -9,7 +9,6 @@ use crate::definition::ScopeKind;
 use ast::crumbs::Crumb;
 use ast::crumbs::InfixCrumb;
 use ast::crumbs::Located;
-use ast::crumbs::PrefixCrumb;
 use ast::opr::match_named_argument;
 use std::borrow::Borrow;
 

--- a/app/gui/controller/double-representation/src/alias_analysis.rs
+++ b/app/gui/controller/double-representation/src/alias_analysis.rs
@@ -291,11 +291,11 @@ impl AliasAnalyzer {
                 // Plain identifier: we just added as the condition side-effect.
                 // No need to do anything more.
             } else if let Some(prefix_chain) = ast::prefix::Chain::from_ast(ast) {
-                self.process_subtree_at(PrefixCrumb::Func, &prefix_chain.func);
+                self.process_located_ast(&prefix_chain.located_func());
                 for argument in prefix_chain.enumerate_args() {
                     // Ignore the assignment used for named arguments. Descend directly into the
                     // argument value.
-                    if let Some(named) = match_named_argument(&argument.item) {
+                    if let Some(named) = match_named_argument(argument.item) {
                         let rhs = argument.descendant(InfixCrumb::RightOperand, named.rarg);
                         self.process_located_ast(&rhs)
                     } else {

--- a/app/gui/controller/double-representation/src/name.rs
+++ b/app/gui/controller/double-representation/src/name.rs
@@ -221,6 +221,21 @@ impl<Segments: AsRef<[ImString]>> QualifiedNameTemplate<Segments> {
         QualifiedNameRef { project: self.project.clone_ref(), path: &self.path.as_ref()[range] }
     }
 
+    /// Split the qualified into two parts: the qualified name of a nth parent module and the
+    /// remaining access chain of requested length. Returns `None` if the requested access chain
+    /// length is too long to split off.
+    pub fn split_chain(&self, access_chain_length: usize) -> Option<(QualifiedNameRef, String)> {
+        let path = self.path.as_ref();
+        if access_chain_length >= path.len() {
+            return None;
+        }
+
+        let (path, chain) = path.split_at(path.len() - access_chain_length);
+        let parent_name = QualifiedNameRef { project: self.project.clone_ref(), path };
+        let chain = chain.iter().map(|s| s.as_str()).join(ACCESS);
+        Some((parent_name, chain))
+    }
+
     /// Return the [`QualifiedNameRef`] referring to the this name's parent.
     ///
     /// ```rust

--- a/app/gui/language/ast/impl/src/lib.rs
+++ b/app/gui/language/ast/impl/src/lib.rs
@@ -186,7 +186,7 @@ impl<T> Layer<T> for Layered<T> {
 /// to either of the implementation need to be applied to the other one as well.
 ///
 /// Each AST node is annotated with span and an optional ID.
-#[derive(CloneRef, Eq, PartialEq, Debug, Deref)]
+#[derive(CloneRef, Eq, PartialEq, Deref)]
 pub struct Ast {
     wrapped: Rc<WithID<WithLength<Shape<Ast>>>>,
 }
@@ -203,6 +203,17 @@ impl<'t> IntoIterator for &'t Ast {
     type IntoIter = <&'t Shape<Ast> as IntoIterator>::IntoIter;
     fn into_iter(self) -> Self::IntoIter {
         self.shape().into_iter()
+    }
+}
+
+/// Custom `Debug` implementation that flattens the `WithID` and `WithLength` wrappers.
+impl Debug for Ast {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Ast")
+            .field("id", &self.id)
+            .field("length", &self.length)
+            .field("shape", &self.shape())
+            .finish()
     }
 }
 

--- a/app/gui/language/span-tree/Cargo.toml
+++ b/app/gui/language/span-tree/Cargo.toml
@@ -11,7 +11,7 @@ enso-text = { path = "../../../../lib/rust/text" }
 enso-prelude = { path = "../../../../lib/rust/prelude" }
 enso-profiler = { path = "../../../../lib/rust/profiler" }
 failure = { workspace = true }
+parser = { path = "../parser" }
 
 [dev-dependencies]
-parser = { path = "../parser" }
 wasm-bindgen-test = { workspace = true }

--- a/app/gui/language/span-tree/src/action.rs
+++ b/app/gui/language/span-tree/src/action.rs
@@ -181,7 +181,6 @@ impl<'a, T> Implementation for node::Ref<'a, T> {
 
                     while let Some(node) = next_parent {
                         next_parent = node.parent()?;
-                        warn!("node: {:?}", node.node.kind);
                         let argument_node = node
                             .get_descendant_by_ast_crumbs(&[Crumb::Prefix(PrefixCrumb::Arg)])
                             .filter(|found| found.ast_crumbs.is_empty());

--- a/app/gui/language/span-tree/src/node/kind.rs
+++ b/app/gui/language/span-tree/src/node/kind.rs
@@ -2,6 +2,7 @@
 //! different information.
 
 use crate::prelude::*;
+use crate::TagValue;
 
 use crate::ArgumentInfo;
 
@@ -169,6 +170,16 @@ impl Kind {
         }
     }
 
+    /// Get a reference to tag values of an argument represented by this node, if available. Returns
+    /// `None` if the node could not be attached with the argument information.
+    pub fn tag_values(&self) -> Option<&[TagValue]> {
+        match self {
+            Self::Argument(t) => Some(&t.tag_values),
+            Self::InsertionPoint(t) => Some(&t.tag_values),
+            _ => None,
+        }
+    }
+
     /// Get the function call AST ID associated with this argument.
     pub fn call_id(&self) -> Option<ast::Id> {
         match self {
@@ -298,7 +309,7 @@ pub struct Argument {
     pub name:             Option<String>,
     pub tp:               Option<String>,
     pub call_id:          Option<ast::Id>,
-    pub tag_values:       Vec<String>,
+    pub tag_values:       Vec<TagValue>,
 }
 
 
@@ -361,7 +372,7 @@ pub struct InsertionPoint {
     pub name:       Option<String>,
     pub tp:         Option<String>,
     pub call_id:    Option<ast::Id>,
-    pub tag_values: Vec<String>,
+    pub tag_values: Vec<TagValue>,
 }
 
 // === Constructors ===

--- a/app/gui/language/span-tree/src/node/kind.rs
+++ b/app/gui/language/span-tree/src/node/kind.rs
@@ -2,9 +2,9 @@
 //! different information.
 
 use crate::prelude::*;
-use crate::TagValue;
 
 use crate::ArgumentInfo;
+use crate::TagValue;
 
 
 

--- a/app/gui/src/controller/graph.rs
+++ b/app/gui/src/controller/graph.rs
@@ -666,6 +666,28 @@ impl Handle {
         }
     }
 
+    /// Add a necessary unqualified import (`from module import name`) to the module, such that
+    /// the provided fully qualified name is imported and available in the module.
+    pub fn add_import_if_missing(
+        &self,
+        qualified_name: double_representation::name::QualifiedName,
+    ) -> FallibleResult {
+        if let Some(module_path) = qualified_name.parent() {
+            let import = model::suggestion_database::entry::Import::Unqualified {
+                module: module_path.to_owned(),
+                name:   qualified_name.name().into(),
+            };
+
+            let mut module = double_representation::module::Info { ast: self.module.ast() };
+            let already_imported = module.iter_imports().any(|info| import.covered_by(&info));
+            if !already_imported {
+                module.add_import(&self.parser, import.into());
+                self.module.update_ast(module.ast)?;
+            }
+        }
+        Ok(())
+    }
+
     /// Reorders lines so the former node is placed after the latter. Does nothing, if the latter
     /// node is already placed after former.
     ///
@@ -1015,7 +1037,7 @@ impl span_tree::generate::Context for Handle {
         // If the name is different than intended method than apparently it is not intended anymore
         // and should be ignored.
         let matching = if let Some(name) = name { name == db_entry.name } else { true };
-        matching.then(|| db_entry.invocation_info(&self.parser))
+        matching.then(|| db_entry.invocation_info(db, &self.parser))
     }
 }
 

--- a/app/gui/src/controller/graph.rs
+++ b/app/gui/src/controller/graph.rs
@@ -1015,7 +1015,7 @@ impl span_tree::generate::Context for Handle {
         // If the name is different than intended method than apparently it is not intended anymore
         // and should be ignored.
         let matching = if let Some(name) = name { name == db_entry.name } else { true };
-        matching.then(|| db_entry.invocation_info())
+        matching.then(|| db_entry.invocation_info(&self.parser))
     }
 }
 

--- a/app/gui/src/controller/graph/executed.rs
+++ b/app/gui/src/controller/graph/executed.rs
@@ -348,9 +348,10 @@ impl Context for Handle {
             let info = self.computed_value_info_registry().get(&id)?;
             let method_call = info.method_call.as_ref()?;
             let suggestion_db = self.project.suggestion_db();
-            let maybe_entry = suggestion_db
-                .lookup_by_method_pointer(method_call)
-                .map(|e| e.invocation_info(&self.parser()).with_called_on_type(false));
+            let maybe_entry = suggestion_db.lookup_by_method_pointer(method_call).map(|e| {
+                let invocation_info = e.invocation_info(&suggestion_db, &self.parser());
+                invocation_info.with_called_on_type(false)
+            });
 
             // When the entry was not resolved but the `defined_on_type` has a `.type` suffix,
             // try resolving it again with the suffix stripped. This indicates that a method was
@@ -360,7 +361,8 @@ impl Context for Handle {
                 let defined_on_type = method_call.defined_on_type.strip_suffix(".type")?.to_owned();
                 let method_call = MethodPointer { defined_on_type, ..method_call.clone() };
                 let entry = suggestion_db.lookup_by_method_pointer(&method_call)?;
-                Some(entry.invocation_info(&self.parser()).with_called_on_type(true))
+                let invocation_info = entry.invocation_info(&suggestion_db, &self.parser());
+                Some(invocation_info.with_called_on_type(true))
             })
         };
         let fallback = || self.graph.borrow().call_info(id, name);

--- a/app/gui/src/controller/graph/widget.rs
+++ b/app/gui/src/controller/graph/widget.rs
@@ -29,7 +29,7 @@ use ide_view::graph_editor::WidgetUpdates;
 /// A module containing the widget visualization method.
 const WIDGET_VISUALIZATION_MODULE: &str = "Standard.Visualization.Widgets";
 /// A name of the widget visualization method.
-const WIDGET_VISUALIZATION_METHOD: &str = "get_full_annotations_json";
+const WIDGET_VISUALIZATION_METHOD: &str = "get_widget_json";
 
 
 
@@ -430,12 +430,26 @@ impl QueryData {
 struct VisualizationData {
     constructor: widget::Kind,
     display:     VisualizationDataDisplay,
-    values:      Vec<String>,
+    values:      Vec<VisualizationDataChoice>,
 }
 
 #[derive(Debug, serde::Deserialize)]
 struct VisualizationDataDisplay {
     constructor: widget::Display,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct VisualizationDataChoice {
+    value: String,
+    label: Option<String>,
+}
+
+impl From<&VisualizationDataChoice> for widget::Entry {
+    fn from(choice: &VisualizationDataChoice) -> Self {
+        let value: ImString = (&choice.value).into();
+        let label = choice.label.as_ref().map_or_else(|| value.clone(), |label| label.into());
+        Self { value, label }
+    }
 }
 
 impl VisualizationData {

--- a/app/gui/src/controller/graph/widget.rs
+++ b/app/gui/src/controller/graph/widget.rs
@@ -448,7 +448,7 @@ impl From<&VisualizationDataChoice> for widget::Entry {
     fn from(choice: &VisualizationDataChoice) -> Self {
         let value: ImString = (&choice.value).into();
         let label = choice.label.as_ref().map_or_else(|| value.clone(), |label| label.into());
-        Self { value, label }
+        Self { required_import: None, value, label }
     }
 }
 

--- a/app/gui/src/ide/initializer.rs
+++ b/app/gui/src/ide/initializer.rs
@@ -258,7 +258,6 @@ pub fn register_views(app: &Application) {
     app.views.register::<ensogl_component::text::Text>();
     app.views.register::<ensogl_component::selector::NumberPicker>();
     app.views.register::<ensogl_component::selector::NumberRangePicker>();
-    app.views.register::<ensogl_component::drop_down::Dropdown<ImString>>();
 
     // As long as .label() of a View is the same, shortcuts and commands are currently also
     // expected to be the same, so it should not be important which concrete type parameter of

--- a/app/gui/src/test.rs
+++ b/app/gui/src/test.rs
@@ -433,9 +433,10 @@ pub fn assert_call_info(
 ) {
     assert_eq!(info.parameters.len(), entry.arguments.len());
     let parser = parser::Parser::new();
+    let db = model::suggestion_database::SuggestionDatabase::new_empty();
     for (encountered, expected) in info.parameters.iter().zip(entry.arguments.iter()) {
         let expected_info =
-            model::suggestion_database::entry::to_span_tree_param(expected, &parser);
+            model::suggestion_database::entry::to_span_tree_param(expected, &db, &parser);
         assert_eq!(encountered, &expected_info);
     }
 }

--- a/app/gui/src/test.rs
+++ b/app/gui/src/test.rs
@@ -432,8 +432,10 @@ pub fn assert_call_info(
     entry: &model::suggestion_database::Entry,
 ) {
     assert_eq!(info.parameters.len(), entry.arguments.len());
+    let parser = parser::Parser::new();
     for (encountered, expected) in info.parameters.iter().zip(entry.arguments.iter()) {
-        let expected_info = model::suggestion_database::entry::to_span_tree_param(expected);
+        let expected_info =
+            model::suggestion_database::entry::to_span_tree_param(expected, &parser);
         assert_eq!(encountered, &expected_info);
     }
 }

--- a/app/gui/src/tests.rs
+++ b/app/gui/src/tests.rs
@@ -86,11 +86,12 @@ fn span_tree_args() {
         args.nth(n).and_then(|node| node.argument_info())
     };
 
+    let parser = executed_graph.parser();
     let expected_this_param =
-        model::suggestion_database::entry::to_span_tree_param(&entry.arguments[0])
+        model::suggestion_database::entry::to_span_tree_param(&entry.arguments[0], &parser)
             .with_call_id(Some(id));
     let expected_arg1_param =
-        model::suggestion_database::entry::to_span_tree_param(&entry.arguments[1])
+        model::suggestion_database::entry::to_span_tree_param(&entry.arguments[1], &parser)
             .with_call_id(Some(id));
 
     // === Method notation, without prefix application ===

--- a/app/gui/src/tests.rs
+++ b/app/gui/src/tests.rs
@@ -88,8 +88,8 @@ fn span_tree_args() {
 
     let parser = executed_graph.parser();
     let mut invocation_info = entry.invocation_info(suggestion_db, &parser);
-    let expected_this_param = invocation_info.parameters.remove(0);
-    let expected_arg1_param = invocation_info.parameters.remove(0);
+    let expected_this_param = invocation_info.parameters.remove(0).with_call_id(Some(id));
+    let expected_arg1_param = invocation_info.parameters.remove(0).with_call_id(Some(id));
 
     // === Method notation, without prefix application ===
     assert_eq!(get_node().info.expression().repr(), "Base.foo");

--- a/app/gui/src/tests.rs
+++ b/app/gui/src/tests.rs
@@ -87,12 +87,9 @@ fn span_tree_args() {
     };
 
     let parser = executed_graph.parser();
-    let expected_this_param =
-        model::suggestion_database::entry::to_span_tree_param(&entry.arguments[0], &parser)
-            .with_call_id(Some(id));
-    let expected_arg1_param =
-        model::suggestion_database::entry::to_span_tree_param(&entry.arguments[1], &parser)
-            .with_call_id(Some(id));
+    let mut invocation_info = entry.invocation_info(suggestion_db, &parser);
+    let expected_this_param = invocation_info.parameters.remove(0);
+    let expected_arg1_param = invocation_info.parameters.remove(0);
 
     // === Method notation, without prefix application ===
     assert_eq!(get_node().info.expression().repr(), "Base.foo");

--- a/app/gui/suggestion-database/src/entry.rs
+++ b/app/gui/suggestion-database/src/entry.rs
@@ -541,9 +541,14 @@ impl Entry {
     /// Generate information about invoking this entity for span tree context.
     pub fn invocation_info(
         &self,
+        suggestion_db: &SuggestionDatabase,
         parser: &parser::Parser,
     ) -> span_tree::generate::context::CalledMethodInfo {
-        let parameters = self.arguments.iter().map(|arg| to_span_tree_param(arg, parser)).collect();
+        let parameters = self
+            .arguments
+            .iter()
+            .map(|arg| to_span_tree_param(arg, suggestion_db, parser))
+            .collect();
         let is_static = self.is_static;
         let is_constructor = matches!(self.kind, Kind::Constructor);
         span_tree::generate::context::CalledMethodInfo {
@@ -836,16 +841,154 @@ impl TryFrom<Entry> for language_server::MethodPointer {
 /// by the span tree nodes.
 pub fn to_span_tree_param(
     param_info: &Argument,
+    db: &SuggestionDatabase,
     parser: &parser::Parser,
 ) -> span_tree::ArgumentInfo {
+    let tag_values = argument_tag_values(&param_info.tag_values, db, parser);
     span_tree::ArgumentInfo {
         // TODO [mwu] Check if database actually do must always have both of these filled.
-        name:       Some(param_info.name.clone()),
-        tp:         Some(param_info.repr_type.clone()),
-        call_id:    None,
-        tag_values: span_tree::TagValue::from_expressions(&param_info.tag_values, parser),
+        name: Some(param_info.name.clone()),
+        tp: Some(param_info.repr_type.clone()),
+        call_id: None,
+        tag_values,
     }
 }
+
+enum TagValueResolution<'a> {
+    Resolved(Rc<Entry>, ast::opr::Chain),
+    Parsed(ast::opr::Chain),
+    Unresolved(&'a str),
+}
+
+fn resolve_tag_value<'a>(
+    raw_expression: &'a str,
+    db: &SuggestionDatabase,
+    parser: &parser::Parser,
+) -> TagValueResolution<'a> {
+    let qualified_name = QualifiedName::from_text(raw_expression).ok();
+    if let Some(mut qualified_name) = qualified_name {
+        let entry = db.lookup_by_qualified_name(&qualified_name).or_else(move || {
+            // Second try at lookup. Enum values usually have the module and type name deduplicated,
+            // but the resolution database does not take that into account. So we need to manually
+            // expand the name and try again.
+            let last_segment = qualified_name.pop_segment()?;
+            let segment_to_duplicate = qualified_name.pop_segment()?;
+            qualified_name.push_segment(segment_to_duplicate.clone());
+            qualified_name.push_segment(segment_to_duplicate);
+            qualified_name.push_segment(last_segment);
+            db.lookup_by_qualified_name(&qualified_name)
+        });
+
+        let resolved = entry.and_then(|(_, entry)| {
+            let qualified_name: String = entry.qualified_name().to_string();
+            let ast = parser.parse_line_ast(qualified_name).ok()?;
+            let chain = ast::opr::as_access_chain(&ast)?;
+            Some(TagValueResolution::Resolved(entry, chain))
+        });
+
+        if let Some(resolved) = resolved {
+            return resolved;
+        }
+    }
+
+    let chain =
+        parser.parse_line_ast(raw_expression).ok().and_then(|ast| ast::opr::as_access_chain(&ast));
+    if let Some(chain) = chain {
+        return TagValueResolution::Parsed(chain);
+    }
+
+    TagValueResolution::Unresolved(raw_expression)
+}
+
+/// Generate tag value suggestion list from argument entry data, shortening labels as appropriate.
+pub fn argument_tag_values(
+    raw_expressions: &[String],
+    db: &SuggestionDatabase,
+    parser: &parser::Parser,
+) -> Vec<span_tree::TagValue> {
+    let resolved = raw_expressions.iter().map(|e| resolve_tag_value(e, db, parser)).collect_vec();
+    let mut only_access_chains_iter = resolved.iter().filter_map(|r| match r {
+        TagValueResolution::Resolved(_, chain) => Some(chain),
+        TagValueResolution::Parsed(chain) => Some(chain),
+        _ => None,
+    });
+
+    // Gather a list of expression reprs from first access chain. Includes each infix element
+    // that can be considered for removal.
+    let operands: Option<Vec<String>> = only_access_chains_iter.next().map(|chain| {
+        let mut operands = chain
+            .enumerate_operands()
+            .map(|operand| operand.map_or_default(|op| op.arg.repr()))
+            .collect_vec();
+        // Pop last chain element, as we never want to strip it from the label.
+        let last = operands.pop();
+
+        // If the last chain element is a "Value" literal, we want to preserve one extra chain
+        // element before it.
+        if last.map_or(false, |last| last == "Value") {
+            operands.pop();
+        }
+        operands
+    });
+
+    // Find the number of operands that are common for all access chains.
+    let common_operands_count: usize = operands.map_or(0, |common_operands| {
+        only_access_chains_iter.fold(common_operands.len(), |common_so_far, chain| {
+            let operand_reprs =
+                chain.enumerate_operands().map(|op| op.map_or_default(|op| op.arg.repr()));
+            operand_reprs
+                .zip(&common_operands[0..common_so_far])
+                .take_while(|(repr, common_repr)| repr == *common_repr)
+                .count()
+        })
+    });
+
+    let chain_to_label = move |chain: &ast::opr::Chain| {
+        if common_operands_count > 0 {
+            let mut chain = chain.clone();
+            chain.erase_leading_operands(common_operands_count);
+            Some(chain.into_ast().repr())
+        } else {
+            None
+        }
+    };
+
+    resolved
+        .into_iter()
+        .map(|resolution| match resolution {
+            TagValueResolution::Resolved(entry, chain) => {
+                let label = chain_to_label(&chain);
+                let qualified_name = entry.qualified_name();
+                let parent_module = qualified_name.parent();
+                let required_import = parent_module.as_ref().map(|n| n.to_string());
+
+                let expression = if let Some(parent) = parent_module {
+                    let in_module_name = qualified_name.name();
+                    let parent_name = parent.name();
+                    [parent_name, in_module_name].join(opr::predefined::ACCESS)
+                } else {
+                    qualified_name.to_string()
+                };
+                let expression =
+                    if entry.arguments.is_empty() { expression } else { format!("({expression})") };
+
+                span_tree::TagValue { required_import, expression, label }
+            }
+            TagValueResolution::Parsed(chain) => {
+                let label = chain_to_label(&chain);
+                let expression = chain.into_ast().repr();
+
+                span_tree::TagValue { required_import: None, expression, label }
+            }
+            TagValueResolution::Unresolved(expression) => span_tree::TagValue {
+                required_import: None,
+                expression:      expression.to_owned(),
+                label:           None,
+            },
+        })
+        .collect_vec()
+}
+
 
 
 // === Entry helpers ===
@@ -881,6 +1024,7 @@ mod test {
     use super::*;
 
     use engine_protocol::language_server::SuggestionArgumentUpdate;
+    use parser::Parser;
 
     use crate::mock;
     use crate::mock_suggestion_database;
@@ -1258,5 +1402,71 @@ mod test {
             SuggestionsDatabaseModification { arguments: vec![remove_argument], ..default() };
         let result = test.check_modification(modification);
         assert!(result.is_empty());
+    }
+
+    fn run_tag_value_test_case(expression_and_expected_label: &[(&str, Option<&str>)]) {
+        let parser = Parser::new();
+        let db = SuggestionDatabase::new_empty();
+        let expressions =
+            expression_and_expected_label.iter().map(|(expr, _)| expr.to_string()).collect_vec();
+        let tag_values = argument_tag_values(&expressions, &db, &parser);
+        let expected_values = expression_and_expected_label
+            .iter()
+            .map(|(expression, label)| span_tree::TagValue {
+                required_import: None,
+                expression:      expression.to_string(),
+                label:           label.map(ToString::to_string),
+            })
+            .collect_vec();
+
+        assert_eq!(tag_values, expected_values);
+    }
+
+    #[test]
+    fn tag_value_shortening_single_entry() {
+        run_tag_value_test_case(&[("Location.Start", Some("Start"))]);
+    }
+
+    #[test]
+    fn tag_value_shortening_single_entry_with_value() {
+        run_tag_value_test_case(&[("Foo.Bar.Value", Some("Bar.Value"))]);
+    }
+
+    #[test]
+    fn tag_value_shortening_common_prefix() {
+        run_tag_value_test_case(&[
+            ("Location.Start", Some("Start")),
+            ("Location.End", Some("End")),
+            ("Location.Both", Some("Both")),
+        ]);
+    }
+
+    #[test]
+    fn tag_value_shortening_multiple_elements() {
+        run_tag_value_test_case(&[
+            ("A.B.C.D", Some("C.D")),
+            ("A.B.C.E", Some("C.E")),
+            ("A.B.F.G.H", Some("F.G.H")),
+        ]);
+    }
+
+    #[test]
+    fn tag_value_shortening_no_prefix() {
+        run_tag_value_test_case(&[("Foo.Bar", None), ("Foo.Baz", None), ("Baz.Qux", None)]);
+    }
+
+    #[test]
+    fn tag_value_non_infix() {
+        run_tag_value_test_case(&[("Foo Bar", None), ("Foo Baz", None), ("Baz Qux", None)]);
+    }
+
+
+    #[test]
+    fn tag_value_some_infix() {
+        run_tag_value_test_case(&[
+            ("Foo.Bar", Some("Bar")),
+            ("Foo.Baz", Some("Baz")),
+            ("Baz Qux", None),
+        ]);
     }
 }

--- a/app/gui/view/examples/interface/src/lib.rs
+++ b/app/gui/view/examples/interface/src/lib.rs
@@ -35,6 +35,7 @@ use ide_view::project;
 use ide_view::root;
 use ide_view::status_bar;
 use parser::Parser;
+use span_tree::TagValue;
 
 
 
@@ -407,11 +408,10 @@ pub fn expression_mock_trim() -> Expression {
     let param0 = span_tree::ArgumentInfo {
         name: Some("where".to_owned()),
         tp: Some("Location".to_owned()),
-        tag_values: vec![
-            "Location.Start".to_owned(),
-            "Location.End".to_owned(),
-            "Location.Both".to_owned(),
-        ],
+        tag_values: TagValue::from_expressions(
+            &["Location.Start", "Location.End", "Location.Both"],
+            &parser,
+        ),
         ..default()
     };
     let param1 = span_tree::ArgumentInfo {

--- a/app/gui/view/examples/interface/src/lib.rs
+++ b/app/gui/view/examples/interface/src/lib.rs
@@ -408,10 +408,23 @@ pub fn expression_mock_trim() -> Expression {
     let param0 = span_tree::ArgumentInfo {
         name: Some("where".to_owned()),
         tp: Some("Location".to_owned()),
-        tag_values: TagValue::from_expressions(
-            &["Location.Start", "Location.End", "Location.Both"],
-            &parser,
-        ),
+        tag_values: vec![
+            TagValue {
+                required_import: None,
+                expression:      "Location.Start".into(),
+                label:           Some("Start".into()),
+            },
+            TagValue {
+                required_import: None,
+                expression:      "Location.End".into(),
+                label:           Some("End".into()),
+            },
+            TagValue {
+                required_import: None,
+                expression:      "Location.Both".into(),
+                label:           Some("Both".into()),
+            },
+        ],
         ..default()
     };
     let param1 = span_tree::ArgumentInfo {

--- a/app/gui/view/graph-editor/src/component/node.rs
+++ b/app/gui/view/graph-editor/src/component/node.rs
@@ -359,6 +359,7 @@ ensogl::define_endpoints_2! {
         /// contains the ID of the call expression the widget is attached to, and the ID of that
         /// call's target expression (`self` or first argument).
         requested_widgets        (ast::Id, ast::Id),
+        request_import           (ImString),
     }
 }
 
@@ -752,6 +753,7 @@ impl Node {
             out.expression                  <+ model.input.frp.expression;
             out.expression_span             <+ model.input.frp.on_port_code_update;
             out.requested_widgets           <+ model.input.frp.requested_widgets;
+            out.request_import              <+ model.input.frp.request_import;
 
             model.input.set_connected              <+ input.set_input_connected;
             model.input.set_disabled               <+ input.set_disabled;

--- a/app/gui/view/graph-editor/src/component/node/input/area.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/area.rs
@@ -576,8 +576,7 @@ impl Model {
         call_info: &CallInfoMap,
     ) -> Option<(WidgetBind, widget::View)> {
         let call_id = port.kind.call_id().filter(|id| call_info.has_target(id))?;
-        let argument_info = port.kind.argument_info()?;
-        let argument_name = argument_info.name.as_ref()?.clone();
+        let argument_name = port.kind.argument_name()?.to_owned();
 
         let widget_bind = WidgetBind { call_id, argument_name };
 
@@ -605,7 +604,8 @@ impl Model {
             None => port.payload.init_widget(&self.app),
         };
 
-        widget.set_node_data(widget::NodeData { argument_info, port_size });
+        let tag_values = port.kind.tag_values().unwrap_or_default().to_vec();
+        widget.set_node_data(widget::NodeData { tag_values, port_size });
 
         Some((widget_bind, widget))
     }

--- a/app/gui/view/graph-editor/src/component/node/input/area.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/area.rs
@@ -544,6 +544,7 @@ impl Model {
                             (crumbs.clone_ref(), expression)
                         }));
                         area_frp.source.on_port_code_update <+ code_update;
+                        area_frp.source.request_import <+ widget.request_import;
                     }
                 }
 
@@ -905,6 +906,7 @@ ensogl::define_endpoints! {
         /// contains the ID of the call expression the widget is attached to, and the ID of that
         /// call's target expression (`self` or first argument).
         requested_widgets   (ast::Id, ast::Id),
+        request_import      (ImString),
     }
 }
 

--- a/app/gui/view/graph-editor/src/component/node/input/widget.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget.rs
@@ -170,7 +170,7 @@ impl View {
         frp::extend! { network
             metadata_change <- input.set_metadata.on_change();
             node_data_change <- input.set_node_data.on_change();
-            widget_data <- all(&metadata_change, &node_data_change).next_tick();
+            widget_data <- all(&metadata_change, &node_data_change).debounce();
 
             set_current_value <- input.set_current_value.sampler();
             set_visible <- input.set_visible.sampler();
@@ -512,7 +512,7 @@ impl LazyDropdown {
 
                     dropdown.set_all_entries <+ set_entries;
                     entries_and_value <- all(&set_entries, set_current_value);
-                    entries_and_value <- entries_and_value.next_tick();
+                    entries_and_value <- entries_and_value.debounce();
 
                     selected_entry <- entries_and_value.map(|(e, v)| entry_for_current_value(e, v));
                     dropdown.set_selected_entries <+ selected_entry.map(|e| e.iter().cloned().collect());

--- a/app/gui/view/graph-editor/src/component/node/input/widget.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget.rs
@@ -513,7 +513,8 @@ impl LazyDropdown {
                     set_entries <- any(...);
 
                     dropdown.set_all_entries <+ set_entries;
-                    selected_entry <- set_entries.all_with(set_current_value, entry_for_current_value);
+                    entries_and_value <- all(&set_entries, set_current_value).next_tick();
+                    selected_entry <- entries_and_value.map(|(e, v)| entry_for_current_value(e, v));
                     dropdown.set_selected_entries <+ selected_entry.map(|e| e.iter().cloned().collect());
 
                     dropdown_output <- dropdown.selected_entries.map(|e| e.iter().next().map(Entry::value));

--- a/app/gui/view/graph-editor/src/component/node/input/widget.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget.rs
@@ -544,7 +544,7 @@ impl LazyDropdown {
 }
 
 fn entry_for_current_value(
-    all_entries: &Vec<Entry>,
+    all_entries: &[Entry],
     current_value: &Option<ImString>,
 ) -> Option<Entry> {
     let current_value = current_value.clone()?;
@@ -553,10 +553,10 @@ fn entry_for_current_value(
         // Handle parentheses in current value. Entries with parenthesized expressions will match if
         // they start with the same expression as the current value. That way it is still matched
         // once extra arguments are added to the nested function call.
-        if current_value.starts_with("(") {
-            let current_value = current_value.trim_start_matches("(").trim_end_matches(")");
+        if current_value.starts_with('(') {
+            let current_value = current_value.trim_start_matches('(').trim_end_matches(')');
             all_entries.iter().find(|entry| {
-                let trimmed_value = entry.value.trim_start_matches("(").trim_end_matches(")");
+                let trimmed_value = entry.value.trim_start_matches('(').trim_end_matches(')');
                 current_value.starts_with(trimmed_value)
             })
         } else {

--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -718,6 +718,7 @@ ensogl::define_endpoints_2! {
         visualization_registry_reload_requested (),
 
         widgets_requested                       (NodeId, ast::Id, ast::Id),
+        request_import                          (ImString),
 
         on_visualization_select     (Switch<NodeId>),
         some_visualisation_selected (bool),
@@ -1596,6 +1597,8 @@ impl GraphEditorModelWithNetwork {
                 let args = (node_id, *call_id, *target_id);
                 model.frp.private.output.widgets_requested.emit(args)
             });
+
+            model.frp.private.output.request_import <+ node.request_import;
 
 
             // === Actions ===

--- a/lib/rust/callback/src/lib.rs
+++ b/lib/rust/callback/src/lib.rs
@@ -40,6 +40,7 @@ pub use callback_types::*;
 
 /// Handle to a callback. When the handle is dropped, the callback is removed.
 #[derive(Clone, CloneRef, Debug, Default)]
+#[must_use]
 pub struct Handle {
     rc: Rc<()>,
 }

--- a/lib/rust/callback/src/lib.rs
+++ b/lib/rust/callback/src/lib.rs
@@ -132,6 +132,14 @@ impl<F: ?Sized> Registry<F> {
     where F: FnMut<Args> {
         self.model.run_impl(args)
     }
+
+    /// Fires all registered callbacks once and removes them. You are allowed to change the registry
+    /// while a callback is running. The callbacks registered during this run will be executed next
+    /// time `run_once_impl` is called.
+    fn run_once_impl<Args: Copy + std::marker::Tuple>(&self, args: Args)
+    where F: FnOnce<Args> {
+        self.model.run_once_impl(args)
+    }
 }
 
 impl<F: ?Sized> RegistryModel<F> {
@@ -172,6 +180,25 @@ impl<F: ?Sized> RegistryModel<F> {
         }
         self.is_running.set(false);
     }
+
+    fn run_once_impl<Args: Copy + std::marker::Tuple>(&self, args: Args)
+    where F: FnOnce<Args> {
+        if self.is_running.get() {
+            error!("Trying to run callback manager while it's already running, ignoring.");
+            return;
+        }
+        self.is_running.set(true);
+        for (guard, callback) in self.callback_list.borrow_mut().drain(..) {
+            if !guard.is_expired() {
+                callback.call_once(args);
+            }
+        }
+        let mut callback_list_during_run = self.callback_list_during_run.borrow_mut();
+        if !callback_list_during_run.is_empty() {
+            self.callback_list.borrow_mut().extend(mem::take(&mut *callback_list_during_run));
+        }
+        self.is_running.set(false);
+    }
 }
 
 
@@ -205,6 +232,7 @@ pub mod registry {
     use super::*;
 
     pub type NoArgs = Registry<dyn FnMut()>;
+    pub type NoArgsOnce = Registry<dyn FnOnce()>;
 
     pub type Copy1<T1> = Registry<dyn FnMut(T1)>;
     pub type Copy2<T1, T2> = Registry<dyn FnMut(T1, T2)>;
@@ -330,6 +358,13 @@ pub mod traits {
             self.run_impl(())
         }
     }
+
+    impl RegistryRunner0 for registry::NoArgsOnce {
+        fn run_all(&self) {
+            self.run_once_impl(())
+        }
+    }
+
 
     impl FnOnce<()> for registry::NoArgs {
         type Output = ();

--- a/lib/rust/ensogl/component/drop-down/src/lib.rs
+++ b/lib/rust/ensogl/component/drop-down/src/lib.rs
@@ -153,7 +153,6 @@ impl<T: DropdownValue> Frp<T> {
         let output = &api.output;
 
         let open_anim = Animation::new(network);
-        let after_animations = ensogl_core::animation::on_after_animations();
 
         frp::extend! { network
             // === Static entries support ===
@@ -184,7 +183,7 @@ impl<T: DropdownValue> Frp<T> {
 
             // === Entry update and dynamic entries support ===
             requested_index <- model.grid.model_for_entry_needed._0();
-            requested_batch <- requested_index.batch(&after_animations);
+            requested_batch <- requested_index.batch();
             ready_and_request_ranges <- requested_batch.map(
                 f!((batch) model.get_ready_and_request_ranges(batch))
             );
@@ -252,8 +251,10 @@ impl<T: DropdownValue> Frp<T> {
 
             // === Initialization ===
             // request initial batch of entries after creating the dropdown
-            once_after_animations <- after_animations.constant(true).on_change().constant(());
-            model.grid.request_model_for_visible_entries <+ once_after_animations;
+            init <- source_();
+            run_once <- init.debounce();
+            init.emit(());
+            model.grid.request_model_for_visible_entries <+ run_once;
         }
     }
 }

--- a/lib/rust/ensogl/core/src/animation/loops.rs
+++ b/lib/rust/ensogl/core/src/animation/loops.rs
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 use crate::system::web::traits::*;
 use enso_callback::traits::*;
+use frp::microtasks::next_tick_late;
 
 use crate::system::web;
 use crate::types::unit2::Duration;
@@ -204,7 +205,7 @@ pub fn on_before_rendering() -> enso_frp::Sampler<TimeInfo> {
 pub struct LoopRegistry {
     #[deref]
     frp:            Frp,
-    callbacks:      callback::registry::NoArgs,
+    callbacks:      callback::registry::Copy1<Duration>,
     animation_loop: JsLoop<OnFrameClosure>,
 }
 
@@ -222,49 +223,90 @@ impl LoopRegistry {
     }
 }
 
-fn create_callback_wrapper(mut callback: impl OnFrameCallback) -> impl FnMut() {
-    let js_performance = web::window.performance_or_panic();
-    let mut is_initialized = false;
-    let mut time_info = TimeInfo::default();
-    move || {
-        let current_time = (js_performance.now() as f32).ms();
-        let prev_time = time_info;
+fn create_callback_wrapper(mut callback: impl OnFrameCallback) -> impl FnMut(Duration) {
+    let mut time_info = InitializedTimeInfo::default();
+    move |current_time: Duration| callback(time_info.next_frame(current_time))
+}
+
+#[derive(Default)]
+struct InitializedTimeInfo {
+    is_initialized: bool,
+    time_info:      TimeInfo,
+}
+
+impl InitializedTimeInfo {
+    fn next_frame(&mut self, current_time: Duration) -> TimeInfo {
+        let prev_time = self.time_info;
         let prev_start = prev_time.animation_loop_start;
-        let animation_loop_start = if is_initialized { prev_start } else { current_time };
+        let animation_loop_start = if self.is_initialized { prev_start } else { current_time };
         let since_animation_loop_started = current_time - animation_loop_start;
         let previous_frame = since_animation_loop_started - prev_time.since_animation_loop_started;
         let time = TimeInfo { animation_loop_start, previous_frame, since_animation_loop_started };
-        time_info = time;
-        is_initialized = true;
-        callback(time);
+        self.time_info = time;
+        self.is_initialized = true;
+        time
     }
 }
 
+
 /// Callback for an animation frame.
 pub type OnFrameClosure = impl FnMut(Duration);
-fn on_frame_closure(frp: &Frp, callbacks: &callback::registry::NoArgs) -> OnFrameClosure {
+fn on_frame_closure(frp: &Frp, callbacks: &callback::registry::Copy1<Duration>) -> OnFrameClosure {
     let on_frame_start = frp.private.output.on_frame_start.clone_ref();
     let frame_end = frp.private.output.frame_end.clone_ref();
     let on_before_animations = frp.private.output.on_before_animations.clone_ref();
     let on_after_animations = frp.private.output.on_after_animations.clone_ref();
     let on_before_rendering = frp.private.output.on_before_rendering.clone_ref();
-    let mut frame_end_fn = create_callback_wrapper(move |t| frame_end.emit(t));
-    let mut before_animations_fn = create_callback_wrapper(move |t| on_before_animations.emit(t));
-    let mut after_animations_fn = create_callback_wrapper(move |t| on_after_animations.emit(t));
-    let mut before_rendering_fn = create_callback_wrapper(move |t| on_before_rendering.emit(t));
     let callbacks = callbacks.clone_ref();
-    move |t: Duration| {
-        let _profiler = profiler::start_debug!(profiler::APP_LIFETIME, "@on_frame");
-        on_frame_start.emit(t);
-        before_animations_fn();
-        callbacks.run_all();
-        after_animations_fn();
-        before_rendering_fn();
-        frame_end_fn();
+
+    let mut time_info = InitializedTimeInfo::default();
+    let h_cell = Rc::new(Cell::new(callback::Handle::default()));
+    move |frame_time: Duration| {
+        let time = time_info.next_frame(frame_time);
+
+        let on_frame_start = on_frame_start.clone_ref();
+        let frame_end = frame_end.clone_ref();
+        let on_before_animations = on_before_animations.clone_ref();
+        let on_after_animations = on_after_animations.clone_ref();
+        let on_before_rendering = on_before_rendering.clone_ref();
+        let callbacks = callbacks.clone_ref();
+        let _profiler = profiler::start_debug!(profiler::APP_LIFETIME, "@on_frame_start");
+
+        schedule_next_phase(h_cell.clone(), move |h_cell| {
+            on_frame_start.emit(frame_time);
+
+            schedule_next_phase(h_cell, move |h_cell| {
+                on_before_animations.emit(time);
+
+                schedule_next_phase(h_cell, move |h_cell| {
+                    callbacks.run_all(frame_time);
+
+                    schedule_next_phase(h_cell, move |h_cell| {
+                        on_after_animations.emit(time);
+
+                        schedule_next_phase(h_cell, move |h_cell| {
+                            frame_end.emit(time);
+
+                            schedule_next_phase(h_cell, move |_| {
+                                on_before_rendering.emit(time);
+
+                                drop(_profiler);
+                            });
+                        });
+                    });
+                });
+            });
+        });
     }
 }
 
-
+fn schedule_next_phase(
+    tick_handle: Rc<Cell<callback::Handle>>,
+    f: impl FnOnce(Rc<Cell<callback::Handle>>) + 'static,
+) {
+    let next_cell = tick_handle.clone();
+    tick_handle.set(next_tick_late(move || f(next_cell)));
+}
 
 // =============================
 // === FixedFrameRateSampler ===

--- a/lib/rust/ensogl/core/src/animation/loops.rs
+++ b/lib/rust/ensogl/core/src/animation/loops.rs
@@ -267,7 +267,7 @@ fn on_frame_closure(frp: &Frp, callbacks: &callback::registry::Copy1<Duration>) 
         let callbacks = callbacks.clone_ref();
         let _profiler = profiler::start_debug!(profiler::APP_LIFETIME, "@on_frame");
 
-        TickPhases::new(h_cell.clone())
+        TickPhases::new(&h_cell)
             .then(move || on_frame_start.emit(frame_time))
             .then(move || on_before_animations.emit(time_info))
             .then(move || callbacks.run_all(frame_time))
@@ -277,7 +277,7 @@ fn on_frame_closure(frp: &Frp, callbacks: &callback::registry::Copy1<Duration>) 
                 output.on_before_rendering.emit(time_info);
                 drop(_profiler);
             })
-            .run();
+            .schedule();
     }
 }
 

--- a/lib/rust/ensogl/core/src/system/gpu/shader/compiler.rs
+++ b/lib/rust/ensogl/core/src/system/gpu/shader/compiler.rs
@@ -842,7 +842,6 @@ impl Controller {
     ///
     /// Note that if the queue is already idle when a callback is attached, the callback will not be
     /// executed until work has been queued and completed.
-    #[must_use]
     pub fn on_idle(&self, f: impl FnMut() + 'static) -> callback::Handle {
         self.rc.borrow_mut().on_idle(f)
     }

--- a/lib/rust/frp/src/lib.rs
+++ b/lib/rust/frp/src/lib.rs
@@ -173,6 +173,7 @@ pub mod fan;
 pub mod future;
 pub mod io;
 pub mod macros;
+pub mod microtasks;
 pub mod network;
 pub mod node;
 pub mod nodes;

--- a/lib/rust/frp/src/microtasks.rs
+++ b/lib/rust/frp/src/microtasks.rs
@@ -328,8 +328,7 @@ where
     fn schedule(self) {
         if let Some(handle_cell) = self.handle_cell.upgrade() {
             let Cons(head, tail) = self.phase_list;
-            let tail_phases =
-                TickPhases { handle_cell: self.handle_cell.clone(), phase_list: tail };
+            let tail_phases = TickPhases { handle_cell: self.handle_cell, phase_list: tail };
             let handle = next_microtask_late(move || {
                 head();
                 tail_phases.schedule();
@@ -364,8 +363,8 @@ mod tests {
         where T: Ord + Debug {
             let data = self.flush();
             let is_sorted = data.windows(2).all(|w| w[0] <= w[1]);
-            assert!(is_sorted, "Expected ordered, got {:?}", data);
-            assert_eq!(data.len(), length, "Expected length {length}, got {:?}", data);
+            assert!(is_sorted, "Expected ordered, got {data:?}");
+            assert_eq!(data.len(), length, "Expected length {length}, got {data:?}");
         }
     }
 
@@ -388,8 +387,8 @@ mod tests {
 
         next_microtask(f!(collector.push(1))).forget();
 
-        let _ = next_microtask(|| assert!(false));
-        let _ = next_microtask_late(|| assert!(false));
+        let _ = next_microtask(|| unreachable!());
+        let _ = next_microtask_late(|| unreachable!());
 
         collector.flush_and_assert_ordered(1);
     }

--- a/lib/rust/frp/src/microtasks.rs
+++ b/lib/rust/frp/src/microtasks.rs
@@ -1,0 +1,140 @@
+//! This module contains implementation of microtask scheduler that is used in implementation of
+//! some FRP nodes.
+
+use crate::prelude::*;
+use enso_callback::traits::*;
+
+use enso_callback as callback;
+use enso_web::traits::WindowOps;
+use enso_web::Closure;
+use enso_web::JsEventHandler;
+use enso_web::JsValue;
+use enso_web::Promise;
+
+const MAX_RESURSIVE_MICROTASKS: usize = 1000;
+
+thread_local! {
+    static SCHEDULER: Scheduler = Scheduler::new();
+}
+
+/// Schedules a callback for evaluation during next microtask. This is useful for scheduling tasks
+/// that should be performed right after current JS event loop iteration, but before animation
+/// frame. All tasks scheduled with this function will be performed in the same order as they were
+/// scheduled. Further microtasks are scheduled in the same render loop as long as `next_microtask`
+/// is recursively called within the scheduled task, up to a safety limit of 1000. If the limit is
+/// reached, an error will be raised and the scheduled tasks will be scheduled after next animation
+/// frame.
+pub fn next_tick(f: impl FnOnce() + 'static) -> callback::Handle {
+    SCHEDULER.with(|schedule| schedule.add(f))
+}
+
+/// Schedules a callback for evaluation once all microtasks in `next_tick` have been performed. If
+/// that callback calls `next_tick` or `next_tick_late` again, those tasks will be scheduled after
+/// the tasks scheduled with this function, but before control is returned to the environment.
+///
+/// TODO[PG]: Use this to separate render loop callbacks into multiple task stages.
+/// TODO - add task number
+#[allow(dead_code)]
+pub fn next_tick_late(f: impl FnOnce() + 'static) -> callback::Handle {
+    SCHEDULER.with(|schedule| schedule.add_late(f))
+}
+
+struct Scheduler {
+    data: Rc<SchedulerData>,
+}
+
+impl Scheduler {
+    fn new() -> Self {
+        let data = Rc::new_cyclic(|weak: &Weak<SchedulerData>| {
+            let resolved_promise = Promise::resolve(&JsValue::NULL);
+            let callbacks = default();
+            let late_callbacks = default();
+            let schedule_depth = default();
+            let is_scheduled = default();
+            let closure = Closure::new(f!([weak] (_: JsValue) {
+                if let Some(data) = weak.upgrade() {
+                    data.run_all();
+                }
+            }));
+            let schedule_closure = Closure::new(f!([weak] (_: f64) {
+                if let Some(data) = weak.upgrade() {
+                    data.schedule_task();
+                }
+            }));
+            SchedulerData {
+                is_scheduled,
+                callbacks,
+                late_callbacks,
+                schedule_depth,
+                resolved_promise,
+                closure,
+                schedule_closure,
+            }
+        });
+        Self { data }
+    }
+
+    fn add(&self, f: impl FnOnce() + 'static) -> callback::Handle {
+        let handle = self.data.callbacks.add(f);
+        self.data.schedule_task();
+        handle
+    }
+
+    fn add_late(&self, f: impl FnOnce() + 'static) -> callback::Handle {
+        let handle = self.data.late_callbacks.add(f);
+        self.data.schedule_task();
+        handle
+    }
+}
+
+struct SchedulerData {
+    is_scheduled:     Cell<bool>,
+    callbacks:        callback::registry::NoArgsOnce,
+    late_callbacks:   callback::registry::NoArgsOnce,
+    schedule_depth:   Cell<usize>,
+    resolved_promise: Promise,
+    closure:          JsEventHandler,
+    schedule_closure: JsEventHandler<f64>,
+}
+
+impl SchedulerData {
+    fn schedule_task(&self) {
+        if !self.is_scheduled.replace(true) {
+            self.resolved_promise.then(&self.closure);
+        }
+    }
+    fn schedule_task_past_limit(&self) {
+        if !self.is_scheduled.replace(true) {
+            enso_web::window.request_animation_frame_with_closure_or_panic(&self.schedule_closure);
+        }
+    }
+
+    fn run_all(&self) {
+        let current_count = self.schedule_depth.get();
+        let task_limit_reached = current_count >= MAX_RESURSIVE_MICROTASKS;
+        if task_limit_reached {
+            error!(
+                "Too many microtasks scheduled. This is a safety limit to prevent infinite loops. \
+                 Further tasks will be scheduled after next animation frame."
+            );
+            self.schedule_depth.set(0);
+            self.is_scheduled.set(false);
+            self.schedule_task_past_limit();
+            return;
+        }
+
+        self.callbacks.run_all();
+
+        if self.callbacks.is_empty() {
+            self.late_callbacks.run_all();
+        }
+
+        self.is_scheduled.set(false);
+        if self.callbacks.is_empty() && self.late_callbacks.is_empty() {
+            self.schedule_depth.set(0);
+        } else {
+            self.schedule_depth.set(current_count + 1);
+            self.schedule_task();
+        }
+    }
+}

--- a/lib/rust/frp/src/microtasks.rs
+++ b/lib/rust/frp/src/microtasks.rs
@@ -100,7 +100,10 @@ struct SchedulerData {
 impl SchedulerData {
     fn schedule_task(&self) {
         if !self.is_scheduled.replace(true) {
-            self.resolved_promise.then(&self.closure);
+            // Result left unused on purpose. We only care about `closure` being run in the next
+            // microtask, which is a guaranteed side effect of providing it to [`Promise::then`]
+            // method on already resolved promise.
+            let _ = self.resolved_promise.then(&self.closure);
         }
     }
     fn schedule_task_past_limit(&self) {

--- a/lib/rust/frp/src/microtasks.rs
+++ b/lib/rust/frp/src/microtasks.rs
@@ -5,6 +5,9 @@ use crate::prelude::*;
 use enso_callback::traits::*;
 
 use enso_callback as callback;
+use enso_generics::Cons;
+use enso_generics::Nil;
+use enso_generics::PushBack;
 use enso_web::traits::WindowOps;
 use enso_web::Closure;
 use enso_web::JsEventHandler;
@@ -18,38 +21,47 @@ use enso_web::Promise;
 /// =================
 
 /// Maximum number of times a new microtask can be scheduled from within previously scheduled
-/// microtask handler. A safety mechanism to prevent infinite loops. See [`next_tick`] for more
+/// microtask handler. A safety mechanism to prevent infinite loops. See [`next_microtask`] for more
 /// information.
 const MAX_RESURSIVE_MICROTASKS: usize = 1000;
 
 
 
 /// =================
-/// === next_tick ===
+/// === next_microtask ===
 /// =================
 
 /// Schedules a callback for evaluation during next microtask. This is useful for scheduling tasks
 /// that should be performed right after current JS event loop iteration, but before animation
 /// frame. All tasks scheduled with this function will be performed in the same order as they were
-/// scheduled. Further microtasks are scheduled in the same render loop as long as `next_tick`
+/// scheduled. Further microtasks are scheduled in the same render loop as long as `next_microtask`
 /// is recursively called within the scheduled task, up to a safety limit defined by
 /// [`MAX_RESURSIVE_MICROTASKS`]. If the limit is reached, an error will be raised and further tasks
 /// will be scheduled after next animation frame.
-pub fn next_tick(f: impl FnOnce() + 'static) -> callback::Handle {
-    SCHEDULER.with(|schedule| schedule.add(f))
+pub fn next_microtask(f: impl FnOnce() + 'static) -> callback::Handle {
+    SCHEDULER.with(|scheduler| scheduler.add(f))
 }
 
-/// Schedules a callback for evaluation once all microtasks in `next_tick` have been performed. If
-/// that callback calls `next_tick` or `next_tick_late` again, those tasks will be scheduled after
-/// the tasks scheduled with this function, but before control is returned to the environment.
-///
-/// TODO[PG]: Use this to delay rendering logic until the microtask queue is empty.
-/// TODO - add task number after review is done
+/// Schedules a callback for evaluation once all microtasks scheduled with `next_microtask` have
+/// been performed. If that callback calls `next_microtask` or `next_microtask_late` again, those
+/// tasks will be scheduled after all tasks scheduled so far, but before control is returned to the
+/// environment (e.g. before next paint).
 #[allow(dead_code)]
-pub fn next_tick_late(f: impl FnOnce() + 'static) -> callback::Handle {
-    SCHEDULER.with(|schedule| schedule.add_late(f))
+pub fn next_microtask_late(f: impl FnOnce() + 'static) -> callback::Handle {
+    SCHEDULER.with(|scheduler| scheduler.add_late(f))
 }
 
+/// Flushes the microtask queue. It is guaranteed that both standard and late microtask queues
+/// of this scheduler will be empty after this function returns. This is mainly useful for
+/// testing.
+///
+/// NOTE: This function performs all microtasks scheduled by the main scheduler synchronously. It
+/// preserves their relative order of execution. If there are other microtasks scheduled by the
+/// environment outside of this scheduler (e.g. `promise.then` calls), they will not be executed
+/// within this function.
+pub fn flush_microtasks() {
+    SCHEDULER.with(|scheduler| scheduler.flush())
+}
 
 
 // =================
@@ -77,7 +89,7 @@ impl Scheduler {
             let late_callbacks = default();
             let schedule_depth = default();
             let is_scheduled = default();
-            let closure = Closure::new(f!([weak] (_: JsValue) {
+            let run_all_closure = Closure::new(f!([weak] (_: JsValue) {
                 if let Some(data) = weak.upgrade() {
                     data.run_all();
                 }
@@ -93,7 +105,7 @@ impl Scheduler {
                 late_callbacks,
                 schedule_depth,
                 resolved_promise,
-                closure,
+                run_all_closure,
                 schedule_closure,
             }
         });
@@ -111,6 +123,10 @@ impl Scheduler {
         self.data.schedule_task();
         handle
     }
+
+    fn flush(&self) {
+        self.data.flush();
+    }
 }
 
 struct SchedulerData {
@@ -119,7 +135,7 @@ struct SchedulerData {
     late_callbacks:   callback::registry::NoArgsOnce,
     schedule_depth:   Cell<usize>,
     resolved_promise: Promise,
-    closure:          JsEventHandler,
+    run_all_closure:  JsEventHandler,
     schedule_closure: JsEventHandler<f64>,
 }
 
@@ -129,7 +145,7 @@ impl SchedulerData {
             // Result left unused on purpose. We only care about `closure` being run in the next
             // microtask, which is a guaranteed side effect of providing it to [`Promise::then`]
             // method on already resolved promise.
-            let _ = self.resolved_promise.then(&self.closure);
+            let _ = self.resolved_promise.then(&self.run_all_closure);
         }
     }
     fn schedule_task_past_limit(&self) {
@@ -166,4 +182,87 @@ impl SchedulerData {
             self.schedule_task();
         }
     }
+
+    fn flush(&self) {
+        while !self.callbacks.is_empty() || !self.late_callbacks.is_empty() {
+            self.callbacks.run_all();
+            if self.callbacks.is_empty() {
+                self.late_callbacks.run_all();
+            }
+        }
+    }
+}
+
+// ==================
+// === TickPhases ===
+// ==================
+
+/// A type that represents a list of phases that should be performed within the same browser task,
+/// one after another. The phases are always performed in the same order as they were added,
+/// allowing the microtask queue to be emptied between each phase. Each phase is queued using
+/// `next_microtask_late` at the end of the previous phase.
+#[must_use]
+#[allow(missing_debug_implementations)]
+pub struct TickPhases<T> {
+    handle_cell: Rc<Cell<callback::Handle>>,
+    phase_list:  T,
+}
+
+
+impl TickPhases<Nil> {
+    /// Create a new empty phases list.
+    pub fn new(handle_cell: Rc<Cell<callback::Handle>>) -> Self {
+        TickPhases { handle_cell, phase_list: Nil }
+    }
+}
+
+impl<T> TickPhases<T> {
+    /// Add a phase to the list. The phase will be performed after all the phases that were added
+    /// before.
+    pub fn then<F>(self, f: F) -> TickPhases<T::Output>
+    where T: PushBack<F> {
+        let handle_cell = self.handle_cell;
+        let phase_list = self.phase_list.push_back(f);
+        TickPhases { handle_cell, phase_list }
+    }
+
+    /// Schedule the phases for execution. The phases will be performed asynchronously in order,
+    /// once the current microtask queue is emptied.
+    pub fn run(self)
+    where Self: TaskPhasesRunImpl {
+        TaskPhasesRunImpl::run(self);
+    }
+}
+
+/// Implementation of [`RunnablePhases`] run method for a list of phases. This needs to be a trait,
+/// so there is a way to specialize the implementation for different variants.
+pub trait TaskPhasesRunImpl {
+    /// Schedule the phases for execution. The phases will be performed asynchronously in order,
+    /// once the current microtask queue is emptied.
+    fn run(self);
+}
+
+impl TaskPhasesRunImpl for TickPhases<Nil> {
+    fn run(self) {}
+}
+
+impl<H, T> TaskPhasesRunImpl for TickPhases<Cons<H, T>>
+where
+    TickPhases<T>: TaskPhasesRunImpl + 'static,
+    H: FnOnce() + 'static,
+{
+    fn run(self) {
+        let Cons(head, tail) = self.phase_list;
+        let tail_phases = TickPhases { handle_cell: self.handle_cell.clone(), phase_list: tail };
+        let handle = next_microtask_late(move || {
+            head();
+            tail_phases.run();
+        });
+        self.handle_cell.set(handle);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
 }

--- a/lib/rust/frp/src/microtasks.rs
+++ b/lib/rust/frp/src/microtasks.rs
@@ -1,6 +1,10 @@
 //! This module contains implementation of microtask scheduler that is used in implementation of
 //! some FRP nodes.
-
+//!
+//! TODO: better docs
+//!
+//! Read more about microtasks:
+/// https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide
 use crate::prelude::*;
 use enso_callback::traits::*;
 

--- a/lib/rust/frp/src/nodes.rs
+++ b/lib/rust/frp/src/nodes.rs
@@ -135,8 +135,8 @@ impl Network {
     }
 
     /// Delay and deduplicate the incoming events. Once an event is received, it will be emitted
-    /// after the current microtask execution is finished. If multiple events are received within
-    /// the same , only the last one will be emitted.
+    /// after the current program execution finishes, but before returning to the event loop. If
+    /// multiple events are received within the same , only the last one will be emitted.
     ///
     /// Use [`Network::batch`] if you want to collect all emitted values within a microtask.
     ///
@@ -150,8 +150,9 @@ impl Network {
         self.register(OwnedDebounce::new(label, event))
     }
 
-    /// Batch all incoming events emitted within a single microtask. The batch is emitted after the
-    /// current microtask execution is finished. All emitted batches are guaranteed to be non-empty.
+    /// Batch all incoming events emitted within a single microtask. The batch will be emitted
+    /// after the current program execution finishes, but before returning to the event loop. All
+    /// emitted batches are guaranteed to be non-empty.
     ///
     /// Use [`Network::debounce`] if you want to receive only the latest value emitted within a
     /// microtask.

--- a/lib/rust/frp/src/nodes.rs
+++ b/lib/rust/frp/src/nodes.rs
@@ -8,13 +8,13 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
 
-use crate::microtasks::next_tick;
 use crate::network::*;
 use crate::node::*;
 use crate::prelude::*;
 use enso_generics::traits::*;
 
 use crate::data::watch;
+use crate::microtasks::next_tick;
 use crate::stream;
 use crate::stream::CallStack;
 use crate::stream::EventOutput;

--- a/lib/rust/web/src/binding/mock.rs
+++ b/lib/rust/web/src/binding/mock.rs
@@ -668,6 +668,7 @@ mock_data! { HtmlHeadElement => HtmlElement }
 // === HtmlHeadElement ===
 mock_data! { Promise
     fn then(&self, cb: &Closure<dyn FnMut(JsValue)>) -> Promise;
+    fn resolve(cb: &JsValue) -> Promise;
 }
 
 

--- a/lib/rust/web/src/binding/wasm.rs
+++ b/lib/rust/web/src/binding/wasm.rs
@@ -13,6 +13,7 @@ pub use js_sys::Function;
 pub use js_sys::JsString;
 pub use js_sys::Map;
 pub use js_sys::Object;
+pub use js_sys::Promise;
 pub use std::time::Duration;
 pub use std::time::Instant;
 pub use wasm_bindgen::prelude::Closure;


### PR DESCRIPTION
### Pull Request Description

Implements #5640 and #5650

It made sense for me to implement those two together, as I wanted to make sure that the necessary widget API changes will support custom entry values for both dynamic and static data.

- Added support for custom dropdown labels defined on the method annotations
- Added shortening of static dropdown values, which resolves 

| dynamic dropdown - custom labels | static dropdown - automatic shortening |
|-|-|
|![image](https://user-images.githubusercontent.com/919491/220117241-8682736e-d750-4eeb-b9bb-cd6cfce42356.png)|![image](https://user-images.githubusercontent.com/919491/220117412-05ad7f4a-3ccf-468b-a976-c52395a497e2.png)|


### Important Notes

During implementation I had multiple data update order issues caused by FRP network forming a diamond shape. Two inputs that are often updated together were combined with `all` combinator, and that was further fed into the dropdown. This caused two updates to propagate through the whole network, and one of them was immediately outdated. To fix this and similar future scenarios, I've added an `next_tick` FRP node. It buffers the incoming events until the next browser microtask, preserving only the last received event. Currently if it is called inside a `requestAnimationFrame` callback, the effects of that processing will only be rendered in the next frame. Later this can be mitigated by delaying the rendering logic until the microtask queue is empty.

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
