### PR TITLE
Make Meta.get_annotation work for constructor

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/GetAnnotationNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/GetAnnotationNode.java
@@ -1,10 +1,5 @@
 package org.enso.interpreter.node.expression.builtin.meta;
 
-import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.library.CachedLibrary;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.BaseNode;
 import org.enso.interpreter.node.callable.thunk.ThunkExecutorNode;
@@ -17,6 +12,12 @@ import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 import org.enso.interpreter.runtime.scope.ModuleScope;
 import org.enso.interpreter.runtime.state.State;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.library.CachedLibrary;
 
 @BuiltinMethod(
     type = "Meta",
@@ -51,15 +52,17 @@ public abstract class GetAnnotationNode extends BaseNode {
         return thunkExecutorNode.executeThunk(frame, thunk, state, getTailStatus());
       }
     }
-    AtomConstructor constructor = getAtomConstructor(targetType, methodName);
-    if (constructor != null) {
-      Function constructorFunction = constructor.getConstructorFunction();
-      String parameterName = expectStringNode.execute(parameter);
-      Annotation annotation = constructorFunction.getSchema().getAnnotation(parameterName);
-      if (annotation != null) {
-        Function thunk =
-            Function.thunk(annotation.getExpression().getCallTarget(), frame.materialize());
-        return thunkExecutorNode.executeThunk(frame, thunk, state, getTailStatus());
+    if (target instanceof Type type) {
+      AtomConstructor constructor = getAtomConstructor(type, methodName);
+      if (constructor != null) {
+        Function constructorFunction = constructor.getConstructorFunction();
+        String parameterName = expectStringNode.execute(parameter);
+        Annotation annotation = constructorFunction.getSchema().getAnnotation(parameterName);
+        if (annotation != null) {
+          Function thunk =
+              Function.thunk(annotation.getExpression().getCallTarget(), frame.materialize());
+          return thunkExecutorNode.executeThunk(frame, thunk, state, getTailStatus());
+        }
       }
     }
     return EnsoContext.get(this).getNothing();

--- a/test/Tests/src/Semantic/Meta_Spec.enso
+++ b/test/Tests/src/Semantic/Meta_Spec.enso
@@ -277,9 +277,16 @@ spec =
 
             Meta.get_annotation value "my_method" "self" . should_equal "self"
 
-            Meta.get_annotation value "Value" "foo" 7 8 . should_equal 15
+        Test.specify "no constructor annotations on value" <|
+            value = My_Type.Value 99 "bar" True
+            Meta.get_annotation value "Value" "foo" . should_equal Nothing
             Meta.get_annotation value "Value" "bar" . should_equal Nothing
-            Meta.get_annotation value "Value" "baz" . should_equal (My_Type.Value 1 2 3)
+            Meta.get_annotation value "Value" "baz" . should_equal Nothing
+
+        Test.specify "get annotations on constructor" <|
+            Meta.get_annotation My_Type "Value" "foo" 7 8 . should_equal 15
+            Meta.get_annotation My_Type "Value" "bar" . should_equal Nothing
+            Meta.get_annotation My_Type "Value" "baz" . should_equal (My_Type.Value 1 2 3)
 
     Test.group "Check Nothing and NaN" <|
         Test.specify "Nothing.is_a Nothing" <|


### PR DESCRIPTION
### Pull Request Description

Fixes #6612 by searching for the atom constructor on the `target` itself, not its type.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
