### PR TITLE
Prevent default for all events, fixing multiple IDE bugs

### DIFF
--- a/lib/rust/ensogl/core/src/control/io/mouse/event.rs
+++ b/lib/rust/ensogl/core/src/control/io/mouse/event.rs
@@ -54,6 +54,7 @@ where JsEvent: AsRef<web::MouseEvent>
 {
     /// Constructor.
     pub fn new(js_event: JsEvent, shape: Shape) -> Self {
+        js_event.as_ref().prevent_default();
         let js_event = Some(js_event);
         let event_type = default();
         Self { js_event, shape, event_type }
@@ -174,11 +175,6 @@ where JsEvent: AsRef<web::MouseEvent>
         self.js_event.as_ref().map(|t| t.as_ref().ctrl_key()).unwrap_or_default()
     }
 
-    /// Prevent the default action of the event.
-    pub fn prevent_default(&self) {
-        self.js_event.as_ref().map(|t| t.as_ref().prevent_default());
-    }
-
     /// Convert the event to a different type. No checks will be performed during this action.
     pub fn unchecked_convert_to<NewEventType: IsEvent>(
         self,
@@ -229,6 +225,13 @@ define_events! {
     // - https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseover_event
     // - https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseup_event
     // - https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event
+    //
+    // ## Preventing default
+    //
+    // To avoid triggerring any builtin bevavior of the browser, we call [`preventDefault`] on all
+    // mouse events.
+    //
+    // [`preventDefault`]: https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault
 
     /// The [`Down`] event is fired at an element when a button on a pointing device (such as a
     /// mouse or trackpad) is pressed while the pointer is inside the element.

--- a/lib/rust/ensogl/core/src/display/navigation/navigator/events.rs
+++ b/lib/rust/ensogl/core/src/display/navigation/navigator/events.rs
@@ -239,10 +239,6 @@ impl NavigatorEvents {
         let listener = self.mouse_manager.on_wheel.add(move |event: &mouse::Wheel| {
             if let Some(data) = data.upgrade() {
                 if event.ctrl_key() {
-                    // Prevent zoom event to be handed to the browser. This avoids browser scaling
-                    // being applied to the whole IDE, thus we need to do this always when ctrl is
-                    // pressed.
-                    event.prevent_default();
                     let position = data.mouse_position();
                     let zoom_speed = data.zoom_speed();
                     let movement = Vector2::new(event.delta_x() as f32, -event.delta_y() as f32);
@@ -267,9 +263,6 @@ impl NavigatorEvents {
         let data = Rc::downgrade(&self.data);
         let listener = self.mouse_manager.on_down.add(move |event: &mouse::Down| {
             if let Some(data) = data.upgrade() {
-                if data.is_navigator_enabled() {
-                    event.prevent_default();
-                }
                 match event.button() {
                     mouse::MiddleButton => data.set_movement_type(Some(MovementType::Pan)),
                     mouse::SecondaryButton => {
@@ -285,22 +278,16 @@ impl NavigatorEvents {
 
     fn initialize_mouse_end_event(&mut self) {
         let data = Rc::downgrade(&self.data);
-        let listener = self.mouse_manager.on_up.add(move |event: &mouse::Up| {
+        let listener = self.mouse_manager.on_up.add(move |_: &mouse::Up| {
             if let Some(data) = data.upgrade() {
-                if data.is_navigator_enabled() {
-                    event.prevent_default();
-                }
                 data.set_movement_type(None);
             }
         });
         self.mouse_up = Some(listener);
 
         let data = Rc::downgrade(&self.data);
-        let listener = self.mouse_manager.on_leave.add(move |event: &mouse::Leave| {
+        let listener = self.mouse_manager.on_leave.add(move |_: &mouse::Leave| {
             if let Some(data) = data.upgrade() {
-                if data.is_navigator_enabled() {
-                    event.prevent_default();
-                }
                 data.set_movement_type(None);
             }
         });

--- a/lib/rust/frp/src/io/keyboard.rs
+++ b/lib/rust/frp/src/io/keyboard.rs
@@ -439,13 +439,18 @@ pub struct DomBindings {
 
 impl DomBindings {
     /// Create new Keyboard and Frp bindings.
+    ///
+    /// We're preventing default on keyboard events, because we don't want the browser to handle
+    /// them.
     pub fn new(keyboard: &Keyboard) -> Self {
-        let key_down = Listener::new_key_down(
-            f!((event:&KeyboardEvent) keyboard.source.down.emit(KeyWithCode::from(event))),
-        );
-        let key_up = Listener::new_key_up(
-            f!((event:&KeyboardEvent) keyboard.source.up.emit(KeyWithCode::from(event))),
-        );
+        let key_down = Listener::new_key_down(f!([keyboard](event:&KeyboardEvent) {
+            event.prevent_default();
+            keyboard.source.down.emit(KeyWithCode::from(event));
+        }));
+        let key_up = Listener::new_key_up(f!([keyboard](event:&KeyboardEvent) {
+            event.prevent_default();
+            keyboard.source.up.emit(KeyWithCode::from(event));
+        }));
         let blur = Listener::new_blur(f_!(keyboard.source.window_defocused.emit(())));
         Self { key_down, key_up, blur }
     }


### PR DESCRIPTION
### Pull Request Description

Fixes #6158 

Possibly related to #6290 

Now we prevent default for every mouse or keyboard event, effectively fixing multiple bugs related to the `Tab` key usage.

### Important Notes

- Preventing default for mouse events is not necessary for fixing a #6158, but it seems logical, and does not cause any visible issues in the IDE.

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
