### PR TITLE
add alignment setting per shape system

### DIFF
--- a/lib/rust/ensogl/core/src/display/object/instance.rs
+++ b/lib/rust/ensogl/core/src/display/object/instance.rs
@@ -2366,6 +2366,13 @@ pub trait LayoutOps: Object {
     gen_content_justification!(y, space_around_y, 0.5.fr(), 0.5.fr(), 1.fr());
     gen_content_justification!(y, space_evenly_y, 1.fr(), 1.fr(), 1.fr());
 
+    /// Set the alignment of this object. Alignment positions the object within the free space
+    /// around them. For example, if objects are placed in a column, the right alignment will
+    /// move them to the right border of the column.
+    fn set_alignment(&self, alignment: alignment::OptDim2) {
+        self.display_object().def.modify_alignment(|a| *a = alignment);
+    }
+
     /// Content justification. See docs of this module to learn more and see examples.
     fn justify_content_center(&self) -> &Self {
         self.justify_content_center_x().justify_content_center_y()
@@ -3116,48 +3123,103 @@ impl Model {
         let hug_children = hug_children && self.layout.size.get_dim(x).is_hug();
         let children = self.children();
 
-        let mut min_x = if children.is_empty() { 0.0 } else { f32::MAX };
-        let mut max_x = if children.is_empty() { 0.0 } else { f32::MIN };
-        let mut children_to_grow = vec![];
+        let mut min_x = f32::MAX;
+        let mut max_x = f32::MIN;
+        let mut x_bounds_set = false;
+        let mut has_aligned_non_grow_children = false;
+        let mut has_grow_children = false;
         for child in &children {
-            if child.layout.grow_factor.get_dim(x) > 0.0 {
-                children_to_grow.push(child);
-            } else {
+            let to_grow = child.layout.grow_factor.get_dim(x) > 0.0;
+            if !to_grow {
                 // If the child is not growing, doesn't depend on parent size and by itself was not
                 // modified since last update, it is guaranteed to already have correct size.
                 if child.should_propagate_parent_layout_refresh(x) {
                     child.reset_size_to_static_values(x, self.layout.computed_size.get_dim(x));
                     child.refresh_layout_internal(x, PassConfig::Default);
                 }
-                let child_pos = child.position().get_dim(x);
-                let child_size = child.computed_size().get_dim(x);
-                let child_content_origin = child.content_origin().get_dim(x);
-                let child_min_x = child_pos + child_content_origin;
-                let child_max_x = child_min_x + child_size;
-                min_x = min_x.min(child_min_x);
-                max_x = max_x.max(child_max_x);
+
+                if child.layout.alignment.get().get_dim(x).is_some() {
+                    // If the child is aligned, the parent manages its position relative to its own
+                    // size and position. That child must not be taken into account when calculating
+                    // size for hugging. It will be hugged again after its alignment is resolved.
+                    has_aligned_non_grow_children = true;
+                } else {
+                    let child_pos = child.position().get_dim(x);
+                    let child_size = child.computed_size().get_dim(x);
+                    let child_content_origin = child.content_origin().get_dim(x);
+                    let child_min_x = child_pos + child_content_origin;
+                    let child_max_x = child_min_x + child_size;
+                    min_x = min_x.min(child_min_x);
+                    max_x = max_x.max(child_max_x);
+                    x_bounds_set = true;
+                }
+            } else {
+                has_grow_children = true;
             }
         }
+
+        if !x_bounds_set {
+            min_x = 0.0;
+            max_x = 0.0;
+        }
+
         if hug_children {
             self.layout.computed_size.set_dim(x, max_x - min_x);
         }
-        for child in children_to_grow {
-            let current_size = self.layout.computed_size.get_dim(x);
-            let current_child_size = child.computed_size().get_dim(x);
-            if current_size != current_child_size || child.should_refresh_layout() {
-                child.layout.computed_size.set_dim(x, current_size);
-                child.refresh_layout_internal(x, PassConfig::DoNotHugDirectChildren);
-            }
-            let child_pos = child.position().get_dim(x);
-            let child_content_origin = child.content_origin().get_dim(x);
-            min_x = min_x.min(child_pos + child_content_origin);
-        }
-        self.layout.content_origin.set_dim(x, min_x);
 
+        // Resolve aligned children and hug them again.
+        if has_aligned_non_grow_children {
+            let base_size = self.layout.computed_size.get_dim(x);
+            for child in &children {
+                let to_grow = child.layout.grow_factor.get_dim(x) > 0.0;
+                if let Some(alignment) = *child.layout.alignment.get().get_dim(x) && !to_grow {
+                    let child_size = child.computed_size().get_dim(x);
+                    let remaining_size = base_size - child_size;
+                    let aligned_position = remaining_size * alignment.normalized();
+                    child.set_position_dim(x, aligned_position);
+                    let child_content_origin = child.content_origin().get_dim(x);
+                    let child_min_x = aligned_position + child_content_origin;
+                    let child_max_x = child_min_x + child_size;
+                    min_x = min_x.min(child_min_x);
+                    max_x = max_x.max(child_max_x);
+                }
+            }
+
+            if hug_children {
+                self.layout.computed_size.set_dim(x, max_x - min_x);
+            }
+        }
+
+        // From this point on, the size of this node is not changing anymore.
         let self_size = self.layout.computed_size.get_dim(x);
+
+        if has_grow_children {
+            for child in &children {
+                let to_grow = child.layout.grow_factor.get_dim(x) > 0.0;
+                if to_grow {
+                    let current_child_size = child.computed_size().get_dim(x);
+                    if self_size != current_child_size || child.should_refresh_layout() {
+                        child.layout.computed_size.set_dim(x, self_size);
+                        child.refresh_layout_internal(x, PassConfig::DoNotHugDirectChildren);
+                    }
+
+                    if child.layout.alignment.get().get_dim(x).is_some() {
+                        // If child is set to grow, there will never be any leftover space to align
+                        // it. It should always be positioned at 0.0
+                        // relative to its parent.
+                        child.set_position_dim(x, 0.0);
+                    }
+
+                    let child_pos = child.position().get_dim(x);
+                    let child_content_origin = child.content_origin().get_dim(x);
+                    min_x = min_x.min(child_pos + child_content_origin);
+                }
+            }
+        }
+
         let forced_origin_alignment = self.layout.forced_origin_alignment.get().get_dim(x);
         let origin_shift = forced_origin_alignment.normalized() * self_size;
-        self.layout.content_origin.update_dim(x, |t| t - origin_shift);
+        self.layout.content_origin.set_dim(x, min_x - origin_shift);
     }
 }
 
@@ -5665,6 +5727,66 @@ mod layout_tests {
                 .assert_node1_position(5.0, 5.0)
                 .assert_root_content_origin(0.0, 0.0)
                 .assert_node1_content_origin(-1.0, -1.0);
+        });
+    }
+
+    /// ```text
+    /// ╭───────────────────╮
+    /// │ root              │
+    /// │    ╭─────────╮    │
+    /// │    │ node1   │    │
+    /// │    │         │    │
+    /// │    │         │    │
+    /// │    ◎─────────╯    │
+    /// │                   │
+    /// ◎───────────────────╯
+    /// ```
+    #[test]
+    fn test_manual_layout_alignment_center() {
+        let test = TestFlatChildren1::new();
+        test.root.set_size((10.0, 10.0));
+        test.node1.set_size((5.0, 5.0));
+        test.node1.set_alignment_center();
+        test.run(|| {
+            test.assert_root_computed_size(10.0, 10.0)
+                .assert_node1_computed_size(5.0, 5.0)
+                .assert_root_position(0.0, 0.0)
+                .assert_node1_position(2.5, 2.5)
+                .assert_node1_content_origin(0.0, 0.0)
+                .assert_root_content_origin(0.0, 0.0);
+        });
+    }
+
+    /// ```text
+    ///        ╭─root─────────────────────╮
+    ///        │╭─node1──╮                │
+    ///        ││        │                │
+    ///        ││        │                │
+    /// ╭─node2┼┼────────┼───────╮        │
+    /// │      ││        │       │        │
+    /// │      ││        │       │        │
+    /// ╰──────┼┼────────┼───────╯        │
+    ///        ││        │                │
+    ///        ││        │                │
+    ///        │╰────────╯                │
+    /// ◎╌╌╌╌╌╌╰──────────────────────────╯
+    /// ```
+    #[test]
+    fn test_manual_layout_alignment_center_hug() {
+        let test = TestFlatChildren2::new();
+        test.node1.set_size((5.0, 10.0));
+        test.node2.set_size((10.0, 5.0));
+        test.node2.set_alignment_center();
+        test.run(|| {
+            test.assert_root_computed_size(10.0, 10.0)
+                .assert_node1_computed_size(5.0, 10.0)
+                .assert_node2_computed_size(10.0, 5.0)
+                .assert_root_position(0.0, 0.0)
+                .assert_node1_position(0.0, 0.0)
+                .assert_node2_position(-2.5, 2.5)
+                .assert_node1_content_origin(0.0, 0.0)
+                .assert_node2_content_origin(0.0, 0.0)
+                .assert_root_content_origin(-2.5, 0.0);
         });
     }
 

--- a/lib/rust/ensogl/core/src/display/object/instance.rs
+++ b/lib/rust/ensogl/core/src/display/object/instance.rs
@@ -3184,7 +3184,6 @@ impl Model {
                     max_x = max_x.max(child_max_x);
                 }
             }
-
             if hug_children {
                 self.layout.computed_size.set_dim(x, max_x - min_x);
             }

--- a/lib/rust/ensogl/core/src/display/shape/compound/rectangle.rs
+++ b/lib/rust/ensogl/core/src/display/shape/compound/rectangle.rs
@@ -16,15 +16,17 @@ use crate::display;
 
 mod shape {
     use super::*;
-    crate::shape! {(
-        style: Style,
-        color: Vector4,
-        corner_radius: f32,
-        inset: f32,
-        border: f32,
-        border_color: Vector4,
-        clip: Vector2,
-    ) {
+    crate::shape! {
+        alignment = left_bottom;
+        (
+            style: Style,
+            color: Vector4,
+            corner_radius: f32,
+            inset: f32,
+            border: f32,
+            border_color: Vector4,
+            clip: Vector2,
+        ) {
             // === Canvas ===
             let canvas_width = Var::<Pixels>::from("input_size.x");
             let canvas_height = Var::<Pixels>::from("input_size.y");
@@ -34,8 +36,8 @@ mod shape {
             // canvas area. Thus, we need to recompute the new canvas size for the scaled shape.
             let canvas_clip_height_diff = &canvas_height * (clip.y() * 2.0);
             let canvas_clip_width_diff = &canvas_width * (clip.x() * 2.0);
-            let canvas_height = canvas_height + &canvas_clip_height_diff;
-            let canvas_width = canvas_width + &canvas_clip_width_diff;
+            let canvas_height = canvas_height + &canvas_clip_height_diff.abs();
+            let canvas_width = canvas_width + &canvas_clip_width_diff.abs();
 
             // === Body ===
             let inset2 = (&inset * 2.0).px();
@@ -149,9 +151,9 @@ impl Rectangle {
     }
 
     /// Set clipping of the shape. The clipping is normalized, which means, that the value of 0.5
-    /// means that we are clipping 50% of the shape. The clipping is performed always on the left
-    /// and on the bottom of the shape. If you want to clip other sides of the shape, you can rotate
-    /// it after clipping or use one of the predefined helper functions, such as
+    /// means that we are clipping 50% of the shape. For positive clip values, the clipping is
+    /// performed always on the left and on the bottom of the shape. For negative clip values, the
+    /// clipping is performed on the right and on the top of the shape.
     /// [`Self::keep_bottom_half`].
     pub fn set_clip(&self, clip: Vector2) -> &Self {
         self.modify_view(|view| view.clip.set(clip))
@@ -164,7 +166,7 @@ impl Rectangle {
 
     /// Keep only the bottom half of the shape.
     pub fn keep_bottom_half(&self) -> &Self {
-        self.keep_top_half().flip()
+        self.set_clip(Vector2(0.0, -0.5))
     }
 
     /// Keep only the right half of the shape.
@@ -174,7 +176,7 @@ impl Rectangle {
 
     /// Keep only the left half of the shape.
     pub fn keep_left_half(&self) -> &Self {
-        self.keep_right_half().flip()
+        self.set_clip(Vector2(-0.5, 0.0))
     }
 
     /// Keep only the top right quarter of the shape.
@@ -184,47 +186,17 @@ impl Rectangle {
 
     /// Keep only the bottom right quarter of the shape.
     pub fn keep_bottom_right_quarter(&self) -> &Self {
-        self.keep_top_right_quarter().rotate_90()
+        self.set_clip(Vector2(0.5, -0.5))
     }
 
     /// Keep only the bottom left quarter of the shape.
     pub fn keep_bottom_left_quarter(&self) -> &Self {
-        self.keep_bottom_right_quarter().rotate_180()
+        self.set_clip(Vector2(-0.5, -0.5))
     }
 
     /// Keep only the top left quarter of the shape.
     pub fn keep_top_left_quarter(&self) -> &Self {
-        self.keep_bottom_left_quarter().rotate_270()
-    }
-
-    /// Flip the shape via its center. This is equivalent to rotating the shape by 180 degrees.
-    pub fn flip(&self) -> &Self {
-        self.rotate_180()
-    }
-
-    /// Rotate the shape by 90 degrees.
-    pub fn rotate_90(&self) -> &Self {
-        self.modify_view(|view| view.set_rotation_z(-std::f32::consts::PI / 2.0))
-    }
-
-    /// Counter rotate the shape by 90 degrees.
-    pub fn counter_rotate_90(&self) -> &Self {
-        self.modify_view(|view| view.set_rotation_z(std::f32::consts::PI / 2.0))
-    }
-
-    /// Rotate the shape by 180 degrees.
-    pub fn rotate_180(&self) -> &Self {
-        self.modify_view(|view| view.set_rotation_z(-std::f32::consts::PI))
-    }
-
-    /// Counter rotate the shape by 180 degrees.
-    pub fn rotate_270(&self) -> &Self {
-        self.modify_view(|view| view.set_rotation_z(-3.0 / 2.0 * std::f32::consts::PI))
-    }
-
-    /// Counter rotate the shape by 270 degrees.
-    pub fn counter_rotate_270(&self) -> &Self {
-        self.modify_view(|view| view.set_rotation_z(3.0 / 2.0 * std::f32::consts::PI))
+        self.set_clip(Vector2(-0.5, 0.5))
     }
 }
 

--- a/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
+++ b/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
@@ -440,7 +440,12 @@ impl ShapeSystemModel {
             "
                 mat4 model_view_projection = input_view_projection * input_transform;
 
-                // Compute the padding and grow the canvas by its value.
+                // Computing the vertex position without shape padding.
+                vec3 input_local_no_padding = vec3((input_uv - input_alignment) * input_size, 0.0);
+                vec4 position_no_padding = model_view_projection * vec4(input_local_no_padding, 1.0);
+                input_local.z = position_no_padding.z;
+
+                // We are now able to compute the padding and grow the canvas by its value.
                 vec2 padding = vec2(aa_side_padding());
                 if (input_display_mode == DISPLAY_MODE_DEBUG_SPRITE_OVERVIEW) {
                     padding = vec2(float(input_mouse_position.y) / 10.0);
@@ -453,10 +458,10 @@ impl ShapeSystemModel {
                 input_uv = input_uv * uv_scale - uv_offset;
 
                 // Compute the vertex position with shape padding, apply alignment to the vertex
-                // position.
-                vec2 position = vec2((input_uv - input_alignment) * input_size);
-                gl_Position = model_view_projection * vec4(position,0.0,1.0);
-                // Compute SDF input position with 0.0 being in the shape's center.
+                // position, but not to the local SDF coordinates. Shape definitions should always
+                // have their origin point in the center of the shape.
+                vec4 position = vec4((input_uv - input_alignment) * input_size, 0.0, 1.0);
+                gl_Position = model_view_projection * position;
                 input_local = vec3((input_uv - vec2(0.5)) * input_size, gl_Position.z);
             ",
         );

--- a/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
+++ b/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
@@ -456,9 +456,10 @@ impl ShapeSystemModel {
                 vec2 uv_scale = padded_size / input_size;
                 vec2 uv_offset = padding / input_size;
 
-                // Note: Due to a shader optimizer issue, the `input_uv` modification is
-                // intentionally split into two separate expressions. When this is written in single
-                // line as follows:
+                // Note: SPIRV-Cross issue https://github.com/KhronosGroup/SPIRV-Cross/issues/2129
+                // To avoid incorrect code generation for `Fma` instruction in SPIRV-Cross, the
+                // `input_uv` modification is intentionally split into two separate expressions.
+                // When this is written in single line as follows:
                 // ```
                 // input_uv = input_uv * uv_scale - uv_offset;
                 // ```

--- a/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
+++ b/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
@@ -455,8 +455,20 @@ impl ShapeSystemModel {
                 vec2 padded_size = input_size + padding2;
                 vec2 uv_scale = padded_size / input_size;
                 vec2 uv_offset = padding / input_size;
-                input_uv = input_uv * uv_scale - uv_offset;
 
+                // Note: Due to a shader optimizer issue, the `input_uv` modification is
+                // intentionally split into two separate expressions. When this is written in single
+                // line as follows:
+                // ```
+                // input_uv = input_uv * uv_scale - uv_offset;
+                // ```
+                // That expression is incorrectly mis-optimized into:
+                // ```
+                // input_uv *= input_uv - uv_offset;
+                // ```
+                input_uv *= uv_scale;
+                input_uv -= uv_offset;
+                
                 // Compute the vertex position with shape padding, apply alignment to the vertex
                 // position, but not to the local SDF coordinates. Shape definitions should always
                 // have their origin point in the center of the shape.

--- a/lib/rust/ensogl/core/src/display/symbol/gpu/geometry/compound/screen.rs
+++ b/lib/rust/ensogl/core/src/display/symbol/gpu/geometry/compound/screen.rs
@@ -23,7 +23,7 @@ impl Screen {
     /// Constructor.
     #[profile(Detail)]
     pub fn new(surface_material: Material) -> Self {
-        let sprite_system = SpriteSystem::new("screen");
+        let sprite_system = SpriteSystem::new("screen", alignment::Dim2::center());
         sprite_system.set_geometry_material(Self::geometry_material());
         sprite_system.set_material(surface_material);
         let sprite = sprite_system.new_instance();

--- a/lib/rust/ensogl/core/src/display/symbol/gpu/geometry/compound/sprite.rs
+++ b/lib/rust/ensogl/core/src/display/symbol/gpu/geometry/compound/sprite.rs
@@ -288,7 +288,7 @@ pub struct SpriteSystem {
 impl SpriteSystem {
     /// Constructor.
     #[profile(Detail)]
-    pub fn new(label: &'static str) -> Self {
+    pub fn new(label: &'static str, alignment: alignment::Dim2) -> Self {
         let (stats, symbol) = world::with_context(|t| (t.stats.clone_ref(), t.new(label)));
         let mesh = symbol.surface();
         let point_scope = mesh.point_scope();
@@ -296,7 +296,7 @@ impl SpriteSystem {
         let uv = point_scope.add_buffer("uv");
         let transform = instance_scope.add_buffer("transform");
         let size = instance_scope.add_buffer("size");
-        let alignment_value = Rc::new(Cell::new(alignment::Dim2::center()));
+        let alignment_value = Rc::new(Cell::new(alignment));
         let initial_alignment = alignment_value.get().normalized();
         let alignment = symbol.variables().add_or_panic("alignment", initial_alignment);
 

--- a/lib/rust/ensogl/core/src/lib.rs
+++ b/lib/rust/ensogl/core/src/lib.rs
@@ -68,6 +68,7 @@ pub use enso_types as types;
 
 /// Commonly used utilities.
 pub mod prelude {
+    pub use super::display::layout::alignment;
     pub use super::display::traits::*;
     pub use super::display::world::scene;
     pub use super::frp;

--- a/lib/rust/ensogl/examples/auto-layout/src/lib.rs
+++ b/lib/rust/ensogl/examples/auto-layout/src/lib.rs
@@ -24,6 +24,7 @@ use ensogl_core::display::object::ObjectOps;
 mod rectangle {
     use super::*;
     ensogl_core::shape! {
+        alignment = left_bottom;
         (style: Style, color: Vector4<f32>) {
             let color = Var::<color::Rgba>::from(color);
             let width = Var::<Pixels>::from("input_size.x");
@@ -52,16 +53,13 @@ pub fn main() {
     let _navigator = Navigator::new(scene, &camera).leak();
 
     let root = scene.new_child_named("root").leak();
-    root.use_auto_layout().set_gap((5.0, 5.0));
+    root.use_auto_layout().reverse_columns().set_gap((5.0, 5.0));
 
     let rect1 = root.new_child_named("rect1").leak();
-    let rect1_bg = rect1.new_child_named("rect1_bg").leak();
-    rect1_bg.use_auto_layout().allow_grow().set_size((0.0, 0.0));
-
-    let rect1_bg_shape = rectangle::View::new().leak();
-    rect1_bg.add_child(&rect1_bg_shape);
-    rect1_bg_shape.color.set(Rgba::new(0.0, 0.0, 0.0, 0.3).into());
-    rect1_bg_shape.allow_grow().set_size((0.0, 0.0));
+    let rect1_bg = rectangle::View::new().leak();
+    rect1.add_child(&rect1_bg);
+    rect1_bg.color.set(Rgba::new(0.0, 0.0, 0.0, 0.3).into());
+    rect1_bg.allow_grow().set_size((0.0, 0.0));
 
     let rect1_content = rect1.new_child_named("rect1_content").leak();
     rect1_content.use_auto_layout().set_gap((5.0, 5.0)).set_padding_all(5.0);
@@ -87,10 +85,15 @@ pub fn main() {
     rect2.set_size(Vector2::new(100.0, 100.0));
     rect2.color.set(Rgba::new(0.5, 0.0, 0.0, 0.3).into());
 
-    let rect2_inner = rectangle::View::new().leak();
-    rect2.add_child(&rect2_inner);
-    rect2_inner.set_size((40, 40));
-    rect2_inner.color.set(Rgba::new(1.0, 1.0, 1.0, 0.4).into());
+    let rect2_inner1 = rectangle::View::new().leak();
+    rect2.add_child(&rect2_inner1);
+    rect2_inner1.set_size((40, 40));
+    rect2_inner1.color.set(Rgba::new(1.0, 1.0, 1.0, 0.4).into());
+
+    let rect2_inner2 = rectangle::View::new().leak();
+    rect2.add_child(&rect2_inner2);
+    rect2_inner2.set_size((40, 40));
+    rect2_inner2.color.set(Rgba::new(0.0, 0.0, 0.0, 0.4).into());
 
 
     let mut logged = false;
@@ -103,6 +106,9 @@ pub fn main() {
             let y = (s * 1.3 * std::f32::consts::PI).cos() * 40.0 + 50.0;
             inner2.set_size((x, y));
 
+            rect2_inner1.set_alignment(anim_align_at_time(s));
+            rect2_inner2.set_alignment(anim_align_at_time(s + 3.0));
+
             if !logged {
                 logged = true;
                 warn!("rect1: {:?}", rect1.display_object());
@@ -110,4 +116,20 @@ pub fn main() {
             }
         })
         .forget();
+}
+
+fn anim_align_at_time(t: f32) -> alignment::OptDim2 {
+    match (t * 2.0) as i64 % 10 {
+        0 => alignment::OptDim2::center_top(),
+        1 => alignment::OptDim2::right_top(),
+        2 => alignment::OptDim2::right_center(),
+        3 => alignment::OptDim2::right_bottom(),
+        4 => alignment::OptDim2::center_bottom(),
+        5 => alignment::OptDim2::left_bottom(),
+        6 => alignment::OptDim2::left_center(),
+        7 => alignment::OptDim2::left_top(),
+        8 => alignment::OptDim2::center_top(),
+        9 => alignment::OptDim2::center(),
+        _ => unreachable!(),
+    }
 }

--- a/lib/rust/ensogl/examples/dom-symbols/src/lib.rs
+++ b/lib/rust/ensogl/examples/dom-symbols/src/lib.rs
@@ -82,7 +82,7 @@ pub fn main() {
     let scene = &world.default_scene;
     let camera = scene.camera();
     let navigator = Navigator::new(scene, &camera);
-    let sprite_system = SpriteSystem::new("test_sprite_system");
+    let sprite_system = SpriteSystem::new("test_sprite_system", alignment::Dim2::center());
     world.add_child(&sprite_system);
 
     let dom_front_layer = &scene.dom.layers.front;

--- a/lib/rust/ensogl/examples/sprite-system-benchmark/src/lib.rs
+++ b/lib/rust/ensogl/examples/sprite-system-benchmark/src/lib.rs
@@ -39,7 +39,7 @@ pub fn main() {
     let scene = &world.default_scene;
     let camera = scene.camera().clone_ref();
     let navigator = Navigator::new(scene, &camera);
-    let sprite_system = SpriteSystem::new("test_sprite_system");
+    let sprite_system = SpriteSystem::new("test_sprite_system", alignment::Dim2::center());
 
     let sprite1 = sprite_system.new_instance();
     sprite1.set_size(Vector2::new(10.0, 10.0));

--- a/lib/rust/ensogl/examples/sprite-system/src/lib.rs
+++ b/lib/rust/ensogl/examples/sprite-system/src/lib.rs
@@ -32,7 +32,7 @@ use ensogl_core::display::symbol::geometry::SpriteSystem;
 pub fn main() {
     let world = World::new().displayed_in("root");
     let navigator = Navigator::new(&world.default_scene, &world.default_scene.camera());
-    let sprite_system = SpriteSystem::new("test_sprite_system");
+    let sprite_system = SpriteSystem::new("test_sprite_system", alignment::Dim2::center());
 
     let sprite2 = sprite_system.new_instance();
     let sprite1 = sprite_system.new_instance();

--- a/lib/rust/types/src/topology.rs
+++ b/lib/rust/types/src/topology.rs
@@ -59,6 +59,12 @@ impl Min for Pixels {
     }
 }
 
+impl Abs for Pixels {
+    fn abs(&self) -> Self {
+        Pixels::from(self.value.abs())
+    }
+}
+
 
 // === Degrees ===
 


### PR DESCRIPTION
### Pull Request Description

- Added alignment configuration option for shape systems. That allows creating bottom-left aligned sprites, which will behave much more naturally inside auto-layouts.
- Added support for alignment in manual layouts. When alignment is set, the manual layout will position the child node at the respective border of its bounding box. The size of aligned node will not be affected. The difference from auto-layout alignment is that each node is aligned individually, and it is not affected by its siblings. This allows for constructing more complicated responsive layouts that don't necessarily follow the grid, without creating wrapper auto-layout elements for each child.


![layout-anim-and-alignment](https://user-images.githubusercontent.com/919491/227951742-7a7fd48a-7d07-4e19-b824-8c136e3fb381.gif)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
