### PR TITLE
Fix "Following using a drop down, the last bracket on a node gets removed"

### DIFF
--- a/app/gui/src/controller/graph.rs
+++ b/app/gui/src/controller/graph.rs
@@ -873,6 +873,7 @@ impl Handle {
         expression_text: impl Str,
         context: &impl SpanTreeContext,
     ) -> FallibleResult {
+        info!("Setting Expression Span {crumbs:?} node {id}  to \"{}\".", expression_text.as_ref());
         let node_ast = self.node_info(id)?.expression();
         let node_span_tree: SpanTree = SpanTree::new(&node_ast, context)?;
         let port = node_span_tree.get_node(crumbs)?;

--- a/app/gui/view/graph-editor/src/component/node/input/area.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/area.rs
@@ -527,8 +527,10 @@ impl Model {
                     builder.parent.add_child(&widget);
 
                     if port.is_argument() {
-                        let range = port.payload.range();
-                        let code = &expression.viz_code[range];
+                        let range = port.span();
+                        let code = &expression.code[range];
+                        debug!("Setting current value while range is {range:?}, code is \"{code}\" \
+                            and full expression is \"{}\".", expression.code);
                         widget.set_current_value(Some(code.into()));
                     } else {
                         widget.set_current_value(None);


### PR DESCRIPTION
### Pull Request Description

Fixes #5789 

This strange bug is caused by taking value for widget from visual code (which includes port placeholders) instead of the original code. 

For example, having such code:
`operator1.filter 'a' (Filter_Condition.Equal)`
makes the visual code looks as follows
`operator1.filter 'a' (Filter_Condition.Equal value) other_argument_i_dont_remember`
And when we took the value to set on widget, we took `(Filter_Condition.Equal ` - mark space instead of `)`.

### Important Notes

### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
