### PR TITLE
Limit the number of reported warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -740,6 +740,7 @@
   finalizers][6335]
 - [Warning.get_all returns only unique warnings][6372]
 - [Reimplement `enso_project` as a proper builtin][6352]
+- [Limit number of reported warnings per value to 100][6577]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -849,6 +850,7 @@
 [6335]: https://github.com/enso-org/enso/pull/6335
 [6372]: https://github.com/enso-org/enso/pull/6372
 [6352]: https://github.com/enso-org/enso/pull/6352
+[6577]: https://github.com/enso-org/enso/pull/6577
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -740,7 +740,7 @@
   finalizers][6335]
 - [Warning.get_all returns only unique warnings][6372]
 - [Reimplement `enso_project` as a proper builtin][6352]
-- [Limit number of reported warnings per value to 100][6577]
+- [Limit number of reported warnings per value][6577]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Warning.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Warning.enso
@@ -57,7 +57,7 @@ type Warning
     get_all value = Vector.from_polyglot_array (get_all_array value)
 
     ## ADVANCED
-       Returns `True` if the maximal number of reported warnings for a value has been reached, `false` otherwise.
+       Returns `True` if the maximal number of reported warnings for a value has been reached, `False` otherwise.
     limit_reached : Any -> Boolean
     limit_reached value = @Builtin_Method "Warning.limit_reached"
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Warning.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Warning.enso
@@ -58,8 +58,8 @@ type Warning
 
     ## ADVANCED
        Returns `True` if the maximal number of reported warnings for a value has been reached, `false` otherwise.
-    reached_max_count : Any -> Boolean
-    reached_max_count value = @Builtin_Method "Warning.reached_max_count"
+    limit_reached : Any -> Boolean
+    limit_reached value = @Builtin_Method "Warning.limit_reached"
 
     ## PRIVATE
        ADVANCED

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Warning.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Warning.enso
@@ -56,6 +56,11 @@ type Warning
     get_all : Any -> Vector Warning
     get_all value = Vector.from_polyglot_array (get_all_array value)
 
+    ## ADVANCED
+       Returns `True` if the maximal number of reported warnings for a value has been reached, `false` otherwise.
+    reached_max_count : Any -> Boolean
+    reached_max_count value = @Builtin_Method "Warning.reached_max_count"
+
     ## PRIVATE
        ADVANCED
 

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Warnings.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Warnings.enso
@@ -11,11 +11,8 @@ from Standard.Base import all
 process_to_json_text : Any -> Text
 process_to_json_text value =
     warnings = Warning.get_all value
-    text = warnings.map w->w.value.to_display_text
-    case Warning.reached_limit value of
-        True ->
-          len = text.length
-          vec = Vector.new (len+1) (i-> if i < len then text.at i else "Warnings limit reached.")
-          vec.to_json
-        False ->
-          text.to_json
+    texts = warnings.map w->w.value.to_display_text
+    vec = case Warning.limit_reached value of
+        True -> texts + ["Warnings limit reached."]
+        False -> texts
+    vec.to_json

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Warnings.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Warnings.enso
@@ -12,7 +12,7 @@ process_to_json_text : Any -> Text
 process_to_json_text value =
     warnings = Warning.get_all value
     text = warnings.map w->w.value.to_display_text
-    case Warning.reached_max_count value of
+    case Warning.reached_limit value of
         True ->
           len = text.length
           vec = Vector.new (len+1) (i-> if i < len then text.at i else "Warnings limit reached.")

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Warnings.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Warnings.enso
@@ -12,4 +12,10 @@ process_to_json_text : Any -> Text
 process_to_json_text value =
     warnings = Warning.get_all value
     text = warnings.map w->w.value.to_display_text
-    text.to_json
+    case Warning.reached_max_count value of
+        True ->
+          len = text.length
+          vec = Vector.new (len+1) (i-> if i < len then text.at i else "Warnings limit reached.")
+          vec.to_json
+        False ->
+          text.to_json

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextEventsListener.scala
@@ -234,7 +234,7 @@ final class ContextEventsListener(
     payload: Api.ExpressionUpdate.Payload.Value.Warnings
   ): ContextRegistryProtocol.ExpressionUpdate.Payload.Value.Warnings =
     ContextRegistryProtocol.ExpressionUpdate.Payload.Value
-      .Warnings(payload.count, payload.warning)
+      .Warnings(payload.count, payload.warning, payload.reachedMaxCount)
 
   /** Convert the runtime profiling info to the context registry protocol
     * representation.

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
@@ -205,8 +205,13 @@ object ContextRegistryProtocol {
           *
           * @param count the number of attached warnings
           * @param value textual representation of the attached warning
+          * @param reachedMaxCount indicated whether maximal number of warnings has been reached
           */
-        case class Warnings(count: Int, value: Option[String])
+        case class Warnings(
+          count: Int,
+          value: Option[String],
+          reachedMaxCount: Boolean
+        )
       }
 
       case class Pending(message: Option[String], progress: Option[Double])

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
@@ -104,6 +104,16 @@ public class RuntimeOptions {
   private static final OptionDescriptor ENABLE_EXECUTION_TIMER_DESCRIPTOR =
       OptionDescriptor.newBuilder(ENABLE_EXECUTION_TIMER_KEY, ENABLE_EXECUTION_TIMER).build();
 
+  public static final String WARNINGS_LIMIT = optionName("warningsLimit");
+
+  @Option(
+      help = "Maximal number of warnings reported to the user.",
+      category = OptionCategory.INTERNAL)
+  public static final OptionKey<Integer> WARNINGS_LIMIT_KEY = new OptionKey<>(100);
+
+  private static final OptionDescriptor WARNINGS_LIMIT_DESCRIPTOR =
+      OptionDescriptor.newBuilder(WARNINGS_LIMIT_KEY, WARNINGS_LIMIT).build();
+
   public static final OptionDescriptors OPTION_DESCRIPTORS =
       OptionDescriptors.create(
           Arrays.asList(
@@ -122,7 +132,8 @@ public class RuntimeOptions {
               PREINITIALIZE_DESCRIPTOR,
               WAIT_FOR_PENDING_SERIALIZATION_JOBS_DESCRIPTOR,
               USE_GLOBAL_IR_CACHE_LOCATION_DESCRIPTOR,
-              ENABLE_EXECUTION_TIMER_DESCRIPTOR));
+              ENABLE_EXECUTION_TIMER_DESCRIPTOR,
+              WARNINGS_LIMIT_DESCRIPTOR));
 
   /**
    * Canonicalizes the option name by prefixing it with the language name.

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
@@ -107,7 +107,7 @@ public class RuntimeOptions {
   public static final String WARNINGS_LIMIT = optionName("warningsLimit");
 
   @Option(
-      help = "Maximal number of warnings reported to the user.",
+      help = "Maximal number of warnings that can be attached to a value.",
       category = OptionCategory.INTERNAL)
   public static final OptionKey<Integer> WARNINGS_LIMIT_KEY = new OptionKey<>(100);
 

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -417,8 +417,13 @@ object Runtime {
             *
             * @param count the number of attached warnings.
             * @param warning textual representation of the attached warning.
+            * @param reachedMaxCount true when reported a maximal number of allowed warnings, false otherwise.
             */
-          case class Warnings(count: Int, warning: Option[String])
+          case class Warnings(
+            count: Int,
+            warning: Option[String],
+            reachedMaxCount: Boolean
+          )
         }
 
         /** TBD

--- a/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
@@ -28,6 +28,7 @@ class ContextFactory {
     *                                 location
     * @param options additional options for the Context
     * @param executionEnvironment optional name of the execution environment to use during execution
+    * @param warningsLimit maximal number of warnings reported to the user
     * @return configured Context instance
     */
   def create(
@@ -42,6 +43,7 @@ class ContextFactory {
     useGlobalIrCacheLocation: Boolean      = true,
     enableAutoParallelism: Boolean         = false,
     executionEnvironment: Option[String]   = None,
+    warningsLimit: Int                     = 100,
     options: java.util.Map[String, String] = java.util.Collections.emptyMap
   ): PolyglotContext = {
     executionEnvironment.foreach { name =>
@@ -66,6 +68,10 @@ class ContextFactory {
       .option(
         RuntimeOptions.ENABLE_AUTO_PARALLELISM,
         enableAutoParallelism.toString
+      )
+      .option(
+        RuntimeOptions.WARNINGS_LIMIT,
+        warningsLimit.toString
       )
       .option("js.foreign-object-prototype", "true")
       .out(out)

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -4387,7 +4387,9 @@ class RuntimeServerTest
           methodPointer =
             Some(Api.MethodPointer(moduleName, moduleName, "attach")),
           payload = Api.ExpressionUpdate.Payload.Value(
-            Some(Api.ExpressionUpdate.Payload.Value.Warnings(1, Some("'y'")))
+            Some(
+              Api.ExpressionUpdate.Payload.Value.Warnings(1, Some("'y'"), false)
+            )
           )
         ),
       TestMessages
@@ -4400,7 +4402,7 @@ class RuntimeServerTest
           payload = Api.ExpressionUpdate.Payload.Value(
             Some(
               Api.ExpressionUpdate.Payload.Value
-                .Warnings(1, Some("(My_Warning.Value 42)"))
+                .Warnings(1, Some("(My_Warning.Value 42)"), false)
             )
           )
         ),
@@ -4412,7 +4414,9 @@ class RuntimeServerTest
           methodPointer =
             Some(Api.MethodPointer(moduleName, moduleName, "attach")),
           payload = Api.ExpressionUpdate.Payload
-            .Value(Some(Api.ExpressionUpdate.Payload.Value.Warnings(2, None)))
+            .Value(
+              Some(Api.ExpressionUpdate.Payload.Value.Warnings(2, None, false))
+            )
         ),
       context.executionComplete(contextId)
     )
@@ -4473,7 +4477,9 @@ class RuntimeServerTest
           idX,
           ConstantsGen.INTEGER,
           payload = Api.ExpressionUpdate.Payload.Value(
-            Some(Api.ExpressionUpdate.Payload.Value.Warnings(1, Some("'y'")))
+            Some(
+              Api.ExpressionUpdate.Payload.Value.Warnings(1, Some("'y'"), false)
+            )
           )
         ),
       TestMessages
@@ -4482,7 +4488,9 @@ class RuntimeServerTest
           idY,
           ConstantsGen.INTEGER,
           payload = Api.ExpressionUpdate.Payload.Value(
-            Some(Api.ExpressionUpdate.Payload.Value.Warnings(1, Some("'y'")))
+            Some(
+              Api.ExpressionUpdate.Payload.Value.Warnings(1, Some("'y'"), false)
+            )
           )
         ),
       TestMessages
@@ -4491,7 +4499,9 @@ class RuntimeServerTest
           idRes,
           ConstantsGen.NOTHING,
           payload = Api.ExpressionUpdate.Payload.Value(
-            Some(Api.ExpressionUpdate.Payload.Value.Warnings(1, Some("'y'")))
+            Some(
+              Api.ExpressionUpdate.Payload.Value.Warnings(1, Some("'y'"), false)
+            )
           )
         ),
       context.executionComplete(contextId)

--- a/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -2874,7 +2874,9 @@ class RuntimeVisualizationsTest
         idMain,
         ConstantsGen.INTEGER,
         payload = Api.ExpressionUpdate.Payload.Value(
-          Some(Api.ExpressionUpdate.Payload.Value.Warnings(1, Some("'y'")))
+          Some(
+            Api.ExpressionUpdate.Payload.Value.Warnings(1, Some("'y'"), false)
+          )
         )
       ),
       context.executionComplete(contextId)
@@ -3074,7 +3076,9 @@ class RuntimeVisualizationsTest
           )
         ),
         payload = Api.ExpressionUpdate.Payload.Value(
-          Some(Api.ExpressionUpdate.Payload.Value.Warnings(1, Some("'x'")))
+          Some(
+            Api.ExpressionUpdate.Payload.Value.Warnings(1, Some("'x'"), false)
+          )
         )
       ),
       TestMessages.update(
@@ -3082,7 +3086,9 @@ class RuntimeVisualizationsTest
         idRes,
         s"$moduleName.Newtype",
         payload = Api.ExpressionUpdate.Payload.Value(
-          Some(Api.ExpressionUpdate.Payload.Value.Warnings(1, Some("'x'")))
+          Some(
+            Api.ExpressionUpdate.Payload.Value.Warnings(1, Some("'x'"), false)
+          )
         ),
         methodPointer = Some(
           Api.MethodPointer(moduleName, s"$moduleName.Newtype", "Mk_Newtype")

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/WarningBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/WarningBenchmarks.java
@@ -18,7 +18,11 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.BenchmarkParams;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -28,27 +32,50 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 public class WarningBenchmarks extends TestBase {
-    private static final int INPUT_VEC_SIZE = 10000;
+    private static final int INPUT_VEC_SIZE = 10_000;
+    private static final int INPUT_DIFF_VEC_SIZE = 10_000;
     private Context ctx;
     private Value vecSumBench;
 
     private Value createVec;
+    private Value mapVecWithWarnings;
     private Value noWarningsVec;
     private Value sameWarningVec;
-
-    private Value elem;
-
-    private Value elemWithWarning;
+    private Value randomVec;
+    private Value randomElemsWithWarningsVec;
+    private Value constElem;
+    private Value constElemWithWarning;
 
     private String benchmarkName;
+
+    private int randomVectorSum = 0;
+
+    private record GeneratedVector(StringBuilder repr, int sum) {}
+
+    private GeneratedVector generateRandomVector(Random random, String vectorName, long vectorSize, int maxRange) {
+        List<Integer> primitiveValues = new ArrayList<>();
+        random.ints(vectorSize, 0, maxRange).forEach(primitiveValues::add);
+        Collections.shuffle(primitiveValues);
+        var sb = new StringBuilder();
+        sb.append(vectorName).append(" = [");
+        var sum = 0;
+        for (Integer intValue : primitiveValues) {
+            sb.append(intValue).append(",");
+            sum += Math.abs(intValue);
+        }
+        sb.setCharAt(sb.length() - 1, ']');
+        sb.append('\n');
+        return new GeneratedVector(sb, sum);
+    }
 
     @Setup
     public void initializeBench(BenchmarkParams params) throws IOException {
         ctx = createDefaultContext();
+        var random = new Random(42);
 
         benchmarkName = SrcUtil.findName(params);
 
-        var code = """
+        var code = new StringBuilder("""
         from Standard.Base import all
 
         vec_sum_bench : Vector Integer -> Integer
@@ -61,18 +88,34 @@ public class WarningBenchmarks extends TestBase {
         elem =
             42
             
-        elem_with_warning =
+        elem_const_with_warning =
             x = 42
             Warning.attach "Foo!" x
-        """;
-        var src = SrcUtil.source(benchmarkName, code);
+
+        elem_with_warning v =
+            Warning.attach "Foo!" v
+
+        map_vector_with_warnings vec =
+            vec.map (e-> elem_with_warning e)
+        """);
+
+        // generate random vector
+        var randomIntVectorName = "vector_with_random_values";
+        var vectorWithRandomValues = generateRandomVector(random, randomIntVectorName, INPUT_DIFF_VEC_SIZE, 3_000);
+        code.append(vectorWithRandomValues.repr());
+        randomVectorSum = vectorWithRandomValues.sum();
+
+        var src = SrcUtil.source(benchmarkName, code.toString());
         Value module = ctx.eval(src);
         vecSumBench = Objects.requireNonNull(module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "vec_sum_bench"));
         createVec = Objects.requireNonNull(module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "create_vec"));
-        elem = Objects.requireNonNull(module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "elem"));
-        elemWithWarning = Objects.requireNonNull(module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "elem_with_warning"));
-        noWarningsVec = createVec.execute(INPUT_VEC_SIZE, elem);
-        sameWarningVec = createVec.execute(INPUT_VEC_SIZE, elemWithWarning);
+        mapVecWithWarnings = Objects.requireNonNull(module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "map_vector_with_warnings"));
+        constElem = Objects.requireNonNull(module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "elem"));
+        constElemWithWarning = Objects.requireNonNull(module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "elem_const_with_warning"));
+        noWarningsVec = createVec.execute(INPUT_VEC_SIZE, constElem);
+        sameWarningVec = createVec.execute(INPUT_VEC_SIZE, constElemWithWarning);
+        randomVec = Objects.requireNonNull(module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, randomIntVectorName));
+        randomElemsWithWarningsVec = mapVecWithWarnings.execute(randomVec);
     }
 
     @TearDown
@@ -83,17 +126,30 @@ public class WarningBenchmarks extends TestBase {
     @Benchmark
     public void noWarningsVecSum() {
         Value res = vecSumBench.execute(noWarningsVec);
-        checkResult(res);
+        checkResult(res, INPUT_VEC_SIZE*42);
     }
 
     @Benchmark
     public void sameWarningVecSum() {
         Value res = vecSumBench.execute(sameWarningVec);
-        checkResult(res);
+        checkResult(res, INPUT_VEC_SIZE*42);
     }
 
-    private static void checkResult(Value res) {
-        if (res.asInt() != INPUT_VEC_SIZE*42) {
+    @Benchmark
+    public void randomElementsVecSum() {
+        Value res = vecSumBench.execute(randomVec);
+        checkResult(res, randomVectorSum);
+    }
+
+    @Benchmark
+    public void diiffWarningRandomElementsVecSum() {
+        Value res = vecSumBench.execute(randomElemsWithWarningsVec);
+        checkResult(res, randomVectorSum);
+    }
+
+
+    private static void checkResult(Value res, int expected) {
+        if (res.asInt() != expected) {
             throw new AssertionError("Expected result: " + INPUT_VEC_SIZE*42 + ", got: " + res.asInt());
         }
     }

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/WarningBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/WarningBenchmarks.java
@@ -19,7 +19,6 @@ import org.openjdk.jmh.infra.BenchmarkParams;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
@@ -55,7 +54,6 @@ public class WarningBenchmarks extends TestBase {
     private GeneratedVector generateRandomVector(Random random, String vectorName, long vectorSize, int maxRange) {
         List<Integer> primitiveValues = new ArrayList<>();
         random.ints(vectorSize, 0, maxRange).forEach(primitiveValues::add);
-        Collections.shuffle(primitiveValues);
         var sb = new StringBuilder();
         sb.append(vectorName).append(" = [");
         var sum = 0;
@@ -142,7 +140,7 @@ public class WarningBenchmarks extends TestBase {
     }
 
     @Benchmark
-    public void diiffWarningRandomElementsVecSum() {
+    public void diffWarningRandomElementsVecSum() {
         Value res = vecSumBench.execute(randomElemsWithWarningsVec);
         checkResult(res, randomVectorSum);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeCallableNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeCallableNode.java
@@ -87,7 +87,7 @@ public abstract class IndirectInvokeCallableNode extends Node {
               isTail);
 
       Warning[] extracted = warnings.getWarnings(warning, null);
-      return WithWarnings.wrap(result, extracted);
+      return WithWarnings.wrap(EnsoContext.get(this), result, extracted);
     } catch (UnsupportedMessageException e) {
       throw CompilerDirectives.shouldNotReachHere(e);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeConversionNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeConversionNode.java
@@ -156,7 +156,7 @@ public abstract class IndirectInvokeConversionNode extends Node {
             argumentsExecutionMode,
             isTail,
             thatArgumentPosition);
-    return WithWarnings.appendTo(result, warnings);
+    return WithWarnings.appendTo(EnsoContext.get(this), result, warnings);
   }
 
   @Specialization(guards = "interop.isString(that)")

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeMethodNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/IndirectInvokeMethodNode.java
@@ -134,7 +134,7 @@ public abstract class IndirectInvokeMethodNode extends Node {
             argumentsExecutionMode,
             isTail,
             thisArgumentPosition);
-    return WithWarnings.appendTo(result, warnings);
+    return WithWarnings.appendTo(EnsoContext.get(this), result, warnings);
   }
 
   @Specialization

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
@@ -297,9 +297,9 @@ public abstract class InvokeCallableNode extends BaseNode {
       if (result instanceof DataflowError) {
         return result;
       } else if (result instanceof WithWarnings withWarnings) {
-        return withWarnings.append(extracted);
+        return withWarnings.append(EnsoContext.get(this), extracted);
       } else {
-        return WithWarnings.wrap(result, extracted);
+        return WithWarnings.wrap(EnsoContext.get(this), result, extracted);
       }
     } catch (UnsupportedMessageException e) {
       throw CompilerDirectives.shouldNotReachHere(e);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeConversionNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeConversionNode.java
@@ -175,7 +175,7 @@ public abstract class InvokeConversionNode extends BaseNode {
     ArrayRope<Warning> warnings = that.getReassignedWarningsAsRope(this);
     Object result =
         childDispatch.execute(frame, state, conversion, self, that.getValue(), arguments);
-    return WithWarnings.appendTo(result, warnings);
+    return WithWarnings.appendTo(EnsoContext.get(this), result, warnings);
   }
 
   @Specialization(guards = "interop.isString(that)")

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeMethodNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeMethodNode.java
@@ -340,7 +340,7 @@ public abstract class InvokeMethodNode extends BaseNode {
     arguments[thisArgumentPosition] = selfWithoutWarnings;
 
     Object result = childDispatch.execute(frame, state, symbol, selfWithoutWarnings, arguments);
-    return WithWarnings.appendTo(result, arrOfWarnings);
+    return WithWarnings.appendTo(EnsoContext.get(this), result, arrOfWarnings);
   }
 
   @ExplodeLoop
@@ -392,7 +392,7 @@ public abstract class InvokeMethodNode extends BaseNode {
     Object res = hostMethodCallNode.execute(polyglotCallType, symbol.getName(), self, args);
     if (anyWarnings) {
       anyWarningsProfile.enter();
-      res = WithWarnings.appendTo(res, accumulatedWarnings);
+      res = WithWarnings.appendTo(EnsoContext.get(this), res, accumulatedWarnings);
     }
     return res;
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CaseNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/CaseNode.java
@@ -81,9 +81,10 @@ public abstract class CaseNode extends ExpressionNode {
   Object doWarning(
       VirtualFrame frame, Object object, @CachedLibrary(limit = "3") WarningsLibrary warnings) {
     try {
+      EnsoContext ctx = EnsoContext.get(this);
       Warning[] ws = warnings.getWarnings(object, this);
       Object result = doMatch(frame, warnings.removeWarnings(object), warnings);
-      return WithWarnings.wrap(result, ws);
+      return WithWarnings.wrap(ctx, result, ws);
     } catch (UnsupportedMessageException e) {
       throw new IllegalStateException(e);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/atom/InstantiateNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/atom/InstantiateNode.java
@@ -10,6 +10,7 @@ import com.oracle.truffle.api.nodes.NodeInfo;
 import com.oracle.truffle.api.profiles.BranchProfile;
 import com.oracle.truffle.api.profiles.ConditionProfile;
 import org.enso.interpreter.node.ExpressionNode;
+import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.atom.AtomConstructor;
 import org.enso.interpreter.runtime.callable.atom.unboxing.Layout;
 import org.enso.interpreter.runtime.data.ArrayRope;
@@ -94,7 +95,8 @@ public abstract class InstantiateNode extends ExpressionNode {
       }
     }
     if (anyWarningsProfile.profile(anyWarnings)) {
-      return WithWarnings.appendTo(createInstanceNode.execute(argumentValues), accumulatedWarnings);
+      return WithWarnings.appendTo(
+          EnsoContext.get(this), createInstanceNode.execute(argumentValues), accumulatedWarnings);
     } else {
       return createInstanceNode.execute(argumentValues);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/ordering/SortVectorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/ordering/SortVectorNode.java
@@ -338,13 +338,14 @@ public abstract class SortVectorNode extends Node {
   }
 
   private Object attachWarnings(Object vector, Set<String> warnings) {
+    var ctx = EnsoContext.get(this);
     var warnArray =
         warnings.stream()
             .map(Text::create)
-            .map(text -> Warning.create(EnsoContext.get(this), text, this))
+            .map(text -> Warning.create(ctx, text, this))
             .limit(MAX_SORT_WARNINGS)
             .toArray(Warning[]::new);
-    return WithWarnings.appendTo(vector, warnArray.length < warnings.size(), warnArray);
+    return WithWarnings.appendTo(ctx, vector, warnArray.length < warnings.size(), warnArray);
   }
 
   private Object attachDifferentComparatorsWarning(Object vector, List<Group> groups) {
@@ -354,8 +355,9 @@ public abstract class SortVectorNode extends Node {
             .map(comparator -> comparator.getQualifiedName().toString())
             .collect(Collectors.joining(", "));
     var text = Text.create("Different comparators: [" + diffCompsMsg + "]");
-    var warn = Warning.create(EnsoContext.get(this), text, this);
-    return WithWarnings.appendTo(vector, false, warn);
+    var ctx = EnsoContext.get(this);
+    var warn = Warning.create(ctx, text, this);
+    return WithWarnings.appendTo(ctx, vector, false, warn);
   }
 
   private String getDefaultComparatorQualifiedName() {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/ordering/SortVectorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/ordering/SortVectorNode.java
@@ -52,6 +52,8 @@ import org.enso.interpreter.runtime.state.State;
 @GenerateUncached
 public abstract class SortVectorNode extends Node {
 
+  private static final int MAX_SORT_WARNINGS = 10;
+
   public static SortVectorNode build() {
     return SortVectorNodeGen.create();
   }
@@ -340,8 +342,9 @@ public abstract class SortVectorNode extends Node {
         warnings.stream()
             .map(Text::create)
             .map(text -> Warning.create(EnsoContext.get(this), text, this))
+            .limit(MAX_SORT_WARNINGS)
             .toArray(Warning[]::new);
-    return WithWarnings.appendTo(vector, new ArrayRope<>(warnArray));
+    return WithWarnings.appendTo(vector, warnArray.length < warnings.size(), warnArray);
   }
 
   private Object attachDifferentComparatorsWarning(Object vector, List<Group> groups) {
@@ -352,7 +355,7 @@ public abstract class SortVectorNode extends Node {
             .collect(Collectors.joining(", "));
     var text = Text.create("Different comparators: [" + diffCompsMsg + "]");
     var warn = Warning.create(EnsoContext.get(this), text, this);
-    return WithWarnings.appendTo(vector, new ArrayRope<>(warn));
+    return WithWarnings.appendTo(vector, false, warn);
   }
 
   private String getDefaultComparatorQualifiedName() {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/foreign/CoerceNothing.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/foreign/CoerceNothing.java
@@ -35,11 +35,12 @@ public abstract class CoerceNothing extends Node {
       @CachedLibrary(limit = "1") InteropLibrary interop,
       @CachedLibrary(limit = "3") WarningsLibrary warningsLibrary,
       @Cached("createCountingProfile()") ConditionProfile nullWarningProfile) {
-    var nothing = EnsoContext.get(this).getBuiltins().nothing();
+    var ctx = EnsoContext.get(this);
+    var nothing = ctx.getBuiltins().nothing();
     if (nullWarningProfile.profile(warningsLibrary.hasWarnings(value))) {
       try {
         Warning[] attachedWarnings = warningsLibrary.getWarnings(value, null);
-        return WithWarnings.wrap(nothing, attachedWarnings);
+        return WithWarnings.wrap(ctx, nothing, attachedWarnings);
       } catch (UnsupportedMessageException e) {
         return nothing;
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -82,6 +82,8 @@ public class EnsoContext {
   private final Shape rootStateShape = Shape.newBuilder().layout(State.Container.class).build();
   private ExecutionEnvironment executionEnvironment;
 
+  private final int warningsLimit;
+
   /**
    * Creates a new Enso context.
    *
@@ -127,6 +129,7 @@ public class EnsoContext {
     this.notificationHandler = notificationHandler;
     this.lockManager = lockManager;
     this.distributionManager = distributionManager;
+    this.warningsLimit = getOption(RuntimeOptions.WARNINGS_LIMIT_KEY);
   }
 
   /** Perform expensive initialization logic for the context. */
@@ -515,6 +518,11 @@ public class EnsoContext {
   /** Set the runtime execution environment of this context. */
   public void setExecutionEnvironment(ExecutionEnvironment executionEnvironment) {
     this.executionEnvironment = executionEnvironment;
+  }
+
+  /** Returns a maximal number of warnings that can be attached to a value */
+  public int getWarningsLimit() {
+    return this.warningsLimit;
   }
 
   public Shape getRootStateShape() {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
@@ -239,10 +239,10 @@ public final class Array implements TruffleObject {
   }
 
   @ExportMessage
-  boolean reachedMaxWarnings(@CachedLibrary(limit = "3") WarningsLibrary warnings) {
+  boolean isLimitReached(@CachedLibrary(limit = "3") WarningsLibrary warnings) {
     try {
       int limit = getMaxNumberOfWarnings(EnsoContext.get(warnings));
-      return getWarnings(null, warnings).length == limit;
+      return getWarnings(null, warnings).length >= limit;
     } catch (UnsupportedMessageException e) {
       return false;
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
@@ -238,6 +238,15 @@ public final class Array implements TruffleObject {
   }
 
   @ExportMessage
+  boolean reachedMaxWarnings(@CachedLibrary(limit = "3") WarningsLibrary warnings) {
+    try {
+      return getWarnings(null, warnings).length >= WithWarnings.MAX_WARNINGS_LIMIT;
+    } catch (UnsupportedMessageException e) {
+      return false;
+    }
+  }
+
+  @ExportMessage
   Type getType(@CachedLibrary("this") TypesLibrary thisLib) {
     return EnsoContext.get(thisLib).getBuiltins().array();
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
@@ -242,7 +242,7 @@ public final class Array implements TruffleObject {
   boolean reachedMaxWarnings(@CachedLibrary(limit = "3") WarningsLibrary warnings) {
     try {
       int limit = getMaxNumberOfWarnings(EnsoContext.get(warnings));
-      return getWarnings(null, warnings).length >= limit;
+      return getWarnings(null, warnings).length == limit;
     } catch (UnsupportedMessageException e) {
       return false;
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
@@ -19,6 +19,7 @@ import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 
 import java.util.Arrays;
 import org.enso.interpreter.runtime.error.WithWarnings;
+import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.collections.EconomicSet;
 
 /** A primitive boxed array type for use in the runtime. */
@@ -114,7 +115,7 @@ public final class Array implements TruffleObject {
       if (warnings.hasWarnings(v)) {
         v = warnings.removeWarnings(v);
       }
-      return WithWarnings.wrap(v, extracted);
+      return WithWarnings.wrap(EnsoContext.get(warnings), v, extracted);
     }
     return v;
   }
@@ -240,7 +241,12 @@ public final class Array implements TruffleObject {
   @ExportMessage
   boolean reachedMaxWarnings(@CachedLibrary(limit = "3") WarningsLibrary warnings) {
     try {
-      return getWarnings(null, warnings).length >= WithWarnings.MAX_WARNINGS_LIMIT;
+      int limit =
+          EnsoContext.get(warnings)
+              .getEnvironment()
+              .getOptions()
+              .get(RuntimeOptions.WARNINGS_LIMIT_KEY);
+      return getWarnings(null, warnings).length >= limit;
     } catch (UnsupportedMessageException e) {
       return false;
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
@@ -241,15 +241,16 @@ public final class Array implements TruffleObject {
   @ExportMessage
   boolean reachedMaxWarnings(@CachedLibrary(limit = "3") WarningsLibrary warnings) {
     try {
-      int limit =
-          EnsoContext.get(warnings)
-              .getEnvironment()
-              .getOptions()
-              .get(RuntimeOptions.WARNINGS_LIMIT_KEY);
+      int limit = getMaxNumberOfWarnings(EnsoContext.get(warnings));
       return getWarnings(null, warnings).length >= limit;
     } catch (UnsupportedMessageException e) {
       return false;
     }
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  private int getMaxNumberOfWarnings(EnsoContext ctx) {
+    return ctx.getEnvironment().getOptions().get(RuntimeOptions.WARNINGS_LIMIT_KEY);
   }
 
   @ExportMessage

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Array.java
@@ -241,16 +241,11 @@ public final class Array implements TruffleObject {
   @ExportMessage
   boolean isLimitReached(@CachedLibrary(limit = "3") WarningsLibrary warnings) {
     try {
-      int limit = getMaxNumberOfWarnings(EnsoContext.get(warnings));
+      int limit = EnsoContext.get(warnings).getWarningsLimit();
       return getWarnings(null, warnings).length >= limit;
     } catch (UnsupportedMessageException e) {
       return false;
     }
-  }
-
-  @CompilerDirectives.TruffleBoundary
-  private int getMaxNumberOfWarnings(EnsoContext ctx) {
-    return ctx.getEnvironment().getOptions().get(RuntimeOptions.WARNINGS_LIMIT_KEY);
   }
 
   @ExportMessage

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArraySlice.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArraySlice.java
@@ -157,4 +157,9 @@ public final class ArraySlice implements TruffleObject {
     return new ArraySlice(newStorage, start, end);
   }
 
+  @ExportMessage
+  boolean reachedMaxWarnings(@CachedLibrary(limit = "3") WarningsLibrary warnings) {
+    return warnings.reachedMaxWarnings(this.storage);
+  }
+
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArraySlice.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArraySlice.java
@@ -159,8 +159,8 @@ public final class ArraySlice implements TruffleObject {
   }
 
   @ExportMessage
-  boolean reachedMaxWarnings(@CachedLibrary(limit = "3") WarningsLibrary warnings) {
-    return warnings.reachedMaxWarnings(this.storage);
+  boolean isLimitReached(@CachedLibrary(limit = "3") WarningsLibrary warnings) {
+    return warnings.isLimitReached(this.storage);
   }
 
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArraySlice.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/ArraySlice.java
@@ -11,6 +11,7 @@ import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.node.expression.builtin.interop.syntax.HostValueToEnsoNode;
+import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.error.Warning;
 import org.enso.interpreter.runtime.error.WarningsLibrary;
 import org.enso.interpreter.runtime.error.WithWarnings;
@@ -95,7 +96,7 @@ public final class ArraySlice implements TruffleObject {
       if (warnings.hasWarnings(v)) {
         v = warnings.removeWarnings(v);
       }
-      return WithWarnings.wrap(toEnso.execute(v), extracted);
+      return WithWarnings.wrap(EnsoContext.get(warnings), toEnso.execute(v), extracted);
     }
     return toEnso.execute(v);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
@@ -223,8 +223,8 @@ public final class Vector implements TruffleObject {
   }
 
   @ExportMessage
-  boolean reachedMaxWarnings(@CachedLibrary(limit = "3") WarningsLibrary warnings) {
-    return warnings.reachedMaxWarnings(this.storage);
+  boolean isLimitReached(@CachedLibrary(limit = "3") WarningsLibrary warnings) {
+    return warnings.isLimitReached(this.storage);
   }
 
   //

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
@@ -222,6 +222,11 @@ public final class Vector implements TruffleObject {
     return new Vector(warnings.removeWarnings(this.storage));
   }
 
+  @ExportMessage
+  boolean reachedMaxWarnings(@CachedLibrary(limit = "3") WarningsLibrary warnings) {
+    return warnings.reachedMaxWarnings(this.storage);
+  }
+
   //
   // helper methods
   //

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Vector.java
@@ -123,7 +123,7 @@ public final class Vector implements TruffleObject {
       if (warnings.hasWarnings(v)) {
         v = warnings.removeWarnings(v);
       }
-      return WithWarnings.wrap(toEnso.execute(v), extracted);
+      return WithWarnings.wrap(EnsoContext.get(interop), toEnso.execute(v), extracted);
     }
     return toEnso.execute(v);
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
@@ -74,7 +74,7 @@ public final class Warning implements TruffleObject {
   @Builtin.Specialize
   public static WithWarnings attach(
       EnsoContext ctx, WithWarnings value, Object warning, Object origin) {
-    return value.append(new Warning(warning, origin, ctx.nextSequenceId()));
+    return value.append(ctx, new Warning(warning, origin, ctx.nextSequenceId()));
   }
 
   @Builtin.Method(
@@ -83,7 +83,7 @@ public final class Warning implements TruffleObject {
       autoRegister = false)
   @Builtin.Specialize(fallback = true)
   public static WithWarnings attach(EnsoContext ctx, Object value, Object warning, Object origin) {
-    return WithWarnings.wrap(value, new Warning(warning, origin, ctx.nextSequenceId()));
+    return WithWarnings.wrap(ctx, value, new Warning(warning, origin, ctx.nextSequenceId()));
   }
 
   @Builtin.Method(
@@ -119,7 +119,8 @@ public final class Warning implements TruffleObject {
 
   @Builtin.Method(
       name = "reached_max_count",
-      description = "Returns `true` if the maximal number of warnings has been reached, `false` otherwise.",
+      description =
+          "Returns `true` if the maximal number of warnings has been reached, `false` otherwise.",
       autoRegister = false)
   @Builtin.Specialize
   public static boolean reachedMaxCount(Object value, WarningsLibrary warnings) {
@@ -142,8 +143,9 @@ public final class Warning implements TruffleObject {
       description = "Sets all the warnings associated with the value.",
       autoRegister = false)
   @Builtin.Specialize
-  public static Object set(WithWarnings value, Object warnings, InteropLibrary interop) {
-    return setGeneric(value.getValue(), interop, warnings);
+  public static Object set(
+      EnsoContext ctx, WithWarnings value, Object warnings, InteropLibrary interop) {
+    return setGeneric(ctx, value.getValue(), interop, warnings);
   }
 
   @Builtin.Method(
@@ -151,11 +153,12 @@ public final class Warning implements TruffleObject {
       description = "Sets all the warnings associated with the value.",
       autoRegister = false)
   @Builtin.Specialize(fallback = true)
-  public static Object set(Object value, Object warnings, InteropLibrary interop) {
-    return setGeneric(value, interop, warnings);
+  public static Object set(EnsoContext ctx, Object value, Object warnings, InteropLibrary interop) {
+    return setGeneric(ctx, value, interop, warnings);
   }
 
-  private static Object setGeneric(Object value, InteropLibrary interop, Object warnings) {
+  private static Object setGeneric(
+      EnsoContext ctx, Object value, InteropLibrary interop, Object warnings) {
     try {
       var size = interop.getArraySize(warnings);
       if (size == 0) {
@@ -165,7 +168,7 @@ public final class Warning implements TruffleObject {
       for (int i = 0; i < warningsCast.length; i++) {
         warningsCast[i] = (Warning) interop.readArrayElement(warnings, i);
       }
-      return WithWarnings.wrap(value, warningsCast);
+      return WithWarnings.wrap(ctx, value, warningsCast);
     } catch (UnsupportedMessageException | InvalidArrayIndexException ex) {
       CompilerDirectives.transferToInterpreter();
       throw new IllegalStateException(ex);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
@@ -117,6 +117,15 @@ public final class Warning implements TruffleObject {
     }
   }
 
+  @Builtin.Method(
+      name = "reached_max_count",
+      description = "Returns `true` if the maximal number of warnings has been reached, `false` otherwise.",
+      autoRegister = false)
+  @Builtin.Specialize
+  public static boolean reachedMaxCount(Object value, WarningsLibrary warnings) {
+    return warnings.hasWarnings(value) ? warnings.reachedMaxWarnings(value) : false;
+  }
+
   @CompilerDirectives.TruffleBoundary
   private static void sortArray(Warning[] arr) {
     Arrays.sort(arr, Comparator.comparing(Warning::getSequenceId).reversed());

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
@@ -123,6 +123,16 @@ public final class Warning implements TruffleObject {
           "Returns `true` if the maximal number of warnings has been reached, `false` otherwise.",
       autoRegister = false)
   @Builtin.Specialize
+  public static boolean reachedMaxCount(WithWarnings value, WarningsLibrary warnings) {
+    return value.reachedMaxWarnings();
+  }
+
+  @Builtin.Method(
+      name = "reached_max_count",
+      description =
+          "Returns `true` if the maximal number of warnings has been reached, `false` otherwise.",
+      autoRegister = false)
+  @Builtin.Specialize(fallback = true)
   public static boolean reachedMaxCount(Object value, WarningsLibrary warnings) {
     return warnings.hasWarnings(value) ? warnings.reachedMaxWarnings(value) : false;
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
@@ -118,23 +118,21 @@ public final class Warning implements TruffleObject {
   }
 
   @Builtin.Method(
-      name = "reached_max_count",
       description =
           "Returns `true` if the maximal number of warnings has been reached, `false` otherwise.",
       autoRegister = false)
   @Builtin.Specialize
-  public static boolean reachedMaxCount(WithWarnings value, WarningsLibrary warnings) {
-    return value.reachedMaxWarnings();
+  public static boolean limitReached(WithWarnings value, WarningsLibrary warnings) {
+    return value.isLimitReached();
   }
 
   @Builtin.Method(
-      name = "reached_max_count",
       description =
           "Returns `true` if the maximal number of warnings has been reached, `false` otherwise.",
       autoRegister = false)
   @Builtin.Specialize(fallback = true)
-  public static boolean reachedMaxCount(Object value, WarningsLibrary warnings) {
-    return warnings.hasWarnings(value) ? warnings.reachedMaxWarnings(value) : false;
+  public static boolean limitReached(Object value, WarningsLibrary warnings) {
+    return warnings.hasWarnings(value) ? warnings.isLimitReached(value) : false;
   }
 
   @CompilerDirectives.TruffleBoundary

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WarningsLibrary.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WarningsLibrary.java
@@ -64,4 +64,15 @@ public abstract class WarningsLibrary extends Library {
   public Object removeWarnings(Object receiver) throws UnsupportedMessageException {
     throw UnsupportedMessageException.create();
   }
+
+  /**
+   * Returns the object with all warnings removed.
+   *
+   * @param receiver the receiver to analyze
+   * @return the receiver with all warnings removed, if any
+   */
+  @GenerateLibrary.Abstract(ifExported = {"hasWarnings"})
+  public boolean reachedMaxWarnings(Object receiver) {
+    return false;
+  }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WarningsLibrary.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WarningsLibrary.java
@@ -66,13 +66,13 @@ public abstract class WarningsLibrary extends Library {
   }
 
   /**
-   * Returns the object with all warnings removed.
+   * Checks if the receiver reached a maximal number of warnings that could be reported.
    *
    * @param receiver the receiver to analyze
-   * @return the receiver with all warnings removed, if any
+   * @return whether the receiver reached a maximal number of warnings
    */
   @GenerateLibrary.Abstract(ifExported = {"hasWarnings"})
-  public boolean reachedMaxWarnings(Object receiver) {
+  public boolean isLimitReached(Object receiver) {
     return false;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
@@ -21,6 +21,9 @@ import java.util.Arrays;
 @ExportLibrary(WarningsLibrary.class)
 @ExportLibrary(ReflectionLibrary.class)
 public final class WithWarnings implements TruffleObject {
+
+  private static final int MAX_WARNINGS_LIMIT = 100;
+
   private final EconomicSet<Warning> warnings;
   private final Object value;
 
@@ -160,15 +163,31 @@ public final class WithWarnings implements TruffleObject {
   @CompilerDirectives.TruffleBoundary
   private EconomicSet<Warning> createSetFromArray(Warning[] entries) {
     EconomicSet<Warning> set = EconomicSet.create(new WarningEquivalence());
-    set.addAll(Arrays.stream(entries).iterator());
+    for (int i=0; i<entries.length; i++) {
+      if (set.size() >= MAX_WARNINGS_LIMIT) {
+        return set;
+      }
+      set.add(entries[i]);
+    }
+
     return set;
   }
 
   @CompilerDirectives.TruffleBoundary
   private EconomicSet<Warning> cloneSetAndAppend(EconomicSet<Warning> initial, Warning[] entries) {
     EconomicSet<Warning> set = EconomicSet.create(new WarningEquivalence());
-    set.addAll(initial.iterator());
-    set.addAll(Arrays.stream(entries).iterator());
+    for (Warning warning: initial) {
+      if (set.size() >= MAX_WARNINGS_LIMIT) {
+        return set;
+      }
+      set.add(warning);
+    }
+    for (int i=0; i<entries.length; i++) {
+      if (set.size() >= MAX_WARNINGS_LIMIT) {
+        return set;
+      }
+      set.add(entries[i]);
+    }
     return set;
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
@@ -17,8 +17,6 @@ import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.collections.EconomicSet;
 import org.graalvm.collections.Equivalence;
 
-import java.util.Arrays;
-
 @ExportLibrary(TypesLibrary.class)
 @ExportLibrary(WarningsLibrary.class)
 @ExportLibrary(ReflectionLibrary.class)
@@ -27,25 +25,25 @@ public final class WithWarnings implements TruffleObject {
   private final EconomicSet<Warning> warnings;
   private final Object value;
 
-  private final boolean reachedMax;
+  private final boolean limitReached;
   private final int maxWarnings;
 
-  private WithWarnings(Object value, int maxWarnings, boolean reachedMaxCount, Warning... warnings) {
+  private WithWarnings(Object value, int maxWarnings, boolean limitReached, Warning... warnings) {
     assert !(value instanceof WithWarnings);
     this.warnings = createSetFromArray(maxWarnings, warnings);
     this.value = value;
-    this.reachedMax = reachedMaxCount || this.warnings.size() >= maxWarnings;
+    this.limitReached = limitReached || this.warnings.size() >= maxWarnings;
     this.maxWarnings = maxWarnings;
   }
   private WithWarnings(Object value, int maxWarnings, Warning... warnings) {
     this(value, maxWarnings, false, warnings);
   }
 
-  private WithWarnings(Object value, int maxWarnings, EconomicSet<Warning> warnings, boolean reachedMaxCount, Warning... additionalWarnings) {
+  private WithWarnings(Object value, int maxWarnings, EconomicSet<Warning> warnings, boolean limitReached, Warning... additionalWarnings) {
     assert !(value instanceof WithWarnings);
     this.warnings = cloneSetAndAppend(maxWarnings, warnings, additionalWarnings);
     this.value = value;
-    this.reachedMax = reachedMaxCount || this.warnings.size() >= maxWarnings;
+    this.limitReached = limitReached || this.warnings.size() >= maxWarnings;
     this.maxWarnings = maxWarnings;
   }
 
@@ -70,8 +68,8 @@ public final class WithWarnings implements TruffleObject {
     return value;
   }
 
-  public WithWarnings append(EnsoContext ctx, boolean reachedMaxCount, Warning... newWarnings) {
-    return new WithWarnings(value, warningsLimitFromContext(ctx), warnings, reachedMaxCount, newWarnings);
+  public WithWarnings append(EnsoContext ctx, boolean limitReached, Warning... newWarnings) {
+    return new WithWarnings(value, warningsLimitFromContext(ctx), warnings, limitReached, newWarnings);
   }
 
   public WithWarnings append(EnsoContext ctx, Warning... newWarnings) {
@@ -167,8 +165,8 @@ public final class WithWarnings implements TruffleObject {
   }
 
   @ExportMessage
-  public boolean reachedMaxWarnings() {
-    return reachedMax;
+  public boolean isLimitReached() {
+    return limitReached;
   }
 
   @ExportMessage
@@ -229,6 +227,6 @@ public final class WithWarnings implements TruffleObject {
 
   @Override
   public String toString() {
-    return "WithWarnings{" + value + " + " + warnings.size() + " warnings" + (reachedMax ? " (warnings limit reached)}" : "}");
+    return "WithWarnings{" + value + " + " + warnings.size() + " warnings" + (limitReached ? " (warnings limit reached)}" : "}");
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
@@ -53,6 +53,7 @@ public final class WithWarnings implements TruffleObject {
     this(value, maxWarnings, warnings, false, additionalWarnings);
   }
 
+  @CompilerDirectives.TruffleBoundary
   private static int warningsLimitFromContext(EnsoContext ctx) {
     return ctx.getEnvironment().getOptions().get(RuntimeOptions.WARNINGS_LIMIT_KEY);
   }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -363,7 +363,11 @@ object ProgramExecutionSupport {
           Api.ExpressionUpdate.Payload.Value(
             Some(
               Api.ExpressionUpdate.Payload.Value
-                .Warnings(warningsCount, warning)
+                .Warnings(
+                  warningsCount,
+                  warning,
+                  withWarnings.reachedMaxWarnings()
+                )
             )
           )
         case _ =>

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -366,7 +366,7 @@ object ProgramExecutionSupport {
                 .Warnings(
                   warningsCount,
                   warning,
-                  withWarnings.reachedMaxWarnings()
+                  withWarnings.isLimitReached()
                 )
             )
           )

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/WarningsTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/WarningsTest.java
@@ -39,8 +39,8 @@ public class WarningsTest extends TestBase {
     var warn2 = Warning.create(ensoContext, "w2", this);
     var value = 42;
 
-    var with1 = WithWarnings.wrap(42, warn1);
-    var with2 = WithWarnings.wrap(with1, warn2);
+    var with1 = WithWarnings.wrap(ensoContext, 42, warn1);
+    var with2 = WithWarnings.wrap(ensoContext, with1, warn2);
 
     assertEquals(value, with1.getValue());
     assertEquals(value, with2.getValue());

--- a/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/MethodProcessor.java
+++ b/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/MethodProcessor.java
@@ -295,7 +295,8 @@ public class MethodProcessor extends BuiltinsMetadataProcessor<MethodProcessor.M
         out.println("    if (anyWarnings) {");
         out.println("      internals.anyWarningsProfile.enter();");
         out.println("      Object result = " + executeCall + ";");
-        out.println("      return WithWarnings.appendTo(result, gatheredWarnings);");
+        out.println("      EnsoContext ctx = EnsoContext.get(bodyNode);");
+        out.println("      return WithWarnings.appendTo(ctx, result, gatheredWarnings);");
         out.println("    } else {");
         out.println("      return " + executeCall + ";");
         out.println("    }");

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -694,6 +694,19 @@ type_spec name alter = Test.group name <|
         expected = "abet".utf_8
         input.sort . should_equal expected
 
+    Test.specify "should report only a limited number of warnings for incomparable values" <|
+        gen x = case (x % 10) of
+            0 -> Nothing
+            1 -> "foo"+x.to_text
+            2 -> x
+            3 -> Number.nan
+            4 -> Date.new
+            5 -> []
+            6 -> -x
+            _ -> x
+        input = 0.up_to 500 . map gen
+        sorted = input.sort on_incomparable=Problem_Behavior.Report_Warning
+        Warning.get_all sorted . length . should_equal 10
 
 spec =
     Test.group "Vector/Array equality" <|

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -703,10 +703,13 @@ type_spec name alter = Test.group name <|
             4 -> Date.new
             5 -> []
             6 -> -x
+            7 -> Number.nan
+            8 -> Time_Of_Day.new
             _ -> x
         input = 0.up_to 500 . map gen
         sorted = input.sort on_incomparable=Problem_Behavior.Report_Warning
         Warning.get_all sorted . length . should_equal 10
+        Warning.reached_max_count sorted . should_equal True
 
 spec =
     Test.group "Vector/Array equality" <|

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -709,7 +709,7 @@ type_spec name alter = Test.group name <|
         input = 0.up_to 500 . map gen
         sorted = input.sort on_incomparable=Problem_Behavior.Report_Warning
         Warning.get_all sorted . length . should_equal 10
-        Warning.reached_max_count sorted . should_equal True
+        Warning.limit_reached sorted . should_equal True
 
 spec =
     Test.group "Vector/Array equality" <|

--- a/test/Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Tests/src/Semantic/Warnings_Spec.enso
@@ -412,9 +412,11 @@ spec = Test.group "Dataflow Warnings" <|
         vec = (0.up_to 500).map(e -> Warning.attach "Foo!" e)
         vec_plus_1 = vec.map(e -> e+1)
         Warning.get_all vec_plus_1 . length . should_equal 100
+        Warning.reached_max_count vec . should_equal True
 
         warn = Warning.attach "Boo!" 42
         vec_2 = (0.up_to 500).map(e -> if (e < 30) then Warning.attach "Foo!" e else (warn + e))
         Warning.get_all vec_2 . length . should_equal 31
+        Warning.reached_max_count vec_2 . should_equal False
 
 main = Test_Suite.run_main spec

--- a/test/Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Tests/src/Semantic/Warnings_Spec.enso
@@ -412,11 +412,11 @@ spec = Test.group "Dataflow Warnings" <|
         vec = (0.up_to 500).map(e -> Warning.attach "Foo!" e)
         vec_plus_1 = vec.map(e -> e+1)
         Warning.get_all vec_plus_1 . length . should_equal 100
-        Warning.reached_max_count vec . should_equal True
+        Warning.limit_reached vec . should_equal True
 
         warn = Warning.attach "Boo!" 42
         vec_2 = (0.up_to 500).map(e -> if (e < 30) then Warning.attach "Foo!" e else (warn + e))
         Warning.get_all vec_2 . length . should_equal 31
-        Warning.reached_max_count vec_2 . should_equal False
+        Warning.limit_reached vec_2 . should_equal False
 
 main = Test_Suite.run_main spec

--- a/test/Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Tests/src/Semantic/Warnings_Spec.enso
@@ -408,4 +408,13 @@ spec = Test.group "Dataflow Warnings" <|
         result_4 = f a 1 + f a 2 + f a 3
         Warning.get_all result_4 . map (x-> x.value.to_text) . should_equal ["Baz!", "Baz!", "Baz!"]
 
+    Test.specify "should only report the first 100 unique warnings" <|
+        vec = (0.up_to 500).map(e -> Warning.attach "Foo!" e)
+        vec_plus_1 = vec.map(e -> e+1)
+        Warning.get_all vec_plus_1 . length . should_equal 100
+
+        warn = Warning.attach "Boo!" 42
+        vec_2 = (0.up_to 500).map(e -> if (e < 30) then Warning.attach "Foo!" e else (warn + e))
+        Warning.get_all vec_2 . length . should_equal 31
+
 main = Test_Suite.run_main spec


### PR DESCRIPTION
### Pull Request Description

Artifically limiting the number of reported warnings to 100. Also added benchmarks with random Ints to investigate perf issues when dealing with warnings (future task).
Ideally we would have a custom set-like collection that allows us internally to specify a maximal number of elements. But `EnsoHashMap` (and potentially `EnsoSet`) are still WIP when it comes to being PE-friendly.

The change also allows for checking if the limit for the number of reported warnings has been reached. It will visualize by adding an additional "Warnings limit reached." to the visualization.

The limit is configurable via `--warnings-limit` parameter to `run`.

Closes #6283.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
