### PR TITLE
Report only unique warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -688,7 +688,7 @@
 - [Optimize Atom storage layouts][3862]
 - [Make instance methods callable like statics for builtin types][4077]
 - [Convert large longs to doubles, safely, for host calls][4099]
-- [Consistent ordering with comparators](4067)
+- [Consistent ordering with comparators][4067]
 - [Profile engine startup][4110]
 - [Report type of polyglot values][4111]
 - [Engine can now recover from serialization failures][5591]
@@ -706,6 +706,7 @@
 - [Vector.sort handles incomparable types][5998]
 - [Removing need for asynchronous thread to execute ResourceManager
   finalizers][6335]
+- [Warning.get_all returns only unique warnings][6372]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -794,9 +795,9 @@
 [4048]: https://github.com/enso-org/enso/pull/4048
 [4049]: https://github.com/enso-org/enso/pull/4049
 [4056]: https://github.com/enso-org/enso/pull/4056
+[4067]: https://github.com/enso-org/enso/pull/4067
 [4077]: https://github.com/enso-org/enso/pull/4077
 [4099]: https://github.com/enso-org/enso/pull/4099
-[4067]: https://github.com/enso-org/enso/pull/4067
 [4110]: https://github.com/enso-org/enso/pull/4110
 [4111]: https://github.com/enso-org/enso/pull/4111
 [5591]: https://github.com/enso-org/enso/pull/5591
@@ -808,11 +809,12 @@
 [5791]: https://github.com/enso-org/enso/pull/5791
 [5900]: https://github.com/enso-org/enso/pull/5900
 [5966]: https://github.com/enso-org/enso/pull/5966
+[5998]: https://github.com/enso-org/enso/pull/5998
 [6067]: https://github.com/enso-org/enso/pull/6067
 [6151]: https://github.com/enso-org/enso/pull/6151
 [6171]: https://github.com/enso-org/enso/pull/6171
-[5998]: https://github.com/enso-org/enso/pull/5998
 [6335]: https://github.com/enso-org/enso/pull/6335
+[6372]: https://github.com/enso-org/enso/pull/6372
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/WarningBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/WarningBenchmarks.java
@@ -3,17 +3,21 @@ package org.enso.interpreter.bench.benchmarks.semantic;
 import org.enso.interpreter.test.TestBase;
 import org.enso.polyglot.MethodNames;
 import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
-import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.BenchmarkParams;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -36,25 +40,11 @@ public class WarningBenchmarks extends TestBase {
 
     private Value elemWithWarning;
 
-    private OutputStream out = new ByteArrayOutputStream();
     private String benchmarkName;
 
     @Setup
     public void initializeBench(BenchmarkParams params) throws IOException {
-        ctx = Context.newBuilder("enso")
-                .allowAllAccess(true)
-                .logHandler(out)
-                .out(out)
-                .err(out)
-                .allowIO(true)
-                .allowExperimentalOptions(true)
-                .option(
-                        "enso.languageHomeOverride",
-                        Paths.get("../../distribution/component").toFile().getAbsolutePath()
-                )
-                .option("engine.MultiTier", "true")
-                .option("engine.BackgroundCompilation", "true")
-                .build();
+        ctx = createDefaultContext();
 
         benchmarkName = params.getBenchmark().replaceFirst(".*\\.", "");
 

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/WarningBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/WarningBenchmarks.java
@@ -1,0 +1,108 @@
+package org.enso.interpreter.bench.benchmarks.semantic;
+
+import org.enso.interpreter.test.TestBase;
+import org.enso.polyglot.MethodNames;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Source;
+import org.graalvm.polyglot.Value;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@Fork(1)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 3, time = 3)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class WarningBenchmarks extends TestBase {
+    private static final int INPUT_VEC_SIZE = 10000;
+    private Context ctx;
+    private Value vecSumBench;
+
+    private Value createVec;
+    private Value noWarningsVec;
+    private Value sameWarningVec;
+
+    private Value elem;
+
+    private Value elemWithWarning;
+
+    private OutputStream out = new ByteArrayOutputStream();
+
+    @Setup
+    public void initializeBench(BenchmarkParams params) throws IOException {
+        ctx = Context.newBuilder("enso")
+                .allowAllAccess(true)
+                .logHandler(out)
+                .out(out)
+                .err(out)
+                .allowIO(true)
+                .allowExperimentalOptions(true)
+                .option(
+                        "enso.languageHomeOverride",
+                        Paths.get("../../distribution/component").toFile().getAbsolutePath()
+                )
+                .option("engine.MultiTier", "true")
+                .option("engine.BackgroundCompilation", "true")
+                .build();
+
+        var code = """
+        from Standard.Base import all
+
+        vec_sum_bench : Vector Integer -> Integer
+        vec_sum_bench vec =
+            vec.fold 0 (x->y->x+y)
+
+        create_vec size elem =
+            Vector.fill size elem
+            
+        elem =
+            42
+            
+        elem_with_warning =
+            x = 42
+            Warning.attach "Foo!" x
+        """;
+
+        var file = File.createTempFile("warnings", ".enso");
+        try (var w = new FileWriter(file)) {
+            w.write(code);
+        }
+        var src = Source.newBuilder("enso", file).build();
+        Value module = ctx.eval(src);
+        vecSumBench = Objects.requireNonNull(module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "vec_sum_bench"));
+        createVec = Objects.requireNonNull(module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "create_vec"));
+        elem = Objects.requireNonNull(module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "elem"));
+        elemWithWarning = Objects.requireNonNull(module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "elem_with_warning"));
+        noWarningsVec = createVec.execute(INPUT_VEC_SIZE, elem);
+        sameWarningVec = createVec.execute(INPUT_VEC_SIZE, elemWithWarning);
+    }
+
+    @Benchmark
+    public void noWarningsVecSum() {
+        Value res = vecSumBench.execute(noWarningsVec);
+        checkResult(res);
+    }
+
+    @Benchmark
+    public void sameWarningVecSum() {
+        Value res = vecSumBench.execute(sameWarningVec);
+        checkResult(res);
+    }
+
+    private static void checkResult(Value res) {
+        if (res.asInt() != INPUT_VEC_SIZE*42) {
+            throw new AssertionError("Expected result: " + INPUT_VEC_SIZE*42 + ", got: " + res.asInt());
+        }
+    }
+
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeConversionNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeConversionNode.java
@@ -142,7 +142,7 @@ public abstract class IndirectInvokeConversionNode extends Node {
       int thatArgumentPosition,
       @Cached IndirectInvokeConversionNode childDispatch) {
     arguments[thatArgumentPosition] = that.getValue();
-    ArrayRope<Warning> warnings = that.getReassignedWarnings(this);
+    ArrayRope<Warning> warnings = that.getReassignedWarningsAsRope(this);
     Object result =
         childDispatch.execute(
             frame,

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeConversionNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeConversionNode.java
@@ -156,7 +156,7 @@ public abstract class IndirectInvokeConversionNode extends Node {
             argumentsExecutionMode,
             isTail,
             thatArgumentPosition);
-    return WithWarnings.prependTo(result, warnings);
+    return WithWarnings.appendTo(result, warnings);
   }
 
   @Specialization(guards = "interop.isString(that)")

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeMethodNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeMethodNode.java
@@ -134,7 +134,7 @@ public abstract class IndirectInvokeMethodNode extends Node {
             argumentsExecutionMode,
             isTail,
             thisArgumentPosition);
-    return WithWarnings.prependTo(result, warnings);
+    return WithWarnings.appendTo(result, warnings);
   }
 
   @Specialization

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeMethodNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeMethodNode.java
@@ -121,7 +121,7 @@ public abstract class IndirectInvokeMethodNode extends Node {
       int thisArgumentPosition,
       @Cached IndirectInvokeMethodNode childDispatch) {
     arguments[thisArgumentPosition] = self.getValue();
-    ArrayRope<Warning> warnings = self.getReassignedWarnings(this);
+    ArrayRope<Warning> warnings = self.getReassignedWarningsAsRope(this);
     Object result =
         childDispatch.execute(
             frame,

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
@@ -297,7 +297,7 @@ public abstract class InvokeCallableNode extends BaseNode {
       if (result instanceof DataflowError) {
         return result;
       } else if (result instanceof WithWarnings withWarnings) {
-        return withWarnings.prepend(extracted);
+        return withWarnings.append(extracted);
       } else {
         return WithWarnings.wrap(result, extracted);
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeConversionNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeConversionNode.java
@@ -172,7 +172,7 @@ public abstract class InvokeConversionNode extends BaseNode {
       }
     }
     arguments[thatArgumentPosition] = that.getValue();
-    ArrayRope<Warning> warnings = that.getReassignedWarnings(this);
+    ArrayRope<Warning> warnings = that.getReassignedWarningsAsRope(this);
     Object result =
         childDispatch.execute(frame, state, conversion, self, that.getValue(), arguments);
     return WithWarnings.prependTo(result, warnings);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeConversionNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeConversionNode.java
@@ -175,7 +175,7 @@ public abstract class InvokeConversionNode extends BaseNode {
     ArrayRope<Warning> warnings = that.getReassignedWarningsAsRope(this);
     Object result =
         childDispatch.execute(frame, state, conversion, self, that.getValue(), arguments);
-    return WithWarnings.prependTo(result, warnings);
+    return WithWarnings.appendTo(result, warnings);
   }
 
   @Specialization(guards = "interop.isString(that)")

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeMethodNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeMethodNode.java
@@ -275,7 +275,7 @@ public abstract class InvokeMethodNode extends BaseNode {
     arguments[thisArgumentPosition] = selfWithoutWarnings;
 
     Object result = childDispatch.execute(frame, state, symbol, selfWithoutWarnings, arguments);
-    return WithWarnings.prependTo(result, arrOfWarnings);
+    return WithWarnings.appendTo(result, arrOfWarnings);
   }
 
   @ExplodeLoop
@@ -327,7 +327,7 @@ public abstract class InvokeMethodNode extends BaseNode {
     Object res = hostMethodCallNode.execute(polyglotCallType, symbol.getName(), self, args);
     if (anyWarnings) {
       anyWarningsProfile.enter();
-      res = WithWarnings.prependTo(res, accumulatedWarnings);
+      res = WithWarnings.appendTo(res, accumulatedWarnings);
     }
     return res;
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -504,7 +504,7 @@ public class EnsoContext {
    *
    * <p>The counter is used to track the creation time of warnings.
    */
-  public long clockTick() {
+  public long nextSequenceId() {
     return clock.getAndIncrement();
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
@@ -28,8 +28,8 @@ import org.graalvm.collections.EconomicSet;
 @Builtin(pkg = "mutable", stdlibName = "Standard.Base.Data.Array.Array")
 public final class Array implements TruffleObject {
   private final Object[] items;
-  private @CompilerDirectives.CompilationFinal Boolean withWarnings;
-  private @CompilerDirectives.CompilationFinal(dimensions = 1) Warning[] cachedWarnings;
+  private Boolean withWarnings;
+  private Warning[] cachedWarnings;
 
   /**
    * Creates a new array

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
@@ -206,7 +206,7 @@ public final class Array implements TruffleObject {
   Warning[] getWarnings(Node location, @CachedLibrary(limit = "3") WarningsLibrary warnings)
       throws UnsupportedMessageException {
     if (cachedWarnings == null) {
-      cachedWarnings = Warning.fromSetToArray(collectAllWarnings(warnings, location), false);
+      cachedWarnings = Warning.fromSetToArray(collectAllWarnings(warnings, location));
     }
     return cachedWarnings;
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
@@ -219,18 +219,18 @@ public final class Array implements TruffleObject {
       Node location, @CachedLibrary(limit = "3") WarningsLibrary warnings)
       throws UnsupportedMessageException {
     if (cachedWarnings == null) {
-      cachedWarnings = collectAllWarnings(warnings);
+      cachedWarnings = collectAllWarnings(warnings, location);
     }
     return cachedWarnings;
   }
 
   @CompilerDirectives.TruffleBoundary
-  private EconomicSet<Warning> collectAllWarnings(WarningsLibrary warnings)
+  private EconomicSet<Warning> collectAllWarnings(WarningsLibrary warnings, Node location)
       throws UnsupportedMessageException {
     EconomicSet<Warning> setOfWarnings = EconomicSet.create(new WithWarnings.WarningEquivalence());
     for (int i = 0; i < items.length; i++) {
       if (warnings.hasWarnings(items[i])) {
-        setOfWarnings.addAll(warnings.getWarningsUnique(items[i], null));
+        setOfWarnings.addAll(warnings.getWarningsUnique(items[i], location));
       }
     }
     return setOfWarnings;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArrayRope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArrayRope.java
@@ -1,5 +1,7 @@
 package org.enso.interpreter.runtime.data;
 
+import com.oracle.truffle.api.CompilerDirectives;
+
 import java.util.Arrays;
 import java.util.function.Function;
 
@@ -33,6 +35,7 @@ public final class ArrayRope<T> {
     return new ArrayRope<>(new ConcatSegment<>(new ArraySegment<>(items), this.segment));
   }
 
+  @CompilerDirectives.TruffleBoundary
   public T[] toArray(Function<Integer, T[]> genArray) {
     T[] res = genArray.apply(size());
     writeArray(res);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArraySlice.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArraySlice.java
@@ -14,7 +14,6 @@ import org.enso.interpreter.node.expression.builtin.interop.syntax.HostValueToEn
 import org.enso.interpreter.runtime.error.Warning;
 import org.enso.interpreter.runtime.error.WarningsLibrary;
 import org.enso.interpreter.runtime.error.WithWarnings;
-import org.graalvm.collections.EconomicSet;
 
 @ExportLibrary(InteropLibrary.class)
 @ExportLibrary(WarningsLibrary.class)

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArraySlice.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArraySlice.java
@@ -14,6 +14,7 @@ import org.enso.interpreter.node.expression.builtin.interop.syntax.HostValueToEn
 import org.enso.interpreter.runtime.error.Warning;
 import org.enso.interpreter.runtime.error.WarningsLibrary;
 import org.enso.interpreter.runtime.error.WithWarnings;
+import org.graalvm.collections.EconomicSet;
 
 @ExportLibrary(InteropLibrary.class)
 @ExportLibrary(WarningsLibrary.class)
@@ -91,7 +92,7 @@ public final class ArraySlice implements TruffleObject {
 
     var v = interop.readArrayElement(storage, start + index);
     if (this.hasWarnings(warnings)) {
-      Warning[] extracted = this.getWarnings(null, warnings);
+      EconomicSet<Warning> extracted = this.getWarningsUnique(null, warnings);
       if (warnings.hasWarnings(v)) {
         v = warnings.removeWarnings(v);
       }
@@ -149,6 +150,11 @@ public final class ArraySlice implements TruffleObject {
   @ExportMessage
   Warning[] getWarnings(Node location, @CachedLibrary(limit = "3") WarningsLibrary warnings) throws UnsupportedMessageException {
     return warnings.getWarnings(this.storage, location);
+  }
+
+  @ExportMessage
+  EconomicSet<Warning> getWarningsUnique(Node location, @CachedLibrary(limit = "3") WarningsLibrary warnings) throws UnsupportedMessageException {
+    return warnings.getWarningsUnique(this.storage, location);
   }
 
   @ExportMessage

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArraySlice.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArraySlice.java
@@ -92,7 +92,7 @@ public final class ArraySlice implements TruffleObject {
 
     var v = interop.readArrayElement(storage, start + index);
     if (this.hasWarnings(warnings)) {
-      EconomicSet<Warning> extracted = this.getWarningsUnique(null, warnings);
+      Warning[] extracted = this.getWarnings(null, warnings);
       if (warnings.hasWarnings(v)) {
         v = warnings.removeWarnings(v);
       }
@@ -150,11 +150,6 @@ public final class ArraySlice implements TruffleObject {
   @ExportMessage
   Warning[] getWarnings(Node location, @CachedLibrary(limit = "3") WarningsLibrary warnings) throws UnsupportedMessageException {
     return warnings.getWarnings(this.storage, location);
-  }
-
-  @ExportMessage
-  EconomicSet<Warning> getWarningsUnique(Node location, @CachedLibrary(limit = "3") WarningsLibrary warnings) throws UnsupportedMessageException {
-    return warnings.getWarningsUnique(this.storage, location);
   }
 
   @ExportMessage

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
@@ -22,7 +22,6 @@ import org.enso.interpreter.runtime.error.Warning;
 import org.enso.interpreter.runtime.error.WarningsLibrary;
 import org.enso.interpreter.runtime.error.WithWarnings;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
-import org.graalvm.collections.EconomicSet;
 
 @ExportLibrary(InteropLibrary.class)
 @ExportLibrary(TypesLibrary.class)

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
@@ -120,7 +120,7 @@ public final class Vector implements TruffleObject {
       throws InvalidArrayIndexException, UnsupportedMessageException {
     var v = interop.readArrayElement(storage, index);
     if (warnings.hasWarnings(this)) {
-      EconomicSet<Warning> extracted = warnings.getWarningsUnique(this, null);
+      Warning[] extracted = warnings.getWarnings(this, null);
       if (warnings.hasWarnings(v)) {
         v = warnings.removeWarnings(v);
       }
@@ -215,13 +215,6 @@ public final class Vector implements TruffleObject {
   Warning[] getWarnings(Node location, @CachedLibrary(limit = "3") WarningsLibrary warnings)
       throws UnsupportedMessageException {
     return warnings.getWarnings(this.storage, location);
-  }
-
-  @ExportMessage
-  EconomicSet<Warning> getWarningsUnique(
-      Node location, @CachedLibrary(limit = "3") WarningsLibrary warnings)
-      throws UnsupportedMessageException {
-    return warnings.getWarningsUnique(this.storage, location);
   }
 
   @ExportMessage

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
@@ -22,6 +22,7 @@ import org.enso.interpreter.runtime.error.Warning;
 import org.enso.interpreter.runtime.error.WarningsLibrary;
 import org.enso.interpreter.runtime.error.WithWarnings;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
+import org.graalvm.collections.EconomicSet;
 
 @ExportLibrary(InteropLibrary.class)
 @ExportLibrary(TypesLibrary.class)
@@ -119,7 +120,7 @@ public final class Vector implements TruffleObject {
       throws InvalidArrayIndexException, UnsupportedMessageException {
     var v = interop.readArrayElement(storage, index);
     if (warnings.hasWarnings(this)) {
-      Warning[] extracted = warnings.getWarnings(this, null);
+      EconomicSet<Warning> extracted = warnings.getWarningsUnique(this, null);
       if (warnings.hasWarnings(v)) {
         v = warnings.removeWarnings(v);
       }
@@ -214,6 +215,13 @@ public final class Vector implements TruffleObject {
   Warning[] getWarnings(Node location, @CachedLibrary(limit = "3") WarningsLibrary warnings)
       throws UnsupportedMessageException {
     return warnings.getWarnings(this.storage, location);
+  }
+
+  @ExportMessage
+  EconomicSet<Warning> getWarningsUnique(
+      Node location, @CachedLibrary(limit = "3") WarningsLibrary warnings)
+      throws UnsupportedMessageException {
+    return warnings.getWarningsUnique(this.storage, location);
   }
 
   @ExportMessage

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
@@ -94,8 +94,8 @@ public final class Warning implements TruffleObject {
   @CompilerDirectives.TruffleBoundary
   public static Array getAll(WithWarnings value, WarningsLibrary warningsLib) {
     Warning[] warnings = value.getWarningsArray(warningsLib);
-    Arrays.sort(warnings, Comparator.comparing(Warning::getCreationTime).reversed());
-    return new Array((Object[])warnings);
+    sortArray(warnings);
+    return new Array((Object[]) warnings);
   }
 
   @Builtin.Method(
@@ -106,7 +106,9 @@ public final class Warning implements TruffleObject {
   public static Array getAll(Object value, WarningsLibrary warnings) {
     if (warnings.hasWarnings(value)) {
       try {
-        return new Array((Object[]) fromSetToArray(warnings.getWarningsUnique(value, null), true));
+        Warning[] arr = warnings.getWarnings(value, null);
+        sortArray(arr);
+        return new Array((Object[]) arr);
       } catch (UnsupportedMessageException e) {
         throw new IllegalStateException(e);
       }
@@ -116,12 +118,14 @@ public final class Warning implements TruffleObject {
   }
 
   @CompilerDirectives.TruffleBoundary
-  static Warning[] fromSetToArray(EconomicSet<Warning> set, boolean sort) {
-    Warning[] arr = set.toArray(new Warning[set.size()]);
-    if (sort) {
-      Arrays.sort(arr, Comparator.comparing(Warning::getCreationTime).reversed());
-    }
-    return arr;
+  private static void sortArray(Warning[] arr) {
+    Arrays.sort(arr, Comparator.comparing(Warning::getCreationTime).reversed());
+  }
+
+  /** Converts set to an array behing a truffle boundary. */
+  @CompilerDirectives.TruffleBoundary
+  public static Warning[] fromSetToArray(EconomicSet<Warning> set) {
+    return set.toArray(new Warning[set.size()]);
   }
 
   @Builtin.Method(

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
@@ -74,7 +74,7 @@ public final class Warning implements TruffleObject {
   @Builtin.Specialize
   public static WithWarnings attach(
       EnsoContext ctx, WithWarnings value, Object warning, Object origin) {
-    return value.prepend(new Warning(warning, origin, ctx.clockTick()));
+    return value.append(new Warning(warning, origin, ctx.clockTick()));
   }
 
   @Builtin.Method(

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
@@ -205,28 +205,13 @@ public final class Warning implements TruffleObject {
     return EnsoContext.get(thisLib).getBuiltins().warning();
   }
 
+  @CompilerDirectives.TruffleBoundary
   private static Warning[] uniqueWarnings(Warning[] warnings) {
     int uniqueLen = 0;
     Warning last = null;
     Warning[] tmp = new Warning[warnings.length];
     System.arraycopy(warnings, 0, tmp, 0, warnings.length);
     Arrays.sort(tmp, Comparator.comparing(Warning::getCreationTime).reversed());
-    for (int i = 0; i < tmp.length; i++) {
-      if (last == null || tmp[i].getCreationTime() != last.getCreationTime()) {
-        last = tmp[i];
-        uniqueLen += 1;
-      }
-    }
-    Warning[] unique = new Warning[uniqueLen];
-    int lastUniqueIndex = 0;
-    last = null;
-    for (int i = 0; i < tmp.length; i++) {
-      if (last == null || tmp[i].getCreationTime() != last.getCreationTime()) {
-        last = tmp[i];
-        unique[lastUniqueIndex] = tmp[i];
-        lastUniqueIndex += 1;
-      }
-    }
-    return unique;
+    return tmp;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
@@ -30,11 +30,11 @@ public final class Warning implements TruffleObject {
   private final ArrayRope<Reassignment> reassignments;
   private final long creationTime;
 
-  public Warning(Object value, Object origin, long creationTime) {
+  private Warning(Object value, Object origin, long creationTime) {
     this(value, origin, creationTime, new ArrayRope<>());
   }
 
-  public Warning(
+  private Warning(
       Object value, Object origin, long creationTime, ArrayRope<Reassignment> reassignments) {
     this.value = value;
     this.origin = origin;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WarningsLibrary.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WarningsLibrary.java
@@ -43,7 +43,7 @@ public abstract class WarningsLibrary extends Library {
   }
 
   /**
-   * Returns all warnings associated with the receiver.
+   * Returns all unique warnings associated with the receiver.
    *
    * @param receiver the receiver to analyze
    * @param location optional parameter specifying the node to which the warnings should be
@@ -52,20 +52,6 @@ public abstract class WarningsLibrary extends Library {
    */
   @GenerateLibrary.Abstract(ifExported = {"hasWarnings"})
   public Warning[] getWarnings(Object receiver, Node location) throws UnsupportedMessageException {
-    throw UnsupportedMessageException.create();
-  }
-
-  /**
-   * Returns a set of warnings associated with the receiver.
-   *
-   * @param receiver the receiver to analyze
-   * @param location optional parameter specifying the node to which the warnings should be
-   *     reassigned to
-   * @return the set of warnings
-   */
-  @GenerateLibrary.Abstract(ifExported = {"hasWarnings"})
-  public EconomicSet<Warning> getWarningsUnique(Object receiver, Node location)
-      throws UnsupportedMessageException {
     throw UnsupportedMessageException.create();
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WarningsLibrary.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WarningsLibrary.java
@@ -5,7 +5,6 @@ import com.oracle.truffle.api.library.GenerateLibrary;
 import com.oracle.truffle.api.library.Library;
 import com.oracle.truffle.api.library.LibraryFactory;
 import com.oracle.truffle.api.nodes.Node;
-import org.graalvm.collections.EconomicSet;
 
 @GenerateLibrary
 public abstract class WarningsLibrary extends Library {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WarningsLibrary.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WarningsLibrary.java
@@ -5,6 +5,7 @@ import com.oracle.truffle.api.library.GenerateLibrary;
 import com.oracle.truffle.api.library.Library;
 import com.oracle.truffle.api.library.LibraryFactory;
 import com.oracle.truffle.api.nodes.Node;
+import org.graalvm.collections.EconomicSet;
 
 @GenerateLibrary
 public abstract class WarningsLibrary extends Library {
@@ -51,6 +52,20 @@ public abstract class WarningsLibrary extends Library {
    */
   @GenerateLibrary.Abstract(ifExported = {"hasWarnings"})
   public Warning[] getWarnings(Object receiver, Node location) throws UnsupportedMessageException {
+    throw UnsupportedMessageException.create();
+  }
+
+  /**
+   * Returns a set of warnings associated with the receiver.
+   *
+   * @param receiver the receiver to analyze
+   * @param location optional parameter specifying the node to which the warnings should be
+   *     reassigned to
+   * @return the set of warnings
+   */
+  @GenerateLibrary.Abstract(ifExported = {"hasWarnings"})
+  public EconomicSet<Warning> getWarningsUnique(Object receiver, Node location)
+      throws UnsupportedMessageException {
     throw UnsupportedMessageException.create();
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
@@ -89,14 +89,14 @@ public final class WithWarnings implements TruffleObject {
     Warning[] allWarnings;
     if (warningsLibrary != null && warningsLibrary.hasWarnings(value)) {
       try {
-        EconomicSet<Warning> valueWarnings = warningsLibrary.getWarningsUnique(value, null);
+        Warning[] valueWarnings = warningsLibrary.getWarnings(value, null);
         EconomicSet<Warning> tmp = cloneSetAndAppend(warnings, valueWarnings);
-        allWarnings = Warning.fromSetToArray(tmp, false);
+        allWarnings = Warning.fromSetToArray(tmp);
       } catch (UnsupportedMessageException e) {
         throw new IllegalStateException(e);
       }
     } else {
-      allWarnings = Warning.fromSetToArray(warnings, false);
+      allWarnings = Warning.fromSetToArray(warnings);
     }
     return allWarnings;
   }
@@ -177,17 +177,7 @@ public final class WithWarnings implements TruffleObject {
     if (location != null) {
       return getReassignedWarnings(location, warningsLibrary);
     } else {
-      return Warning.fromSetToArray(warnings, false);
-    }
-  }
-
-  @ExportMessage
-  EconomicSet<Warning> getWarningsUnique(
-          Node location, @CachedLibrary(limit = "3") WarningsLibrary warningsLibrary) {
-    if (location != null) {
-      return createSetFromArray(getReassignedWarnings(location, warningsLibrary));
-    } else {
-      return warnings;
+      return Warning.fromSetToArray(warnings);
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
@@ -37,12 +37,6 @@ public final class WithWarnings implements TruffleObject {
     this.value = value;
   }
 
-  private WithWarnings(Object value, EconomicSet<Warning> warnings, EconomicSet<Warning> additionalWarnings) {
-    assert !(value instanceof WithWarnings);
-    this.warnings = cloneSetAndAppend(warnings, additionalWarnings);
-    this.value = value;
-  }
-
   public static WithWarnings wrap(Object value, Warning... warnings) {
     if (value instanceof WithWarnings with) {
       return with.append(warnings);
@@ -59,12 +53,8 @@ public final class WithWarnings implements TruffleObject {
     return new WithWarnings(value, warnings, newWarnings);
   }
 
-  public WithWarnings prepend(ArrayRope<Warning> newWarnings) {
-    return new WithWarnings(value, createSetFromArray(newWarnings.toArray(Warning[]::new)), warnings);
-  }
-
-  public WithWarnings prepend(Warning... newWarnings) {
-    return new WithWarnings(value, createSetFromArray(newWarnings), warnings);
+  public WithWarnings append(ArrayRope<Warning> newWarnings) {
+    return new WithWarnings(value, warnings, newWarnings.toArray(Warning[]::new));
   }
 
   public Warning[] getWarningsArray(WarningsLibrary warningsLibrary) {
@@ -111,22 +101,6 @@ public final class WithWarnings implements TruffleObject {
   public static WithWarnings appendTo(Object target, Warning[] warnings) {
     if (target instanceof WithWarnings) {
       return ((WithWarnings) target).append(warnings);
-    } else {
-      return new WithWarnings(target, warnings);
-    }
-  }
-
-  public static WithWarnings prependTo(Object target, ArrayRope<Warning> warnings) {
-    if (target instanceof WithWarnings) {
-      return ((WithWarnings) target).prepend(warnings);
-    } else {
-      return new WithWarnings(target, warnings.toArray(Warning[]::new));
-    }
-  }
-
-  public static WithWarnings prependTo(Object target, Warning[] warnings) {
-    if (target instanceof WithWarnings) {
-      return ((WithWarnings) target).prepend(warnings);
     } else {
       return new WithWarnings(target, warnings);
     }
@@ -196,15 +170,6 @@ public final class WithWarnings implements TruffleObject {
     EconomicSet<Warning> set = EconomicSet.create(new WarningEquivalence());
     set.addAll(initial.iterator());
     set.addAll(Arrays.stream(entries).iterator());
-    return set;
-  }
-
-  @CompilerDirectives.TruffleBoundary
-  @SuppressWarnings("unchecked")
-  private EconomicSet<Warning> cloneSetAndAppend(EconomicSet<Warning> initial, EconomicSet<Warning> entries) {
-    EconomicSet<Warning> set = EconomicSet.create(new WarningEquivalence());
-    set.addAll(initial.iterator());
-    set.addAll(entries.iterator());
     return set;
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
@@ -31,12 +31,6 @@ public final class WithWarnings implements TruffleObject {
     this.value = value;
   }
 
-  private WithWarnings(Object value, EconomicSet<Warning> warnings) {
-    assert !(value instanceof WithWarnings);
-    this.warnings = cloneSet(warnings);
-    this.value = value;
-  }
-
   private WithWarnings(Object value, EconomicSet<Warning> warnings, Warning... additionalWarnings) {
     assert !(value instanceof WithWarnings);
     this.warnings = cloneSetAndAppend(warnings, additionalWarnings);
@@ -57,23 +51,11 @@ public final class WithWarnings implements TruffleObject {
     }
   }
 
-  public static WithWarnings wrap(Object value, EconomicSet<Warning> warnings) {
-    if (value instanceof WithWarnings with) {
-      return with.append(warnings);
-    } else {
-      return new WithWarnings(value, warnings);
-    }
-  }
-
   public Object getValue() {
     return value;
   }
 
   public WithWarnings append(Warning... newWarnings) {
-    return new WithWarnings(value, warnings, newWarnings);
-  }
-
-  public WithWarnings append(EconomicSet<Warning> newWarnings) {
     return new WithWarnings(value, warnings, newWarnings);
   }
 
@@ -113,10 +95,6 @@ public final class WithWarnings implements TruffleObject {
 
   public ArrayRope<Warning> getReassignedWarningsAsRope(Node location) {
     return new ArrayRope<>(getReassignedWarnings(location, null));
-  }
-
-  public Warning[] getReassignedWarnings(Node location) {
-    return getReassignedWarnings(location, null);
   }
 
   public Warning[] getReassignedWarnings(Node location, WarningsLibrary warningsLibrary) {
@@ -233,14 +211,6 @@ public final class WithWarnings implements TruffleObject {
     EconomicSet<Warning> set = EconomicSet.create(new WarningEquivalence());
     set.addAll(initial.iterator());
     set.addAll(entries.iterator());
-    return set;
-  }
-
-  @CompilerDirectives.TruffleBoundary
-  @SuppressWarnings("unchecked")
-  private EconomicSet<Warning> cloneSet(EconomicSet<Warning> initial) {
-    EconomicSet<Warning> set = EconomicSet.create(new WarningEquivalence());
-    set.addAll(initial.iterator());
     return set;
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
@@ -16,7 +16,6 @@ import org.graalvm.collections.EconomicSet;
 import org.graalvm.collections.Equivalence;
 
 import java.util.Arrays;
-import java.util.function.Function;
 
 @ExportLibrary(TypesLibrary.class)
 @ExportLibrary(WarningsLibrary.class)
@@ -147,14 +146,14 @@ public final class WithWarnings implements TruffleObject {
     @Override
     public boolean equals(Object a, Object b) {
       if (a instanceof Warning thisObj && b instanceof Warning thatObj) {
-        return thisObj.getCreationTime() == thatObj.getCreationTime();
+        return thisObj.getSequenceId() == thatObj.getSequenceId();
       }
       return false;
     }
 
     @Override
     public int hashCode(Object o) {
-      return (int)((Warning)o).getCreationTime();
+      return (int)((Warning)o).getSequenceId();
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
@@ -83,11 +83,6 @@ public final class WithWarnings implements TruffleObject {
     return allWarnings;
   }
 
-  @CompilerDirectives.TruffleBoundary
-  private static Function<Integer, Warning[]> genArrayFun() {
-    return Warning[]::new;
-  }
-
   /** @return the number of warnings. */
   public int getWarningsCount() {
     return warnings.size();
@@ -105,10 +100,9 @@ public final class WithWarnings implements TruffleObject {
     return warnings;
   }
 
-  @CompilerDirectives.TruffleBoundary
   public static WithWarnings appendTo(Object target, ArrayRope<Warning> warnings) {
     if (target instanceof WithWarnings) {
-      return ((WithWarnings) target).append(warnings.toArray(genArrayFun()));
+      return ((WithWarnings) target).append(warnings.toArray(Warning[]::new));
     } else {
       return new WithWarnings(target, warnings.toArray(Warning[]::new));
     }

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/ArrayTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/ArrayTest.java
@@ -1,29 +1,24 @@
 package org.enso.interpreter.test;
 
 import java.net.URI;
-import java.util.Map;
 import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Language;
 import org.graalvm.polyglot.Source;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ArrayTest extends TestBase {
-  private Context ctx;
+  private static Context ctx;
 
-  @Before
-  public void prepareCtx() {
-    this.ctx = createDefaultContext();
-    final Map<String, Language> langs = ctx.getEngine().getLanguages();
-    assertNotNull("Enso found: " + langs, langs.get("enso"));
+  @BeforeClass
+  public static void prepareCtx() {
+    ctx = createDefaultContext();
   }
 
-  @After
-  public void disposeCtx() {
+  @AfterClass
+  public static void disposeCtx() {
     ctx.close();
   }
 

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/ArrayTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/ArrayTest.java
@@ -1,34 +1,30 @@
 package org.enso.interpreter.test;
 
-import java.io.ByteArrayOutputStream;
 import java.net.URI;
-import java.nio.file.Paths;
 import java.util.Map;
-import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Language;
 import org.graalvm.polyglot.Source;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ArrayTest {
+public class ArrayTest extends TestBase {
   private Context ctx;
 
   @Before
   public void prepareCtx() {
-    this.ctx = Context.newBuilder()
-      .allowExperimentalOptions(true)
-      .allowIO(true)
-      .allowAllAccess(true)
-      .logHandler(new ByteArrayOutputStream())
-      .option(
-        RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-        Paths.get("../../distribution/component").toFile().getAbsolutePath()
-      ).build();
+    this.ctx = createDefaultContext();
     final Map<String, Language> langs = ctx.getEngine().getLanguages();
     assertNotNull("Enso found: " + langs, langs.get("enso"));
+  }
+
+  @After
+  public void disposeCtx() {
+    ctx.close();
   }
 
   @Test

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/BigNumberTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/BigNumberTest.java
@@ -4,9 +4,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.Map;
 import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Language;
 import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import static org.junit.Assert.assertEquals;
@@ -14,22 +12,20 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class BigNumberTest extends TestBase {
-  private Context ctx;
+  private static Context ctx;
 
-  @Before
-  public void prepareCtx() {
-    this.ctx = createDefaultContext();
-    final Map<String, Language> langs = ctx.getEngine().getLanguages();
-    assertNotNull("Enso found: " + langs, langs.get("enso"));
+  @BeforeClass
+  public static void prepareCtx() {
+    ctx = createDefaultContext();
   }
 
-  @After
-  public void disposeCtx() {
+  @AfterClass
+  public static void disposeCtx() {
     ctx.close();
   }
 

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/BigNumberTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/BigNumberTest.java
@@ -1,13 +1,10 @@
 package org.enso.interpreter.test;
 
-import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Map;
-import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Language;
 import org.graalvm.polyglot.Source;
@@ -16,26 +13,26 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class BigNumberTest {
+public class BigNumberTest extends TestBase {
   private Context ctx;
 
   @Before
   public void prepareCtx() {
-    this.ctx = Context.newBuilder()
-      .allowExperimentalOptions(true)
-      .allowIO(true)
-      .allowAllAccess(true)
-      .logHandler(new ByteArrayOutputStream())
-      .option(
-        RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-        Paths.get("../../distribution/component").toFile().getAbsolutePath()
-      ).build();
+    this.ctx = createDefaultContext();
     final Map<String, Language> langs = ctx.getEngine().getLanguages();
     assertNotNull("Enso found: " + langs, langs.get("enso"));
   }
+
+  @After
+  public void disposeCtx() {
+    ctx.close();
+  }
+
 
   @Test
   public void evaluation() throws Exception {

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/ForeignMethodInvokeTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/ForeignMethodInvokeTest.java
@@ -1,40 +1,24 @@
 package org.enso.interpreter.test;
 
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeNotNull;
 
-import java.io.ByteArrayOutputStream;
-import java.nio.file.Paths;
-import java.util.Map;
-import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Language;
 import org.graalvm.polyglot.Value;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class ForeignMethodInvokeTest {
-  private Context ctx;
+public class ForeignMethodInvokeTest extends TestBase {
+  private static Context ctx;
 
-  @Before
-  public void prepareCtx() {
-    this.ctx = Context.newBuilder("enso")
-        .allowExperimentalOptions(true)
-        .allowIO(true)
-        .allowAllAccess(true)
-        .logHandler(new ByteArrayOutputStream())
-        .option(
-            RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-            Paths.get("../../distribution/component").toFile().getAbsolutePath()
-        ).build();
-    final Map<String, Language> langs = ctx.getEngine().getLanguages();
-    assumeNotNull("Enso not found: " + langs, langs.get("enso"));
+  @BeforeClass
+  public static void prepareCtx() {
+    ctx = createDefaultContext();
   }
 
-  @After
-  public void disposeCtx() {
-    this.ctx.close();
+  @AfterClass
+  public static void disposeCtx() {
+    ctx.close();
   }
 
   @Test

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/LazyAtomFieldTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/LazyAtomFieldTest.java
@@ -4,39 +4,35 @@ import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
-import java.util.Map;
 import java.util.stream.Collectors;
 import org.enso.polyglot.MethodNames;
-import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Language;
 import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class LazyAtomFieldTest {
+public class LazyAtomFieldTest extends TestBase {
   private static final ByteArrayOutputStream out = new ByteArrayOutputStream();
-  private Context ctx;
+  private static Context ctx;
+
+  @BeforeClass
+  public static void prepareCtx() {
+    ctx = createDefaultContext(out);
+  }
 
   @Before
-  public void prepareCtx() {
-    this.ctx = Context.newBuilder()
-      .allowExperimentalOptions(true)
-      .allowIO(true)
-      .allowAllAccess(true)
-      .logHandler(new ByteArrayOutputStream())
-      .out(out)
-      .option(
-        RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-        Paths.get("../../distribution/component").toFile().getAbsolutePath()
-      ).build();
-    final Map<String, Language> langs = ctx.getEngine().getLanguages();
-    assertNotNull("Enso found: " + langs, langs.get("enso"));
+  public void resetOut() {
     out.reset();
+  }
+
+  @AfterClass
+  public static void disposeCtx() {
+    ctx.close();
   }
 
   @Test

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/ListTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/ListTest.java
@@ -4,9 +4,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.Map;
 import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Language;
 import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import static org.junit.Assert.assertEquals;
@@ -31,9 +29,6 @@ public class ListTest extends TestBase {
   @Before
   public void prepareCtx() throws Exception {
     this.ctx = createDefaultContext();
-
-    final Map<String, Language> langs = ctx.getEngine().getLanguages();
-    assertNotNull("Enso found: " + langs, langs.get("enso"));
 
     final String code = """
     from Standard.Base.Data.List.List import Cons, Nil

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/ListTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/ListTest.java
@@ -1,13 +1,10 @@
 package org.enso.interpreter.test;
 
-import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Map;
-import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Language;
 import org.graalvm.polyglot.Source;
@@ -15,10 +12,12 @@ import org.graalvm.polyglot.Value;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ListTest {
+public class ListTest extends TestBase {
   private Context ctx;
   private final int size = 100_000;
   private Value generator;
@@ -31,15 +30,7 @@ public class ListTest {
 
   @Before
   public void prepareCtx() throws Exception {
-    this.ctx = Context.newBuilder()
-      .allowExperimentalOptions(true)
-      .allowIO(true)
-      .allowAllAccess(true)
-      .logHandler(new ByteArrayOutputStream())
-      .option(
-        RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-        Paths.get("../../distribution/component").toFile().getAbsolutePath()
-      ).build();
+    this.ctx = createDefaultContext();
 
     final Map<String, Language> langs = ctx.getEngine().getLanguages();
     assertNotNull("Enso found: " + langs, langs.get("enso"));
@@ -72,6 +63,11 @@ public class ListTest {
     init = evalCode(code, "init");
     asVector = evalCode(code, "as_vector");
     asText = evalCode(code, "as_text");
+  }
+
+  @After
+  public void disposeCtx() {
+    this.ctx.close();
   }
 
   @Test

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/MetaObjectTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/MetaObjectTest.java
@@ -16,20 +16,20 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class MetaObjectTest extends TestBase {
-  private Context ctx;
+  private static Context ctx;
 
-  @Before
-  public void prepareCtx() {
+  @BeforeClass
+  public static void prepareCtx() {
     ctx = createDefaultContext();
   }
 
-  @After
-  public void disposeCtx() {
+  @AfterClass
+  public static void disposeCtx() {
     ctx.close();
   }
 

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/PolyglotErrorTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/PolyglotErrorTest.java
@@ -1,22 +1,16 @@
 package org.enso.interpreter.test;
 
-import java.io.ByteArrayOutputStream;
-import java.nio.file.Paths;
-import java.util.Map;
-import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Language;
 import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class PolyglotErrorTest {
+public class PolyglotErrorTest extends TestBase {
   private Context ctx;
   private Value panic;
 
@@ -26,17 +20,7 @@ public class PolyglotErrorTest {
 
   @Before
   public void prepareCtx() throws Exception {
-    this.ctx = Context.newBuilder()
-      .allowExperimentalOptions(true)
-      .allowIO(true)
-      .allowAllAccess(true)
-      .logHandler(new ByteArrayOutputStream())
-      .option(
-        RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-        Paths.get("../../distribution/component").toFile().getAbsolutePath()
-      ).build();
-    final Map<String, Language> langs = ctx.getEngine().getLanguages();
-    assertNotNull("Enso found: " + langs, langs.get("enso"));
+    this.ctx = createDefaultContext();
 
     var code = """
     import Standard.Base.Panic.Panic

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/PolyglotErrorTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/PolyglotErrorTest.java
@@ -11,6 +11,8 @@ import org.graalvm.polyglot.Value;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -100,6 +102,11 @@ public class PolyglotErrorTest {
 
     this.panic = module.invokeMember("eval_expression", "panic");
     assertTrue("It is a function", this.panic.canExecute());
+  }
+
+  @After
+  public void disposeCtx() {
+    this.ctx.close();
   }
 
   @Test

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/PrintTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/PrintTest.java
@@ -1,11 +1,10 @@
 package org.enso.interpreter.test;
 
 import org.enso.polyglot.MethodNames;
-import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Language;
 import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -13,30 +12,22 @@ import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
-import java.util.Map;
 
 import static org.junit.Assert.*;
 
-public class PrintTest {
+public class PrintTest extends TestBase {
   private static final ByteArrayOutputStream out = new ByteArrayOutputStream();
   private Context ctx;
 
   @Before
   public void prepareCtx() {
-    this.ctx = Context.newBuilder()
-        .allowExperimentalOptions(true)
-        .allowIO(true)
-        .allowAllAccess(true)
-        .logHandler(new ByteArrayOutputStream())
-        .out(out)
-        .option(
-            RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-            Paths.get("../../distribution/component").toFile().getAbsolutePath()
-        ).build();
-    final Map<String, Language> langs = ctx.getEngine().getLanguages();
-    assertNotNull("Enso found: " + langs, langs.get("enso"));
+    ctx = createDefaultContext(out);
     out.reset();
+  }
+
+  @After
+  public void disposeCtx() {
+    ctx.close();
   }
 
   private void checkPrint(String code, String expected) throws Exception {

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/TestBase.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/TestBase.java
@@ -10,6 +10,7 @@ import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -24,19 +25,28 @@ import org.graalvm.polyglot.proxy.ProxyExecutable;
 
 public abstract class TestBase {
   protected static Context createDefaultContext() {
-    var context =
-        Context.newBuilder()
-            .allowExperimentalOptions(true)
-            .allowIO(true)
-            .allowAllAccess(true)
-            .logHandler(new ByteArrayOutputStream())
-            .option(
-                RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-                Paths.get("../../distribution/component").toFile().getAbsolutePath())
-            .build();
+    var context = defaultContextBuilder().build();
     final Map<String, Language> langs = context.getEngine().getLanguages();
     assertNotNull("Enso found: " + langs, langs.get("enso"));
     return context;
+  }
+
+  protected static Context createDefaultContext(OutputStream out) {
+    var context = defaultContextBuilder().out(out).build();
+    final Map<String, Language> langs = context.getEngine().getLanguages();
+    assertNotNull("Enso found: " + langs, langs.get("enso"));
+    return context;
+  }
+
+  private static Context.Builder defaultContextBuilder() {
+    return Context.newBuilder()
+        .allowExperimentalOptions(true)
+        .allowIO(true)
+        .allowAllAccess(true)
+        .logHandler(new ByteArrayOutputStream())
+        .option(
+            RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
+            Paths.get("../../distribution/component").toFile().getAbsolutePath());
   }
 
   /**

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/TypeMembersTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/TypeMembersTest.java
@@ -1,13 +1,8 @@
 package org.enso.interpreter.test;
 
-import java.io.ByteArrayOutputStream;
 import java.net.URI;
-import java.nio.file.Paths;
-import java.util.Map;
 import java.util.Set;
-import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Language;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
@@ -16,27 +11,23 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class TypeMembersTest {
+public class TypeMembersTest extends TestBase {
   private Context ctx;
 
   @Before
   public void prepareCtx() {
-    this.ctx = Context.newBuilder()
-      .allowExperimentalOptions(true)
-      .allowIO(true)
-      .allowAllAccess(true)
-      .logHandler(new ByteArrayOutputStream())
-      .option(
-        RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-        Paths.get("../../distribution/component").toFile().getAbsolutePath()
-      ).build();
-    final Map<String, Language> langs = ctx.getEngine().getLanguages();
-    assertNotNull("Enso found: " + langs, langs.get("enso"));
+    ctx = createDefaultContext();
   }
 
+  @After
+  public void disposeCtx() {
+    ctx.close();
+  }
 
   @Test
   public void checkAtomMembers() throws Exception {

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/VectorTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/VectorTest.java
@@ -1,40 +1,31 @@
 package org.enso.interpreter.test;
 
-import java.io.ByteArrayOutputStream;
 import java.net.URI;
-import java.nio.file.Paths;
 import java.util.BitSet;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
-import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Language;
 import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.proxy.ProxyArray;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import org.junit.Before;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class VectorTest {
-  private Context ctx;
+public class VectorTest extends TestBase {
+  private static Context ctx;
 
-  @Before
-  public void prepareCtx() {
-    this.ctx = Context.newBuilder()
-      .allowExperimentalOptions(true)
-      .allowIO(true)
-      .allowAllAccess(true)
-      .logHandler(new ByteArrayOutputStream())
-      .option(
-        RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-        Paths.get("../../distribution/component").toFile().getAbsolutePath()
-      ).build();
-    final Map<String, Language> langs = ctx.getEngine().getLanguages();
-    assertNotNull("Enso found: " + langs, langs.get("enso"));
+  @BeforeClass
+  public static void prepareCtx() {
+    ctx = createDefaultContext();
+  }
+
+  @AfterClass
+  public static void disposeCtx() {
+    ctx.close();
   }
 
   @Test

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/WarningsTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/WarningsTest.java
@@ -1,17 +1,54 @@
 package org.enso.interpreter.test;
 
+import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.error.Warning;
 import org.enso.interpreter.runtime.error.WarningsLibrary;
 import org.enso.interpreter.runtime.error.WithWarnings;
-import org.junit.Assert;
+import org.enso.polyglot.LanguageInfo;
+import org.enso.polyglot.MethodNames;
+import org.enso.polyglot.RuntimeOptions;
+import org.graalvm.polyglot.Context;
+import org.junit.*;
+
 import static org.junit.Assert.assertEquals;
-import org.junit.Test;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.OutputStream;
+import java.nio.file.Paths;
 
 public class WarningsTest {
+
+  private static Context ctx;
+
+  @BeforeClass
+  public static void initEnsoContext() {
+    ctx =
+        Context.newBuilder()
+            .allowExperimentalOptions(true)
+            .allowIO(true)
+            .option(
+                RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
+                Paths.get("../../distribution/component").toFile().getAbsolutePath())
+            .logHandler(OutputStream.nullOutputStream())
+            .allowAllAccess(true)
+            .build();
+    assertNotNull("Enso language is supported", ctx.getEngine().getLanguages().get("enso"));
+  }
+
+  @AfterClass
+  public static void disposeContext() {
+    ctx.close();
+  }
+
   @Test
   public void doubleWithWarningsWrap() {
-    var warn1 = new Warning("w1", this, 1L);
-    var warn2 = new Warning("w2", this, 2L);
+    var ensoContext =
+        (EnsoContext)
+            ctx.getBindings(LanguageInfo.ID)
+                .invokeMember(MethodNames.TopScope.LEAK_CONTEXT)
+                .asHostObject();
+    var warn1 = Warning.create(ensoContext, "w1", this);
+    var warn2 = Warning.create(ensoContext, "w2", this);
     var value = 42;
 
     var with1 = WithWarnings.wrap(42, warn1);

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/WarningsTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/WarningsTest.java
@@ -6,33 +6,21 @@ import org.enso.interpreter.runtime.error.WarningsLibrary;
 import org.enso.interpreter.runtime.error.WithWarnings;
 import org.enso.polyglot.LanguageInfo;
 import org.enso.polyglot.MethodNames;
-import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
-import org.junit.*;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
-import java.io.OutputStream;
-import java.nio.file.Paths;
-
-public class WarningsTest {
+public class WarningsTest extends TestBase {
 
   private static Context ctx;
 
   @BeforeClass
   public static void initEnsoContext() {
-    ctx =
-        Context.newBuilder()
-            .allowExperimentalOptions(true)
-            .allowIO(true)
-            .option(
-                RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-                Paths.get("../../distribution/component").toFile().getAbsolutePath())
-            .logHandler(OutputStream.nullOutputStream())
-            .allowAllAccess(true)
-            .build();
-    assertNotNull("Enso language is supported", ctx.getEngine().getLanguages().get("enso"));
+    ctx = createDefaultContext();
   }
 
   @AfterClass

--- a/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/MethodProcessor.java
+++ b/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/MethodProcessor.java
@@ -502,7 +502,7 @@ public class MethodProcessor extends BuiltinsMetadataProcessor<MethodProcessor.M
                 + arrayRead(argumentsArray, arg.getPosition())
                 + " = withWarnings.getValue();");
         out.println(
-            "      gatheredWarnings = gatheredWarnings.prepend(withWarnings.getReassignedWarnings(bodyNode));");
+            "      gatheredWarnings = gatheredWarnings.prepend(withWarnings.getReassignedWarningsAsRope(bodyNode));");
         out.println("    }");
       }
       return true;

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -172,4 +172,11 @@ spec =
 
         file.delete_if_exists
 
+        Test.specify 'should not duplicate warnings' <|
+            c = Database.connect (SQLite In_Memory)
+            t0 = Table.new [["X", ["a", "bc", "def"]]]
+            t1 = c.upload_table "Tabela" t0
+            t2 = t1.cast "X" (Value_Type.Char size=1)
+            Warning.get_all t2 . length . should_equal 1
+
 main = Test_Suite.run_main spec

--- a/test/Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Tests/src/Semantic/Warnings_Spec.enso
@@ -19,6 +19,8 @@ My_Type.my_method self = self.a + self.b + self.c
 type Wrap
     Value foo
 
+f x _ = Warning.attach "Baz!" x
+
 type My_Fancy_Collection
     Value (x:Integer)
 
@@ -402,5 +404,8 @@ spec = Test.group "Dataflow Warnings" <|
 
         result_3 = b + b + d
         Warning.get_all result_3 . map (x-> x.value.to_text) . should_equal ["Foo!", "Foo!"]
+
+        result_4 = f a 1 + f a 2 + f a 3
+        Warning.get_all result_4 . map (x-> x.value.to_text) . should_equal ["Baz!", "Baz!", "Baz!"]
 
 main = Test_Suite.run_main spec

--- a/test/Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Tests/src/Semantic/Warnings_Spec.enso
@@ -388,5 +388,11 @@ spec = Test.group "Dataflow Warnings" <|
         Problems.assume_no_problems <| condition_1 False x3
         Problems.assume_no_problems <| condition_2 False x3
 
+    Test.specify "should only report unique warnings" <|
+        x = 1
+        y = Warning.attach "Foo!" x
+        z = Warning.attach "Bar!" y
+        result = y + z
+        Warning.get_all result . length . should_equal 2
 
 main = Test_Suite.run_main spec

--- a/test/Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Tests/src/Semantic/Warnings_Spec.enso
@@ -389,10 +389,18 @@ spec = Test.group "Dataflow Warnings" <|
         Problems.assume_no_problems <| condition_2 False x3
 
     Test.specify "should only report unique warnings" <|
-        x = 1
-        y = Warning.attach "Foo!" x
-        z = Warning.attach "Bar!" y
-        result = y + z
-        Warning.get_all result . length . should_equal 2
+        a = 1
+        b = Warning.attach "Foo!" a
+        c = Warning.attach "Bar!" b
+        d = Warning.attach "Foo!" b
+
+        result_1 = b + c
+        Warning.get_all result_1 . map (x-> x.value.to_text) . should_equal ["Bar!", "Foo!"]
+
+        result_2 = b + b + b
+        Warning.get_all result_2 . length . should_equal 1
+
+        result_3 = b + b + d
+        Warning.get_all result_3 . map (x-> x.value.to_text) . should_equal ["Foo!", "Foo!"]
 
 main = Test_Suite.run_main spec


### PR DESCRIPTION
### Pull Request Description

This change makes sure that reported warnings are unique, based on the value of internal clock tick and ignoring differences in reassignments.

Before:
![Screenshot from 2023-04-20 15-42-55](https://user-images.githubusercontent.com/292128/233415710-925c1045-37c7-49f5-9bc3-bfbfd30270a3.png)
After:
![Screenshot from 2023-04-20 15-27-27](https://user-images.githubusercontent.com/292128/233415807-8cb67bc2-ac37-4db7-924e-ae7619074b5b.png)

On the positive side, no further changes, like in LS, have to be done. 


Closes #6257.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
