### PR TITLE
Fix passing custom options to Electron app in ./run ide watch

### DIFF
--- a/app/ide-desktop/lib/client/watch.ts
+++ b/app/ide-desktop/lib/client/watch.ts
@@ -74,7 +74,7 @@ await fs.symlink(
     'dir'
 )
 
-const ELECTRON_ARGS = [path.join(IDE_DIR_PATH, 'index.cjs'), '--', ...process.argv.slice(2)]
+const ELECTRON_ARGS = [path.join(IDE_DIR_PATH, 'index.cjs'), ...process.argv.slice(2)]
 
 process.on('SIGINT', () => {
     console.log('SIGINT received. Exiting.')


### PR DESCRIPTION
### Pull Request Description

Closes #5838 

Now `--ide-option` argument works correctly.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
