### PR TITLE
Finishing Vector Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,9 @@
 - [Added capability to create node widgets with complex UI][6347]. Node widgets
   such as dropdown can now be placed in the node and affect the code text flow.
 - [The IDE UI element for selecting the execution mode of the project is now
-  sending messages to the backend.][6341].
+  sending messages to the backend][6341].
+- [List Editor Widget][6470]. Now you can edit lists by clicking buttons on
+  nodes or by dragging the elements.
 
 #### EnsoGL (rendering engine)
 
@@ -198,7 +200,8 @@
 [5895]: https://github.com/enso-org/enso/pull/6130
 [6035]: https://github.com/enso-org/enso/pull/6035
 [6097]: https://github.com/enso-org/enso/pull/6097
-[6097]: https://github.com/enso-org/enso/pull/6341
+[6341]: https://github.com/enso-org/enso/pull/6341
+[6470]: https://github.com/enso-org/enso/pull/6470
 
 #### Enso Standard Library
 

--- a/app/gui/language/ast/impl/src/lib.rs
+++ b/app/gui/language/ast/impl/src/lib.rs
@@ -623,6 +623,14 @@ impl<T> SpanSeed<T> {
     pub fn child(node: T) -> Self {
         Self::Child(SpanSeedChild { node })
     }
+
+    pub fn token(token: String) -> Self {
+        Self::Token(SpanSeedToken { token })
+    }
+
+    pub fn is_child(&self) -> bool {
+        matches!(self, SpanSeed::Child { .. })
+    }
 }
 
 

--- a/app/gui/language/span-tree/src/action.rs
+++ b/app/gui/language/span-tree/src/action.rs
@@ -316,7 +316,6 @@ impl<'a, T> Implementation for node::Ref<'a, T> {
                                 (None, None) => (-1, index..=index),
                             };
 
-                        warn!("insertion_point_offset: {insertion_point_offset}");
                         reinsert_crumbs =
                             Some(self.crumbs.relative_sibling(insertion_point_offset));
                         span_info.drain(removed_range);

--- a/app/gui/language/span-tree/src/generate.rs
+++ b/app/gui/language/span-tree/src/generate.rs
@@ -5,7 +5,6 @@ use enso_text::unit::*;
 
 use crate::generate::context::CalledMethodInfo;
 use crate::node;
-use crate::node::InsertionPoint;
 use crate::node::InsertionPointType;
 use crate::node::Payload;
 use crate::ArgumentInfo;

--- a/app/gui/language/span-tree/src/generate.rs
+++ b/app/gui/language/span-tree/src/generate.rs
@@ -821,7 +821,7 @@ fn tree_generate_node<T: Payload>(
         let mut parent_offset = ByteDiff::from(0);
         let mut sibling_offset = ByteDiff::from(0);
         let first_token_or_child =
-            tree.span_info.iter().filter(|span| !matches!(span, SpanSeed::Space(_))).next();
+            tree.span_info.iter().find(|span| !matches!(span, SpanSeed::Space(_)));
         let is_array = matches!(first_token_or_child, Some(SpanSeed::Token(ast::SpanSeedToken { token })) if token == "[");
         let last_children_index =
             tree.span_info.iter().rposition(|span| matches!(span, SpanSeed::Child(_)));
@@ -852,7 +852,7 @@ fn tree_generate_node<T: Payload>(
                         sibling_offset = 0.byte_diff();
                     }
 
-                    let kind = node::Kind::argument();
+                    let kind = node::Kind::argument().with_removable(is_array);
                     let node = node.generate_node(kind, context)?;
                     let child_size = node.size;
                     let ast_crumbs = vec![TreeCrumb { index }.into()];

--- a/app/gui/language/span-tree/src/node.rs
+++ b/app/gui/language/span-tree/src/node.rs
@@ -255,6 +255,13 @@ impl Crumbs {
         vec.push(child);
         self
     }
+
+    /// Create crumbs to the sibling node, which is `offset` nodes away from the current node.
+    pub fn relative_sibling(&self, offset: isize) -> Self {
+        let mut vec = self.vec.deref().clone();
+        vec.last_mut().map(|last| *last = last.saturating_add_signed(offset));
+        Self { vec: Rc::new(vec) }
+    }
 }
 
 impl<T: IntoIterator<Item = Crumb>> From<T> for Crumbs {
@@ -391,7 +398,7 @@ impl<'a, T> Ref<'a, T> {
     }
 
     /// Iterator over all direct children producing `Ref`s.
-    pub fn children_iter(self) -> impl DoubleEndedIterator<Item = Ref<'a, T>> {
+    pub fn children_iter(self) -> impl DoubleEndedIterator<Item = Ref<'a, T>> + Clone {
         let children_count = self.node.children.len();
         (0..children_count).map(move |i| self.clone().child(i).unwrap())
     }

--- a/app/gui/language/span-tree/src/node.rs
+++ b/app/gui/language/span-tree/src/node.rs
@@ -259,7 +259,9 @@ impl Crumbs {
     /// Create crumbs to the sibling node, which is `offset` nodes away from the current node.
     pub fn relative_sibling(&self, offset: isize) -> Self {
         let mut vec = self.vec.deref().clone();
-        vec.last_mut().map(|last| *last = last.saturating_add_signed(offset));
+        if let Some(last) = vec.last_mut() {
+            *last = last.saturating_add_signed(offset)
+        }
         Self { vec: Rc::new(vec) }
     }
 }

--- a/app/gui/src/presenter/graph.rs
+++ b/app/gui/src/presenter/graph.rs
@@ -307,9 +307,7 @@ impl Model {
                         // If we are still using this edge (e.g. when dragging it), we need to
                         // update its target endpoint. Otherwise it will not reflect expression
                         // update performed on the target node.
-                        let edge = self.view.model.edges.get_cloned_ref(&id)?;
-                        let outdated_target = edge.target()?;
-                        edge.set_target(EdgeEndpoint::new(outdated_target.node_id, crumbs));
+                        self.view.replace_detached_edge_target((id, crumbs));
                         Some(())
                     });
                 }))

--- a/app/gui/src/presenter/graph.rs
+++ b/app/gui/src/presenter/graph.rs
@@ -300,7 +300,7 @@ impl Model {
                 let update = self.state.update_from_view();
                 let ast_to_remove = update.remove_connection(id)?;
                 Some(self.controller.disconnect(&ast_to_remove).map(|target_crumbs| {
-                    target_crumbs.and_then(|crumbs| {
+                    if let Some(crumbs) = target_crumbs {
                         trace!(
                             "Updating edge target after disconnecting it. New crumbs: {crumbs:?}"
                         );
@@ -308,8 +308,7 @@ impl Model {
                         // update its target endpoint. Otherwise it will not reflect expression
                         // update performed on the target node.
                         self.view.replace_detached_edge_target((id, crumbs));
-                        Some(())
-                    });
+                    };
                 }))
             },
             "delete connection",

--- a/app/gui/view/graph-editor/src/component/breadcrumbs.rs
+++ b/app/gui/view/graph-editor/src/component/breadcrumbs.rs
@@ -166,7 +166,7 @@ impl BreadcrumbsModel {
     pub fn new(app: Application, frp: &Frp) -> Self {
         let scene = &app.display.default_scene;
         let project_name = app.new_view();
-        let display_object = display::object::Instance::new();
+        let display_object = display::object::Instance::new_named("Breadcrumbs");
         let root = display::object::Instance::new();
         let breadcrumbs_container = display::object::Instance::new();
         let scene = scene.clone_ref();

--- a/app/gui/view/graph-editor/src/component/edge.rs
+++ b/app/gui/view/graph-editor/src/component/edge.rs
@@ -779,7 +779,7 @@ macro_rules! define_components {
             /// Constructor.
             #[allow(clippy::vec_init_then_push)]
             pub fn new() -> Self {
-                let display_object = display::object::Instance::new();
+                let display_object = display::object::Instance::new_named(stringify!($name));
                 $(let $field = <$field_type>::new();)*
                 $(display_object.add_child(&$field);)*
                 let mut shape_view_events:Vec<PointerTarget_DEPRECATED> = Vec::default();
@@ -1304,7 +1304,7 @@ impl EdgeModelData {
     /// Constructor.
     #[profile(Debug)]
     pub fn new(scene: &Scene, network: &frp::Network) -> Self {
-        let display_object = display::object::Instance::new();
+        let display_object = display::object::Instance::new_named("Edge");
         let front = Front::new();
         let back = Back::new();
         let joint = joint::View::new();

--- a/app/gui/view/graph-editor/src/component/node.rs
+++ b/app/gui/view/graph-editor/src/component/node.rs
@@ -513,7 +513,7 @@ impl NodeModel {
         let background = background::View::new();
         let drag_area = drag_area::View::new();
         let vcs_indicator = vcs::StatusIndicator::new(app);
-        let display_object = display::object::Instance::new();
+        let display_object = display::object::Instance::new_named("Node");
 
         display_object.add_child(&profiling_label);
         display_object.add_child(&drag_area);

--- a/app/gui/view/graph-editor/src/component/node/input/area.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/area.rs
@@ -277,7 +277,7 @@ impl Model {
     #[profile(Debug)]
     fn set_expression(&self, new_expression: impl Into<node::Expression>, area_frp: &FrpEndpoints) {
         let new_expression = Expression::from(new_expression.into());
-        debug!("Set expression: \n{:?}", new_expression.tree_pretty_printer());
+        warn!("Set expression: \n{:?}", new_expression.tree_pretty_printer());
 
         self.widget_tree.rebuild_tree(
             &new_expression.span_tree,

--- a/app/gui/view/graph-editor/src/component/node/input/area.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/area.rs
@@ -152,7 +152,7 @@ impl Model {
     #[profile(Debug)]
     pub fn new(app: &Application) -> Self {
         let app = app.clone_ref();
-        let display_object = display::object::Instance::new();
+        let display_object = display::object::Instance::new_named("input");
 
         let edit_mode_label = app.new_view::<text::Text>();
         let expression = default();

--- a/app/gui/view/graph-editor/src/component/node/input/area.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/area.rs
@@ -19,6 +19,7 @@ use enso_frp;
 use ensogl::application::Application;
 use ensogl::data::color;
 use ensogl::display;
+use ensogl::display::world::with_context;
 use ensogl::gui::cursor;
 use ensogl::Animation;
 use ensogl_component::text;
@@ -159,6 +160,7 @@ impl Model {
         let styles = StyleWatch::new(&app.display.default_scene.style_sheet);
         let styles_frp = StyleWatchFrp::new(&app.display.default_scene.style_sheet);
         let widget_tree = widget::Tree::new(&app);
+        with_context(|ctx| ctx.layers.widget.add(&widget_tree));
         Self { app, display_object, edit_mode_label, expression, styles, styles_frp, widget_tree }
             .init()
     }

--- a/app/gui/view/graph-editor/src/component/node/input/area.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/area.rs
@@ -279,7 +279,7 @@ impl Model {
     #[profile(Debug)]
     fn set_expression(&self, new_expression: impl Into<node::Expression>, area_frp: &FrpEndpoints) {
         let new_expression = Expression::from(new_expression.into());
-        warn!("Set expression: \n{:?}", new_expression.tree_pretty_printer());
+        debug!("Set expression: \n{:?}", new_expression.tree_pretty_printer());
 
         self.widget_tree.rebuild_tree(
             &new_expression.span_tree,

--- a/app/gui/view/graph-editor/src/component/node/input/port.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/port.rs
@@ -133,8 +133,8 @@ impl Port {
         port_shape.set_corner_radius_max().set_pointer_events(false);
         hover_shape.set_pointer_events(true).set_color(shape::INVISIBLE_HOVER_COLOR);
 
-        port_root.set_alignment_left_center().add_child(&widget_root);
-        widget_root.set_alignment_left_center().set_margin_left(0.0);
+        port_root.add_child(&widget_root);
+        widget_root.set_margin_left(0.0);
         port_shape
             .set_size_y(BASE_PORT_HEIGHT)
             .allow_grow()
@@ -239,7 +239,7 @@ impl Port {
             self.port_root.remove_child(&self.widget_root);
             self.port_root.add_child(new_root);
             self.widget_root = new_root.clone_ref();
-            self.widget_root.set_alignment_left_center().set_margin_left(0.0);
+            self.widget_root.set_margin_left(0.0);
         }
     }
 

--- a/app/gui/view/graph-editor/src/component/node/input/port.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/port.rs
@@ -126,15 +126,15 @@ impl Port {
     /// Create a new port for given widget. The widget will be placed as a child of the port's root
     /// display object, and its layout size will be used to determine the port's size.
     pub fn new(widget: DynWidget, app: &Application, frp: &WidgetsFrp) -> Self {
-        let port_root = display::object::Instance::new();
+        let port_root = display::object::Instance::new_named("Port");
         let widget_root = widget.root_object().clone_ref();
         let port_shape = PortShape::new();
         let hover_shape = HoverShape::new();
         port_shape.set_corner_radius_max().set_pointer_events(false);
         hover_shape.set_pointer_events(true).set_color(shape::INVISIBLE_HOVER_COLOR);
 
-        port_root.add_child(&widget_root);
-        widget_root.set_margin_left(0.0);
+        port_root.set_alignment_left_center().add_child(&widget_root);
+        widget_root.set_alignment_left_center().set_margin_left(0.0);
         port_shape
             .set_size_y(BASE_PORT_HEIGHT)
             .allow_grow()
@@ -239,6 +239,7 @@ impl Port {
             self.port_root.remove_child(&self.widget_root);
             self.port_root.add_child(new_root);
             self.widget_root = new_root.clone_ref();
+            self.widget_root.set_alignment_left_center().set_margin_left(0.0);
         }
     }
 

--- a/app/gui/view/graph-editor/src/component/node/input/port.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/port.rs
@@ -23,9 +23,13 @@ use ensogl::display::shape;
 // === Constants ===
 // =================
 
-/// The horizontal padding of ports. It affects how the port hover should extend the target text
+/// The horizontal padding of ports. It affects how the port shape should extend the target text
 /// boundary on both sides.
 pub const PORT_PADDING_X: f32 = 4.0;
+
+/// The horizontal padding of port hover areas. It affects how the port hover should extend the
+/// target text boundary on both sides.
+pub const HOVER_PADDING_X: f32 = 2.0;
 
 /// The minimum size of the port visual area.
 pub const BASE_PORT_HEIGHT: f32 = 18.0;
@@ -140,8 +144,8 @@ impl Port {
         hover_shape
             .set_size_y(BASE_PORT_HEIGHT)
             .allow_grow()
-            .set_margin_left(-PORT_PADDING_X)
-            .set_margin_right(-PORT_PADDING_X)
+            .set_margin_left(-HOVER_PADDING_X)
+            .set_margin_right(-HOVER_PADDING_X)
             .set_alignment_left_center();
 
         let layers = app.display.default_scene.extension::<PortLayers>();
@@ -262,6 +266,18 @@ impl Port {
     /// can be reinserted into the display hierarchy of widget tree.
     pub(super) fn into_widget(self) -> DynWidget {
         self.widget
+    }
+
+    /// Get a reference to a widget currently wrapped by the port. The widget may change during
+    /// the next tree rebuild.
+    pub(super) fn widget(&self) -> &DynWidget {
+        &self.widget
+    }
+
+    /// Get a mutable reference to a widget currently wrapped by the port. The widget may change
+    /// during the next tree rebuild.
+    pub(super) fn widget_mut(&mut self) -> &mut DynWidget {
+        &mut self.widget
     }
 
     /// Get the port's hover shape. Used for testing to simulate mouse events.

--- a/app/gui/view/graph-editor/src/component/node/input/widget.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget.rs
@@ -296,8 +296,7 @@ impl Configuration {
         match kind {
             Kind::Argument(arg) if !arg.tag_values.is_empty() =>
                 Self::static_dropdown(arg.name.as_ref().map(Into::into), &arg.tag_values),
-            Kind::Argument(arg) if is_list_editor_enabled && looks_like_vector =>
-                Self::list_editor(),
+            Kind::Argument(_) if is_list_editor_enabled && looks_like_vector => Self::list_editor(),
             Kind::Root if is_list_editor_enabled && looks_like_vector => Self::list_editor(),
             Kind::InsertionPoint(arg) if arg.kind.is_expected_argument() =>
                 if is_list_editor_enabled && (type_is_vector(&arg.tp) || looks_like_vector) {
@@ -718,7 +717,7 @@ impl TreeModel {
     /// argument info.
     fn new(app: &Application) -> Self {
         let app = app.clone_ref();
-        let display_object = display::object::Instance::new();
+        let display_object = display::object::Instance::new_named("Tree");
         display_object.use_auto_layout();
         display_object.set_children_alignment_left_center().justify_content_center_y();
         display_object.set_size_y(NODE_HEIGHT);

--- a/app/gui/view/graph-editor/src/component/node/input/widget.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget.rs
@@ -749,7 +749,6 @@ impl TreeModel {
 
     /// Set the connection status under given widget. It may cause the tree to be marked as dirty.
     fn set_connected(&self, crumbs: &span_tree::Crumbs, status: Option<color::Lcha>) -> bool {
-        warn!("set_connected({:?}, {:?})", crumbs, status);
         let mut map = self.connected_map.borrow_mut();
         let dirty = map.synchronize_entry(crumbs.clone(), status);
         self.mark_dirty_flag(dirty)
@@ -829,8 +828,6 @@ impl TreeModel {
         let usage_type_map = self.usage_type_map.borrow();
         let old_nodes = self.nodes_map.take();
         let node_disabled = self.node_disabled.get();
-
-        warn!("REBUILD. Connected: {:?}", connected_map);
 
         // Old hierarchy is not used during the rebuild, so we might as well reuse the allocation.
         let mut hierarchy = self.hierarchy.take();

--- a/app/gui/view/graph-editor/src/component/node/input/widget.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget.rs
@@ -780,7 +780,7 @@ impl TreeModel {
         };
 
         let child = builder.child_widget(tree.root_ref(), default());
-        self.display_object.replace_children(&[child]);
+        self.display_object.replace_children(&[child.root_object]);
 
         self.nodes_map.replace(builder.new_nodes);
         self.hierarchy.replace(builder.hierarchy);
@@ -1139,7 +1139,7 @@ impl<'a> TreeBuilder<'a> {
         &mut self,
         span_node: span_tree::node::Ref<'_>,
         nesting_level: NestingLevel,
-    ) -> display::object::Instance {
+    ) -> Child {
         self.child_widget_of_type(span_node, nesting_level, None)
     }
 
@@ -1159,7 +1159,7 @@ impl<'a> TreeBuilder<'a> {
         span_node: span_tree::node::Ref<'_>,
         nesting_level: NestingLevel,
         configuration: Option<&Configuration>,
-    ) -> display::object::Instance {
+    ) -> Child {
         // This call can recurse into itself within the widget configuration logic. We need to save
         // the current layer's state, so it can be restored later after visiting the child node.
         let parent_last_ast_depth = self.last_ast_depth;
@@ -1298,7 +1298,7 @@ impl<'a> TreeBuilder<'a> {
 
         let entry = TreeEntry { node: child_node, index: insertion_index };
         self.new_nodes.insert(widget_id, entry);
-        child_root
+        Child { id: widget_id, root_object: child_root }
     }
 }
 

--- a/app/gui/view/graph-editor/src/component/node/input/widget/hierarchy.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/hierarchy.rs
@@ -41,7 +41,7 @@ impl super::SpanWidget for Widget {
     }
 
     fn new(_: &Config, _: &super::ConfigContext) -> Self {
-        let display_object = object::Instance::new();
+        let display_object = object::Instance::new_named("widget::Hierarchy");
         display_object.use_auto_layout();
         display_object.set_children_alignment_left_center().justify_content_center_y();
         Self { display_object }

--- a/app/gui/view/graph-editor/src/component/node/input/widget/hierarchy.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/hierarchy.rs
@@ -50,7 +50,8 @@ impl super::SpanWidget for Widget {
     fn configure(&mut self, _: &Config, ctx: super::ConfigContext) {
         let child_level = ctx.info.nesting_level.next_if(ctx.span_node.is_argument());
         let children_iter = ctx.span_node.children_iter();
-        let children = children_iter.map(|node| ctx.builder.child_widget(node, child_level));
+        let children =
+            children_iter.map(|node| ctx.builder.child_widget(node, child_level).root_object);
         self.display_object.replace_children(&children.collect::<CollectedChildren>());
     }
 }

--- a/app/gui/view/graph-editor/src/component/node/input/widget/insertion_point.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/insertion_point.rs
@@ -20,7 +20,7 @@ use ensogl::display::object;
 pub struct Config;
 
 
-/// Insertion point widget. Displays nothing.
+/// Insertion point widget. Displays nothing when not connected.
 #[derive(Clone, Debug)]
 pub struct Widget {
     root: object::Instance,
@@ -35,6 +35,7 @@ impl super::SpanWidget for Widget {
 
     fn new(_: &Config, _: &super::ConfigContext) -> Self {
         let root = object::Instance::new();
+        root.set_size(Vector2::<f32>::zero());
         Self { root }
     }
 

--- a/app/gui/view/graph-editor/src/component/node/input/widget/insertion_point.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/insertion_point.rs
@@ -34,7 +34,7 @@ impl super::SpanWidget for Widget {
     }
 
     fn new(_: &Config, _: &super::ConfigContext) -> Self {
-        let root = object::Instance::new();
+        let root = object::Instance::new_named("widget::InsertionPoint");
         root.set_size(Vector2::<f32>::zero());
         Self { root }
     }

--- a/app/gui/view/graph-editor/src/component/node/input/widget/label.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/label.rs
@@ -51,11 +51,9 @@ impl super::SpanWidget for Widget {
         let app = ctx.app();
         let widgets_frp = ctx.frp();
         let layers = &ctx.app().display.default_scene.layers;
-        let root = object::Instance::new();
-        root.set_size_y(TEXT_SIZE);
+        let root = object::Instance::new_named("widget::Label");
         let label = text::Text::new(app);
         label.set_property_default(text::Size(TEXT_SIZE));
-        label.set_y(TEXT_SIZE);
         layers.label.add(&label);
         root.add_child(&label);
         let frp = Frp::new();
@@ -81,7 +79,12 @@ impl super::SpanWidget for Widget {
             eval content_change((content) label.set_content(content));
 
             width <- label.width.on_change();
+            height <- label.height.on_change();
             eval width((w) root.set_size_x(*w); );
+            eval height([root, label] (h) {
+                root.set_size_y(*h);
+                label.set_y(*h);
+            });
         }
 
         Self { frp, root, label }

--- a/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
@@ -1,6 +1,8 @@
 //! Module dedicated to the [List Editor widget](Widget).
+
 // FIXME[ao]: This code miss important documentation (e.g. for `Element`, `DragData` and `ListItem`)
 //  and may be unreadable at some places. It should be improved in several next debugging PRs.
+
 use crate::prelude::*;
 
 use crate::component::node::input::area::TEXT_SIZE;

--- a/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
@@ -278,6 +278,7 @@ impl super::SpanWidget for Widget {
     }
 
     fn new(_: &Config, ctx: &super::ConfigContext) -> Self {
+        console_log!("NEW");
         let display_object = display::object::Instance::new();
         let list = ListEditor::new(&ctx.app().cursor);
         // list.push(Element::new(default(), default(), default(), default()));
@@ -300,6 +301,7 @@ impl super::SpanWidget for Widget {
     }
 
     fn configure(&mut self, cfg: &Config, ctx: super::ConfigContext) {
+        console_log!("CONFIGURE");
         let current_value: Option<ImString> = Some(ctx.expression_at(ctx.span_node.span()).into());
         self.config_frp.current_value(current_value);
         if ctx.span_node.is_insertion_point() {

--- a/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
@@ -1,11 +1,12 @@
-#![allow(unused_imports)]
-#![allow(dead_code)]
-
 //! Module dedicated to the List Editor widget. The main structure is [`Model`] which is one of
 //! the [KindModel](crate::component::node::widget::KindModel) variants.
 //!
 //! Currently the view is a simple [`Elements`] component, which will be replaced with a rich
 //! view in [future tasks](https://github.com/enso-org/enso/issues/5631).
+
+// === Non-Standard Linter Configuration ===
+#![allow(unused_imports)]
+#![allow(dead_code)]
 
 use crate::prelude::*;
 
@@ -31,6 +32,8 @@ use ensogl_hardcoded_theme as theme;
 use span_tree::node::InsertionPointType;
 use span_tree::node::Kind;
 use std::fmt::Write;
+
+
 
 // ==============
 // === Widget ===
@@ -70,7 +73,7 @@ impl PartialEq for ListItem {
 impl ListItem {
     fn take_drag_data(&self) -> Option<DragData> {
         let mut borrow = self.drag_data.borrow_mut();
-        let can_take = matches!(&*borrow, Some(data) if &data.element_id == &*self.element_id);
+        let can_take = matches!(&*borrow, Some(data) if data.element_id == *self.element_id);
         can_take.and_option_from(|| borrow.take())
     }
 }
@@ -134,11 +137,11 @@ impl Widget {
 
         frp::extend! { network
             // Adding elements.
-            requested_new <- list.request_new_item.filter_map(|resp| resp.clone().gui_interaction_payload());
+            requested_new <- list.request_new_item.filter_map(|resp| resp.gui_interaction_payload());
             widgets_frp.value_changed <+ requested_new.filter_map(f!((idx) model.borrow_mut().on_new_item(*idx)));
 
             // Inserting dragged elements.
-            inserted_by_user <- list.on_item_added.filter_map(|resp| resp.clone().gui_interaction_payload());
+            inserted_by_user <- list.on_item_added.filter_map(|resp| resp.gui_interaction_payload());
             widgets_frp.value_changed <+ inserted_by_user.filter_map(f!([list, model](index) {
                 let item = list.item_at(*index)?;
                 model.borrow_mut().on_item_added(item, *index)
@@ -436,7 +439,7 @@ fn list_diff<'old, 'new, T>(
         let remaining_old = &old_elements[current_old + 1..];
         let remaining_new = &new_elements[current_new + 1..];
 
-        let old_still_in_new_list = remaining_new.contains(&old);
+        let old_still_in_new_list = remaining_new.contains(old);
         if !old_still_in_new_list {
             f(DiffOp::Delete { at, old, present_later: None });
             current_old += 1;

--- a/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
@@ -9,6 +9,8 @@ use crate::prelude::*;
 use crate::component::node::input::widget::single_choice::triangle;
 use crate::component::node::input::widget::single_choice::ACTIVATION_SHAPE_SIZE;
 use crate::component::node::input::widget::Configuration;
+use crate::component::node::input::widget::TransferRequest;
+use crate::component::node::input::widget::TreeNode;
 use crate::component::node::input::widget::WidgetIdentity;
 use crate::component::node::input::widget::WidgetsFrp;
 
@@ -17,6 +19,7 @@ use ensogl::control::io::mouse;
 use ensogl::display;
 use ensogl::display::object::event;
 use ensogl::display::shape::StyleWatch;
+use ensogl::display::world::with_context;
 use ensogl_component::list_editor::ListEditor;
 use ensogl_component::text::Text;
 use ensogl_hardcoded_theme as theme;
@@ -36,13 +39,67 @@ ensogl::define_endpoints_2! {
 
 #[derive(Clone, CloneRef, Debug)]
 struct Element {
+    widget_id:              Immutable<WidgetIdentity>,
+    code:                   ImString,
+    display_object:         display::object::Instance,
+    content:                display::object::Instance,
+    background:             display::shape::Rectangle,
     insertion_point_before: display::object::Instance,
     element:                display::object::Instance,
+    owned_element:          Rc<RefCell<Option<TreeNode>>>,
+}
+
+impl Element {
+    fn new(
+        widget_id: WidgetIdentity,
+        code: ImString,
+        element: display::object::Instance,
+        insertion_point_before: display::object::Instance,
+    ) -> Self {
+        let widget_id = Immutable(widget_id);
+        let display_object = display::object::Instance::new();
+        let content = display::object::Instance::new();
+        let background = display::shape::Rectangle::new();
+        background.set_color(display::shape::INVISIBLE_HOVER_COLOR);
+        background.allow_grow().set_alignment_left_center();
+        content.use_auto_layout();
+        content.set_children_alignment_left_center().justify_content_center_y();
+        content.replace_children(&[&insertion_point_before, &element]);
+        display_object.replace_children(&[background.display_object(), &content]);
+        with_context(|ctx| ctx.layers.label.add(&background));
+        Self {
+            widget_id,
+            code,
+            display_object,
+            content,
+            background,
+            element,
+            insertion_point_before,
+            owned_element: default(),
+        }
+    }
+
+    fn update(
+        &mut self,
+        code: ImString,
+        element: display::object::Instance,
+        insertion_point_before: display::object::Instance,
+    ) {
+        self.content.replace_children(&[&insertion_point_before, &element]);
+        self.insertion_point_before = insertion_point_before;
+        self.element = element;
+        self.code = code;
+        self.owned_element.take();
+    }
+
+    fn take_ownership(&self, owned: TreeNode) {
+        *self.owned_element.borrow_mut() = Some(owned);
+    }
 }
 
 impl display::Object for Element {
     fn display_object(&self) -> &display::object::Instance {
-        self.element.display_object()
+        &self.display_object
     }
 }
 
@@ -62,30 +119,42 @@ pub struct Widget {
     insertion_point_append: Option<display::object::Instance>,
     crumbs_to_insert:       Rc<RefCell<HashMap<usize, span_tree::Crumbs>>>,
     crumbs_to_remove:       Rc<RefCell<HashMap<usize, span_tree::Crumbs>>>,
+    elements:               HashMap<WidgetIdentity, Element>,
 }
 
 impl Widget {
     /// A gap between the `activation_shape` and `elements` view.
     const GAP: f32 = 3.0;
 
-    fn init_list_updates(self, widgets_frp: &WidgetsFrp) -> Self {
+    fn init_list_updates(self, ctx: &super::ConfigContext, widgets_frp: &WidgetsFrp) -> Self {
         let config_frp = &self.config_frp;
         let network = &config_frp.network;
         let list = &self.list;
         let crumbs_to_insert = &self.crumbs_to_insert;
         let crumbs_to_remove = &self.crumbs_to_remove;
-
+        let my_id = ctx.info.identity;
 
         frp::extend! { network
             // Inserting elements.
             inserted_by_user <- list.on_item_added.filter_map(|resp| resp.clone().gui_interaction_payload());
+            trace inserted_by_user;
+            code_inserted_by_user <- inserted_by_user.filter_map(f!([list](index) list.items().get(*index).map(|e| e.code.clone_ref())));
+            trace code_inserted_by_user;
             requested_insert <- list.request_new_item.filter_map(|resp| resp.clone().gui_interaction_payload());
+            default_code <- config_frp.elements_default_value.sample(&requested_insert);
+            trace default_code;
+            code_to_insert <- any(code_inserted_by_user, default_code);
+            trace code_to_insert;
             insert <- any(inserted_by_user, requested_insert);
             insert_st_crumb <- insert.filter_map(f!((index) crumbs_to_insert.borrow().get(index).cloned()));
-            widgets_frp.value_changed <+ insert_st_crumb.map2(&config_frp.elements_default_value, |crumb, val| (crumb.clone(), Some(val.clone_ref())));
+            widgets_frp.value_changed <+ insert_st_crumb.map2(&code_to_insert, |crumb, val| (crumb.clone(), Some(val.clone_ref())));
 
             // Removing elements.
             removed_by_user <- list.on_item_removed.filter_map(|resp| resp.clone().gui_interaction_payload());
+            widgets_frp.transfer_ownership <+ removed_by_user.filter_map(move |(_, element)| Some(TransferRequest {
+                to_transfer: *element.borrow().as_ref()?.widget_id,
+                new_owner: my_id,
+            }));
             remove <- removed_by_user._0();
             remove_st_crumb <- remove.filter_map(f!((index) crumbs_to_remove.borrow().get(index).cloned()));
             widgets_frp.value_changed <+ remove_st_crumb.map(|crumb| (crumb.clone(), None));
@@ -116,7 +185,7 @@ impl super::SpanWidget for Widget {
     fn new(_: &Config, ctx: &super::ConfigContext) -> Self {
         let display_object = display::object::Instance::new();
         let list = ListEditor::new(&ctx.app().cursor);
-        display_object.use_auto_layout();
+        display_object.use_auto_layout().set_alignment_left_center();
         display_object.add_child(&list);
 
         let widgets_frp = &ctx.builder.frp;
@@ -127,8 +196,9 @@ impl super::SpanWidget for Widget {
             insertion_point_append: None,
             crumbs_to_insert: default(),
             crumbs_to_remove: default(),
+            elements: default(),
         }
-        .init_list_updates(widgets_frp)
+        .init_list_updates(ctx, widgets_frp)
     }
 
     fn configure(&mut self, cfg: &Config, ctx: super::ConfigContext) {
@@ -138,29 +208,57 @@ impl super::SpanWidget for Widget {
 
         let child_level = ctx.info.nesting_level.next_if(ctx.span_node.is_argument());
 
+        let left_token =
+            ctx.span_node.clone().children_iter().next().filter(|node| node.is_token());
+        let left_token_widget =
+            left_token.map(|node| ctx.builder.child_widget(node, child_level).root_object);
+        let right_token =
+            ctx.span_node.clone().children_iter().last().filter(|node| node.is_token());
+        let right_token_widget =
+            right_token.map(|node| ctx.builder.child_widget(node, child_level).root_object);
+
         let element_nodes = ctx.span_node.clone().children_iter().filter(|node| node.is_argument());
         let mut insertion_points =
             ctx.span_node.clone().children_iter().filter(|node| node.is_insertion_point()).fuse();
+        let mut old_elements = mem::take(&mut self.elements);
         let children =
             element_nodes.zip(&mut insertion_points).map(|(element_node, insertion_point)| {
                 let insertion_point_before = ctx.builder.child_widget(insertion_point, child_level);
+                let code = ImString::new(ctx.expression_at(element_node.span()));
                 let element = ctx.builder.child_widget_of_type(
                     element_node,
                     child_level,
                     cfg.item_widget.as_deref(),
                 );
-                element.add_child(&insertion_point_before.root_object);
-                Element {
-                    element:                element.root_object,
-                    insertion_point_before: insertion_point_before.root_object,
-                }
+                let element = match old_elements.remove(&element.id) {
+                    Some(mut existing) => {
+                        existing.update(
+                            code,
+                            element.root_object,
+                            insertion_point_before.root_object,
+                        );
+                        existing
+                    }
+                    None => Element::new(
+                        element.id,
+                        code,
+                        element.root_object,
+                        insertion_point_before.root_object,
+                    ),
+                };
+                element
             });
         self.list.replace_list(children);
-        if let Some(insertion_point) = insertion_points.next() {
-            let insertion_point_append = ctx.builder.child_widget(insertion_point, child_level);
-            self.display_object.add_child(&insertion_point_append.root_object);
-            self.insertion_point_append = Some(insertion_point_append.root_object);
-        }
+        self.insertion_point_append = insertion_points
+            .next()
+            .map(|node| ctx.builder.child_widget(node, child_level).root_object);
+        let display_children = left_token_widget
+            .as_ref()
+            .into_iter()
+            .chain(iter::once(self.list.display_object()))
+            .chain(self.insertion_point_append.as_ref())
+            .chain(right_token_widget.as_ref());
+        self.display_object.replace_children(&display_children.collect_vec());
 
         let crumbs_to_insert = ctx
             .span_node
@@ -180,5 +278,11 @@ impl super::SpanWidget for Widget {
             .map(|(index, node)| (index, node.crumbs.clone()))
             .collect();
         *self.crumbs_to_remove.borrow_mut() = crumbs_to_remove
+    }
+
+    fn receive_ownership(&mut self, node: TreeNode, node_identity: WidgetIdentity) {
+        if let Some(element) = self.elements.get(&node_identity) {
+            element.take_ownership(node);
+        }
     }
 }

--- a/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
@@ -9,6 +9,7 @@ use crate::prelude::*;
 use crate::component::node::input::widget::single_choice::triangle;
 use crate::component::node::input::widget::single_choice::ACTIVATION_SHAPE_SIZE;
 use crate::component::node::input::widget::Configuration;
+use crate::component::node::input::widget::WidgetIdentity;
 use crate::component::node::input::widget::WidgetsFrp;
 
 use ensogl::application::Application;
@@ -33,6 +34,37 @@ ensogl::define_endpoints_2! {
     }
 }
 
+// #[derive(Clone, CloneRef, Debug, Deref)]
+// struct Element {
+//     #[deref]
+//     display_object: display::object::Instance,
+//     widget:         Rc<RefCell<super::Child>>,
+// }
+//
+// impl Element {
+//     fn new(widget: super::Child) -> Self {
+//         let display_object = display::object::Instance::new();
+//         display_object.add_child(&widget.root_object);
+//         let widget = Rc::new(RefCell::new(widget));
+//         Self { display_object, widget }
+//     }
+//
+//     fn set_widget(&self, widget: super::Child) {
+//         self.display_object.replace_children(&[widget.root_object.clone_ref()]);
+//         *self.widget.borrow_mut() = widget;
+//     }
+//
+//     fn widget_id(&self) -> WidgetIdentity {
+//         self.widget.borrow().id
+//     }
+// }
+//
+// impl display::Object for Element {
+//     fn display_object(&self) -> &display::object::Instance {
+//         &self.display_object
+//     }
+// }
+
 /// A model for the vector editor widget.
 ///
 /// Currently it displays an activation shape (a triangle) which, on click, displays the widget
@@ -43,76 +75,13 @@ ensogl::define_endpoints_2! {
 /// new widget hierarchy](https://github.com/enso-org/enso/issues/5923).
 #[derive(Clone, CloneRef, Debug)]
 pub struct Widget {
-    config_frp:       Frp,
-    display_object:   display::object::Instance,
-    child_container:  display::object::Instance,
-    list_container:   display::object::Instance,
-    activation_shape: triangle::View,
-    list:             ListEditor<Text>,
+    config_frp: Frp,
+    list:       ListEditor<display::object::Instance>,
 }
 
 impl Widget {
     /// A gap between the `activation_shape` and `elements` view.
     const GAP: f32 = 3.0;
-
-    /// Create Model for Vector Editor widget.
-    pub fn new(app: &Application, widgets_frp: &WidgetsFrp, styles: &StyleWatch) -> Self {
-        let display_object = display::object::Instance::new();
-        let list_container = display::object::Instance::new();
-        let child_container = display::object::Instance::new();
-        let activation_shape = triangle::View::new();
-        let list = ListEditor::new(&app.cursor);
-
-        let toggle_color = styles.get_color(theme::widget::activation_shape::connected);
-        activation_shape.set_size(ACTIVATION_SHAPE_SIZE);
-        activation_shape.color.set(toggle_color.into());
-
-        display_object.add_child(&child_container);
-        display_object.add_child(&list_container);
-        display_object.add_child(&activation_shape);
-        display_object
-            .use_auto_layout()
-            .set_column_count(1)
-            .set_gap_y(Self::GAP)
-            .set_children_alignment_center();
-        display_object.set_size_hug();
-
-        let config_frp = Frp::new();
-        Self { config_frp, display_object, child_container, list_container, activation_shape, list }
-            .init_toggle(widgets_frp)
-            .init_list_updates(app, widgets_frp)
-    }
-
-    fn init_toggle(self, widgets_frp: &WidgetsFrp) -> Self {
-        let network = &self.config_frp.network;
-        let display_object = &self.display_object;
-        let list_container = &self.list_container;
-        let list = &self.list;
-        let dot_clicked = self.activation_shape.on_event::<mouse::Down>();
-        let focus_in = self.display_object.on_event::<event::FocusIn>();
-        let focus_out = self.display_object.on_event::<event::FocusOut>();
-
-        frp::extend! { network
-            init <- source_();
-            set_focused <- dot_clicked.map(f!([display_object](_) !display_object.is_focused()));
-            eval set_focused([display_object](focus) match focus {
-                true => display_object.focus(),
-                false => display_object.blur(),
-            });
-
-            readonly_set <- widgets_frp.set_read_only.on_true();
-            do_open <- focus_in.gate_not(&widgets_frp.set_read_only);
-            do_close <- any_(focus_out, readonly_set);
-            is_open <- bool(&do_close, &do_open).on_change();
-
-            eval is_open([list_container, list](open) match open {
-                true => list_container.add_child(&list),
-                false => list_container.remove_child(&list),
-            });
-        }
-        init.emit(());
-        self
-    }
 
     fn init_list_updates(self, app: &Application, widgets_frp: &WidgetsFrp) -> Self {
         let config_frp = &self.config_frp;
@@ -120,77 +89,39 @@ impl Widget {
         let list = &self.list;
         frp::extend! { network
             init <- source_();
-            value <- all(config_frp.current_value, init)._0();
-            non_empty_value <- value.filter_map(|v| v.clone());
-            empty_value <- value.filter_map(|v| v.is_none().then_some(()));
-            eval non_empty_value ([list, app](val) Self::update_list(&app, val.as_str(), &list));
-            eval_ empty_value ([list] Self::clear_list(&list));
-
-            code_changed_by_user <-
-                list.request_new_item.map(f_!([app, list] Self::push_new_element(&app, &list)));
-            value_changed <- code_changed_by_user.map(f_!([list] {
-                Some(ImString::new(Self::construct_code(&list)))
-            }));
-            widgets_frp.value_changed <+ value_changed.map2(&config_frp.current_crumbs,
-                move |t: &Option<ImString>, crumbs: &span_tree::Crumbs| (crumbs.clone(), t.clone())
-            );
-
         }
         init.emit(());
         self
     }
 
-    fn clear_list(list: &ListEditor<Text>) {
-        for _ in 0..list.items().len() {
-            list.remove(0);
-        }
+    fn update_list(&mut self, children: impl Iterator<Item = super::Child>) {
+        // let mut widgets_kept = 0;
+        // let mut children = children.fuse();
+        // for element in self.list.items() {
+        //     match children.next() {
+        //         Some(child) => {
+        //             widgets_kept += 1;
+        //             if child.id != element.widget_id() {
+        //                 element.set_widget(child);
+        //             }
+        //         }
+        //         None => {
+        //             self.list.remove(widgets_kept);
+        //         }
+        //     }
+        // }
+        // for child in children {
+        //     let element = Element::new(child);
+        //     self.list.push(element);
+        // }
+        self.list.replace_list(children.map(|child| child.root_object));
     }
 
-    fn update_list(app: &Application, code: &str, list: &ListEditor<Text>) {
-        let mut codes = Self::parse_array_code(code).fuse();
-        let mut widgets_kept = 0;
-        for widget in list.items() {
-            match codes.next() {
-                Some(code) => {
-                    widgets_kept += 1;
-                    if widget.content.value().to_string() != code {
-                        widget.set_content(ImString::new(code));
-                    }
-                }
-                None => {
-                    list.remove(widgets_kept);
-                }
-            }
-        }
-        for code in codes {
-            let widget = Text::new(app);
-            widget.set_content(ImString::new(code));
-            app.display.default_scene.layers.label.add(&widget);
-            list.push(widget);
-        }
-    }
-
-    fn push_new_element(app: &Application, list: &ListEditor<Text>) {
-        let widget = Text::new(app);
-        widget.set_content("_");
-        list.push(widget);
-    }
-
-    fn construct_code(list: &ListEditor<Text>) -> String {
-        let subwidgets = list.items().into_iter();
-        let mut subwidgets_codes = subwidgets.map(|sub| sub.content.value().to_string());
-        format!("[{}]", subwidgets_codes.join(","))
-    }
-
-    fn parse_array_code(code: &str) -> impl Iterator<Item = &str> {
-        let looks_like_array = code.starts_with('[') && code.ends_with(']');
-        let opt_iterator = looks_like_array.then(|| {
-            let without_braces = code.trim_start_matches([' ', '[']).trim_end_matches([' ', ']']);
-            let elements_with_trailing_spaces = without_braces.split(',');
-            elements_with_trailing_spaces.map(|s| s.trim())
-        });
-        opt_iterator.into_iter().flatten()
-    }
+    // fn construct_code(list: &ListEditor<>) -> String {
+    //     let subwidgets = list.items().into_iter();
+    //     let mut subwidgets_codes = subwidgets.map(|sub| sub.content.value().to_string());
+    //     format!("[{}]", subwidgets_codes.join(","))
+    // }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -209,21 +140,25 @@ impl super::SpanWidget for Widget {
     type Config = Config;
 
     fn root_object(&self) -> &display::object::Instance {
-        &self.display_object
+        self.list.display_object()
     }
 
     fn new(_: &Config, ctx: &super::ConfigContext) -> Self {
-        Self::new(ctx.app(), ctx.frp(), ctx.styles())
+        let list = ListEditor::new(&ctx.app().cursor);
+        let config_frp = Frp::new();
+        Self { config_frp, list } //.init_list_updates(app, widgets_frp)
     }
 
-    fn configure(&mut self, _: &Config, ctx: super::ConfigContext) {
+    fn configure(&mut self, cfg: &Config, ctx: super::ConfigContext) {
         let current_value: Option<ImString> = Some(ctx.expression_at(ctx.span_node.span()).into());
         self.config_frp.current_value(current_value);
         self.config_frp.current_crumbs(ctx.span_node.crumbs.clone());
 
         let child_level = ctx.info.nesting_level.next_if(ctx.span_node.is_argument());
-        let label_meta = super::Configuration::always(super::label::Config);
-        let child = ctx.builder.child_widget_of_type(ctx.span_node, child_level, Some(&label_meta));
-        self.child_container.replace_children(&[child]);
+        let children_iter = ctx.span_node.children_iter();
+        let children = children_iter.filter(|node| node.is_argument()).map(|node| {
+            ctx.builder.child_widget_of_type(node, child_level, cfg.item_widget.as_deref())
+        });
+        self.update_list(children);
     }
 }

--- a/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
@@ -1,10 +1,4 @@
-//! Module dedicated to the List Editor widget. The main structure is [`Model`] which is one of
-//! the [KindModel](crate::component::node::widget::KindModel) variants.
-//!
-//! Currently the view is a simple [`Elements`] component, which will be replaced with a rich
-//! view in [future tasks](https://github.com/enso-org/enso/issues/5631).
-
-// === Non-Standard Linter Configuration ===
+//! Module dedicated to the [List Editor widget](Widget).
 use crate::prelude::*;
 
 use crate::component::node::input::area::TEXT_SIZE;
@@ -22,9 +16,9 @@ use std::fmt::Write;
 
 
 
-// ==============
-// === Widget ===
-// ==============
+// ===============
+// === Element ===
+// ===============
 
 #[derive(Debug)]
 struct Element {
@@ -67,8 +61,6 @@ impl ListItem {
     }
 }
 
-
-
 impl display::Object for ListItem {
     fn display_object(&self) -> &object::Instance {
         &self.display_object
@@ -103,13 +95,6 @@ impl display::Object for Element {
 }
 
 /// A model for the vector editor widget.
-///
-/// Currently it displays an activation shape (a triangle) which, on click, displays the widget
-/// view. The view is a [`ListEditor`] - see its documentation for available GUI actions. Currently
-/// only adding new elements is supported.
-///
-/// The component does not handle nested arrays well. They should be fixed once [integrated into
-/// new widget hierarchy](https://github.com/enso-org/enso/issues/5923).
 #[derive(Clone, CloneRef, Debug)]
 pub struct Widget {
     display_object: object::Instance,

--- a/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
@@ -173,6 +173,7 @@ struct Model {
 impl Model {
     fn new(ctx: &super::ConfigContext, display_object: &object::Instance) -> Self {
         let list = ListEditor::new(&ctx.app().cursor);
+        with_context(|ctx| ctx.layers.port.add(&list));
         list.set_size_hug_y(TEXT_SIZE).allow_grow_y().set_alignment_left_center();
         display_object.use_auto_layout().set_alignment_left_center();
         Self {

--- a/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
@@ -173,7 +173,6 @@ struct Model {
 impl Model {
     fn new(ctx: &super::ConfigContext, display_object: &object::Instance) -> Self {
         let list = ListEditor::new(&ctx.app().cursor);
-        with_context(|ctx| ctx.layers.port.add(&list));
         list.set_size_hug_y(TEXT_SIZE).allow_grow_y();
         display_object.use_auto_layout().set_children_alignment_left_center();
         Self {

--- a/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
@@ -1,4 +1,6 @@
 //! Module dedicated to the [List Editor widget](Widget).
+// FIXME[ao]: This code miss important documentation (e.g. for `Element`, `DragData` and `ListItem`)
+//  and may be unreadable at some places. It should be improved in several next debugging PRs.
 use crate::prelude::*;
 
 use crate::component::node::input::area::TEXT_SIZE;

--- a/app/gui/view/graph-editor/src/component/node/input/widget/single_choice.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/single_choice.rs
@@ -182,7 +182,7 @@ impl super::SpanWidget for Widget {
         };
         let child_level = ctx.info.nesting_level;
         let child = ctx.builder.child_widget_of_type(ctx.span_node, child_level, Some(&config));
-        self.label_wrapper.replace_children(&[child]);
+        self.label_wrapper.replace_children(&[child.root_object]);
     }
 }
 

--- a/app/gui/view/graph-editor/src/component/node/input/widget/single_choice.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/single_choice.rs
@@ -119,7 +119,7 @@ impl super::SpanWidget for Widget {
         let layers = &app.display.default_scene.layers;
         layers.label.add(&activation_shape);
 
-        let display_object = display::object::Instance::new();
+        let display_object = display::object::Instance::new_named("widget::SingleChoice");
         let content_wrapper = display_object.new_child();
         content_wrapper.add_child(&activation_shape);
         let label_wrapper = content_wrapper.new_child();

--- a/app/gui/view/graph-editor/src/component/node/output/area.rs
+++ b/app/gui/view/graph-editor/src/component/node/output/area.rs
@@ -171,7 +171,7 @@ impl Model {
     /// Constructor.
     #[profile(Debug)]
     pub fn new(app: &Application, frp: &Frp) -> Self {
-        let display_object = display::object::Instance::new();
+        let display_object = display::object::Instance::new_named("output");
         let ports = display::object::Instance::new();
         let app = app.clone_ref();
         let label = app.new_view::<text::Text>();

--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -1829,7 +1829,7 @@ impl GraphEditorModel {
     pub fn new(app: &Application, cursor: cursor::Cursor, frp: &Frp) -> Self {
         let network = frp.network();
         let scene = &app.display.default_scene;
-        let display_object = display::object::Instance::new();
+        let display_object = display::object::Instance::new_named("GraphEditor");
         let nodes = Nodes::new();
         let edges = Edges::new();
         let vis_registry = visualization::Registry::with_default_visualizations();

--- a/app/ide-desktop/lib/content-config/src/config.json
+++ b/app/ide-desktop/lib/content-config/src/config.json
@@ -116,7 +116,7 @@
           "primary": false
         },
         "vectorEditor": {
-          "value": false,
+          "value": true,
           "description": "Show Vector Editor widget on nodes.",
           "primary": false
         },

--- a/app/ide-desktop/lib/content/src/style.css
+++ b/app/ide-desktop/lib/content/src/style.css
@@ -199,3 +199,27 @@ body {
   background: #b96a50;
   margin: 0.8em -1em;
 }
+
+#debug-root {
+  width: 100vw;
+  height: 100vh;
+  position: absolute;
+  top: 0;
+  left: 0;
+  margin: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+#debug-root > .debug-layer {
+  position: absolute;
+  top: 50vh;
+  left: 50vw;
+  width: 0px;
+  height: 0px;
+}
+
+#debug-root > .debug-layer * {
+  position: absolute;
+  background: rgba(0,0,0,0.05);
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.1);
+}

--- a/app/ide-desktop/lib/content/src/style.css
+++ b/app/ide-desktop/lib/content/src/style.css
@@ -220,6 +220,6 @@ body {
 
 #debug-root > .debug-layer * {
   position: absolute;
-  background: rgba(0,0,0,0.05);
-  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.1);
+  background: rgba(0, 0, 0, 0.05);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
 }

--- a/build-config.yaml
+++ b/build-config.yaml
@@ -1,6 +1,6 @@
 # Options intended to be common for all developers.
 
-wasm-size-limit: 15.80 MiB
+wasm-size-limit: 15.83 MiB
 
 required-versions:
   # NB. The Rust version is pinned in rust-toolchain.toml.

--- a/lib/rust/ensogl/component/list-editor/src/item.rs
+++ b/lib/rust/ensogl/component/list-editor/src/item.rs
@@ -34,9 +34,9 @@ impl<T: display::Object> Item<T> {
 
     pub fn new_from_placeholder(elem: T, placeholder: StrongPlaceholder) -> Self {
         let frp = Frp::new();
-        placeholder.add_child(&elem);
         let network = frp.network();
         let elem_obj = elem.display_object();
+        placeholder.replace_children(&[&elem_obj]);
         let margin_left = Animation::<f32>::new_with_init(network, 0.0);
         let elem_offset = Animation::<Vector2>::new_with_init(network, elem.position().xy());
         margin_left.simulator.update_spring(|s| s * crate::DEBUG_ANIMATION_SPRING_FACTOR);

--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -407,7 +407,7 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
         let network = self.frp.network();
         let model = &self.model;
 
-        let on_add_elem_icon_down = model.borrow().add_elem_icon.on_event::<mouse::Down>();
+        let on_add_elem_icon_up = model.borrow().add_elem_icon.on_event::<mouse::Up>();
         let on_down = model.borrow().layout.on_event_capturing::<mouse::Down>();
         let on_up_source = scene.on_event::<mouse::Up>();
         let on_move = scene.on_event::<mouse::Move>();
@@ -417,7 +417,7 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
         let drag_target = cursor::DragTarget::new();
         frp::extend! { network
 
-            frp.private.output.request_new_item <+ on_add_elem_icon_down.map(f_!([model] {
+            frp.private.output.request_new_item <+ on_add_elem_icon_up.map(f_!([model] {
                 Response::gui(model.borrow().len())
             }));
 

--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -599,6 +599,7 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
             eval target_on_start([model, on_item_removed] (t) {
                 let item = model.borrow_mut().start_item_drag(t);
                 if let Some((index, item)) = item {
+                    cursor.start_drag(item.clone_ref());
                     on_item_removed.emit(Response::gui((index, Rc::new(RefCell::new(Some(item))))));
                 }
             });

--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -73,6 +73,7 @@
 #![allow(clippy::bool_to_int_with_if)]
 #![allow(clippy::let_and_return)]
 
+use ensogl_core::display::shape::compound::rectangle::*;
 use ensogl_core::display::world::*;
 use ensogl_core::prelude::*;
 
@@ -82,7 +83,6 @@ use ensogl_core::data::color;
 use ensogl_core::display;
 use ensogl_core::display::object::Event;
 use ensogl_core::display::object::ObjectOps;
-use ensogl_core::display::shape::compound::rectangle::*;
 use ensogl_core::gui::cursor;
 use ensogl_core::gui::cursor::Cursor;
 use ensogl_core::gui::cursor::Trash;
@@ -422,7 +422,6 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
             }));
 
             target <= on_down.map(|event| event.target());
-            trace target;
 
             on_up <- on_up_source.identity();
             on_up_cleaning_phase <- on_up_source.identity();
@@ -605,7 +604,6 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
             is_dragging <- bool(&on_up_cleaning_phase, &init_drag_not_disabled).on_change();
             drag_diff <- pos_diff.gate(&is_dragging);
             no_drag <- drag_disabled.gate_not(&is_dragging).on_change();
-            trace no_drag;
 
             status <- bool(&on_up_cleaning_phase, &drag_diff).on_change();
             start <- status.on_true();

--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -93,7 +93,6 @@ use placeholder::StrongPlaceholder;
 use placeholder::WeakPlaceholder;
 
 
-
 // ==============
 // === Export ===
 // ==============
@@ -108,7 +107,7 @@ pub mod placeholder;
 // =================
 
 /// If set to true, animations will be running slow. This is useful for debugging purposes.
-pub const DEBUG_ANIMATION_SLOWDOWN: bool = false;
+pub const DEBUG_ANIMATION_SLOWDOWN: bool = true;
 
 pub const DEBUG_PLACEHOLDERS_VIZ: bool = false;
 
@@ -806,29 +805,40 @@ impl<T: display::Object + CloneRef + 'static> Model<T> {
 
     fn replace_list(&mut self, elements: impl Iterator<Item = T>) {
         let mut self_position = self.layout.global_position();
-        let new_items = elements
-            .map(|elem| {
+        let self_size = self.layout.computed_size();
+        let mut new_items = elements
+            .enumerate()
+            .map(|(index, elem)| {
                 let elem_object = elem.display_object();
-                let size = elem_object.computed_size();
-                let placeholder = StrongPlaceholder::new_with_size(size.x());
+                // let size = elem_object.computed_size()
+                //     + Vector2(if index == 0 { self.gap } else { 0.0 }, 0.0);
+                let placeholder = StrongPlaceholder::new_with_size(0.0);
                 let item_position = elem_object.global_position();
-                let animate_to_position = elem.has_parent();
+                let animate_to_position = item_position != Vector2(0.0, 0.0);
                 let relative_position = if animate_to_position {
                     item_position - self_position
                 } else {
                     Vector3::zero()
                 };
-                self_position.update_x(|x| x + size.x() + self.gap);
+                // self_position.update_x(|x| x + size.x() + self.gap);
                 elem.set_position(relative_position);
                 let item = Item::new_from_placeholder(elem, placeholder);
+                // if index != 0 {
+                //     item.set_margin_left(self.gap);
+                //     item.frp.skip_margin_anim();
+                // }
                 item
             })
             .collect_vec();
-
-        self.layout.replace_children(&new_items);
+        console_log!("{:?}", self_size);
+        let mut placeholder = StrongPlaceholder::new_with_size(self_size.x());
+        let displays = new_items.iter().map(|item| item.display_object());
+        // .chain(iter::once(placeholder.display_object()));
+        self.layout.replace_children(&displays.collect_vec());
         self.items.clear();
-        self.items.extend(new_items.into_iter().map(Into::into));
-        self.recompute_margins();
+        self.items
+            .extend(new_items.into_iter().map(Into::into).chain(iter::once(placeholder.into())));
+        self.collapse_all_placeholders();
     }
 
     /// Remove all items and add them again, in order of their current position.

--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -523,7 +523,7 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
             ).on_change();
             index <= opt_index;
             enabled <- opt_index.is_some();
-            pointer_style <- enabled.then_constant(cursor::Style::plus());
+            pointer_style <- enabled.then_constant(cursor::Style::plus()).on_change();
             on_up_in_gap <- on_up.gate(&enabled);
             insert_in_gap <- index.sample(&on_up_in_gap);
             frp.private.output.request_new_item <+ insert_in_gap.map(|t| Response::gui(*t));

--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -108,7 +108,7 @@ pub mod placeholder;
 // =================
 
 /// If set to true, animations will be running slow. This is useful for debugging purposes.
-pub const DEBUG_ANIMATION_SLOWDOWN: bool = true;
+pub const DEBUG_ANIMATION_SLOWDOWN: bool = false;
 
 pub const DEBUG_PLACEHOLDERS_VIZ: bool = false;
 
@@ -152,6 +152,10 @@ impl<T> Response<T> {
     /// Constructor indicating that the response was triggered by a GUI interaction.
     pub fn gui(payload: T) -> Self {
         Self::new(payload, true)
+    }
+
+    pub fn gui_interaction_payload(self) -> Option<T> {
+        self.gui_interaction.then_some(self.payload)
     }
 }
 

--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -107,7 +107,7 @@ pub mod placeholder;
 // =================
 
 /// If set to true, animations will be running slow. This is useful for debugging purposes.
-pub const DEBUG_ANIMATION_SLOWDOWN: bool = true;
+pub const DEBUG_ANIMATION_SLOWDOWN: bool = false;
 
 pub const DEBUG_PLACEHOLDERS_VIZ: bool = false;
 
@@ -371,7 +371,7 @@ impl<T> Model<T> {
         root.add_child(&layout_with_icons);
         let add_elem_icon = Rectangle().build(|t| {
             t.set_corner_radius_max()
-                .set_size((24.0, 24.0))
+                .set_size((14.0, 14.0))
                 .set_color(color::Rgba::new(0.0, 0.0, 0.0, 0.2));
         });
         layout_with_icons.add_child(&add_elem_icon);
@@ -695,7 +695,10 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
         let mut model = self.model.borrow_mut();
         let index = model.index_to_item_or_placeholder_index(index)?;
         match model.items.remove(index) {
-            ItemOrPlaceholder::Item(item) => Some(item.elem),
+            ItemOrPlaceholder::Item(item) => {
+                model.item_count_changed();
+                Some(item.elem)
+            }
             ItemOrPlaceholder::Placeholder(_) => unreachable!(),
         }
     }
@@ -838,6 +841,7 @@ impl<T: display::Object + CloneRef + 'static> Model<T> {
             self.push(item)
         };
         self.reposition_items();
+        self.item_count_changed();
         index
     }
 

--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -596,7 +596,7 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
             start <- status.on_true();
             target_on_start <- target.sample(&start);
             let on_item_removed = &frp.private.output.on_item_removed;
-            eval target_on_start([model, on_item_removed] (t) {
+            eval target_on_start([model, cursor, on_item_removed] (t) {
                 let item = model.borrow_mut().start_item_drag(t);
                 if let Some((index, item)) = item {
                     cursor.start_drag(item.clone_ref());

--- a/lib/rust/ensogl/component/list-editor/src/placeholder.rs
+++ b/lib/rust/ensogl/component/list-editor/src/placeholder.rs
@@ -7,6 +7,7 @@ use ensogl_core::display::world::with_context;
 use ensogl_core::Animation;
 
 
+
 // ===================
 // === Placeholder ===
 // ===================

--- a/lib/rust/ensogl/component/list-editor/src/placeholder.rs
+++ b/lib/rust/ensogl/component/list-editor/src/placeholder.rs
@@ -3,8 +3,8 @@ use ensogl_core::prelude::*;
 
 use ensogl_core::data::color;
 use ensogl_core::display;
+use ensogl_core::display::world::with_context;
 use ensogl_core::Animation;
-
 
 
 // ===================
@@ -124,6 +124,9 @@ impl PlaceholderModel {
                     .set_border_color(color::Rgba::new(1.0, 0.0, 0.0, 1.0));
             });
             root.add_child(&viz);
+            with_context(|ctx| {
+                ctx.layers.above_nodes.add(&viz);
+            });
             viz
         });
         Self { frp, root, self_ref, collapsing, size, _deubg_viz }

--- a/lib/rust/ensogl/component/list-editor/src/placeholder.rs
+++ b/lib/rust/ensogl/component/list-editor/src/placeholder.rs
@@ -111,7 +111,7 @@ pub struct PlaceholderModel {
 impl PlaceholderModel {
     fn new() -> Self {
         let frp = Frp::new();
-        let root = display::object::Instance::new();
+        let root = display::object::Instance::new_named("Placeholder");
         let self_ref = default();
         let collapsing = default();
         let size = Animation::<f32>::new(frp.network());

--- a/lib/rust/ensogl/component/scroll-area/src/lib.rs
+++ b/lib/rust/ensogl/component/scroll-area/src/lib.rs
@@ -247,18 +247,18 @@ impl ScrollArea {
     #[profile(Detail)]
     pub fn new(app: &Application) -> ScrollArea {
         let scene = &app.display.default_scene;
-        let display_object = display::object::Instance::new();
+        let display_object = display::object::Instance::new_named("ScrollArea");
         let masked_layer = layer::Masked::new();
         let display_object = display::object::InstanceWithLayer::new(display_object, masked_layer);
 
         let content_layer = display_object.layer.masked_layer.create_sublayer("content_layer");
         let ui_layer = display_object.layer.masked_layer.create_sublayer("ui_layer");
 
-        let content = display::object::Instance::new();
+        let content = display::object::Instance::new_named("content");
         display_object.add_child(&content);
         content_layer.add(&content);
 
-        let scrollbars = display::object::Instance::new();
+        let scrollbars = display::object::Instance::new_named("scrollbars");
         display_object.add_child(&scrollbars);
         ui_layer.add(&scrollbars);
 

--- a/lib/rust/ensogl/component/text/src/component/text.rs
+++ b/lib/rust/ensogl/component/text/src/component/text.rs
@@ -734,7 +734,7 @@ impl TextModel {
         let app = app.clone_ref();
         let scene = &app.display.default_scene;
         let selection_map = default();
-        let display_object = display::object::Instance::new();
+        let display_object = display::object::Instance::new_named("Text");
         let glyph_system = font::glyph::System::new(scene, font::DEFAULT_FONT_MONO);
         frp.private.output.glyph_system.emit(Some(glyph_system.clone()));
         let glyph_system = RefCell::new(glyph_system);

--- a/lib/rust/ensogl/component/text/src/font/glyph.rs
+++ b/lib/rust/ensogl/component/text/src/font/glyph.rs
@@ -504,7 +504,7 @@ impl System {
     #[profile(Debug)]
     pub fn new_glyph(&self) -> Glyph {
         let context = self.context.clone();
-        let display_object = display::object::Instance::new();
+        let display_object = display::object::Instance::new_no_debug();
         let font = self.font.clone_ref();
         let glyph_id = default();
         let line_byte_offset = default();

--- a/lib/rust/ensogl/core/src/display/camera/camera2d.rs
+++ b/lib/rust/ensogl/core/src/display/camera/camera2d.rs
@@ -205,7 +205,7 @@ impl Camera2dData {
         let z_zoom_1 = 1.0;
         let matrix = default();
         let dirty = Dirty::new();
-        let display_object = display::object::Instance::new();
+        let display_object = display::object::Instance::new_no_debug();
         let zoom_update_registry = default();
         let screen_update_registry = default();
         display_object.modify_position(|p| p.z = 1.0);

--- a/lib/rust/ensogl/core/src/display/object/instance.rs
+++ b/lib/rust/ensogl/core/src/display/object/instance.rs
@@ -1125,7 +1125,7 @@ use unit2::Fraction;
 
 /// Enable debugging of display objects hierarchy. When enabled, all display objects will be
 /// represented in the DOM tree, which can be inspected using browser devtools inspector.
-pub const ENABLE_DOM_DEBUG: bool = true;
+pub const ENABLE_DOM_DEBUG: bool = false;
 
 /// Enable DOM debugging for all display objects as a default. When enabled, all display objects
 /// created with `new` or `new_named` constructors will be represented in the debug DOM tree. When

--- a/lib/rust/ensogl/core/src/display/object/instance.rs
+++ b/lib/rust/ensogl/core/src/display/object/instance.rs
@@ -1125,7 +1125,7 @@ use unit2::Fraction;
 
 /// Enable debugging of display objects hierarchy. When enabled, all display objects will be
 /// represented in the DOM tree, which can be inspected using browser devtools inspector.
-pub const ENABLE_DOM_DEBUG: bool = false;
+pub const ENABLE_DOM_DEBUG: bool = true;
 
 /// Enable DOM debugging for all display objects as a default. When enabled, all display objects
 /// created with `new` or `new_named` constructors will be represented in the debug DOM tree. When
@@ -1403,6 +1403,7 @@ impl Root {
     /// Constructor of a named display object. The name is used for debugging purposes only.
     pub fn new_named(name: &'static str) -> Self {
         let def = Instance::new_named(name);
+        def.set_size((0.0, 0.0));
         Self { def }.init()
     }
 

--- a/lib/rust/ensogl/core/src/display/object/instance.rs
+++ b/lib/rust/ensogl/core/src/display/object/instance.rs
@@ -1119,6 +1119,25 @@ use unit2::Fraction;
 
 
 
+// =================
+// === CONSTANTS ===
+// =================
+
+/// Enable debugging of display objects hierarchy. When enabled, all display objects will be
+/// represented in the DOM tree, which can be inspected using browser devtools inspector.
+pub const ENABLE_DOM_DEBUG: bool = true;
+
+/// Enable DOM debugging for all display objects as a default. When enabled, all display objects
+/// created with `new` or `new_named` constructors will be represented in the debug DOM tree. When
+/// disabled, only display objects created with explicitly enabled debugging (e.g. using `new_debug`
+/// constructor) will have that behavior.
+///
+/// Has effect only when [`ENABLE_DOM_DEBUG`] is already enabled.
+pub const ENABLE_DOM_DEBUG_ALL: bool = true;
+
+/// The name of a display object when not specified. Object names are visible in the DOM inspector.
+pub const DEFAULT_NAME: &str = "UnnamedDisplayObject";
+
 // ==========
 // === Id ===
 // ==========
@@ -1144,7 +1163,7 @@ pub struct ChildIndex(usize);
 // =============
 
 /// The main display object structure. Read the docs of [this module](self) to learn more.
-#[derive(Clone, CloneRef, Default, Deref, From)]
+#[derive(Clone, CloneRef, Deref, From)]
 #[repr(transparent)]
 pub struct Instance {
     def: InstanceDef,
@@ -1182,33 +1201,65 @@ pub struct Model {
     hierarchy:   HierarchyModel,
     event:       EventModel,
     layout:      LayoutModel,
+    debug_dom:   Option<enso_web::HtmlDivElement>,
 }
 
 
 // === Contructors ===
 
 impl Instance {
-    /// Constructor.
-    #[profile(Debug)]
+    /// Constructor with default name. Will have DOM debugging enabled if [`ENABLE_DOM_DEBUG_ALL`]
+    /// flag is enabled.
     pub fn new() -> Self {
-        default()
+        Self::new_named_with_debug(DEFAULT_NAME, ENABLE_DOM_DEBUG_ALL)
     }
 
-    /// Constructor of a named display object. The name is used for debugging purposes only.
+    /// Constructor with DOM debugging always disabled.
+    pub fn new_no_debug() -> Self {
+        Self::new_named_with_debug(DEFAULT_NAME, false)
+    }
+
+    /// Constructor with DOM debugging always enabled.
+    pub fn new_debug() -> Self {
+        Self::new_named_with_debug(DEFAULT_NAME, true)
+    }
+
+    /// Constructor with custom name. Will have DOM debugging enabled if [`ENABLE_DOM_DEBUG_ALL`]
+    /// flag is enabled.
     pub fn new_named(name: &'static str) -> Self {
-        Self { def: InstanceDef::new_named(name) }
+        Self::new_named_with_debug(name, ENABLE_DOM_DEBUG_ALL)
+    }
+
+    /// Constructor with custom name and DOM debugging always disabled.
+    pub fn new_named_no_debug(name: &'static str) -> Self {
+        Self::new_named_with_debug(name, false)
+    }
+
+    /// Constructor with custom name and DOM debugging always enabled.
+    pub fn new_named_debug(name: &'static str) -> Self {
+        Self::new_named_with_debug(name, true)
+    }
+
+    /// Constructor with custom name and DOM debugging enabled with an argument.
+    pub fn new_named_with_debug(name: &'static str, enable_debug: bool) -> Self {
+        Self { def: InstanceDef::new(name, enable_debug) }
     }
 }
 
 impl InstanceDef {
-    /// Constructor.
-    pub fn new() -> Self {
-        Self { rc: Rc::new(Model::new()) }.init_events_handling()
-    }
+    #[profile(Debug)]
+    fn new(name: &'static str, enable_debug: bool) -> Self {
+        let mut model = Model::new_named(name);
+        if ENABLE_DOM_DEBUG && enable_debug {
+            use enso_web::prelude::*;
+            if let Some(document) = enso_web::window.document() {
+                let dom = document.create_div_or_panic();
+                dom.set_attribute_or_warn("data-name", name);
+                model.debug_dom = Some(dom);
+            }
+        }
 
-    /// Constructor.
-    pub fn new_named(name: &'static str) -> Self {
-        Self { rc: Rc::new(Model::new_named(name)) }.init_events_handling()
+        Self { rc: Rc::new(model) }.init_events_handling().init_dom_debug(enable_debug)
     }
 
     /// ID getter of this display object.
@@ -1229,14 +1280,24 @@ impl Model {
         let hierarchy = HierarchyModel::new(&network);
         let event = EventModel::new(&network);
         let layout = LayoutModel::default();
-        Self { network, hierarchy, event, layout, name }
+        let debug_dom = None;
+        Self { network, hierarchy, event, layout, name, debug_dom }
     }
 }
 
+impl Drop for Model {
+    fn drop(&mut self) {
+        if ENABLE_DOM_DEBUG {
+            if let Some(dom) = self.debug_dom.take() {
+                dom.remove();
+            }
+        }
+    }
+}
 
 // === Impls ===
 
-impl Default for InstanceDef {
+impl Default for Instance {
     fn default() -> Self {
         Self::new()
     }
@@ -2273,7 +2334,7 @@ impl Model {
         self.transformation.borrow().rotation()
     }
 
-    /// Transformation matrix of the object in the parent coordinate space.
+    /// Transformation matrix of the object in the camera coordinate space.
     fn transformation_matrix(&self) -> Matrix4<f32> {
         self.transformation.borrow().matrix()
     }
@@ -2402,6 +2463,77 @@ impl InstanceDef {
                 Self::emit_event_impl(event, parent, &capturing_event_fan, &bubbling_event_fan);
             });
         }
+        self
+    }
+
+    fn init_dom_debug(self, enable_debug: bool) -> Self {
+        use enso_web::prelude::*;
+        use std::fmt::Write;
+
+        if !(ENABLE_DOM_DEBUG && enable_debug) {
+            return self;
+        }
+
+        let style_string = RefCell::new(String::new());
+        let display = Rc::new(Cell::new(""));
+        let last_parent_node = RefCell::new(None);
+        let weak = self.downgrade();
+        let network = &self.network;
+        frp::extend! { network
+            eval_ self.on_show (display.set(""));
+            eval_ self.on_hide (display.set("display:none;"));
+            eval_ self.on_transformed ([display] {
+                let Some(object) = weak.upgrade() else { return };
+                let Some(dom) = object.debug_dom.as_ref() else { return };
+                let mut parent_node = last_parent_node.borrow_mut();
+                let transform;
+                let new_parent;
+
+                let upgrade = |l: &LayerAssignment| l.layer.upgrade();
+                if let Some(layer) = object.assigned_layer.borrow().as_ref().and_then(upgrade) {
+                    transform = object.transformation.borrow().matrix();
+                    new_parent = layer.debug_dom.clone();
+                } else if let Some(parent) = object.parent().and_then(|p| p.debug_dom.clone()) {
+                    transform = object.transformation.borrow().local_matrix();
+                    new_parent = Some(parent);
+                } else if let Some(layer) = object.layer.borrow().as_ref().and_then(upgrade) {
+                    transform = object.transformation.borrow().matrix();
+                    new_parent = layer.debug_dom.clone();
+                } else {
+                    transform = Matrix4::zero();
+                    new_parent = None;
+                }
+
+
+                if *parent_node != new_parent {
+                    if let Some(parent) = &new_parent {
+                        parent.append_child(dom).unwrap();
+                    } else {
+                        dom.remove();
+                    }
+                    *parent_node = new_parent;
+                }
+
+                let size = object.computed_size();
+                let transform = transform.as_slice();
+                let mut style_string = style_string.borrow_mut();
+                let x = size.x();
+                let y = size.y();
+                let display = display.get();
+                let (first, rest) = transform.split_first().unwrap();
+                write!(style_string, "\
+                    {display}\
+                    width:{x}px;\
+                    height:{y}px;\
+                    transform:matrix3d({first:.4}"
+                ).unwrap();
+                rest.iter().for_each(|f| write!(style_string, ",{f:.4}").unwrap());
+                style_string.write_str(");").unwrap();
+                dom.set_attribute_or_warn("style", &*style_string);
+                style_string.clear();
+            });
+        }
+
         self
     }
 

--- a/lib/rust/ensogl/core/src/display/object/transformation.rs
+++ b/lib/rust/ensogl/core/src/display/object/transformation.rs
@@ -202,6 +202,10 @@ impl CachedTransformation {
 // === Getters ===
 
 impl CachedTransformation {
+    pub fn local_matrix(&self) -> Matrix4<f32> {
+        self.transform_matrix
+    }
+
     pub fn matrix(&self) -> Matrix4<f32> {
         self.matrix
     }

--- a/lib/rust/ensogl/core/src/display/scene.rs
+++ b/lib/rust/ensogl/core/src/display/scene.rs
@@ -602,6 +602,7 @@ pub struct HardcodedLayers {
     pub viz:                Layer,
     pub below_main:         Layer,
     pub main:               Layer,
+    pub widget:             Layer,
     pub port:               Layer,
     pub port_selection:     Layer,
     pub label:              Layer,
@@ -645,6 +646,7 @@ impl HardcodedLayers {
         let viz = root.create_sublayer("viz");
         let below_main = root.create_sublayer("below_main");
         let main = root.create_sublayer("main");
+        let widget = root.create_sublayer("widget");
         let port = root.create_sublayer("port");
         let port_selection =
             root.create_sublayer_with_camera("port_selection", &port_selection_cam);
@@ -671,6 +673,7 @@ impl HardcodedLayers {
             viz,
             below_main,
             main,
+            widget,
             port,
             port_selection,
             label,

--- a/lib/rust/ensogl/core/src/display/scene.rs
+++ b/lib/rust/ensogl/core/src/display/scene.rs
@@ -970,6 +970,7 @@ impl SceneData {
         // Updating all other cameras (the main camera was already updated, so it will be skipped).
         self.layers.iter_sublayers_and_masks_nested(|layer| {
             let dirty = layer.camera().update(scene);
+            layer.update_debug_view();
             was_dirty = was_dirty || dirty;
         });
 

--- a/lib/rust/ensogl/core/src/display/scene/dom.rs
+++ b/lib/rust/ensogl/core/src/display/scene/dom.rs
@@ -172,7 +172,6 @@ impl DomScene {
         dom.set_style_or_warn("position", "absolute");
         dom.set_style_or_warn("top", "0px");
         dom.set_style_or_warn("overflow", "hidden");
-        dom.set_style_or_warn("overflow", "hidden");
         dom.set_style_or_warn("width", "100%");
         dom.set_style_or_warn("height", "100%");
         // We ignore pointer events to avoid stealing them from other DomScenes.

--- a/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
+++ b/lib/rust/ensogl/core/src/display/shape/primitive/system.rs
@@ -137,6 +137,11 @@ pub trait Shape: 'static + Sized + AsRef<Self::InstanceParams> {
     fn flavor(_data: &Self::ShapeData) -> ShapeSystemFlavor {
         ShapeSystemFlavor { flavor: 0 }
     }
+    fn enable_dom_debug() -> bool {
+        // By default, only shapes with alignment compatible with layout are enabled for DOM debug.
+        // Otherwise, due to different shape offsets, the debug view is very confusing.
+        Self::default_alignment() == alignment::Dim2::left_bottom()
+    }
 }
 
 /// An alias for [`Shape]` where [`Shape::ShapeData`] is [`Default`].
@@ -323,7 +328,9 @@ impl<S: Shape> ShapeSystem<S> {
         let instance_id = sprite.instance_id;
         let global_id = sprite.global_instance_id;
         let shape = S::new_instance_params(&self.gpu_params, instance_id);
-        let display_object = display::object::Instance::new_named("ShapeSystem");
+        let debug = S::enable_dom_debug();
+        let display_object =
+            display::object::Instance::new_named_with_debug(type_name::<S>(), debug);
         display_object.add_child(&sprite);
         // FIXME: workaround:
         // display_object.use_auto_layout();

--- a/lib/rust/ensogl/core/src/display/symbol/gpu.rs
+++ b/lib/rust/ensogl/core/src/display/symbol/gpu.rs
@@ -564,7 +564,7 @@ impl SymbolData {
         let bindings = default();
         let stats = SymbolStats::new(stats);
         let context = default();
-        let display_object = display::object::Instance::new();
+        let display_object = display::object::Instance::new_no_debug();
         let is_hidden = Rc::new(Cell::new(false));
 
         let instance_scope = surface.instance_scope();

--- a/lib/rust/ensogl/core/src/display/symbol/gpu/geometry/compound/sprite.rs
+++ b/lib/rust/ensogl/core/src/display/symbol/gpu/geometry/compound/sprite.rs
@@ -126,7 +126,7 @@ pub struct SizedObject {
 impl SizedObject {
     fn new(attr: Attribute<Vector2<f32>>, transform: &Attribute<Matrix4<f32>>) -> Self {
         let size = Size::new(attr);
-        let display_object = display::object::Instance::new_named("Sprite");
+        let display_object = display::object::Instance::new_named_no_debug("Sprite");
         let weak_display_object = display_object.downgrade();
         let network = &display_object.network;
         frp::extend! { network

--- a/lib/rust/ensogl/core/src/gui/component.rs
+++ b/lib/rust/ensogl/core/src/gui/component.rs
@@ -152,7 +152,7 @@ impl<S: Shape> Drop for ShapeViewModel<S> {
 
 impl<S: Shape> ShapeViewModel<S> {
     /// Constructor.
-    pub fn new_with_data(data: S::ShapeData) -> Self {
+    fn new_with_data(data: S::ShapeData) -> Self {
         let (shape, _) = world::with_context(|t| t.layers.DETACHED.instantiate(&data, default()));
         let events_deprecated = PointerTarget_DEPRECATED::new();
         let pointer_targets = default();

--- a/lib/rust/ensogl/core/src/gui/cursor.rs
+++ b/lib/rust/ensogl/core/src/gui/cursor.rs
@@ -247,7 +247,7 @@ impl CursorModel {
 
         display_object.add_child(&view);
         display_object.add_child(&port_selection);
-        view.add_child(&dragged_elem);
+        scene.add_child(&dragged_elem);
         let tgt_layer = &scene.layers.cursor;
         let port_selection_layer = &scene.layers.port_selection;
         tgt_layer.add(&view);
@@ -563,7 +563,7 @@ impl Cursor {
             eval position             ((t) model.display_object.set_position(*t));
             eval front_color          ((t) model.view.color.set(t.into()));
             eval port_selection_color ((t) model.port_selection.color.set(t.into()));
-
+            eval_ screen_position     (model.update_drag_position());
 
             // === Outputs ===
 
@@ -592,18 +592,31 @@ impl CursorModel {
             warn!("Can't start dragging an item because another item is already being dragged.");
         } else {
             let object = target.display_object().clone();
-            self.dragged_elem.add_child(&object);
-            let target_position = object.global_position().xy();
-            let cursor_position = self.frp.scene_position.value().xy();
-            object.set_xy(target_position - cursor_position);
 
+            if let Some(object_layer) = object.display_layer() {
+                object_layer.add(&self.dragged_elem);
+            }
             let scene = scene();
-            let camera = scene.camera();
-            let zoom = camera.zoom();
-            self.dragged_elem.set_scale_xy((zoom, zoom));
+            let screen_pos = self.frp.screen_position.value().xy();
+            let offset = scene.screen_to_object_space(&object, screen_pos);
+            object.set_xy(-offset);
+            self.dragged_elem.add_child(&object);
+
             *self.dragged_item.borrow_mut() = Some((Box::new(target), object));
 
             self.frp.private.output.start_drag.emit(());
+        }
+    }
+
+    fn update_drag_position(&self) {
+        if self.dragged_item.borrow().is_some() {
+            let scene = scene();
+            let layer = self.dragged_elem.display_layer();
+            let camera = layer.map_or(scene.camera(), |l| l.camera());
+
+            let screen_pos = self.frp.screen_position.value().xy() / camera.zoom();
+            let pos_in_layer = camera.inversed_view_matrix() * screen_pos.push(0.0).push(1.0);
+            self.dragged_elem.set_xy(pos_in_layer.xy());
         }
     }
 

--- a/lib/rust/ensogl/core/src/gui/cursor.rs
+++ b/lib/rust/ensogl/core/src/gui/cursor.rs
@@ -240,7 +240,7 @@ impl CursorModel {
     pub fn new(scene: &Scene, frp: WeakFrp) -> Self {
         let scene = scene.clone_ref();
         let display_object = display::object::Instance::new_no_debug();
-        let dragged_elem = display::object::Instance::new_no_debug();
+        let dragged_elem = display::object::Instance::new_named("dragged_elem");
         let view = shape::View::new();
         let port_selection = shape::View::new();
         let style = default();

--- a/lib/rust/ensogl/core/src/gui/cursor.rs
+++ b/lib/rust/ensogl/core/src/gui/cursor.rs
@@ -239,8 +239,8 @@ impl CursorModel {
     /// Constructor.
     pub fn new(scene: &Scene, frp: WeakFrp) -> Self {
         let scene = scene.clone_ref();
-        let display_object = display::object::Instance::new();
-        let dragged_elem = display::object::Instance::new();
+        let display_object = display::object::Instance::new_no_debug();
+        let dragged_elem = display::object::Instance::new_no_debug();
         let view = shape::View::new();
         let port_selection = shape::View::new();
         let style = default();

--- a/lib/rust/ensogl/core/src/gui/cursor.rs
+++ b/lib/rust/ensogl/core/src/gui/cursor.rs
@@ -210,8 +210,9 @@ crate::define_endpoints_2! {
         scene_position        (Vector3),
          /// Change between the current and the previous scene position.
         scene_position_delta  (Vector3),
-        start_drag (),
+        start_drag(),
         stop_drag(),
+        is_dragging(bool),
     }
 }
 
@@ -571,6 +572,7 @@ impl Cursor {
             frp.private.output.screen_position      <+ screen_position;
             frp.private.output.scene_position       <+ scene_position;
             frp.private.output.scene_position_delta <+ scene_position_delta;
+            frp.private.output.is_dragging <+ bool(&frp.stop_drag, &frp.start_drag);
         }
 
         // Hide on init.

--- a/lib/rust/frp/src/nodes.rs
+++ b/lib/rust/frp/src/nodes.rs
@@ -2162,7 +2162,7 @@ impl<T: EventOutput> OwnedTrace<T> {
 
 impl<T: EventOutput> stream::EventConsumer<Output<T>> for OwnedTrace<T> {
     fn on_event(&self, stack: CallStack, event: &Output<T>) {
-        warn!("[FRP] {}: {:?}", self.label(), event);
+        console_log!("[FRP] {}: {:?}", self.label(), event);
         // warn!("[FRP] {}", stack);
         self.emit_event(stack, event);
     }

--- a/lib/rust/frp/src/nodes.rs
+++ b/lib/rust/frp/src/nodes.rs
@@ -2162,7 +2162,7 @@ impl<T: EventOutput> OwnedTrace<T> {
 
 impl<T: EventOutput> stream::EventConsumer<Output<T>> for OwnedTrace<T> {
     fn on_event(&self, stack: CallStack, event: &Output<T>) {
-        console_log!("[FRP] {}: {:?}", self.label(), event);
+        warn!("[FRP] {}: {:?}", self.label(), event);
         // warn!("[FRP] {}", stack);
         self.emit_event(stack, event);
     }

--- a/lib/rust/web/src/binding/mock.rs
+++ b/lib/rust/web/src/binding/mock.rs
@@ -537,6 +537,7 @@ mock_data! { Document => EventTarget
 
 // === Window ===
 mock_data! { Window => EventTarget
+    fn document(&self) -> Option<Document>;
     fn open_with_url_and_target(&self, url: &str, target: &str)
         -> Result<Option<Window>, JsValue>;
     fn request_animation_frame(&self, callback: &Function) -> Result<i32, JsValue>;
@@ -685,6 +686,11 @@ mock_data! { HtmlDivElement => HtmlElement }
 impl From<HtmlDivElement> for EventTarget {
     fn from(_: HtmlDivElement) -> Self {
         default()
+    }
+}
+impl PartialEq<HtmlDivElement> for HtmlDivElement {
+    fn eq(&self, _: &HtmlDivElement) -> bool {
+        true
     }
 }
 

--- a/lib/rust/web/src/lib.rs
+++ b/lib/rust/web/src/lib.rs
@@ -664,10 +664,8 @@ ops! { HtmlElementOps for HtmlElement
         fn set_style_or_warn(&self, name: impl AsRef<str>, value: impl AsRef<str>) {
             let name = name.as_ref();
             let value = value.as_ref();
-            let values = format!("\"{name}\" = \"{value}\" on \"{self:?}\"");
-            let warn_msg: &str = &format!("Failed to set style {values}");
             if self.style().set_property(name, value).is_err() {
-                warn!("{warn_msg}");
+                warn!("Failed to set style \"{name}\" = \"{value}\" on \"{self:?}\"");
             }
         }
     }


### PR DESCRIPTION
### Pull Request Description

Fixes #5948 
Fixes #5949 
Fixes #5923

The vector editor is integrated with List Editor EnsoGL component and put into the new widget hierarchy. 

https://user-images.githubusercontent.com/3919101/235624416-10a773a9-169a-4a4f-b531-99d2855b9e0a.mp4

### Important Notes

1. The widget/list_editor.rs file still lacks some useful documentation - this state should be improved in next PRs where we'll be debugging things.
1. SpanTree nodes with arrays now contains insertion points. That was necessary to have working vector editor.
2. There is a new debug mode where all display objects adds a div to DOM, making debugging layouts easier (authored by @Frizi ).

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
