### PR TITLE
Replace Table should_equal with should_equal_verbose

### DIFF
--- a/test/Table_Tests/src/In_Memory/Parse_To_Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Parse_To_Table_Spec.enso
@@ -18,48 +18,48 @@ spec =
             expected = Table.from_rows ["Column"]
                                        [["a"], ["ab12"], ["bt100"], ["c12"], ["d20"], ["q"]]
             actual = "a 7 ab12 bt100 c12d20q 12".parse_to_table "[a-z]+\d*"
-            actual.should_equal_verbose expected
+            actual.should_equal expected
 
     Test.group "Text.parse_to_table with groups" <|
         Test.specify "with groups" <|
             expected = Table.from_rows ["Column 1", "Column 2"]
                                        [["ab", 12], ["bt", 100], ["c", 12], ["d", 20]]
             actual = "a 7 ab-12 bt-100 c-12d-20q q8 12".parse_to_table "([a-z]+)-(\d*)"
-            actual.should_equal_verbose expected
+            actual.should_equal expected
 
         Test.specify "with named groups" <|
             expected = Table.from_rows ["letters", "Column 2"]
                                        [["ab", 12], ["bt", 100], ["c", 12], ["d", 20]]
             actual = "a 7 ab-12 bt-100 c-12d-20q q8 12".parse_to_table "(?<letters>[a-z]+)-(\d*)"
-            actual.should_equal_verbose expected
+            actual.should_equal expected
 
     Test.group "Text.parse_to_table with case-insensitivity" <|
         Test.specify "case insensitivity" <|
             expected = Table.from_rows ["Column 1", "Column 2"]
                                        [["a", "B"], ["A", "b"], ["a", "b"], ["A", "B"]]
             actual = "xy aB Ab ab AB".parse_to_table "(a)(b)" case_sensitivity=Case_Sensitivity.Insensitive
-            actual.should_equal_verbose expected
+            actual.should_equal expected
 
     Test.group "Text.parse_to_table parsing" <|
         Test.specify "parsing on" <|
             expected = Table.from_rows ["Column 1", "Column 2"]
                                        [["ab", 12], ["bt", 100], ["c", 12], ["d", 20]]
             actual = "a 7 ab-12 bt-100 c-12d-20q q8 12".parse_to_table "([a-z]+)-(\d*)"
-            actual.should_equal_verbose expected
+            actual.should_equal expected
             actual.columns.map .value_type . should_equal [Value_Type.Char Nothing True, Value_Type.Integer Bits.Bits_64]
 
         Test.specify "parsing on, with a mixed column" <|
             expected = Table.from_rows ["Column 1", "Column 2"]
                                        [["ab", "12"], ["bt", "100"], ["c", "012"], ["d", "20"]]
             actual = "a 7 ab-12 bt-100 c-012d-20q q8 12".parse_to_table "([a-z]+)-(\d*)"
-            actual.should_equal_verbose expected
+            actual.should_equal expected
             actual.columns.map .value_type . should_equal [Value_Type.Char Nothing True, Value_Type.Char Nothing True]
 
         Test.specify "parsing off" <|
             expected = Table.from_rows ["Column 1", "Column 2"]
                                        [["ab", "12"], ["bt", "100"], ["c", "12"], ["d", "20"]]
             actual = "a 7 ab-12 bt-100 c-12d-20q q8 12".parse_to_table "([a-z]+)-(\d*)" parse_values=False
-            actual.should_equal_verbose expected
+            actual.should_equal expected
             actual.columns.map .value_type . should_equal [Value_Type.Char Nothing True, Value_Type.Char Nothing True]
 
     Test.group "Text.parse_to_table errors" <|

--- a/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
@@ -16,7 +16,7 @@ spec =
             expected_rows = [[0, "a", "c", Nothing], [1, "c", "d", "ef"], [2, "gh", "ij", "u"]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2"] expected_rows
             t2 = t.split_to_columns "bar" "b"
-            t2.should_equal_verbose expected
+            t2.should_equal expected
 
         Test.specify "can do split_to_rows" <|
             cols = [["foo", [0, 1, 2]], ["bar", ["abc", "cbdbef", "ghbijbu"]]]
@@ -24,7 +24,7 @@ spec =
             expected_rows = [[0, "a"], [0, "c"], [1, "c"], [1, "d"], [1, "ef"], [2, "gh"], [2, "ij"], [2, "u"]]
             expected = Table.from_rows ["foo", "bar"] expected_rows
             t2 = t.split_to_rows "bar" "b"
-            t2.should_equal_verbose expected
+            t2.should_equal expected
 
         Test.specify "can do split_to_columns with some Nothings" <|
             cols = [["foo", [0, 1, 2, 3]], ["bar", ["abc", "cbdbef", Nothing, "ghbijbu"]]]
@@ -32,7 +32,7 @@ spec =
             expected_rows = [[0, "a", "c", Nothing], [1, "c", "d", "ef"], [2, Nothing, Nothing, Nothing], [3, "gh", "ij", "u"]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2"] expected_rows
             t2 = t.split_to_columns "bar" "b"
-            t2.should_equal_verbose expected
+            t2.should_equal expected
 
         Test.specify "can do split_to_rows with some Nothings" <|
             cols = [["foo", [0, 1, 2, 3]], ["bar", ["abc", "cbdbef", Nothing, "ghbijbu"]]]
@@ -40,7 +40,7 @@ spec =
             expected_rows = [[0, "a"], [0, "c"], [1, "c"], [1, "d"], [1, "ef"], [3, "gh"], [3, "ij"], [3, "u"]]
             expected = Table.from_rows ["foo", "bar"] expected_rows
             t2 = t.split_to_rows "bar" "b"
-            t2.should_equal_verbose expected
+            t2.should_equal expected
 
     Test.group "Table.tokenize" <|
         Test.specify "can do tokenize_to_columns" <|
@@ -49,7 +49,7 @@ spec =
             expected_rows = [[0, "12", "34", "5"], [1, "23", Nothing, Nothing], [2, "2", "4", "55"]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2"] expected_rows
             t2 = t.tokenize_to_columns "bar" "\d+"
-            t2.should_equal_verbose expected
+            t2.should_equal expected
 
         Test.specify "can do tokenize_to_rows" <|
             cols = [["foo", [0, 1, 2]], ["bar", ["a12b34r5", "23", "2r4r55"]]]
@@ -57,7 +57,7 @@ spec =
             expected_rows = [[0, "12"], [0, "34"], [0, "5"], [1, "23"], [2, "2"], [2, "4"], [2, "55"]]
             expected = Table.from_rows ["foo", "bar"] expected_rows
             t2 = t.tokenize_to_rows "bar" "\d+"
-            t2.should_equal_verbose expected
+            t2.should_equal expected
 
         Test.specify "can do tokenize_to_columns with some nothings" <|
             cols = [["foo", [0, 1, 2, 3]], ["bar", ["a12b34r5", Nothing, "23", "2r4r55"]]]
@@ -65,7 +65,7 @@ spec =
             expected_rows = [[0, "12", "34", "5"], [1, Nothing, Nothing, Nothing], [2, "23", Nothing, Nothing], [3, "2", "4", "55"]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2"] expected_rows
             t2 = t.tokenize_to_columns "bar" "\d+"
-            t2.should_equal_verbose expected
+            t2.should_equal expected
 
         Test.specify "can do tokenize_to_rows with some Nothings" <|
             cols = [["foo", [0, 1, 2, 3]], ["bar", ["a12b34r5", Nothing, "23", "2r4r55"]]]
@@ -73,7 +73,7 @@ spec =
             expected_rows = [[0, "12"], [0, "34"], [0, "5"], [2, "23"], [3, "2"], [3, "4"], [3, "55"]]
             expected = Table.from_rows ["foo", "bar"] expected_rows
             t2 = t.tokenize_to_rows "bar" "\d+"
-            t2.should_equal_verbose expected
+            t2.should_equal expected
 
         Test.specify "can do tokenize_to_rows with some rows that have no matches" <|
             cols = [["foo", [0, 1, 2, 3]], ["bar", ["a12b34r5", "23", "q", "2r4r55"]]]
@@ -81,7 +81,7 @@ spec =
             expected_rows = [[0, "12"], [0, "34"], [0, "5"], [1, "23"], [3, "2"], [3, "4"], [3, "55"]]
             expected = Table.from_rows ["foo", "bar"] expected_rows
             t2 = t.tokenize_to_rows "bar" "\d+"
-            t2.should_equal_verbose expected
+            t2.should_equal expected
 
         Test.specify "can do tokenize_to_columns with groups" <|
             cols = [["foo", [0, 1]], ["bar", ["r a-1, b-12,qd-50", "ab-10:bc-20c"]]]
@@ -89,7 +89,7 @@ spec =
             expected_rows = [[0, "a1", "b12", "d50"], [1, "b10", "c20", Nothing]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2"] expected_rows
             t2 = t.tokenize_to_columns "bar" "([a-z]).(\d+)"
-            t2.should_equal_verbose expected
+            t2.should_equal expected
 
         Test.specify "can do tokenize_to_rows with groups" <|
             cols = [["foo", [0, 1]], ["bar", ["r a-1, b-12,qd-50", "ab-10:bc-20c"]]]
@@ -97,7 +97,7 @@ spec =
             expected_rows = [[0, "a1"], [0, "b12"], [0, "d50"], [1, "b10"], [1, "c20"]]
             expected = Table.from_rows ["foo", "bar"] expected_rows
             t2 = t.tokenize_to_rows "bar" "([a-z]).(\d+)"
-            t2.should_equal_verbose expected
+            t2.should_equal expected
 
         Test.specify "can do tokenize_to_columns case-insensitively" <|
             cols = [["foo", [0, 1, 2]], ["bar", ["aBqcE", "qcBr", "cCb"]]]
@@ -105,7 +105,7 @@ spec =
             expected_rows = [[0, "B", "c", Nothing], [1, "c", "B", Nothing], [2, "c", "C", "b"]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2"] expected_rows
             t2 = t.tokenize_to_columns "bar" "[bc]" case_sensitivity=Case_Sensitivity.Insensitive
-            t2.should_equal_verbose expected
+            t2.should_equal expected
 
         Test.specify "can do tokenize_to_rows case-insensitively" <|
             cols = [["foo", [0, 1, 2]], ["bar", ["aBqcE", "qcBr", "cCb"]]]
@@ -113,7 +113,7 @@ spec =
             expected_rows = [[0, "B"], [0, "c"], [1, "c"], [1, "B"], [2, "c"], [2, "C"], [2, "b"]]
             expected = Table.from_rows ["foo", "bar"] expected_rows
             t2 = t.tokenize_to_rows "bar" "[bc]" case_sensitivity=Case_Sensitivity.Insensitive
-            t2.should_equal_verbose expected
+            t2.should_equal expected
 
     Test.group "Table.split/tokenize column count" <|
         Test.specify "should generate extra empty columns if column_count is set" <|
@@ -122,7 +122,7 @@ spec =
             expected_rows = [[0, "a", "c", Nothing, Nothing], [1, "c", "d", "ef", Nothing], [2, "gh", "ij", "u", Nothing]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2", "bar 3"] expected_rows
             t2 = t.split_to_columns "bar" "b" column_count=4
-            t2.should_equal_verbose expected
+            t2.should_equal expected
             t2.at "bar 3" . value_type . is_text . should_be_true
 
         Test.specify "split should limit columns and return problems when exceeding the column limit" <|
@@ -131,7 +131,7 @@ spec =
             expected_rows = [[0, "a", "c"], [1, "c", "d"], [2, "gh", "ij"]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1"] expected_rows
             action = t.split_to_columns "bar" "b" column_count=2 on_problems=_
-            tester = t-> t.should_equal_verbose expected
+            tester = t-> t.should_equal expected
             problems = [Column_Count_Exceeded.Error 2 3]
             Problems.test_problem_handling action problems tester
 
@@ -141,7 +141,7 @@ spec =
             expected_rows = [[0, "a1", "b12", "d50"], [1, "b10", "c20", Nothing]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1"] expected_rows
             action = t.tokenize_to_columns "bar" "([a-z]).(\d+)" column_count=2 on_problems=_
-            tester = t-> t.should_equal_verbose expected
+            tester = t-> t.should_equal expected
             problems = [Column_Count_Exceeded.Error 2 3]
             Problems.test_problem_handling action problems tester
 
@@ -151,7 +151,7 @@ spec =
             expected_rows = [[0, "gh", "ij", "u", Nothing], [1, "c", "d", "ef", Nothing], [2, "a", "c", Nothing, Nothing]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2", "bar 3"] expected_rows
             t2 = t.split_to_columns "bar" "b" column_count=4
-            t2.should_equal_verbose expected
+            t2.should_equal expected
             t2.at "bar 3" . value_type . is_text . should_be_true
 
     Test.group "Table.split/tokenize errors" <|
@@ -188,7 +188,7 @@ spec =
             expected_rows = [[0, "a", "c", Nothing, "a"], [1, "c", "d", "ef", "b"], [2, "gh", "ij", "u", "c"]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1_1", "bar 2", "bar 1"] expected_rows
             action = t.split_to_columns "bar" "b" on_problems=_
-            tester = t-> t.should_equal_verbose expected
+            tester = t-> t.should_equal expected
             problems = [Duplicate_Output_Column_Names.Error ["bar 1"]]
             Problems.test_problem_handling action problems tester
 
@@ -198,7 +198,7 @@ spec =
             expected_rows = [[0, "12", "34", "5", "a"], [1, "23", Nothing, Nothing, "b"], [2, "2", "4", "55", "c"]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1_1", "bar 2", "bar 1"] expected_rows
             action = t.tokenize_to_columns "bar" "\d+"  on_problems=_
-            tester = t-> t.should_equal_verbose expected
+            tester = t-> t.should_equal expected
             problems = [Duplicate_Output_Column_Names.Error ["bar 1"]]
             Problems.test_problem_handling action problems tester
 
@@ -209,91 +209,91 @@ spec =
             expected_rows = [[0, "a", "c", Nothing, 1], [1, "c", "d", "ef", 2], [2, "gh", "ij", "u", 3]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2", "baz"] expected_rows
             t2 = t.split_to_columns "bar" "b"
-            t2.should_equal_verbose expected
+            t2.should_equal expected
 
     Test.group "Table.parse_to_columns" <|
         Test.specify "can parse to columns" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "12 34p q56", "y"], ["xx", "a48 59b", "yy"]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1", "baz"] [["x", 1, 2, "y"], ["x", 3, 4, "y"], ["x", 5, 6, "y"], ["xx", 4, 8, "yy"], ["xx", 5, 9, "yy"]]
             actual = t.parse_to_columns "bar" "(\d)(\d)"
-            actual.should_equal_verbose expected
+            actual.should_equal expected
 
         Test.specify "no regex groups" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "12 34p q56", "y"], ["xx", "a48 59b", "yy"]]
             expected = Table.from_rows ["foo", "bar", "baz"] [["x", 12, "y"], ["x", 34, "y"], ["x", 56, "y"], ["xx", 48, "yy"], ["xx", 59, "yy"]]
             actual = t.parse_to_columns "bar" "\d\d"
-            actual.should_equal_verbose expected
+            actual.should_equal expected
 
         Test.specify "named groups" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "12 34p q56", "y"], ["xx", "a48 59b", "yy"]]
             expected = Table.from_rows ["foo", "xomt", "biff", "baz"] [["x", 1, 2, "y"], ["x", 3, 4, "y"], ["x", 5, 6, "y"], ["xx", 4, 8, "yy"], ["xx", 5, 9, "yy"]]
             actual = t.parse_to_columns "bar" "(?<xomt>\d)(?<biff>\d)"
-            actual.should_equal_verbose expected
+            actual.should_equal expected
 
         Test.specify "non-participating groups" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "q1", "y"], ["xx", "qp", "yy"]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1", "bar 2", "baz"] [["x", "1", 1, Nothing, "y"], ["xx", "p", Nothing, "p", "yy"]]
             actual = t.parse_to_columns "bar" "q((\d)|([a-z]))"
-            actual.should_equal_verbose expected
+            actual.should_equal expected
 
         Test.specify "case-insensitive" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "qq", "y"], ["xx", "qQ", "yy"]]
             expected = Table.from_rows ["foo", "bar 0", "baz"] [["x", "q", "y"], ["xx", "Q", "yy"]]
             actual = t.parse_to_columns "bar" "q(q)" case_sensitivity=Case_Sensitivity.Insensitive
-            actual.should_equal_verbose expected
+            actual.should_equal expected
 
         Test.specify "no post-parsing" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "12 34p q56", "y"], ["xx", "a48 59b", "yy"]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1", "baz"] [["x", "1", "2", "y"], ["x", "3", "4", "y"], ["x", "5", "6", "y"], ["xx", "4", "8", "yy"], ["xx", "5", "9", "yy"]]
             actual = t.parse_to_columns "bar" "(\d)(\d)" parse_values=False
-            actual.should_equal_verbose expected
+            actual.should_equal expected
 
         Test.specify "column name clash" <|
             t = Table.from_rows ["foo", "bar", "bar 1"] [["x", "12 34p q56", "y"], ["xx", "a48 59b", "yy"]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1_1", "bar 1"] [["x", 1, 2, "y"], ["x", 3, 4, "y"], ["x", 5, 6, "y"], ["xx", 4, 8, "yy"], ["xx", 5, 9, "yy"]]
             actual = t.parse_to_columns "bar" "(\d)(\d)"
-            actual.should_equal_verbose expected
+            actual.should_equal expected
 
         Test.specify "column and group name clash" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "123", "y"]]
             expected = Table.from_rows ["foo", "bar", "baz_1", "quux", "baz"] [["x", 1, 2, 3, "y"]]
             actual = t.parse_to_columns "bar" "(?<bar>\d)(?<baz>\d)(?<quux>\d)"
-            actual.should_equal_verbose expected
+            actual.should_equal expected
 
         Test.specify "empty table" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "a", "y"]] . take 0
             expected = Table.from_rows ["foo", "bar", "baz"] []
             actual = t.parse_to_columns "bar" "\d+"
-            actual.should_equal_verbose expected
+            actual.should_equal expected
 
         Test.specify "empty table, with regex groups" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "a", "y"]] . take 0
             expected = Table.from_rows ["foo", "bar 0", "bar 1", "baz"] [["x", "a", "a", "y"]] . take 0
             actual = t.parse_to_columns "bar" "(\d)(\d)"
-            actual.should_equal_verbose expected
+            actual.should_equal expected
 
         Test.specify "empty table, with named and unnamed regex groups" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "a", "y"]] . take 0
             expected = Table.from_rows ["foo", "quux", "bar 0", "foo_1", "bar 1", "baz"] [["x", "a", "a", "a", "a", "y"]] . take 0
             actual = t.parse_to_columns "bar" "(?<quux>)(\d)(?<foo>\d)(\d)"
-            actual.should_equal_verbose expected
+            actual.should_equal expected
 
         Test.specify "input with no matches" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "a", "y"]]
             expected = Table.from_rows ["foo", "bar", "baz"] []
             actual = t.parse_to_columns "bar" "\d+"
-            actual.should_equal_verbose expected
+            actual.should_equal expected
 
         Test.specify "input with no matches, with regex groups" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "a", "y"]]
             expected = Table.from_rows ["foo", "bar 0", "bar 1", "baz"] []
             actual = t.parse_to_columns "bar" "(\d)(\d)"
-            actual.should_equal_verbose expected
+            actual.should_equal expected
 
         Test.specify "input with no matches, with named and unnamed regex groups" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "a", "y"]]
             expected = Table.from_rows ["foo", "quux", "bar 0", "foo_1", "bar 1", "baz"] []
             actual = t.parse_to_columns "bar" "(?<quux>)(\d)(?<foo>\d)(\d)"
-            actual.should_equal_verbose expected
+            actual.should_equal expected
 
 main = Test_Suite.run_main spec

--- a/test/Table_Tests/src/Util.enso
+++ b/test/Table_Tests/src/Util.enso
@@ -7,15 +7,17 @@ import Standard.Test.Extensions
 
 polyglot java import org.enso.base_test_helpers.FileSystemHelper
 
-Table.should_equal self expected =
-    tables_equal t0 t1 =
-        same_headers = (t0.columns.map .name) == (t1.columns.map .name)
-        same_columns = (t0.columns.map .to_vector) == (t1.columns.map .to_vector)
-        same_headers && same_columns
-    equal = tables_equal self expected
-    if equal.not then
-        msg = 'Tables differ.\nActual:\n' + self.display + '\nExpected:\n' + expected.display
-        Test.fail msg
+Table.should_equal self expected = case expected of
+    _ : Table ->
+        tables_equal t0 t1 =
+            same_headers = (t0.columns.map .name) == (t1.columns.map .name)
+            same_columns = (t0.columns.map .to_vector) == (t1.columns.map .to_vector)
+            same_headers && same_columns
+        equal = tables_equal self expected
+        if equal.not then
+            msg = 'Tables differ.\nActual:\n' + self.display + '\nExpected:\n' + expected.display
+            Test.fail msg
+    _ -> Test.fail "Got a Table, but expected a "+expected.to_display_text
 
 Column.should_equal self expected =
     if self.name != expected.name then

--- a/test/Table_Tests/src/Util.enso
+++ b/test/Table_Tests/src/Util.enso
@@ -8,12 +8,6 @@ import Standard.Test.Extensions
 polyglot java import org.enso.base_test_helpers.FileSystemHelper
 
 Table.should_equal self expected =
-    self_cols = self.columns
-    that_cols = expected.columns
-    self_cols.map .name . should_equal (that_cols.map .name) frames_to_skip=1
-    self_cols.map .to_vector . should_equal (that_cols.map .to_vector) frames_to_skip=1
-
-Table.should_equal_verbose self expected =
     tables_equal t0 t1 =
         same_headers = (t0.columns.map .name) == (t1.columns.map .name)
         same_columns = (t0.columns.map .to_vector) == (t1.columns.map .to_vector)


### PR DESCRIPTION
### Pull Request Description

Table.should_equal_verbose shows the contents of the tables on failure; let's make this the standard comparison.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
