### PR TITLE
Proper handling of multiple list views.

### DIFF
--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -357,6 +357,7 @@ impl<T> Model<T> {
                 .set_size((24.0, 24.0))
                 .set_color(color::Rgba::new(0.0, 0.0, 0.0, 0.2));
         });
+        layout_with_icons.add_child(&add_elem_icon);
         Self { cursor, items, root, layout, layout_with_icons, gap, add_elem_icon }
     }
 }

--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -108,7 +108,7 @@ pub mod placeholder;
 /// If set to true, animations will be running slow. This is useful for debugging purposes.
 pub const DEBUG_ANIMATION_SLOWDOWN: bool = false;
 
-pub const DEBUG_PLACEHOLDERS_VIZ: bool = false;
+pub const DEBUG_PLACEHOLDERS_VIZ: bool = true;
 
 /// Spring factor for animations. If [`DEBUG_ANIMATION_SLOWDOWN`] is set to true, this value will be
 /// used for animation simulators.
@@ -516,7 +516,7 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
                         enabled.and_option_from(|| model.item_or_placeholder_index_to_index(gap))
                     })
                 })
-            );
+            ).on_change();
             index <= opt_index;
             enabled <- opt_index.is_some();
             pointer_style <- enabled.then_constant(cursor::Style::plus());

--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -929,10 +929,6 @@ impl<T: display::Object + CloneRef + 'static> Model<T> {
     /// ```   
     fn start_item_drag_at(&mut self, index: ItemOrPlaceholderIndex) -> Option<T> {
         self.replace_item_with_placeholder(index)
-        //     .map(|item| {
-        //     // self.cursor.start_drag(item.clone_ref());
-        //     item
-        // })
     }
 
     fn replace_item_with_placeholder(&mut self, index: ItemOrPlaceholderIndex) -> Option<T> {

--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -905,7 +905,7 @@ impl<T: display::Object + CloneRef + 'static> Model<T> {
     ///
     /// See docs of [`Self::start_item_drag_at`] for more information.
     fn start_item_drag(&mut self, target: &display::object::Instance) -> Option<(Index, T)> {
-        let objs = target.rev_parent_chain();
+        let objs = target.rev_parent_chain().reversed();
         let tarrget_index = objs.into_iter().find_map(|t| self.item_index_of(&t));
         if let Some((index, index_or_placeholder_index)) = tarrget_index {
             self.start_item_drag_at(index_or_placeholder_index).map(|item| (index, item))

--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -434,7 +434,7 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
                     *dragged_item_network.borrow_mut() = Some(subnet);
                 }
             });
-            trace dragged_item_offset;
+            // trace dragged_item_offset;
 
             this_bbox <- on_resized.map(|t| BoundingBox::from_size(*t));
             dragged_item_bbox <- all_with3(&dragged_item_size, &dragged_item_offset, &pos_on_move,
@@ -442,7 +442,8 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
             );
             // trace dragged_item_bbox;
             is_close2 <- all_with(&this_bbox, &dragged_item_bbox, |a, b| a.intersects(b));
-            trace is_close2;
+            dragged_item_bbox_center <- dragged_item_bbox.map(|bbox| bbox.center());
+            // trace is_close2;
         }
 
         self.init_add_and_remove();
@@ -458,9 +459,8 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
             on_up_dragging <- on_up.gate(&is_dragging);
         }
         let (is_trashing, trash_pointer_style) = self.init_trashing(&on_up, &drag_diff);
-        self.init_dropping(&on_up_dragging, &pos_on_move, &is_close2, &is_trashing);
-        let insert_pointer_style =
-            self.init_insertion_points(&on_up_dragging, &pos_on_move, &is_dragging);
+        self.init_dropping(&on_up_dragging, &dragged_item_bbox_center, &is_close2, &is_trashing);
+        let insert_pointer_style = self.init_insertion_points(&on_up, &pos_on_move, &is_dragging);
 
         frp::extend! { network
             cursor.frp.set_style_override <+ all [insert_pointer_style, trash_pointer_style].fold();
@@ -518,6 +518,7 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
             pointer_style <- enabled.then_constant(cursor::Style::plus());
             on_up_in_gap <- on_up.gate(&enabled);
             insert_in_gap <- index.sample(&on_up_in_gap);
+            trace on_up;
             frp.private.output.request_new_item <+ insert_in_gap.map(|t| Response::gui(*t));
         }
         pointer_style
@@ -653,7 +654,7 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
             // insert_index <- insert_index.sampled_gate_not(&is_trashing);
             insert_index <- insert_index.sampled_gate(&is_close);
 
-            _eval <- insert_index.trace_if(&frp.debug);
+            // _eval <- insert_index.trace_if(&frp.debug);
 
             eval_ on_far (model.collapse_all_placeholders());
             eval insert_index ((i) model.borrow_mut().add_insertion_point_if_type_match(*i));

--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -108,7 +108,7 @@ pub mod placeholder;
 /// If set to true, animations will be running slow. This is useful for debugging purposes.
 pub const DEBUG_ANIMATION_SLOWDOWN: bool = false;
 
-pub const DEBUG_PLACEHOLDERS_VIZ: bool = true;
+pub const DEBUG_PLACEHOLDERS_VIZ: bool = false;
 
 /// Spring factor for animations. If [`DEBUG_ANIMATION_SLOWDOWN`] is set to true, this value will be
 /// used for animation simulators.

--- a/lib/rust/ensogl/component/slider/src/model.rs
+++ b/lib/rust/ensogl/component/slider/src/model.rs
@@ -213,6 +213,9 @@ impl Model {
         self.background.set_x(size.x / 2.0);
         self.track.set_x(size.x / 2.0);
         self.value.set_x(size.x / 2.0);
+        self.background.set_y(size.y / 2.0);
+        self.track.set_y(size.y / 2.0);
+        self.value.set_y(size.y / 2.0);
     }
 
     /// Set the color of the slider track or thumb.

--- a/lib/rust/ensogl/core/src/data/bounding_box.rs
+++ b/lib/rust/ensogl/core/src/data/bounding_box.rs
@@ -55,6 +55,8 @@ impl BoundingBox {
         Self::from_corners(position - size / 2.0, position + size / 2.0)
     }
 
+    /// Constructor of the bounding box with left bottom corner placed at the origin and the given
+    /// size.
     pub fn from_size(size: Vector2) -> Self {
         Self::from_corners(Vector2::zeros(), size)
     }

--- a/lib/rust/ensogl/core/src/data/bounding_box.rs
+++ b/lib/rust/ensogl/core/src/data/bounding_box.rs
@@ -55,6 +55,10 @@ impl BoundingBox {
         Self::from_corners(position - size / 2.0, position + size / 2.0)
     }
 
+    pub fn from_size(size: Vector2) -> Self {
+        Self::from_corners(Vector2::zeros(), size)
+    }
+
     /// Check whether the given `pos` lies within the bounding box.
     pub fn contains(&self, pos: Vector2) -> bool {
         self.contains_x(pos.x) && self.contains_y(pos.y)

--- a/lib/rust/ensogl/core/src/gui/cursor.rs
+++ b/lib/rust/ensogl/core/src/gui/cursor.rs
@@ -363,10 +363,6 @@ impl Cursor {
             frp.set_style_override <+ should_trash.then_constant(Style::trash());
             perform_trash <- on_up.gate(&should_trash);
             eval_ perform_trash (model.trash_dragged_item());
-            // trace should_trash;
-
-            // eval drag_target_to_revoke ([] (t) t.revoke.emit(()));
-            // drag_target <+ frp.switch_drag_target.map(|(t, enabled)| enabled.as_some_from(|| t.clone()));
 
 
 

--- a/lib/rust/ensogl/core/src/gui/cursor.rs
+++ b/lib/rust/ensogl/core/src/gui/cursor.rs
@@ -748,6 +748,7 @@ impl Default for DragTargetModel {
 }
 
 
+
 // =============
 // === Trash ===
 // =============
@@ -764,6 +765,7 @@ mod trash {
         model: Rc<TrashModel<T>>,
     }
 
+    /// Internal representation of [`Trash`].
     #[derive(Debug)]
     pub struct TrashModel<T> {
         _frp: Frp,

--- a/lib/rust/ensogl/core/src/gui/cursor.rs
+++ b/lib/rust/ensogl/core/src/gui/cursor.rs
@@ -5,6 +5,7 @@ use crate::gui::style::*;
 use crate::prelude::*;
 
 use crate::application::command::FrpNetworkProvider;
+use crate::control::io::mouse;
 use crate::data::color;
 use crate::define_style;
 use crate::display;
@@ -200,6 +201,7 @@ crate::define_endpoints_2! {
     Input {
         set_style_override (Option<Style>),
         set_style (Style),
+        switch_drag_target((DragTarget, bool)),
     }
 
     Output {
@@ -209,7 +211,7 @@ crate::define_endpoints_2! {
          /// Change between the current and the previous scene position.
         scene_position_delta  (Vector3),
         start_drag (),
-        stop_drag()
+        stop_drag(),
     }
 }
 
@@ -230,11 +232,12 @@ pub struct CursorModel {
     pub port_selection: shape::View,
     pub style:          Rc<RefCell<Style>>,
     pub dragged_item:   Rc<RefCell<Option<(Box<dyn Any>, display::object::Instance)>>>,
+    frp:                WeakFrp,
 }
 
 impl CursorModel {
     /// Constructor.
-    pub fn new(scene: &Scene) -> Self {
+    pub fn new(scene: &Scene, frp: WeakFrp) -> Self {
         let scene = scene.clone_ref();
         let display_object = display::object::Instance::new();
         let dragged_elem = display::object::Instance::new();
@@ -251,7 +254,7 @@ impl CursorModel {
         port_selection_layer.add(&port_selection);
 
         let dragged_item = default();
-        Self { scene, display_object, dragged_elem, view, port_selection, style, dragged_item }
+        Self { scene, display_object, dragged_elem, view, port_selection, style, dragged_item, frp }
     }
 
     fn for_each_view(&self, f: impl Fn(&shape::View)) {
@@ -268,10 +271,11 @@ impl CursorModel {
 // ==============
 
 /// Cursor (mouse pointer) definition.
-#[derive(Clone, CloneRef, Debug)]
+#[derive(Clone, CloneRef, Debug, Deref)]
 #[allow(missing_docs)]
 pub struct Cursor {
     pub frp:   Frp,
+    #[deref]
     pub model: Rc<CursorModel>,
 }
 
@@ -280,7 +284,7 @@ impl Cursor {
     pub fn new(scene: &Scene) -> Self {
         let frp = Frp::new();
         let network = frp.network();
-        let model = CursorModel::new(scene);
+        let model = CursorModel::new(scene, frp.downgrade());
         let mouse = &scene.mouse.frp_deprecated;
 
         // === Animations ===
@@ -323,7 +327,51 @@ impl Cursor {
         let fade_out_spring = inactive_fade.spring() * 0.2;
         let fade_in_spring = inactive_fade.spring();
 
+        let on_up = scene.on_event::<mouse::Up>();
+
         frp::extend! { network
+
+            // === Drag Target ===
+
+            drag_target <- any_mut::<Option<DragTarget>>();
+            drag_target <+ frp.switch_drag_target.map2(&drag_target,
+                |(target, enabled), prev| {
+                    if let Some(prev) = prev.as_ref() {
+                        let new_target = *enabled && target != prev;
+                        let revoke_target = !enabled && target == prev;
+                        if new_target {
+                            prev.revoke.emit(());
+                            target.grant.emit(());
+                            Some(target.clone())
+                        } else if revoke_target {
+                            prev.revoke.emit(());
+                            None
+                        } else {
+                            Some(target.clone())
+                        }
+                    } else {
+                        target.grant.emit(());
+                        Some(target.clone())
+                    }
+                }
+            );
+
+            has_drag_target <- drag_target.map(|t| t.is_some()).on_change();
+            should_trash <- has_drag_target.map(f!([model] (has_drag_target) {
+                model.dragged_item.borrow().is_some() && !has_drag_target
+            }));
+            frp.set_style_override <+ should_trash.then_constant(Style::trash());
+            perform_trash <- on_up.gate(&should_trash);
+            eval_ perform_trash (model.trash_dragged_item());
+            // trace should_trash;
+
+            // eval drag_target_to_revoke ([] (t) t.revoke.emit(()));
+            // drag_target <+ frp.switch_drag_target.map(|(t, enabled)| enabled.as_some_from(|| t.clone()));
+
+
+
+            // === Press / Release ===
+
             eval press.value  ((v) model.for_each_view(|vw| vw.press.set(*v)));
             eval radius.value ((v) model.for_each_view(|vw| vw.radius.set(*v)));
             eval size.value   ([model] (v) {
@@ -537,16 +585,18 @@ impl Cursor {
         let model = Rc::new(model);
         Cursor { frp, model }
     }
+}
 
+impl CursorModel {
     /// Initialize item dragging. The provided item should implement [`display::Object`]. It will be
     /// stored in the cursor and moved around with it. You can retrieve the item back using the
     /// [`Self::stop_drag`] method or another similar one.
     pub fn start_drag<T: display::Object + 'static>(&self, target: T) {
-        if self.model.dragged_item.borrow().is_some() {
+        if self.dragged_item.borrow().is_some() {
             warn!("Can't start dragging an item because another item is already being dragged.");
         } else {
             let object = target.display_object().clone();
-            self.model.dragged_elem.add_child(&object);
+            self.dragged_elem.add_child(&object);
             let target_position = object.global_position().xy();
             let cursor_position = self.frp.scene_position.value().xy();
             object.set_xy(target_position - cursor_position);
@@ -554,8 +604,8 @@ impl Cursor {
             let scene = scene();
             let camera = scene.camera();
             let zoom = camera.zoom();
-            self.model.dragged_elem.set_scale_xy((zoom, zoom));
-            *self.model.dragged_item.borrow_mut() = Some((Box::new(target), object));
+            self.dragged_elem.set_scale_xy((zoom, zoom));
+            *self.dragged_item.borrow_mut() = Some((Box::new(target), object));
 
             self.frp.private.output.start_drag.emit(());
         }
@@ -564,24 +614,27 @@ impl Cursor {
     /// Remove the dragged item and return it as [`Any`]. If you want to retrieve the item if it is
     /// of a particular type, use the [`Self::stop_drag_if_is`] method instead.
     pub fn stop_drag(&self) -> Option<Box<dyn Any>> {
-        self.stop_drag_if_is()
+        let item_and_object = mem::take(&mut *self.dragged_item.borrow_mut());
+        if let Some((item, _)) = item_and_object {
+            self.stop_drag_internal();
+            Some(item)
+        } else {
+            warn!("Can't stop dragging an item because no item is being dragged.");
+            None
+        }
     }
 
     /// Check whether the dragged item is of a particular type. If it is, remove and return it.
     pub fn stop_drag_if_is<T: 'static>(&self) -> Option<T> {
-        if let Some((item, obj)) = mem::take(&mut *self.model.dragged_item.borrow_mut()) {
+        let item_and_object = mem::take(&mut *self.dragged_item.borrow_mut());
+        if let Some((item, obj)) = item_and_object {
             match item.downcast::<T>() {
                 Ok(item) => {
-                    let elems = self.model.dragged_elem.remove_all_children();
-                    let cursor_position = self.frp.scene_position.value().xy();
-                    for elem in &elems {
-                        elem.update_xy(|t| t + cursor_position);
-                    }
-                    self.frp.private.output.stop_drag.emit(());
+                    self.stop_drag_internal();
                     Some(*item)
                 }
                 Err(item) => {
-                    *self.model.dragged_item.borrow_mut() = Some((item, obj));
+                    *self.dragged_item.borrow_mut() = Some((item, obj));
                     None
                 }
             }
@@ -591,20 +644,37 @@ impl Cursor {
         }
     }
 
+    fn stop_drag_internal(&self) {
+        let elems = self.dragged_elem.remove_all_children();
+        let cursor_position = self.frp.scene_position.value().xy();
+        for elem in &elems {
+            elem.update_xy(|t| t + cursor_position);
+        }
+        self.frp.private.output.stop_drag.emit(());
+    }
+
     pub fn dragged_display_object(&self) -> Option<display::object::Instance> {
-        self.model.dragged_item.borrow().as_ref().map(|t| t.1.clone())
+        self.dragged_item.borrow().as_ref().map(|t| t.1.clone())
     }
 
     /// Check whether the dragged item is of a particular type.
     pub fn dragged_item_is<T: 'static>(&self) -> bool {
-        self.model.dragged_item.borrow().as_ref().map(|item| item.0.is::<T>()).unwrap_or(false)
+        self.dragged_item.borrow().as_ref().map(|item| item.0.is::<T>()).unwrap_or(false)
     }
 
     /// Check whether the dragged item is of a particular type. If it is, call the provided function
     /// on it's reference.
     pub fn with_dragged_item_if_is<T, Out>(&self, f: impl FnOnce(&T) -> Out) -> Option<Out>
     where T: 'static {
-        self.model.dragged_item.borrow().as_ref().and_then(|item| item.0.downcast_ref::<T>().map(f))
+        self.dragged_item.borrow().as_ref().and_then(|item| item.0.downcast_ref::<T>().map(f))
+    }
+
+    pub fn trash_dragged_item(&self) {
+        let obj = self.dragged_display_object();
+        if let Some(obj) = obj {
+            self.stop_drag();
+            self.dragged_elem.add_child(&Trash::new(obj));
+        }
     }
 }
 
@@ -613,3 +683,97 @@ impl display::Object for Cursor {
         &self.model.display_object
     }
 }
+
+
+#[derive(Debug, Clone, CloneRef, Deref, Default)]
+pub struct DragTarget {
+    model: Rc<DragTargetModel>,
+}
+
+impl DragTarget {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl PartialEq for DragTarget {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.model, &other.model)
+    }
+}
+
+#[derive(Debug)]
+pub struct DragTargetModel {
+    network:     frp::Network,
+    grant:       frp::Source,
+    revoke:      frp::Source,
+    pub granted: frp::Sampler<bool>,
+}
+
+impl DragTargetModel {
+    pub fn new() -> Self {
+        let network = frp::Network::new("DragTarget");
+        frp::extend! { network
+            grant <- source();
+            revoke <- source();
+            granted <- bool(&revoke, &grant).sampler();
+        }
+        DragTargetModel { network, grant, revoke, granted }
+    }
+}
+
+impl Default for DragTargetModel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+
+// =============
+// === Trash ===
+// =============
+
+mod trash {
+    use super::*;
+    crate::define_endpoints_2! {}
+
+    #[derive(Debug, CloneRef, Derivative)]
+    #[derivative(Clone(bound = ""))]
+    pub struct Trash<T> {
+        model: Rc<TrashModel<T>>,
+    }
+
+    #[derive(Debug)]
+    pub struct TrashModel<T> {
+        _frp: Frp,
+        elem: T,
+    }
+
+    impl<T: display::Object + 'static> Trash<T> {
+        pub fn new(elem: T) -> Self {
+            let self_ref = Rc::new(RefCell::new(None));
+            let _frp = Frp::new();
+            let display_object = elem.display_object();
+            let network = &_frp.network;
+            let scale_animation = Animation::<f32>::new_with_init(network, 1.0);
+            // scale_animation.simulator.update_spring(|s| s * DEBUG_ANIMATION_SPRING_FACTOR);
+            frp::extend! { network
+                eval scale_animation.value ((t) display_object.set_scale_xy(Vector2(*t,*t)));
+                eval_ scale_animation.on_end (self_ref.borrow_mut().take(););
+            }
+            scale_animation.target.emit(0.0);
+
+            let model = TrashModel { _frp, elem };
+            let model = Rc::new(model);
+            *self_ref.borrow_mut() = Some(model.clone());
+            Self { model }
+        }
+    }
+
+    impl<T: display::Object> display::Object for Trash<T> {
+        fn display_object(&self) -> &display::object::Instance {
+            self.model.elem.display_object()
+        }
+    }
+}
+pub use trash::Trash;

--- a/lib/rust/ensogl/examples/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/examples/list-editor/src/lib.rs
@@ -48,13 +48,8 @@ pub fn main() {
     run_once_initialized(run);
 }
 
-fn run() {
-    let app = Application::new("root");
-    let world = app.display.clone();
-    let scene = &world.default_scene;
-    let camera = scene.camera().clone_ref();
-    let navigator = Navigator::new(scene, &camera);
-    let vector_editor = ListEditor::new(&app.cursor);
+fn new_list_editor(app: &Application) -> ListEditor<slider::Slider> {
+    let list_editor = ListEditor::new(&app.cursor);
 
     let slider1 = app.new_view::<slider::Slider>();
     slider1.set_size((200.0, 24.0));
@@ -69,25 +64,42 @@ fn run() {
     let network = frp.network();
 
     frp::extend! { network
-        vector_editor.insert <+ vector_editor.request_new_item.map(move |index| {
+        list_editor.insert <+ list_editor.request_new_item.map(f!([app] (index) {
             let slider = app.new_view::<slider::Slider>();
             slider.set_size((200.0, 24.0));
             (**index, Rc::new(RefCell::new(Some(slider))))
-        });
+        }));
     }
 
-    vector_editor.push(slider1);
-    vector_editor.push(slider2);
-    vector_editor.push(slider3);
+    mem::forget(frp);
+    list_editor.push(slider1);
+    list_editor.push(slider2);
+    list_editor.push(slider3);
+    list_editor
+}
+
+fn run() {
+    let app = Application::new("root");
+    let world = app.display.clone();
+    let scene = &world.default_scene;
+    let camera = scene.camera().clone_ref();
+    let navigator = Navigator::new(scene, &camera);
+
+    let list_editor1 = new_list_editor(&app);
+    // let list_editor2 = new_list_editor(&app);
+    // list_editor2.set_y(50.0);
+
+    list_editor1.debug(true);
 
     let root = display::object::Instance::new();
     root.set_size(Vector2(300.0, 100.0));
-    root.add_child(&vector_editor);
+    root.add_child(&list_editor1);
+    // root.add_child(&list_editor2);
     world.add_child(&root);
 
     world.keep_alive_forever();
-    mem::forget(frp);
     mem::forget(navigator);
     mem::forget(root);
-    mem::forget(vector_editor);
+    mem::forget(list_editor1);
+    // mem::forget(list_editor2);
 }

--- a/lib/rust/ensogl/examples/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/examples/list-editor/src/lib.rs
@@ -25,7 +25,6 @@ use ensogl_core::prelude::*;
 
 use enso_frp as frp;
 use ensogl_core::application::Application;
-use ensogl_core::display;
 use ensogl_core::display::navigation::navigator::Navigator;
 use ensogl_list_editor::ListEditor;
 use ensogl_slider as slider;

--- a/lib/rust/ensogl/examples/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/examples/list-editor/src/lib.rs
@@ -90,11 +90,11 @@ fn run() {
     world.add_child(&list_editor1);
     mem::forget(list_editor1);
 
-    // let list_editor2 = new_list_editor(&app);
-    // list_editor2.set_y(50.0);
-    // world.add_child(&list_editor2);
-    // // list_editor2.debug(true);
-    // mem::forget(list_editor2);
+    let list_editor2 = new_list_editor(&app);
+    list_editor2.set_y(50.0);
+    world.add_child(&list_editor2);
+    // list_editor2.debug(true);
+    mem::forget(list_editor2);
 
     world.keep_alive_forever();
     mem::forget(navigator);

--- a/lib/rust/ensogl/examples/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/examples/list-editor/src/lib.rs
@@ -86,20 +86,16 @@ fn run() {
     let navigator = Navigator::new(scene, &camera);
 
     let list_editor1 = new_list_editor(&app);
+    list_editor1.debug(true);
+    world.add_child(&list_editor1);
+    mem::forget(list_editor1);
+
     // let list_editor2 = new_list_editor(&app);
     // list_editor2.set_y(50.0);
-
-    list_editor1.debug(true);
-
-    let root = display::object::Instance::new();
-    root.set_size(Vector2(300.0, 100.0));
-    root.add_child(&list_editor1);
-    // root.add_child(&list_editor2);
-    world.add_child(&root);
+    // world.add_child(&list_editor2);
+    // // list_editor2.debug(true);
+    // mem::forget(list_editor2);
 
     world.keep_alive_forever();
     mem::forget(navigator);
-    mem::forget(root);
-    mem::forget(list_editor1);
-    // mem::forget(list_editor2);
 }


### PR DESCRIPTION
### Pull Request Description

This PR improves how List Editor work, allowing multiple List Editors to co-exist:
1. It allows dragging items between list editors.
2. When there are no more items, it displays a button allowing adding new items.


https://user-images.githubusercontent.com/1623053/235414613-c063ee73-48ed-423d-80ff-d4528edbe474.mov


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
