### PR TITLE
Exclude comparison operators from modifier logic

### DIFF
--- a/app/gui/language/ast/impl/src/opr.rs
+++ b/app/gui/language/ast/impl/src/opr.rs
@@ -686,6 +686,15 @@ mod tests {
     }
 
     #[test]
+    fn infix_section() {
+        let a = Ast::var("a");
+        let a_plus = Ast::section_left(a.clone(), "+");
+        let chain = Chain::try_new(&a_plus).unwrap();
+        expect_at(&chain.target, &a);
+        test_enumerating(&chain, &a_plus, &[&a]);
+    }
+
+    #[test]
     fn infix_chain_tests_right() {
         let a = Ast::var("a");
         let b = Ast::var("b");

--- a/app/gui/language/span-tree/src/main.rs
+++ b/app/gui/language/span-tree/src/main.rs
@@ -1,0 +1,39 @@
+//! Command-line debug tool for `SpanTree`. Accepts a single line of Enso source code as an
+//! argument, and prints a debug representation of the resulting `SpanTree`.
+
+// === Standard Linter Configuration ===
+#![deny(non_ascii_idents)]
+#![warn(unsafe_code)]
+#![allow(clippy::bool_to_int_with_if)]
+#![allow(clippy::let_and_return)]
+// === Non-Standard Linter Configuration ===
+#![warn(missing_docs)]
+#![warn(trivial_casts)]
+#![warn(trivial_numeric_casts)]
+#![warn(unused_import_braces)]
+#![warn(unused_qualifications)]
+#![warn(missing_copy_implementations)]
+#![warn(missing_debug_implementations)]
+
+use span_tree::generate;
+use span_tree::generate::SpanTreeGenerator;
+use span_tree::SpanTree;
+
+
+
+// ===================
+// === Entry point ===
+// ===================
+
+#[allow(missing_docs)]
+pub fn main() {
+    let mut args = std::env::args();
+    let _ = args.next().unwrap();
+    let code = args.next().unwrap();
+
+    let parser = parser::Parser::new();
+    let ast = parser.parse_line_ast(&code).unwrap();
+    let tree: SpanTree = ast.generate_tree(&generate::context::Empty).unwrap();
+    let tree = tree.debug_print(&code);
+    println!("{tree}");
+}

--- a/lib/rust/parser/src/lexer.rs
+++ b/lib/rust/parser/src/lexer.rs
@@ -673,6 +673,14 @@ fn analyze_operator(token: &str) -> token::OperatorProperties {
     if token.ends_with("->") && !token.starts_with("<-") {
         operator = operator.as_right_associative();
     }
+    if token.ends_with('=') && !token.bytes().all(|c| c == b'=') {
+        match token {
+            // Inclusive comparison operators are not modifiers.
+            ">=" | "<=" => (),
+            // Any other operator ending with "=" is a modifier.
+            _ => operator = operator.as_modifier(),
+        }
+    }
     match token {
         // Operators that can be unary.
         "\\" =>

--- a/lib/rust/parser/src/syntax/token.rs
+++ b/lib/rust/parser/src/syntax/token.rs
@@ -333,6 +333,7 @@ pub struct OperatorProperties {
     // Special properties
     is_compile_time_operation: bool,
     is_right_associative:      bool,
+    is_modifier:               bool,
     // Unique operators
     is_decimal:                bool,
     is_type_annotation:        bool,
@@ -373,6 +374,11 @@ impl OperatorProperties {
     /// Return a copy of this operator, modified to be flagged as right associative.
     pub fn as_right_associative(self) -> Self {
         Self { is_right_associative: true, ..self }
+    }
+
+    /// Return a copy of this operator, modified to be flagged as an modified-assignment operator.
+    pub fn as_modifier(self) -> Self {
+        Self { is_modifier: true, ..self }
     }
 
     /// Return a copy of this operator, modified to be flagged as special.
@@ -465,6 +471,11 @@ impl OperatorProperties {
     /// Return whether this operator is the assignment operator.
     pub fn is_assignment(&self) -> bool {
         self.is_assignment
+    }
+
+    /// Return whether this operator is a modified-assignment operator.
+    pub fn is_modifier(&self) -> bool {
+        self.is_modifier
     }
 
     /// Return whether this operator is the arrow operator.


### PR DESCRIPTION
### Pull Request Description

Fix behavior of `<=` and `>=`: Add exceptions to the logic identifying modified-assignment operators, to exclude the inclusive-comparison operators and treat them as normal operators.

### Important Notes

- Modifier vs operator distinction has been moved from IDE to the lexer.
- New CLI for debugging span trees; can be invoked like `cargo run -p span-tree -- "a <"`

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] ~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
