### PR TITLE
bump shader tools version and use distribution install by default

### DIFF
--- a/build/ci_utils/src/goodies/shader_tools.rs
+++ b/build/ci_utils/src/goodies/shader_tools.rs
@@ -29,7 +29,7 @@ use crate::programs::spirv_cross::SpirvCross;
 pub const SHADER_TOOLS_REPO: RepoRef = RepoRef { owner: "enso-org", name: "shader-tools" };
 
 /// Version of the shader tools package that we download.
-pub const VERSION: Version = Version::new(0, 1, 0);
+pub const VERSION: Version = Version::new(0, 2, 0);
 
 
 // =========================

--- a/build/cli/src/arg/wasm.rs
+++ b/build/cli/src/arg/wasm.rs
@@ -81,6 +81,12 @@ pub struct BuildInput {
         default_value_if("skip-wasm-opt", None, Some("0")),
     )]
     pub wasm_size_limit: Option<byte_unit::Byte>,
+
+    /// Allow usage of system installation of `shaderc`, `spirv-opt` and `spirv-cross`. When
+    /// present, the binaries from PATH will be preferred over downloading prebuilt distribution.
+    /// Caution: old versions of those tools might introduce subtle bugs in optimized shaders.
+    #[clap(long, enso_env())]
+    pub system_shader_tools: bool,
 }
 
 #[derive(Args, Clone, Debug, PartialEq, Eq)]

--- a/build/cli/src/lib.rs
+++ b/build/cli/src/lib.rs
@@ -616,6 +616,7 @@ impl Resolvable for Wasm {
             wasm_uncollapsed_log_level,
             wasm_size_limit,
             skip_wasm_opt,
+            system_shader_tools,
         } = from;
         ok_ready_boxed(wasm::BuildInput {
             crate_path,
@@ -627,6 +628,7 @@ impl Resolvable for Wasm {
             log_level: wasm_log_level,
             uncollapsed_log_level: wasm_uncollapsed_log_level,
             wasm_size_limit: wasm_size_limit.filter(|size_limit| size_limit.get_bytes() > 0),
+            system_shader_tools,
         })
     }
 }

--- a/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
+++ b/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
@@ -455,21 +455,8 @@ impl ShapeSystemModel {
                 vec2 padded_size = input_size + padding2;
                 vec2 uv_scale = padded_size / input_size;
                 vec2 uv_offset = padding / input_size;
+                input_uv = input_uv * uv_scale - uv_offset;
 
-                // Note: SPIRV-Cross issue https://github.com/KhronosGroup/SPIRV-Cross/issues/2129
-                // To avoid incorrect code generation for `Fma` instruction in SPIRV-Cross, the
-                // `input_uv` modification is intentionally split into two separate expressions.
-                // When this is written in single line as follows:
-                // ```
-                // input_uv = input_uv * uv_scale - uv_offset;
-                // ```
-                // That expression is incorrectly mis-optimized into:
-                // ```
-                // input_uv *= input_uv - uv_offset;
-                // ```
-                input_uv *= uv_scale;
-                input_uv -= uv_offset;
-                
                 // Compute the vertex position with shape padding, apply alignment to the vertex
                 // position, but not to the local SDF coordinates. Shape definitions should always
                 // have their origin point in the center of the shape.


### PR DESCRIPTION
### Pull Request Description

Update shader tools to new version. Notably, this release contains spirv-cross with fixed issue https://github.com/KhronosGroup/SPIRV-Cross/issues/2129.

### Important Notes

Spirv-cross has no versioning that we could use to specify requirements for using system-wide installed versions. Instead, we have to download the prebuilt distribution by default, so we can rely on known good versions. The usage of binaries in PATH can still be enabled with a build flag, but it is discouraged due to severity of the bug and no easy way of detecting it. If the project is built with buggy shader tools version, the application will run, but it will be visually slightly broken in unexpected ways.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] ~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
