### PR TITLE
Force pending saves if client closes abruptly

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
@@ -810,7 +810,7 @@ class CollaborativeBuffer(
   }
 
   def stop(autoSave: Map[ClientId, (ContentVersion, Cancellable)]): Unit = {
-    autoSave.values.foreach(_._2.cancel())
+    autoSave.foreach { case (_, (_, cancellable)) => cancellable.cancel() }
     context.system.eventStream.publish(BufferClosed(bufferPath))
     context.stop(self)
   }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
@@ -146,8 +146,8 @@ class CollaborativeBuffer(
               client.clientId,
               contentVersion,
               autoSave,
-              isAutoSave = true,
-              onClose = Some(client.clientId),
+              isAutoSave     = true,
+              onClose        = Some(client.clientId),
               reportProgress = Some(sender())
             )
           case None =>

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
@@ -1,6 +1,5 @@
 package org.enso.languageserver.websocket.json
 
-import akka.actor.ActorRef
 import akka.testkit.TestProbe
 import io.circe.literal._
 import io.circe.parser.parse

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
@@ -1,5 +1,6 @@
 package org.enso.languageserver.websocket.json
 
+import akka.actor.ActorRef
 import akka.testkit.TestProbe
 import io.circe.literal._
 import io.circe.parser.parse
@@ -360,6 +361,14 @@ class BaseServerTest
     val client = new WsTestClient(address, debugMessages = debug)
     initSession(client)
     client
+  }
+
+  def getInitialisedWsClientAndId(
+    debug: Boolean = false
+  ): (WsTestClient, ClientId) = {
+    val client = new WsTestClient(address, debugMessages = debug)
+    val uuid   = initSession(client)
+    (client, uuid)
   }
 
   private def initSession(client: WsTestClient): UUID = {

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
@@ -2,8 +2,9 @@ package org.enso.languageserver.websocket.json
 
 import akka.testkit.TestProbe
 import io.circe.literal._
-import org.enso.languageserver.event.BufferClosed
+import org.enso.languageserver.event.{BufferClosed, JsonSessionTerminated}
 import org.enso.languageserver.filemanager.Path
+import org.enso.languageserver.session.JsonSession
 import org.enso.testkit.FlakySpec
 import scala.concurrent.duration._
 
@@ -2601,6 +2602,128 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             "result": null
           }
           """)
+      client2.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "file/read",
+            "id": 4,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "foo.txt" ]
+              }
+            }
+          }
+          """)
+      client2.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 4,
+            "result": { "contents": "bar123456789foo" }
+          }
+          """)
+
+    }
+
+    "be triggered when a client closed session abruptly" in {
+      this.timingsConfig.withAutoSave(10.seconds)
+
+      val (client1, client1Id) = getInitialisedWsClientAndId()
+      val client2              = getInitialisedWsClient()
+      client1.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "file/write",
+            "id": 0,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "foo.txt" ]
+              },
+              "contents": "123456789"
+            }
+          }
+          """)
+      client1.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 0,
+            "result": null
+          }
+          """)
+      client1.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "text/openFile",
+            "id": 1,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "foo.txt" ]
+              }
+            }
+          }
+          """)
+      client1.expectJson(json"""
+          {
+            "jsonrpc" : "2.0",
+            "id" : 1,
+            "result" : {
+              "writeCapability" : {
+                "method" : "text/canEdit",
+                "registerOptions" : {
+                  "path" : {
+                    "rootId" : $testContentRootId,
+                    "segments" : [
+                      "foo.txt"
+                    ]
+                  }
+                }
+              },
+              "content" : "123456789",
+              "currentVersion" : "5795c3d628fd638c9835a4c79a55809f265068c88729a1a3fcdf8522"
+            }
+          }
+          """)
+
+      client1.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "text/applyEdit",
+            "id": 2,
+            "params": {
+              "edit": {
+                "path": {
+                  "rootId": $testContentRootId,
+                  "segments": [ "foo.txt" ]
+                },
+                "oldVersion": "5795c3d628fd638c9835a4c79a55809f265068c88729a1a3fcdf8522",
+                "newVersion": "ebe55342f9c8b86857402797dd723fb4a2174e0b56d6ace0a6929ec3",
+                "edits": [
+                  {
+                    "range": {
+                      "start": { "line": 0, "character": 0 },
+                      "end": { "line": 0, "character": 0 }
+                    },
+                    "text": "bar"
+                  },
+                  {
+                    "range": {
+                      "start": { "line": 0, "character": 12 },
+                      "end": { "line": 0, "character": 12 }
+                    },
+                    "text": "foo"
+                  }
+                ]
+              }
+            }
+          }
+          """)
+      client1.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 2,
+            "result": null
+          }
+          """)
+
+      // Simulate client1 closing
+      system.eventStream.publish(
+        JsonSessionTerminated(JsonSession(client1Id, client1.actorRef()))
+      )
       client2.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/read",

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
@@ -2601,8 +2601,6 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             "result": null
           }
           """)
-      Thread.sleep(5.seconds.toMillis)
-      // Should return the original contents of the file
       client2.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/read",
@@ -2621,6 +2619,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             "result": { "contents": "bar123456789foo" }
           }
           """)
+
     }
 
   }

--- a/lib/scala/json-rpc-server-test/src/main/scala/org/enso/jsonrpc/test/JsonRpcServerTestKit.scala
+++ b/lib/scala/json-rpc-server-test/src/main/scala/org/enso/jsonrpc/test/JsonRpcServerTestKit.scala
@@ -140,6 +140,10 @@ abstract class JsonRpcServerTestKit
     }
 
     def expectNoMessage(): Unit = outActor.expectNoMessage()
+
+    def actorRef(): ActorRef = {
+      outActor.ref
+    }
   }
 }
 

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerController.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerController.scala
@@ -292,6 +292,11 @@ class LanguageServerController(
         maybeRequester.foreach(_ ! ServerShutdownTimedOut)
         stop()
 
+      case ClientDisconnected(clientId) =>
+        logger.debug(
+          s"Received client ($clientId) disconnect request during shutdown. Ignoring."
+        )
+
       case m: StartServer =>
         // This instance has not yet been shut down. Retry
         context.parent.forward(Retry(m))


### PR DESCRIPTION
### Pull Request Description

Force pending saves when JsonSession is terminated for the client.

Potentially closes #6395.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
