### PR TITLE
Use AG Grid instead of the old table.js rendering

### DIFF
--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -145,6 +145,7 @@ class TableVisualization extends Visualization {
 
         let columnDefs = []
         let rowData = []
+        let dataTruncated = false
 
         if (parsedData.error !== undefined) {
             this.agGridOptions.api.setColumnDefs([
@@ -156,17 +157,20 @@ class TableVisualization extends Visualization {
             ])
             this.agGridOptions.api.setRowData([{ error: parsedData.error }])
         } else if (parsedData.json !== undefined && isMatrix(parsedData.json)) {
-            columnDefs = parsedData.json.map((_, i) => ({ field: i.toString() }))
-            rowData = parsedData.json[0].map((_, i) => parsedData.json.map(r => toRender(r[i])))
+            columnDefs = parsedData.json[0].map((_, i) => ({ field: i.toString() }))
+            rowData = parsedData.json
+            dataTruncated = parsedData.all_rows_count !== parsedData.json.length
         } else if (parsedData.json !== undefined && isObjectMatrix(parsedData.json)) {
             let firstKeys = Object.keys(data[0])
             columnDefs = firstKeys.map(key => ({ field: key }))
             rowData = parsedData.json.map(obj =>
                 firstKeys.reduce((acc, key) => ({ ...acc, [key]: toRender(obj[key]) }), {})
             )
+            dataTruncated = parsedData.all_rows_count !== parsedData.json.length
         } else if (parsedData.json !== undefined && Array.isArray(parsedData.json)) {
             columnDefs = [{ field: '#', headerName: 'Row#' }, { field: 'value' }]
             rowData = parsedData.json.map((row, i) => ({ ['#']: i, value: toRender(row) }))
+            dataTruncated = parsedData.all_rows_count !== parsedData.json.length
         } else if (parsedData.json !== undefined) {
             columnDefs = [{ field: 'value' }]
             rowData = [{ value: toRender(parsedData.json) }]
@@ -196,9 +200,10 @@ class TableVisualization extends Visualization {
                 )
                 return row
             })
+
+            dataTruncated = parsedData.all_rows_count !== rowData.length
         }
 
-        const dataTruncated = parsedData.all_rows_count !== rowData.length
         if (dataTruncated) {
             columnDefs[0].colSpan = p => {
                 if (p.data['__COL_SPAN__'] !== undefined) {

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -1,4 +1,8 @@
 /** Table visualization. */
+loadScript('https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.js')
+// loadScript('https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-enterprise.min.js')
+// loadStyle('https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-grid.css')
+// loadStyle('https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-theme-alpine.css')
 
 // ============================
 // === Style Initialisation ===
@@ -25,37 +29,8 @@ class TableVisualization extends Visualization {
     }
 
     onDataReceived(data) {
-        function tableOf(content, level) {
-            let open = '<table class="level' + level + '">'
-            return open + content + '</table>'
-        }
-
         function hasExactlyKeys(keys, obj) {
             return Object.keys(obj).length === keys.length && keys.every(k => obj.hasOwnProperty(k))
-        }
-
-        function getAtNestedKey(data, key) {
-            let res = data
-            key.forEach(k => (res = res[k]))
-            return res
-        }
-
-        function repNestedKey(key) {
-            return key.join('.')
-        }
-
-        function generateNestings(data, key) {
-            let first = getAtNestedKey(data[0], key)
-            if (!(first instanceof Object)) return [key]
-            let firstKeys = Object.keys(first)
-            let isNestable = data.every(obj => hasExactlyKeys(firstKeys, getAtNestedKey(obj, key)))
-            if (isNestable) {
-                let withNests = firstKeys.map(k => key.concat([k]))
-                let furtherNestings = withNests.map(k => generateNestings(data, k))
-                return [].concat.apply([], furtherNestings)
-            } else {
-                return [key]
-            }
         }
 
         function isObjectMatrix(data) {
@@ -63,27 +38,6 @@ class TableVisualization extends Visualization {
             if (!isList || !(typeof data[0] === 'object')) return false
             let firstKeys = Object.keys(data[0])
             return data.every(obj => hasExactlyKeys(firstKeys, obj))
-        }
-
-        function genObjectMatrix(data, level) {
-            let result = '<tr><th></th>'
-            let keys = Object.keys(data[0])
-            let nests = [].concat.apply(
-                [],
-                keys.map(k => generateNestings(data, [k]))
-            )
-            nests.forEach(key => {
-                result += '<th>' + repNestedKey(key) + '</th>'
-            })
-            result += '</tr>'
-            data.forEach((row, ix) => {
-                result += '<tr><th>' + ix + '</th>'
-                nests.forEach(k => {
-                    result += toTableCell(getAtNestedKey(row, k), level)
-                })
-                result += '</tr>'
-            })
-            return tableOf(result, level)
         }
 
         function isMatrix(data) {
@@ -95,328 +49,124 @@ class TableVisualization extends Visualization {
             return data.every(d => d.length === firstLen)
         }
 
-        function genMatrix(data, level, header) {
-            let result = '<tr><th></th>'
-            result += header
-                ? header.map(h => `<th>${h}</th>`).join('')
-                : data[0].map((_, ix) => `<th>${ix}</th>`).join('')
-            result += '</tr>'
-
-            const rows = data.map((row, ix) => {
-                let row_html = `<tr><th>${ix}</th>`
-                row_html += row.map(d => toTableCell(d, level)).join('')
-                row_html += '</tr>'
-                return row_html
-            })
-            result += rows.join('')
-
-            return tableOf(result, level)
-        }
-
-        function genGenericTable(data, level) {
-            let result = ''
-            if (Array.isArray(data)) {
-                data.forEach((point, ix) => {
-                    result += '<tr><th>' + ix + '</th>' + toTableCell(point, level) + '</tr>'
-                })
-            } else {
-                result += '<tr>' + toTableCell(data, level) + '</tr>'
-            }
-            return tableOf(result, level)
-        }
-
-        function genRowObjectTable(data, level) {
-            let keys = Object.keys(data)
-            let result = '<tr>'
-            keys.forEach(key => {
-                result += '<th>' + key + '</th>'
-            })
-            result += '</tr><tr>'
-            keys.forEach(key => {
-                result += toTableCell(data[key], level)
-            })
-            result += '</tr>'
-            return tableOf(result, level)
-        }
-
-        function toTableCell(data, level) {
-            if (Array.isArray(data)) {
-                return '<td>' + genTable(data, level + 1) + '</td>'
-            } else if (data instanceof Object) {
-                return '<td>' + genRowObjectTable(data, level + 1) + '</td>'
-            } else {
-                if (data === undefined || data === null) data = ''
-                let res = data.toString()
-                return '<td class="plaintext">' + (res === '' ? 'N/A' : res) + '</td>'
-            }
-        }
-
-        function genTable(data, level, header) {
-            if (isMatrix(data)) {
-                return genMatrix(data, level, header)
-            } else if (isObjectMatrix(data)) {
-                return genObjectMatrix(data, level)
-            } else {
-                return genGenericTable(data, level)
-            }
-        }
-
-        function genDataframe(parsedData) {
-            let result = ''
-            function addHeader(content) {
-                result += '<th>' + content + '</th>'
-            }
-            function addCell(content) {
-                let to_render = content
-                if (content instanceof Object) {
-                    const type = content.type
-                    if (type === 'BigInt') {
-                        to_render = BigInt(content.value)
-                    } else if (type === 'Date') {
-                        to_render = new Date(content.year, content.month - 1, content.day)
-                            .toISOString()
-                            .substring(0, 10)
-                        to_render = '<span style="white-space: nowrap;">' + to_render + '</span>'
-                    } else if (type === 'Time_Of_Day') {
-                        const js_date = new Date(
-                            0,
-                            0,
-                            1,
-                            content.hour,
-                            content.minute,
-                            content.second,
-                            content.nanosecond / 1000000
-                        )
-                        to_render =
-                            js_date.toTimeString().substring(0, 8) +
-                            (js_date.getMilliseconds() === 0 ? '' : '.' + js_date.getMilliseconds())
-                        to_render = '<span style="white-space: nowrap;">' + to_render + '</span>'
-                    } else if (type === 'Date_Time') {
-                        const js_date = new Date(
-                            content.year,
-                            content.month - 1,
-                            content.day,
-                            content.hour,
-                            content.minute,
-                            content.second,
-                            content.nanosecond / 1000000
-                        )
-                        to_render =
-                            js_date.toISOString().substring(0, 19).replace('T', ' ') +
-                            (js_date.getMilliseconds() === 0 ? '' : '.' + js_date.getMilliseconds())
-                        to_render = '<span style="white-space: nowrap;">' + to_render + '</span>'
-                    }
+        function toRender(content) {
+            if (content instanceof Array) {
+                if (isMatrix(content)) {
+                    return `[Vector ${content.length} rows x ${content[0].length} cols]`
+                } else if (isObjectMatrix(content)) {
+                    return `[Vector ${content.length} objects]`
+                } else {
+                    return `[Vector ${content.length} items]`
                 }
-                result += '<td class="plaintext">' + to_render + '</td>'
             }
-            result += '<tr>'
-            if (parsedData.indices_header) {
-                parsedData.indices_header.forEach(addHeader)
-            }
-            parsedData.header.forEach(addHeader)
-            result += '</tr>'
-            let rows = 0
-            if (parsedData.data && parsedData.data.length > 0) {
-                rows = parsedData.data[0].length
-            } else if (parsedData.indices && parsedData.indices.length > 0) {
-                rows = parsedData.indices[0].length
-            }
-            for (let i = 0; i < rows; ++i) {
-                result += '<tr>'
-                if (parsedData.indices) {
-                    parsedData.indices.forEach(ix => addHeader(ix[i]))
+
+            if (content instanceof Object) {
+                const type = content.type
+                if (type === 'BigInt') {
+                    return BigInt(content.value)
+                } else if (type === 'Date') {
+                    return new Date(content.year, content.month - 1, content.day)
+                } else if (type === 'Time_Of_Day') {
+                    return new Date(
+                        0,
+                        0,
+                        1,
+                        content.hour,
+                        content.minute,
+                        content.second,
+                        content.nanosecond / 1000000
+                    )
+                } else if (type === 'Date_Time') {
+                    return new Date(
+                        content.year,
+                        content.month - 1,
+                        content.day,
+                        content.hour,
+                        content.minute,
+                        content.second,
+                        content.nanosecond / 1000000
+                    )
+                } else {
+                    return `[Object of type '${type}']`
                 }
-                parsedData.data.forEach(col => addCell(col[i]))
-                result += '</tr>'
             }
-            return tableOf(result, 0)
+
+            return content
         }
 
-        while (this.dom.firstChild) {
-            this.dom.removeChild(this.dom.lastChild)
+        if (!this.tabElem) {
+            while (this.dom.firstChild) {
+                this.dom.removeChild(this.dom.lastChild)
+            }
+
+            const style = ".ag-theme-alpine { --ag-grid-size: 3px; --ag-list-item-height: 20px; display: inline; }";
+            const styleElem = document.createElement('style')
+            styleElem.innerHTML = style
+            this.dom.appendChild(styleElem)
+
+            const tabElem = document.createElement('div')
+            tabElem.setAttributeNS(null, 'id', 'vis-tbl-view')
+            tabElem.setAttributeNS(null, 'class', 'scrollable ag-theme-alpine')
+            tabElem.setAttributeNS(null, 'width', '100%')
+            tabElem.setAttributeNS(null, 'height', '100%')
+            this.dom.appendChild(tabElem)
+            this.updateTableSize()
+
+            this.agGridOptions = {
+                rowData: [],
+                columnDefs: [],
+                defaultColDef: {
+                    editable: false,
+                    sortable: true,
+                    filter: true,
+                    resizable: true,
+                    minWidth: 50
+                },
+                enableRangeSelection: true
+            }
+            this.agGrid = new agGrid.Grid(tabElem, this.agGridOptions)
         }
 
-        const style_dark = `
-        <style>
-        table, .hiddenrows {
-            font-family: DejaVuSansMonoBook, sans-serif;
-            font-size: 12px;
-        }
-
-        table {
-            border-spacing: 1px;
-            padding: 1px;
-        }
-
-        table > tbody > tr:first-child > th:first-child,
-        table > tbody > tr:first-child > td:first-child {
-            border-top-left-radius: 9px;
-        }
-
-        table > tbody > tr:first-child > th:last-child,
-        table > tbody > tr:first-child > td:last-child {
-            border-top-right-radius: 9px;
-        }
-
-        table > tbody > tr:last-child > th:first-child,
-        table > tbody > tr:last-child > td:first-child {
-            border-bottom-left-radius: 9px;
-        }
-
-        table > tbody > tr:last-child > th:last-child,
-        table > tbody > tr:last-child > td:last-child {
-            border-bottom-right-radius: 9px;
-        }
-
-        td {
-            color: rgba(255, 255, 255, 0.9);
-            padding: 0;
-        }
-
-        td.plaintext,
-        th {
-            padding: 5px;
-        }
-
-        th,
-        td {
-            border: 1px solid transparent;
-            background-clip: padding-box;
-        }
-
-        th, .hiddenrows {
-            color: rgba(255, 255, 255, 0.7);
-            font-weight: 400;
-        }
-
-        td {
-            background-color: rgba(255, 255, 255, 0.03);
-        }
-
-        th {
-            background-color: rgba(255, 255, 200, 0.1);
-        }
-
-        .hiddenrows {
-            margin-left: 5px;
-            margin-top: 5px;
-        }
-        </style>
-        `
-
-        const style_light = `
-        <style>
-        table, .hiddenrows {
-            font-family: DejaVuSansMonoBook, sans-serif;
-            font-size: 12px;
-        }
-
-        table {
-            border-spacing: 1px;
-            padding: 1px;
-        }
-
-        table > tbody > tr:first-child > th:first-child,
-        table > tbody > tr:first-child > td:first-child {
-            border-top-left-radius: 9px;
-        }
-
-        table > tbody > tr:first-child > th:last-child,
-        table > tbody > tr:first-child > td:last-child {
-            border-top-right-radius: 9px;
-        }
-
-        table > tbody > tr:last-child > th:first-child,
-        table > tbody > tr:last-child > td:first-child {
-            border-bottom-left-radius: 9px;
-        }
-
-        table > tbody > tr:last-child > th:last-child,
-        table > tbody > tr:last-child > td:last-child {
-            border-bottom-right-radius: 9px;
-        }
-
-        td {
-            color: rgba(0, 0, 0, 0.7);
-            padding: 0;
-        }
-
-        td.plaintext,
-            th {
-            padding: 5px;
-        }
-
-        th,
-            td {
-            border: 1px solid transparent;
-            background-clip: padding-box;
-        }
-
-        th, .hiddenrows {
-            color: rgba(0, 0, 0, 0.9);
-            font-weight: 400;
-        }
-
-        td {
-            background-color: rgba(0, 0, 0, 0.025);
-        }
-
-        th {
-            background-color: rgba(30, 30, 20, 0.1);
-        }
-
-        .hiddenrows {
-            margin-left: 5px;
-            margin-top: 5px;
-        }
-        </style>`
-
-        const tabElem = document.createElement('div')
-        tabElem.setAttributeNS(null, 'id', 'vis-tbl-view')
-        tabElem.setAttributeNS(null, 'class', 'scrollable')
-        tabElem.setAttributeNS(null, 'width', '100%')
-        tabElem.setAttributeNS(null, 'height', '100%')
-        this.tabElem = tabElem
-        this.dom.appendChild(tabElem)
-        this.updateTableSize()
-
-        let parsedData = data
-        if (typeof data === 'string') {
-            parsedData = JSON.parse(data)
-        }
-
-        let style = style_light
-        if (document.getElementById('root').classList.contains('dark-theme')) {
-            style = style_dark
-        }
+        let parsedData = (typeof data === 'string') ? JSON.parse(data) : data
 
         if (parsedData.error !== undefined) {
-            tabElem.innerHTML = 'Error: ' + parsedData.error
+            this.agGridOptions.api.setColumnDefs([{
+                field: "error",
+                width: 1000,
+                cellStyle: {'white-space': 'normal'}
+            }])
+            this.agGridOptions.api.setRowData([{error: parsedData.error}])
+        } else if (parsedData.json !== undefined && isMatrix(parsedData.json)) {
+            this.agGridOptions.api.setColumnDefs(parsedData.json.map((_, i) => ({field: i.toString()})))
+            const data = parsedData.json[0].map((_, i) => parsedData.json.map(r => toRender(r[i])))
+            this.agGridOptions.api.setRowData(data)
+        } else if (parsedData.json !== undefined && isObjectMatrix(parsedData.json)) {
+            let firstKeys = Object.keys(data[0])
+            this.agGridOptions.api.setColumnDefs(firstKeys.map((key) => ({field: key})))
+            const data = parsedData.json.map(obj => firstKeys.reduce((acc, key) => ({...acc, [key]: toRender(obj[key])}), {}))
+            this.agGridOptions.api.setRowData(data)
+        } else if (parsedData.json !== undefined && Array.isArray(parsedData.json)) {
+            const data = parsedData.json.map((row, i) => ({row: i+1, value: toRender(row)}))
+            this.agGridOptions.api.setColumnDefs([{field: "row"}, {field: "value"}])
+            this.agGridOptions.api.setRowData(data)
         } else if (parsedData.json !== undefined) {
-            const table = genTable(parsedData.json, 0, undefined)
-            tabElem.innerHTML = style + table
+            const data = [{ value: toRender(parsedData.json) }]
+            this.agGridOptions.api.setColumnDefs([{field: "value"}])
+            this.agGridOptions.api.setRowData(data)
         } else {
-            const table = genDataframe(parsedData)
-            let suffix = ''
-            const allRowsCount = parsedData.all_rows_count
-            if (allRowsCount !== undefined) {
-                const includedRowsCount = parsedData.data.length > 0 ? parsedData.data[0].length : 0
-                const hiddenCount = allRowsCount - includedRowsCount
-                if (hiddenCount > 0) {
-                    let rows = 'rows'
-                    if (hiddenCount === 1) {
-                        rows = 'row'
-                    }
-                    suffix =
-                        '<span class="hiddenrows">&#8230; and ' +
-                        hiddenCount +
-                        ' more ' +
-                        rows +
-                        '.</span>'
-                }
-            }
-            tabElem.innerHTML = style + table + suffix
+            const headers = [...(parsedData.indices_header ? parsedData.indices_header : []), ...parsedData.header]
+            const rows = parsedData.data && parsedData.data.length > 0 ? parsedData.data[0].length : (parsedData.indices && parsedData.indices.length > 0 ? parsedData.indices[0].length : 0)
+            const data = Array.apply(null, Array(rows)).map((_, i) => {
+                const row = {}
+                const shift = parsedData.indices ? parsedData.indices.length : 0
+                headers.map((h, j) => row[h] = toRender(j < shift ? parsedData.indices[j][i]  : parsedData.data[j - shift][i]))
+                return row
+            })
+            this.agGridOptions.api.setColumnDefs(headers.map((h) => ({field: h})))
+            this.agGridOptions.api.setRowData(data)
         }
+
+        this.agGridOptions.api.sizeColumnsToFit()
     }
 
     updateTableSize() {

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -78,8 +78,12 @@ class TableVisualization extends Visualization {
                         content.hour,
                         content.minute,
                         content.second,
-                        content.nanosecond / 1000000)
-                    return js_date.toTimeString().substring(0, 8) + (js_date.getMilliseconds() === 0 ? '' : '.' + js_date.getMilliseconds())
+                        content.nanosecond / 1000000
+                    )
+                    return (
+                        js_date.toTimeString().substring(0, 8) +
+                        (js_date.getMilliseconds() === 0 ? '' : '.' + js_date.getMilliseconds())
+                    )
                 } else if (type === 'Date_Time') {
                     const js_date = new Date(
                         content.year,
@@ -88,8 +92,14 @@ class TableVisualization extends Visualization {
                         content.hour,
                         content.minute,
                         content.second,
-                        content.nanosecond / 1000000)
-                    return js_date.toISOString().substring(0, 10) + ' ' + js_date.toTimeString().substring(0, 8) + (js_date.getMilliseconds() === 0 ? '' : '.' + js_date.getMilliseconds())
+                        content.nanosecond / 1000000
+                    )
+                    return (
+                        js_date.toISOString().substring(0, 10) +
+                        ' ' +
+                        js_date.toTimeString().substring(0, 8) +
+                        (js_date.getMilliseconds() === 0 ? '' : '.' + js_date.getMilliseconds())
+                    )
                 } else {
                     return `{ ${type} Object }`
                 }
@@ -124,7 +134,7 @@ class TableVisualization extends Visualization {
                     sortable: true,
                     filter: true,
                     resizable: true,
-                    minWidth: 50
+                    minWidth: 50,
                 },
                 enableRangeSelection: true,
             }
@@ -134,7 +144,7 @@ class TableVisualization extends Visualization {
         let parsedData = typeof data === 'string' ? JSON.parse(data) : data
 
         let columnDefs = []
-        let rowData = undefined
+        let rowData = []
 
         if (parsedData.error !== undefined) {
             this.agGridOptions.api.setColumnDefs([
@@ -161,10 +171,12 @@ class TableVisualization extends Visualization {
             columnDefs = [{ field: 'value' }]
             rowData = [{ value: toRender(parsedData.json) }]
         } else {
-            const indices_header = (parsedData.indices_header ? parsedData.indices_header : []).map(h => {
-                const headerName =  h === '#' ? 'Row#' : h;
-                return { field: h, headerName: headerName, pinned: 'left' }
-            });
+            const indices_header = (parsedData.indices_header ? parsedData.indices_header : []).map(
+                h => {
+                    const headerName = h === '#' ? 'Row#' : h
+                    return { field: h, headerName: headerName, pinned: 'left' }
+                }
+            )
             columnDefs = [...indices_header, ...parsedData.header.map(h => ({ field: h }))]
 
             const rows =

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -204,6 +204,9 @@ class TableVisualization extends Visualization {
             dataTruncated = parsedData.all_rows_count !== rowData.length
         }
 
+        // If the table contains more rows than an upper limit, the engine will send only some of all rows.
+        // If data is truncated, we cannot rely on sorting/filtering so will disable.
+        // A pinned row is added to tell the user the row count and that filter/sort is disabled.
         if (dataTruncated) {
             columnDefs[0].colSpan = p => {
                 if (p.data['__COL_SPAN__'] !== undefined) {

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -1,8 +1,8 @@
 /** Table visualization. */
 loadScript('https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.js')
-// loadScript('https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-enterprise.min.js')
-// loadStyle('https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-grid.css')
-// loadStyle('https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-theme-alpine.css')
+// loadScript('https://cdn.jsdelivr.net/npm/ag-grid-enterprise@29.1.0/dist/ag-grid-enterprise.min.js')
+loadStyle('https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-grid.css')
+loadStyle('https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-theme-alpine.css')
 
 // ============================
 // === Style Initialisation ===

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -112,8 +112,6 @@ class TableVisualization extends Visualization {
             const tabElem = document.createElement('div')
             tabElem.setAttributeNS(null, 'id', 'vis-tbl-view')
             tabElem.setAttributeNS(null, 'class', 'scrollable ag-theme-alpine')
-            tabElem.setAttributeNS(null, 'width', '100%')
-            tabElem.setAttributeNS(null, 'height', '100%')
             this.dom.appendChild(tabElem)
             this.tabElem = tabElem
             this.updateTableSize()
@@ -157,14 +155,14 @@ class TableVisualization extends Visualization {
                 firstKeys.reduce((acc, key) => ({ ...acc, [key]: toRender(obj[key]) }), {})
             )
         } else if (parsedData.json !== undefined && Array.isArray(parsedData.json)) {
-            columnDefs = [{ field: '#', headerName: 'Row Number', pinned: 'left' }, { field: 'value' }]
-            rowData = parsedData.json.map((row, i) => ({ ['#']: i + 1, value: toRender(row) }))
+            columnDefs = [{ field: '#', headerName: 'Row#', pinned: 'left' }, { field: 'value' }]
+            rowData = parsedData.json.map((row, i) => ({ ['#']: i, value: toRender(row) }))
         } else if (parsedData.json !== undefined) {
             columnDefs = [{ field: 'value' }]
             rowData = [{ value: toRender(parsedData.json) }]
         } else {
             const indices_header = (parsedData.indices_header ? parsedData.indices_header : []).map(h => {
-                const headerName =  h === '#' ? 'Row Number' : h;
+                const headerName =  h === '#' ? 'Row#' : h;
                 return { field: h, headerName: headerName, pinned: 'left' }
             });
             columnDefs = [...indices_header, ...parsedData.header.map(h => ({ field: h }))]
@@ -188,7 +186,7 @@ class TableVisualization extends Visualization {
             })
         }
 
-        const dataTruncated = parsedData.all_rows_count !== data.length
+        const dataTruncated = parsedData.all_rows_count !== rowData.length
         this.agGridOptions.defaultColDef.filter = !dataTruncated
         this.agGridOptions.defaultColDef.sortable = !dataTruncated
         this.agGridOptions.api.setColumnDefs(columnDefs)
@@ -200,12 +198,9 @@ class TableVisualization extends Visualization {
         if (this.tabElem !== undefined) {
             const width = this.dom.getAttributeNS(null, 'width')
             const height = this.dom.getAttributeNS(null, 'height')
-            const tblViewStyle = `width: ${width - 5}px;
-                 height: ${height - 5}px;
-                 overflow: scroll;
-                 padding:2.5px;`
+            const tblViewStyle = `width: ${width}px; height: ${height}px; overflow: scroll;`
             this.tabElem.setAttributeNS(null, 'style', tblViewStyle)
-            this.tabElem.setAttributeNS(null, 'viewBox', '0 0 ' + width + ' ' + height)
+            // this.tabElem.setAttributeNS(null, 'viewBox', '0 0 ' + width + ' ' + height)
         }
 
         this.agGridOptions && this.agGridOptions.api.sizeColumnsToFit()

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -162,7 +162,7 @@ class TableVisualization extends Visualization {
             dataTruncated = parsedData.all_rows_count !== parsedData.json.length
         } else if (parsedData.json != null && isObjectMatrix(parsedData.json)) {
             let firstKeys = Object.keys(data[0])
-            columnDefs = firstKeys.map(field => ({field}))
+            columnDefs = firstKeys.map(field => ({ field }))
             rowData = parsedData.json.map(obj =>
                 firstKeys.reduce((acc, key) => ({ ...acc, [key]: toRender(obj[key]) }), {})
             )
@@ -209,7 +209,7 @@ class TableVisualization extends Visualization {
         // A pinned row is added to tell the user the row count and that filter/sort is disabled.
         const col_span = '__COL_SPAN__'
         if (dataTruncated) {
-            columnDefs[0].colSpan = p => (p.data[col_span] || 1)
+            columnDefs[0].colSpan = p => p.data[col_span] || 1
         }
         this.agGridOptions.defaultColDef.filter = !dataTruncated
         this.agGridOptions.defaultColDef.sortable = !dataTruncated

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -26,7 +26,7 @@ prepare_visualization y max_rows=1000 = Helpers.recover_errors <|
             dataframe = x.take (First max_rows)
             all_rows_count = x.row_count
             included_rows = dataframe.row_count
-            index = Dataframe_Column.from_vector "#" (Vector.new included_rows i->(i+1))
+            index = Dataframe_Column.from_vector "#" (Vector.new included_rows i->i)
 
             make_json dataframe [index] all_rows_count
 

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -26,7 +26,7 @@ prepare_visualization y max_rows=1000 = Helpers.recover_errors <|
             dataframe = x.take (First max_rows)
             all_rows_count = x.row_count
             included_rows = dataframe.row_count
-            index = Dataframe_Column.from_vector "#" (Vector.new included_rows i->i)
+            index = Dataframe_Column.from_vector "#" (Vector.new included_rows i->(i+1))
 
             make_json dataframe [index] all_rows_count
 


### PR DESCRIPTION
### Pull Request Description

![image](https://user-images.githubusercontent.com/4699705/225099111-2d51d414-7312-4862-a40b-32df5a173df2.png)

Expanded view:
![image](https://user-images.githubusercontent.com/4699705/224783583-8b6bf0a1-2003-4e3b-baca-842c4ff0828f.png)

Truncated view:
![image](https://user-images.githubusercontent.com/4699705/225092432-d8d70953-2da2-4922-8c15-b27cd677cc3c.png)

Replaces the code generating the JS Table visualization with AG Grid Community.
- Supports all of the inputs from the old table.js support.
- Consistently renders values regardless of source.
- **No support for nested tables - by design, we can assess value later.**
- Grid allows sorting and filtering.
- Pins the header row.
- Alternate row coloring.

### Important Notes

To switch to the Enterprise edition, we would need to solve the licensing issues. This would add:

- Filter with values in the grid (like Excel).
- Column auto-sizing.
- Column pining.
- Clipboard copy support (subject to solving the electron issue) - including with or without headers.
- Ability to export to Excel and CSV from the grid.
- Column selector.
- Better options for larger datasets (community only supports infinite scroll).

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
