### PR TITLE
Don't log installed engines and runtimes in prod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -629,6 +629,7 @@
 - [Comparators support partial ordering][5778]
 - [Merge ordered and unordered comparators][5845]
 - [Use SHA-1 for calculating hashes of modules' IR and bindings][5791]
+- [Don't install Python component on Windows][5900]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -729,6 +730,7 @@
 [5778]: https://github.com/enso-org/enso/pull/5778
 [5845]: https://github.com/enso-org/enso/pull/5845
 [5791]: https://github.com/enso-org/enso/pull/5791
+[5900]: https://github.com/enso-org/enso/pull/5900
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/LanguageServerConfig.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/LanguageServerConfig.scala
@@ -12,6 +12,7 @@ import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
   * @param contentRootUuid an id of content root
   * @param contentRootPath a path to the content root
   * @param profilingConfig an application profiling configuration
+  * @param startupConfig a startup configuration
   */
 case class LanguageServerConfig(
   interface: String,
@@ -20,6 +21,7 @@ case class LanguageServerConfig(
   contentRootUuid: UUID,
   contentRootPath: String,
   profilingConfig: ProfilingConfig,
+  startupConfig: StartupConfig,
   name: String                                      = "language-server",
   computeExecutionContext: ExecutionContextExecutor = ExecutionContext.global
 )

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -91,7 +91,8 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: LogLevel) {
     PathWatcherConfig(),
     ExecutionContextConfig(),
     directoriesConfig,
-    serverConfig.profilingConfig
+    serverConfig.profilingConfig,
+    serverConfig.startupConfig
   )
   log.trace("Created Language Server config [{}].", languageServerConfig)
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/StartupConfig.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/StartupConfig.scala
@@ -1,0 +1,7 @@
+package org.enso.languageserver.boot
+
+/** Startup configuration.
+  *
+  * @param skipGraalVMUpdater indicates if the check and installation of GraalVM should be performed
+  */
+case class StartupConfig(skipGraalVMUpdater: Boolean = false)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/data/Config.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/data/Config.scala
@@ -1,6 +1,6 @@
 package org.enso.languageserver.data
 
-import org.enso.languageserver.boot.ProfilingConfig
+import org.enso.languageserver.boot.{ProfilingConfig, StartupConfig}
 import org.enso.languageserver.filemanager.ContentRootWithFile
 import org.enso.logger.masking.{MaskedPath, ToLogString}
 
@@ -143,6 +143,7 @@ object ProjectDirectoriesConfig {
   * @param executionContext the executionContext config
   * @param directories the configuration of internal directories
   * @param profiling the profiling configuration
+  * @param startup the startup configuration
   */
 case class Config(
   projectContentRoot: ContentRootWithFile,
@@ -151,7 +152,8 @@ case class Config(
   pathWatcher: PathWatcherConfig,
   executionContext: ExecutionContextConfig,
   directories: ProjectDirectoriesConfig,
-  profiling: ProfilingConfig
+  profiling: ProfilingConfig,
+  startup: StartupConfig
 ) extends ToLogString {
 
   /** @inheritdoc */

--- a/engine/language-server/src/test/scala/org/enso/languageserver/boot/resource/RepoInitializationSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/boot/resource/RepoInitializationSpec.scala
@@ -3,7 +3,7 @@ package org.enso.languageserver.boot.resource
 import akka.actor.ActorSystem
 import akka.testkit._
 import org.apache.commons.io.FileUtils
-import org.enso.languageserver.boot.ProfilingConfig
+import org.enso.languageserver.boot.{ProfilingConfig, StartupConfig}
 import org.enso.languageserver.data._
 import org.enso.languageserver.event.InitializedEvent
 import org.enso.languageserver.filemanager.{ContentRoot, ContentRootWithFile}
@@ -21,7 +21,6 @@ import org.sqlite.SQLiteException
 
 import java.nio.file.{Files, StandardOpenOption}
 import java.util.UUID
-
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -214,7 +213,8 @@ class RepoInitializationSpec
       PathWatcherConfig(),
       ExecutionContextConfig(requestTimeout = 3.seconds.dilated),
       ProjectDirectoriesConfig.initialize(root.file),
-      ProfilingConfig()
+      ProfilingConfig(),
+      StartupConfig()
     )
   }
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/filemanager/ContentRootManagerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/filemanager/ContentRootManagerSpec.scala
@@ -3,7 +3,7 @@ package org.enso.languageserver.filemanager
 import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.{TestDuration, TestKit, TestProbe}
 import org.apache.commons.lang3.SystemUtils
-import org.enso.languageserver.boot.ProfilingConfig
+import org.enso.languageserver.boot.{ProfilingConfig, StartupConfig}
 import org.enso.languageserver.data._
 import org.enso.languageserver.filemanager.ContentRootManagerProtocol.{
   ContentRootsAddedNotification,
@@ -20,7 +20,6 @@ import org.scalatest.{Inside, OptionValues}
 import java.io.File
 import java.nio.file.{Path => JPath}
 import java.util.UUID
-
 import scala.concurrent.duration.DurationInt
 
 class ContentRootManagerSpec
@@ -50,7 +49,8 @@ class ContentRootManagerSpec
       PathWatcherConfig(),
       ExecutionContextConfig(requestTimeout = 3.seconds.dilated),
       ProjectDirectoriesConfig.initialize(root.file),
-      ProfilingConfig()
+      ProfilingConfig(),
+      StartupConfig()
     )
     rootActor   = system.actorOf(ContentRootManagerActor.props(config))
     rootManager = new ContentRootManagerWrapper(config, rootActor)

--- a/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
@@ -3,7 +3,7 @@ package org.enso.languageserver.runtime
 import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import org.apache.commons.io.FileUtils
-import org.enso.languageserver.boot.ProfilingConfig
+import org.enso.languageserver.boot.{ProfilingConfig, StartupConfig}
 import org.enso.languageserver.data._
 import org.enso.languageserver.filemanager.{
   ContentRoot,
@@ -27,7 +27,6 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import java.nio.file.Files
 import java.util.UUID
-
 import scala.concurrent.duration._
 
 class ContextEventsListenerSpec
@@ -424,7 +423,8 @@ class ContextEventsListenerSpec
       PathWatcherConfig(),
       ExecutionContextConfig(requestTimeout = 3.seconds),
       ProjectDirectoriesConfig.initialize(root.file),
-      ProfilingConfig()
+      ProfilingConfig(),
+      StartupConfig()
     )
   }
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
@@ -3,7 +3,7 @@ package org.enso.languageserver.search
 import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import org.apache.commons.io.FileUtils
-import org.enso.languageserver.boot.ProfilingConfig
+import org.enso.languageserver.boot.{ProfilingConfig, StartupConfig}
 import org.enso.languageserver.capability.CapabilityProtocol.{
   AcquireCapability,
   CapabilityAcquired
@@ -1052,7 +1052,8 @@ class SuggestionsHandlerSpec
       PathWatcherConfig(),
       ExecutionContextConfig(requestTimeout = 3.seconds),
       ProjectDirectoriesConfig.initialize(root.file),
-      ProfilingConfig()
+      ProfilingConfig(),
+      StartupConfig()
     )
   }
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/binary/BaseBinaryServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/binary/BaseBinaryServerTest.scala
@@ -6,7 +6,7 @@ import akka.actor.{ActorRef, Props}
 import akka.http.scaladsl.model.RemoteAddress
 import com.google.flatbuffers.FlatBufferBuilder
 import org.apache.commons.io.FileUtils
-import org.enso.languageserver.boot.ProfilingConfig
+import org.enso.languageserver.boot.{ProfilingConfig, StartupConfig}
 import org.enso.languageserver.data.{
   Config,
   ExecutionContextConfig,
@@ -49,7 +49,8 @@ class BaseBinaryServerTest extends BinaryServerTestKit {
     PathWatcherConfig(),
     ExecutionContextConfig(requestTimeout = 3.seconds),
     ProjectDirectoriesConfig.initialize(testContentRoot.file),
-    ProfilingConfig()
+    ProfilingConfig(),
+    StartupConfig()
   )
 
   sys.addShutdownHook(FileUtils.deleteQuietly(testContentRoot.file))

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
@@ -12,7 +12,11 @@ import org.enso.editions.{EditionResolver, Editions}
 import org.enso.jsonrpc.test.JsonRpcServerTestKit
 import org.enso.jsonrpc.{ClientControllerFactory, Protocol}
 import org.enso.languageserver.TestClock
-import org.enso.languageserver.boot.{ProfilingConfig, TimingsConfig}
+import org.enso.languageserver.boot.{
+  ProfilingConfig,
+  StartupConfig,
+  TimingsConfig
+}
 import org.enso.languageserver.boot.resource.{
   DirectoriesInitialization,
   RepoInitialization,
@@ -95,7 +99,8 @@ class BaseServerTest
       PathWatcherConfig(),
       ExecutionContextConfig(requestTimeout = 3.seconds),
       ProjectDirectoriesConfig(testContentRoot.file),
-      ProfilingConfig()
+      ProfilingConfig(),
+      StartupConfig()
     )
 
   override def protocol: Protocol = JsonRpc.protocol

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/FileManagerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/FileManagerTest.scala
@@ -4,7 +4,7 @@ import io.circe.literal._
 import io.circe.parser.parse
 import org.apache.commons.io.FileUtils
 import org.bouncycastle.util.encoders.Hex
-import org.enso.languageserver.boot.ProfilingConfig
+import org.enso.languageserver.boot.{ProfilingConfig, StartupConfig}
 import org.enso.languageserver.data._
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.testkit.RetrySpec
@@ -14,7 +14,6 @@ import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{Files, Paths}
 import java.security.MessageDigest
 import java.util.UUID
-
 import scala.concurrent.duration._
 
 class FileManagerTest extends BaseServerTest with RetrySpec {
@@ -29,7 +28,8 @@ class FileManagerTest extends BaseServerTest with RetrySpec {
       PathWatcherConfig(),
       ExecutionContextConfig(requestTimeout = 3.seconds),
       ProjectDirectoriesConfig.initialize(testContentRoot.file),
-      ProfilingConfig()
+      ProfilingConfig(),
+      StartupConfig()
     )
   }
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/VcsManagerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/VcsManagerTest.scala
@@ -7,7 +7,7 @@ import org.eclipse.jgit.api.{Git => JGit}
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.revwalk.RevCommit
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder
-import org.enso.languageserver.boot.ProfilingConfig
+import org.enso.languageserver.boot.{ProfilingConfig, StartupConfig}
 import org.enso.languageserver.data._
 import org.enso.languageserver.vcsmanager.VcsApi
 import org.enso.testkit.RetrySpec
@@ -31,7 +31,8 @@ class VcsManagerTest extends BaseServerTest with RetrySpec {
       PathWatcherConfig(),
       ExecutionContextConfig(requestTimeout = 3.seconds),
       ProjectDirectoriesConfig.initialize(testContentRoot.file),
-      ProfilingConfig()
+      ProfilingConfig(),
+      StartupConfig()
     )
   }
 

--- a/engine/launcher/src/main/scala/org/enso/launcher/Launcher.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/Launcher.scala
@@ -39,7 +39,6 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
   private lazy val componentsManager = {
     val manager =
       runtimeVersionManager(cliOptions, alwaysInstallMissing = false)
-    manager.logAvailableComponentsForDebugging()
     manager
   }
   private lazy val configurationManager =

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/configuration.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/configuration.scala
@@ -84,10 +84,12 @@ object configuration {
     *
     * @param numberOfRetries how many times a bootloader should try to boot the LS
     * @param delayBetweenRetry delays between retries
+    * @param skipGraalVMUpdater indicates if the check and installation of the required GraalVM should be skipped
     */
   case class BootloaderConfig(
     numberOfRetries: Int,
-    delayBetweenRetry: FiniteDuration
+    delayBetweenRetry: FiniteDuration,
+    skipGraalVMUpdater: Boolean = false
   )
 
   /** A configuration object for supervisor properties.

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ExecutorWithUnlimitedPool.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ExecutorWithUnlimitedPool.scala
@@ -73,8 +73,6 @@ object ExecutorWithUnlimitedPool extends LanguageServerExecutor {
     val versionManager = RuntimeVersionManagerFactory(distributionConfiguration)
       .makeRuntimeVersionManager(progressTracker)
 
-    versionManager.logAvailableComponentsForDebugging()
-
     val inheritedLogLevel =
       LoggingServiceManager.currentLogLevelForThisApplication()
     val options = LanguageServerOptions(
@@ -108,10 +106,14 @@ object ExecutorWithUnlimitedPool extends LanguageServerExecutor {
         .flatMap(path =>
           Seq("--server-profiling-events-log-path", path.toString)
         )
+    val startupArgs =
+      if (descriptor.skipGraalVMUpdater) Seq("--skip-graalvm-updater")
+      else Seq()
     val additionalArguments =
       profilingPathArguments ++
       profilingTimeArguments ++
-      profilingEventsLogPathArguments
+      profilingEventsLogPathArguments ++
+      startupArgs
     val runSettings = runner
       .startLanguageServer(
         options             = options,

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerController.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerController.scala
@@ -82,7 +82,8 @@ class LanguageServerController(
       profilingEventsLogPath         = processConfig.profilingEventsLogPath,
       profilingPath                  = processConfig.profilingPath,
       profilingTime                  = processConfig.profilingTime,
-      deferredLoggingServiceEndpoint = loggingServiceDescriptor.getEndpoint
+      deferredLoggingServiceEndpoint = loggingServiceDescriptor.getEndpoint,
+      skipGraalVMUpdater             = bootloaderConfig.skipGraalVMUpdater
     )
 
   override def supervisorStrategy: SupervisorStrategy =
@@ -162,7 +163,7 @@ class LanguageServerController(
     clients: Set[UUID] = Set.empty
   ): Receive =
     LoggingReceive.withLabel("supervising") {
-      case StartServer(clientId, _, requestedEngineVersion, _) =>
+      case StartServer(clientId, _, requestedEngineVersion, _, _) =>
         if (requestedEngineVersion != engineVersion) {
           sender() ! ServerBootFailed(
             new IllegalStateException(
@@ -262,7 +263,7 @@ class LanguageServerController(
   }
 
   private def bootFailed(failure: ServerStartupFailure): Receive = {
-    case StartServer(_, _, _, _) =>
+    case StartServer(_, _, _, _, _) =>
       sender() ! failure
       stop()
   }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerDescriptor.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerDescriptor.scala
@@ -33,6 +33,8 @@ import scala.concurrent.duration.FiniteDuration
   *                                       if the child component should connect
   *                                       to the logging service, it should
   *                                       contain the Uri to connect to
+  * @param skipGraalVMUpdater indicates if the check and installation of GraalVM
+  *                              should be skipped
   */
 case class LanguageServerDescriptor(
   name: String,
@@ -46,5 +48,6 @@ case class LanguageServerDescriptor(
   profilingEventsLogPath: Option[Path],
   profilingPath: Option[Path],
   profilingTime: Option[FiniteDuration],
-  deferredLoggingServiceEndpoint: Future[Option[Uri]]
+  deferredLoggingServiceEndpoint: Future[Option[Uri]],
+  skipGraalVMUpdater: Boolean
 )

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerGatewayImpl.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerGatewayImpl.scala
@@ -54,7 +54,8 @@ class LanguageServerGatewayImpl[
           clientId,
           project,
           version,
-          progressTracker
+          progressTracker,
+          engineUpdate = false
         )).mapTo[ServerStartupResult]
       }
       .mapError(_ => ServerBootTimedOut)

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerProtocol.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerProtocol.scala
@@ -23,7 +23,8 @@ object LanguageServerProtocol {
     clientId: UUID,
     project: Project,
     engineVersion: SemVer,
-    progressTracker: ActorRef
+    progressTracker: ActorRef,
+    engineUpdate: Boolean
   )
 
   /** Base trait for server startup results.

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerRegistry.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerRegistry.scala
@@ -46,7 +46,13 @@ class LanguageServerRegistry(
   private def running(
     serverControllers: Map[UUID, ActorRef] = Map.empty
   ): Receive = {
-    case msg @ StartServer(_, project, engineVersion, progressTracker) =>
+    case msg @ StartServer(
+          _,
+          project,
+          engineVersion,
+          progressTracker,
+          engineUpdate
+        ) =>
       if (serverControllers.contains(project.id)) {
         serverControllers(project.id).forward(msg)
       } else {
@@ -57,7 +63,7 @@ class LanguageServerRegistry(
               engineVersion,
               progressTracker,
               networkConfig,
-              bootloaderConfig,
+              bootloaderConfig.copy(skipGraalVMUpdater = engineUpdate),
               supervisionConfig,
               timeoutConfig,
               distributionConfiguration,

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectCreationService.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectCreationService.scala
@@ -41,7 +41,6 @@ class ProjectCreationService[
       val versionManager = RuntimeVersionManagerFactory(
         distributionConfiguration
       ).makeRuntimeVersionManager(progressTracker, missingComponentAction)
-      versionManager.logAvailableComponentsForDebugging()
       val configurationManager = new GlobalRunnerConfigurationManager(
         versionManager,
         distributionConfiguration.distributionManager

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectService.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectService.scala
@@ -294,10 +294,8 @@ class ProjectService[
         val runtimeVersionManager =
           RuntimeVersionManagerFactory(distributionConfiguration)
             .makeRuntimeVersionManager(progressTracker, missingComponentAction)
-        runtimeVersionManager.logAvailableComponentsForDebugging()
         val engine = runtimeVersionManager.findOrInstallEngine(version)
         runtimeVersionManager.findOrInstallGraalRuntime(engine)
-        runtimeVersionManager.logAvailableComponentsForDebugging()
         ()
       }
       .mapRuntimeManagerErrors(th =>

--- a/lib/scala/runtime-version-manager-test/src/main/scala/org/enso/runtimeversionmanager/test/NoopComponentUpdater.scala
+++ b/lib/scala/runtime-version-manager-test/src/main/scala/org/enso/runtimeversionmanager/test/NoopComponentUpdater.scala
@@ -11,7 +11,7 @@ import scala.util.Try
 object NoopComponentUpdater extends RuntimeComponentUpdater {
 
   /** @inheritdoc */
-  override def list: Try[Seq[GraalVMComponent]] =
+  override def list(): Try[Seq[GraalVMComponent]] =
     Try(Seq())
 
   /** @inheritdoc */

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/GraalVMComponentConfiguration.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/GraalVMComponentConfiguration.scala
@@ -11,15 +11,18 @@ class GraalVMComponentConfiguration extends RuntimeComponentConfiguration {
   override def getRequiredComponents(
     version: GraalVMVersion,
     os: OS
-  ): Seq[GraalVMComponent] =
+  ): Seq[GraalVMComponent] = {
+    val optPythonComponent =
+      if (os.hasPythonSupport) Seq(GraalVMComponent.python) else Seq()
     version.graalVersion match {
       case GraalVersions.Major(v) if v >= 22 =>
-        Seq(GraalVMComponent.js, GraalVMComponent.python, GraalVMComponent.R)
+        Seq(GraalVMComponent.js, GraalVMComponent.R) ++ optPythonComponent
       case GraalVersions.Major(v) if v > 20 && os.hasSulongSupport =>
-        Seq(GraalVMComponent.python, GraalVMComponent.R)
+        Seq(GraalVMComponent.R) ++ optPythonComponent
       case _ =>
         Seq()
     }
+  }
 
 }
 object GraalVMComponentConfiguration {
@@ -39,6 +42,17 @@ object GraalVMComponentConfiguration {
         case OS.Linux   => true
         case OS.MacOS   => true
         case OS.Windows => false
+      }
+
+    /** Check if the provided OS supports Python.
+      * Python is currently not supported in any form on Windows.
+      *
+      * @return `true` if the OS supports Pythong runtime
+      */
+    def hasPythonSupport: Boolean =
+      os match {
+        case OS.Windows => false
+        case _          => true
       }
   }
 

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/GraalVMComponentUpdater.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/GraalVMComponentUpdater.scala
@@ -23,7 +23,7 @@ class GraalVMComponentUpdater(runtime: GraalRuntime)
     *
     * @return the list of installed GraalVM components
     */
-  override def list: Try[Seq[GraalVMComponent]] = {
+  override def list(): Try[Seq[GraalVMComponent]] = {
     val command = Seq("list", "-v")
     val process = Process(
       gu.toAbsolutePath.toString +: command,

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/RuntimeComponentUpdater.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/RuntimeComponentUpdater.scala
@@ -9,7 +9,7 @@ trait RuntimeComponentUpdater {
     *
     * @return the list of installed runtime components
     */
-  def list: Try[Seq[GraalVMComponent]]
+  def list(): Try[Seq[GraalVMComponent]]
 
   /** Install the provided runtime components.
     *

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/RuntimeVersionManager.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/RuntimeVersionManager.scala
@@ -339,7 +339,7 @@ class RuntimeVersionManager(
     result match {
       case (path, Failure(exception)) =>
         logger.warn(
-          "{} at [{}] has been skipped due to the following error: {}",
+          "{} at [{}] has been skipped due to the error",
           name,
           path,
           exception
@@ -801,7 +801,7 @@ class RuntimeVersionManager(
     if (requiredComponents.isEmpty) Success(())
     else {
       for {
-        installedComponents <- cu.list
+        installedComponents <- cu.list()
         _ = logger.debug(
           "Available GraalVM components: [{}].",
           installedComponents
@@ -870,7 +870,8 @@ class RuntimeVersionManager(
 
   /** Logs on trace level all installed engines and runtimes.
     *
-    * Useful for debugging.
+    * NOTE: Useful for debugging but should not be added to production code since it may
+    *       cause unnecessary installations for different engine versions.
     */
   def logAvailableComponentsForDebugging(): Unit = logger.whenTraceEnabled {
     logger.trace("Discovering available components...")

--- a/lib/scala/runtime-version-manager/src/test/scala/org/enso/runtimeversionmanager/components/GraalVMComponentConfigurationSpec.scala
+++ b/lib/scala/runtime-version-manager/src/test/scala/org/enso/runtimeversionmanager/components/GraalVMComponentConfigurationSpec.scala
@@ -34,6 +34,19 @@ class GraalVMComponentConfigurationSpec extends AnyWordSpec with Matchers {
       ) should contain theSameElementsAs requiredAbove22
 
       conf.getRequiredComponents(
+        GraalVMVersion("22.3.0", "11"),
+        OS.MacOS
+      ) should contain theSameElementsAs requiredAbove22
+
+      conf.getRequiredComponents(
+        GraalVMVersion("22.3.0", "11"),
+        OS.Windows
+      ) should contain theSameElementsAs Seq(
+        GraalVMComponent.js,
+        GraalVMComponent.R
+      )
+
+      conf.getRequiredComponents(
         GraalVMVersion("20.0.0.0", "11"),
         OS.Linux
       ) should contain theSameElementsAs Seq()

--- a/lib/scala/runtime-version-manager/src/test/scala/org/enso/runtimeversionmanager/components/GraalVMComponentUpdaterSpec.scala
+++ b/lib/scala/runtime-version-manager/src/test/scala/org/enso/runtimeversionmanager/components/GraalVMComponentUpdaterSpec.scala
@@ -63,7 +63,7 @@ class GraalVMComponentUpdaterSpec extends AnyWordSpec with Matchers {
       val graal = getOrElseFail(graalRuntime)
       val ru    = new GraalVMComponentUpdater(graal)
 
-      ru.list match {
+      ru.list() match {
         case Success(components) =>
           components should not be empty
         case Failure(cause) =>


### PR DESCRIPTION
### Pull Request Description

The `logAvailableComponentsForDebugging` will check and install all necessary components of GraalVM for every mentioned version. While not harmful, it adds up to startup time.
Additionally added an option in language server startup to skip installation of GraalVM components. The latter is already performed by project-manager when opening the project and it is unnecessary to do it twice. Due to LS' architecture this configuration has to be passed around via multiple configs.

Finally, skipped the attempt to install Python component on Windows - this is not supported by GraalVM atm.

Closes #5749.

### Important Notes

The impact of this problem could be really felt the more versions of Enso and GraalVM one had since it would go through all of them.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
