### PR TITLE
Continued Execution Context work and some little fixes

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Runtime.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Runtime.enso
@@ -174,6 +174,11 @@ type Context
     with_enabled self ~action =
         with_enabled_context self Runtime.current_execution_environment action
 
+    ## PRIVATE
+       Run an action with the Context disabled.
+    with_disabled : Function -> Any
+    with_disabled self ~action =
+        with_disabled_context self Runtime.current_execution_environment action
 
 ## PRIVATE
    ADVANCED

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -160,7 +160,7 @@ type File
             resource = Managed_Resource.register stream_2 close_stream
             Output_Stream.Value file resource
 
-        if Context.Output.is_enabled.not then Error.throw (Forbidden_Operation.Error "File writing is forbidden as the Output context is disabled") else
+        if Context.Output.is_enabled.not then Error.throw (Forbidden_Operation.Error "File writing is forbidden as the Output context is disabled.") else
             Managed_Resource.bracket (new_output_stream self open_options) (_.close) action
 
     ## PRIVATE
@@ -414,7 +414,7 @@ type File
                 (Examples.data_dir / "my_directory") . create_directory
     create_directory : Nothing
     create_directory self =
-        if Context.Output.is_enabled.not then Error.throw (Forbidden_Operation.Error "Directory creation is forbidden as the Output context is disabled") else
+        if Context.Output.is_enabled.not then Error.throw (Forbidden_Operation.Error "Directory creation is forbidden as the Output context is disabled.") else
             self.create_directory_builtin
 
 
@@ -546,7 +546,7 @@ type File
                  file.delete
     delete : Nothing ! File_Error
     delete self =
-        if Context.Output.is_enabled.not then Error.throw (Forbidden_Operation.Error "File deleting is forbidden as the Output context is disabled") else
+        if Context.Output.is_enabled.not then Error.throw (Forbidden_Operation.Error "File deleting is forbidden as the Output context is disabled.") else
             File_Error.handle_java_exceptions self self.delete_builtin
 
     ## Moves the file to the specified destination.
@@ -557,7 +557,7 @@ type File
          destination file already exists. Defaults to `False`.
     copy_to : File -> Boolean -> Nothing ! File_Error
     copy_to self destination replace_existing=False =
-        if Context.Output.is_enabled.not then Error.throw (Forbidden_Operation.Error "File copying is forbidden as the Output context is disabled") else
+        if Context.Output.is_enabled.not then Error.throw (Forbidden_Operation.Error "File copying is forbidden as the Output context is disabled.") else
             File_Error.handle_java_exceptions self <| case replace_existing of
                 True ->
                   copy_options = [StandardCopyOption.REPLACE_EXISTING].to_array
@@ -572,7 +572,7 @@ type File
          destination file already exists. Defaults to `False`.
     move_to : File -> Boolean -> Nothing ! File_Error
     move_to self destination replace_existing=False =
-        if Context.Output.is_enabled.not then Error.throw (Forbidden_Operation.Error "File moving is forbidden as the Output context is disabled") else
+        if Context.Output.is_enabled.not then Error.throw (Forbidden_Operation.Error "File moving is forbidden as the Output context is disabled.") else
             File_Error.handle_java_exceptions self <| case replace_existing of
                 True ->
                   copy_options = [StandardCopyOption.REPLACE_EXISTING].to_array

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -86,7 +86,8 @@ type File
         if temp_path.is_nothing then Error.throw (File_Error.IO_Error "Unable to create a temporary file.") else
             temp = File.new temp_path
             if self.exists && copy_original then
-                self.copy_to temp replace_existing=True
+                Context.Output.with_enabled <|
+                    self.copy_to temp replace_existing=True
             temp
 
     ## ALIAS Current Directory

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
@@ -47,7 +47,8 @@ format_widget =
     make_ctor type_obj =
         type_name = Meta.get_qualified_type_name type_obj
         ctors = Meta.meta type_obj . constructors
-        if ctors.length == 0 then type_name else
+        is_singleton_type = ctors.length == 0
+        if is_singleton_type then type_name else
             "(" + type_name + "." + ctors.first.name + ")"
     make_name type_obj = type_obj.to_text.replace "_Format" "" . replace "_" " "
     Single_Choice display=Display.Always values=(all_types.map n->(Option (make_name n) (make_ctor n)))

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
@@ -46,12 +46,9 @@ format_widget =
     all_types = [Auto_Detect] + format_types
     make_ctor type_obj =
         type_name = Meta.get_qualified_type_name type_obj
-
-        ## Temporary work around to work out if need to add the constructor name
-        is_singleton_type = type_obj==JSON_Format || (type_name.ends_with "_Format" . not)
-        if is_singleton_type then type_name else
-            simple_name = Meta.get_simple_type_name type_obj
-            "(" + type_name + "." + (simple_name.replace "_Format" "") + ")"
+        ctors = Meta.meta type_obj . constructors
+        if ctors.length == 0 then type_name else
+            "(" + type_name + "." + ctors.first.name + ")"
     make_name type_obj = type_obj.to_text.replace "_Format" "" . replace "_" " "
     Single_Choice display=Display.Always values=(all_types.map n->(Option (make_name n) (make_ctor n)))
 

--- a/distribution/lib/Standard/Image/0.0.0-dev/src/Data/Image.enso
+++ b/distribution/lib/Standard/Image/0.0.0-dev/src/Data/Image.enso
@@ -98,15 +98,16 @@ type Image
              image.write path image [Write_Flag.JPEG_Quality 40, Write_Flag.JPEG_Progressive]
     write : (Text | File)  -> (Write_Flag | Vector) -> Nothing ! File_Error
     write self location flags=[] =
-        path = case location of
-            _ : File -> location.path
-            _ -> location
-        write_flags = case flags of
-            _ : Vector -> flags
-            _ -> [flags]
-        int_flags = MatOfInt.new (write_flags.flat_map x-> [x.to_integer, x.value]).to_array
-        Panic.catch JException (Java_Codecs.write path self.opencv_mat int_flags) _->
-            Error.throw (File_Error.IO_Error (File.new path) 'Failed to write to the file')
+        if Context.Output.is_enabled.not then Error.throw (Forbidden_Operation.Error "Writing the image to a file is forbidden as the Output context is disabled.") else
+            path = case location of
+                _ : File -> location.path
+                _ -> location
+            write_flags = case flags of
+                _ : Vector -> flags
+                _ -> [flags]
+            int_flags = MatOfInt.new (write_flags.flat_map x-> [x.to_integer, x.value]).to_array
+            Panic.catch JException (Java_Codecs.write path self.opencv_mat int_flags) _->
+                Error.throw (File_Error.IO_Error (File.new path) 'Failed to write to the file')
 
     ## PRIVATE
 

--- a/distribution/lib/Standard/Image/0.0.0-dev/src/Data/Image.enso
+++ b/distribution/lib/Standard/Image/0.0.0-dev/src/Data/Image.enso
@@ -1,4 +1,6 @@
 from Standard.Base import all
+import Standard.Base.Runtime.Context
+import Standard.Base.Errors.Common.Forbidden_Operation
 import Standard.Base.Errors.File_Error.File_Error
 
 from Standard.Base.Data.Ordering import all

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
@@ -255,7 +255,7 @@ type Invalid_Format
        Pretty print the invalid format error.
     to_display_text : Text
     to_display_text self =
-        self.cells.length+" cells in column "+self.column+" had invalid format for type "+self.value_type.to_text+"."
+        self.cells.length.to_text+" cells in column "+self.column+" had invalid format for type "+self.value_type.to_text+"."
 
 ## Indicates that an empty file was encountered, so no data could be loaded.
 type Empty_File_Error

--- a/test/Image_Tests/src/Image_Read_Write_Spec.enso
+++ b/test/Image_Tests/src/Image_Read_Write_Spec.enso
@@ -1,5 +1,7 @@
 from Standard.Base import all
+import Standard.Base.Errors.Common.Forbidden_Operation
 import Standard.Base.Errors.File_Error.File_Error
+import Standard.Base.Runtime.Context
 
 from Standard.Image import Image, Read_Flag, Write_Flag
 import Standard.Image.Image_File_Format.Image_File_Format
@@ -27,16 +29,19 @@ spec =
             result = Image.read (enso_project.root / 'no_such_file.png')
             result . should_fail_with File_Error
             result.catch.should_be_a File_Error.IO_Error
+
         Test.specify "should read a color image" <|
             img = Image.read rgba_file
             img.rows.should_equal 160
             img.columns.should_equal 320
             img.channels.should_equal 3
+
         Test.specify "should read an image as grayscale" <|
             img = Image.read rgba_file Read_Flag.Grayscale
             img.rows.should_equal 160
             img.columns.should_equal 320
             img.channels.should_equal 1
+
         Test.specify "should read an image with an alpha channel" <|
             img = Image.read rgba_file Read_Flag.Alpha_Channel
             img.rows.should_equal 160
@@ -73,5 +78,30 @@ spec =
             img.rows.should_equal 160
             img.columns.should_equal 320
             img.channels.should_equal 3
+
+    Test.group "Image Write" <|
+        Test.specify "should write a Bitmap file" <|
+            img = Image.read rgba_file
+
+            out = enso_project.root / "out_alpha.bmp"
+            img.write out
+            out.exists.should_be_true
+
+            bmp = Image.read out
+            bmp.rows.should_equal 160
+            bmp.columns.should_equal 320
+
+            out.delete_if_exists
+
+        Test.specify "should not write if Context.Output is disabled." <|
+            img = Image.read rgba_file
+
+            out = enso_project.root / "out_alpha.bmp"
+
+            Context.Output.with_disabled <|
+                img.write out . should_fail_with Forbidden_Operation
+                out.exists.should_be_false
+
+            out.delete_if_exists
 
 main = Test_Suite.run_main spec

--- a/test/Image_Tests/src/Main.enso
+++ b/test/Image_Tests/src/Main.enso
@@ -2,11 +2,11 @@ from Standard.Base import all
 
 from Standard.Test import Test_Suite
 
-import project.Image_Read_Spec
+import project.Image_Read_Write_Spec
 import project.Data.Image_Spec
 import project.Data.Matrix_Spec
 
 main = Test_Suite.run_main <|
-    Image_Read_Spec.spec
+    Image_Read_Write_Spec.spec
     Matrix_Spec.spec
     Image_Spec.spec

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -155,11 +155,11 @@ sqlite_spec connection prefix =
 spec =
     enso_project.data.create_directory
     file = enso_project.data / "sqlite_test.db"
-    Context.Output.with_enabled <| file.delete_if_exists
+    file.delete_if_exists
     in_file_prefix = "[SQLite File] "
     sqlite_spec (Database.connect (SQLite file)) in_file_prefix
     Upload_Spec.spec (_ -> Database.connect (SQLite file)) in_file_prefix
-    Context.Output.with_enabled <| file.delete
+    file.delete
 
     in_memory_prefix = "[SQLite In-Memory] "
     sqlite_spec (Database.connect (SQLite In_Memory)) in_memory_prefix
@@ -167,7 +167,7 @@ spec =
 
     SQLite_Type_Mapping_Spec.spec
 
-    Test.group "SQLite_Format should allow connecting to SQLite files" <| Context.Output.with_enabled <|
+    Test.group "SQLite_Format should allow connecting to SQLite files" <|
         file.delete_if_exists
 
         connection = Database.connect (SQLite file)

--- a/test/Table_Tests/src/IO/Csv_Spec.enso
+++ b/test/Table_Tests/src/IO/Csv_Spec.enso
@@ -92,7 +92,7 @@ spec =
             res.should_equal expected
 
 
-        Test.specify 'should write CSV to a file' <| Context.Output.with_enabled <|
+        Test.specify 'should write CSV to a file' <|
             varied_column = (enso_project.data / "varied_column.csv") . read
             out = enso_project.data / "transient" / "out.csv"
             out.delete_if_exists
@@ -110,7 +110,7 @@ spec =
             out.read_text.should_equal exp
             out.delete_if_exists
 
-    Test.group "Integration" <| Context.Output.with_enabled <|
+    Test.group "Integration" <|
         Test.specify "should be able to round-trip a table with all kinds of weird characters to CSV and back" <|
             names = ['Śłąęźż");DROP TABLE Students;--', 'This;Name;;Is""Strange', 'Marcin,,', '\'', 'a\n\nb', 'a\tc', Nothing, Nothing, Nothing, '42', '💁👌🎍😍', '', 'null?\0?', 'FFFD', '\uFFFD', '\r\n', 'a\r\nb\n\rc\rd\ne', 'what about these # ?? // /* hmm */ is it included?', 'and the rare \v vertical tab?']
             d = Date_Time.new 2015 10 29 23 55 49

--- a/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
+++ b/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
@@ -103,7 +103,7 @@ spec =
             r2.should_fail_with File_Error
             r2.catch.should_be_a File_Error.IO_Error
 
-        Test.specify "should work with all kinds of line endings" <| Context.Output.with_enabled <|
+        Test.specify "should work with all kinds of line endings" <|
             path name = enso_project.data / 'transient' / name
             create_file name ending_style =
                 lines = ['a,b,c', 'd,e,f', '1,2,3']
@@ -130,7 +130,7 @@ spec =
 
             ['crlf.csv', 'lf.csv', 'cr.csv', 'mixed.csv'].each (path >> .delete)
 
-        Test.specify "should allow to override line endings style" <| Context.Output.with_enabled <|
+        Test.specify "should allow to override line endings style" <|
             file = enso_project.data / "transient" / "lf.csv"
             lines = ['a,b,c', 'd,e,f', '1,2,3']
             text = lines.join '\n'
@@ -171,7 +171,7 @@ spec =
             table.at '🚀b' . to_vector . should_equal ['✨🚀🚧😍😃😍😎😙😉☺']
             table.at 'ć😎' . to_vector . should_equal ['แมวมีสี่ขา']
 
-        Test.specify "should report errors when encountering malformed characters" <| Context.Output.with_enabled <|
+        Test.specify "should report errors when encountering malformed characters" <|
             utf8_file = (enso_project.data / "transient" / "utf8_invalid.csv")
             utf8_bytes = [97, 44, 98, 44, 99, 10, -60, -123, 44, -17, -65, -65, 44, -61, 40, -61, 40, 10]
             utf8_bytes.write_bytes utf8_file

--- a/test/Table_Tests/src/IO/Delimited_Write_Spec.enso
+++ b/test/Table_Tests/src/IO/Delimited_Write_Spec.enso
@@ -25,7 +25,7 @@ join_lines lines trailing_newline=True =
 
 spec =
     line_ending_pairs = [[Line_Ending_Style.Unix, '\n'], [Line_Ending_Style.Windows, '\r\n'], [Line_Ending_Style.Mac_Legacy, '\r']]
-    Test.group "Delimited File Writing" <| Context.Output.with_enabled <|
+    Test.group "Delimited File Writing" <|
         Test.specify "should correctly write a simple table and return the written file object on success" <|
             table = Table.new [["A", [1,2,3]], ["B", [1.0,1.5,2.2]], ["C", ["x","y","z"]], ["D", ["a", 2, My_Type.Value 10]]]
             file = (enso_project.data / "transient" / "written.csv")

--- a/test/Table_Tests/src/IO/Excel_Spec.enso
+++ b/test/Table_Tests/src/IO/Excel_Spec.enso
@@ -68,7 +68,7 @@ spec_fmt header file read_method sheet_count=5 =
             t_3.at 'C' . to_vector . should_equal [43.2, 54]
 
 spec_write suffix test_sheet_name =
-    Test.group ("Write " + suffix + " Files") <| Context.Output.with_enabled <|
+    Test.group ("Write " + suffix + " Files") <|
         out = enso_project.data / ('out.' + suffix)
         out_bak = enso_project.data / ('out.' + suffix + '.bak')
         table = enso_project.data/'varied_column.csv' . read
@@ -679,7 +679,7 @@ spec =
             r2.should_fail_with File_Error
             r2.catch.should_be_a File_Error.Corrupted_Format
 
-        Test.specify "should handle malformed XLS files gracefully" <| Context.Output.with_enabled <|
+        Test.specify "should handle malformed XLS files gracefully" <|
             bad_file = enso_project.data / "transient" / "malformed.xls"
             "not really an XLS file contents...".write bad_file on_existing_file=Existing_File_Behavior.Overwrite
 

--- a/test/Table_Tests/src/IO/Formats_Spec.enso
+++ b/test/Table_Tests/src/IO/Formats_Spec.enso
@@ -10,8 +10,7 @@ import Standard.Test.Extensions
 
 import project.Util
 
-
-spec = Test.group 'Various File Format support on Table' <| Context.Output.with_enabled <|
+spec = Test.group 'Various File Format support on Table' <|
     t1 = Table.new [["X", [1, 2, 3]]]
     transient = enso_project.data / "transient"
     simple_empty = enso_project.data/'simple_empty.csv' . read

--- a/test/Tests/src/System/File_Spec.enso
+++ b/test/Tests/src/System/File_Spec.enso
@@ -108,7 +108,7 @@ spec =
             f.delete
             f.exists.should_be_false
 
-        Test.specify "should only allow writing a file if Output is enabled" <|
+        Test.specify "should only allow with_output_stream if Output is enabled" <|
             f = enso_project.data / "short.txt"
             f.delete_if_exists
 
@@ -398,13 +398,14 @@ spec =
             f.delete_if_exists
             f.exists.should_be_false
 
-            Context.Output.with_disabled <|
+            r = Context.Output.with_disabled <|
                 r = "line 1!".write f
                 Problems.expect_only_warning Dry_Run_Operation r
                 f.exists.should_be_false
                 r.exists.should_be_true
+                r
 
-                Context.Output.with_enabled <| r.delete_if_exists
+            r.delete_if_exists
 
         Test.specify "should allow appending text to a file" <|
             f = transient / "work.txt"
@@ -468,12 +469,14 @@ spec =
             "line 1!".write f on_existing_file=Existing_File_Behavior.Overwrite on_problems=Report_Error . should_succeed . should_equal f
             f.exists.should_be_true
 
-            Context.Output.with_disabled <|
-                "line 2!".write f on_existing_file=Existing_File_Behavior.Overwrite
-                f.read_text.should_equal "line 1!"
+            r = Context.Output.with_disabled <|
+                r = "line 2!".write f on_existing_file=Existing_File_Behavior.Overwrite
+                r.read_text.should_equal "line 2!"
+                r
+            r.delete_if_exists
 
-            f.delete
-            f.exists.should_be_false
+            f.read_text.should_equal "line 1!"
+            f.delete_if_exists
 
         Test.specify "should fail if a file already exists, depending on the settings" <|
             f = transient / "work.txt"
@@ -528,13 +531,22 @@ spec =
                 n.read_text . should_equal "new content"
             [f, bak, n0, n1, n2, n4].each .delete
 
-        Test.specify "should create a backup when writing a dry run file with Context.Output disabled" <|
+        Test.specify "should not create a backup when writing a dry run file with Context.Output disabled" <|
             f = transient / "work.txt"
             f.delete_if_exists
             f.exists.should_be_false
             "line 1!".write f on_problems=Report_Error . should_succeed . should_equal f
 
-            r = Context.Output.with_disabled <| "New Content!".write f
+            r = Context.Output.with_disabled <|
+                s = "New Content!".write f on_existing_file=Existing_File_Behavior.Backup
+                s.exists.should_be_true
+                s.read_text.should_equal "New Content!"
+
+                "Other Content!".write s on_existing_file=Existing_File_Behavior.Backup
+                s.read_text.should_equal "Other Content!"
+                t = File.new s.path+".bak"
+                t.exists.should_be_false
+                s
 
             bak = transient / "work.txt.bak"
             bak.exists.should_be_false

--- a/test/Tests/src/System/File_Spec.enso
+++ b/test/Tests/src/System/File_Spec.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Errors.Common.Forbidden_Operation
+import Standard.Base.Errors.Common.Dry_Run_Operation
 import Standard.Base.Errors.Encoding_Error.Encoding_Error
 import Standard.Base.Errors.File_Error.File_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
@@ -364,6 +365,19 @@ spec =
             f.delete
             f.exists.should_be_false
 
+        Test.specify "should perform a dry run write of text to a new file and return this file's descriptor on success" <|
+            f = transient / "work.txt"
+            f.delete_if_exists
+            f.exists.should_be_false
+
+            Context.Output.with_disabled <|
+                r = "line 1!".write f
+                Problems.expect_only_warning Dry_Run_Operation r
+                f.exists.should_be_false
+                r.exists.should_be_true
+
+                Context.Output.with_enabled <| r.delete_if_exists
+
         Test.specify "should allow appending text to a file" <|
             f = transient / "work.txt"
             f.delete_if_exists
@@ -372,6 +386,40 @@ spec =
             f.read_text.should_equal 'line 1!\nline 2!'
             f.delete
             f.exists.should_be_false
+
+        Test.specify "should perform a dry run append text to a file" <|
+            f = transient / "work.txt"
+            f.delete_if_exists
+            "line 1!".write f on_existing_file=Existing_File_Behavior.Append on_problems=Report_Error . should_succeed . should_equal f
+
+            Context.Output.with_disabled <|
+                r = '\nline 2!'.write f on_existing_file=Existing_File_Behavior.Append on_problems=Report_Error
+                Problems.expect_only_warning Dry_Run_Operation r
+                r.exists.should_be_true
+                r.read_text.should_equal 'line 1!\nline 2!'
+                f.read_text.should_equal 'line 1!'
+
+                Context.Output.with_enabled <| r.delete_if_exists
+
+        Test.specify "should perform a dry run create and append text to a file" <|
+            f = transient / "dry_append.txt"
+            f.delete_if_exists
+
+            Context.Output.with_disabled <|
+                r = "line 1!".write f on_existing_file=Existing_File_Behavior.Append on_problems=Report_Error
+                Problems.expect_only_warning Dry_Run_Operation r
+                r.exists.should_be_true
+
+                s = '\nline 2!'.write f on_existing_file=Existing_File_Behavior.Append on_problems=Report_Error
+                Problems.expect_only_warning Dry_Run_Operation s
+                s.exists.should_be_true
+
+                s.read_text.should_equal 'line 1!\nline 2!'
+                s.should_equal r
+
+                f.exists.should_be_false
+
+                Context.Output.with_enabled <| r.delete_if_exists
 
         Test.specify "should allow to overwrite files" <|
             f = transient / "work.txt"
@@ -382,6 +430,20 @@ spec =
             f.read_text.should_equal "line 1!"
             "line 2!".write f on_existing_file=Existing_File_Behavior.Overwrite on_problems=Report_Error . should_succeed . should_equal f
             f.read_text.should_equal "line 2!"
+            f.delete
+            f.exists.should_be_false
+
+        Test.specify "should not overwrite original file in dry run mode" <|
+            f = transient / "work.txt"
+            f.delete_if_exists
+            f.exists.should_be_false
+            "line 1!".write f on_existing_file=Existing_File_Behavior.Overwrite on_problems=Report_Error . should_succeed . should_equal f
+            f.exists.should_be_true
+
+            Context.Output.with_disabled <|
+                "line 2!".write f on_existing_file=Existing_File_Behavior.Overwrite
+                f.read_text.should_equal "line 1!"
+
             f.delete
             f.exists.should_be_false
 

--- a/test/Tests/src/System/File_Spec.enso
+++ b/test/Tests/src/System/File_Spec.enso
@@ -454,10 +454,18 @@ spec =
             "line 1!".write f on_existing_file=Existing_File_Behavior.Error on_problems=Report_Error . should_succeed . should_equal f
             f.exists.should_be_true
             f.read_text.should_equal "line 1!"
+
             r1 = "line 2!".write f on_existing_file=Existing_File_Behavior.Error
             r1.should_fail_with File_Error
             r1.catch.should_be_a File_Error.Already_Exists
             f.read_text.should_equal "line 1!"
+
+            Context.Output.with_disabled <|
+                r2 = "line 2!".write f on_existing_file=Existing_File_Behavior.Error
+                r2.should_fail_with File_Error
+                r2.catch.should_be_a File_Error.Already_Exists
+                f.read_text.should_equal "line 1!"
+
             f.delete
             f.exists.should_be_false
 

--- a/test/Tests/src/System/File_Spec.enso
+++ b/test/Tests/src/System/File_Spec.enso
@@ -393,7 +393,7 @@ spec =
             f.delete
             f.exists.should_be_false
 
-        Test.specify "should perform a dry run write of text to a new file and return this file's descriptor on success" <|
+        Test.specify "should perform a dry run writing text to a new file if Context.Output is disabled" <|
             f = transient / "work.txt"
             f.delete_if_exists
             f.exists.should_be_false
@@ -415,7 +415,7 @@ spec =
             f.delete
             f.exists.should_be_false
 
-        Test.specify "should perform a dry run append text to a file" <|
+        Test.specify "should perform a dry run appending text to a file if Context.Output is disabled" <|
             f = transient / "work.txt"
             f.delete_if_exists
             "line 1!".write f on_existing_file=Existing_File_Behavior.Append on_problems=Report_Error . should_succeed . should_equal f
@@ -429,7 +429,7 @@ spec =
 
                 Context.Output.with_enabled <| r.delete_if_exists
 
-        Test.specify "should perform a dry run create and append text to a file" <|
+        Test.specify "should perform a dry run creating and appending text to a file if Context.Output is disabled" <|
             f = transient / "dry_append.txt"
             f.delete_if_exists
 
@@ -461,7 +461,7 @@ spec =
             f.delete
             f.exists.should_be_false
 
-        Test.specify "should not overwrite original file in dry run mode" <|
+        Test.specify "should not overwrite original file if Context.Output is disabled" <|
             f = transient / "work.txt"
             f.delete_if_exists
             f.exists.should_be_false
@@ -527,6 +527,22 @@ spec =
             written_news.each n->
                 n.read_text . should_equal "new content"
             [f, bak, n0, n1, n2, n4].each .delete
+
+        Test.specify "should create a backup when writing a dry run file with Context.Output disabled" <|
+            f = transient / "work.txt"
+            f.delete_if_exists
+            f.exists.should_be_false
+            "line 1!".write f on_problems=Report_Error . should_succeed . should_equal f
+
+            r = Context.Output.with_disabled <| "New Content!".write f
+
+            bak = transient / "work.txt.bak"
+            bak.exists.should_be_false
+
+            f.read_text.should_equal "line 1!"
+            f.delete_if_exists
+            bak.delete_if_exists
+            r.delete_if_exists
 
         Test.specify "should correctly handle failure of the write operation when working with the backup" <|
             f = transient / "work.txt"

--- a/test/Tests/src/System/File_Spec.enso
+++ b/test/Tests/src/System/File_Spec.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base.Errors.Common.Forbidden_Operation
 import Standard.Base.Errors.Encoding_Error.Encoding_Error
 import Standard.Base.Errors.File_Error.File_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
@@ -19,7 +20,7 @@ spec =
     windows_file = enso_project.data / "windows.txt"
     non_existent_file = File.new "does_not_exist.txt"
 
-    Test.group "File Operations" <| Context.Output.with_enabled <|
+    Test.group "File Operations" <|
         Test.specify "should allow creating a new file" <|
             path = sample_file.path
             File.new path
@@ -77,6 +78,76 @@ spec =
                 stream.read_byte.should_equal -1
             f.delete
             f.exists.should_be_false
+
+        Test.specify "should only allow writing a file if Output is enabled" <|
+            f = enso_project.data / "short.txt"
+            f.delete_if_exists
+
+            byte_vector = "Hello World!".bytes Encoding.utf_8
+            write_bytes bytes = f.with_output_stream [File_Access.Create, File_Access.Write] stream->
+                stream.write_bytes bytes
+                stream.close
+
+            write_bytes byte_vector . should_succeed
+            f.exists.should_be_true
+            f.delete
+
+            Context.Output.with_disabled <|
+                write_bytes byte_vector . should_fail_with Forbidden_Operation
+                f.exists.should_be_false
+
+            f.delete_if_exists
+
+        Test.specify "should only allow deleting a file if Output is enabled" <|
+            f = enso_project.data / "short.txt"
+            f.delete_if_exists
+            "Cup".write f on_existing_file=Existing_File_Behavior.Overwrite
+
+            Context.Output.with_disabled <|
+                f.delete . should_fail_with Forbidden_Operation
+                f.exists.should_be_true
+
+            f.delete.should_succeed
+            f.exists.should_be_false
+
+        Test.specify "should only allow copying a file if Output is enabled" <|
+            f = enso_project.data / "short.txt"
+            f.delete_if_exists
+            "Cup".write f on_existing_file=Existing_File_Behavior.Overwrite
+
+            g = enso_project.data / "short_copy.txt"
+            g.delete_if_exists
+
+            f.copy_to g . should_succeed
+            g.exists.should_be_true
+            g.delete_if_exists
+
+            Context.Output.with_disabled <|
+                f.copy_to g . should_fail_with Forbidden_Operation
+                g.exists.should_be_false
+
+            f.delete_if_exists
+            g.delete_if_exists
+
+        Test.specify "should only allow moving a file if Output is enabled" <|
+            f = enso_project.data / "short.txt"
+            f.delete_if_exists
+            "Cup".write f on_existing_file=Existing_File_Behavior.Overwrite
+
+            g = enso_project.data / "short_copy.txt"
+            g.delete_if_exists
+
+            Context.Output.with_disabled <|
+                f.move_to g . should_fail_with Forbidden_Operation
+                f.exists.should_be_true
+                g.exists.should_be_false
+
+            f.move_to g . should_succeed
+            f.exists.should_be_false
+            g.exists.should_be_true
+
+            f.delete_if_exists
+            g.delete_if_exists
 
         Test.specify "should handle exceptions when deleting a missing file" <|
             file = File.new "does_not_exist.txt"
@@ -205,7 +276,7 @@ spec =
             contents_2 = Data.read_text file
             contents_2.should_start_with "Cupcake ipsum dolor sit amet."
 
-    Test.group "write operations" <| Context.Output.with_enabled <|
+    Test.group "write operations" <|
         data = [32, 127, -128, 0]
         data_2 = [10, 15, 20, 30]
 

--- a/test/Tests/src/System/File_Spec.enso
+++ b/test/Tests/src/System/File_Spec.enso
@@ -67,6 +67,34 @@ spec =
             (File.new "foo").should_equal (File.new "foo")
             (File.new "bar").should_not_equal (File.new "foo")
 
+        Test.specify "should allow creating a directory" <|
+            f = enso_project.data / "good_dir"
+            f.delete_if_exists
+            f.exists.should_be_false
+
+            f.create_directory
+            f.exists.should_be_true
+            f.is_directory.should_be_true
+
+            g = f / "bar" / "baz"
+            g.exists.should_be_false
+
+            g.create_directory
+            g.exists.should_be_true
+
+            g.delete_if_exists
+            g.parent.delete_if_exists
+            f.delete_if_exists
+
+        Test.specify "should only allow creating a directory if Output is enabled" <|
+            f = enso_project.data / "bad_dir"
+            f.delete_if_exists
+            f.exists.should_be_false
+
+            Context.Output.with_disabled <|
+                f.create_directory . should_fail_with Forbidden_Operation
+                f.exists.should_be_false
+
         Test.specify "should allow reading a file byte by byte" <|
             f = enso_project.data / "short.txt"
             f.delete_if_exists

--- a/test/Tests/src/System/Reporting_Stream_Decoder_Spec.enso
+++ b/test/Tests/src/System/Reporting_Stream_Decoder_Spec.enso
@@ -25,7 +25,7 @@ spec =
             f.delete
             f.exists.should_be_false
 
-        Test.specify "should work correctly when reading chunks of varying sizes" <| Context.Output.with_enabled <|
+        Test.specify "should work correctly when reading chunks of varying sizes" <|
             f = enso_project.data / "transient" / "varying_chunks.txt"
             fragment = 'Hello 😎🚀🚧!'
             contents = 1.up_to 1000 . map _->fragment . join '\n'

--- a/test/Tests/src/System/Reporting_Stream_Encoder_Spec.enso
+++ b/test/Tests/src/System/Reporting_Stream_Encoder_Spec.enso
@@ -10,7 +10,7 @@ from Standard.Test import Test, Test_Suite, Problems
 import Standard.Test.Extensions
 
 spec =
-    Test.group "ReportingStreamEncoder" <| Context.Output.with_enabled <|
+    Test.group "ReportingStreamEncoder" <|
         Test.specify "should allow writing a file codepoint by codepoint" <|
             f = enso_project.data / "transient" / "char-by-char.txt"
             f.delete_if_exists

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -100,7 +100,7 @@ visualization_spec connection =
             Visualization.prepare_visualization Value_Type.Char . should_equal (make_json Value_Type.Char)
             Visualization.prepare_visualization Value_Type.Unsupported_Data_Type . should_equal (make_json Value_Type.Unsupported_Data_Type)
 
-spec = Context.Output.with_enabled <|
+spec =
     enso_project.data.create_directory
     file = enso_project.data / "sqlite_test.db"
     file.delete_if_exists


### PR DESCRIPTION
### Pull Request Description

- Add `with_disabled` shortcut for `Context`.
- Protect `Image.write` behind `Context.Output`.
- Correct text on the `Forbidden_Operation` error message.
- Remove context overrides from tests.
- Add `File` operations tests with `Context.Output` disabled.
- Add tests for `Text.write` operations with `Context.Output` disabled.
- Use a better method to make `File_Format` dropdown widget.
- Fix bug in `Invalid_Format.to_display_text`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
