### PR TITLE
Fix layer ordering between dropdown and breadcrumbs backgrounds. 

### DIFF
--- a/app/gui/view/execution-environment-selector/src/lib.rs
+++ b/app/gui/view/execution-environment-selector/src/lib.rs
@@ -212,7 +212,7 @@ impl component::Model for Model {
         scene.layers.panel.add(&inner_root);
         scene.layers.panel.add(&dropdown);
         scene.layers.panel.add(&divider);
-        scene.layers.panel_background.add(&background);
+        scene.layers.panel_background_rect_level_1.add(&background);
         dropdown.set_label_layer(&scene.layers.panel_text);
 
         Self { display_object, background, play_button, dropdown, inner_root, divider }

--- a/app/gui/view/execution-environment-selector/src/lib.rs
+++ b/app/gui/view/execution-environment-selector/src/lib.rs
@@ -212,7 +212,7 @@ impl component::Model for Model {
         scene.layers.panel.add(&inner_root);
         scene.layers.panel.add(&dropdown);
         scene.layers.panel.add(&divider);
-
+        scene.layers.panel_background.add(&background);
         dropdown.set_label_layer(&scene.layers.panel_text);
 
         Self { display_object, background, play_button, dropdown, inner_root, divider }

--- a/app/gui/view/graph-editor/src/component/breadcrumbs.rs
+++ b/app/gui/view/graph-editor/src/component/breadcrumbs.rs
@@ -181,7 +181,7 @@ impl BreadcrumbsModel {
         use ensogl_hardcoded_theme::graph_editor::breadcrumbs;
         background.set_style(breadcrumbs::background::HERE, &style);
 
-        scene.layers.panel_background.add(&background);
+        scene.layers.panel_background_rect_level_0.add(&background);
 
         Self {
             display_object,

--- a/lib/rust/ensogl/core/src/display/scene.rs
+++ b/lib/rust/ensogl/core/src/display/scene.rs
@@ -593,7 +593,8 @@ impl Renderer {
 
 type RectLayerPartition = Rc<LayerSymbolPartition<rectangle::Shape>>;
 
-
+/// Create a new layer partition with the given name, wrapped in an `Rc` for use in the
+/// [`HardcodedLayers`] structure.
 fn partition_layer<S: display::shape::primitive::system::Shape>(
     base_layer: &Layer,
     name: &str,

--- a/lib/rust/ensogl/core/src/display/scene.rs
+++ b/lib/rust/ensogl/core/src/display/scene.rs
@@ -15,6 +15,8 @@ use crate::display;
 use crate::display::camera::Camera2d;
 use crate::display::render;
 use crate::display::scene::dom::DomScene;
+use crate::display::scene::layer::LayerSymbolPartition;
+use crate::display::shape::compound::rectangle;
 use crate::display::shape::primitive::glsl;
 use crate::display::style;
 use crate::display::style::data::DataMatch;
@@ -46,12 +48,11 @@ pub mod layer;
 #[warn(missing_docs)]
 pub mod pointer_target;
 
-use crate::display::scene::layer::LayerSymbolPartition;
-use crate::display::shape::compound::rectangle;
 pub use crate::system::web::dom::Shape;
 pub use layer::Layer;
 pub use pointer_target::PointerTargetId;
 pub use pointer_target::PointerTarget_DEPRECATED;
+
 
 
 // =====================

--- a/lib/rust/ensogl/core/src/display/scene.rs
+++ b/lib/rust/ensogl/core/src/display/scene.rs
@@ -622,8 +622,8 @@ pub struct HardcodedLayers {
     pub port_hover: Layer,
     pub above_nodes: Layer,
     pub above_nodes_text: Layer,
-    /// `panel` layer contains all panels with fixed position (not moving with the panned scene)
-    /// like status bar, breadcrumbs or similar.
+    // `panel_*` layers contains UI elements with fixed position (not moving with the panned scene)
+    // like status bar, breadcrumbs or similar.
     pub panel_background_rect_level_0: RectLayerPartition,
     pub panel_background_rect_level_1: RectLayerPartition,
     pub panel_background: Layer,


### PR DESCRIPTION
### Pull Request Description

This PR fixes #6371.


### Important Notes

@kazcw @wdanilo I don't particularly like this solution, but I don't see any other good way to define the relationship between two instances of the same shape (`Rectangle`) used in different UI elements. If you are aware of a more elegant solution, I’d be happy to hear any suggestions. 

### QA Note

This should be tested on Windows, Linux, and Mac. 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] ~Unit tests have been written where possible.~
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
