### PR TITLE
Fixing web content input config bug

### DIFF
--- a/app/ide-desktop/lib/content/src/index.ts
+++ b/app/ide-desktop/lib/content/src/index.ts
@@ -76,15 +76,22 @@ function displayDeprecatedVersionDialog() {
 // === Main Entry Point ===
 // ========================
 
+interface StringConfig {
+    [key: string]: string | StringConfig
+}
+
 class Main {
-    async main() {
-        const config = {
-            loader: {
-                wasmUrl: 'pkg-opt.wasm',
-                jsUrl: 'pkg.js',
-                shadersUrl: 'shaders',
+    async main(inputConfig: StringConfig) {
+        const config = Object.assign(
+            {
+                loader: {
+                    wasmUrl: 'pkg-opt.wasm',
+                    jsUrl: 'pkg.js',
+                    shadersUrl: 'shaders',
+                },
             },
-        }
+            inputConfig
+        )
 
         const appInstance = new app.App({
             config,


### PR DESCRIPTION
### Pull Request Description
The input config to the web content app was ignored by accident. This PR fixes it.


### Checklist

Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed: Enso GUI was tested when built using BOTH
        `./run ide build` and `./run ide watch`.
