### PR TITLE
Fix uncaught sign up error; minor code style changes

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/cognito.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/cognito.ts
@@ -364,7 +364,7 @@ const SIGN_UP_INVALID_PARAMETER_ERROR = {
 } as const
 
 const SIGN_UP_INVALID_PASSWORD_ERROR = {
-    internalCode: 'InvalidParameterException',
+    internalCode: 'InvalidPasswordException',
     kind: 'InvalidPassword',
 } as const
 

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/cognito.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/cognito.ts
@@ -363,8 +363,14 @@ const SIGN_UP_INVALID_PARAMETER_ERROR = {
     kind: 'InvalidParameter',
 } as const
 
+const SIGN_UP_INVALID_PASSWORD_ERROR = {
+    internalCode: 'InvalidParameterException',
+    kind: 'InvalidPassword',
+} as const
+
 type SignUpErrorKind =
     | (typeof SIGN_UP_INVALID_PARAMETER_ERROR)['kind']
+    | (typeof SIGN_UP_INVALID_PASSWORD_ERROR)['kind']
     | (typeof SIGN_UP_USERNAME_EXISTS_ERROR)['kind']
 
 export interface SignUpError {
@@ -383,6 +389,11 @@ function intoSignUpErrorOrThrow(error: AmplifyError): SignUpError {
             kind: SIGN_UP_INVALID_PARAMETER_ERROR.kind,
             message: error.message,
         }
+    } else if (error.code === SIGN_UP_INVALID_PASSWORD_ERROR.internalCode) {
+        return {
+            kind: SIGN_UP_INVALID_PASSWORD_ERROR.kind,
+            message: error.message,
+        }
     } else {
         throw error
     }
@@ -396,8 +407,7 @@ async function confirmSignUp(email: string, code: string) {
     return results.Result.wrapAsync(async () => {
         await amplify.Auth.confirmSignUp(email, code)
     })
-        .then(result => result.mapErr(intoAmplifyErrorOrThrow))
-        .then(result => result.mapErr(intoConfirmSignUpErrorOrThrow))
+        .then(result => result.mapErr(intoAmplifyErrorOrThrow).mapErr(intoConfirmSignUpErrorOrThrow))
 }
 
 const CONFIRM_SIGN_UP_USER_ALREADY_CONFIRMED_ERROR = {
@@ -461,8 +471,7 @@ async function signInWithPassword(username: string, password: string) {
     return results.Result.wrapAsync(async () => {
         await amplify.Auth.signIn(username, password)
     })
-        .then(result => result.mapErr(intoAmplifyErrorOrThrow))
-        .then(result => result.mapErr(intoSignInWithPasswordErrorOrThrow))
+        .then(result => result.mapErr(intoAmplifyErrorOrThrow).mapErr(intoSignInWithPasswordErrorOrThrow))
 }
 
 type SignInWithPasswordErrorKind = 'NotAuthorized' | 'UserNotConfirmed' | 'UserNotFound'
@@ -508,8 +517,7 @@ async function forgotPassword(email: string) {
     return results.Result.wrapAsync(async () => {
         await amplify.Auth.forgotPassword(email)
     })
-        .then(result => result.mapErr(intoAmplifyErrorOrThrow))
-        .then(result => result.mapErr(intoForgotPasswordErrorOrThrow))
+        .then(result => result.mapErr(intoAmplifyErrorOrThrow).mapErr(intoForgotPasswordErrorOrThrow))
 }
 
 type ForgotPasswordErrorKind = 'UserNotConfirmed' | 'UserNotFound'

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/cognito.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/cognito.ts
@@ -406,8 +406,7 @@ function intoSignUpErrorOrThrow(error: AmplifyError): SignUpError {
 async function confirmSignUp(email: string, code: string) {
     return results.Result.wrapAsync(async () => {
         await amplify.Auth.confirmSignUp(email, code)
-    })
-        .then(result => result.mapErr(intoAmplifyErrorOrThrow).mapErr(intoConfirmSignUpErrorOrThrow))
+    }).then(result => result.mapErr(intoAmplifyErrorOrThrow).mapErr(intoConfirmSignUpErrorOrThrow))
 }
 
 const CONFIRM_SIGN_UP_USER_ALREADY_CONFIRMED_ERROR = {
@@ -470,8 +469,9 @@ async function signInWithGitHub() {
 async function signInWithPassword(username: string, password: string) {
     return results.Result.wrapAsync(async () => {
         await amplify.Auth.signIn(username, password)
-    })
-        .then(result => result.mapErr(intoAmplifyErrorOrThrow).mapErr(intoSignInWithPasswordErrorOrThrow))
+    }).then(result =>
+        result.mapErr(intoAmplifyErrorOrThrow).mapErr(intoSignInWithPasswordErrorOrThrow)
+    )
 }
 
 type SignInWithPasswordErrorKind = 'NotAuthorized' | 'UserNotConfirmed' | 'UserNotFound'
@@ -516,8 +516,7 @@ const FORGOT_PASSWORD_USER_NOT_CONFIRMED_ERROR = {
 async function forgotPassword(email: string) {
     return results.Result.wrapAsync(async () => {
         await amplify.Auth.forgotPassword(email)
-    })
-        .then(result => result.mapErr(intoAmplifyErrorOrThrow).mapErr(intoForgotPasswordErrorOrThrow))
+    }).then(result => result.mapErr(intoAmplifyErrorOrThrow).mapErr(intoForgotPasswordErrorOrThrow))
 }
 
 type ForgotPasswordErrorKind = 'UserNotConfirmed' | 'UserNotFound'

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/components/resetPassword.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/components/resetPassword.tsx
@@ -129,7 +129,7 @@ function ResetPassword() {
                                 Confirm New Password:
                             </label>
                             <div className="relative">
-                                {svg.LOCK}
+                                <SvgIcon svg={svg.LOCK} />
 
                                 <Input
                                     id="new_password_confirm"


### PR DESCRIPTION
### Pull Request Description
Fixes "invalid password" error not being caught and displayed as a toast notification. Also fixes minor UI issue

### Important Notes
Most important QA is to check the fix: sign up with an invalid password (too short, missing uppercase, missing symbols, missing numbers)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
