### PR TITLE
Automatic type based dropdown does not include singleton in a union type

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/Any.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/Any.java
@@ -10,7 +10,7 @@ public class Any extends Builtin {
   }
 
   @Override
-  protected boolean containsValues() {
+  public boolean containsValues() {
     return true;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/Builtin.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/Builtin.java
@@ -74,7 +74,7 @@ public abstract class Builtin {
     postInitialize();
   }
 
-  protected boolean containsValues() {
+  public boolean containsValues() {
     return getDeclaredConstructors().size() > 0;
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/Error.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/Error.java
@@ -10,7 +10,7 @@ public class Error extends Builtin {
   }
 
   @Override
-  protected boolean containsValues() {
+  public boolean containsValues() {
     return true;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/Nothing.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/Nothing.java
@@ -5,7 +5,7 @@ import org.enso.interpreter.dsl.BuiltinType;
 @BuiltinType(name = "Standard.Base.Nothing.Nothing")
 public class Nothing extends Builtin {
   @Override
-  protected boolean containsValues() {
+  public boolean containsValues() {
     return false;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/Panic.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/Panic.java
@@ -6,7 +6,7 @@ import org.enso.interpreter.node.expression.builtin.Builtin;
 @BuiltinType(name = "Standard.Base.Panic.Panic")
 public class Panic extends Builtin {
   @Override
-  protected boolean containsValues() {
+  public boolean containsValues() {
     return true;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/function/Function.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/function/Function.java
@@ -6,7 +6,7 @@ import org.enso.interpreter.node.expression.builtin.Builtin;
 @BuiltinType(name = "Standard.Base.Function.Function")
 public class Function extends Builtin {
   @Override
-  protected boolean containsValues() {
+  public boolean containsValues() {
     return true;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/Decimal.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/Decimal.java
@@ -11,7 +11,7 @@ public class Decimal extends Builtin {
   }
 
   @Override
-  protected boolean containsValues() {
+  public boolean containsValues() {
     return true;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/Integer.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/Integer.java
@@ -11,7 +11,7 @@ public class Integer extends Builtin {
   }
 
   @Override
-  protected boolean containsValues() {
+  public boolean containsValues() {
     return true;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/Number.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/Number.java
@@ -6,7 +6,7 @@ import org.enso.interpreter.node.expression.builtin.Builtin;
 @BuiltinType(name = "Standard.Base.Data.Numbers.Number")
 public class Number extends Builtin {
   @Override
-  protected boolean containsValues() {
+  public boolean containsValues() {
     return true;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/Text.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/Text.java
@@ -6,7 +6,7 @@ import org.enso.interpreter.node.expression.builtin.Builtin;
 @BuiltinType(name = "Standard.Base.Data.Text.Text")
 public class Text extends Builtin {
   @Override
-  protected boolean containsValues() {
+  public boolean containsValues() {
     return true;
   }
 }

--- a/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
@@ -238,7 +238,7 @@ final class SerializationManager(
         compiler.packageRepository
           .getModulesForLibrary(libraryName)
           .flatMap { module =>
-            SuggestionBuilder(module)
+            SuggestionBuilder(module, compiler)
               .build(module.getName, module.getIr)
               .toVector
               .filter(Suggestion.isGlobal)

--- a/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
@@ -381,19 +381,25 @@ final class SuggestionBuilder[A: IndexedSource](
 
   private def buildResolvedUnionTypeName(
     resolvedName: BindingsMap.ResolvedName
-  ): TypeArg = resolvedName match {
-    case tp: BindingsMap.ResolvedType =>
-      if (tp.getVariants.size > 1) {
-        TypeArg.Sum(
-          Some(tp.qualifiedName),
-          tp.getVariants.map(r => TypeArg.Value(r.qualifiedName))
-        )
-      } else {
-        TypeArg.Sum(Some(tp.qualifiedName), Seq.empty)
-      }
-    case _: BindingsMap.ResolvedName =>
-      TypeArg.Value(resolvedName.qualifiedName)
-  }
+  ): TypeArg =
+    resolvedName match {
+      case tp: BindingsMap.ResolvedType =>
+        if (tp.getVariants.size > 1) {
+          TypeArg.Sum(
+            Some(tp.qualifiedName),
+            tp.getVariants.map(r => TypeArg.Value(r.qualifiedName))
+          )
+        } else if (tp.getVariants.size == 1) {
+          TypeArg.Sum(Some(tp.qualifiedName), Seq())
+        } else {
+          TypeArg.Sum(
+            Some(tp.qualifiedName),
+            Seq(TypeArg.Value(tp.qualifiedName))
+          )
+        }
+      case _: BindingsMap.ResolvedName =>
+        TypeArg.Value(resolvedName.qualifiedName)
+    }
 
   /** Build type signature from the ir metadata.
     *
@@ -551,24 +557,29 @@ final class SuggestionBuilder[A: IndexedSource](
       isSuspended  = varg.suspended,
       hasDefault   = varg.defaultValue.isDefined,
       defaultValue = varg.defaultValue.flatMap(buildDefaultValue),
-      tagValues = targ match {
-        case s: TypeArg.Sum => {
-          val tagValues = pluckVariants(s)
-          if (tagValues.nonEmpty) {
-            Some(tagValues)
-          } else {
-            None
-          }
-        }
-        case _ => None
-      }
+      tagValues    = buildTagValues(targ)
     )
 
-  private def pluckVariants(arg: TypeArg): Seq[String] = arg match {
-    case TypeArg.Sum(_, List())   => Seq()
-    case TypeArg.Sum(_, variants) => variants.flatMap(pluckVariants)
-    case TypeArg.Value(n)         => Seq(n.toString)
-    case _                        => Seq()
+  /** Build tag values of type argument.
+    *
+    * @param targ the type argument
+    * @return the list of tag values
+    */
+  private def buildTagValues(targ: TypeArg): Option[Seq[String]] = {
+    def go(arg: TypeArg): Seq[String] = arg match {
+      case TypeArg.Sum(_, List())   => Seq()
+      case TypeArg.Sum(_, variants) => variants.flatMap(go)
+      case TypeArg.Value(n)         => Seq(n.toString)
+      case _                        => Seq()
+    }
+
+    targ match {
+      case s: TypeArg.Sum =>
+        val tagValues = go(s)
+        Option.unless(tagValues.isEmpty)(tagValues)
+      case _ => None
+
+    }
   }
 
   /** Build the name of type argument.
@@ -722,7 +733,7 @@ object SuggestionBuilder {
 
     /** Function type, like `A -> A`.
       *
-      * @param signature the list of types defining the function
+      * @param arguments the list of types defining the function
       */
     case class Function(arguments: Vector[TypeArg], result: TypeArg)
         extends TypeArg

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/AnalyzeModuleInScopeJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/AnalyzeModuleInScopeJob.scala
@@ -44,9 +44,10 @@ final class AnalyzeModuleInScopeJob(
       ctx.executionService.getLogger
         .log(Level.FINEST, s"Analyzing module in scope ${module.getName}")
       val moduleName = module.getName
-      val newSuggestions = SuggestionBuilder(module.getSource.getCharacters)
-        .build(moduleName, module.getIr)
-        .filter(Suggestion.isGlobal)
+      val newSuggestions =
+        SuggestionBuilder(module, ctx.executionService.getContext.getCompiler)
+          .build(moduleName, module.getIr)
+          .filter(Suggestion.isGlobal)
       val prevExports = ModuleExports(moduleName.toString, Set())
       val newExports  = exportsBuilder.build(module.getName, module.getIr)
       val notification = Api.SuggestionsDatabaseModuleUpdateNotification(

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/AnalyzeModuleJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/AnalyzeModuleJob.scala
@@ -51,13 +51,15 @@ object AnalyzeModuleJob {
     changeset: Changeset[Rope]
   )(implicit ctx: RuntimeContext): Unit = {
     val moduleName = module.getName
+    val compiler   = ctx.executionService.getContext.getCompiler
     if (module.isIndexed) {
       ctx.executionService.getLogger
         .log(Level.FINEST, s"Analyzing indexed module $moduleName")
-      val prevSuggestions = SuggestionBuilder(changeset.source)
-        .build(moduleName, changeset.ir)
+      val prevSuggestions =
+        SuggestionBuilder(changeset.source, compiler)
+          .build(moduleName, changeset.ir)
       val newSuggestions =
-        SuggestionBuilder(module.getSource.getCharacters)
+        SuggestionBuilder(module, compiler)
           .build(moduleName, module.getIr)
       val diff = SuggestionDiff
         .compute(prevSuggestions, newSuggestions)
@@ -75,7 +77,7 @@ object AnalyzeModuleJob {
       ctx.executionService.getLogger
         .log(Level.FINEST, s"Analyzing not-indexed module ${module.getName}")
       val newSuggestions =
-        SuggestionBuilder(module.getSource.getCharacters)
+        SuggestionBuilder(module, compiler)
           .build(moduleName, module.getIr)
       val prevExports = ModuleExports(moduleName.toString, Set())
       val newExports  = exportsBuilder.build(moduleName, module.getIr)

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
@@ -615,6 +615,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
                   Some(
                     Seq(
                       "Number",
+                      "Unnamed.Test.Other_Atom",
                       "Unnamed.Test.My_Atom.Variant_1",
                       "Unnamed.Test.My_Atom.Variant_2"
                     )
@@ -624,6 +625,102 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               selfType      = "Unnamed.Test.Other_Atom",
               returnType    = "Number",
               isStatic      = false,
+              documentation = None
+            ),
+            Vector()
+          )
+        )
+      )
+    }
+
+    "build argument tag values111" in {
+
+      val code =
+        """type Value
+          |    A
+          |    B
+          |
+          |type Auto
+          |
+          |foo : Value | Auto -> Any
+          |foo a = a
+          |""".stripMargin
+      val module = code.preprocessModule
+
+      build(code, module) shouldEqual Tree.Root(
+        Vector(
+          ModuleNode,
+          Tree.Node(
+            Suggestion.Type(
+              externalId    = None,
+              module        = "Unnamed.Test",
+              name          = "Value",
+              params        = Seq(),
+              returnType    = "Unnamed.Test.Value",
+              parentType    = Some(SuggestionBuilder.Any),
+              documentation = None
+            ),
+            Vector()
+          ),
+          Tree.Node(
+            Suggestion.Constructor(
+              externalId    = None,
+              module        = "Unnamed.Test",
+              name          = "A",
+              arguments     = Seq(),
+              returnType    = "Unnamed.Test.Value",
+              documentation = None
+            ),
+            Vector()
+          ),
+          Tree.Node(
+            Suggestion.Constructor(
+              externalId    = None,
+              module        = "Unnamed.Test",
+              name          = "B",
+              arguments     = Seq(),
+              returnType    = "Unnamed.Test.Value",
+              documentation = None
+            ),
+            Vector()
+          ),
+          Tree.Node(
+            Suggestion.Type(
+              externalId    = None,
+              module        = "Unnamed.Test",
+              name          = "Auto",
+              params        = Seq(),
+              returnType    = "Unnamed.Test.Auto",
+              parentType    = Some(SuggestionBuilder.Any),
+              documentation = None
+            ),
+            Vector()
+          ),
+          Tree.Node(
+            Suggestion.Method(
+              externalId = None,
+              module     = "Unnamed.Test",
+              name       = "foo",
+              arguments = Seq(
+                Suggestion.Argument("self", "Unnamed.Test", false, false, None),
+                Suggestion.Argument(
+                  "a",
+                  "Unnamed.Test.Value | Unnamed.Test.Auto",
+                  false,
+                  false,
+                  None,
+                  Some(
+                    Seq(
+                      "Unnamed.Test.Value.A",
+                      "Unnamed.Test.Value.B",
+                      "Unnamed.Test.Auto"
+                    )
+                  )
+                )
+              ),
+              selfType      = "Unnamed.Test",
+              returnType    = "Any",
+              isStatic      = true,
               documentation = None
             ),
             Vector()
@@ -699,7 +796,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
                   false,
                   false,
                   None,
-                  None
+                  Some(Seq("Unnamed.Test.A"))
                 )
               ),
               selfType      = "Unnamed.Test",
@@ -1123,7 +1220,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
                         false,
                         false,
                         None,
-                        None
+                        Some(Seq("Unnamed.Test.A"))
                       )
                   ),
                   returnType = "Unnamed.Test.A",
@@ -2589,7 +2686,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
       )
       val arg2 = method.get.arguments(2)
       arg2.reprType shouldEqual "Standard.Base.Data.Text.Text | (Standard.Base.Data.Text.Text -> Boolean)"
-      arg2.tagValues shouldEqual None
+      arg2.tagValues shouldEqual Some(Seq("Standard.Base.Data.Text.Text"))
     }
   }
 

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
@@ -633,16 +633,19 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
       )
     }
 
-    "build argument tag values111" in {
+    "build argument tag values" in {
 
       val code =
-        """type Value
+        """import Standard.Base.Data.Text.Text
+          |import Standard.Base.Data.Boolean.Boolean
+          |
+          |type Value
           |    A
           |    B
           |
           |type Auto
           |
-          |foo : Value | Auto -> Any
+          |foo : Text | Boolean | Value | Auto -> Any
           |foo a = a
           |""".stripMargin
       val module = code.preprocessModule
@@ -705,12 +708,14 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
                 Suggestion.Argument("self", "Unnamed.Test", false, false, None),
                 Suggestion.Argument(
                   "a",
-                  "Unnamed.Test.Value | Unnamed.Test.Auto",
+                  "Standard.Base.Data.Text.Text | Standard.Base.Data.Boolean.Boolean | Unnamed.Test.Value | Unnamed.Test.Auto",
                   false,
                   false,
                   None,
                   Some(
                     Seq(
+                      "Standard.Base.Data.Boolean.Boolean.True",
+                      "Standard.Base.Data.Boolean.Boolean.False",
                       "Unnamed.Test.Value.A",
                       "Unnamed.Test.Value.B",
                       "Unnamed.Test.Auto"
@@ -2686,7 +2691,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
       )
       val arg2 = method.get.arguments(2)
       arg2.reprType shouldEqual "Standard.Base.Data.Text.Text | (Standard.Base.Data.Text.Text -> Boolean)"
-      arg2.tagValues shouldEqual Some(Seq("Standard.Base.Data.Text.Text"))
+      arg2.tagValues shouldEqual None
     }
   }
 
@@ -2695,5 +2700,5 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
     ir: IR.Module,
     module: QualifiedName = Module
   ): Tree.Root[Suggestion] =
-    SuggestionBuilder(source).build(module, ir)
+    SuggestionBuilder(source, langCtx.getCompiler).build(module, ir)
 }

--- a/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/BuiltinsProcessor.java
+++ b/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/BuiltinsProcessor.java
@@ -108,7 +108,7 @@ public class BuiltinsProcessor extends AbstractProcessor {
       out.println("public class " + builtinType.name() + " extends Builtin {");
       out.println("""
         @Override
-        protected boolean containsValues() {
+        public boolean containsValues() {
           return true;
         }
       }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #6532 

Set tag values to display `Auto` type in dropdowns correctly.

### Important Notes

![2023-05-10-141458_969x566_scrot](https://github.com/enso-org/enso/assets/357683/9a048b3c-d192-4382-bf76-9cbe6c9556d1)
![2023-05-10-141513_991x232_scrot](https://github.com/enso-org/enso/assets/357683/c50e1e73-23a6-4b32-90bf-f849a127c85d)


<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
