### PR TITLE
Fix #5969

### DIFF
--- a/app/ide-desktop/eslint.config.js
+++ b/app/ide-desktop/eslint.config.js
@@ -21,9 +21,10 @@ const NAME = 'enso'
  * and conversely type errors may not mean they don't support ESM -
  * but we add those to the whitelist anyway otherwise we get type errors.
  * In particular, `string-length` supports ESM but its type definitions don't.
- * `yargs` and `react-hot-toast` are modules we explicitly want the default imports of. */
+ * `yargs` and `react-hot-toast` are modules we explicitly want the default imports of.
+ * `node:process` is here because `process.on` does not exist on the namespace import. */
 const DEFAULT_IMPORT_ONLY_MODULES =
-    'chalk|string-length|yargs|yargs\\u002Fyargs|sharp|to-ico|connect|morgan|serve-static|create-servers|electron-is-dev|fast-glob|esbuild-plugin-alias|esbuild-plugin-time|esbuild-plugin-yaml|opener'
+    'node:process|chalk|string-length|yargs|yargs\\u002Fyargs|sharp|to-ico|connect|morgan|serve-static|create-servers|electron-is-dev|fast-glob|esbuild-plugin-alias|esbuild-plugin-time|esbuild-plugin-yaml|opener'
 const ALLOWED_DEFAULT_IMPORT_MODULES = `${DEFAULT_IMPORT_ONLY_MODULES}|react-hot-toast`
 const OUR_MODULES = 'enso-content-config|enso-common'
 const RELATIVE_MODULES =

--- a/app/ide-desktop/lib/client/src/index.ts
+++ b/app/ide-desktop/lib/client/src/index.ts
@@ -8,7 +8,7 @@
 import * as fs from 'node:fs/promises'
 import * as fsSync from 'node:fs'
 import * as pathModule from 'node:path'
-import * as process from 'node:process'
+import process from 'node:process'
 
 import * as electron from 'electron'
 

--- a/app/ide-desktop/lib/client/watch.ts
+++ b/app/ide-desktop/lib/client/watch.ts
@@ -12,7 +12,7 @@
 import * as childProcess from 'node:child_process'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
-import * as process from 'node:process'
+import process from 'node:process'
 
 import * as esbuild from 'esbuild'
 

--- a/app/ide-desktop/utils.ts
+++ b/app/ide-desktop/utils.ts
@@ -1,7 +1,7 @@
 /** @file Shared utility functions. */
 import * as fs from 'node:fs'
 import * as path from 'node:path'
-import * as process from 'node:process'
+import process from 'node:process'
 
 /**
  * Get the environment variable value.


### PR DESCRIPTION
### Pull Request Description
Should fix #5969
The cause was the switch to `* as moduleName` namespace imports - `process.on` is missing from the namespace import, causing an error.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
