### PR TITLE
Ensure `linked-dist` is built for lint CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1937,6 +1937,7 @@ dependencies = [
  "enso-build",
  "enso-build-base",
  "enso-formatter",
+ "ensogl-pack",
  "futures",
  "futures-util",
  "glob",

--- a/app/ide-desktop/lib/types/modules.d.ts
+++ b/app/ide-desktop/lib/types/modules.d.ts
@@ -2,23 +2,6 @@
  *
  * This file MUST NOT `export {}` for the modules to be visible to other files. */
 
-declare module '*/build.json' {
-    interface BuildInfo {
-        commit: string
-        version: string
-        engineVersion: string
-        name: string
-    }
-
-    const BUILD_INFO: BuildInfo
-    export default BUILD_INFO
-}
-
-declare module '*/ensogl-pack/linked-dist' {
-    // eslint-disable-next-line no-restricted-syntax
-    export * from '../../../../lib/rust/ensogl/pack/js/src/runner/index'
-}
-
 declare module '*/gui/config.yaml' {
     interface Config {
         windowAppScopeName: string

--- a/app/ide-desktop/lib/types/modules.d.ts
+++ b/app/ide-desktop/lib/types/modules.d.ts
@@ -2,6 +2,19 @@
  *
  * This file MUST NOT `export {}` for the modules to be visible to other files. */
 
+// Required because this is a build artifact and so would not otherwise work on a clean repository.
+declare module '*/build.json' {
+    interface BuildInfo {
+        commit: string
+        version: string
+        engineVersion: string
+        name: string
+    }
+
+    const BUILD_INFO: BuildInfo
+    export default BUILD_INFO
+}
+
 declare module '*/gui/config.yaml' {
     interface Config {
         windowAppScopeName: string

--- a/build/cli/Cargo.toml
+++ b/build/cli/Cargo.toml
@@ -13,6 +13,7 @@ derivative = { workspace = true }
 enso-build-base = { path = "../base" }
 enso-build = { path = "../build" }
 enso-formatter = { path = "../enso-formatter" }
+ensogl-pack = { path = "../../lib/rust/ensogl/pack" }
 futures = { workspace = true }
 futures-util = "0.3.17"
 glob = "0.3.0"

--- a/build/cli/src/lib.rs
+++ b/build/cli/src/lib.rs
@@ -837,7 +837,7 @@ pub async fn main_internal(config: Option<enso_build::config::Config>) -> Result
                 .await?;
 
             let build_json_exists = ctx.repo_root.join("app/ide-desktop/build.json").exists();
-            let ide_artifacts_exist = ctx.repo_root.join("dist").exists();
+            let ide_artifacts_exist = ctx.repo_root.join("target/ensogl-pack/linked-dist").exists();
             if !build_json_exists || !ide_artifacts_exist {
                 let ide_cli = Cli::parse_from([
                     "./run",

--- a/lib/rust/ensogl/pack/src/lib.rs
+++ b/lib/rust/ensogl/pack/src/lib.rs
@@ -353,7 +353,7 @@ fn check_if_ts_needs_rebuild(paths: &Paths) -> Result<bool> {
 }
 
 /// Compile TypeScript sources of this crate in case they were not compiled yet.
-async fn compile_this_crate_ts_sources(paths: &Paths) -> Result<()> {
+pub async fn compile_this_crate_ts_sources(paths: &Paths) -> Result<()> {
     println!("compile_this_crate_ts_sources");
     if check_if_ts_needs_rebuild(paths)? {
         info!("EnsoGL Pack TypeScript sources changed, recompiling.");


### PR DESCRIPTION
### Pull Request Description
Attempts to fix Lint CI by ensuring IDE build artifacts always exist, because TS relies on `build.json` and `linked-dist` for typechecking.

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
