### PR TITLE
Feat: Tool tip support for larger values in Table visualization

### DIFF
--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -14,6 +14,7 @@ loadStyleFromString(scrollbarStyle)
 // ===========================
 // === CreateCustomTooltip ===
 // ===========================
+
 const createCustomTooltip = tableElem =>
     class CustomTooltip {
         isOverflowing(element) {

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -12,6 +12,38 @@ loadStyle('https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-theme-alpine
 loadStyleFromString(scrollbarStyle)
 
 // ===========================
+// === CreateCustomTooltip ===
+// ===========================
+const createCustomTooltip = tableElem =>
+    class CustomTooltip {
+        isOverflowing(element) {
+            return element.scrollWidth > element.offsetWidth
+        }
+
+        init(params) {
+            const eGui = (this.eGui = document.createElement('div'))
+            eGui.style.backgroundColor = 'white'
+            eGui.style.border = '1px solid gray'
+            eGui.innerHTML = `
+                <p>${params.value}</p>
+            `
+
+            const cell = tableElem.querySelector(
+                `[row-id="${params.rowIndex}"] > .ag-cell[col-id="${params.column.colId}"]`
+            )
+            if (this.isOverflowing(cell)) {
+                eGui.style.visibility = 'visible'
+            } else {
+                eGui.style.visibility = 'hidden'
+            }
+        }
+
+        getGui() {
+            return this.eGui
+        }
+    }
+
+// ===========================
 // === Table visualization ===
 // ===========================
 
@@ -136,7 +168,11 @@ class TableVisualization extends Visualization {
                     filter: true,
                     resizable: true,
                     minWidth: 50,
+                    tooltipComponent: createCustomTooltip(tabElem),
                 },
+                tooltipShowDelay: 1000,
+                tooltipMouseTrack: true,
+                enableRangeSelection: true,
             }
             this.agGrid = new agGrid.Grid(tabElem, this.agGridOptions)
         }
@@ -180,7 +216,10 @@ class TableVisualization extends Visualization {
                     return { field: h, headerName: headerName }
                 }
             )
-            columnDefs = [...indices_header, ...parsedData.header.map(h => ({ field: h }))]
+            columnDefs = [
+                ...indices_header,
+                ...parsedData.header.map(h => ({ field: h, tooltipField: h })),
+            ]
 
             const rows =
                 parsedData.data && parsedData.data.length > 0


### PR DESCRIPTION
### Pull Request Description
Fixes #5968
When the content exceeds the width and causes additional content to be displayed as "...", hovering the mouse for one second will use a tooltip to display all the content.

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->
![1679314293639](https://user-images.githubusercontent.com/52877578/226336687-8dd75578-979e-4019-94f9-aab1c3d98e5c.jpg)
![1679314316214](https://user-images.githubusercontent.com/52877578/226336697-d1f15b71-5af7-4ca0-af52-c2441934faf1.jpg)
![1679314326304](https://user-images.githubusercontent.com/52877578/226336704-f0f7a8cb-ac2d-49d7-836c-0accd2bf1163.jpg)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
