### PR TITLE
Disable buffer compaction

### DIFF
--- a/lib/rust/ensogl/core/src/system/gpu/data/attribute.rs
+++ b/lib/rust/ensogl/core/src/system/gpu/data/attribute.rs
@@ -155,7 +155,8 @@ impl {
     pub fn update(&mut self) {
         debug_span!("Updating.").in_scope(|| {
             if self.used_size * 2 < self.size() {
-                self.shrink_to_fit();
+                // FIXME
+                // self.shrink_to_fit();
             }
             if self.shape_dirty.check() {
                 for i in 0..self.buffers.len() {


### PR DESCRIPTION
### Pull Request Description

Buffer compaction is causing a crash. Disable it until the algorithm is fixed.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] ~The documentation has been updated, if necessary.~
- [ ] ~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] ~Unit tests have been written where possible.~
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.