### PR TITLE
Change order of arguments when controlling context

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Runtime.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Runtime.enso
@@ -178,8 +178,8 @@ current_execution_environment = @Builtin_Method "Runtime.current_execution_envir
    - environment: Name of the execution environment.
    - context: The context to enable.
    - action: Action to be performed with the context enabled.
-with_enabled_context : Context -> Function -> Text -> Any
-with_enabled_context context ~action environment=Runtime.current_execution_environment = with_enabled_context_builtin context action environment
+with_enabled_context : Context -> Text -> Function -> Any
+with_enabled_context context environment=Runtime.current_execution_environment ~action = with_enabled_context_builtin context environment action
 
 ## PRIVATE
    ADVANCED
@@ -192,8 +192,8 @@ with_enabled_context context ~action environment=Runtime.current_execution_envir
    - environment: Name of the execution environment.
    - context: The context to enable.
    - action: Action to be performed with the context enabled.
-with_enabled_context_builtin : Context -> Function -> Text -> Any
-with_enabled_context_builtin context ~action environment = @Builtin_Method "Runtime.with_enabled_context_builtin"
+with_enabled_context_builtin : Context -> Text -> Function -> Any
+with_enabled_context_builtin context environment ~action = @Builtin_Method "Runtime.with_enabled_context_builtin"
 
 ## PRIVATE
    ADVANCED
@@ -204,8 +204,8 @@ with_enabled_context_builtin context ~action environment = @Builtin_Method "Runt
    - environment: Name of the execution environment.
    - context: The context to disable.
    - action: Action to be performed with the context disabled.
-with_disabled_context : Context -> Function -> Text -> Any
-with_disabled_context context ~action environment=Runtime.current_execution_environment = with_disabled_context_builtin context action environment
+with_disabled_context : Context -> Text -> Function -> Any
+with_disabled_context context environment=Runtime.current_execution_environment ~action = with_disabled_context_builtin context environment action
 
 ## PRIVATE
    ADVANCED
@@ -218,5 +218,5 @@ with_disabled_context context ~action environment=Runtime.current_execution_envi
    - environment: Name of the execution environment.
    - context: The context to disable.
    - action: Action to be performed with the context disabled.
-with_disabled_context_builtin : Context -> Function -> Text -> Any
-with_disabled_context_builtin context ~action environment = @Builtin_Method "Runtime.with_disabled_context_builtin"
+with_disabled_context_builtin : Context -> Text -> Function -> Any
+with_disabled_context_builtin context environment ~action = @Builtin_Method "Runtime.with_disabled_context_builtin"

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/runtime/RuntimeWithDisabledContextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/runtime/RuntimeWithDisabledContextNode.java
@@ -18,7 +18,7 @@ public class RuntimeWithDisabledContextNode extends Node {
   private @Child ThunkExecutorNode thunkExecutorNode = ThunkExecutorNode.build();
   private @Child ExpectStringNode expectStringNode = ExpectStringNode.build();
 
-  Object execute(State state, Atom context, @Suspend Object action, Object env_name) {
+  Object execute(State state, Atom context, Object env_name, @Suspend Object action) {
     String envName = expectStringNode.execute(env_name);
     return thunkExecutorNode.executeThunk(
         action, state.withContextDisabledIn(context, envName), BaseNode.TailStatus.NOT_TAIL);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/runtime/RuntimeWithEnabledContextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/runtime/RuntimeWithEnabledContextNode.java
@@ -18,7 +18,7 @@ public class RuntimeWithEnabledContextNode extends Node {
   private @Child ThunkExecutorNode thunkExecutorNode = ThunkExecutorNode.build();
   private @Child ExpectStringNode expectStringNode = ExpectStringNode.build();
 
-  Object execute(State state, Atom context, @Suspend Object action, Object env_name) {
+  Object execute(State state, Atom context, Object env_name, @Suspend Object action) {
     String envName = expectStringNode.execute(env_name);
     return thunkExecutorNode.executeThunk(
         action, state.withContextEnabledIn(context, envName), BaseNode.TailStatus.NOT_TAIL);

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/DesignExecutionEnvironmentTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/DesignExecutionEnvironmentTest.scala
@@ -63,7 +63,7 @@ class DesignExecutionEnvironmentTest extends InterpreterTest {
           |input_action : Integer -> Integer
           |input_action i = Input.if_enabled i environment="design"
           |
-          |main = Runtime.with_enabled_context Input (input_action 2)
+          |main = Runtime.with_enabled_context Input action=(input_action 2)
           |""".stripMargin
       eval(code) shouldEqual 2
     }
@@ -90,7 +90,7 @@ class DesignExecutionEnvironmentTest extends InterpreterTest {
           |input_action i = Input.if_enabled i
           |
           |main =
-          |    res = Runtime.with_enabled_context Input (input_action 2)
+          |    res = Runtime.with_enabled_context Input action=(input_action 2)
           |    Panic.catch Any (input_action 2) p-> res.to_text+" and "+p.payload.to_text
           |""".stripMargin
       eval(code) shouldEqual "2 and (Forbidden_Operation.Error 'Input')"

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/LiveExecutionEnvironmentTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/LiveExecutionEnvironmentTest.scala
@@ -35,7 +35,7 @@ class LiveExecutionEnvironmentTest extends InterpreterTest {
           |input_action : Integer -> Integer
           |input_action i = Input.if_enabled i environment="live"
           |
-          |main = Panic.catch Any (Runtime.with_disabled_context Input (input_action 2)) p-> p.payload.to_text
+          |main = Panic.catch Any (Runtime.with_disabled_context Input action=(input_action 2)) p-> p.payload.to_text
           |""".stripMargin
       eval(code) shouldEqual "(Forbidden_Operation.Error 'Input')"
     }
@@ -63,7 +63,7 @@ class LiveExecutionEnvironmentTest extends InterpreterTest {
           |input_action : Integer -> Integer
           |input_action i = Input.if_enabled i environment="live"
           |
-          |main = Runtime.with_enabled_context Input (input_action 2)
+          |main = Runtime.with_enabled_context Input action=(input_action 2)
           |""".stripMargin
       eval(code) shouldEqual 2
     }

--- a/test/Tests/src/Semantic/Runtime_Spec.enso
+++ b/test/Tests/src/Semantic/Runtime_Spec.enso
@@ -27,12 +27,12 @@ spec =
             res = Panic.catch Any (in_fn 1) p-> p.payload.to_text
             res . should_equal "(Forbidden_Operation.Error 'Input')"
         Test.specify "should be configurable" <|
-            r1 = Runtime.with_enabled_context Input <|
-                Runtime.with_enabled_context Output <|
+            r1 = Runtime.with_enabled_context Input environment=Runtime.current_execution_environment <|
+                Runtime.with_enabled_context Output environment=Runtime.current_execution_environment <|
                   in_fn (out_fn 10)
             r1.should_equal 22
 
-            r2 = Panic.catch Any (Runtime.with_enabled_context Output <| in_fn (out_fn 10)) p-> p.payload.to_text
+            r2 = Panic.catch Any (Runtime.with_enabled_context Output environment=Runtime.current_execution_environment  <| in_fn (out_fn 10)) p-> p.payload.to_text
             r2 . should_equal "(Forbidden_Operation.Error 'Input')"
 
 main = Test_Suite.run_main spec

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Runtime.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Runtime.enso
@@ -28,16 +28,16 @@ type Context
 current_execution_environment : Text
 current_execution_environment = @Builtin_Method "Runtime.current_execution_environment"
 
-with_enabled_context : Context -> Function -> Text -> Any
-with_enabled_context context ~action environment=Runtime.current_execution_environment = with_enabled_context_builtin context action environment
+with_enabled_context : Context -> Text -> Function -> Any
+with_enabled_context context environment=Runtime.current_execution_environment ~action = with_enabled_context_builtin context environment action
 
-with_enabled_context_builtin : Context -> Function -> Text -> Any
-with_enabled_context_builtin context ~action environment = @Builtin_Method "Runtime.with_enabled_context_builtin"
+with_enabled_context_builtin : Context -> Text -> Function -> Any
+with_enabled_context_builtin context environment ~action = @Builtin_Method "Runtime.with_enabled_context_builtin"
 
-with_disabled_context : Context -> Function -> Text -> Any
-with_disabled_context context ~action environment=Runtime.current_execution_environment = with_disabled_context_builtin context action environment
+with_disabled_context : Context -> Text -> Function -> Any
+with_disabled_context context environment=Runtime.current_execution_environment ~action = with_disabled_context_builtin context environment action
 
-with_disabled_context_builtin : Context -> Function -> Text -> Any
-with_disabled_context_builtin context ~action environment = @Builtin_Method "Runtime.with_disabled_context_builtin"
+with_disabled_context_builtin : Context -> Text -> Function -> Any
+with_disabled_context_builtin context environment ~action = @Builtin_Method "Runtime.with_disabled_context_builtin"
 
 primitive_get_stack_trace = @Builtin_Method "Runtime.primitive_get_stack_trace"


### PR DESCRIPTION
### Pull Request Description

https://github.com/orgs/enso-org/discussions/6344 requested to change the order of arguments when controlling context permissions.

### Important Notes

The change brings it closer to the design doc but IMHO also a bit cumbersome to use (see changed tests) - applications involving default arguments don't play well when the last argument is not the default :shrug: .`

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
