### PR TITLE
Infer correct synthetic name for nested modules

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/compiler/PackageRepository.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/PackageRepository.scala
@@ -391,11 +391,12 @@ object PackageRepository {
               s"""|import $modName
                   |export $modName
                   |""".stripMargin
-            (
-              QualifiedName(namespace :: name :: parts, lastModuleName),
+            val syntheticModuleInfo = (
+              QualifiedName(namespace :: name :: parts.reverse, lastModuleName),
               QualifiedName(namespace :: name :: pathElems, exportItem),
               modSource
-            ) :: listAllIntermediateModules(
+            )
+            syntheticModuleInfo :: listAllIntermediateModules(
               namespace,
               name,
               parts,

--- a/engine/runtime/src/test/resources/Test_Deeply_Nested_Modules/package.yaml
+++ b/engine/runtime/src/test/resources/Test_Deeply_Nested_Modules/package.yaml
@@ -1,0 +1,6 @@
+name: Test_Deeply_Nested_Modules
+license: APLv2
+enso-version: default
+version: "0.0.1"
+author: "Enso Team <contact@enso.org>"
+maintainer: "Enso Team <contact@enso.org>"

--- a/engine/runtime/src/test/resources/Test_Deeply_Nested_Modules/src/A.enso
+++ b/engine/runtime/src/test/resources/Test_Deeply_Nested_Modules/src/A.enso
@@ -1,0 +1,1 @@
+type Foo_A

--- a/engine/runtime/src/test/resources/Test_Deeply_Nested_Modules/src/A/A_Mod.enso
+++ b/engine/runtime/src/test/resources/Test_Deeply_Nested_Modules/src/A/A_Mod.enso
@@ -1,0 +1,2 @@
+type A_Mod
+    Value a

--- a/engine/runtime/src/test/resources/Test_Deeply_Nested_Modules/src/A/B.enso
+++ b/engine/runtime/src/test/resources/Test_Deeply_Nested_Modules/src/A/B.enso
@@ -1,0 +1,1 @@
+type Foo_B

--- a/engine/runtime/src/test/resources/Test_Deeply_Nested_Modules/src/A/B/B_Mod.enso
+++ b/engine/runtime/src/test/resources/Test_Deeply_Nested_Modules/src/A/B/B_Mod.enso
@@ -1,0 +1,2 @@
+type B_Mod
+    Value a

--- a/engine/runtime/src/test/resources/Test_Deeply_Nested_Modules/src/A/B/C/C_Mod.enso
+++ b/engine/runtime/src/test/resources/Test_Deeply_Nested_Modules/src/A/B/C/C_Mod.enso
@@ -1,0 +1,2 @@
+type C_Mod
+    Value a

--- a/engine/runtime/src/test/resources/Test_Deeply_Nested_Modules/src/A/B/C/D/D_Mod.enso
+++ b/engine/runtime/src/test/resources/Test_Deeply_Nested_Modules/src/A/B/C/D/D_Mod.enso
@@ -1,0 +1,2 @@
+type D_Mod
+    Value a

--- a/engine/runtime/src/test/resources/Test_Deeply_Nested_Modules/src/Main.enso
+++ b/engine/runtime/src/test/resources/Test_Deeply_Nested_Modules/src/Main.enso
@@ -1,0 +1,11 @@
+from Standard.Base import all
+
+import project.A.A_Mod
+import project.A.B.B_Mod
+import project.A.B
+
+main =
+    IO.println (A_Mod.A_Mod.Value 1)
+    IO.println (B.C.C_Mod.C_Mod.Value 1)
+    IO.println (B.C.D.D_Mod.D_Mod.Value 1)
+    0

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ImportsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ImportsTest.scala
@@ -191,4 +191,15 @@ class ImportsTest extends PackageTest {
     ) shouldEqual "Main.enso[2:1-2:57]: The exported type `Atom` in `local.Test_Fully_Qualified_Name_Conflict.Atom` module will cause name conflict when attempting to use a fully qualified name of the `local.Test_Fully_Qualified_Name_Conflict.Atom.Foo` module."
   }
 
+  "Deeply nested modules" should "infer correct synthetic modules" in {
+    evalTestProject(
+      "Test_Deeply_Nested_Modules"
+    ).toString shouldEqual "0"
+    val outLines = consumeOut
+    outLines should have length 3
+    outLines(0) shouldEqual "(A_Mod.Value 1)"
+    outLines(1) shouldEqual "(C_Mod.Value 1)"
+    outLines(2) shouldEqual "(D_Mod.Value 1)"
+  }
+
 }


### PR DESCRIPTION
### Pull Request Description

Deeply nested modules (of depth at least 3) would have the incorrect name inferred for synthetic modules. This also became apparent in a much bigger rewrite.

Instead of having module `A.B.C`, as described in the test, it would infer the name to be `B.A.C`, which would break when trying to reference symbols from `C`.

### Important Notes

No ticket reference, as this was something that @radeusgd discovered while working on another component. 
The PR includes a minimal example that would previously fail to compile.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
