### PR TITLE
Avoid double WithWarnings wrapping

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeCallableNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeCallableNode.java
@@ -87,7 +87,7 @@ public abstract class IndirectInvokeCallableNode extends Node {
               isTail);
 
       Warning[] extracted = warnings.getWarnings(warning, null);
-      return new WithWarnings(result, extracted);
+      return WithWarnings.wrap(result, extracted);
     } catch (UnsupportedMessageException e) {
       throw CompilerDirectives.shouldNotReachHere(e);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
@@ -299,7 +299,7 @@ public abstract class InvokeCallableNode extends BaseNode {
       } else if (result instanceof WithWarnings withWarnings) {
         return withWarnings.prepend(extracted);
       } else {
-        return new WithWarnings(result, extracted);
+        return WithWarnings.wrap(result, extracted);
       }
     } catch (UnsupportedMessageException e) {
       throw CompilerDirectives.shouldNotReachHere(e);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CaseNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CaseNode.java
@@ -83,7 +83,7 @@ public abstract class CaseNode extends ExpressionNode {
     try {
       Warning[] ws = warnings.getWarnings(object, this);
       Object result = doMatch(frame, warnings.removeWarnings(object), warnings);
-      return new WithWarnings(result, ws);
+      return WithWarnings.wrap(result, ws);
     } catch (UnsupportedMessageException e) {
       throw new IllegalStateException(e);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/foreign/CoerceNothing.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/foreign/CoerceNothing.java
@@ -39,7 +39,7 @@ public abstract class CoerceNothing extends Node {
     if (nullWarningProfile.profile(warningsLibrary.hasWarnings(value))) {
       try {
         Warning[] attachedWarnings = warningsLibrary.getWarnings(value, null);
-        return new WithWarnings(nothing, attachedWarnings);
+        return WithWarnings.wrap(nothing, attachedWarnings);
       } catch (UnsupportedMessageException e) {
         return nothing;
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
@@ -112,7 +112,7 @@ public final class Array implements TruffleObject {
       if (warnings.hasWarnings(v)) {
         v = warnings.removeWarnings(v);
       }
-      return new WithWarnings(v, extracted);
+      return WithWarnings.wrap(v, extracted);
     }
     return v;
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArraySlice.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArraySlice.java
@@ -95,7 +95,7 @@ public final class ArraySlice implements TruffleObject {
       if (warnings.hasWarnings(v)) {
         v = warnings.removeWarnings(v);
       }
-      return new WithWarnings(toEnso.execute(v), extracted);
+      return WithWarnings.wrap(toEnso.execute(v), extracted);
     }
     return toEnso.execute(v);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
@@ -17,7 +17,10 @@ import org.enso.interpreter.dsl.Builtin;
 import org.enso.interpreter.node.expression.builtin.interop.syntax.HostValueToEnsoNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.function.Function;
-import org.enso.interpreter.runtime.error.*;
+import org.enso.interpreter.runtime.error.DataflowError;
+import org.enso.interpreter.runtime.error.Warning;
+import org.enso.interpreter.runtime.error.WarningsLibrary;
+import org.enso.interpreter.runtime.error.WithWarnings;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 
 @ExportLibrary(InteropLibrary.class)
@@ -120,7 +123,7 @@ public final class Vector implements TruffleObject {
       if (warnings.hasWarnings(v)) {
         v = warnings.removeWarnings(v);
       }
-      return new WithWarnings(toEnso.execute(v), extracted);
+      return WithWarnings.wrap(toEnso.execute(v), extracted);
     }
     return toEnso.execute(v);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
@@ -82,7 +82,7 @@ public final class Warning implements TruffleObject {
       autoRegister = false)
   @Builtin.Specialize(fallback = true)
   public static WithWarnings attach(EnsoContext ctx, Object value, Object warning, Object origin) {
-    return new WithWarnings(value, new Warning(warning, origin, ctx.clockTick()));
+    return WithWarnings.wrap(value, new Warning(warning, origin, ctx.clockTick()));
   }
 
   @Builtin.Method(
@@ -144,7 +144,7 @@ public final class Warning implements TruffleObject {
       for (int i = 0; i < warningsCast.length; i++) {
         warningsCast[i] = (Warning) interop.readArrayElement(warnings, i);
       }
-      return new WithWarnings(value, warningsCast);
+      return WithWarnings.wrap(value, warningsCast);
     } catch (UnsupportedMessageException | InvalidArrayIndexException ex) {
       CompilerDirectives.transferToInterpreter();
       throw new IllegalStateException(ex);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
@@ -1,5 +1,8 @@
 package org.enso.interpreter.runtime.error;
 
+import org.enso.interpreter.runtime.data.ArrayRope;
+import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
+
 import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
@@ -8,8 +11,6 @@ import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.library.Message;
 import com.oracle.truffle.api.library.ReflectionLibrary;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.runtime.data.ArrayRope;
-import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 
 @ExportLibrary(TypesLibrary.class)
 @ExportLibrary(WarningsLibrary.class)
@@ -18,7 +19,8 @@ public final class WithWarnings implements TruffleObject {
   private final ArrayRope<Warning> warnings;
   private final Object value;
 
-  public WithWarnings(Object value, Warning... warnings) {
+  private WithWarnings(Object value, Warning... warnings) {
+    assert !(value instanceof WithWarnings);
     this.warnings = new ArrayRope<>(warnings);
     this.value = value;
   }
@@ -26,6 +28,14 @@ public final class WithWarnings implements TruffleObject {
   private WithWarnings(Object value, ArrayRope<Warning> warnings) {
     this.warnings = warnings;
     this.value = value;
+  }
+
+  public static WithWarnings wrap(Object value, Warning... warnings) {
+    if (value instanceof WithWarnings with) {
+      return with.append(warnings);
+    } else {
+      return new WithWarnings(value, warnings);
+    }
   }
 
   public Object getValue() {

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/WarningsTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/WarningsTest.java
@@ -1,0 +1,27 @@
+package org.enso.interpreter.test;
+
+import org.enso.interpreter.runtime.error.Warning;
+import org.enso.interpreter.runtime.error.WarningsLibrary;
+import org.enso.interpreter.runtime.error.WithWarnings;
+import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class WarningsTest {
+  @Test
+  public void doubleWithWarningsWrap() {
+    var warn1 = new Warning("w1", this, 1L);
+    var warn2 = new Warning("w2", this, 2L);
+    var value = 42;
+
+    var with1 = WithWarnings.wrap(42, warn1);
+    var with2 = WithWarnings.wrap(with1, warn2);
+
+    assertEquals(value, with1.getValue());
+    assertEquals(value, with2.getValue());
+    Assert.assertArrayEquals(
+        new Object[] {warn1}, with1.getWarningsArray(WarningsLibrary.getUncached()));
+    Assert.assertArrayEquals(
+        new Object[] {warn1, warn2}, with2.getWarningsArray(WarningsLibrary.getUncached()));
+  }
+}


### PR DESCRIPTION
### Pull Request Description

Fixes #6258 by hiding constructor and checking `value instanceof WithWarnings` in the factory method.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
