### PR TITLE
DataflowAnalysis preserves dependencies order

### DIFF
--- a/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -3138,8 +3138,12 @@ class RuntimeVisualizationsTest
     val moduleName      = "Enso_Test.Test.Main"
     val metadata        = new Metadata
 
-    val idX = metadata.addItem(65, 1, "aa")
-    val idY = metadata.addItem(65, 7, "ab")
+    val idX      = metadata.addItem(65, 1, "aa")
+    val idY      = metadata.addItem(65, 7, "ab")
+    val idS      = metadata.addItem(81, 1)
+    val idZ      = metadata.addItem(91, 5, "ac")
+    val idZexprS = metadata.addItem(93, 1)
+    val idZexpr1 = metadata.addItem(95, 1)
 
     val code =
       """type T
@@ -3150,7 +3154,11 @@ class RuntimeVisualizationsTest
         |main =
         |    x = T.C
         |    y = x.inc 7
-        |    y
+        |    s = 1
+        |    z = p y s
+        |    z
+        |
+        |p x y = x + y
         |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
@@ -3177,7 +3185,7 @@ class RuntimeVisualizationsTest
       Api.Request(requestId, Api.PushContextRequest(contextId, item1))
     )
     context.receiveNIgnorePendingExpressionUpdates(
-      5
+      9
     ) should contain theSameElementsAs Seq(
       Api.Response(Api.BackgroundJobsStartedNotification()),
       Api.Response(requestId, Api.PushContextResponse(contextId)),
@@ -3188,6 +3196,15 @@ class RuntimeVisualizationsTest
         ConstantsGen.INTEGER_BUILTIN,
         Api.MethodPointer(moduleName, s"$moduleName.T", "inc")
       ),
+      TestMessages.update(contextId, idS, ConstantsGen.INTEGER_BUILTIN),
+      TestMessages.update(
+        contextId,
+        idZ,
+        ConstantsGen.INTEGER_BUILTIN,
+        Api.MethodPointer(moduleName, moduleName, "p")
+      ),
+      TestMessages.update(contextId, idZexprS, ConstantsGen.INTEGER_BUILTIN),
+      TestMessages.update(contextId, idZexpr1, ConstantsGen.INTEGER_BUILTIN),
       context.executionComplete(contextId)
     )
 


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #6324 

Changelog
- feat: DataflowAnalysis compiler pass preserves the order of dependencies. This way when attaching the visualization to the sub-expression, the engine can find the first cached parent node, and properly invalidate it.
- update: runtime visualization test is updated to reproduce the issue


### Important Notes

The dropdown for the column `"LOCATION"` is available right after the Restaurants project startup.

![2023-05-01-171700_1386x975_scrot](https://user-images.githubusercontent.com/357683/235466166-9d25cfa5-0e39-49a3-9c41-93cda59edb81.png)


<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
