### PR TITLE
Always print stacktrace to provide some guidance of what is going on

### DIFF
--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -723,7 +723,7 @@ object Main {
       .reverse
     val msg: String = HostEnsoUtils.findExceptionMessage(exception)
     println(s"Execution finished with an error: ${msg}")
-    dropInitJava.foreach { frame =>
+    def printFrame(frame: PolyglotException#StackFrame): Unit = {
       val langId =
         if (frame.isHostFrame) "java" else frame.getLanguage.getId
       val fmtFrame = if (frame.getLanguage.getId == LanguageInfo.ID) {
@@ -763,6 +763,11 @@ object Main {
         frame.toString
       }
       println(s"        at <$langId> $fmtFrame")
+    }
+    if (dropInitJava.isEmpty) {
+      fullStack.foreach(printFrame)
+    } else {
+      dropInitJava.foreach(printFrame)
     }
   }
 


### PR DESCRIPTION
### Pull Request Description

Avoid displaying just `Execution finished with an error: java.lang.NullPointerException` without any additional detail. 

### Important Notes

When there is an execution error outside of Enso code (identified by the fact that all stack frames belong to `java` language), let's print the whole stack rather than printing nothing. To simulate one can:
```diff
diff --git engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
index ff0636bc66..42e5eae32e 100644
--- engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -453,7 +453,8 @@ class Compiler(
             pool
           )
         } else {
-          CompletableFuture.completedFuture(ensureParsedAndAnalyzed(module))
+          // CompletableFuture.completedFuture(ensureParsedAndAnalyzed(module))
+          CompletableFuture.completedFuture(())
         }
       }
``` 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Existing Unit tests are passing OK
