### PR TITLE
Don't propagate warnings on suspended arguments

### DIFF
--- a/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/model/MethodDefinition.java
+++ b/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/model/MethodDefinition.java
@@ -549,11 +549,11 @@ public class MethodDefinition {
     }
 
     public boolean shouldCheckErrors() {
-      return isPositional() && !isSelf() && !acceptsError();
+      return isPositional() && !isSelf() && !acceptsError() && !isSuspended();
     }
 
     public boolean shouldCheckWarnings() {
-      return isPositional() && !isSelf() && !acceptsWarning();
+      return isPositional() && !isSelf() && !acceptsWarning() && !isSuspended();
     }
 
     public boolean isImplicit() {

--- a/test/Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Tests/src/Semantic/Warnings_Spec.enso
@@ -6,7 +6,7 @@ polyglot java import java.lang.Long
 polyglot java import java.util.function.Function as Java_Function
 polyglot java import org.enso.base_test_helpers.CallbackHelper
 
-from Standard.Test import Test, Test_Suite
+from Standard.Test import Test, Test_Suite, Problems
 import Standard.Test.Extensions
 
 type My_Warning
@@ -84,12 +84,6 @@ throw_a_bar =
     Panic.throw "bar"
 
 Any.is_static_nothing self x = x.is_nothing
-
-extract_warnings_or_errors result =
-    case result.is_error of
-        True  -> result.catch
-        False -> Warning.get_all result . map .value
-
 
 spec = Test.group "Dataflow Warnings" <|
     Test.specify "should allow to attach multiple warnings and read them back" <|
@@ -385,14 +379,14 @@ spec = Test.group "Dataflow Warnings" <|
         condition_1 x y = if x then y else 42
         condition_2 x y = if x then y + 100 else 42
 
-        (extract_warnings_or_errors <| condition_1 False x1) . should_equal []
-        (extract_warnings_or_errors <| condition_2 False x1) . should_equal []
+        Problems.assume_no_problems <| condition_1 False x1
+        Problems.assume_no_problems <| condition_2 False x1
 
-        (extract_warnings_or_errors <| condition_1 False x2) . should_equal []
-        (extract_warnings_or_errors <| condition_2 False x2) . should_equal []
+        Problems.assume_no_problems <| condition_1 False x2
+        Problems.assume_no_problems <| condition_2 False x2
 
-        (extract_warnings_or_errors <| condition_1 False x3) . should_equal []
-        (extract_warnings_or_errors <| condition_2 False x3) . should_equal []
+        Problems.assume_no_problems <| condition_1 False x3
+        Problems.assume_no_problems <| condition_2 False x3
 
 
 main = Test_Suite.run_main spec

--- a/test/Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Tests/src/Semantic/Warnings_Spec.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Errors.Unimplemented.Unimplemented
+import Standard.Base.Errors.Illegal_State.Illegal_State
 
 polyglot java import java.lang.Long
 polyglot java import java.util.function.Function as Java_Function
@@ -83,6 +84,12 @@ throw_a_bar =
     Panic.throw "bar"
 
 Any.is_static_nothing self x = x.is_nothing
+
+extract_warnings_or_errors result =
+    case result.is_error of
+        True  -> result.catch
+        False -> Warning.get_all result . map .value
+
 
 spec = Test.group "Dataflow Warnings" <|
     Test.specify "should allow to attach multiple warnings and read them back" <|
@@ -369,6 +376,23 @@ spec = Test.group "Dataflow Warnings" <|
         b.has_warnings . should_equal False
         a.remove_warnings . should_equal 42
         b.remove_warnings . should_equal 42
+
+    Test.specify "should not automatically propagate from suspended arguments" <|
+        x1 = 33
+        x2 = Warning.attach "WARN" 44
+        x3 = Error.throw (Illegal_State.Error "ERR")
+
+        condition_1 x y = if x then y else 42
+        condition_2 x y = if x then y + 100 else 42
+
+        (extract_warnings_or_errors <| condition_1 False x1) . should_equal []
+        (extract_warnings_or_errors <| condition_2 False x1) . should_equal []
+
+        (extract_warnings_or_errors <| condition_1 False x2) . should_equal []
+        (extract_warnings_or_errors <| condition_2 False x2) . should_equal []
+
+        (extract_warnings_or_errors <| condition_1 False x3) . should_equal []
+        (extract_warnings_or_errors <| condition_2 False x3) . should_equal []
 
 
 main = Test_Suite.run_main spec


### PR DESCRIPTION

### Pull Request Description

In the current implementation, application of arguments with warnings first extracts warnings, does the application and appends the warnings to the result.
This process was however too eager if the suspended argument was a literal (we don't know if it will be executed after all).

The change modifies method processor to take into account the `@Suspend` annotation and not gather warnings before the application takes place.

Closes #5762 .

### Checklist

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
