### PR TITLE
Limit Dead Letter logging

### DIFF
--- a/engine/language-server/src/main/resources/application.conf
+++ b/engine/language-server/src/main/resources/application.conf
@@ -1,7 +1,15 @@
-akka.actor.debug.lifecycle = on
-akka.http.server.idle-timeout = infinite
-akka.http.server.remote-address-header = on
-akka.http.server.websocket.periodic-keep-alive-max-idle = 1 second
+akka {
+  actor.debug.lifecycle = on
+  http {
+      server {
+          server.idle-timeout = infinite
+          server.remote-address-header = on
+          server.websocket.periodic-keep-alive-max-idle = 1 second
+      }
+  }
+  log-dead-letters = 1
+  log-dead-letters-during-shutdown = off
+}
 
 logging-service.logger {
   akka.actor = info

--- a/lib/scala/project-manager/src/main/resources/application.conf
+++ b/lib/scala/project-manager/src/main/resources/application.conf
@@ -1,7 +1,15 @@
-akka.actor.debug.lifecycle = on
-akka.http.server.idle-timeout = infinite
-akka.http.server.remote-address-header = on
-akka.http.server.websocket.periodic-keep-alive-max-idle = 1 second
+akka {
+  actor.debug.lifecycle = on
+  http {
+      server {
+          server.idle-timeout = infinite
+          server.remote-address-header = on
+          server.websocket.periodic-keep-alive-max-idle = 1 second
+      }
+  }
+  log-dead-letters = 1
+  log-dead-letters-during-shutdown = off
+}
 
 logging-service.logger {
   akka.actor = info


### PR DESCRIPTION
### Pull Request Description

Dead Letter logging is occasionally flooding our logs which is confusing to users reporting bugs. Left the possibility of a single report so that we know that something is happening.

