### PR TITLE
Provide Forbidden_Operation.to_display_text

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ForbiddenOperationToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ForbiddenOperationToDisplayTextNode.java
@@ -1,0 +1,31 @@
+package org.enso.interpreter.node.expression.builtin.error.displaytext;
+
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.library.CachedLibrary;
+import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.callable.atom.Atom;
+import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
+import org.enso.interpreter.runtime.callable.atom.StructsLibrary;
+import org.enso.interpreter.runtime.data.text.Text;
+
+@BuiltinMethod(type = "Forbidden_Operation", name = "to_display_text")
+public abstract class ForbiddenOperationToDisplayTextNode extends Node {
+  static ForbiddenOperationToDisplayTextNode build() {
+    return ForbiddenOperationToDisplayTextNodeGen.create();
+  }
+
+  abstract Text execute(Object self);
+
+  @Specialization
+  Text doAtom(Atom self, @CachedLibrary(limit = "3") StructsLibrary structs) {
+    return Text.create("Forbidden operation: ")
+        .add(String.valueOf(structs.getField(self, 0)))
+        .add(".");
+  }
+
+  @Specialization
+  Text doConstructor(AtomConstructor self) {
+    return Text.create("Forbidden operation.");
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ForbiddenOperationToDisplayTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/displaytext/ForbiddenOperationToDisplayTextNode.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.node.expression.builtin.error.displaytext;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
@@ -18,6 +19,7 @@ public abstract class ForbiddenOperationToDisplayTextNode extends Node {
   abstract Text execute(Object self);
 
   @Specialization
+  @CompilerDirectives.TruffleBoundary
   Text doAtom(Atom self, @CachedLibrary(limit = "3") StructsLibrary structs) {
     return Text.create("Forbidden operation: ")
         .add(String.valueOf(structs.getField(self, 0)))


### PR DESCRIPTION
### Pull Request Description

Added a missing `to_display_text` method which, by convention, is defined via a builtin method.

Also re-enabled and fixed pending tests.

Closes #6227.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- ~[ ] The documentation has been updated, if necessary.~
- ~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - ~[ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~
