### PR TITLE
More elaborate error message for invalid text edit

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
@@ -612,12 +612,16 @@ class CollaborativeBuffer(
   }
 
   private val toEditFailure: TextEditValidationFailure => ApplyEditFailure = {
-    case EndPositionBeforeStartPosition =>
-      TextEditValidationFailed("The start position is after the end position")
-    case NegativeCoordinateInPosition =>
-      TextEditValidationFailed("Negative coordinate in a position object")
-    case InvalidPosition(position) =>
-      TextEditValidationFailed(s"Invalid position: $position")
+    case EndPositionBeforeStartPosition(start, end) =>
+      TextEditValidationFailed(
+        s"The start position ($start) is after the end position ($end)"
+      )
+    case NegativeCoordinateInPosition(coord, reason) =>
+      TextEditValidationFailed(
+        s"Negative coordinate ($coord) in a position object: $reason"
+      )
+    case InvalidPosition(position, reason) =>
+      TextEditValidationFailed(s"Invalid position ($position): $reason")
   }
 
   private def readFile(

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
@@ -1190,7 +1190,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             "id": 2,
             "error": {
               "code": 3002,
-              "message": "Negative coordinate in a position object"
+              "message": "Negative coordinate (-1) in a position object: text edit start line"
             }
           }
           """)

--- a/lib/scala/text-buffer/src/main/scala/org/enso/text/editing/TextEditValidationFailure.scala
+++ b/lib/scala/text-buffer/src/main/scala/org/enso/text/editing/TextEditValidationFailure.scala
@@ -8,14 +8,17 @@ sealed trait TextEditValidationFailure
 
 /** Signals that an end position is before a start position.
   */
-case object EndPositionBeforeStartPosition extends TextEditValidationFailure
+case class EndPositionBeforeStartPosition(start: Position, end: Position)
+    extends TextEditValidationFailure
 
 /** Signals the a position object contains negative coordinates.
   */
-case object NegativeCoordinateInPosition extends TextEditValidationFailure
+case class NegativeCoordinateInPosition(coordinates: Int, checkReason: String)
+    extends TextEditValidationFailure
 
 /** Signals that a position is outside the buffer.
   *
   * @param position an invalid position
   */
-case class InvalidPosition(position: Position) extends TextEditValidationFailure
+case class InvalidPosition(position: Position, checkReason: String)
+    extends TextEditValidationFailure

--- a/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/EditorOpsSpec.scala
+++ b/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/EditorOpsSpec.scala
@@ -39,7 +39,12 @@ class EditorOpsSpec extends AnyFlatSpec with Matchers with EitherValues {
     //when
     val result = EditorOps.applyEdits(testSnippet, diffs)
     //then
-    result mustBe Left(InvalidPosition(Position(5, 4)))
+    result mustBe Left(
+      InvalidPosition(
+        Position(5, 4),
+        "text edit start line (5) outside of buffer's line count (4)"
+      )
+    )
   }
 
   it should "apply edit when end position is an empty line" in {

--- a/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/TextEditValidatorSpec.scala
+++ b/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/TextEditValidatorSpec.scala
@@ -10,23 +10,41 @@ class TextEditValidatorSpec extends AnyFlatSpec with Matchers {
 
   "A rope text editor" should "fail when end position is before start position" in {
     val diff1 = TextEdit(Range(Position(0, 3), Position(0, 2)), "a")
-    validate(buffer, diff1) mustBe Left(EndPositionBeforeStartPosition)
+    validate(buffer, diff1) mustBe Left(
+      EndPositionBeforeStartPosition(Position(0, 3), Position(0, 3))
+    )
     val diff2 = TextEdit(Range(Position(0, 3), Position(0, 2)), "a")
-    validate(buffer, diff2) mustBe Left(EndPositionBeforeStartPosition)
+    validate(buffer, diff2) mustBe Left(
+      EndPositionBeforeStartPosition(Position(0, 3), Position(0, 3))
+    )
   }
 
   it should "fail when range contains negative numbers" in {
     val diff1 = TextEdit(Range(Position(-1, 3), Position(0, 2)), "a")
-    validate(buffer, diff1) mustBe Left(NegativeCoordinateInPosition)
+    validate(buffer, diff1) mustBe Left(
+      NegativeCoordinateInPosition(-1, "text edit start line")
+    )
     val diff2 = TextEdit(Range(Position(0, -3), Position(0, 2)), "a")
-    validate(buffer, diff2) mustBe Left(NegativeCoordinateInPosition)
+    validate(buffer, diff2) mustBe Left(
+      NegativeCoordinateInPosition(-3, "text edit start character")
+    )
   }
 
   it should "fail if position is outside of buffer" in {
     val diff1 = TextEdit(Range(Position(0, 3), Position(10, 2)), "a")
-    validate(buffer, diff1) mustBe Left(InvalidPosition(Position(10, 2)))
+    validate(buffer, diff1) mustBe Left(
+      InvalidPosition(
+        Position(10, 2),
+        "text edit end line (10) outside of buffer's line count (2)"
+      )
+    )
     val diff2 = TextEdit(Range(Position(0, 10), Position(1, 2)), "a")
-    validate(buffer, diff2) mustBe Left(InvalidPosition(Position(0, 10)))
+    validate(buffer, diff2) mustBe Left(
+      InvalidPosition(
+        Position(0, 10),
+        " character (10) is outside of line's length (8)"
+      )
+    )
   }
 
   it should "succeed when character coordinate is equal to line length" in {


### PR DESCRIPTION


### Pull Request Description

It is sometimes impossible to figure out the real reason for invalid text edit request. Added a bit of context to failures to narrow down the cause of the failure.

### Important Notes

Should help with diagnosing issues like #6099.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] ~~The documentation has been updated, if necessary.~~
- [ ] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
