### PR TITLE
Make play button clickable and hide it when irrelevant

### DIFF
--- a/app/gui/src/presenter/project.rs
+++ b/app/gui/src/presenter/project.rs
@@ -388,7 +388,7 @@ impl Project {
     /// implementation of #5930.
     fn init_execution_modes(self) -> Self {
         let graph = &self.model.view.graph();
-        let entries = Rc::new(vec!["development".to_string(), "production".to_string()]);
+        let entries = Rc::new(vec!["design".to_string(), "live".to_string()]);
         graph.set_available_execution_modes(entries);
         self
     }

--- a/app/gui/view/examples/execution-mode-dropdown/src/lib.rs
+++ b/app/gui/view/examples/execution-mode-dropdown/src/lib.rs
@@ -28,7 +28,7 @@ use ide_view_execution_mode_selector as execution_mode_selector;
 // ======================
 
 fn make_entries() -> execution_mode_selector::ExecutionModes {
-    Rc::new(vec!["development".to_string(), "production".to_string()])
+    Rc::new(vec!["design".to_string(), "live".to_string()])
 }
 
 fn init(app: &Application) {

--- a/app/gui/view/examples/interface/src/lib.rs
+++ b/app/gui/view/examples/interface/src/lib.rs
@@ -256,8 +256,7 @@ fn init(app: &Application) {
 
     // === Execution Modes ===
 
-    graph_editor
-        .set_available_execution_modes(vec!["development".to_string(), "production".to_string()]);
+    graph_editor.set_available_execution_modes(vec!["design".to_string(), "live".to_string()]);
 
 
     // === Rendering ===

--- a/app/gui/view/execution-mode-selector/src/play_button.rs
+++ b/app/gui/view/execution-mode-selector/src/play_button.rs
@@ -1,0 +1,180 @@
+use enso_prelude::*;
+use ensogl::prelude::*;
+
+use enso_frp as frp;
+use ensogl::application::Application;
+use ensogl::display;
+use ensogl::display::shape::StyleWatchFrp;
+use ensogl_derive_theme::FromTheme;
+use ensogl_gui_component::component;
+use ensogl_hardcoded_theme::graph_editor::execution_mode_selector::play_button as theme;
+
+
+
+// =============
+// === Style ===
+// ==============
+
+#[derive(Debug, Clone, Copy, Default, FromTheme)]
+#[base_path = "theme"]
+pub struct Style {
+    triangle_size: f32,
+    offset:        f32,
+    padding_x:     f32,
+    padding_y:     f32,
+}
+
+
+
+// ==============
+// === Shapes ===
+// ==============
+
+mod play_icon {
+    use super::*;
+
+    use std::f32::consts::PI;
+
+    ensogl::shape! {
+        above = [display::shape::compound::rectangle::shape];
+        (style: Style) {
+            let triangle_size = style.get_number(theme::triangle_size);
+            let color = style.get_color(theme::color);
+            let triangle = Triangle(triangle_size, triangle_size).rotate((PI / 2.0).radians());
+            let triangle = triangle.fill(color);
+            let bg_size = Var::canvas_size();
+            let bg = Rect(bg_size).fill(INVISIBLE_HOVER_COLOR);
+            (bg + triangle).into()
+        }
+    }
+}
+
+mod spinner_icon {
+    use super::*;
+
+    use std::f32::consts::FRAC_PI_3;
+
+    ensogl::shape! {
+        above = [display::shape::compound::rectangle::shape];
+        (style: Style) {
+            let color = style.get_color(theme::spinner::color);
+            let speed = style.get_number(theme::spinner::speed);
+            let width = Var::<Pixels>::from("input_size.x");
+            let time = Var::<f32>::from("input_time");
+            let unit = &width / 16.0;
+            let arc = RoundedArc(&unit * 5.0, (4.0 * FRAC_PI_3).radians(), &unit * 2.0);
+            let rotated_arc = arc.rotate(time * speed);
+            rotated_arc.fill(color).into()
+        }
+    }
+}
+
+
+
+// ===========
+// === FRP ===
+// ===========
+
+ensogl::define_endpoints_2! {
+    Input {
+        reset   (),
+    }
+    Output {
+        pressed (),
+    }
+}
+
+
+
+// =============
+// === Model ===
+// =============
+
+#[derive(Debug, Clone, CloneRef)]
+pub struct Model {
+    display_object: display::object::Instance,
+    play_icon:      play_icon::View,
+    spinner_icon:   spinner_icon::View,
+}
+
+impl Model {
+    fn update_style(&self, style: &Style) {
+        let triangle_size = Vector2::new(style.triangle_size, style.triangle_size);
+        let padding = Vector2::new(style.padding_x, style.padding_y);
+        let size = triangle_size + 2.0 * padding;
+        self.play_icon.set_size(size);
+        self.spinner_icon.set_size(size);
+        self.play_icon.set_x(-size.x / 2.0 - style.offset);
+        self.spinner_icon.set_x(-size.x / 2.0 - style.offset);
+    }
+
+    fn set_playing(&self, playing: bool) {
+        if playing {
+            self.display_object.remove_child(&self.play_icon);
+            self.display_object.add_child(&self.spinner_icon);
+        } else {
+            self.display_object.remove_child(&self.spinner_icon);
+            self.display_object.add_child(&self.play_icon);
+        }
+    }
+}
+
+impl display::Object for Model {
+    fn display_object(&self) -> &display::object::Instance {
+        &self.display_object
+    }
+}
+
+
+
+// ===================
+// === Play Button ===
+// ===================
+
+impl component::Model for Model {
+    fn label() -> &'static str {
+        "PlayButton"
+    }
+
+    fn new(_app: &Application) -> Self {
+        let display_object = display::object::Instance::new();
+        let play_icon = play_icon::View::new();
+        let spinner_icon = spinner_icon::View::new();
+
+        display_object.add_child(&play_icon);
+
+        Self { display_object, play_icon, spinner_icon }
+    }
+}
+
+impl component::Frp<Model> for Frp {
+    fn init(
+        network: &enso_frp::Network,
+        frp: &<Self as ensogl::application::frp::API>::Private,
+        _app: &Application,
+        model: &Model,
+        style_watch: &StyleWatchFrp,
+    ) {
+        let play_icon = &model.play_icon;
+        let input = &frp.input;
+        let output = &frp.output;
+
+        let style = Style::from_theme(network, style_watch);
+
+        frp::extend! { network
+            eval style.update ((style) model.update_style(style));
+
+            eval_ input.reset (model.set_playing(false));
+
+            output.pressed <+ play_icon.events_deprecated.mouse_down.constant(());
+
+            eval_ output.pressed (model.set_playing(true));
+        }
+        style.init.emit(());
+    }
+}
+
+/// A button to execute the workflow in a fully enabled way within the current execution
+/// environment. The button should be visible in any execution environment where one or more
+/// contexts are disabled.
+pub type PlayButton = component::ComponentView<Model, Frp>;

--- a/app/gui/view/execution-mode-selector/src/play_button.rs
+++ b/app/gui/view/execution-mode-selector/src/play_button.rs
@@ -3,6 +3,7 @@ use ensogl::prelude::*;
 
 use enso_frp as frp;
 use ensogl::application::Application;
+use ensogl::control::io::mouse;
 use ensogl::display;
 use ensogl::display::shape::StyleWatchFrp;
 use ensogl_derive_theme::FromTheme;
@@ -166,7 +167,8 @@ impl component::Frp<Model> for Frp {
 
             eval_ input.reset (model.set_playing(false));
 
-            output.pressed <+ play_icon.events_deprecated.mouse_down.constant(());
+            let play_icon_mouse_down = play_icon.on_event::<mouse::Down>();
+            output.pressed <+ play_icon_mouse_down.constant(());
 
             eval_ output.pressed (model.set_playing(true));
         }

--- a/lib/rust/ensogl/app/theme/hardcoded/src/lib.rs
+++ b/lib/rust/ensogl/app/theme/hardcoded/src/lib.rs
@@ -110,6 +110,7 @@ macro_rules! _define_theme_wrapper_and_literals {
         pub mod $name {
             use super::*;
             use ensogl_core::application::Application;
+            use ensogl_core::data::color::Lch;
             use ensogl_core::data::color::Lcha;
             use ensogl_core::data::color::Rgb;
             use ensogl_core::data::color::Rgba;
@@ -657,15 +658,22 @@ define_themes! { [light:0, dark:1]
         execution_mode_selector {
             background = Rgb::from_base_255(100.0, 181.0, 38.0), Rgb::from_base_255(100.0, 181.0, 38.0);
             divider = Rgba::black_with_alpha(0.12), Rgba::black_with_alpha(0.12);
-            triangle = Rgba::white_with_alpha(0.75), Rgba::white_with_alpha(0.75);
-            play_button_size = 10.0,  10.0;
-            play_button_offset = 15.0, 15.0;
-            play_button_padding = 10.0, 10.0;
             divider_offset = 32.5, 32.5;
             divider_padding = 10.0, 10.0;
             dropdown_width = 95.0, 95.0;
             height = 24.0, 24.0;
             menu_offset = 20.0, 20.0;
+            play_button {
+                color = Rgba::white_with_alpha(0.75), Rgba::white_with_alpha(0.75);
+                triangle_size = 10.0, 10.0;
+                offset = 15.0, 15.0;
+                padding_x = 5.0, 5.0;
+                padding_y = 7.0, 7.0;
+                spinner {
+                    color = Lch(0.8, 0.0, 0.0), Lch(0.8, 0.0, 0.0);
+                    speed = 0.003, 0.003; // Radians/ms
+                }
+            }
         }
     }
     widget {


### PR DESCRIPTION
### Pull Request Description

Closes #6177: Clicking the play button should show a spinner icon. The play button should only be visible on execution environments that have one or more execution contexts disabled.

https://user-images.githubusercontent.com/607786/231464097-8d6fafe4-1013-47d9-89e8-2a8e5d6d39a6.mp4

### Important Notes

There's a bug in the existing code that's exacerbated by this PR: the clickable area for the drop down menu is not directly placed on top of the text. Michael is fixing that in a [separate branch](https://github.com/enso-org/enso/tree/wip/MichaelMauderer/Ability_to_change_the_execution_environment_between_design_and_live_on_shortcut) (39ce6a23464493a8299918ca05dc9ac5a2e206bf).

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md), [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md), and [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.