### PR TITLE
Fix FRP events that deactivate visualizations.

### DIFF
--- a/app/gui/view/graph-editor/src/component/visualization/container.rs
+++ b/app/gui/view/graph-editor/src/component/visualization/container.rs
@@ -516,7 +516,8 @@ impl Container {
             default_visualisation <- visualisation_uninitialised.on_true().map(|_| {
                 Some(visualization::Registry::default_visualisation())
             });
-            vis_input_type <- frp.set_vis_input_type.gate(&visualisation_uninitialised).unwrap();
+            vis_input_type <- frp.set_vis_input_type.on_change();
+            vis_input_type <- vis_input_type.gate(&visualisation_uninitialised).unwrap();
             default_visualisation_for_type <- vis_input_type.map(f!((tp) {
                registry.default_visualization_for_type(tp)
             }));


### PR DESCRIPTION
### Pull Request Description

Addresses the issue described here: https://github.com/enso-org/enso/issues/6561#issuecomment-1536205322 .
This was caused by FRP events that would re-set the visualization path when ending the node editing. This would eventually clear the visualization before setting it again, losing the already received data.


https://github.com/enso-org/enso/assets/1428930/6e324ddf-f365-48b8-bb2a-c68b2fbd24ef

also addresses the issue described here https://github.com/enso-org/enso/issues/6561#issuecomment-1543856257


https://github.com/enso-org/enso/assets/1428930/437f7822-7c35-48ba-a055-59d6f712a813

Note that now the default visualization is already shown on the first hover of the action bar, where before it was empty. This was caused by a faulty initialization. 


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
