### PR TITLE
Fix shortcuts table formatting

### DIFF
--- a/app/gui/docs/product/shortcuts.md
+++ b/app/gui/docs/product/shortcuts.md
@@ -126,7 +126,7 @@ broken and require further investigation.
 #### Debug
 
 | Shortcut                                                           | Action                                                                                                                         |
-| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ | ---------------------- |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
 | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>d</kbd>                  | Toggle Debug Mode. All actions below are only possible when it is activated.                                                   |
 | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>shift</kbd> + <kbd>i</kbd> | Open the developer console.                                                                                                    |
 | <kbd>ctrl</kbd> + <kbd>alt</kbd> + <kbd>shift</kbd> + <kbd>r</kbd> | Reload the visual interface.                                                                                                   |
@@ -137,4 +137,4 @@ broken and require further investigation.
 | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>enter</kbd>              | Push a hardcoded breadcrumb without navigating.                                                                                |
 | <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>arrow up</kbd>           | Pop a breadcrumb without navigating.                                                                                           |
 | <kbd>cmd</kbd> + <kbd>i</kbd>                                      | Reload visualizations. To see the effect in the currently shown visualizations, you need to switch to another and switch back. |
-| <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>b</kbd>                  |                                                                                                                                | Toggle read-only mode. |
+| <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>b</kbd>                  | Toggle read-only mode.                                                                                                         |


### PR DESCRIPTION
Just a minor style fixes of `shortcuts.md` table. Seems like it was broken in 719bd8cfa135dcc2b315ff65cc58aad29e1f1dbf