### PR TITLE
Use new common parse method throwing less exceptions.

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoDateTime.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoDateTime.java
@@ -262,5 +262,6 @@ public final class EnsoDateTime implements TruffleObject {
   private static final EnsoDateTime epochStart =
       EnsoDateTime.create(1582, 10, 15, 0, 0, 0, 0, EnsoTimeZone.parse("UTC"));
 
-  private static final DateTimeFormatter DATE_TIME_FORMATTER = Core_Date_Utils.defaultZonedDateTimeFormatter();
+  private static final DateTimeFormatter DATE_TIME_FORMATTER =
+      Core_Date_Utils.defaultZonedDateTimeFormatter();
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoDateTime.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoDateTime.java
@@ -9,7 +9,6 @@ import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import java.time.DateTimeException;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -73,13 +72,8 @@ public final class EnsoDateTime implements TruffleObject {
   public static EnsoDateTime parse(String text) {
     String iso = Core_Date_Utils.normaliseISODateTime(text);
 
-    var datetime = DATE_TIME_FORMATTER.parseBest(iso, ZonedDateTime::from, LocalDateTime::from);
-    if (datetime instanceof ZonedDateTime zdt) {
-      return new EnsoDateTime(zdt);
-    } else if (datetime instanceof LocalDateTime ldt) {
-      return new EnsoDateTime(ldt.atZone(ZoneId.systemDefault()));
-    }
-    throw new DateTimeException("Text '" + text + "' could not be parsed as Time.");
+    var datetime = Core_Date_Utils.parseZonedDateTime(iso, DATE_TIME_FORMATTER);
+    return new EnsoDateTime(datetime);
   }
 
   @Builtin.Method(

--- a/lib/scala/common-polyglot-core-utils/src/main/java/org/enso/polyglot/common_utils/Core_Date_Utils.java
+++ b/lib/scala/common-polyglot-core-utils/src/main/java/org/enso/polyglot/common_utils/Core_Date_Utils.java
@@ -1,7 +1,13 @@
 package org.enso.polyglot.common_utils;
 
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalQueries;
+
+import static java.time.temporal.ChronoField.INSTANT_SECONDS;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
 
 public class Core_Date_Utils {
   /**
@@ -25,5 +31,41 @@ public class Core_Date_Utils {
         .optionalStart().parseLenient().appendOffsetId().optionalEnd()
         .optionalStart().appendLiteral('[').parseCaseSensitive().appendZoneRegionId().appendLiteral(']')
         .toFormatter();
+  }
+
+  /**
+   * Parse a date time string into a ZonedDateTime.
+   *
+   * @param dateString the date time string
+   * @param formatter the formatter to use
+   * @return the parsed date time
+   */
+  public static ZonedDateTime parseZonedDateTime(String dateString, DateTimeFormatter formatter) {
+    var resolved = formatter.parse(dateString);
+
+    try {
+      // Resolve Zone
+      var zone = resolved.query(TemporalQueries.zoneId());
+      zone = zone != null ? zone :
+              (resolved.isSupported(ChronoField.OFFSET_SECONDS)
+                      ? ZoneOffset.ofTotalSeconds(resolved.get(ChronoField.OFFSET_SECONDS))
+                      : ZoneId.systemDefault());
+
+      // Instant Based
+      if (resolved.isSupported(INSTANT_SECONDS)) {
+        long epochSecond = resolved.getLong(INSTANT_SECONDS);
+        int nanoOfSecond = resolved.get(NANO_OF_SECOND);
+        return ZonedDateTime.ofInstant(java.time.Instant.ofEpochSecond(epochSecond, nanoOfSecond), zone);
+      }
+
+      // Local Based
+      var localDate = LocalDate.from(resolved);
+      var localTime = LocalTime.from(resolved);
+      return ZonedDateTime.of(localDate, localTime, zone);
+    } catch (DateTimeException e) {
+      throw new DateTimeException("Unable to parse Text '" + dateString + "' to Date_Time.", e);
+    } catch (ArithmeticException e) {
+      throw new DateTimeException("Unable to parse Text '" + dateString + "' to Date_Time due to arithmetic error.", e);
+    }
   }
 }

--- a/std-bits/base/src/main/java/org/enso/base/Time_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/Time_Utils.java
@@ -7,18 +7,14 @@ import org.enso.base.time.Time_Of_Day_Utils;
 import org.enso.polyglot.common_utils.Core_Date_Utils;
 import org.graalvm.polyglot.Value;
 
-import java.time.DateTimeException;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Period;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalField;
 import java.time.temporal.WeekFields;
 import java.util.Locale;
@@ -149,16 +145,8 @@ public class Time_Utils {
    * @return parsed ZonedDateTime instance.
    */
   public static ZonedDateTime parse_datetime(String text, String pattern, Locale locale) {
-    TemporalAccessor time =
-        DateTimeFormatter.ofPattern(pattern)
-            .withLocale(locale)
-            .parseBest(text, ZonedDateTime::from, LocalDateTime::from);
-    if (time instanceof ZonedDateTime) {
-      return (ZonedDateTime) time;
-    } else if (time instanceof LocalDateTime) {
-      return ((LocalDateTime) time).atZone(ZoneId.systemDefault());
-    }
-    throw new DateTimeException("Text '" + text + "' could not be parsed as Time.");
+    var formatter = DateTimeFormatter.ofPattern(pattern).withLocale(locale);
+    return Core_Date_Utils.parseZonedDateTime(text, formatter);
   }
 
   /**

--- a/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
+++ b/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
@@ -7,15 +7,13 @@ import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
 
 import org.enso.base.Time_Utils;
+import org.enso.polyglot.common_utils.Core_Date_Utils;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Value;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
-import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -319,12 +317,8 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
     var text = Time_Utils.normaliseISODateTime(ctx.text.getText());
 
     try {
-      var datetime = Time_Utils.default_zoned_date_time_formatter().parseBest(text, ZonedDateTime::from, LocalDateTime::from);
-      if (datetime instanceof ZonedDateTime zonedDateTime) {
-        return Value.asValue(zonedDateTime);
-      } else if (datetime instanceof LocalDateTime localDateTime) {
-        return Value.asValue(localDateTime.atZone(ZoneId.systemDefault()));
-      }
+      var dateTime = Core_Date_Utils.parseZonedDateTime(text, Time_Utils.default_zoned_date_time_formatter());
+      return Value.asValue(dateTime);
     } catch (DateTimeParseException ignored) {
     }
 

--- a/std-bits/table/src/main/java/org/enso/table/parsing/DateTimeParser.java
+++ b/std-bits/table/src/main/java/org/enso/table/parsing/DateTimeParser.java
@@ -1,29 +1,14 @@
 package org.enso.table.parsing;
 
+import org.enso.polyglot.common_utils.Core_Date_Utils;
 import org.enso.table.data.column.builder.object.Builder;
 import org.enso.table.data.column.builder.object.DateTimeBuilder;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.Locale;
 
 public class DateTimeParser extends BaseTimeParser {
   public DateTimeParser(String[] formats, Locale locale) {
-    super(formats, locale, DateTimeParser::parse);
-  }
-
-  private static ZonedDateTime parse(String text, DateTimeFormatter formatter)
-      throws DateTimeParseException {
-    var datetime = formatter.parseBest(text, ZonedDateTime::from, LocalDateTime::from);
-    if (datetime instanceof ZonedDateTime zdt) {
-      return zdt;
-    } else if (datetime instanceof LocalDateTime ldt) {
-      return ldt.atZone(ZoneId.systemDefault());
-    }
-    throw new DateTimeParseException("Invalid date time", text, 0);
+    super(formats, locale, Core_Date_Utils::parseZonedDateTime);
   }
 
   @Override


### PR DESCRIPTION
### Pull Request Description

Avoiding exceptions by not using parseBest.

Time now in CLI is 1.15s for 500k rows vs 1.65s in GUI.

CLI:
![image](https://user-images.githubusercontent.com/4699705/227711266-bc005b0d-5011-450f-964b-65dd2e437c2e.png)

GUI:
![image](https://user-images.githubusercontent.com/4699705/227711259-f7ddda29-86c7-4eef-a002-4bf0bda6063f.png)

Added it as a function in the shared library so used by both engine and polyglot.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
