### PR TITLE
Fix a font specification. Fixes #5912.

### DIFF
--- a/lib/rust/ensogl/app/theme/hardcoded/src/lib.rs
+++ b/lib/rust/ensogl/app/theme/hardcoded/src/lib.rs
@@ -20,6 +20,7 @@ use enso_prelude::*;
 use enso_shapely::before_main;
 use ensogl_core::prelude::ImString;
 use ensogl_text::font::DEFAULT_FONT;
+use ensogl_text::font::DEFAULT_FONT_MONO;
 
 
 
@@ -660,7 +661,7 @@ define_themes! { [light:0, dark:1]
             text = Lcha(0.0,0.0,0.0,0.7) , Lcha(1.0,0.0,0.0,0.7);
             text {
                 selection = Lcha(0.7,0.0,0.125,0.7) , Lcha(0.7,0.0,0.125,0.7);
-                font      = "default-mono", "default-mono";
+                font      = DEFAULT_FONT_MONO, DEFAULT_FONT_MONO;
                 size      = 12.0, 12.0;
                 highlight_bold = 0.02, 0.02;
             }


### PR DESCRIPTION
### Pull Request Description

#5811 changed how the default fonts are referenced, but I missed one instance of the old convention. For some reason(??), the invalid font name didn't cause any problem until the visualization chooser was opened.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
