### PR TITLE
Fix list editor panics during insertion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,7 +683,7 @@ checksum = "e5694b64066a2459918d8074c2ce0d5a88f409431994c2356617c8ae0c4721fc"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "http",
@@ -796,6 +796,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a6904aef64d73cf10ab17ebace7befb918b82164785cb89907993be7f83813"
 
 [[package]]
 name = "block-buffer"
@@ -1022,7 +1028,7 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "textwrap 0.11.0",
  "unicode-width",
 ]
@@ -1034,7 +1040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
  "indexmap",
@@ -2594,7 +2600,7 @@ version = "0.1.0"
 dependencies = [
  "Inflector",
  "bit_field",
- "bitflags",
+ "bitflags 2.2.1",
  "code-builder",
  "console_error_panic_hook",
  "enso-callback",
@@ -3825,7 +3831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "headers-core",
  "http",
@@ -4338,6 +4344,7 @@ dependencies = [
  "ast",
  "base64 0.13.1",
  "bimap",
+ "bitflags 2.2.1",
  "engine-protocol",
  "enso-config",
  "enso-frp",
@@ -4544,7 +4551,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a989afac88279b0482f402d234b5fbd405bf1ad051308595b58de4e6de22346b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "serde",
  "unicode-segmentation",
 ]
@@ -4805,7 +4812,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb67c6dd0fa9b00619c41c5700b6f92d5f418be49b45ddb9970fbd4569df3c8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4900,7 +4907,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "libc",
  "memoffset",
@@ -5103,7 +5110,7 @@ version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -5593,7 +5600,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "getopts",
  "memchr",
  "unicase",
@@ -5738,7 +5745,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -5897,7 +5904,7 @@ version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -5972,7 +5979,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a617c811f5c9a7060fe511d35d13bf5b9f0463ce36d63ce666d05779df2b4eba"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytemuck",
  "smallvec 1.10.0",
  "ttf-parser",
@@ -6065,7 +6072,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -6867,7 +6874,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,3 +136,4 @@ syn = { version = "1.0", features = [
 quote = { version = "1.0.23" }
 semver = { version = "1.0.0", features = ["serde"] }
 thiserror = "1.0.40"
+bitflags = { version = "2.2.1" }

--- a/app/gui/language/span-tree/src/generate.rs
+++ b/app/gui/language/span-tree/src/generate.rs
@@ -145,7 +145,7 @@ impl<T: Payload> ChildGenerator<T> {
         let kind = kind.into();
         let size = self.current_offset;
         let children = self.children;
-        Node { kind, size, children, ast_id, parenthesized: false, payload: default() }
+        Node { kind, size, children, ast_id, ..default() }
     }
 }
 
@@ -498,12 +498,11 @@ fn generate_node_for_opr_chain<T: Payload>(
 
         Ok((
             Node {
-                kind:          if is_last { kind.clone() } else { node::Kind::chained().into() },
-                parenthesized: false,
-                size:          gen.current_offset,
-                children:      gen.children,
-                ast_id:        elem.infix_id,
-                payload:       default(),
+                kind: if is_last { kind.clone() } else { node::Kind::chained().into() },
+                size: gen.current_offset,
+                children: gen.children,
+                ast_id: elem.infix_id,
+                ..default()
             },
             elem.offset,
         ))
@@ -778,11 +777,12 @@ fn generate_expected_argument<T: Payload>(
     argument_info: ArgumentInfo,
 ) -> Node<T> {
     let mut gen = ChildGenerator::default();
+    let extended_ast_id = node.ast_id.or(node.extended_ast_id);
     gen.add_node(ast::Crumbs::new(), node);
     let arg_node = gen.generate_empty_node(InsertionPointType::ExpectedArgument { index, named });
     arg_node.node.set_argument_info(argument_info);
     let kind = node::Kind::chained().into();
-    Node { kind, size: gen.current_offset, children: gen.children, ..default() }
+    Node { kind, size: gen.current_offset, children: gen.children, extended_ast_id, ..default() }
 }
 
 /// Build a prefix application-like span tree structure where no prefix argument has been provided
@@ -873,8 +873,7 @@ fn tree_generate_node<T: Payload>(
         }
         size = parent_offset;
     }
-    let payload = default();
-    Ok(Node { kind, parenthesized, size, children, ast_id, payload })
+    Ok(Node { kind, parenthesized, size, children, ast_id, ..default() })
 }
 
 

--- a/app/gui/language/span-tree/src/generate.rs
+++ b/app/gui/language/span-tree/src/generate.rs
@@ -939,6 +939,7 @@ mod test {
     /// cleaner the expression IDs are removed before comparing trees.
     fn clear_expression_ids<T>(node: &mut Node<T>) {
         node.ast_id = None;
+        node.extended_ast_id = None;
         for child in &mut node.children {
             clear_expression_ids(&mut child.node);
         }

--- a/app/gui/language/span-tree/src/node.rs
+++ b/app/gui/language/span-tree/src/node.rs
@@ -36,12 +36,16 @@ pub trait Payload = Default + Clone;
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[allow(missing_docs)]
 pub struct Node<T> {
-    pub kind:          Kind,
-    pub size:          ByteDiff,
-    pub children:      Vec<Child<T>>,
-    pub ast_id:        Option<ast::Id>,
-    pub parenthesized: bool,
-    pub payload:       T,
+    pub kind:            Kind,
+    pub size:            ByteDiff,
+    pub children:        Vec<Child<T>>,
+    pub ast_id:          Option<ast::Id>,
+    /// When this `Node` is a part of an AST extension (a virtual span that only exists in
+    /// span-tree, but not in AST), this field will contain the AST ID of the expression it extends
+    /// (e.g. the AST of a function call with missing arguments, extended with expected arguments).
+    pub extended_ast_id: Option<ast::Id>,
+    pub parenthesized:   bool,
+    pub payload:         T,
 }
 
 impl<T> Deref for Node<T> {
@@ -74,8 +78,9 @@ impl<T> Node<T> {
         let size = self.size;
         let children = self.children.into_iter().map(|t| t.map(f)).collect_vec();
         let ast_id = self.ast_id;
+        let extended_ast_id = self.extended_ast_id;
         let payload = f(self.payload);
-        Node { kind, parenthesized, size, children, ast_id, payload }
+        Node { kind, parenthesized, size, children, ast_id, extended_ast_id, payload }
     }
 }
 

--- a/app/gui/src/controller/graph/widget/configuration.rs
+++ b/app/gui/src/controller/graph/widget/configuration.rs
@@ -32,7 +32,7 @@ pub fn deserialize_widget_definitions(
                             e.context(format!("{msg} '{argument_name}'"))
                         })?;
                     let meta = widget.map(to_configuration);
-                    let argument_name = argument_name.to_owned();
+                    let argument_name = argument_name.into_owned();
                     Ok(ArgumentWidgetConfig { argument_name, config: meta })
                 },
             );
@@ -60,25 +60,25 @@ fn to_kind(inner: response::WidgetKindDefinition) -> widget::DynConfig {
         response::WidgetKindDefinition::SingleChoice { label, values } =>
             widget::single_choice::Config {
                 label:   label.map(Into::into),
-                entries: Rc::new(to_entries(&values)),
+                entries: Rc::new(to_entries(values)),
             }
             .into(),
         response::WidgetKindDefinition::ListEditor { item_widget, item_default } =>
             widget::list_editor::Config {
                 item_widget:  Some(Rc::new(to_configuration(*item_widget))),
-                item_default: item_default.into(),
+                item_default: ImString::from(item_default).into(),
             }
             .into(),
         _ => widget::label::Config::default().into(),
     }
 }
 
-fn to_entries(choices: &[response::Choice]) -> Vec<widget::Entry> {
-    choices.iter().map(to_entry).collect()
+fn to_entries(choices: Vec<response::Choice>) -> Vec<widget::Entry> {
+    choices.into_iter().map(to_entry).collect()
 }
 
-fn to_entry(choice: &response::Choice) -> widget::Entry {
-    let value: ImString = (&choice.value).into();
-    let label = choice.label.as_ref().map_or_else(|| value.clone(), |label| label.into());
+fn to_entry(choice: response::Choice) -> widget::Entry {
+    let value: ImString = choice.value.into();
+    let label = choice.label.map_or_else(|| value.clone(), |label| label.into());
     widget::Entry { required_import: None, value, label }
 }

--- a/app/gui/view/graph-editor/Cargo.toml
+++ b/app/gui/view/graph-editor/Cargo.toml
@@ -37,6 +37,7 @@ sourcemap = "6.0"
 span-tree = { path = "../../language/span-tree" }
 uuid = { version = "0.8", features = ["serde", "v4", "wasm-bindgen"] }
 wasm-bindgen = { workspace = true }
+bitflags = { workspace = true }
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/app/gui/view/graph-editor/src/component/edge.rs
+++ b/app/gui/view/graph-editor/src/component/edge.rs
@@ -287,6 +287,7 @@ pub mod joint {
     use super::*;
 
     ensogl::shape! {
+        above = [compound::rectangle::shape];
         pointer_events = false;
         alignment = center;
         (style: Style, color_rgba: Vector4<f32>) {
@@ -320,13 +321,13 @@ fn corner_base_shape(
 // FIXME [WD]: The 2 following impls are almost the same. Should be merged. This task should be
 //             handled by Wojciech.
 macro_rules! define_corner_start {
-    () => {
+    ($($args:tt)*) => {
         /// Shape definition.
         pub mod corner {
             use super::*;
 
             ensogl::shape! {
-                below = [joint];
+                $($args)*
                 alignment = center;
                 ( style:               Style
                 , radius             : f32
@@ -421,12 +422,12 @@ macro_rules! define_corner_start {
 
 
 macro_rules! define_corner_end {
-    () => {
+    ($($args:tt)*) => {
         /// Shape definition.
         pub mod corner {
             use super::*;
             ensogl::shape! {
-                below = [joint];
+                $($args)*
                 alignment = center;
                 (
                     style: Style,
@@ -526,12 +527,12 @@ macro_rules! define_corner_end {
 }
 
 macro_rules! define_line {
-    () => {
+    ($($args:tt)*) => {
         /// Shape definition.
         pub mod line {
             use super::*;
             ensogl::shape! {
-                below = [joint];
+                $($args)*
                 alignment = center;
                 (
                     style: Style,
@@ -595,12 +596,12 @@ macro_rules! define_line {
     };
 }
 
-macro_rules! define_arrow { () => {
+macro_rules! define_arrow { ($($args:tt)*) => {
     /// Shape definition.
     pub mod arrow {
         use super::*;
         ensogl::shape! {
-            above = [joint];
+            $($args)*
             alignment = center;
             (
                 style: Style,
@@ -743,17 +744,31 @@ impl LayoutLine for back::line::View {
 /// Shape definitions which will be rendered in the front layer (on top of nodes).
 pub mod front {
     use super::*;
-    define_corner_start!();
-    define_line!();
-    define_arrow!();
+    define_corner_start!(
+        above = [node::backdrop, compound::rectangle::shape];
+        below = [joint];
+    );
+    define_line!(
+        above = [node::backdrop, compound::rectangle::shape];
+        below = [joint];
+    );
+    define_arrow!(
+        above = [joint, node::backdrop, compound::rectangle::shape];
+    );
 }
 
 /// Shape definitions which will be rendered in the bottom layer (below nodes).
 pub mod back {
     use super::*;
-    define_corner_end!();
-    define_line!();
-    define_arrow!();
+    define_corner_end!(
+        below = [node::backdrop];
+    );
+    define_line!(
+        below = [node::backdrop];
+    );
+    define_arrow!(
+        below = [node::backdrop];
+    );
 }
 
 

--- a/app/gui/view/graph-editor/src/component/node.rs
+++ b/app/gui/view/graph-editor/src/component/node.rs
@@ -687,8 +687,7 @@ impl Node {
 
             let background_press = model.background.on_event::<mouse::Down>();
             let input_press = model.input.on_event::<mouse::Down>();
-            ports_were_visible <- model.input.ports_visible.debounce();
-            input_as_background_press <- input_press.gate_not(&ports_were_visible);
+            input_as_background_press <- input_press.gate(&input.set_edit_ready_mode);
             any_background_press <- any(&background_press, &input_as_background_press);
             any_primary_press <- any_background_press.filter(mouse::event::is_primary);
             out.background_press <+ any_primary_press.constant(());

--- a/app/gui/view/graph-editor/src/component/node.rs
+++ b/app/gui/view/graph-editor/src/component/node.rs
@@ -14,7 +14,6 @@ use crate::view;
 use crate::CallWidgetsConfig;
 use crate::Type;
 
-use super::edge;
 use engine_protocol::language_server::ExecutionEnvironment;
 use enso_frp as frp;
 use enso_frp;
@@ -111,6 +110,7 @@ pub mod backdrop {
 
     ensogl::shape! {
         // Disabled to allow interaction with the output port.
+        below = [compound::rectangle::shape];
         pointer_events = false;
         alignment = center;
         (style:Style, selection:f32) {
@@ -446,27 +446,6 @@ impl NodeModel {
     /// Constructor.
     #[profile(Debug)]
     pub fn new(app: &Application, registry: visualization::Registry) -> Self {
-        ensogl::shapes_order_dependencies! {
-            app.display.default_scene => {
-                //TODO[ao] The two lines below should not be needed - the ordering should be
-                //    transitive. But removing them causes a visual glitches described in
-                //    https://github.com/enso-org/ide/issues/1624
-                //    The matter should be further investigated.
-                edge::back::corner         -> backdrop;
-                edge::back::line           -> backdrop;
-                edge::back::arrow          -> backdrop;
-                backdrop                   -> error_shape;
-                backdrop                   -> output::port::single_port;
-                backdrop                   -> output::port::multi_port;
-                backdrop                   -> compound::rectangle::shape;
-                output::port::single_port  -> compound::rectangle::shape;
-                output::port::multi_port   -> compound::rectangle::shape;
-                compound::rectangle::shape -> edge::front::corner;
-                compound::rectangle::shape -> edge::front::line;
-                compound::rectangle::shape -> edge::front::arrow;
-            }
-        }
-
         let scene = &app.display.default_scene;
 
         let error_indicator = error_shape::View::new();

--- a/app/gui/view/graph-editor/src/component/node.rs
+++ b/app/gui/view/graph-editor/src/component/node.rs
@@ -606,10 +606,14 @@ impl NodeModel {
         self.error_indicator.set_size(padded_size);
         self.vcs_indicator.frp.set_size(padded_size);
         let x_offset_to_node_center = x_offset_to_node_center(width);
+
+        // Position shapes such that the center of their left edge is at the node origin:
+        // - Most shapes are still center-aligned, we have to move them horizontally.
         self.backdrop.set_x(x_offset_to_node_center);
-        self.background.set_y(-height / 2.0);
         self.error_indicator.set_x(x_offset_to_node_center);
         self.vcs_indicator.set_x(x_offset_to_node_center);
+        // - Background is a bottom-left aligned Rectangle, thus we have to move it vertically.
+        self.background.set_y(-height / 2.0);
 
         let action_bar_width = ACTION_BAR_WIDTH;
         self.action_bar

--- a/app/gui/view/graph-editor/src/component/node.rs
+++ b/app/gui/view/graph-editor/src/component/node.rs
@@ -687,7 +687,8 @@ impl Node {
 
             let background_press = model.background.on_event::<mouse::Down>();
             let input_press = model.input.on_event::<mouse::Down>();
-            input_as_background_press <- input_press.gate(&input.set_edit_ready_mode);
+            ports_were_visible <- model.input.ports_visible.debounce();
+            input_as_background_press <- input_press.gate_not(&ports_were_visible);
             any_background_press <- any(&background_press, &input_as_background_press);
             any_primary_press <- any_background_press.filter(mouse::event::is_primary);
             out.background_press <+ any_primary_press.constant(());

--- a/app/gui/view/graph-editor/src/component/node.rs
+++ b/app/gui/view/graph-editor/src/component/node.rs
@@ -709,7 +709,6 @@ impl Node {
             let background_press = model.background.on_event::<mouse::Down>();
             let input_press = model.input.on_event::<mouse::Down>();
             input_as_background_press <- input_press.gate(&input.set_edit_ready_mode);
-            trace input_as_background_press;
             any_background_press <- any(&background_press, &input_as_background_press);
             any_primary_press <- any_background_press.filter(mouse::event::is_primary);
             out.background_press <+ any_primary_press.constant(());

--- a/app/gui/view/graph-editor/src/component/node/input/area.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/area.rs
@@ -365,7 +365,6 @@ ensogl::define_endpoints! {
         on_port_press       (Crumbs),
         on_port_hover       (Switch<Crumbs>),
         on_port_code_update (Crumbs,ImString),
-        on_background_press (),
         view_mode           (view::Mode),
         /// A set of widgets attached to a method requests their definitions to be queried from an
         /// external source. The tuple contains the ID of the call expression the widget is attached
@@ -439,6 +438,7 @@ impl Area {
             frp.output.source.ports_visible <+ port_vis;
             frp.output.source.editing <+ set_editing;
             model.widget_tree.set_ports_visible <+ frp.ports_visible;
+            model.widget_tree.set_edit_ready_mode <+ frp.set_edit_ready_mode;
             refresh_edges <- model.widget_tree.connected_port_updated.debounce();
             frp.output.source.input_edges_need_refresh <+ refresh_edges;
 

--- a/app/gui/view/graph-editor/src/component/node/input/area.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/area.rs
@@ -434,7 +434,7 @@ impl Area {
             let ports_active = &frp.set_ports_active;
             edit_or_ready <- frp.set_edit_ready_mode || set_editing;
             reacts_to_hover <- all_with(&edit_or_ready, ports_active, |e, (a, _)| *e && !a);
-            port_vis <- all_with(&edit_or_ready, ports_active, |e, (a, _)| !e && *a);
+            port_vis <- all_with(&set_editing, ports_active, |e, (a, _)| !e && *a);
             frp.output.source.ports_visible <+ port_vis;
             frp.output.source.editing <+ set_editing;
             model.widget_tree.set_ports_visible <+ frp.ports_visible;

--- a/app/gui/view/graph-editor/src/component/node/input/port.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/port.rs
@@ -23,12 +23,13 @@ use ensogl::display::shape;
 // === Constants ===
 // =================
 
-/// The horizontal padding of ports. It affects how the port shape should extend the target text
-/// boundary on both sides.
+/// The default horizontal padding of ports. It affects how the port shape should extend the target
+/// text boundary on both sides. Can be overriden per widget by using
+/// [`super::ConfigContext::set_port_hover_padding`].
 pub const PORT_PADDING_X: f32 = 4.0;
 
-/// The horizontal padding of port hover areas. It affects how the port hover should extend the
-/// target text boundary on both sides.
+/// The default horizontal padding of port hover areas. It affects how the port hover should extend
+/// the target text boundary on both sides.
 pub const HOVER_PADDING_X: f32 = 2.0;
 
 /// The minimum size of the port visual area.
@@ -107,19 +108,16 @@ impl PortLayers {
 #[derive(Debug)]
 pub struct Port {
     /// Drop source must be kept at the top of the struct, so it will be dropped first.
-    _on_cleanup:     frp::DropSource,
-    crumbs:          Rc<RefCell<span_tree::Crumbs>>,
-    port_root:       display::object::Instance,
-    widget_root:     display::object::Instance,
-    widget:          DynWidget,
-    port_shape:      PortShape,
-    hover_shape:     HoverShape,
+    _on_cleanup:   frp::DropSource,
+    crumbs:        Rc<RefCell<span_tree::Crumbs>>,
+    port_root:     display::object::Instance,
+    widget_root:   display::object::Instance,
+    widget:        DynWidget,
+    port_shape:    PortShape,
+    hover_shape:   HoverShape,
     /// Last set tree depth of the port. Allows skipping layout update when the depth has not
     /// changed during reconfiguration.
-    current_depth:   usize,
-    /// Whether or not the port was configured as primary. Allows skipping layout update when the
-    /// hierarchy level has not changed significantly during reconfiguration.
-    current_primary: bool,
+    current_depth: usize,
 }
 
 impl Port {
@@ -141,12 +139,7 @@ impl Port {
             .set_margin_left(-PORT_PADDING_X)
             .set_margin_right(-PORT_PADDING_X)
             .set_alignment_left_center();
-        hover_shape
-            .set_size_y(BASE_PORT_HEIGHT)
-            .allow_grow()
-            .set_margin_left(-HOVER_PADDING_X)
-            .set_margin_right(-HOVER_PADDING_X)
-            .set_alignment_left_center();
+        hover_shape.set_size_y(BASE_PORT_HEIGHT).allow_grow().set_alignment_left_center();
 
         let layers = app.display.default_scene.extension::<PortLayers>();
         layers.add_to_partition(port_shape.display_object(), hover_shape.display_object(), 0);
@@ -201,7 +194,6 @@ impl Port {
             widget_root,
             port_root,
             crumbs,
-            current_primary: false,
             current_depth: 0,
         }
     }
@@ -211,10 +203,15 @@ impl Port {
     ///
     /// See [`crate::component::node::input::widget`] module for more information about widget
     /// lifecycle.
-    pub fn configure(&mut self, config: &DynConfig, ctx: ConfigContext) {
+    pub fn configure(
+        &mut self,
+        config: &DynConfig,
+        ctx: ConfigContext,
+        pad_x_override: Option<f32>,
+    ) {
         self.crumbs.replace(ctx.span_node.crumbs.clone());
         self.set_connected(ctx.info.connection);
-        self.set_port_layout(&ctx);
+        self.set_port_layout(&ctx, pad_x_override.unwrap_or(PORT_PADDING_X));
         self.widget.configure(config, ctx);
         self.update_root();
     }
@@ -243,7 +240,7 @@ impl Port {
         }
     }
 
-    fn set_port_layout(&mut self, ctx: &ConfigContext) {
+    fn set_port_layout(&mut self, ctx: &ConfigContext, margin_x: f32) {
         let node_depth = ctx.span_node.crumbs.len();
         if self.current_depth != node_depth {
             self.current_depth = node_depth;
@@ -254,12 +251,15 @@ impl Port {
         }
 
         let is_primary = ctx.info.nesting_level.is_primary();
-        if self.current_primary != is_primary {
-            self.current_primary = is_primary;
-            let margin = if is_primary { PRIMARY_PORT_HOVER_PADDING_Y } else { 0.0 };
-            self.hover_shape.set_size_y(BASE_PORT_HEIGHT + 2.0 * margin);
-            self.hover_shape.set_margin_top(-margin);
-            self.hover_shape.set_margin_bottom(-margin);
+        let margin_y = if is_primary { PRIMARY_PORT_HOVER_PADDING_Y } else { 0.0 };
+
+        let current_margin = self.hover_shape.margin();
+        let margin_needs_update = current_margin.x().start.as_pixels() != Some(-margin_x)
+            || current_margin.y().start.as_pixels() != Some(-margin_y);
+
+        if margin_needs_update {
+            self.hover_shape.set_size_y(BASE_PORT_HEIGHT + 2.0 * margin_y);
+            self.hover_shape.set_margin_vh(-margin_y, -margin_x);
         }
     }
 

--- a/app/gui/view/graph-editor/src/component/node/input/port.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/port.rs
@@ -30,14 +30,17 @@ pub const PORT_PADDING_X: f32 = 4.0;
 
 /// The default horizontal padding of port hover areas. It affects how the port hover should extend
 /// the target text boundary on both sides.
-pub const HOVER_PADDING_X: f32 = 2.0;
+const HOVER_PADDING_X: f32 = 2.0;
 
 /// The minimum size of the port visual area.
 pub const BASE_PORT_HEIGHT: f32 = 18.0;
 
+/// The minimum size of the port hover area.
+const BASE_PORT_HOVER_HEIGHT: f32 = 16.0;
+
 /// The vertical hover padding of ports at low depth. It affects how the port hover should extend
 /// the target text boundary on both sides.
-pub const PRIMARY_PORT_HOVER_PADDING_Y: f32 = (crate::node::HEIGHT - BASE_PORT_HEIGHT) / 2.0;
+const PRIMARY_PORT_HOVER_PADDING_Y: f32 = (crate::node::HEIGHT - BASE_PORT_HOVER_HEIGHT) / 2.0;
 
 
 
@@ -136,10 +139,9 @@ impl Port {
         port_shape
             .set_size_y(BASE_PORT_HEIGHT)
             .allow_grow()
-            .set_margin_left(-PORT_PADDING_X)
-            .set_margin_right(-PORT_PADDING_X)
+            .set_margin_vh(0.0, -PORT_PADDING_X)
             .set_alignment_left_center();
-        hover_shape.set_size_y(BASE_PORT_HEIGHT).allow_grow().set_alignment_left_center();
+        hover_shape.set_size_y(BASE_PORT_HOVER_HEIGHT).allow_grow().set_alignment_left_center();
 
         let layers = app.display.default_scene.extension::<PortLayers>();
         layers.add_to_partition(port_shape.display_object(), hover_shape.display_object(), 0);
@@ -211,7 +213,7 @@ impl Port {
     ) {
         self.crumbs.replace(ctx.span_node.crumbs.clone());
         self.set_connected(ctx.info.connection);
-        self.set_port_layout(&ctx, pad_x_override.unwrap_or(PORT_PADDING_X));
+        self.set_port_layout(&ctx, pad_x_override.unwrap_or(HOVER_PADDING_X));
         self.widget.configure(config, ctx);
         self.update_root();
     }
@@ -258,7 +260,7 @@ impl Port {
             || current_margin.y().start.as_pixels() != Some(-margin_y);
 
         if margin_needs_update {
-            self.hover_shape.set_size_y(BASE_PORT_HEIGHT + 2.0 * margin_y);
+            self.hover_shape.set_size_y(BASE_PORT_HOVER_HEIGHT + 2.0 * margin_y);
             self.hover_shape.set_margin_vh(-margin_y, -margin_x);
         }
     }

--- a/app/gui/view/graph-editor/src/component/node/input/widget.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget.rs
@@ -316,7 +316,7 @@ impl Configuration {
 
         let first_decl_is_vector = || {
             decl_type
-                .map_or(false, |t| t.trim_start_matches("(").starts_with(list_editor::VECTOR_TYPE))
+                .map_or(false, |t| t.trim_start_matches('(').starts_with(list_editor::VECTOR_TYPE))
         };
         let type_may_be_vector = || {
             decl_type.map_or(false, |t| t.contains(list_editor::VECTOR_TYPE))

--- a/app/gui/view/graph-editor/src/component/node/input/widget.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget.rs
@@ -84,6 +84,7 @@ pub const PRIMARY_PORT_MAX_NESTING_LEVEL: usize = 0;
 ensogl::define_endpoints_2! {
     Input {
         set_ports_visible    (bool),
+        set_edit_ready_mode  (bool),
         set_read_only        (bool),
         set_view_mode        (crate::view::Mode),
         set_profiling_status (crate::node::profiling::Status),
@@ -414,6 +415,7 @@ impl DropdownValue for Entry {
 #[derive(Debug, Clone, CloneRef)]
 pub struct WidgetsFrp {
     pub(super) set_ports_visible:      frp::Sampler<bool>,
+    pub(super) set_edit_ready_mode:    frp::Sampler<bool>,
     pub(super) set_read_only:          frp::Sampler<bool>,
     pub(super) set_view_mode:          frp::Sampler<crate::view::Mode>,
     pub(super) set_profiling_status:   frp::Sampler<crate::node::profiling::Status>,
@@ -485,6 +487,7 @@ impl Tree {
             eval transfer_ownership((request) model.transfer_ownership(*request));
 
             set_ports_visible <- frp.set_ports_visible.sampler();
+            set_edit_ready_mode <- frp.set_edit_ready_mode.sampler();
             set_read_only <- frp.set_read_only.sampler();
             set_view_mode <- frp.set_view_mode.sampler();
             set_profiling_status <- frp.set_profiling_status.sampler();
@@ -501,6 +504,7 @@ impl Tree {
         let connected_port_updated = frp.private.output.connected_port_updated.clone_ref();
         let widgets_frp = WidgetsFrp {
             set_ports_visible,
+            set_edit_ready_mode,
             set_read_only,
             set_view_mode,
             set_profiling_status,

--- a/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
@@ -349,7 +349,7 @@ impl Model {
                     }
 
                     let element = entry.or_insert_with(Element::new);
-                    set_insertion_margins(&*insert, -ITEMS_GAP * 0.5);
+                    set_insertion_margins(&insert, -ITEMS_GAP * 0.5);
                     element.alive = Some(());
                     element.item_crumb = index;
                     element.expr_range = range;
@@ -482,7 +482,7 @@ impl Model {
         let (mut expression, import) = match &self.default_value {
             DefaultValue::Tag(tag) => (
                 tag.expression.clone().into(),
-                tag.required_import.as_ref().map(|i| ImString::from(i)),
+                tag.required_import.as_ref().map(ImString::from),
             ),
             DefaultValue::Expression(expr) => (expr.clone(), None),
             DefaultValue::StaticExpression(expr) => (expr.into(), None),
@@ -708,7 +708,7 @@ fn split_type_groups() -> impl FnMut(char) -> bool {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 enum DefaultVariant {
     NotDefined,
     Numeric,

--- a/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
@@ -34,7 +34,7 @@ pub const VECTOR_TYPE: &str = "Standard.Base.Data.Vector.Vector";
 const LIST_HOVER_MARGIN: f32 = 4.0;
 
 const ITEMS_GAP: f32 = 10.0;
-const INSERT_HOVER_MARGIN: f32 = 3.0;
+const INSERT_HOVER_MARGIN: f32 = 4.0;
 const ITEM_HOVER_MARGIN: f32 = (ITEMS_GAP - INSERT_HOVER_MARGIN * 2.0) * 0.5;
 const INSERTION_OFFSET: f32 = ITEMS_GAP * 0.5;
 

--- a/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
@@ -3,8 +3,6 @@
 // FIXME[ao]: This code miss important documentation (e.g. for `Element`, `DragData` and `ListItem`)
 //  and may be unreadable at some places. It should be improved in several next debugging PRs.
 
-use std::collections::hash_map::Entry;
-
 use crate::prelude::*;
 
 use crate::component::node::input::area::TEXT_SIZE;
@@ -14,6 +12,7 @@ use crate::component::node::input::widget::TransferRequest;
 use crate::component::node::input::widget::TreeNode;
 use crate::component::node::input::widget::WidgetIdentity;
 
+use std::collections::hash_map::Entry;
 use ensogl::control::io::mouse;
 use ensogl::display;
 use ensogl::display::object;

--- a/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/list_editor.rs
@@ -35,13 +35,23 @@ struct Element {
     alive:          Option<()>,
 }
 
-#[derive(Debug)]
 struct DragData {
     element_id:    WidgetIdentity,
     element:       Element,
     expression:    String,
     #[allow(dead_code)]
     owned_subtree: Vec<(WidgetIdentity, TreeNode)>,
+}
+
+impl Debug for DragData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DragData")
+            .field("element_id", &self.element_id)
+            .field("element", &self.element)
+            .field("expression", &self.expression)
+            .field("owned_subtree.len", &self.owned_subtree.len())
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, CloneRef)]
@@ -382,7 +392,6 @@ impl super::SpanWidget for Widget {
     }
 
     fn configure(&mut self, cfg: &Config, ctx: super::ConfigContext) {
-        console_log!("CONFIGURE");
         let mut model = self.model.borrow_mut();
         model.configure(&self.display_object, cfg, ctx);
     }

--- a/app/gui/view/graph-editor/src/component/node/input/widget/single_choice.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/single_choice.rs
@@ -177,12 +177,7 @@ impl super::SpanWidget for Widget {
             ctx.modify_extension::<super::label::Extension>(|ext| ext.bold = true);
         }
 
-        let config = match ctx.span_node.children.is_empty() {
-            true => super::Configuration::always(super::label::Config),
-            false => super::Configuration::always(super::hierarchy::Config),
-        };
-        let child_level = ctx.info.nesting_level;
-        let child = ctx.builder.child_widget_of_type(ctx.span_node, child_level, Some(&config));
+        let child = ctx.builder.child_widget(ctx.span_node, ctx.info.nesting_level);
         self.label_wrapper.replace_children(&[child.root_object]);
     }
 }

--- a/app/gui/view/graph-editor/src/component/node/input/widget/single_choice.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/single_choice.rs
@@ -40,6 +40,7 @@ const DROPDOWN_MAX_SIZE: Vector2 = Vector2(300.0, 500.0);
 pub mod triangle {
     use super::*;
     ensogl::shape! {
+        above = [display::shape::compound::rectangle::shape];
         alignment = left_bottom;
         (style:Style, color:Vector4) {
             let size   = Var::canvas_size();

--- a/app/gui/view/graph-editor/src/component/node/output/port.rs
+++ b/app/gui/view/graph-editor/src/component/node/output/port.rs
@@ -173,6 +173,8 @@ pub mod single_port {
     use ensogl::display::shape::*;
 
     ensogl::shape! {
+        above = [node::backdrop];
+        below = [compound::rectangle::shape];
         alignment = center;
         (style:Style, size_multiplier:f32, opacity:f32, color_rgb:Vector3<f32>) {
             let overall_width  = Var::<Pixels>::from("input_size.x");
@@ -300,6 +302,8 @@ pub mod multi_port {
     }
 
     ensogl::shape! {
+        above = [node::backdrop];
+        below = [compound::rectangle::shape];
         alignment = center;
         ( style           : Style
         , size_multiplier : f32

--- a/app/gui/view/graph-editor/src/component/node/vcs.rs
+++ b/app/gui/view/graph-editor/src/component/node/vcs.rs
@@ -58,6 +58,7 @@ mod status_indicator_shape {
     const INDICATOR_WIDTH_INNER: f32 = 10.0;
 
     ensogl::shape! {
+        pointer_events = false;
         alignment = center;
         (style:Style,color_rgba:Vector4<f32>) {
             let width  = Var::<Pixels>::from("input_size.x");

--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -3178,7 +3178,7 @@ fn new_graph_editor(app: &Application) -> GraphEditor {
     frp::extend! { network
         _eval <- all_with(&out.node_hovered,&edit_mode,f!([model](tgt,e)
             if let Some(tgt) = tgt {
-                model.with_node(tgt.value,|t| t.model().input.set_edit_ready_mode(*e && tgt.is_on()));
+                model.with_node(tgt.value,|t| t.set_edit_ready_mode(*e && tgt.is_on()));
             }
         ));
         _eval <- all_with(&out.node_hovered,&out.some_edge_targets_unset,f!([model](tgt,ok)

--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -8,6 +8,7 @@
 #![feature(drain_filter)]
 #![feature(entry_insert)]
 #![feature(fn_traits)]
+#![feature(macro_metavar_expr)]
 #![feature(option_result_contains)]
 #![feature(specialization)]
 #![feature(trait_alias)]

--- a/app/ide-desktop/lib/content-config/src/config.json
+++ b/app/ide-desktop/lib/content-config/src/config.json
@@ -115,11 +115,6 @@
           "description": "Color theme.",
           "primary": false
         },
-        "vectorEditor": {
-          "value": true,
-          "description": "Show Vector Editor widget on nodes.",
-          "primary": false
-        },
         "newDashboard": {
           "value": false,
           "description": "Determines whether the new dashboard with cloud integration is enabled."

--- a/build-config.yaml
+++ b/build-config.yaml
@@ -1,6 +1,6 @@
 # Options intended to be common for all developers.
 
-wasm-size-limit: 15.85 MiB
+wasm-size-limit: 15.87 MiB
 
 required-versions:
   # NB. The Rust version is pinned in rust-toolchain.toml.

--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -408,7 +408,7 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
         let model = &self.model;
 
         let on_add_elem_icon_up = model.borrow().add_elem_icon.on_event::<mouse::Up>();
-        let on_down = model.borrow().layout.on_event_capturing::<mouse::Down>();
+        let on_down = model.borrow().root.on_event_capturing::<mouse::Down>();
         let on_up_source = scene.on_event::<mouse::Up>();
         let on_move = scene.on_event::<mouse::Move>();
 
@@ -527,7 +527,7 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
                 &frp.enable_last_insertion_point,
                 f!([model] (gap, gaps, pos, size, is_dragging, enable_all, enable_last) {
                     let is_close_x = pos.x > -gap && pos.x < size.x + gap;
-                    let is_close_y = pos.y > -gap && pos.y < size.y + gap;
+                    let is_close_y = pos.y > 0.0 && pos.y < size.y;
                     let is_close = is_close_x && is_close_y;
                     let opt_gap = gaps.find(pos.x);
                     opt_gap.and_then(|gap| {

--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -73,13 +73,11 @@
 #![allow(clippy::bool_to_int_with_if)]
 #![allow(clippy::let_and_return)]
 
-use ensogl_core::display::shape::compound::rectangle::*;
 use ensogl_core::display::world::*;
 use ensogl_core::prelude::*;
 
 use ensogl_core::control::io::mouse;
 use ensogl_core::data::bounding_box::BoundingBox;
-use ensogl_core::data::color;
 use ensogl_core::display;
 use ensogl_core::display::object::Event;
 use ensogl_core::display::object::ObjectOps;
@@ -351,13 +349,11 @@ pub struct ListEditor<T: 'static + Debug> {
 
 #[derive(Debug)]
 pub struct Model<T> {
-    cursor:            Cursor,
-    items:             VecIndexedBy<ItemOrPlaceholder<T>, ItemOrPlaceholderIndex>,
-    root:              display::object::Instance,
-    layout_with_icons: display::object::Instance,
-    layout:            display::object::Instance,
-    gap:               f32,
-    add_elem_icon:     Rectangle,
+    cursor: Cursor,
+    items:  VecIndexedBy<ItemOrPlaceholder<T>, ItemOrPlaceholderIndex>,
+    root:   display::object::Instance,
+    layout: display::object::Instance,
+    gap:    f32,
 }
 
 impl<T> Model<T> {
@@ -367,19 +363,10 @@ impl<T> Model<T> {
         let items = default();
         let root = display::object::Instance::new_named("ListEditor");
         let layout = display::object::Instance::new_named("layout");
-        let layout_with_icons = display::object::Instance::new_named("layout_with_icons");
         let gap = default();
-        layout_with_icons.use_auto_layout();
-        layout.use_auto_layout();
-        layout_with_icons.add_child(&layout);
-        root.add_child(&layout_with_icons);
-        let add_elem_icon = Rectangle().build(|t| {
-            t.set_corner_radius_max()
-                .set_size((14.0, 14.0))
-                .set_color(color::Rgba::new(0.0, 0.0, 0.0, 0.2));
-        });
-        layout_with_icons.add_child(&add_elem_icon);
-        Self { cursor, items, root, layout, layout_with_icons, gap, add_elem_icon }
+        layout.use_auto_layout().allow_grow_y();
+        root.add_child(&layout);
+        Self { cursor, items, root, layout, gap }
     }
 }
 
@@ -411,7 +398,6 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
         let network = self.frp.network();
         let model = &self.model;
 
-        let on_add_elem_icon_up = model.borrow().add_elem_icon.on_event::<mouse::Up>();
         let on_down = model.borrow().root.on_event_capturing::<mouse::Down>();
         let on_up_source = scene.on_event::<mouse::Up>();
         let on_move = scene.on_event::<mouse::Move>();
@@ -421,10 +407,6 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
         let drag_target = cursor::DragTarget::new();
         frp::extend! { network
             on_down <- on_down.gate(&frp.enable_dragging);
-            frp.private.output.request_new_item <+ on_add_elem_icon_up.map(f_!([model] {
-                Response::gui(model.borrow().len())
-            }));
-
             target <= on_down.map(|event| event.target());
 
             on_up <- on_up_source.identity();
@@ -490,10 +472,8 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
             // Do not pass events to children, as we don't know whether we are about to drag
             // them yet.
             eval on_down_drag ([] (event) event.stop_propagation());
-            _eval <- no_drag.on_true().map2(&on_down, |_, event| event.resume_propagation());
-
-            item_count_changed <- any_(&frp.on_item_added, &frp.on_item_removed);
-            eval_ item_count_changed (model.borrow().item_count_changed());
+            resume_propagation <- no_drag.on_true().sync_gate(&on_down_drag);
+            _eval <- resume_propagation.map2(&on_down, |_, event| event.resume_propagation());
         }
         self
     }
@@ -513,7 +493,8 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
         let model_borrowed = model.borrow();
 
         frp::extend! { network
-            gaps <- model_borrowed.layout.on_resized.map(f_!(model.gaps()));
+            init <- source_();
+            gaps <- all(&model_borrowed.layout.on_resized, &init)._0().map(f_!(model.gaps()));
 
             // We are debouncing the `is_dragging` stream to avoid double-borrow of list editor, as
             // this event is fired immediately after list-editor instructs cursor to stop dragging.
@@ -523,7 +504,7 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
                 &frp.gap,
                 &gaps,
                 &pos_on_move,
-                &model.borrow().layout.on_resized,
+                &model_borrowed.layout.on_resized,
                 &is_dragging,
                 &frp.enable_all_insertion_points,
                 &frp.enable_last_insertion_point,
@@ -531,13 +512,11 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
                     let is_close_x = pos.x > -gap && pos.x < size.x + gap;
                     let is_close_y = pos.y > 0.0 && pos.y < size.y;
                     let is_close = is_close_x && is_close_y;
-                    let opt_gap = gaps.find(pos.x);
-                    opt_gap.and_then(|gap| {
-                        let last_gap = *gap == gaps.len() - 1;
-                        let enabled = is_close && !is_dragging;
-                        let enabled = enabled && (*enable_all || (*enable_last && last_gap));
-                        enabled.and_option_from(|| model.item_or_placeholder_index_to_index(gap))
-                    })
+                    let enabled = is_close && !is_dragging && (*enable_all || *enable_last);
+                    enabled
+                        .and_option_from(|| gaps.find(pos.x))
+                        .filter(|gap| *enable_all || (*enable_last && **gap == gaps.len() - 1))
+                        .and_then(|gap| model.item_or_placeholder_index_to_index(gap))
                 })
             ).on_change();
             index <= opt_index;
@@ -547,6 +526,9 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
             insert_in_gap <- index.sample(&on_up_in_gap);
             frp.private.output.request_new_item <+ insert_in_gap.map(|t| Response::gui(*t));
         }
+
+        init.emit(());
+
         pointer_style
     }
 
@@ -613,21 +595,27 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
             init_drag_not_disabled <- init_drag.gate_not(&drag_disabled);
             is_dragging <- bool(&on_up_cleaning_phase, &init_drag_not_disabled).on_change();
             drag_diff <- pos_diff.gate(&is_dragging);
-            no_drag <- drag_disabled.gate_not(&is_dragging).on_change();
-            no_drag <- any(no_drag, no_action);
+            just_disabled <- drag_disabled.gate_not(&is_dragging).on_change();
+            no_drag <- any(...);
+            no_drag <+ no_action;
+            no_drag <+ just_disabled;
+
             status <- bool(&on_up_cleaning_phase, &drag_diff).on_change();
             start <- status.on_true();
             target_on_start <- target.sample(&start);
             let on_item_removed = &frp.private.output.on_item_removed;
-            eval target_on_start([model, cursor, on_item_removed] (t) {
+            eval target_on_start([model, cursor, on_item_removed, no_drag] (t) {
                 let item = model.borrow_mut().start_item_drag(t);
                 if let Some((index, item)) = item {
                     cursor.start_drag(item.clone_ref());
                     on_item_removed.emit(Response::gui((index, Rc::new(RefCell::new(Some(item))))));
+                } else {
+                    no_drag.emit(true);
+                    no_drag.emit(false);
                 }
             });
         }
-        no_drag
+        no_drag.into()
     }
 
     /// Implementation of dropping items logic, including showing empty placeholders when the item
@@ -704,10 +692,7 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
         let mut model = self.model.borrow_mut();
         let index = model.index_to_item_or_placeholder_index(index)?;
         match model.items.remove(index) {
-            ItemOrPlaceholder::Item(item) => {
-                model.item_count_changed();
-                Some(item.elem)
-            }
+            ItemOrPlaceholder::Item(item) => Some(item.elem),
             ItemOrPlaceholder::Placeholder(_) => unreachable!(),
         }
     }
@@ -850,7 +835,6 @@ impl<T: display::Object + CloneRef + 'static> Model<T> {
             self.push(item)
         };
         self.reposition_items();
-        self.item_count_changed();
         index
     }
 
@@ -960,18 +944,16 @@ impl<T: display::Object + CloneRef + 'static> Model<T> {
 
     /// Remove the selected item from the item list and mark it as an element being dragged. In the
     /// place where the element was a new placeholder will be created or existing placeholder will
-    /// be reused and scaled to cover the size of the dragged element.
+    /// be reused and scaled to cover the size of the dragged element. Returns `None` if the target
+    /// is not an item.
     ///
     /// See docs of [`Self::start_item_drag_at`] for more information.
     fn start_item_drag(&mut self, target: &display::object::Instance) -> Option<(Index, T)> {
         let objs = target.rev_parent_chain().reversed();
         let target_index = objs.into_iter().find_map(|t| self.item_index_of(&t));
-        if let Some((index, index_or_placeholder_index)) = target_index {
+        target_index.and_then(|(index, index_or_placeholder_index)| {
             self.start_item_drag_at(index_or_placeholder_index).map(|item| (index, item))
-        } else {
-            warn!("Could not find the item to drag.");
-            None
-        }
+        })
     }
 
     /// Remove the selected item from the item list and mark it as an element being dragged. In the
@@ -1141,6 +1123,10 @@ impl<T: display::Object + CloneRef + 'static> Model<T> {
     }
 
     fn gaps(&self) -> Gaps {
+        if self.items.is_empty() {
+            return Gaps { gaps: vec![f32::NEG_INFINITY..=f32::INFINITY] };
+        }
+
         let mut gaps = Vec::new();
         gaps.push(f32::NEG_INFINITY..=0.0);
         let mut fist_gap = true;
@@ -1161,15 +1147,6 @@ impl<T: display::Object + CloneRef + 'static> Model<T> {
     /// The insertion point of the given vertical offset.
     fn insert_index(&self, x: f32, center_points: &[f32]) -> ItemOrPlaceholderIndex {
         center_points.iter().position(|t| x < *t).unwrap_or(self.items.len()).into()
-    }
-
-    /// If the item count drops to 0, display a button to add new items.
-    fn item_count_changed(&self) {
-        if self.len() == 0 {
-            self.layout_with_icons.add_child(&self.add_elem_icon);
-        } else {
-            self.add_elem_icon.unset_parent();
-        }
     }
 }
 

--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -311,6 +311,10 @@ ensogl_core::define_endpoints_2! { <T: ('static + Debug)>
         /// See docs of this module to learn more.
         thrashing_offset_ratio(f32),
 
+        /// Enable dragging of the list items. When disabled, the mouse events are always passed to
+        /// the items immediately.
+        enable_dragging(bool),
+
         /// Enable insertion points (plus icons) when moving mouse next to any of the list items.
         enable_all_insertion_points(bool),
 
@@ -416,7 +420,7 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
         let on_resized = model.borrow().layout.on_resized.clone_ref();
         let drag_target = cursor::DragTarget::new();
         frp::extend! { network
-
+            on_down <- on_down.gate(&frp.enable_dragging);
             frp.private.output.request_new_item <+ on_add_elem_icon_up.map(f_!([model] {
                 Response::gui(model.borrow().len())
             }));
@@ -669,6 +673,7 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
         self.frp.primary_axis_no_drag_threshold(4.0);
         self.frp.primary_axis_no_drag_threshold_decay_time(1000.0);
         self.frp.thrashing_offset_ratio(1.0);
+        self.frp.enable_dragging(true);
         self.frp.enable_all_insertion_points(true);
         self.frp.enable_last_insertion_point(true);
         self

--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -1077,8 +1077,9 @@ impl<T: display::Object + CloneRef + 'static> Model<T> {
                 warn!("An element was inserted without a placeholder. This should not happen.");
                 index
             };
+            let index = self.item_or_placeholder_index_to_index(actual_index);
             self.reposition_items();
-            self.item_or_placeholder_index_to_index(actual_index)
+            index
         } else {
             warn!("Called function to insert dragged element, but no element is being dragged.");
             None

--- a/lib/rust/ensogl/core/Cargo.toml
+++ b/lib/rust/ensogl/core/Cargo.toml
@@ -27,7 +27,7 @@ enso-types = { path = "../../types" }
 enso-web = { path = "../../web" }
 ensogl-text-embedded-fonts = { path = "../component/text/src/font/embedded" }
 bit_field = { version = "0.10.0" }
-bitflags = { version = "1.3.2" }
+bitflags = { workspace = true }
 console_error_panic_hook = { workspace = true }
 enum_dispatch = { version = "0.3.6" }
 failure = { workspace = true }

--- a/lib/rust/ensogl/core/src/display/object/event.rs
+++ b/lib/rust/ensogl/core/src/display/object/event.rs
@@ -18,12 +18,31 @@ use crate::display::object::instance::WeakInstance;
 /// is cancelled, or that the propagation cannot be cancelled. See docs of this module to learn
 /// more.
 #[allow(missing_docs)]
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum State {
+    Running(Phase),
+    RunningNonCancellable(Phase),
+    // Event has been cancelled, but the event handler is still running.
+    Cancelled(Phase),
+    // Event has been cancelled and [`InstanceDef::emit_event_impl`] function has returned.
+    Stopped(Phase),
+    Finished,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        State::Running(default())
+    }
+}
+
+/// Current phase of the event propagation. For cancelled events, it's the phase in which the event
+/// was cancelled.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Ord, PartialOrd)]
+pub enum Phase {
     #[default]
-    Running,
-    RunningNonCancellable,
-    Cancelled,
+    Capturing,
+    Bubbling,
 }
 
 
@@ -49,11 +68,14 @@ pub struct SomeEvent {
 impl SomeEvent {
     /// Constructor.
     pub fn new<T: 'static>(target: Option<WeakInstance>, payload: T) -> Self {
-        let event = Event::new(target, payload);
+        Self::from_event(Event::new(target, payload))
+    }
+
+    fn from_event<T: 'static>(event: Event<T>) -> Self {
         let state = event.state.clone_ref();
         let current_target = event.current_target.clone_ref();
-        let captures = Rc::new(Cell::new(true));
-        let bubbles = Rc::new(Cell::new(true));
+        let captures = event.captures.clone_ref();
+        let bubbles = event.bubbles.clone_ref();
         Self { data: frp::AnyData::new(event), state, current_target, captures, bubbles }
     }
 
@@ -64,12 +86,47 @@ impl SomeEvent {
 
     /// Check whether the event was cancelled.
     pub fn is_cancelled(&self) -> bool {
-        self.state() == State::Cancelled
+        matches!(self.state(), State::Cancelled(_) | State::Stopped(_))
     }
 
     /// Enables or disables bubbling for this event.
     pub fn set_bubbling(&self, value: bool) {
         self.bubbles.set(value);
+    }
+
+    /// Determine the phase at which the event propagation should continue. This is internal
+    /// function and should not be used directly.
+    pub(crate) fn begin_propagation(&self) -> Option<(Phase, Option<Instance>)> {
+        match self.state.get() {
+            State::Stopped(phase) => {
+                let target = self.current_target.borrow().as_ref()?.upgrade()?;
+                self.state.set(State::Running(phase));
+                Some((phase, Some(target)))
+            }
+            _ => Some((Phase::Capturing, None)),
+        }
+    }
+
+    pub(crate) fn enter_phase(&self, phase: Phase) {
+        self.state.set(match self.state.get() {
+            State::Running(_) => State::Running(phase),
+            State::RunningNonCancellable(_) => State::RunningNonCancellable(phase),
+            State::Cancelled(_) => State::Cancelled(phase),
+            State::Stopped(_) => State::Stopped(phase),
+            State::Finished => State::Finished,
+        });
+    }
+
+    /// Mark the end of the event propagation. This is internal function and should not be used
+    /// directly.
+    pub(crate) fn finish_propagation(&self) {
+        self.state.set(match self.state.get() {
+            State::Cancelled(phase) => State::Stopped(phase),
+            _ => {
+                self.set_current_target(None);
+                State::Finished
+            }
+        });
     }
 
     /// Set the current target of the event. This is internal function and should not be used
@@ -125,6 +182,8 @@ pub struct EventData<T> {
     target:         Option<WeakInstance>,
     current_target: Rc<RefCell<Option<WeakInstance>>>,
     state:          Rc<Cell<State>>,
+    captures:       Rc<Cell<bool>>,
+    bubbles:        Rc<Cell<bool>>,
 }
 
 impl<T: Debug> Debug for EventData<T> {
@@ -136,11 +195,13 @@ impl<T: Debug> Debug for EventData<T> {
     }
 }
 
-impl<T> Event<T> {
+impl<T: 'static> Event<T> {
     fn new(target: Option<WeakInstance>, payload: T) -> Self {
         let state = default();
         let current_target = Rc::new(RefCell::new(target.clone()));
-        let data = Rc::new(EventData { payload, target, current_target, state });
+        let captures = Rc::new(Cell::new(true));
+        let bubbles = Rc::new(Cell::new(true));
+        let data = Rc::new(EventData { payload, target, current_target, state, captures, bubbles });
         Self { data }
     }
 
@@ -149,12 +210,34 @@ impl<T> Event<T> {
     ///
     /// See: https://developer.mozilla.org/en-US/docs/Web/API/Event/stopPropagation.
     pub fn stop_propagation(&self) {
-        if self.state.get() == State::RunningNonCancellable {
-            warn!("Trying to cancel a non-cancellable event.");
-        } else {
-            self.state.set(State::Cancelled);
+        match self.state.get() {
+            State::Running(phase) => self.state.set(State::Cancelled(phase)),
+            State::RunningNonCancellable(_) => warn!("Trying to cancel a non-cancellable event."),
+            _ => {}
         }
     }
+
+
+    /// Emit event again with the same payload after it was cancelled. The event will start its
+    /// capturing phase handling again, starting at but not including this instance. If the passed
+    /// instance is no longer a part of the parent chain of the event's original target, the event
+    /// will start its capturing phase from scratch. If the original target no longer exists, the
+    /// event will be discarded.
+    pub fn resume_propagation(&self) {
+        match self.state.get() {
+            State::Cancelled(phase) => {
+                // When cancelled but not stopped yet, the propagation is still ongoing. We can
+                // reset the state back to running and let it continue.
+                self.state.set(State::Running(phase));
+            }
+            State::Stopped(_) =>
+                if let Some(target) = self.target() {
+                    target.resume_event(SomeEvent::from_event(self.clone()));
+                },
+            _ => warn!("Trying to resume propagation of a non-cancelled event."),
+        }
+    }
+
 
     /// A reference to the object onto which the event was dispatched.
     ///

--- a/lib/rust/ensogl/core/src/display/object/instance.rs
+++ b/lib/rust/ensogl/core/src/display/object/instance.rs
@@ -2536,6 +2536,16 @@ impl InstanceDef {
         self
     }
 
+    /// The main event propagation implementation. Propagates the event through the display object
+    /// hierarchy in two phases: capturing and bubbling. See [`crate::display::object::event`]
+    /// module to learn more about event phases.
+    ///
+    /// The propagation itself is done in following steps:
+    /// - If event has been previously cancelled, figure out where to resume the propagation.
+    /// - Collect the parent chain of the event target.
+    /// - Execute capturing phase - propagate event from the root to the target.
+    /// - Execute bubbling phase - propagate event from the target to the root.
+    /// - If event has been cancelled, store the phase and target to resume the propagation.
     fn emit_event_impl(&self, event: &event::SomeEvent) {
         let Some((resume_phase, resume_target)) = event.begin_propagation() else { return; };
 

--- a/lib/rust/ensogl/core/src/display/object/instance.rs
+++ b/lib/rust/ensogl/core/src/display/object/instance.rs
@@ -2220,6 +2220,8 @@ impl InstanceDef {
             }
         }
 
+        self.next_child_index.set(ChildIndex(new_children.len()));
+
         // At this point, all children that were in the new list are in the right position. We
         // only need to remove the children that were not in the new list. All of them are still
         // in the children list, and their indices are past the inserted indices.
@@ -2252,7 +2254,6 @@ impl InstanceDef {
 
             drop(children_borrow);
 
-            self.next_child_index.set(ChildIndex(new_children.len()));
             for (bind, weak) in binds_to_drop {
                 bind.drop_with_removed_element(self, weak)
             }
@@ -3091,6 +3092,14 @@ pub trait LayoutOps: Object {
         let horizontal = SideSpacing::new(left.into(), right.into());
         let vertical = SideSpacing::new(bottom.into(), top.into());
         self.display_object().layout.padding.set(Vector2(horizontal, vertical));
+    }
+
+    /// Set vertical and horizontal padding of the object. Padding is the free space inside the
+    /// object.
+    fn set_padding_vh(&self, vertical: impl Into<Unit>, horizontal: impl Into<Unit>) -> &Self {
+        let padding = Vector2(horizontal.into().into(), vertical.into().into());
+        self.display_object().layout.padding.set(padding);
+        self
     }
 }
 
@@ -4679,6 +4688,7 @@ mod hierarchy_tests {
         assert.new_node_parents([false, false, false, true, false]);
     }
 
+    #[test]
     fn replace_children_replace_all_test() {
         let (root, nodes, assert) = ReplaceChildrenTest::<5>::new();
         root.replace_children(&nodes);

--- a/lib/rust/ensogl/core/src/display/object/instance.rs
+++ b/lib/rust/ensogl/core/src/display/object/instance.rs
@@ -3012,6 +3012,14 @@ pub trait LayoutOps: Object {
         self.display_object().layout.margin.set(Vector2(margin, margin));
     }
 
+    /// Set vertical and horizontal margins of the object. Margin is the free space around the
+    /// object.
+    fn set_margin_vh(&self, vertical: impl Into<Unit>, horizontal: impl Into<Unit>) -> &Self {
+        let margin = Vector2(horizontal.into().into(), vertical.into().into());
+        self.display_object().layout.margin.set(margin);
+        self
+    }
+
     /// Set margin of all sides of the object. Margin is the free space around the object.
     fn set_margin_trbl(
         &self,

--- a/lib/rust/ensogl/core/src/display/scene.rs
+++ b/lib/rust/ensogl/core/src/display/scene.rs
@@ -219,19 +219,19 @@ impl Mouse {
             (event: &mouse::Up) {
                 if display_mode.get().allow_mouse_events() {
                     let button = event.button();
-                    frp_deprecated.up.emit(button);
 
                     let current_target = target.get();
                     if let Some(last_target) = last_pressed_elem.borrow_mut().remove(&button) {
                         pointer_target_registry.with_mouse_target(last_target, |t, d| {
-                            t.emit_mouse_release(button);
                             d.emit_event(event.clone().unchecked_convert_to::<mouse::Release>());
+                            t.emit_mouse_release(button);
                         });
                     }
                     pointer_target_registry.with_mouse_target(current_target, |t, d| {
-                        t.emit_mouse_up(button);
                         d.emit_event(event.clone());
+                        t.emit_mouse_up(button);
                     });
+                    frp_deprecated.up.emit(button);
                 }
             }),
         );

--- a/lib/rust/ensogl/core/src/display/shape/compound/rectangle.rs
+++ b/lib/rust/ensogl/core/src/display/shape/compound/rectangle.rs
@@ -28,7 +28,7 @@ pub use shape::Shape;
 pub mod shape {
     use super::*;
     crate::shape! {
-        pointer_events_instanced = true,
+        pointer_events_instanced = true;
         (
             style: Style,
             color: Vector4,

--- a/lib/rust/ensogl/core/src/display/shape/compound/rectangle.rs
+++ b/lib/rust/ensogl/core/src/display/shape/compound/rectangle.rs
@@ -92,10 +92,16 @@ pub mod shape {
 /// such as circles, rings, or ring segments. The advantage of having a singular shape for these
 /// cases is that a single draw call can be used to render multiple GUI elements, which ultimately
 /// enhances performance.
-#[derive(Clone, CloneRef, Debug, Deref, Default)]
+#[derive(Clone, CloneRef, Deref, Default)]
 #[allow(missing_docs)]
 pub struct Rectangle {
     pub view: shape::View,
+}
+
+impl Debug for Rectangle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Rectangle").finish()
+    }
 }
 
 impl Rectangle {

--- a/lib/rust/ensogl/core/src/gui/cursor.rs
+++ b/lib/rust/ensogl/core/src/gui/cursor.rs
@@ -365,6 +365,7 @@ impl Cursor {
             }));
             frp.set_style_override <+ should_trash.then_constant(Style::trash());
             perform_trash <- on_up.gate(&should_trash);
+            frp.set_style_override <+ perform_trash.constant(None);
             eval_ perform_trash (model.trash_dragged_item());
 
 

--- a/lib/rust/ensogl/core/src/gui/cursor.rs
+++ b/lib/rust/ensogl/core/src/gui/cursor.rs
@@ -639,7 +639,6 @@ impl CursorModel {
             self.stop_drag_internal();
             Some(item)
         } else {
-            warn!("Can't stop dragging an item because no item is being dragged.");
             None
         }
     }
@@ -659,7 +658,6 @@ impl CursorModel {
                 }
             }
         } else {
-            warn!("Can't stop dragging an item because no item is being dragged.");
             None
         }
     }

--- a/lib/rust/ensogl/core/src/gui/cursor.rs
+++ b/lib/rust/ensogl/core/src/gui/cursor.rs
@@ -48,6 +48,7 @@ define_style! {
     /// label selection. After setting the host to the label, cursor will not follow mouse anymore,
     /// it will inherit its position from the label instead.
     host: display::object::Instance,
+    pointer_events: bool,
     size: Vector2<f32>,
     offset: Vector2<f32>,
     color: color::Lcha,
@@ -132,6 +133,7 @@ impl Style {
         let def_size = DEFAULT_SIZE();
         self.offset = Some(StyleValue::new_no_animation(-size / 2.0));
         self.size = Some(StyleValue::new_no_animation(size.abs() + def_size));
+        self.pointer_events = Some(StyleValue::new_no_animation(true));
         self
     }
 }
@@ -146,7 +148,7 @@ impl Style {
 pub mod shape {
     use super::*;
     crate::shape! {
-        pointer_events = false;
+        pointer_events_instanced = true,
         alignment = center; (
             style: Style,
             press: f32,
@@ -460,6 +462,13 @@ impl Cursor {
                     None => plus.target.emit(0.0),
                     Some(t) => plus.target.emit(t.value.unwrap_or(0.0)),
                 }
+
+                let pointer_events = match &new_style.pointer_events {
+                    None => false,
+                    Some(t) => t.value.unwrap_or(false),
+                };
+                let disable_pointer_events = (!pointer_events) as i32 as f32;
+                model.for_each_view(|vw| vw.disable_pointer_events.set(disable_pointer_events));
 
                 *model.style.borrow_mut() = new_style.clone();
             });

--- a/lib/rust/ensogl/core/src/gui/cursor.rs
+++ b/lib/rust/ensogl/core/src/gui/cursor.rs
@@ -148,7 +148,7 @@ impl Style {
 pub mod shape {
     use super::*;
     crate::shape! {
-        pointer_events_instanced = true,
+        pointer_events_instanced = true;
         alignment = center; (
             style: Style,
             press: f32,

--- a/lib/rust/ensogl/examples/cached-shape/src/lib.rs
+++ b/lib/rust/ensogl/examples/cached-shape/src/lib.rs
@@ -144,7 +144,7 @@ mod background {
     ensogl_core::shape! {
         below = [texture, icon1, icon2];
         alignment = center;
-        (style: Style,) {
+        (style: Style) {
             Rect((296.0.px(), 326.0.px())).fill(color::Rgba::black()).into()
         }
     }

--- a/lib/rust/prelude/src/string.rs
+++ b/lib/rust/prelude/src/string.rs
@@ -245,6 +245,12 @@ impl From<&&str> for ImString {
     }
 }
 
+impl From<Cow<'_, str>> for ImString {
+    fn from(t: Cow<str>) -> Self {
+        t.into_owned().into()
+    }
+}
+
 impl From<ImString> for String {
     fn from(value: ImString) -> Self {
         match Rc::try_unwrap(value.content) {


### PR DESCRIPTION
Fixes #6522 

- Fixed occasional panics when inserting or moving elements around.
- Improved mouse events handling in list editor to behave correctly during box selection.
- Removed vectorEditor feature flag, enabling the list editor permanently.
- Replaced node background shape with `Rectangle` and removed unnecessary separation between hover area and background. Switched node hover state to use new mouse events system.
- Adjusted size of hover area of the list editor such that it is harder do accidentally insert a new element and easier to drag the nodes around.
- Fixed mouse down event propagation inside list editor when clicking without dragging. This allows dropdowns nested within list items to work correctly.
![image](https://user-images.githubusercontent.com/919491/236062164-96c20652-d109-44db-9cb2-0cb89ce53809.png)
![image](https://user-images.githubusercontent.com/919491/236062101-5b35e1db-298c-43a7-8329-591eb9790439.png)
![image](https://user-images.githubusercontent.com/919491/236358329-b58d4ae5-6d45-4c02-a9b4-64a461cbbd4c.png)


### Important Notes

The mouse handling changes involve an unfortunate huge hack, where we enable mouse events on the mouse shape during box selection. That way we know for sure that no other shape will be able to receive mouse enter event. Then the list editor widget is modified to only actually respond to events when its background is hovered. We will definitely want a more proper way to handle mouse event contention, but it's definitely out of scope for current bugfixing.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
