### PR TITLE
do not override default shape alignment in macro

### DIFF
--- a/app/gui/view/src/window_control_buttons.rs
+++ b/app/gui/view/src/window_control_buttons.rs
@@ -28,6 +28,7 @@ pub mod fullscreen;
 mod shape {
     use super::*;
     shape! {
+        alignment = center;
         (style: Style) {
             Plane().fill(INVISIBLE_HOVER_COLOR).into()
         }

--- a/app/gui/view/src/window_control_buttons/close.rs
+++ b/app/gui/view/src/window_control_buttons/close.rs
@@ -20,6 +20,7 @@ pub mod shape {
     use super::*;
 
     ensogl::shape! {
+        alignment = center;
         (style: Style, background_color: Vector4<f32>, icon_color: Vector4<f32>) {
             let size       = Var::canvas_size();
             let radius     = Min::min(size.x(),size.y()) / 2.0;

--- a/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
+++ b/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
@@ -887,11 +887,9 @@ macro_rules! _shape {
                     _out
                 }
 
-                fn default_alignment() -> $crate::display::layout::alignment::Dim2 {
-                    let _out = $crate::display::layout::alignment::Dim2::center();
-                    $(let _out = $crate::display::layout::alignment::Dim2::$alignment();)?
-                    _out
-                }
+                $(fn default_alignment() -> $crate::display::layout::alignment::Dim2 {
+                    $crate::display::layout::alignment::Dim2::$alignment()
+                })?
 
                 fn always_above() -> Vec<ShapeSystemId> {
                     vec![$($( ShapeSystem::<$always_above_1 $(::$always_above_2)*::Shape>::id() ),*)?]
@@ -945,11 +943,6 @@ macro_rules! _shape {
                 $(fn flavor(data: &Self::ShapeData) -> $crate::display::shape::system::ShapeSystemFlavor {
                     $flavor(data)
                 })?
-
-                $(fn initial_alignment(data: &Self::ShapeData) -> $crate::display::shape::system::ShapeSystemFlavor {
-                    $flavor(data)
-                })?
-
             }
 
             /// Register the shape definition in the global shape registry. It is used for shader


### PR DESCRIPTION
### Pull Request Description

This was supposed to be a part of #6087, but one bad macro definition slipped through. The only consequence of that was that `compound::Rectangle` shape had `center` alignment instead of `bottom_left`. That shape is not used in the application at any place yet, so it only affected new uses (including @wdanilo's vector editor branch) and one example scene.

Fixed example scene with compound shape inside auto-layout:
![image](https://user-images.githubusercontent.com/919491/229346163-8a4226ce-8238-457b-adca-4b89ba63d00c.png)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
