### PR TITLE
Report errors when generating indexes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2120,7 +2120,32 @@ buildEngineDistribution := {
     editionName         = currentEdition,
     sourceStdlibVersion = stdLibVersion,
     targetStdlibVersion = targetStdlibVersion,
-    targetDir           = (`syntax-rust-definition` / rustParserTargetDirectory).value
+    targetDir           = (`syntax-rust-definition` / rustParserTargetDirectory).value,
+    generateIndex       = true
+  )
+  log.info(s"Engine package created at $root")
+}
+
+lazy val buildEngineDistributionNoIndex =
+  taskKey[Unit]("Builds the engine distribution without generating indexes")
+buildEngineDistributionNoIndex := {
+  val _ = (`engine-runner` / assembly).value
+  updateLibraryManifests.value
+  val root         = engineDistributionRoot.value
+  val log          = streams.value.log
+  val cacheFactory = streams.value.cacheStoreFactory
+  DistributionPackage.createEnginePackage(
+    distributionRoot    = root,
+    cacheFactory        = cacheFactory,
+    log                 = log,
+    graalVersion        = graalVersion,
+    javaVersion         = javaVersion,
+    ensoVersion         = ensoVersion,
+    editionName         = currentEdition,
+    sourceStdlibVersion = stdLibVersion,
+    targetStdlibVersion = targetStdlibVersion,
+    targetDir           = (`syntax-rust-definition` / rustParserTargetDirectory).value,
+    generateIndex       = false
   )
   log.info(s"Engine package created at $root")
 }

--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -502,13 +502,19 @@ object Main {
       logLevel,
       logMasking,
       enableIrCaches           = true,
+      strictErrors             = true,
       useGlobalIrCacheLocation = shouldUseGlobalCache
     )
     val topScope = context.getTopScope
-    topScope.compile(shouldCompileDependencies)
-
-    context.context.close()
-    exitSuccess()
+    try {
+      topScope.compile(shouldCompileDependencies)
+      exitSuccess()
+    } catch {
+      case _: Throwable =>
+        exitFail()
+    } finally {
+      context.context.close()
+    }
   }
 
   /** Handles the `--run` CLI option.

--- a/engine/runtime/src/main/java/org/enso/compiler/Cache.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/Cache.java
@@ -262,7 +262,7 @@ public abstract class Cache<T, M extends Cache.Metadata> {
           if (cachedObject != null) {
             return Optional.of(cachedObject);
           } else {
-            logger.log(logLevel, "`" + logName + "` was corrupt on disk.");
+            logger.log(logLevel, "`{0}` was corrupt on disk.", logName);
             invalidateCache(cacheRoot, logger);
             return Optional.empty();
           }
@@ -276,8 +276,7 @@ public abstract class Cache<T, M extends Cache.Metadata> {
           return Optional.empty();
         }
       } else {
-        logger.log(
-            logLevel, "One or more digests did not match for the cache for [" + logName + "].");
+        logger.log(logLevel, "One or more digests did not match for the cache for [{0}].", logName);
         invalidateCache(cacheRoot, logger);
         return Optional.empty();
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
@@ -14,6 +14,8 @@ import com.oracle.truffle.api.library.ExportMessage;
 import java.io.File;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
 import org.enso.compiler.PackageRepository;
 import org.enso.interpreter.EnsoLanguage;
 import org.enso.interpreter.runtime.EnsoContext;
@@ -173,9 +175,13 @@ public final class TopLevelScope implements TruffleObject {
               .getOptions()
               .get(RuntimeOptions.USE_GLOBAL_IR_CACHE_LOCATION_KEY);
       boolean shouldCompileDependencies = Types.extractArguments(arguments, Boolean.class);
-      context.getCompiler().compile(shouldCompileDependencies, useGlobalCache);
-
-      return true;
+      try {
+        return context.getCompiler().compile(shouldCompileDependencies, useGlobalCache).get();
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      } catch (ExecutionException e) {
+        throw new RuntimeException(e);
+      }
     }
 
     @Specialization

--- a/project/DistributionPackage.scala
+++ b/project/DistributionPackage.scala
@@ -120,7 +120,8 @@ object DistributionPackage {
     editionName: String,
     sourceStdlibVersion: String,
     targetStdlibVersion: String,
-    targetDir: File
+    targetDir: File,
+    generateIndex: Boolean
   ): Unit = {
     copyDirectoryIncremental(
       file("distribution/engine/THIRD-PARTY"),
@@ -171,14 +172,16 @@ object DistributionPackage {
       javaVersion  = javaVersion
     )
 
-    indexStdLibs(
-      stdLibVersion  = targetStdlibVersion,
-      ensoVersion    = ensoVersion,
-      stdLibRoot     = distributionRoot / "lib",
-      ensoExecutable = distributionRoot / "bin" / "enso",
-      cacheFactory   = cacheFactory.sub("stdlib"),
-      log            = log
-    )
+    if (generateIndex) {
+      indexStdLibs(
+        stdLibVersion  = targetStdlibVersion,
+        ensoVersion    = ensoVersion,
+        stdLibRoot     = distributionRoot / "lib",
+        ensoExecutable = distributionRoot / "bin" / "enso",
+        cacheFactory   = cacheFactory.sub("stdlib"),
+        log            = log
+      )
+    }
   }
 
   def indexStdLibs(


### PR DESCRIPTION
### Pull Request Description

`--compile` command would run the compilation pipeline but silently omit any encountered errors, thus skipping the serialization. This maybe was a good idea in the past but it was problematic now that we generate indexes on build time.
This resulted in rather obscure errors (#6092) for modules that were missing their caches.

The change should significantly improve developers' experience when working on stdlib.

### Important Notes

Making compilation more resilient to sudden cache misses is a separate item to be worked on.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] ~The documentation has been updated, if necessary.~
- [ ] ~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] ~~Unit tests have been written where possible.~~
  - [ ] ~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~
