### PR TITLE
Rendering improvement/debugging support

### DIFF
--- a/app/gui/config/build.rs
+++ b/app/gui/config/build.rs
@@ -1,8 +1,16 @@
 const CONFIG_PATH: &str = "../config.yaml";
 
+const JSON_CONFIG: &[&str] = &[
+    "../../../lib/rust/ensogl/pack/js/src/runner/config.json",
+    "../../../app/ide-desktop/lib/content-config/src/config.json",
+];
+
 fn main() {
     println!("cargo:rerun-if-changed={CONFIG_PATH}");
     println!("cargo:rerun-if-changed=build.rs");
+    for path in JSON_CONFIG {
+        println!("cargo:rerun-if-changed={path}");
+    }
 
     config_reader::generate_config_module_from_yaml(CONFIG_PATH);
 }

--- a/app/gui/src/ide/initializer.rs
+++ b/app/gui/src/ide/initializer.rs
@@ -70,6 +70,14 @@ impl Initializer {
 
         ensogl_text_msdf::initialized().await;
         let ensogl_app = ensogl::application::Application::new(self.config.dom_parent_id());
+        let pixel_read_period =
+            enso_config::ARGS.groups.debug.options.pixel_read_period.value.parse();
+        match pixel_read_period {
+            Ok(read_period) => ensogl_app.display.set_pixel_read_period(read_period),
+            Err(e) => {
+                error!("Invalid pixel read period argument provided: `{e}`.");
+            }
+        }
         register_views(&ensogl_app);
         let view = ensogl_app.new_view::<ide_view::root::View>();
 

--- a/app/ide-desktop/lib/client/src/config.ts
+++ b/app/ide-desktop/lib/client/src/config.ts
@@ -256,7 +256,7 @@ export const CONFIG = contentConfig.OPTIONS.merge(
 
             profile: new contentConfig.Group({
                 options: {
-                    loadProfile: new contentConfig.Option<string[]>({
+                    load: new contentConfig.Option<string[]>({
                         passToWebApplication: false,
                         value: [],
                         description:
@@ -264,13 +264,13 @@ export const CONFIG = contentConfig.OPTIONS.merge(
                             `the 'profiling-run-graph' entry point.`,
                         primary: false,
                     }),
-                    saveProfile: new contentConfig.Option({
+                    save: new contentConfig.Option({
                         passToWebApplication: false,
-                        value: '',
+                        value: 'profile.json',
                         description:
                             `Record a performance profile and save it to a file. To view the ` +
                             `results, use the 'profiling-run-graph' entry point, such as ` +
-                            `'enso -startup.entry=profiling-run-graph -profile.load-profile=profile.json'.`,
+                            `'enso -startup.entry=profiling-run-graph -profile.load=profile.json'.`,
                         primary: false,
                     }),
                 },

--- a/app/ide-desktop/lib/client/src/index.ts
+++ b/app/ide-desktop/lib/client/src/index.ts
@@ -242,7 +242,7 @@ class App {
         electron.ipcMain.on(ipc.Channel.error, (_event, data) => {
             logger.error(`IPC error: ${JSON.stringify(data)}`)
         })
-        const argProfiles = this.args.groups.profile.options.loadProfile.value
+        const argProfiles = this.args.groups.profile.options.load.value
         const profilePromises: Promise<string>[] = argProfiles.map((path: string) =>
             fs.readFile(path, 'utf8')
         )
@@ -252,7 +252,7 @@ class App {
                 event.reply('profiles-loaded', profiles)
             })
         })
-        const profileOutPath = this.args.groups.profile.options.saveProfile.value
+        const profileOutPath = this.args.groups.profile.options.save.value
         if (profileOutPath) {
             electron.ipcMain.on(ipc.Channel.saveProfile, (_event, data: string) => {
                 fsSync.writeFileSync(profileOutPath, data)

--- a/app/ide-desktop/lib/content-config/src/config.json
+++ b/app/ide-desktop/lib/content-config/src/config.json
@@ -51,7 +51,6 @@
         }
       }
     },
-
     "engine": {
       "description": "Options that control the Enso Engine, the data processing backend.",
       "options": {
@@ -95,7 +94,6 @@
         }
       }
     },
-
     "style": {
       "description": "The available visual and tactile configurations of the application.",
       "options": {
@@ -105,7 +103,6 @@
         }
       }
     },
-
     "featurePreview": {
       "description": "Options that enable experimental features that are not yet stable.",
       "options": {
@@ -121,7 +118,6 @@
         }
       }
     },
-
     "authentication": {
       "description": "Options to manage application authentication properties.",
       "options": {
@@ -133,7 +129,6 @@
       },
       "primary": false
     },
-
     "profile": {
       "description": "Options for diagnosing application performance problems.",
       "options": {

--- a/app/ide-desktop/lib/content/esbuild-config.ts
+++ b/app/ide-desktop/lib/content/esbuild-config.ts
@@ -141,12 +141,6 @@ export function bundlerOptions(args: Arguments) {
         incremental: trueBoolean,
         color: trueBoolean,
         logOverride: {
-            // Happens in ScalaJS-generated parser (scala-parser.js):
-            //    6 │   "fileLevelThis": this
-            'this-is-undefined-in-esm': 'silent',
-            // Happens in ScalaJS-generated parser (scala-parser.js):
-            // 1553 │   } else if ((a === (-0))) {
-            'equals-negative-zero': 'silent',
             // Happens in Emscripten-generated MSDF (msdfgen_wasm.js):
             //    1 │ ...typeof module!=="undefined"){module["exports"]=Module}process["o...
             'commonjs-variable-in-esm': 'silent',

--- a/build/build/paths.yaml
+++ b/build/build/paths.yaml
@@ -87,9 +87,7 @@
       dist/: # Here ensogl-pack outputs its artifacts
       linked-dist/: # Either symlink to dist or to the gui artifacts.
     generated-java/:
-    parser-upload/:
     test-results/:
-    scala-parser.js:
   test/:
     Benchmarks/:
   tools/:

--- a/docs/profiler/profiling.md
+++ b/docs/profiler/profiling.md
@@ -135,9 +135,9 @@ procedure to collect data is:
   ./run ide build --profiling-level=detail
   ```
 - To profile in Electron:
-  - Start Enso with the `save-profile` option, e.g.:
+  - Start Enso with the `profile.save` option, e.g.:
     ```shell
-    ./distribution/bin/enso --save-profile=your_profile.json
+    ./distribution/bin/enso --profile.save=your_profile.json
     ```
   - Perform any activity the profiler should record (the profiler is always
     running).
@@ -164,12 +164,12 @@ without user-interaction. It can be run as follows:
 # First build with full profiling information.
 ./run ide build --profiling-level=debug
 # Now run the generated binary in batch mode.
-./distribution/bin/enso --entry-point profile --workflow create_node --save-profile create_node.json
+./distribution/bin/enso --startup.entry=profile --profile.workflow=create_node --profile.save=create_node.json
 ```
 
 The `profile` entry point selects batch mode; when it is used, the
-`save-profile` and `workflow` arguments are mandatory. `save-profile` specifies
-an output filename; `workflow` selects from a list of defined batch-mode
+`profile.workflow` argument is mandatory. `profile.save` specifies an output
+filename; `profile.workflow` selects from a list of defined batch-mode
 workflows to measure. Supported workflows include:
 
 - `new_project`: This workflow includes starting the application, opening an
@@ -218,7 +218,7 @@ https://www.cs.middlebury.edu/~candrews/showcase/infovis_techniques_s16/icicle_p
 Invocation:
 
 ```shell
-./distribution/bin/enso --entry-point=profiling-run-graph --load-profile=profile.json
+./distribution/bin/enso --startup.entry=profiling-run-graph --profile.load=profile.json
 ```
 
 It takes as input the profiling data representing a single run

--- a/docs/profiler/profiling.md
+++ b/docs/profiler/profiling.md
@@ -169,8 +169,8 @@ without user-interaction. It can be run as follows:
 
 The `profile` entry point selects batch mode; when it is used, the
 `profile.workflow` argument is mandatory. `profile.save` specifies an output
-filename; `profile.workflow` selects from a list of defined batch-mode
-workflows to measure. Supported workflows include:
+filename; `profile.workflow` selects from a list of defined batch-mode workflows
+to measure. Supported workflows include:
 
 - `new_project`: This workflow includes starting the application, opening an
   empty project, and closing the application.

--- a/lib/rust/ensogl/pack/js/src/runner/config.json
+++ b/lib/rust/ensogl/pack/js/src/runner/config.json
@@ -58,6 +58,11 @@
           "value": false,
           "description": "Enables SpectorJS. This is a temporary flag to test Spector. It will be removed after all Spector integration issues are resolved. See: https://github.com/BabylonJS/Spector.js/issues/252.",
           "primary": false
+        },
+        "pixelReadPeriod": {
+          "value": "1",
+          "description": "Minimum number of frames from one pixel read pass to the next.",
+          "primary": false
         }
       }
     }


### PR DESCRIPTION
### Pull Request Description

Some small improvements relating to rendering:

- Add a debug option: `-debug.pixel-read-period`. This can be used to measure the performance impact of checking the pointer location on different hardware. [On my development box, it makes no difference to performance.] (Closes #5940).
- Unbind pixel pack buffers after each use. This is recommended practice. It has no performance impact on my machine, and allows SpectorJS to run (`-debug.enable-spector`). (Closes #5941).

Also, simplify the profiling CLI: the `profile.load-profile` and `profile.save-profile` options have been renamed to `profile.load`/`profile.save`; `profile.save` now has a default filename, so you can capture a profile at any time in Electron with Ctrl+Alt+P and it will be written to `profile.json`.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
