### PR TITLE
Fix disappearing cached shapes

### DIFF
--- a/lib/rust/ensogl/core/src/display/render/pass.rs
+++ b/lib/rust/ensogl/core/src/display/render/pass.rs
@@ -20,7 +20,9 @@ use crate::system::gpu::data::texture::class::TextureOps;
 pub trait Definition: CloneBoxedForDefinition + Debug + 'static {
     fn initialize(&mut self, _instance: &Instance) {}
     fn run(&mut self, _instance: &Instance, update_status: UpdateStatus);
-    fn is_screen_size_independent(&self) -> bool { false }
+    fn is_screen_size_independent(&self) -> bool {
+        false
+    }
 }
 
 clone_boxed!(Definition);

--- a/lib/rust/ensogl/core/src/display/render/pass.rs
+++ b/lib/rust/ensogl/core/src/display/render/pass.rs
@@ -170,7 +170,7 @@ impl OutputDefinition {
     /// Constructor of the RGBA u8 output with default texture parameters. It is the most popular
     /// option and you should use it to render colors with your passes.
     pub fn new_rgba<Name: Str>(name: Name) -> Self {
-        let internal_format = texture::Rgba;
+        let internal_format = texture::Rgba8;
         let item_type = texture::item_type::u8;
         let texture_parameters = default();
         OutputDefinition::new(name, internal_format, item_type, texture_parameters)

--- a/lib/rust/ensogl/core/src/display/render/pass.rs
+++ b/lib/rust/ensogl/core/src/display/render/pass.rs
@@ -20,6 +20,7 @@ use crate::system::gpu::data::texture::class::TextureOps;
 pub trait Definition: CloneBoxedForDefinition + Debug + 'static {
     fn initialize(&mut self, _instance: &Instance) {}
     fn run(&mut self, _instance: &Instance, update_status: UpdateStatus);
+    fn is_screen_size_independent(&self) -> bool { false }
 }
 
 clone_boxed!(Definition);

--- a/lib/rust/ensogl/core/src/display/render/pass.rs
+++ b/lib/rust/ensogl/core/src/display/render/pass.rs
@@ -217,3 +217,9 @@ impl Framebuffer {
         result
     }
 }
+
+impl Drop for Framebuffer {
+    fn drop(&mut self) {
+        self.context.delete_framebuffer(Some(&self.native));
+    }
+}

--- a/lib/rust/ensogl/core/src/display/render/passes/cache_shapes.rs
+++ b/lib/rust/ensogl/core/src/display/render/passes/cache_shapes.rs
@@ -115,6 +115,10 @@ impl pass::Definition for CacheShapesPass {
             }
         }
     }
+
+    fn is_screen_size_independent(&self) -> bool {
+        true
+    }
 }
 
 fn with_display_mode<R>(mode: DisplayModes, f: impl FnOnce() -> R) -> R {

--- a/lib/rust/ensogl/core/src/display/render/passes/cache_shapes.rs
+++ b/lib/rust/ensogl/core/src/display/render/passes/cache_shapes.rs
@@ -37,6 +37,7 @@ use crate::gui::component::AnyShapeView;
 pub struct CacheShapesPass {
     scene:               Scene,
     framebuffer:         Option<pass::Framebuffer>,
+    texture:             Option<crate::system::gpu::data::uniform::AnyTextureUniform>,
     #[derivative(Debug = "ignore")]
     shapes_to_render:    Vec<Rc<dyn AnyShapeView>>,
     /// Texture size in device pixels.
@@ -49,6 +50,7 @@ impl CacheShapesPass {
     pub fn new(scene: &Scene) -> Self {
         Self {
             framebuffer:         default(),
+            texture:             default(),
             shapes_to_render:    default(),
             layer:               Layer::new("Cached Shapes"),
             scene:               scene.clone_ref(),
@@ -88,6 +90,7 @@ impl pass::Definition for CacheShapesPass {
         let texture =
             instance.new_texture(&output, self.texture_size_device.x, self.texture_size_device.y);
         self.framebuffer = Some(instance.new_framebuffer(&[&texture]));
+        self.texture = Some(texture);
     }
 
     fn run(&mut self, instance: &Instance, _update_status: UpdateStatus) {

--- a/lib/rust/ensogl/core/src/system/gpu/data/texture/class.rs
+++ b/lib/rust/ensogl/core/src/system/gpu/data/texture/class.rs
@@ -58,9 +58,9 @@ impl Drop for TextureBindGuard {
 /// For more background see: https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Parameters {
-    /// Specifies the setting for the texture magnification filter (`Context::TEXTURE_MIN_FILTER`).
+    /// Specifies the setting for the texture minification filter (`Context::TEXTURE_MIN_FILTER`).
     pub min_filter: MinFilter,
-    /// Specifies the setting for the texture minification filter (`Context::TEXTURE_MAG_FILTER`).
+    /// Specifies the setting for the texture magnification filter (`Context::TEXTURE_MAG_FILTER`).
     pub mag_filter: MagFilter,
     /// Specifies the setting for the wrapping function for texture coordinate s
     /// (`Context::TEXTURE_WRAP_S`).
@@ -75,7 +75,7 @@ impl Parameters {
     pub fn apply_parameters(self, context: &Context) {
         let target = Context::TEXTURE_2D;
         context.tex_parameteri(*target, *Context::TEXTURE_MIN_FILTER, *self.min_filter as i32);
-        context.tex_parameteri(*target, *Context::TEXTURE_MIN_FILTER, *self.mag_filter as i32);
+        context.tex_parameteri(*target, *Context::TEXTURE_MAG_FILTER, *self.mag_filter as i32);
         context.tex_parameteri(*target, *Context::TEXTURE_WRAP_S, *self.wrap_s as i32);
         context.tex_parameteri(*target, *Context::TEXTURE_WRAP_T, *self.wrap_t as i32);
     }


### PR DESCRIPTION
### Pull Request Description

Fix cached-shapes disappearance when resizing window or moving to differently-shaped monitor (#6125).

The bug:
`CacheShapesPass` relied on old behavior of `display_object.update(..)`: The update used to be finished when the call returned, but now it spawns an asynchronous task. It is now necessary to schedule a task to update the layer's camera after the scene's display object update has propagated its transformation matrix to the pass's layer.

Additional optimization:
- Don't re-render cached shapes when the canvas size changes.

Some cleanups:
- Fix dangling GL texture objects.
- Fix GL framebuffer leak.
- Fix mixed-up GL texture parameters.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] ~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] ~Unit tests have been written where possible.~
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
