### PR TITLE
Removing need for asynchronous thread to execute ResourceManager finalizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -688,6 +688,7 @@
 - [One can define lazy atom fields][6151]
 - [Replace IOContexts with Execution Environment and generic Context][6171]
 - [Vector.sort handles incomparable types][5998]
+- [Removing need for asynchronous thread to execute ResourceManager finalizers][6335]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -794,6 +795,7 @@
 [6151]: https://github.com/enso-org/enso/pull/6151
 [6171]: https://github.com/enso-org/enso/pull/6171
 [5998]: https://github.com/enso-org/enso/pull/5998
+[6335]: https://github.com/enso-org/enso/pull/6335
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -688,7 +688,8 @@
 - [One can define lazy atom fields][6151]
 - [Replace IOContexts with Execution Environment and generic Context][6171]
 - [Vector.sort handles incomparable types][5998]
-- [Removing need for asynchronous thread to execute ResourceManager finalizers][6335]
+- [Removing need for asynchronous thread to execute ResourceManager
+  finalizers][6335]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248

--- a/engine/interpreter-dsl-test/src/test/java/org/enso/interpreter/dsl/test/InliningBuiltinsOutNode.java
+++ b/engine/interpreter-dsl-test/src/test/java/org/enso/interpreter/dsl/test/InliningBuiltinsOutNode.java
@@ -9,7 +9,7 @@ import org.junit.Assert;
 final class InliningBuiltinsOutNode extends Node {
 
   long execute(VirtualFrame frame, long a, long b) {
-    Assert.assertNotNull("VirtualFrame is always provided " + frame);
+    Assert.assertNotNull("VirtualFrame is always provided", frame);
     return a + b;
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/ResourceManager.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/ResourceManager.java
@@ -240,21 +240,22 @@ public class ResourceManager {
      */
     public void doFinalize(EnsoContext context) {
       var futureToCancel = new AtomicReference<Future<Void>>(null);
-      var performFinalizer = new ThreadLocalAction(false, false, true) {
-        @Override
-        protected void perform(ThreadLocalAction.Access access) {
-          var tmp = futureToCancel.getAndSet(null);
-          if (tmp == null) {
-            return;
-          }
-          tmp.cancel(false);
-          try {
-            InteropLibrary.getUncached(finalizer).execute(finalizer, underlying);
-          } catch (Exception e) {
-            context.getErr().println("Exception in finalizer: " + e.getMessage());
-          }
-        }
-      };
+      var performFinalizer =
+          new ThreadLocalAction(false, false, true) {
+            @Override
+            protected void perform(ThreadLocalAction.Access access) {
+              var tmp = futureToCancel.getAndSet(null);
+              if (tmp == null) {
+                return;
+              }
+              tmp.cancel(false);
+              try {
+                InteropLibrary.getUncached(finalizer).execute(finalizer, underlying);
+              } catch (Exception e) {
+                context.getErr().println("Exception in finalizer: " + e.getMessage());
+              }
+            }
+          };
       futureToCancel.set(context.getEnvironment().submitThreadLocal(null, performFinalizer));
     }
 

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/InterpreterTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/InterpreterTest.scala
@@ -113,6 +113,7 @@ class InterpreterContext(
       .newBuilder(LanguageInfo.ID)
       .allowExperimentalOptions(true)
       .allowAllAccess(true)
+      .allowCreateThread(false)
       .out(output)
       .err(err)
       .option(RuntimeOptions.LOG_LEVEL, "WARNING")

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/RuntimeManagementTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/RuntimeManagementTest.scala
@@ -83,9 +83,9 @@ class RuntimeManagementTest extends InterpreterTest {
         round = round + 1
         if (round % 10 == 0) {
           forceGC();
-          val res = eval("main a b = a * b").execute(7, 6)
-          assertResult(42)(res.asInt)
         }
+        val res = eval("main a b = a * b").execute(7, 6)
+        assertResult(42)(res.asInt)
         Thread.sleep(100)
         totalOut ++= consumeOut
       }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/RuntimeManagementTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/RuntimeManagementTest.scala
@@ -81,7 +81,11 @@ class RuntimeManagementTest extends InterpreterTest {
       totalOut = consumeOut
       while (totalOut.length < expect && round < 500) {
         round = round + 1
-        if (round % 10 == 0) forceGC();
+        if (round % 10 == 0) {
+          forceGC();
+          val res = eval("main a b = a * b").execute(7, 6)
+          assertResult(42)(res.asInt)
+        }
         Thread.sleep(100)
         totalOut ++= consumeOut
       }


### PR DESCRIPTION
### Pull Request Description

While Enso runs single-threaded, its `ResourceManager` required additional asynchronous thread to execute its _"finalizers"_. What has been necessary back then is no longer needed since _GraalVM 21.1_. GraalVM now provides support for submitting `ThreadLocalAction` that gets then picked and executed via `TruffleSafepoint` locations. This PR uses such mechanism to _"inject"_ finalizer execution into already running Enso evaluation thread.

Requiring more than one thread has complicated Enso's co-existence with other Truffle language. For example Graal.js is strictly singlethreaded and used to refuse (simple) co-existence with Enso. By allowing Enso to perform all its actions in a single thread, the synergy with Graal.js becomes better.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides
- [x] Finalize on `Context` closing
- All code has been tested:
  - [x] Unit tests continue to pass
