### PR TITLE
No need for -- when using withDebug command

### DIFF
--- a/project/WithDebugCommand.scala
+++ b/project/WithDebugCommand.scala
@@ -53,11 +53,28 @@ object WithDebugCommand {
   val runCommandName       = "run"
   val testOnlyCommandName  = "testOnly"
 
+  private def isDebugFlag(f : String): Boolean = f match {
+    case `dumpGraphsOption` => true
+    case `showCompilationsOptions` => true
+    case `printAssemblyOption` => true
+    case `debuggerOption` => true
+    case `benchOnlyCommandName` => true
+    case `runCommandName` => true
+    case `testOnlyCommandName` => true
+    case _ => false
+  }
+
   /** The main logic for parsing and transforming the debug flags into JVM level flags */
   def withDebug: Command =
     Command.args(commandName, "<arguments>") { (state, args) =>
-      val (debugFlags, prefixedRunArgs) = args.span(_ != argSeparator)
-      val runArgs                       = " " + prefixedRunArgs.drop(1).mkString(" ")
+      var (debugFlags, prefixedRunArgs) = args.span(isDebugFlag(_))
+      System.err.println(prefixedRunArgs)
+      if (prefixedRunArgs(0) == argSeparator) {
+        prefixedRunArgs = prefixedRunArgs.drop(1)
+      }
+      System.err.println(debugFlags)
+      val runArgs                       = " " + prefixedRunArgs.mkString(" ")
+      System.err.println(runArgs)
 
       val taskKey =
         if (debugFlags.contains(benchOnlyCommandName)) BenchTasks.benchOnly


### PR DESCRIPTION
### Pull Request Description

I am tired of always adding `--` when using `withDebug` command. With this change one can simply prefix:
```
sbt> withDebug --debugger testOnly *SomeTest
```
rather than having to add `--` after `testOnly`:
```
sbt> withDebug --debugger testOnly -- *SomeTest
```

### Important Notes

Both (the new as well as the old) variants remain possible however.

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
