### PR TITLE
Do not cancel detach visualization jobs

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/DetachVisualisationJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/DetachVisualisationJob.scala
@@ -23,7 +23,7 @@ class DetachVisualisationJob(
   expressionId: ExpressionId,
   contextId: ContextId,
   response: ApiResponse
-) extends Job[Unit](List(contextId), true, false) {
+) extends UniqueJob[Unit](expressionId, List(contextId), false) {
 
   /** @inheritdoc */
   override def run(implicit ctx: RuntimeContext): Unit = {


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #5889

Changelog:
- update: make `DetachVisualizationJob` a unique job to make sure that they are not canceled during the re-compilation after `text/applyEdit` command.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] ~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~
