### PR TITLE
Keep scheduled execution job on text edit

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/JobControlPlane.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/JobControlPlane.scala
@@ -1,14 +1,21 @@
 package org.enso.interpreter.instrument.execution
 
+import org.enso.interpreter.instrument.job.Job
+
 import java.util.UUID
 
 /** Controls running jobs.
   */
 trait JobControlPlane {
 
-  /** Aborts all interruptible jobs.
-    */
+  /** Aborts all interruptible jobs. */
   def abortAllJobs(): Unit
+
+  /** Abort all jobs except the ignored jobs.
+    *
+    * @param ignoredJobs the list of jobs to keep in the execution queue
+    */
+  def abortAllExcept(ignoredJobs: Class[_ <: Job[_]]*): Unit
 
   /** Aborts all jobs that relates to the specified execution context.
     *


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #6346

Changelog:
- fix: keep scheduled execution job in the queue when applying a text edit

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
