### PR TITLE
Fix early resize

### DIFF
--- a/lib/rust/ensogl/core/src/display/render/pass.rs
+++ b/lib/rust/ensogl/core/src/display/render/pass.rs
@@ -52,7 +52,6 @@ pub struct Instance {
 
 impl Instance {
     /// Constructor
-    #[allow(clippy::borrowed_box)]
     pub fn new(
         context: &Context,
         variables: &UniformScope,


### PR DESCRIPTION
### Pull Request Description

Apply screen size to screen-size-independent passes

It is needed to restore the viewport. Fixes #6500.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] ~The documentation has been updated, if necessary.~
- [ ] ~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] ~Unit tests have been written where possible.~
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
