### PR TITLE
Provide a better error than null when request handler fails

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/vcs/InitVcsHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/vcs/InitVcsHandler.scala
@@ -54,7 +54,8 @@ class InitVcsHandler(
 
     case Status.Failure(ex) =>
       logger.error(
-        s"Initialize project request [$id] for [${rpcSession.clientId}] failed with: ${ex.getMessage}.",
+        s"Initialize project request [$id] for [${rpcSession.clientId}] failed with: ${if (ex.getMessage == null) ex.getClass
+        else ex.getMessage}}.",
         ex
       )
       cancellable.cancel()


### PR DESCRIPTION
### Pull Request Description

Something is creating an exception with an empty message. A class of the exception is better than nothing.
Any failures reported during initialization of vcs are wrapped properly so an exception is likely coming from the executor but it is not particularly revealing when it lacks the message or stacktrace.

### Important Notes

Current log
```
[org.enso.languageserver.requesthandler.vcs.InitVcsHandler] Initialize project request [Number(2)] for [...] failed with: null.
```
is useless.
