### PR TITLE
Fix render issues, re-enable buffer compaction

### DIFF
--- a/lib/rust/ensogl/core/src/display/symbol/gpu.rs
+++ b/lib/rust/ensogl/core/src/display/symbol/gpu.rs
@@ -379,7 +379,9 @@ impl Symbol {
             if self.is_hidden() {
                 return;
             }
-            if let Some(context) = &*self.context.borrow() {
+            let count = self.surface.point_scope().size() as i32;
+            let instance_count = self.surface.instance_scope().size() as i32;
+            if count > 0 && instance_count > 0 && let Some(context) = &*self.context.borrow() {
                 self.with_program(context, |_| {
                     for binding in &self.bindings.borrow().uniforms {
                         binding.upload(context);
@@ -391,15 +393,9 @@ impl Symbol {
 
                     let mode = Context::TRIANGLE_STRIP;
                     let first = 0;
-                    let count = self.surface.point_scope().size() as i32;
-                    let instance_count = self.surface.instance_scope().size() as i32;
 
                     self.stats.register_draw_call(self.id);
-                    if instance_count > 0 {
-                        context.draw_arrays_instanced(*mode, first, count, instance_count);
-                    } else {
-                        context.draw_arrays(*mode, first, count);
-                    }
+                    context.draw_arrays_instanced(*mode, first, count, instance_count);
                 });
             }
         })

--- a/lib/rust/ensogl/core/src/system/gpu/data/attribute.rs
+++ b/lib/rust/ensogl/core/src/system/gpu/data/attribute.rs
@@ -221,14 +221,14 @@ impl {
                 //self.shrink_to_fit();
             }
             if self.shape_dirty.check() {
-                for i in 0..self.buffers.len() {
-                    self.buffers[i].update()
+                for buffer in self.buffers.iter() {
+                    buffer.update()
                 }
             } else {
-                for i in 0..self.buffers.len() {
-                    if self.buffer_dirty.check(&i) {
-                        self.buffers[i].update()
-                    }
+                let dirty_buffers = self.buffers.iter_enumerate().filter_map(|(i, buffer)|
+                    self.buffer_dirty.check(&i).then_some(buffer));
+                for buffer in dirty_buffers {
+                    buffer.update()
                 }
             }
             self.shape_dirty.unset();

--- a/lib/rust/ensogl/core/src/system/gpu/data/attribute.rs
+++ b/lib/rust/ensogl/core/src/system/gpu/data/attribute.rs
@@ -217,8 +217,7 @@ impl {
     pub fn update(&mut self) {
         debug_span!("Updating.").in_scope(|| {
             if self.used_size * 2 < self.size() {
-                // FIXME (#6340)
-                //self.shrink_to_fit();
+                self.shrink_to_fit();
             }
             if self.shape_dirty.check() {
                 for buffer in self.buffers.iter() {


### PR DESCRIPTION
### Pull Request Description

- Fix handling of a `Symbol` with no instances. We had logic to call `context.draw_arrays` (non-instanced) if `instance_scope().size() == 0`. This was incorrect: All `Symbol`s are instanced symbols, and should only be drawn if at least one instance exists. This didn't cause a problem before because it was unreachable: We never instantiated a `Symbol` without creating at least one instance, and without buffer compaction it was not possible for instance count to decrease. Fixed by skipping all draw-related GL calls if there are no instances (this might also improve performance in some conditions).
- Fix an incorrect `OptVec` iteration pattern (would cause a crash in conditions not currently reachable).
- Re-enable buffer compaction.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] ~The documentation has been updated, if necessary.~
- [ ] ~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] ~Unit tests have been written where possible.~
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
