### PR TITLE
change template names to correspond with language server values

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/dashboard.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/dashboard.tsx
@@ -623,7 +623,7 @@ function Dashboard(props: DashboardProps) {
         const projectName = getNewProjectName(templateName)
         const body: backendModule.CreateProjectRequestBody = {
             projectName,
-            projectTemplateName: templateName?.replace(/_/g, '').toLocaleLowerCase() ?? null,
+            projectTemplateName: templateName ?? null,
             parentDirectoryId: directoryId,
         }
         const projectAsset = await backend.createProject(body)

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/templates.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/templates.tsx
@@ -19,19 +19,19 @@ interface Template {
 const CLOUD_TEMPLATES: Template[] = [
     {
         title: 'Colorado COVID',
-        id: 'Colorado_COVID',
+        id: 'Colorado_Covid',
         description: 'Learn to glue multiple spreadsheets to analyses all your data at once.',
         background: '#6b7280',
     },
     {
         title: 'KMeans',
-        id: 'Kmeans',
+        id: 'KMeans',
         description: 'Learn where to open a coffee shop to maximize your income.',
         background: '#6b7280',
     },
     {
         title: 'NASDAQ Returns',
-        id: 'NASDAQ_Returns',
+        id: 'NasdaqReturns',
         description: 'Learn how to clean your data to prepare it for advanced analysis.',
         background: '#6b7280',
     },


### PR DESCRIPTION
### Pull Request Description

Small PR that adjust project templates names to be the same as used in the backend. We are storing them similar to the names used by language server. 

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
