### PR TITLE
5127 Add Table.parse_to_columns to parse a single column to a set of columns.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -387,6 +387,7 @@
 - [Implemented `Table.split` and `Table.tokenize` for in-memory tables.][6233]
 - [Added `trim` and `replace` to `Column`. Enhanced number parsing with support
   for thousands and decimal point automatic detection.][6253]
+- [Added `Table.parse_to_columns`.][6383]
 
 [debug-shortcuts]:
   https://github.com/enso-org/enso/blob/develop/app/gui/docs/product/shortcuts.md#debug
@@ -586,6 +587,7 @@
 [6218]: https://github.com/enso-org/enso/pull/6218
 [6233]: https://github.com/enso-org/enso/pull/6233
 [6253]: https://github.com/enso-org/enso/pull/6253
+[6383]: https://github.com/enso-org/enso/pull/6383
 
 #### Enso Compiler
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Pattern.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Pattern.enso
@@ -319,6 +319,12 @@ type Pattern
         map = polyglot_map_to_map self.internal_regex_object.groups
         map.keys
 
+    ## Return a map from group number to group name. Only includes named groups.
+    group_nums_to_names : Map Integer Text
+    group_nums_to_names self =
+        map = polyglot_map_to_map self.internal_regex_object.groups
+        map.transform k-> v-> [v, k]
+
 ## PRIVATE
 
     Performs the regex match, and iterates through the results. Yields both

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -1468,12 +1468,12 @@ type Table
        The values of other columns are repeated for the new rows.
 
        If there are no marked groups, a single column with whole content of
-       match. Otherwise, each group becomes a column (with group name if named
-       in Regex).
+       match is added. Otherwise, each group becomes a column (with group name
+       if named in Regex).
 
        Arguments:
        - column: The column to split the text of.
-       - pattern: The pattern used to find within the text.
+       - pattern: The pattern used to search within the text.
        - case_sensitivity: Specifies if the text values should be compared case
          sensitively.
        - parse_values: Parse any values using the default value parser.
@@ -1487,7 +1487,7 @@ type Table
        suffixing strategy.
     parse_to_columns : Text | Integer -> Text -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table
     parse_to_columns self column pattern="." case_sensitivity=Case_Sensitivity.Sensitive parse_values=True on_problems=Report_Error =
-        Error.throw (Unsupported_Database_Operation.Error "Table.parse_text_to_column is not implemented yet for the Database backends.")
+        Error.throw (Unsupported_Database_Operation.Error "Table.parse_to_columns is not implemented yet for the Database backends.")
 
     ## PRIVATE
        UNSTABLE

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -1466,6 +1466,34 @@ type Table
         _ = [column pattern case_sensitivity]
         Error.throw (Unsupported_Database_Operation.Error "Table.tokenize_to_rows is not implemented yet for the Database backends.")
 
+    ## Converts a Text column into new columns using a regular expression
+       pattern.
+
+       Each match becomes a row in the table.
+       The values of other columns are repeated for the new rows.
+
+       If there are no marked groups, a single column with whole content of
+       match. Otherwise, each group becomes a column (with group name if named
+       in Regex).
+
+       Arguments:
+       - column: The column to split the text of.
+       - pattern: The pattern used to find within the text.
+       - case_sensitivity: Specifies if the text values should be compared case
+         sensitively.
+       - parse_values: Parse any values using the default value parser.
+
+       ? Column Names
+
+       If no marked group, the new column will have the same name as the input.
+       If the marked groups are named, the names will be used otherwise the column
+       will be named `<Input Column> <N>` where `N` is the number of the marked group.
+       If the new name is already in use it will be renamed following the normal
+       suffixing strategy.
+    parse_to_columns : Text | Integer -> Text -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table
+    parse_to_columns self column pattern="." case_sensitivity=Case_Sensitivity.Sensitive parse_values=True on_problems=Report_Error =
+        Error.throw (Unsupported_Database_Operation.Error "Table.parse_text_to_column is not implemented yet for the Database backends.")
+
     ## PRIVATE
        UNSTABLE
        Cast the selected columns to a specific type.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1005,12 +1005,12 @@ type Table
        The values of other columns are repeated for the new rows.
 
        If there are no marked groups, a single column with whole content of
-       match. Otherwise, each group becomes a column (with group name if named
-       in Regex).
+       match is added. Otherwise, each group becomes a column (with group name
+       if named in Regex).
 
        Arguments:
        - column: The column to split the text of.
-       - pattern: The pattern used to find within the text.
+       - pattern: The pattern used to search within the text.
        - case_sensitivity: Specifies if the text values should be compared case
          sensitively.
        - parse_values: Parse any values using the default value parser.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -937,6 +937,34 @@ type Table
     tokenize_to_rows self column pattern="." case_sensitivity=Case_Sensitivity.Sensitive =
         Split_Tokenize.tokenize_to_rows self column pattern case_sensitivity
 
+    ## Converts a Text column into new columns using a regular expression
+       pattern.
+
+       Each match becomes a row in the table.
+       The values of other columns are repeated for the new rows.
+
+       If there are no marked groups, a single column with whole content of
+       match. Otherwise, each group becomes a column (with group name if named
+       in Regex).
+
+       Arguments:
+       - column: The column to split the text of.
+       - pattern: The pattern used to find within the text.
+       - case_sensitivity: Specifies if the text values should be compared case
+         sensitively.
+       - parse_values: Parse any values using the default value parser.
+
+       ? Column Names
+
+       If no marked group, the new column will have the same name as the input.
+       If the marked groups are named, the names will be used otherwise the column
+       will be named `<Input Column> <N>` where `N` is the number of the marked group.
+       If the new name is already in use it will be renamed following the normal
+       suffixing strategy.
+    parse_to_columns : Text | Integer -> Text -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table
+    parse_to_columns self column pattern="." case_sensitivity=Case_Sensitivity.Sensitive parse_values=True on_problems=Report_Error =
+        Split_Tokenize.parse_to_columns self column pattern case_sensitivity parse_values on_problems
+
     ## ALIAS Filter Rows
 
        Selects only the rows of this table that correspond to `True` values of

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
@@ -368,5 +368,6 @@ uniform_length target_length v problem_builder = if v.length == target_length th
             new_v.append_vector_range v
             repeat_each num_paddings <| new_v.append Nothing
             new_v.to_vector
-        False -> # Truncate.
+		# Truncate.
+        False -> 
             v.take target_length

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
@@ -115,7 +115,7 @@ fan_out_to_rows table input_column_id function on_problems=Report_Error =
      x | 12 34 56  |   y    ===>
    ... | ...       | ...
 
-   foo | bar_1 | bar_2 | baz
+   foo | bar 0 | bar 1 | baz
    ----+-------+-------+----
      x |     1 |     2 |   y
      x |     3 |     4 |   y

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
@@ -6,6 +6,8 @@ import project.Data.Type.Value_Type.Value_Type
 import project.Internal.Java_Exports
 import project.Internal.Problem_Builder.Problem_Builder
 import project.Internal.Unique_Name_Strategy.Unique_Name_Strategy
+import Standard.Base.Data.Text.Regex
+import Standard.Base.Data.Text.Regex.Pattern.Pattern
 
 from project import Value_Type
 from project.Errors import Column_Count_Exceeded, Column_Count_Mismatch, Duplicate_Output_Column_Names, Invalid_Value_Type, Missing_Input_Columns
@@ -50,6 +52,39 @@ tokenize_to_rows table input_column_id pattern="." case_sensitivity=Case_Sensiti
     column = table.at input_column_id
     Value_Type.expect_text (column.value_type) related_column=column <|
         fan_out_to_rows table input_column_id (handle_nothing (_.tokenize pattern case_sensitivity))
+
+parse_to_columns : Table -> Text | Integer -> Text -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table
+parse_to_columns table input_column_id pattern="." case_sensitivity=Case_Sensitivity.Sensitive parse_values=True on_problems=Report_Error =
+    case_insensitive = case_sensitivity.is_case_insensitive_in_memory
+    pat = Regex.compile pattern case_insensitive=case_insensitive
+
+    fun = handle_nothing (parse_to_vectors pat)
+    column_namer = regex_to_column_namer pat
+
+    column = table.at input_column_id
+    Value_Type.expect_text (column.value_type) related_column=column <|
+        fan_out_to_rows_and_columns table input_column_id fun column_namer on_problems
+
+## PRIVATE
+   Create a parser of a `Text` to a nested `Vector. Each match becomes an element outer
+   vector; each group (or the whole match, if there aren o groups) because an
+   element of the inner vectors.
+parse_to_vectors : Pattern -> (Text -> Vector (Vector (Text | Any)))
+parse_to_vectors pattern =
+    input->
+        matches = pattern.match_all input
+        matches.map match-> case pattern.group_count of
+            0 -> [match.text]
+            _ -> match.groups . drop 1
+
+## PRIVATE
+   Create a column namer that uses regex group names, if any.
+regex_to_column_namer : Pattern -> (Integer -> Text | Nothing)
+regex_to_column_namer pattern =
+    group_nums_to_names = pattern.group_nums_to_names
+    i-> case group_nums_to_names.contains_key i of
+        True -> group_nums_to_names.at i
+        False -> Nothing
 
 ## PRIVATE
    Transform a table by transforming a column into a set of columns. Takes a
@@ -132,7 +167,7 @@ fan_out_to_rows table input_column_id function on_problems=Report_Error =
      the provided namer returns Nothing, then the default namer is used in that
      case as well.
    - on_problems: Specifies the behavior when a problem occurs.
-fan_out_to_rows_and_columns : Table -> Text | Integer -> (Any -> Vector Any) -> (Integer -> Text) -> Problem_Behavior -> Table
+fan_out_to_rows_and_columns : Table -> Text | Integer -> (Any -> Vector Any) -> (Integer -> Text | Nothing) -> Problem_Behavior -> Table
 fan_out_to_rows_and_columns table input_column_id function column_namer=Nothing on_problems=Report_Error =
     problem_builder = Problem_Builder.new
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
@@ -8,7 +8,7 @@ import project.Internal.Problem_Builder.Problem_Builder
 import project.Internal.Unique_Name_Strategy.Unique_Name_Strategy
 
 from project import Value_Type
-from project.Errors import Column_Count_Exceeded, Duplicate_Output_Column_Names, Invalid_Value_Type, Missing_Input_Columns
+from project.Errors import Column_Count_Exceeded, Column_Count_Mismatch, Duplicate_Output_Column_Names, Invalid_Value_Type, Missing_Input_Columns
 from project.Internal.Java_Exports import make_string_builder
 
 polyglot java import org.enso.table.data.mask.OrderMask
@@ -87,7 +87,7 @@ fan_out_to_rows table input_column_id function on_problems=Report_Error =
        Wrap the provided function to convert each value to a singleton `Vector`.
     wrapped_function x = function x . map y-> [y]
     column_namer = _-> input_column_id
-    fan_out_to_rows_and_columns table input_column_id wrapped_function namer on_problems
+    fan_out_to_rows_and_columns table input_column_id wrapped_function column_namer on_problems
 
 ## PRIVATE
    Transform a column by applying the given function to the values in the
@@ -103,7 +103,9 @@ fan_out_to_rows table input_column_id function on_problems=Report_Error =
      value is used to determine the length, and the other output values must
      have the same length. If a value is too short, it will be padded with
      Nothing, and if it is too long, it will be truncated. In either case,
-     Column_Count_Mismatch will be added as a warning.
+     Column_Count_Mismatch will be added as a warning. (It is expected that the
+     caller of this private method will ensure that the provided function will
+     produce inner vectors of the same length, but we check for it anyway.)
 
    > Example
    f("12 34 56") -> [[1, 2], [3, 4], [5, 6]]
@@ -130,17 +132,17 @@ fan_out_to_rows table input_column_id function on_problems=Report_Error =
      the provided namer returns Nothing, then the default namer is used in that
      case as well.
    - on_problems: Specifies the behavior when a problem occurs.
-fan_out_to_rows_and_columns : Table -> Text | Integer -> (Any -> Vector Any) -> (Integer -> String) -> Problem_Behavior -> Table
+fan_out_to_rows_and_columns : Table -> Text | Integer -> (Any -> Vector Any) -> (Integer -> Text) -> Problem_Behavior -> Table
 fan_out_to_rows_and_columns table input_column_id function column_namer=Nothing on_problems=Report_Error =
     problem_builder = Problem_Builder.new
 
     # Integer -> String
-    effective_column_namer = case namer of
+    effective_column_namer = case column_namer of
         # Use the default namer for all columns.
         Nothing -> default_column_namer input_column_id
         # Use the default if the provided namer returns Nothing
-        _ -> i-> case namer i of
-            Nothing -> default_column_namer input_column_id
+        _ -> i-> case column_namer i of
+            Nothing -> default_column_namer input_column_id i
             name -> name
 
     input_column = table.at input_column_id
@@ -148,9 +150,11 @@ fan_out_to_rows_and_columns table input_column_id function column_namer=Nothing 
     num_input_rows = input_storage.size
 
     num_output_columns = if input_column.length == 0 then 0 else
-        function (input_column.at 0) . length
-    IO.println "NOC"
-    IO.println num_output_columns
+        output_value = function (input_column.at 0)
+        case output_value.is_empty of
+            # If there are no output values, treat the column count as 0
+            0 -> 0
+            _ -> output_value.at 0 . length
 
     # Guess that most of the time, we'll get at least one value for each input.
     initial_size = input_column.length
@@ -170,10 +174,10 @@ fan_out_to_rows_and_columns table input_column_id function column_namer=Nothing 
         repeat_each output_values.length <| order_mask_positions.append i
 
     # Build the output column
-    output_storages = output_column_builders map .seal
+    output_storages = output_column_builders.map .seal
     output_columns = output_storages.map_with_index i-> output_storage->
-        column_name = effective_column_namer input_column_id i
-        Column.from_storage name output_storage
+        column_name = effective_column_namer i
+        Column.from_storage column_name output_storage
 
     # Build the order mask.
     order_mask = OrderMask.new (order_mask_positions.to_vector)
@@ -324,7 +328,7 @@ uniform_length target_length v problem_builder = if v.length == target_length th
             num_paddings = target_length - v.length
             new_v = Vector.new_builder
             new_v.append_vector_range v
-            num_paddings.each _-> new_v.append Nothing
+            repeat_each num_paddings <| new_v.append Nothing
             new_v.to_vector
         False ->
             # Truncate.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
@@ -62,8 +62,10 @@ parse_to_columns table input_column_id pattern="." case_sensitivity=Case_Sensiti
     column_namer = regex_to_column_namer pat
 
     column = table.at input_column_id
-    Value_Type.expect_text (column.value_type) related_column=column <|
+
+    new_table = Value_Type.expect_text (column.value_type) related_column=column <|
         fan_out_to_rows_and_columns table input_column_id fun column_namer on_problems
+    if parse_values then new_table.parse on_problems=on_problems else new_table
 
 ## PRIVATE
    Create a parser of a `Text` to a nested `Vector. Each match becomes an element outer

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
@@ -53,6 +53,10 @@ tokenize_to_rows table input_column_id pattern="." case_sensitivity=Case_Sensiti
     Value_Type.expect_text column
         fan_out_to_rows table input_column_id (handle_nothing (_.tokenize pattern case_sensitivity))
 
+## PRIVATE
+   Converts a Text column into new columns using a regular expression
+   pattern.
+   See `Table.parse_to_columns`.
 parse_to_columns : Table -> Text | Integer -> Text -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table
 parse_to_columns table input_column_id pattern="." case_sensitivity=Case_Sensitivity.Sensitive parse_values=True on_problems=Report_Error =
     case_insensitive = case_sensitivity.is_case_insensitive_in_memory
@@ -69,9 +73,9 @@ parse_to_columns table input_column_id pattern="." case_sensitivity=Case_Sensiti
 
 ## PRIVATE
    Create a parser from a regex to a nested `Vector`. Each match becomes an
-   element outer vector; each group (or the whole match, if there are no groups)
-   becomes an element of the inner vectors.
-regex_parse_to_vectors : Pattern -> (Text -> Vector (Vector (Text | Any)))
+   element of the vector; each group (or the whole match, if there are no
+   groups) becomes an element of the inner vectors.
+regex_parse_to_vectors : Pattern -> (Text -> Vector (Vector (Text | Nothing)))
 regex_parse_to_vectors pattern =
     input->
         matches = pattern.match_all input
@@ -176,6 +180,7 @@ fan_out_to_rows table input_column_id function on_problems=Report_Error =
 fan_out_to_rows_and_columns : Table -> Text | Integer -> (Any -> Vector (Vector Any)) -> (Integer -> Text | Nothing) -> Problem_Behavior -> Table
 fan_out_to_rows_and_columns table input_column_id function column_namer=Nothing on_problems=Report_Error =
     problem_builder = Problem_Builder.new
+    unique = Unique_Name_Strategy.new
 
     # Integer -> String
     effective_column_namer = case column_namer of
@@ -211,10 +216,14 @@ fan_out_to_rows_and_columns table input_column_id function column_namer=Nothing 
         # Append n copies of the input row position, n = # of output values.
         repeat_each output_values.length <| order_mask_positions.append i
 
+    # Reserve the non-input column names that will not be changing.
+    non_input_columns = table.columns.filter c-> c.name != input_column.name
+    unique.mark_used <| non_input_columns.map .name
+
     # Build the output column
     output_storages = output_column_builders.map .seal
     output_columns = output_storages.map_with_index i-> output_storage->
-        column_name = effective_column_namer i
+        column_name = unique.make_unique <| effective_column_namer i
         Column.from_storage column_name output_storage
 
     # Build the order mask.
@@ -362,12 +371,7 @@ uniform_length target_length v problem_builder = if v.length == target_length th
     problem = Column_Count_Mismatch.Error target_length v.length
     problem_builder.report_other_warning problem
     case v.length < target_length of
-        True -> # Pad.
-            num_paddings = target_length - v.length
-            new_v = Vector.new_builder
-            new_v.append_vector_range v
-            repeat_each num_paddings <| new_v.append Nothing
-            new_v.to_vector
+        # Pad.
+        True -> v.pad target_length Nothing
 		# Truncate.
-        False -> 
-            v.take target_length
+        False -> v.take target_length

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
@@ -88,9 +88,7 @@ regex_to_column_namer pattern original_column_name =
         1 -> _-> original_column_name
         _ ->
             group_nums_to_names = pattern.group_nums_to_names
-            i-> case group_nums_to_names.contains_key i of
-                True -> group_nums_to_names.at i
-                False -> Nothing
+            i-> group_nums_to_names.get (i+1)  # explicit groups start at 1
 
 ## PRIVATE
    Transform a table by transforming a column into a set of columns. Takes a

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
@@ -58,7 +58,7 @@ parse_to_columns table input_column_id pattern="." case_sensitivity=Case_Sensiti
     case_insensitive = case_sensitivity.is_case_insensitive_in_memory
     pat = Regex.compile pattern case_insensitive=case_insensitive
 
-    fun = handle_nothing (parse_to_vectors pat)
+    fun = handle_nothing (regex_parse_to_vectors pat)
     column_namer = regex_to_column_namer pat input_column_id
 
     column = table.at input_column_id
@@ -68,20 +68,21 @@ parse_to_columns table input_column_id pattern="." case_sensitivity=Case_Sensiti
     if parse_values then new_table.parse on_problems=on_problems else new_table
 
 ## PRIVATE
-   Create a parser of a `Text` to a nested `Vector. Each match becomes an element outer
-   vector; each group (or the whole match, if there aren o groups) because an
-   element of the inner vectors.
-parse_to_vectors : Pattern -> (Text -> Vector (Vector (Text | Any)))
-parse_to_vectors pattern =
+   Create a parser from a regex to a nested `Vector`. Each match becomes an
+   element outer vector; each group (or the whole match, if there are no groups)
+   becomes an element of the inner vectors.
+regex_parse_to_vectors : Pattern -> (Text -> Vector (Vector (Text | Any)))
+regex_parse_to_vectors pattern =
     input->
         matches = pattern.match_all input
-        matches.map match-> case pattern.group_count of
-            1 -> [match.text]
-            _ -> match.groups . drop 1
+        case pattern.group_count of
+            1 -> matches.map match-> [match.text]
+            _ -> matches.map match-> match.groups . drop 1
 
 ## PRIVATE
    Create a column namer that uses regex group names, if any.
-   If the regex has no groups, it returns the original column name unchanged.
+   If the regex has no explicit groups, it returns the original column name
+   unchanged.
 regex_to_column_namer : Pattern -> Text -> (Integer -> Text | Nothing)
 regex_to_column_namer pattern original_column_name =
     case pattern.group_count of
@@ -122,8 +123,9 @@ fan_out_to_columns table input_column_id function column_count=Nothing on_proble
      to multiple values.
 fan_out_to_rows : Table -> Text | Integer -> (Any -> Vector Any) -> Problem_Behavior -> Table
 fan_out_to_rows table input_column_id function on_problems=Report_Error =
-    ## Treat as a special case of fan_out_to_rows_and_columns with one column.
-       Wrap the provided function to convert each value to a singleton `Vector`.
+    ## Treat this as a special case of fan_out_to_rows_and_columns, with one
+       column. Wrap the provided function to convert each value to a singleton
+       `Vector`.
     wrapped_function x = function x . map y-> [y]
     column_namer = _-> input_column_id
     fan_out_to_rows_and_columns table input_column_id wrapped_function column_namer on_problems
@@ -132,7 +134,7 @@ fan_out_to_rows table input_column_id function on_problems=Report_Error =
    Transform a column by applying the given function to the values in the
    column. The function returns a `Vector` of `Vectors`. Each inner vector turns
    into multiple new columns in a single row. Each inner vector within the outer
-   vector produces an output rows, so each row is duplicated, with each row
+   vector produces an output row, so each row is duplicated, with each row
    getting a distinct set of output values in place of the original input value.
    The other column values are just duplicated.
 
@@ -165,13 +167,13 @@ fan_out_to_rows table input_column_id function on_problems=Report_Error =
    - table: The table to transform.
    - input_column: The column to transform.
    - function: A function that transforms a single element of `input_column`
-     to multiple values.
-   - column_namer: A function to name output columns. If Nothing, uses the
+     to a `Vector` of `Vector` of values.
+   - column_namer: A function to name output columns. If it is Nothing, uses the
      default namer, which appends an column index to the input column name. If
      the provided namer returns Nothing, then the default namer is used in that
      case as well.
    - on_problems: Specifies the behavior when a problem occurs.
-fan_out_to_rows_and_columns : Table -> Text | Integer -> (Any -> Vector Any) -> (Integer -> Text | Nothing) -> Problem_Behavior -> Table
+fan_out_to_rows_and_columns : Table -> Text | Integer -> (Any -> Vector (Vector Any)) -> (Integer -> Text | Nothing) -> Problem_Behavior -> Table
 fan_out_to_rows_and_columns table input_column_id function column_namer=Nothing on_problems=Report_Error =
     problem_builder = Problem_Builder.new
 
@@ -190,14 +192,11 @@ fan_out_to_rows_and_columns table input_column_id function column_namer=Nothing 
 
     num_output_columns = if input_column.length == 0 then 0 else
         output_value = function (input_column.at 0)
-        case output_value.is_empty of
-            # If there are no output values, treat the column count as 0
-            0 -> 0
-            _ -> output_value.at 0 . length
+        if output_value.is_empty then 0 else output_value.at 0 . length
 
     # Guess that most of the time, we'll get at least one value for each input.
     initial_size = input_column.length
-    # Accumulates the output of the output column values.
+    # Accumulates the outputs of the function.
     output_column_builders = Vector.new num_output_columns _-> make_string_builder initial_size
     # Accumulates repeated position indices for the order mask.
     order_mask_positions = Vector.new_builder initial_size
@@ -205,7 +204,7 @@ fan_out_to_rows_and_columns table input_column_id function column_namer=Nothing 
     0.up_to num_input_rows . each i->
         input_value = input_storage.getItemBoxed i
         output_values = function input_value
-        # Append each value.
+        # Append each group of values to the builder.
         output_values.each row_unchecked->
             row = uniform_length num_output_columns row_unchecked problem_builder
             row.each_with_index i-> v-> output_column_builders.at i . append v
@@ -221,11 +220,12 @@ fan_out_to_rows_and_columns table input_column_id function column_namer=Nothing 
     # Build the order mask.
     order_mask = OrderMask.new (order_mask_positions.to_vector)
 
-    # Build the other columns, and include the output_column while doing it.
+    ## Build the new table, replacing the input column with the new output
+       columns.
     new_columns_unflattened = table.columns.map column->
         case column.name == input_column_id of
             True ->
-                # Replace the input column with the output column.
+                # Replace the input column with the output columns.
                 output_columns
             False ->
                 # Build a new column from the old one with the mask
@@ -339,7 +339,7 @@ maximum vec = if vec.is_empty then Nothing else
     vec.reduce (a-> b-> a.max b)
 
 ## PRIVATE
-   Wrap a function so that it returns [] if passed Nothing
+   Wrap a function so that it returns [] if passed Nothing.
 handle_nothing : (Any -> Any) -> (Any -> Any)
 handle_nothing function = x-> case x of
     _ : Nothing -> []
@@ -350,7 +350,7 @@ handle_nothing function = x-> case x of
 repeat_each n ~action = 0.up_to n . each _-> action
 
 ## PRIVATE
-   Name a column by appending an integer to a base column name
+   Name a column by appending an integer to a base column name.
 default_column_namer : Text -> Integer -> Text
 default_column_namer base_name i = base_name + " " + i.to_text
 
@@ -362,13 +362,11 @@ uniform_length target_length v problem_builder = if v.length == target_length th
     problem = Column_Count_Mismatch.Error target_length v.length
     problem_builder.report_other_warning problem
     case v.length < target_length of
-        True ->
-            # Pad.
+        True -> # Pad.
             num_paddings = target_length - v.length
             new_v = Vector.new_builder
             new_v.append_vector_range v
             repeat_each num_paddings <| new_v.append Nothing
             new_v.to_vector
-        False ->
-            # Truncate.
+        False -> # Truncate.
             v.take target_length

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
@@ -59,7 +59,7 @@ parse_to_columns table input_column_id pattern="." case_sensitivity=Case_Sensiti
     pat = Regex.compile pattern case_insensitive=case_insensitive
 
     fun = handle_nothing (parse_to_vectors pat)
-    column_namer = regex_to_column_namer pat
+    column_namer = regex_to_column_namer pat input_column_id
 
     column = table.at input_column_id
 
@@ -76,17 +76,21 @@ parse_to_vectors pattern =
     input->
         matches = pattern.match_all input
         matches.map match-> case pattern.group_count of
-            0 -> [match.text]
+            1 -> [match.text]
             _ -> match.groups . drop 1
 
 ## PRIVATE
    Create a column namer that uses regex group names, if any.
-regex_to_column_namer : Pattern -> (Integer -> Text | Nothing)
-regex_to_column_namer pattern =
-    group_nums_to_names = pattern.group_nums_to_names
-    i-> case group_nums_to_names.contains_key i of
-        True -> group_nums_to_names.at i
-        False -> Nothing
+   If the regex has no groups, it returns the original column name unchanged.
+regex_to_column_namer : Pattern -> Text -> (Integer -> Text | Nothing)
+regex_to_column_namer pattern original_column_name =
+    case pattern.group_count of
+        1 -> _-> original_column_name
+        _ ->
+            group_nums_to_names = pattern.group_nums_to_names
+            i-> case group_nums_to_names.contains_key i of
+                True -> group_nums_to_names.at i
+                False -> Nothing
 
 ## PRIVATE
    Transform a table by transforming a column into a set of columns. Takes a

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
@@ -81,16 +81,62 @@ fan_out_to_columns table input_column_id function column_count=Nothing on_proble
    - input_column: The column to transform.
    - function: A function that transforms a single element of `input_column`
      to multiple values.
-fan_out_to_rows : Table -> Text | Integer -> (Any -> Vector Any) -> Table
-fan_out_to_rows table input_column_id function =
+fan_out_to_rows : Table -> Text | Integer -> (Any -> Vector Any) -> Problem_Behavior -> Table
+fan_out_to_rows table input_column_id function on_problems=Report_Error =
+
+## PRIVATE
+   Transform a column by applying the given function to the values in the
+   column. The function returns a `Vector` of `Vectors`. Each inner vector turns
+   into multiple new columns in a single row. Each inner vector within the outer
+   vector produces an output rows, so each row is duplicated, with each row
+   getting a distinct set of output values in place of the original input value.
+   The other column values are just duplicated.
+
+   ! Error Conditions
+
+     The inner vectors must all have the same number of values. The first output
+     value is used to determine the length, and the other output values must
+     have the same length. If a value is too short, it will be padded with
+     Nothing, and if it is too long, it will be truncated. In either case,
+     Column_Count_Mismatch will be added as a warning.
+
+   > Example
+   f("12 34 56") -> [[1, 2], [3, 4], [5, 6]]
+
+   foo | bar       | baz
+   ----+-----------+----
+     x | 12 34 56  |   y    ===>
+   ... | ...       | ...
+
+   foo | bar_1 | bar_2 | baz
+   ----+-------+-------+----
+     x |     1 |     2 |   y
+     x |     3 |     4 |   y
+     x |     5 |     6 |   y
+   ... | ...   | ...   | ...
+
+   Arguments:
+   - table: The table to transform.
+   - input_column: The column to transform.
+   - function: A function that transforms a single element of `input_column`
+     to multiple values.
+fan_out_to_rows_and_columns : Table -> Text | Integer -> (Any -> Vector Any) -> Problem_Behavior -> Table
+fan_out_to_rows_and_columns table input_column_id function on_problems=Report_Error =
+    problem_builder = Problem_Builder.new
+
     input_column = table.at input_column_id
     input_storage = input_column.java_column.getStorage
     num_input_rows = input_storage.size
 
+    num_output_columns = if input_column.length == 0 then 0 else
+        function (input_column.at 0) . length
+    IO.println "NOC"
+    IO.println num_output_columns
+
     # Guess that most of the time, we'll get at least one value for each input.
     initial_size = input_column.length
     # Accumulates the output of the output column values.
-    output_column_builder = make_string_builder initial_size
+    output_column_builders = Vector.new num_output_columns _-> make_string_builder initial_size
     # Accumulates repeated position indices for the order mask.
     order_mask_positions = Vector.new_builder initial_size
 
@@ -98,30 +144,36 @@ fan_out_to_rows table input_column_id function =
         input_value = input_storage.getItemBoxed i
         output_values = function input_value
         # Append each value.
-        output_values.each v-> output_column_builder.append v
+        output_values.each row_unchecked->
+            row = uniform_length row_unchecked problem_builder
+            row.each_with_index i-> v-> output_column_builders.at i . append v
         # Append n copies of the input row position, n = # of output values.
         repeat_each output_values.length <| order_mask_positions.append i
 
     # Build the output column
-    output_storage = output_column_builder.seal
-    output_column = Column.from_storage input_column_id output_storage
+    output_storages = output_column_builders map .seal
+    output_columns = output_storages.map_with_index i-> output_storage->
+        column_name = column_namer input_column_id i
+        Column.from_storage name output_storage
 
     # Build the order mask.
     order_mask = OrderMask.new (order_mask_positions.to_vector)
 
     # Build the other columns, and include the output_column while doing it.
-    new_columns = table.columns.map column->
+    new_columns_unflattened = table.columns.map column->
         case column.name == input_column_id of
             True ->
                 # Replace the input column with the output column.
-                output_column
+                output_columns
             False ->
                 # Build a new column from the old one with the mask
                 old_storage = column.java_column.getStorage
                 new_storage = old_storage.applyMask order_mask
-                Column.from_storage column.name new_storage
+                [Column.from_storage column.name new_storage]
+    new_columns = new_columns_unflattened.flatten
 
-    Table.new new_columns
+    new_table = Table.new new_columns
+    problem_builder.attach_problems_after on_problems new_table
 
 ## PRIVATE
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
@@ -63,7 +63,7 @@ parse_to_columns table input_column_id pattern="." case_sensitivity=Case_Sensiti
 
     column = table.at input_column_id
 
-    new_table = Value_Type.expect_text (column.value_type) related_column=column <|
+    new_table = Value_Type.expect_text column <|
         fan_out_to_rows_and_columns table input_column_id fun column_namer on_problems
     if parse_values then new_table.parse on_problems=on_problems else new_table
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
@@ -83,6 +83,11 @@ fan_out_to_columns table input_column_id function column_count=Nothing on_proble
      to multiple values.
 fan_out_to_rows : Table -> Text | Integer -> (Any -> Vector Any) -> Problem_Behavior -> Table
 fan_out_to_rows table input_column_id function on_problems=Report_Error =
+    ## Treat as a special case of fan_out_to_rows_and_columns with one column.
+       Wrap the provided function to convert each value to a singleton `Vector`.
+    wrapped_function x = function x . map y-> [y]
+    column_namer = _-> input_column_id
+    fan_out_to_rows_and_columns table input_column_id wrapped_function namer on_problems
 
 ## PRIVATE
    Transform a column by applying the given function to the values in the
@@ -120,9 +125,23 @@ fan_out_to_rows table input_column_id function on_problems=Report_Error =
    - input_column: The column to transform.
    - function: A function that transforms a single element of `input_column`
      to multiple values.
-fan_out_to_rows_and_columns : Table -> Text | Integer -> (Any -> Vector Any) -> Problem_Behavior -> Table
-fan_out_to_rows_and_columns table input_column_id function on_problems=Report_Error =
+   - column_namer: A function to name output columns. If Nothing, uses the
+     default namer, which appends an column index to the input column name. If
+     the provided namer returns Nothing, then the default namer is used in that
+     case as well.
+   - on_problems: Specifies the behavior when a problem occurs.
+fan_out_to_rows_and_columns : Table -> Text | Integer -> (Any -> Vector Any) -> (Integer -> String) -> Problem_Behavior -> Table
+fan_out_to_rows_and_columns table input_column_id function column_namer=Nothing on_problems=Report_Error =
     problem_builder = Problem_Builder.new
+
+    # Integer -> String
+    effective_column_namer = case namer of
+        # Use the default namer for all columns.
+        Nothing -> default_column_namer input_column_id
+        # Use the default if the provided namer returns Nothing
+        _ -> i-> case namer i of
+            Nothing -> default_column_namer input_column_id
+            name -> name
 
     input_column = table.at input_column_id
     input_storage = input_column.java_column.getStorage
@@ -145,7 +164,7 @@ fan_out_to_rows_and_columns table input_column_id function on_problems=Report_Er
         output_values = function input_value
         # Append each value.
         output_values.each row_unchecked->
-            row = uniform_length row_unchecked problem_builder
+            row = uniform_length num_output_columns row_unchecked problem_builder
             row.each_with_index i-> v-> output_column_builders.at i . append v
         # Append n copies of the input row position, n = # of output values.
         repeat_each output_values.length <| order_mask_positions.append i
@@ -153,7 +172,7 @@ fan_out_to_rows_and_columns table input_column_id function on_problems=Report_Er
     # Build the output column
     output_storages = output_column_builders map .seal
     output_columns = output_storages.map_with_index i-> output_storage->
-        column_name = column_namer input_column_id i
+        column_name = effective_column_namer input_column_id i
         Column.from_storage name output_storage
 
     # Build the order mask.
@@ -247,7 +266,7 @@ map_columns_to_multiple input_column function column_count problem_builder =
 
     # Build Columns.
     builders.map .seal . map_with_index i-> storage->
-        name = input_column.name + "_" + i.to_text
+        name = default_column_namer input_column.name i
         Column.from_storage name storage
 
 ## PRIVATE
@@ -286,3 +305,27 @@ handle_nothing function = x-> case x of
 ## PRIVATE
    Repeat a computation n times.
 repeat_each n ~action = 0.up_to n . each _-> action
+
+## PRIVATE
+   Name a column by appending an integer to a base column name
+default_column_namer : Text -> Integer -> Text
+default_column_namer base_name i = base_name + " " + i.to_text
+
+## PRIVATE
+   Pad or truncate a vector to be a specified length; if altered, report
+   it as a Column_Count_Mismatch warning.
+uniform_length : Integer -> Vector Any -> Problem_Builder -> Vector Any
+uniform_length target_length v problem_builder = if v.length == target_length then v else
+    problem = Column_Count_Mismatch.Error target_length v.length
+    problem_builder.report_other_warning problem
+    case v.length < target_length of
+        True ->
+            # Pad.
+            num_paddings = target_length - v.length
+            new_v = Vector.new_builder
+            new_v.append_vector_range v
+            num_paddings.each _-> new_v.append Nothing
+            new_v.to_vector
+        False ->
+            # Truncate.
+            v.take target_length

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Split_Tokenize.enso
@@ -63,12 +63,12 @@ parse_to_columns table input_column_id pattern="." case_sensitivity=Case_Sensiti
     pat = Regex.compile pattern case_insensitive=case_insensitive
 
     fun = handle_nothing (regex_parse_to_vectors pat)
-    column_namer = regex_to_column_namer pat input_column_id
+    column_names = regex_to_column_names pat input_column_id
 
     column = table.at input_column_id
 
     new_table = Value_Type.expect_text column <|
-        fan_out_to_rows_and_columns table input_column_id fun column_namer on_problems
+        fan_out_to_rows_and_columns table input_column_id fun column_names on_problems
     if parse_values then new_table.parse on_problems=on_problems else new_table
 
 ## PRIVATE
@@ -84,16 +84,29 @@ regex_parse_to_vectors pattern =
             _ -> matches.map match-> match.groups . drop 1
 
 ## PRIVATE
-   Create a column namer that uses regex group names, if any.
-   If the regex has no explicit groups, it returns the original column name
-   unchanged.
-regex_to_column_namer : Pattern -> Text -> (Integer -> Text | Nothing)
-regex_to_column_namer pattern original_column_name =
+   Generate column names for the output columns from a regex match.
+   If the regex has no explicit groups, it uses the original column name
+   unchanged; otherwise, it uses the group name if it exists, or the original
+   column name with a number.
+regex_to_column_names : Pattern -> Text -> Vector Text
+regex_to_column_names pattern original_column_name =
     case pattern.group_count of
-        1 -> _-> original_column_name
+        1 ->
+            [original_column_name]
         _ ->
             group_nums_to_names = pattern.group_nums_to_names
-            i-> group_nums_to_names.get (i+1)  # explicit groups start at 1
+
+            unnamed_group_numbers = 1.up_to pattern.group_count . filter i-> group_nums_to_names.contains_key i . not
+            group_number_to_column_name_suffix = Map.from_vector <| unnamed_group_numbers.zip (0.up_to unnamed_group_numbers.length)
+
+            Vector.new (pattern.group_count-1) i->
+                # explicit groups start at 1
+                case group_nums_to_names.get (i+1) of
+                    Nothing ->
+                        suffix = group_number_to_column_name_suffix.at (i+1)
+                        default_column_namer original_column_name suffix
+                    name : Text ->
+                        name
 
 ## PRIVATE
    Transform a table by transforming a column into a set of columns. Takes a
@@ -131,8 +144,8 @@ fan_out_to_rows table input_column_id function on_problems=Report_Error =
        column. Wrap the provided function to convert each value to a singleton
        `Vector`.
     wrapped_function x = function x . map y-> [y]
-    column_namer = _-> input_column_id
-    fan_out_to_rows_and_columns table input_column_id wrapped_function column_namer on_problems
+    column_names = [input_column_id]
+    fan_out_to_rows_and_columns table input_column_id wrapped_function column_names on_problems
 
 ## PRIVATE
    Transform a column by applying the given function to the values in the
@@ -144,13 +157,13 @@ fan_out_to_rows table input_column_id function on_problems=Report_Error =
 
    ! Error Conditions
 
-     The inner vectors must all have the same number of values. The first output
-     value is used to determine the length, and the other output values must
-     have the same length. If a value is too short, it will be padded with
-     Nothing, and if it is too long, it will be truncated. In either case,
-     Column_Count_Mismatch will be added as a warning. (It is expected that the
-     caller of this private method will ensure that the provided function will
-     produce inner vectors of the same length, but we check for it anyway.)
+     The inner vectors should all have the same number of values, which should
+     match the provided `column_names`. If a value is too short, it will be
+     padded with Nothing, and if it is too long, it will be truncated. In either
+     case, Column_Count_Mismatch will be added as a warning. (It is expected
+     that the caller of this private method will ensure that the provided
+     function will produce inner vectors of the correct length, but we check for
+     it anyway.)
 
    > Example
    f("12 34 56") -> [[1, 2], [3, 4], [5, 6]]
@@ -172,32 +185,18 @@ fan_out_to_rows table input_column_id function on_problems=Report_Error =
    - input_column: The column to transform.
    - function: A function that transforms a single element of `input_column`
      to a `Vector` of `Vector` of values.
-   - column_namer: A function to name output columns. If it is Nothing, uses the
-     default namer, which appends an column index to the input column name. If
-     the provided namer returns Nothing, then the default namer is used in that
-     case as well.
+   - column_names: The names for the generated columns.
    - on_problems: Specifies the behavior when a problem occurs.
-fan_out_to_rows_and_columns : Table -> Text | Integer -> (Any -> Vector (Vector Any)) -> (Integer -> Text | Nothing) -> Problem_Behavior -> Table
-fan_out_to_rows_and_columns table input_column_id function column_namer=Nothing on_problems=Report_Error =
+fan_out_to_rows_and_columns : Table -> Text | Integer -> (Any -> Vector (Vector Any)) -> Vector Text -> Problem_Behavior -> Table
+fan_out_to_rows_and_columns table input_column_id function column_names on_problems=Report_Error =
     problem_builder = Problem_Builder.new
     unique = Unique_Name_Strategy.new
-
-    # Integer -> String
-    effective_column_namer = case column_namer of
-        # Use the default namer for all columns.
-        Nothing -> default_column_namer input_column_id
-        # Use the default if the provided namer returns Nothing
-        _ -> i-> case column_namer i of
-            Nothing -> default_column_namer input_column_id i
-            name -> name
 
     input_column = table.at input_column_id
     input_storage = input_column.java_column.getStorage
     num_input_rows = input_storage.size
 
-    num_output_columns = if input_column.length == 0 then 0 else
-        output_value = function (input_column.at 0)
-        if output_value.is_empty then 0 else output_value.at 0 . length
+    num_output_columns = column_names.length
 
     # Guess that most of the time, we'll get at least one value for each input.
     initial_size = input_column.length
@@ -223,7 +222,7 @@ fan_out_to_rows_and_columns table input_column_id function column_namer=Nothing 
     # Build the output column
     output_storages = output_column_builders.map .seal
     output_columns = output_storages.map_with_index i-> output_storage->
-        column_name = unique.make_unique <| effective_column_namer i
+        column_name = unique.make_unique <| column_names.at i
         Column.from_storage column_name output_storage
 
     # Build the order mask.

--- a/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
@@ -14,7 +14,7 @@ spec =
             cols = [["foo", [0, 1, 2]], ["bar", ["abc", "cbdbef", "ghbijbu"]]]
             t = Table.new cols
             expected_rows = [[0, "a", "c", Nothing], [1, "c", "d", "ef"], [2, "gh", "ij", "u"]]
-            expected = Table.from_rows ["foo", "bar_0", "bar_1", "bar_2"] expected_rows
+            expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2"] expected_rows
             t2 = t.split_to_columns "bar" "b"
             t2.should_equal_verbose expected
 
@@ -30,7 +30,7 @@ spec =
             cols = [["foo", [0, 1, 2, 3]], ["bar", ["abc", "cbdbef", Nothing, "ghbijbu"]]]
             t = Table.new cols
             expected_rows = [[0, "a", "c", Nothing], [1, "c", "d", "ef"], [2, Nothing, Nothing, Nothing], [3, "gh", "ij", "u"]]
-            expected = Table.from_rows ["foo", "bar_0", "bar_1", "bar_2"] expected_rows
+            expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2"] expected_rows
             t2 = t.split_to_columns "bar" "b"
             t2.should_equal_verbose expected
 
@@ -47,7 +47,7 @@ spec =
             cols = [["foo", [0, 1, 2]], ["bar", ["a12b34r5", "23", "2r4r55"]]]
             t = Table.new cols
             expected_rows = [[0, "12", "34", "5"], [1, "23", Nothing, Nothing], [2, "2", "4", "55"]]
-            expected = Table.from_rows ["foo", "bar_0", "bar_1", "bar_2"] expected_rows
+            expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2"] expected_rows
             t2 = t.tokenize_to_columns "bar" "\d+"
             t2.should_equal_verbose expected
 
@@ -63,7 +63,7 @@ spec =
             cols = [["foo", [0, 1, 2, 3]], ["bar", ["a12b34r5", Nothing, "23", "2r4r55"]]]
             t = Table.new cols
             expected_rows = [[0, "12", "34", "5"], [1, Nothing, Nothing, Nothing], [2, "23", Nothing, Nothing], [3, "2", "4", "55"]]
-            expected = Table.from_rows ["foo", "bar_0", "bar_1", "bar_2"] expected_rows
+            expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2"] expected_rows
             t2 = t.tokenize_to_columns "bar" "\d+"
             t2.should_equal_verbose expected
 
@@ -87,7 +87,7 @@ spec =
             cols = [["foo", [0, 1]], ["bar", ["r a-1, b-12,qd-50", "ab-10:bc-20c"]]]
             t = Table.new cols
             expected_rows = [[0, "a1", "b12", "d50"], [1, "b10", "c20", Nothing]]
-            expected = Table.from_rows ["foo", "bar_0", "bar_1", "bar_2"] expected_rows
+            expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2"] expected_rows
             t2 = t.tokenize_to_columns "bar" "([a-z]).(\d+)"
             t2.should_equal_verbose expected
 
@@ -103,7 +103,7 @@ spec =
             cols = [["foo", [0, 1, 2]], ["bar", ["aBqcE", "qcBr", "cCb"]]]
             t = Table.new cols
             expected_rows = [[0, "B", "c", Nothing], [1, "c", "B", Nothing], [2, "c", "C", "b"]]
-            expected = Table.from_rows ["foo", "bar_0", "bar_1", "bar_2"] expected_rows
+            expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2"] expected_rows
             t2 = t.tokenize_to_columns "bar" "[bc]" case_sensitivity=Case_Sensitivity.Insensitive
             t2.should_equal_verbose expected
 
@@ -120,16 +120,16 @@ spec =
             cols = [["foo", [0, 1, 2]], ["bar", ["abc", "cbdbef", "ghbijbu"]]]
             t = Table.new cols
             expected_rows = [[0, "a", "c", Nothing, Nothing], [1, "c", "d", "ef", Nothing], [2, "gh", "ij", "u", Nothing]]
-            expected = Table.from_rows ["foo", "bar_0", "bar_1", "bar_2", "bar_3"] expected_rows
+            expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2", "bar 3"] expected_rows
             t2 = t.split_to_columns "bar" "b" column_count=4
             t2.should_equal_verbose expected
-            t2.at "bar_3" . value_type . is_text . should_be_true
+            t2.at "bar 3" . value_type . is_text . should_be_true
 
         Test.specify "split should limit columns and return problems when exceeding the column limit" <|
             cols = [["foo", [0, 1, 2]], ["bar", ["abc", "cbdbef", "ghbijbu"]]]
             t = Table.new cols
             expected_rows = [[0, "a", "c"], [1, "c", "d"], [2, "gh", "ij"]]
-            expected = Table.from_rows ["foo", "bar_0", "bar_1"] expected_rows
+            expected = Table.from_rows ["foo", "bar 0", "bar 1"] expected_rows
             action = t.split_to_columns "bar" "b" column_count=2 on_problems=_
             tester = t-> t.should_equal_verbose expected
             problems = [Column_Count_Exceeded.Error 2 3]
@@ -139,7 +139,7 @@ spec =
             cols = [["foo", [0, 1]], ["bar", ["r a-1, b-12,qd-50", "ab-10:bc-20c"]]]
             t = Table.new cols
             expected_rows = [[0, "a1", "b12", "d50"], [1, "b10", "c20", Nothing]]
-            expected = Table.from_rows ["foo", "bar_0", "bar_1"] expected_rows
+            expected = Table.from_rows ["foo", "bar 0", "bar 1"] expected_rows
             action = t.tokenize_to_columns "bar" "([a-z]).(\d+)" column_count=2 on_problems=_
             tester = t-> t.should_equal_verbose expected
             problems = [Column_Count_Exceeded.Error 2 3]
@@ -149,10 +149,10 @@ spec =
             cols = [["foo", [0, 1, 2]], ["bar", ["ghbijbu", "cbdbef", "abc"]]]
             t = Table.new cols
             expected_rows = [[0, "gh", "ij", "u", Nothing], [1, "c", "d", "ef", Nothing], [2, "a", "c", Nothing, Nothing]]
-            expected = Table.from_rows ["foo", "bar_0", "bar_1", "bar_2", "bar_3"] expected_rows
+            expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2", "bar 3"] expected_rows
             t2 = t.split_to_columns "bar" "b" column_count=4
             t2.should_equal_verbose expected
-            t2.at "bar_3" . value_type . is_text . should_be_true
+            t2.at "bar 3" . value_type . is_text . should_be_true
 
     Test.group "Table.split/tokenize errors" <|
         Test.specify "won't work on a non-text column" <|
@@ -183,23 +183,23 @@ spec =
 
     Test.group "Table.split/tokenize name conflicts" <|
         Test.specify "split will make column names unique" <|
-            cols = [["foo", [0, 1, 2]], ["bar", ["abc", "cbdbef", "ghbijbu"]], ["bar_1", ["a", "b", "c"]]]
+            cols = [["foo", [0, 1, 2]], ["bar", ["abc", "cbdbef", "ghbijbu"]], ["bar 1", ["a", "b", "c"]]]
             t = Table.new cols
             expected_rows = [[0, "a", "c", Nothing, "a"], [1, "c", "d", "ef", "b"], [2, "gh", "ij", "u", "c"]]
-            expected = Table.from_rows ["foo", "bar_0", "bar_1_1", "bar_2", "bar_1"] expected_rows
+            expected = Table.from_rows ["foo", "bar 0", "bar 1_1", "bar 2", "bar 1"] expected_rows
             action = t.split_to_columns "bar" "b" on_problems=_
             tester = t-> t.should_equal_verbose expected
-            problems = [Duplicate_Output_Column_Names.Error ["bar_1"]]
+            problems = [Duplicate_Output_Column_Names.Error ["bar 1"]]
             Problems.test_problem_handling action problems tester
 
         Test.specify "tokenize will make column names unique" <|
-            cols = [["foo", [0, 1, 2]], ["bar", ["a12b34r5", "23", "2r4r55"]], ["bar_1", ["a", "b", "c"]]]
+            cols = [["foo", [0, 1, 2]], ["bar", ["a12b34r5", "23", "2r4r55"]], ["bar 1", ["a", "b", "c"]]]
             t = Table.new cols
             expected_rows = [[0, "12", "34", "5", "a"], [1, "23", Nothing, Nothing, "b"], [2, "2", "4", "55", "c"]]
-            expected = Table.from_rows ["foo", "bar_0", "bar_1_1", "bar_2", "bar_1"] expected_rows
+            expected = Table.from_rows ["foo", "bar 0", "bar 1_1", "bar 2", "bar 1"] expected_rows
             action = t.tokenize_to_columns "bar" "\d+"  on_problems=_
             tester = t-> t.should_equal_verbose expected
-            problems = [Duplicate_Output_Column_Names.Error ["bar_1"]]
+            problems = [Duplicate_Output_Column_Names.Error ["bar 1"]]
             Problems.test_problem_handling action problems tester
 
     Test.group "Table.split/tokenize column order" <|
@@ -207,7 +207,7 @@ spec =
             cols = [["foo", [0, 1, 2]], ["bar", ["abc", "cbdbef", "ghbijbu"]], ["baz", [1, 2, 3]]]
             t = Table.new cols
             expected_rows = [[0, "a", "c", Nothing, 1], [1, "c", "d", "ef", 2], [2, "gh", "ij", "u", 3]]
-            expected = Table.from_rows ["foo", "bar_0", "bar_1", "bar_2", "baz"] expected_rows
+            expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2", "baz"] expected_rows
             t2 = t.split_to_columns "bar" "b"
             t2.should_equal_verbose expected
 

--- a/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
@@ -218,6 +218,12 @@ spec =
             actual = t.parse_to_columns "bar" "(\d)(\d)"
             actual.should_equal_verbose expected
 
+        Test.specify "can parse to columns, with no regex groups" <|
+            t = Table.from_rows ["foo", "bar", "baz"] [["x", "12 34p q56", "y"], ["xx", "a48 59b", "yy"]]
+            expected = Table.from_rows ["foo", "bar", "baz"] [["x", 12, "y"], ["x", 34, "y"], ["x", 56, "y"], ["xx", 48, "yy"], ["xx", 59, "yy"]]
+            actual = t.parse_to_columns "bar" "\d\d"
+            actual.should_equal_verbose expected
+
         Test.specify "can parse to columns (no post-parsing)" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "12 34p q56", "y"], ["xx", "a48 59b", "yy"]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1", "baz"] [["x", "1", "2", "y"], ["x", "3", "4", "y"], ["x", "5", "6", "y"], ["xx", "4", "8", "yy"], ["xx", "5", "9", "yy"]]

--- a/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
@@ -260,6 +260,24 @@ spec =
             actual = t.parse_to_columns "bar" "(?<bar>\d)(?<baz>\d)(?<quux>\d)"
             actual.should_equal_verbose expected
 
+        Test.specify "empty table" <|
+            t = Table.from_rows ["foo", "bar", "baz"] [["x", "a", "y"]] . take 0
+            expected = Table.from_rows ["foo", "bar", "baz"] []
+            actual = t.parse_to_columns "bar" "\d+"
+            actual.should_equal_verbose expected
+
+        Test.specify "empty table, with regex groups" <|
+            t = Table.from_rows ["foo", "bar", "baz"] [["x", "a", "y"]] . take 0
+            expected = Table.from_rows ["foo", "bar 0", "bar 1", "baz"] [["x", "a", "a", "y"]] . take 0
+            actual = t.parse_to_columns "bar" "(\d)(\d)"
+            actual.should_equal_verbose expected
+
+        Test.specify "empty table, with named and unnamed regex groups" <|
+            t = Table.from_rows ["foo", "bar", "baz"] [["x", "a", "y"]] . take 0
+            expected = Table.from_rows ["foo", "quux", "bar 0", "foo_1", "bar 1", "baz"] [["x", "a", "a", "a", "a", "y"]] . take 0
+            actual = t.parse_to_columns "bar" "(?<quux>)(\d)(?<foo>\d)(\d)"
+            actual.should_equal_verbose expected
+
         Test.specify "input with no matches" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "a", "y"]]
             expected = Table.from_rows ["foo", "bar", "baz"] []

--- a/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
@@ -211,4 +211,11 @@ spec =
             t2 = t.split_to_columns "bar" "b"
             t2.should_equal_verbose expected
 
+    Test.group "Table.parse_to_columns" <|
+        Test.specify "can parse to columns" <|
+            t = Table.from_rows ["foo", "bar", "baz"] [["x", "12 34p q56", "y"], ["xx", "a48 59b", "yy"]]
+            expected = Table.from_rows ["foo", "bar 0", "bar 1", "baz"] [["x", "1", "2", "y"], ["x", "3", "4", "y"], ["x", "5", "6", "y"], ["xx", "4", "8", "yy"], ["xx", "5", "9", "yy"]]
+            actual = t.parse_to_columns "bar" "(\d)(\d)"
+            actual.should_equal_verbose expected
+
 main = Test_Suite.run_main spec

--- a/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
@@ -248,12 +248,6 @@ spec =
             actual = t.parse_to_columns "bar" "(\d)(\d)" parse_values=False
             actual.should_equal_verbose expected
 
-        Test.specify "no matches" <|
-            t = Table.from_rows ["foo", "bar", "baz"] [["x", "12 34p q56", "y"], ["xx", "a48 59b", "yy"]]
-            expected = Table.from_rows ["foo", "baz"] []
-            actual = t.parse_to_columns "bar" "asdf"
-            actual.should_equal_verbose expected
-
         Test.specify "column name clash" <|
             t = Table.from_rows ["foo", "bar", "bar 1"] [["x", "12 34p q56", "y"], ["xx", "a48 59b", "yy"]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1_1", "bar 1"] [["x", 1, 2, "y"], ["x", 3, 4, "y"], ["x", 5, 6, "y"], ["xx", 4, 8, "yy"], ["xx", 5, 9, "yy"]]
@@ -264,6 +258,24 @@ spec =
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "123", "y"]]
             expected = Table.from_rows ["foo", "bar", "baz_1", "quux", "baz"] [["x", 1, 2, 3, "y"]]
             actual = t.parse_to_columns "bar" "(?<bar>\d)(?<baz>\d)(?<quux>\d)"
+            actual.should_equal_verbose expected
+
+        Test.specify "input with no matches" <|
+            t = Table.from_rows ["foo", "bar", "baz"] [["x", "a", "y"]]
+            expected = Table.from_rows ["foo", "bar", "baz"] []
+            actual = t.parse_to_columns "bar" "\d+"
+            actual.should_equal_verbose expected
+
+        Test.specify "input with no matches, with regex groups" <|
+            t = Table.from_rows ["foo", "bar", "baz"] [["x", "a", "y"]]
+            expected = Table.from_rows ["foo", "bar 0", "bar 1", "baz"] []
+            actual = t.parse_to_columns "bar" "(\d)(\d)"
+            actual.should_equal_verbose expected
+
+        Test.specify "input with no matches, with named and unnamed regex groups" <|
+            t = Table.from_rows ["foo", "bar", "baz"] [["x", "a", "y"]]
+            expected = Table.from_rows ["foo", "quux", "bar 0", "foo_1", "bar 1", "baz"] []
+            actual = t.parse_to_columns "bar" "(?<quux>)(\d)(?<foo>\d)(\d)"
             actual.should_equal_verbose expected
 
 main = Test_Suite.run_main spec

--- a/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
@@ -248,4 +248,10 @@ spec =
             actual = t.parse_to_columns "bar" "(\d)(\d)" parse_values=False
             actual.should_equal_verbose expected
 
+        Test.specify "no matches" <|
+            t = Table.from_rows ["foo", "bar", "baz"] [["x", "12 34p q56", "y"], ["xx", "a48 59b", "yy"]]
+            expected = Table.from_rows ["foo", "baz"] []
+            actual = t.parse_to_columns "bar" "asdf"
+            actual.should_equal_verbose expected
+
 main = Test_Suite.run_main spec

--- a/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
@@ -254,4 +254,10 @@ spec =
             actual = t.parse_to_columns "bar" "asdf"
             actual.should_equal_verbose expected
 
+        Test.specify "column name clash" <|
+            t = Table.from_rows ["foo", "bar", "bar 1"] [["x", "12 34p q56", "y"], ["xx", "a48 59b", "yy"]]
+            expected = Table.from_rows ["foo", "bar 0", "bar 1_1", "bar 1"] [["x", 1, 2, "y"], ["x", 3, 4, "y"], ["x", 5, 6, "y"], ["xx", 4, 8, "yy"], ["xx", 5, 9, "yy"]]
+            actual = t.parse_to_columns "bar" "(\d)(\d)"
+            actual.should_equal_verbose expected
+
 main = Test_Suite.run_main spec

--- a/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
@@ -218,13 +218,31 @@ spec =
             actual = t.parse_to_columns "bar" "(\d)(\d)"
             actual.should_equal_verbose expected
 
-        Test.specify "can parse to columns, with no regex groups" <|
+        Test.specify "no regex groups" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "12 34p q56", "y"], ["xx", "a48 59b", "yy"]]
             expected = Table.from_rows ["foo", "bar", "baz"] [["x", 12, "y"], ["x", 34, "y"], ["x", 56, "y"], ["xx", 48, "yy"], ["xx", 59, "yy"]]
             actual = t.parse_to_columns "bar" "\d\d"
             actual.should_equal_verbose expected
 
-        Test.specify "can parse to columns (no post-parsing)" <|
+        Test.specify "named groups" <|
+            t = Table.from_rows ["foo", "bar", "baz"] [["x", "12 34p q56", "y"], ["xx", "a48 59b", "yy"]]
+            expected = Table.from_rows ["foo", "xomt", "biff", "baz"] [["x", 1, 2, "y"], ["x", 3, 4, "y"], ["x", 5, 6, "y"], ["xx", 4, 8, "yy"], ["xx", 5, 9, "yy"]]
+            actual = t.parse_to_columns "bar" "(?<xomt>\d)(?<biff>\d)"
+            actual.should_equal_verbose expected
+
+        Test.specify "non-participating groups" <|
+            t = Table.from_rows ["foo", "bar", "baz"] [["x", "q1", "y"], ["xx", "qp", "yy"]]
+            expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2", "baz"] [["x", "1", 1, Nothing, "y"], ["xx", "p", Nothing, "p", "yy"]]
+            actual = t.parse_to_columns "bar" "q((\d)|([a-z]))"
+            actual.should_equal_verbose expected
+
+        Test.specify "case-insensitive" <|
+            t = Table.from_rows ["foo", "bar", "baz"] [["x", "qq", "y"], ["xx", "qQ", "yy"]]
+            expected = Table.from_rows ["foo", "bar 0", "baz"] [["x", "q", "y"], ["xx", "Q", "yy"]]
+            actual = t.parse_to_columns "bar" "q(q)" case_sensitivity=Case_Sensitivity.Insensitive
+            actual.should_equal_verbose expected
+
+        Test.specify "no post-parsing" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "12 34p q56", "y"], ["xx", "a48 59b", "yy"]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1", "baz"] [["x", "1", "2", "y"], ["x", "3", "4", "y"], ["x", "5", "6", "y"], ["xx", "4", "8", "yy"], ["xx", "5", "9", "yy"]]
             actual = t.parse_to_columns "bar" "(\d)(\d)" parse_values=False

--- a/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
@@ -260,4 +260,10 @@ spec =
             actual = t.parse_to_columns "bar" "(\d)(\d)"
             actual.should_equal_verbose expected
 
+        Test.specify "column and group name clash" <|
+            t = Table.from_rows ["foo", "bar", "baz"] [["x", "123", "y"]]
+            expected = Table.from_rows ["foo", "bar", "baz_1", "quux", "baz"] [["x", 1, 2, 3, "y"]]
+            actual = t.parse_to_columns "bar" "(?<bar>\d)(?<baz>\d)(?<quux>\d)"
+            actual.should_equal_verbose expected
+
 main = Test_Suite.run_main spec

--- a/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
@@ -214,8 +214,14 @@ spec =
     Test.group "Table.parse_to_columns" <|
         Test.specify "can parse to columns" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "12 34p q56", "y"], ["xx", "a48 59b", "yy"]]
-            expected = Table.from_rows ["foo", "bar 0", "bar 1", "baz"] [["x", "1", "2", "y"], ["x", "3", "4", "y"], ["x", "5", "6", "y"], ["xx", "4", "8", "yy"], ["xx", "5", "9", "yy"]]
+            expected = Table.from_rows ["foo", "bar 0", "bar 1", "baz"] [["x", 1, 2, "y"], ["x", 3, 4, "y"], ["x", 5, 6, "y"], ["xx", 4, 8, "yy"], ["xx", 5, 9, "yy"]]
             actual = t.parse_to_columns "bar" "(\d)(\d)"
+            actual.should_equal_verbose expected
+
+        Test.specify "can parse to columns (no post-parsing)" <|
+            t = Table.from_rows ["foo", "bar", "baz"] [["x", "12 34p q56", "y"], ["xx", "a48 59b", "yy"]]
+            expected = Table.from_rows ["foo", "bar 0", "bar 1", "baz"] [["x", "1", "2", "y"], ["x", "3", "4", "y"], ["x", "5", "6", "y"], ["xx", "4", "8", "yy"], ["xx", "5", "9", "yy"]]
+            actual = t.parse_to_columns "bar" "(\d)(\d)" parse_values=False
             actual.should_equal_verbose expected
 
 main = Test_Suite.run_main spec


### PR DESCRIPTION
### Pull Request Description

Implement Table.parse_to_columns

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
