### PR TITLE
Downgrade hashing to SHA-1 and other optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -605,6 +605,7 @@
 - [Update to GraalVM 22.3.1][5602]
 - [Cache library bindings to optimize import/export resolution][5700]
 - [Comparators support partial ordering][5778]
+- [Use SHA-1 for calculating hashes of modules' IR and bindings][5791]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -703,6 +704,7 @@
 [5602]: https://github.com/enso-org/enso/pull/5602
 [5700]: https://github.com/enso-org/enso/pull/5700
 [5778]: https://github.com/enso-org/enso/pull/5778
+[5791]: https://github.com/enso-org/enso/pull/5791
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/docs/runtime/ir-caching.md
+++ b/docs/runtime/ir-caching.md
@@ -142,9 +142,9 @@ It is a JSON file as follows:
 }
 ```
 
-All hashes are encoded in SHA1 format, for performance reasons.
-The engine version is encoded in the cache path, and hence does not need
-to be explicitly specified in the metadata.
+All hashes are encoded in SHA1 format, for performance reasons. The engine
+version is encoded in the cache path, and hence does not need to be explicitly
+specified in the metadata.
 
 ### Portability Guarantees
 

--- a/docs/runtime/ir-caching.md
+++ b/docs/runtime/ir-caching.md
@@ -142,8 +142,8 @@ It is a JSON file as follows:
 }
 ```
 
-All hashes are encoded in SHA3-224 format, as is used by other components in the
-Engine. The engine version is encoded in the cache path, and hence does not need
+All hashes are encoded in SHA1 format, for performance reasons.
+The engine version is encoded in the cache path, and hence does not need
 to be explicitly specified in the metadata.
 
 ### Portability Guarantees

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -42,6 +42,7 @@ import com.oracle.truffle.api.TruffleLogger;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.object.Shape;
 import java.util.concurrent.ExecutorService;
+import java.util.stream.StreamSupport;
 
 import scala.jdk.javaapi.OptionConverters;
 
@@ -357,7 +358,7 @@ public class EnsoContext {
     if (file == null) {
       return Optional.empty();
     }
-    return ScalaConversions.asJava(packageRepository.getLoadedPackages()).stream()
+    return StreamSupport.stream(packageRepository.getLoadedPackagesJava().spliterator(), true)
         .filter(pkg -> file.getAbsoluteFile().startsWith(pkg.root().getAbsoluteFile()))
         .findFirst();
   }

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/QualifiedName.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/QualifiedName.scala
@@ -11,9 +11,13 @@ import scala.jdk.CollectionConverters._
   * @param item the name of the item
   */
 case class QualifiedName(path: List[String], item: String) {
+
+  lazy val qualifiedNameString: String =
+    (path :+ item).mkString(QualifiedName.separator)
+
   @CompilerDirectives.TruffleBoundary
   override def toString: String =
-    (path :+ item).mkString(QualifiedName.separator)
+    qualifiedNameString
 
   /** Get the parent of this qualified name.
     *

--- a/project/DistributionPackage.scala
+++ b/project/DistributionPackage.scala
@@ -205,8 +205,8 @@ object DistributionPackage {
             "--compile",
             path.toString
           )
-          log.info(command.mkString(" "))
-          val exitCode = command.!
+          log.debug(command.mkString(" "))
+          val exitCode = Process(command, None, "JAVA_OPTS"->"-Dorg.jline.terminal.dumb=true").!
           if (exitCode != 0) {
             throw new RuntimeException(s"Cannot compile $libMajor.$libName.")
           }


### PR DESCRIPTION
### Pull Request Description

This change downgrades hashing algorithm used in caching IR and library bindings to SHA-1. It is sufficient and significantly faster for the purpose of simple checksum we use it for.

Additionally, don't calculate the digest for serialized bytes - if we get the expected object type then we are confident about the integrity.

Don't initialize Jackson's ObjectMapper for every metadata serialization/de-serialization. Initialization is very costly.

Avoid unnecessary conversions between Scala and Java. Those back-and-forth `asScala` and `asJava` are pretty expensive.

Finally fix an SBT warning when generating library cache.

Closes https://github.com/enso-org/enso/issues/5763

### Important Notes

The change cuts roughly 0.8-1s from the overall startup.
This change will certainly lead to invalidation of existing caches. It is advised to simply start with a clean slate.

### Checklist

Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
