### PR TITLE
Fix `./run gui watch` on Windows

### DIFF
--- a/app/ide-desktop/lib/content/esbuild-config.ts
+++ b/app/ide-desktop/lib/content/esbuild-config.ts
@@ -117,7 +117,7 @@ export function bundlerOptions(args: Arguments) {
                 // in `ensogl/pack/js/src/runner/index.ts`
                 name: 'pkg-js-is-cjs',
                 setup: build => {
-                    build.onLoad({ filter: /\/pkg.js$/ }, async ({ path }) => ({
+                    build.onLoad({ filter: /[/\\]pkg.js$/ }, async ({ path }) => ({
                         contents: await fs.readFile(path),
                         loader: 'copy',
                     }))


### PR DESCRIPTION
### Pull Request Description
Fixes a bug in the plugin used to workaround a bug in esbuild. The bug has since been fixed, however another plugin is causing issues with the *proper* fix

### Important Notes
N/A

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
