### PR TITLE
fix paths to dashboard modules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,13 +41,13 @@ Cargo.toml
 /std-bits/ @jdunkerley @radeusgd
 
 # Cloud Dashboard & Authentication
-/app/ide-desktop/dashboard @PabloBuchu @indiv0 @somebody1234
-/app/ide-desktop/content @PabloBuchu @indiv0 @somebody1234
-/app/ide-desktop/client @PabloBuchu @indiv0 @somebody1234
-/app/ide-desktop/types @PabloBuchu @indiv0 @somebody1234
-/app/ide-desktop/common @PabloBuchu @indiv0 @somebody1234
+/app/ide-desktop/lib/dashboard @PabloBuchu @indiv0 @somebody1234
+/app/ide-desktop/lib/content @PabloBuchu @indiv0 @somebody1234
+/app/ide-desktop/lib/client @PabloBuchu @indiv0 @somebody1234
+/app/ide-desktop/lib/types @PabloBuchu @indiv0 @somebody1234
+/app/ide-desktop/lib/common @PabloBuchu @indiv0 @somebody1234
 
-# Eslint configuration
-/app/ide-desktop/esbuild-plugin-copy-directories @somebody1234
+# Eslint & Esbuild Configuration
+/app/ide-desktop/lib/esbuild-plugin-copy-directories @somebody1234
 /app/ide-desktop/eslint.config.js @somebody1234
 /app/ide-desktop/utils.ts @somebody1234


### PR DESCRIPTION
### Pull Request Description

This PR fixes adding proper codeowners to prs which touch cloud dashboard. There was a missing `/lib` directory in the paths.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
