### PR TITLE
Fix crash when editing certain names in the CB

### DIFF
--- a/app/gui/src/controller/searcher/input.rs
+++ b/app/gui/src/controller/searcher/input.rs
@@ -426,7 +426,7 @@ impl InsertContext<'_> {
                 .flatten()
                 .filter_map(|opr| ast::identifier::name(&opr.item.arg).map(ImString::new))
                 .collect_vec();
-            !name_segments.is_empty().as_some(name_segements)
+            (!name_segments.is_empty()).as_some(name_segments)
         } else {
             None
         }

--- a/app/gui/src/controller/searcher/input.rs
+++ b/app/gui/src/controller/searcher/input.rs
@@ -426,7 +426,7 @@ impl InsertContext<'_> {
                 .flatten()
                 .filter_map(|opr| ast::identifier::name(&opr.item.arg).map(ImString::new))
                 .collect_vec();
-            if name_segments.len() > 0 {
+            if name_segments.is_empty() {
                 Some(name_segments)
             } else {
                 None

--- a/app/gui/src/controller/searcher/input.rs
+++ b/app/gui/src/controller/searcher/input.rs
@@ -402,13 +402,14 @@ impl InsertContext<'_> {
     /// infix chain of `ACCESS` operators with identifiers.
     fn has_qualified_name(&self) -> bool {
         if let Some(ref context) = self.context {
+            let there_are_operands = context.enumerate_operands().flatten().count() > 0;
             let every_operand_is_name = context.enumerate_operands().flatten().all(|opr| {
                 matches!(opr.item.arg.shape(), ast::Shape::Cons(_) | ast::Shape::Var(_))
             });
             let every_operator_is_access = context
                 .enumerate_operators()
                 .all(|opr| opr.item.ast().repr() == ast::opr::predefined::ACCESS);
-            every_operand_is_name && every_operator_is_access
+            there_are_operands && every_operand_is_name && every_operator_is_access
         } else {
             false
         }
@@ -425,7 +426,11 @@ impl InsertContext<'_> {
                 .flatten()
                 .filter_map(|opr| ast::identifier::name(&opr.item.arg).map(ImString::new))
                 .collect_vec();
-            Some(name_segments)
+            if name_segments.len() > 0 {
+                Some(name_segments)
+            } else {
+                None
+            }
         } else {
             None
         }

--- a/app/gui/src/controller/searcher/input.rs
+++ b/app/gui/src/controller/searcher/input.rs
@@ -426,11 +426,7 @@ impl InsertContext<'_> {
                 .flatten()
                 .filter_map(|opr| ast::identifier::name(&opr.item.arg).map(ImString::new))
                 .collect_vec();
-            if !name_segments.is_empty() {
-                Some(name_segments)
-            } else {
-                None
-            }
+            !name_segments.is_empty().as_some(name_segements)
         } else {
             None
         }

--- a/app/gui/src/controller/searcher/input.rs
+++ b/app/gui/src/controller/searcher/input.rs
@@ -426,7 +426,7 @@ impl InsertContext<'_> {
                 .flatten()
                 .filter_map(|opr| ast::identifier::name(&opr.item.arg).map(ImString::new))
                 .collect_vec();
-            if name_segments.is_empty() {
+            if !name_segments.is_empty() {
                 Some(name_segments)
             } else {
                 None


### PR DESCRIPTION
### Pull Request Description

Fixes #6119 #6117 

The issue was caused by the usage of `slice::windows`, which panics if the input is `0`. After two modifications of the code that should never happen again. Technically any of the two would work fine without the other.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
