### PR TITLE
Add some logs for Component Browser destruction

### DIFF
--- a/app/gui/src/presenter/searcher.rs
+++ b/app/gui/src/presenter/searcher.rs
@@ -487,6 +487,7 @@ impl Searcher {
     /// node, its AST ID is returned.
     #[profile(Task)]
     pub fn commit_editing(self, entry_id: Option<view::searcher::entry::Id>) -> Option<AstNodeId> {
+        warn!("Commit editing");
         self.model.commit_editing(entry_id)
     }
 
@@ -500,6 +501,7 @@ impl Searcher {
         self,
         entry_id: Option<component_grid::GroupEntryId>,
     ) -> Option<AstNodeId> {
+        warn!("Expression Accepted");
         self.model.expression_accepted(entry_id)
     }
 
@@ -508,6 +510,7 @@ impl Searcher {
     /// This method takes `self`, as the presenter (with the searcher view) should be dropped once
     /// editing finishes.
     pub fn abort_editing(self) {
+        warn!("Abort Editing");
         self.model.controller.abort_editing()
     }
 

--- a/app/gui/view/src/project.rs
+++ b/app/gui/view/src/project.rs
@@ -438,6 +438,7 @@ impl View {
                 });
             eval searcher_cam_pos ((pos) searcher_cam.set_xy(*pos));
 
+            trace searcher.is_visible;
             eval searcher.is_visible ([model](is_visible) {
                 let is_attached = model.searcher.has_parent();
                 if !is_attached && *is_visible {

--- a/lib/rust/frp/src/nodes.rs
+++ b/lib/rust/frp/src/nodes.rs
@@ -2163,7 +2163,7 @@ impl<T: EventOutput> OwnedTrace<T> {
 impl<T: EventOutput> stream::EventConsumer<Output<T>> for OwnedTrace<T> {
     fn on_event(&self, stack: CallStack, event: &Output<T>) {
         console_log!("[FRP] {}: {:?}", self.label(), event);
-        // warn!("[FRP] {}", stack);
+        console_log!("[FRP] {}", stack);
         self.emit_event(stack, event);
     }
 }


### PR DESCRIPTION
### Pull Request Description

Branch for making package with debug logs for @xvcgreg 

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
