### PR TITLE
Rollback cloud options groups

### DIFF
--- a/app/ide-desktop/lib/content-config/src/config.json
+++ b/app/ide-desktop/lib/content-config/src/config.json
@@ -1,5 +1,13 @@
 {
   "options": {
+    "authentication": {
+      "value": false,
+      "description": "Determines whether user authentication is enabled. This option is disregarded if the application is executed in the cloud."
+    },
+    "newDashboard": {
+      "value": false,
+      "description": "Determines whether the dashboard (containing the directory listing) is enabled. This option is disregarded if the application is executed in the cloud."
+    },
     "dataCollection": {
       "value": true,
       "description": "Determines whether anonymous usage data is to be collected.",
@@ -141,19 +149,6 @@
           "value": false,
           "description": "When enabled, profiling measurements will be submitted continuously to the User Timing Web API, which can be viewed using standard developer tools. Note that this mode significantly affects performance.",
           "primary": false
-        }
-      }
-    },
-    "cloud": {
-      "description": "Options related to cloud authentication, project storage, and project execution.",
-      "options": {
-        "authentication": {
-          "value": false,
-          "description": "Determines whether user authentication is enabled. This option is disregarded if the application is executed in the cloud."
-        },
-        "dashboard": {
-          "value": false,
-          "description": "Determines whether the dashboard (containing the directory listing) is enabled. This option is disregarded if the application is executed in the cloud."
         }
       }
     }

--- a/app/ide-desktop/lib/content-config/src/config.json
+++ b/app/ide-desktop/lib/content-config/src/config.json
@@ -6,7 +6,7 @@
     },
     "newDashboard": {
       "value": false,
-      "description": "Determines whether the dashboard (containing the directory listing) is enabled. This option is disregarded if the application is executed in the cloud."
+      "description": "Determines whether the dashboard (containing the directory listing) is enabled."
     },
     "dataCollection": {
       "value": true,

--- a/app/ide-desktop/lib/content-config/src/config.json
+++ b/app/ide-desktop/lib/content-config/src/config.json
@@ -4,10 +4,6 @@
       "value": false,
       "description": "Determines whether user authentication is enabled. This option is disregarded if the application is executed in the cloud."
     },
-    "newDashboard": {
-      "value": false,
-      "description": "Determines whether the dashboard (containing the directory listing) is enabled."
-    },
     "dataCollection": {
       "value": true,
       "description": "Determines whether anonymous usage data is to be collected.",
@@ -123,6 +119,10 @@
           "value": false,
           "description": "Show Vector Editor widget on nodes.",
           "primary": false
+        },
+        "newDashboard": {
+          "value": false,
+          "description": "Determines whether the new dashboard with cloud integration is enabled."
         }
       }
     },

--- a/app/ide-desktop/lib/content-config/src/config.json
+++ b/app/ide-desktop/lib/content-config/src/config.json
@@ -2,7 +2,7 @@
   "options": {
     "authentication": {
       "value": false,
-      "description": "Determines whether user authentication is enabled. This option is disregarded if the application is executed in the cloud."
+      "description": "Determines whether user authentication is enabled. This option is always true when executed in the cloud."
     },
     "dataCollection": {
       "value": true,

--- a/app/ide-desktop/lib/content/src/index.ts
+++ b/app/ide-desktop/lib/content/src/index.ts
@@ -156,8 +156,8 @@ class Main {
                 displayDeprecatedVersionDialog()
             } else {
                 if (
-                    (contentConfig.OPTIONS.groups.cloud.options.authentication.value ||
-                        contentConfig.OPTIONS.groups.cloud.options.dashboard.value) &&
+                    (contentConfig.OPTIONS.options.authentication.value ||
+                    contentConfig.OPTIONS.options.newDashboard.value) &&
                     contentConfig.OPTIONS.groups.startup.options.entry.value ===
                         contentConfig.OPTIONS.groups.startup.options.entry.default
                 ) {
@@ -182,7 +182,7 @@ class Main {
                      * where it will be called only once. */
                     let appInstanceRan = false
                     const onAuthenticated = () => {
-                        if (!contentConfig.OPTIONS.groups.cloud.options.dashboard.value) {
+                        if (!contentConfig.OPTIONS.options.newDashboard.value) {
                             hideAuth()
                             if (!appInstanceRan) {
                                 appInstanceRan = true
@@ -194,7 +194,7 @@ class Main {
                         logger,
                         platform,
                         projectManager: projectManager.ProjectManager.default(),
-                        showDashboard: contentConfig.OPTIONS.groups.cloud.options.dashboard.value,
+                        showDashboard: contentConfig.OPTIONS.options.newDashboard.value,
                         onAuthenticated,
                     })
                 } else {

--- a/app/ide-desktop/lib/content/src/index.ts
+++ b/app/ide-desktop/lib/content/src/index.ts
@@ -157,7 +157,7 @@ class Main {
             } else {
                 if (
                     (contentConfig.OPTIONS.options.authentication.value ||
-                    contentConfig.OPTIONS.options.newDashboard.value) &&
+                        contentConfig.OPTIONS.groups.featurePreview.options.newDashboard.value) &&
                     contentConfig.OPTIONS.groups.startup.options.entry.value ===
                         contentConfig.OPTIONS.groups.startup.options.entry.default
                 ) {
@@ -182,7 +182,9 @@ class Main {
                      * where it will be called only once. */
                     let appInstanceRan = false
                     const onAuthenticated = () => {
-                        if (!contentConfig.OPTIONS.options.newDashboard.value) {
+                        if (
+                            !contentConfig.OPTIONS.groups.featurePreview.options.newDashboard.value
+                        ) {
                             hideAuth()
                             if (!appInstanceRan) {
                                 appInstanceRan = true
@@ -194,7 +196,8 @@ class Main {
                         logger,
                         platform,
                         projectManager: projectManager.ProjectManager.default(),
-                        showDashboard: contentConfig.OPTIONS.options.newDashboard.value,
+                        showDashboard:
+                            contentConfig.OPTIONS.groups.featurePreview.options.newDashboard.value,
                         onAuthenticated,
                     })
                 } else {

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/index.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/index.tsx
@@ -43,8 +43,10 @@ export function run(props: app.AppProps) {
     if (root == null) {
         logger.error(`Could not find root element with ID '${ROOT_ELEMENT_ID}'.`)
     } else {
-        // FIXME[sb]: This is a temporary workaround and will be fixed
-        // when IDE support is properly integrated into the dashboard.
+        // FIXME: https://github.com/enso-org/cloud-v2/issues/386
+        // Temporary workaround on hiding the Enso root element preventing it from
+        // rendering next to authentication templates. We are uncovering this once the
+        // authentication library sets the user session.
         const ide = document.getElementById(IDE_ELEMENT_ID)
         if (ide != null) {
             ide.style.display = 'none'

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/index.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/index.tsx
@@ -43,8 +43,12 @@ export function run(props: app.AppProps) {
     if (root == null) {
         logger.error(`Could not find root element with ID '${ROOT_ELEMENT_ID}'.`)
     } else {
-        // This element is re-added by the `Ide` component.
-        document.getElementById(IDE_ELEMENT_ID)?.remove()
+        // FIXME[sb]: This is a temporary workaround and will be fixed
+        // when IDE support is properly integrated into the dashboard.
+        const ide = document.getElementById(IDE_ELEMENT_ID)
+        if (ide != null) {
+            ide.style.display = 'none'
+        }
         reactDOM.createRoot(root).render(<App {...props} />)
     }
 }


### PR DESCRIPTION
### Pull Request Description

This PR rollback newly created `cloud` options groups. Instead in introduced new options flags `-new-dashboard` which indicated rendering new, react based ide dashboard instead of a rust one.

It also fixes the regression when trying to enable authentication with old IDE.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
