### PR TITLE
Tests: Use debug-info level 1 instead of 2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ debug-assertions = false
 [profile.test]
 opt-level = 0
 lto = false
-debug = true
+debug = 1
 debug-assertions = true
 
 [profile.integration-test]


### PR DESCRIPTION
### Pull Request Description

This reduces WASM module size by about 90%, which avoids some code size limitation of the toolchain.

This doesn't seem to affect stack traces visible when a WASM-test fails: As before this change, we have stack traces with function names, but no line numbers.

This is a quick-fix for #6315; however, even without the bug described there, this substantially reduces resources needed to run tests, with no major loss of debugability (it probably affects information available to the in-browser debugger, and gdb for native tests).

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] ~The documentation has been updated, if necessary.~
- [ ] ~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] ~Unit tests have been written where possible.~
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
