### PR TITLE
Improvements to the Table visualization.

### DIFF
--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -94,7 +94,7 @@ class TableVisualization extends Visualization {
 
             const style =
                 '.ag-theme-alpine { --ag-grid-size: 3px; --ag-list-item-height: 20px; display: inline; }\n' +
-                '.vis-status-bar { height: 20x; background-color: white; font-size:14px; white-space:nowrap; padding: 0 5px; overflow:hidden }\n' +
+                '.vis-status-bar { height: 20x; background-color: white; font-size:14px; white-space:nowrap; padding: 0 5px; overflow:hidden; border-radius: 16px }\n' +
                 '.vis-status-bar > button { width: 12px; margin: 0 2px; display: none }\n' +
                 '.vis-tbl-grid { height: calc(100% - 20px); width: 100%; }\n'
             const styleElem = document.createElement('style')
@@ -128,6 +128,14 @@ class TableVisualization extends Visualization {
                     resizable: true,
                     minWidth: 25,
                     headerValueGetter: params => params.colDef.field,
+                    cellRenderer: params => {
+                        if (params.value === null) {
+                            return '<span style="color:grey; font-style: italic;">Nothing</span>'
+                        } else if (params.value === undefined) {
+                            return ''
+                        }
+                        return params.value.toString()
+                    }
                 },
                 onColumnResized: e => this.lockColumnSize(e),
             }
@@ -234,14 +242,14 @@ class TableVisualization extends Visualization {
     makeOption(value, label) {
         const optionElem = document.createElement('option')
         optionElem.value = value
-        optionElem.innerHTML = document.createTextNode(label)
+        optionElem.appendChild(document.createTextNode(label))
         return optionElem
     }
 
     makeButton(label, onclick) {
         const buttonElem = document.createElement('button')
         buttonElem.name = label
-        buttonElem.innerHTML = document.createTextNode(label)
+        buttonElem.appendChild(document.createTextNode(label))
         buttonElem.addEventListener('click', onclick)
         return buttonElem
     }

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -38,8 +38,7 @@ class TableVisualization extends Visualization {
             this.setPreprocessor(
                 'Standard.Visualization.Table.Visualization',
                 'prepare_visualization',
-                this.row_limit.toString(),
-                this.page.toString()
+                this.row_limit.toString()
             )
         }
     }
@@ -238,7 +237,7 @@ class TableVisualization extends Visualization {
         }
 
         // Update Status Bar
-        this.createRowDropdown(
+        this.updateStatusBarControls(
             parsedData.all_rows_count === undefined ? 1 : parsedData.all_rows_count,
             dataTruncated
         )
@@ -266,7 +265,10 @@ class TableVisualization extends Visualization {
         return buttonElem
     }
 
-    createRowDropdown(all_rows_count, dataTruncated) {
+    // Updates the status bar to reflect the current row limit and page, shown at top of the visualization.
+    // - Creates the row dropdown and page buttons.
+    // - Updated the row counts and filter available options.
+    updateStatusBarControls(all_rows_count, dataTruncated) {
         const pageLimit = Math.ceil(all_rows_count / this.row_limit)
         if (this.page > pageLimit) {
             this.page = pageLimit
@@ -317,8 +319,10 @@ class TableVisualization extends Visualization {
                 25000,
                 50000,
                 100000,
-                all_rows_count,
-            ].filter(r => r <= all_rows_count && r <= 100000)
+            ].filter(r => r <= all_rows_count)
+            if (all_rows_count < rowCounts[rowCounts.length-1] && rowCounts.indexOf(all_rows_count) === -1) {
+                rowCounts.push(all_rows_count)
+            }
             rowLimitElem.innerHTML = ''
             rowCounts.forEach(r => {
                 const option = this.makeOption(r, r.toString())

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -35,7 +35,7 @@ class TableVisualization extends Visualization {
         if (this.row_limit !== row_limit || this.page !== page) {
             this.row_limit = row_limit
             this.page = page
-            this.setPreprocessor('Standard.Visualization.Table.Visualization', 'prepare_visualization', `${this.row_limit}`)
+            this.setPreprocessor('Standard.Visualization.Table.Visualization', 'prepare_visualization', this.row_limit.toString(), this.page.toString())
         }
     }
 
@@ -234,14 +234,14 @@ class TableVisualization extends Visualization {
     makeOption(value, label) {
         const optionElem = document.createElement('option')
         optionElem.value = value
-        optionElem.appendChild(document.createTextNode(label))
+        optionElem.innerHTML = document.createTextNode(label)
         return optionElem
     }
 
     makeButton(label, onclick) {
         const buttonElem = document.createElement('button')
         buttonElem.name = label
-        buttonElem.appendChild(document.createTextNode(label))
+        buttonElem.innerHTML = document.createTextNode(label)
         buttonElem.addEventListener('click', onclick)
         return buttonElem
     }
@@ -276,7 +276,6 @@ class TableVisualization extends Visualization {
 
         // Update row limit dropdown and row count
         const rowCountElem = this.statusElem.getElementsByTagName("span")[0]
-        rowCountElem.innerHTML = ''
         const rowLimitElem = this.statusElem.children.namedItem("row-limit")
         if (all_rows_count > 1000) {
             rowLimitElem.style.display = 'inline-block'
@@ -288,11 +287,10 @@ class TableVisualization extends Visualization {
             })
             rowLimitElem.value = this.row_limit
 
-            const rowCountText = dataTruncated ? ` of ${all_rows_count} rows (Sorting/Filtering disabled).` : ` rows.`
-            rowCountElem.appendChild(document.createTextNode(rowCountText))
+            rowCountElem.innerHTML = dataTruncated ? ` of ${all_rows_count} rows (Sorting/Filtering disabled).` : ` rows.`
         } else {
             rowLimitElem.style.display = 'none'
-            rowCountElem.appendChild(document.createTextNode(`${all_rows_count} rows.`))
+            rowCountElem.innerHTML = all_rows_count === 1 ? "1 row." : `${all_rows_count} rows.`
         }
     }
 

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -28,14 +28,19 @@ class TableVisualization extends Visualization {
 
     constructor(data) {
         super(data)
-        this.setRowLimitAndPage(1000, 0);
+        this.setRowLimitAndPage(1000, 0)
     }
 
     setRowLimitAndPage(row_limit, page) {
         if (this.row_limit !== row_limit || this.page !== page) {
             this.row_limit = row_limit
             this.page = page
-            this.setPreprocessor('Standard.Visualization.Table.Visualization', 'prepare_visualization', this.row_limit.toString(), this.page.toString())
+            this.setPreprocessor(
+                'Standard.Visualization.Table.Visualization',
+                'prepare_visualization',
+                this.row_limit.toString(),
+                this.page.toString()
+            )
         }
     }
 
@@ -135,7 +140,7 @@ class TableVisualization extends Visualization {
                             return ''
                         }
                         return params.value.toString()
-                    }
+                    },
                 },
                 onColumnResized: e => this.lockColumnSize(e),
             }
@@ -229,7 +234,10 @@ class TableVisualization extends Visualization {
         }
 
         // Update Status Bar
-        this.createRowDropdown(parsedData.all_rows_count === undefined ? 1 : parsedData.all_rows_count, dataTruncated);
+        this.createRowDropdown(
+            parsedData.all_rows_count === undefined ? 1 : parsedData.all_rows_count,
+            dataTruncated
+        )
 
         // If data is truncated, we cannot rely on sorting/filtering so will disable.
         this.agGridOptions.defaultColDef.filter = !dataTruncated
@@ -261,33 +269,52 @@ class TableVisualization extends Visualization {
         }
 
         if (this.statusElem.childElementCount === 0) {
-            this.statusElem.appendChild(this.makeButton("«", () => this.setRowLimitAndPage(this.row_limit, 0)))
-            this.statusElem.appendChild(this.makeButton("‹", () => this.setRowLimitAndPage(this.row_limit, this.page - 1)))
+            this.statusElem.appendChild(
+                this.makeButton('«', () => this.setRowLimitAndPage(this.row_limit, 0))
+            )
+            this.statusElem.appendChild(
+                this.makeButton('‹', () => this.setRowLimitAndPage(this.row_limit, this.page - 1))
+            )
 
             const selectElem = document.createElement('select')
-            selectElem.name = "row-limit"
-            selectElem.addEventListener('change', e => { this.setRowLimitAndPage(e.target.value, this.page) })
+            selectElem.name = 'row-limit'
+            selectElem.addEventListener('change', e => {
+                this.setRowLimitAndPage(e.target.value, this.page)
+            })
             this.statusElem.appendChild(selectElem)
 
             const rowCountSpanElem = document.createElement('span')
             this.statusElem.appendChild(rowCountSpanElem)
 
-            this.statusElem.appendChild(this.makeButton("›", () => this.setRowLimitAndPage(this.row_limit, this.page + 1)))
-            this.statusElem.appendChild(this.makeButton("»", () => this.setRowLimitAndPage(this.row_limit, pageLimit - 1)))
+            this.statusElem.appendChild(
+                this.makeButton('›', () => this.setRowLimitAndPage(this.row_limit, this.page + 1))
+            )
+            this.statusElem.appendChild(
+                this.makeButton('»', () => this.setRowLimitAndPage(this.row_limit, pageLimit - 1))
+            )
         }
 
         // Enable/Disable Page buttons
-        this.statusElem.children.namedItem("«").disabled = this.page === 0
-        this.statusElem.children.namedItem("‹").disabled = this.page === 0
-        this.statusElem.children.namedItem("›").disabled = this.page === pageLimit - 1
-        this.statusElem.children.namedItem("»").disabled = this.page === pageLimit - 1
+        this.statusElem.children.namedItem('«').disabled = this.page === 0
+        this.statusElem.children.namedItem('‹').disabled = this.page === 0
+        this.statusElem.children.namedItem('›').disabled = this.page === pageLimit - 1
+        this.statusElem.children.namedItem('»').disabled = this.page === pageLimit - 1
 
         // Update row limit dropdown and row count
-        const rowCountElem = this.statusElem.getElementsByTagName("span")[0]
-        const rowLimitElem = this.statusElem.children.namedItem("row-limit")
+        const rowCountElem = this.statusElem.getElementsByTagName('span')[0]
+        const rowLimitElem = this.statusElem.children.namedItem('row-limit')
         if (all_rows_count > 1000) {
             rowLimitElem.style.display = 'inline-block'
-            const rowCounts = [1000, 2500, 5000, 10000, 25000, 50000, 100000, all_rows_count].filter(r => r <= all_rows_count && r <= 100000)
+            const rowCounts = [
+                1000,
+                2500,
+                5000,
+                10000,
+                25000,
+                50000,
+                100000,
+                all_rows_count,
+            ].filter(r => r <= all_rows_count && r <= 100000)
             rowLimitElem.innerHTML = ''
             rowCounts.forEach(r => {
                 const option = this.makeOption(r, r.toString())
@@ -295,10 +322,12 @@ class TableVisualization extends Visualization {
             })
             rowLimitElem.value = this.row_limit
 
-            rowCountElem.innerHTML = dataTruncated ? ` of ${all_rows_count} rows (Sorting/Filtering disabled).` : ` rows.`
+            rowCountElem.innerHTML = dataTruncated
+                ? ` of ${all_rows_count} rows (Sorting/Filtering disabled).`
+                : ` rows.`
         } else {
             rowLimitElem.style.display = 'none'
-            rowCountElem.innerHTML = all_rows_count === 1 ? "1 row." : `${all_rows_count} rows.`
+            rowCountElem.innerHTML = all_rows_count === 1 ? '1 row.' : `${all_rows_count} rows.`
         }
     }
 

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -92,6 +92,17 @@ class TableVisualization extends Visualization {
             return content
         }
 
+        function cellRenderer(params) {
+            if (params.value === null) {
+                return '<span style="color:grey; font-style: italic;">Nothing</span>'
+            } else if (params.value === undefined) {
+                return ''
+            } else if (params.value === '') {
+                return '<span style="color:grey; font-style: italic;">Empty</span>'
+            }
+            return params.value.toString()
+        }
+
         if (!this.tabElem) {
             while (this.dom.firstChild) {
                 this.dom.removeChild(this.dom.lastChild)
@@ -133,14 +144,7 @@ class TableVisualization extends Visualization {
                     resizable: true,
                     minWidth: 25,
                     headerValueGetter: params => params.colDef.field,
-                    cellRenderer: params => {
-                        if (params.value === null) {
-                            return '<span style="color:grey; font-style: italic;">Nothing</span>'
-                        } else if (params.value === undefined) {
-                            return ''
-                        }
-                        return params.value.toString()
-                    },
+                    cellRenderer: cellRenderer,
                 },
                 onColumnResized: e => this.lockColumnSize(e),
             }

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -311,16 +311,13 @@ class TableVisualization extends Visualization {
         const rowLimitElem = this.statusElem.children.namedItem('row-limit')
         if (all_rows_count > 1000) {
             rowLimitElem.style.display = 'inline-block'
-            const rowCounts = [
-                1000,
-                2500,
-                5000,
-                10000,
-                25000,
-                50000,
-                100000,
-            ].filter(r => r <= all_rows_count)
-            if (all_rows_count < rowCounts[rowCounts.length-1] && rowCounts.indexOf(all_rows_count) === -1) {
+            const rowCounts = [1000, 2500, 5000, 10000, 25000, 50000, 100000].filter(
+                r => r <= all_rows_count
+            )
+            if (
+                all_rows_count < rowCounts[rowCounts.length - 1] &&
+                rowCounts.indexOf(all_rows_count) === -1
+            ) {
                 rowCounts.push(all_rows_count)
             }
             rowLimitElem.innerHTML = ''

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -347,7 +347,7 @@ Text.split self delimiter="," case_sensitivity=Case_Sensitivity.Sensitive use_re
             _ : Vector -> delimiter.length == 1
             _ -> False
         # If it's a vector of one element, just call it on that one element.
-        if delimiter_is_singleton_vector then self.split delimiter=(delimiter.first) case_sensitivity=case_sensitivity use_regex=use_regex else`
+        if delimiter_is_singleton_vector then self.split delimiter=(delimiter.first) case_sensitivity=case_sensitivity use_regex=use_regex else
             case use_regex of
                 False ->
                     delimiters = split_find_delimiters self delimiter case_sensitivity

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -40,6 +40,8 @@ from project.Data.Json import Json, Invalid_JSON, JS_Object
 from project.Data.Numbers import Decimal, Integer, Number, Number_Parse_Error
 from project.Data.Text.Text_Sub_Range import Codepoint_Ranges, Text_Sub_Range
 
+from project.Metadata import make_single_choice
+
 import project.Data.Index_Sub_Range as Index_Sub_Range_Module
 
 polyglot java import com.ibm.icu.lang.UCharacter
@@ -333,7 +335,8 @@ Text.match self pattern=".*" case_sensitivity=Case_Sensitivity.Sensitive =
      Split with a vector of strings.
 
          'azbzczdzezfzg'.split ['b', 'zez'] == ['az', 'zczd', 'fzg']
-Text.split : Text | Vector Text  -> Case_Sensitivity -> Boolean -> Vector Text | Illegal_Argument
+@delimiter (make_single_choice [',', ';', '|', ['{tab}', "'\t'"], ['{space}', "' '"], ['{newline}', "['\n', '\r\n', '\r']"], ['Custom', ""]])
+Text.split : Text | Vector Text -> Case_Sensitivity -> Boolean -> Vector Text | Illegal_Argument
 Text.split self delimiter="," case_sensitivity=Case_Sensitivity.Sensitive use_regex=False =
     delimiter_is_empty = case delimiter of
         _ : Text -> delimiter.is_empty
@@ -344,7 +347,7 @@ Text.split self delimiter="," case_sensitivity=Case_Sensitivity.Sensitive use_re
             _ : Vector -> delimiter.length == 1
             _ -> False
         # If it's a vector of one element, just call it on that one element.
-        if delimiter_is_singleton_vector then self.split delimiter=(delimiter.first) case_sensitivity=case_sensitivity use_regex=use_regex else
+        if delimiter_is_singleton_vector then self.split delimiter=(delimiter.first) case_sensitivity=case_sensitivity use_regex=use_regex else`
             case use_regex of
                 False ->
                     delimiters = split_find_delimiters self delimiter case_sensitivity

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
@@ -77,3 +77,11 @@ type Widget
 
     ## Describes a file chooser.
     File_Browse label:(Nothing | Text)=Nothing display:Display=Display.When_Modified action:File_Action=File_Action.Open file_types:(Vector Pair)=[Pair.new "All Files" "*.*"]
+
+## PRIVATE
+make_single_choice : Vector -> Display -> Widget
+make_single_choice values display=Display.Always =
+    make_option value = case value of
+        _ : Vector -> Choice.Option value.first value.second
+        _ -> Choice.Option value value.pretty
+    Widget.Single_Choice (values.map make_option) Nothing display

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
@@ -83,5 +83,5 @@ make_single_choice : Vector -> Display -> Widget
 make_single_choice values display=Display.Always =
     make_option value = case value of
         _ : Vector -> Choice.Option value.first value.second
-        _ -> Choice.Option value value.pretty
+        _ : Text -> Choice.Option value value.pretty
     Widget.Single_Choice (values.map make_option) Nothing display

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -17,12 +17,10 @@ import project.Helpers
    Arguments:
    - x: The table to prepare for visualisation.
    - max_rows: The maximum number of rows to display.
-   - page: The page to display.
 
    In case of Database backed data, it materializes a fragment of the data.
-prepare_visualization : Any -> Integer -> Integer -> Text
-prepare_visualization y max_rows=1000 page=0 =
-    _ = page
+prepare_visualization : Any -> Integer -> Text
+prepare_visualization y max_rows=1000 =
     x = Warning.set y []
 
     result = case x of
@@ -42,7 +40,7 @@ prepare_visualization y max_rows=1000 page=0 =
             all_rows_count = x.row_count
             make_json_for_table dataframe [] all_rows_count
         _ : Function ->
-            pairs = [['_display_text_', '[Function]']]
+            pairs = [['_display_text_', '[Function '+x.to_text+']']]
             value = JS_Object.from_pairs pairs
             JS_Object.from_pairs [["json", value]]
         _ ->
@@ -102,7 +100,7 @@ make_json_for_object_matrix current vector idx=0 = if idx == vector.length then 
         _ ->
             js_object = row.to_js_object
             if js_object.is_a JS_Object . not then False else
-                if js_object.field_names.sort == ["type" , "constructor"] then False else
+                if js_object.field_names.sort == ["constructor", "type"] then False else
                     pairs = js_object.field_names.map f-> [f, make_json_for_value (js_object.get f)]
                     JS_Object.from_pairs pairs
     if to_append == False then Nothing else
@@ -190,5 +188,5 @@ make_json_for_value val level=0 = case val of
             truncated = val.columns.take 5 . map _.name
             prepared = if val.column_count > 5 then truncated + ["… " + (val.column_count - 5).to_text+ " more"] else truncated
             "Table{" + val.row_count.to_text + " rows x [" + (prepared.join ", ") + "]}"
-    _ : Function -> "[Function]"
+    _ : Function -> "[Function "+val.to_text+"]"
     _ -> val.to_display_text

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -17,10 +17,12 @@ import project.Helpers
    Arguments:
    - x: The table to prepare for visualisation.
    - max_rows: The maximum number of rows to display.
+   - page: The page to display.
 
    In case of Database backed data, it materializes a fragment of the data.
-prepare_visualization : Any -> Integer -> Text
-prepare_visualization y max_rows=1000 =
+prepare_visualization : Any -> Integer -> Integer -> Text
+prepare_visualization y max_rows=1000 page=0 =
+    _ = page
     x = Warning.set y []
 
     result = case x of
@@ -39,6 +41,10 @@ prepare_visualization y max_rows=1000 =
             dataframe = x.read max_rows
             all_rows_count = x.row_count
             make_json_for_table dataframe [] all_rows_count
+        _ : Function ->
+            pairs = [['_display_text_', '[Function]']]
+            value = JS_Object.from_pairs pairs
+            JS_Object.from_pairs [["json", value]]
         _ ->
             js_value = x.to_js_object
             value = if js_value.is_a JS_Object . not then js_value else
@@ -184,4 +190,5 @@ make_json_for_value val level=0 = case val of
             truncated = val.columns.take 5 . map _.name
             prepared = if val.column_count > 5 then truncated + ["… " + (val.column_count - 5).to_text+ " more"] else truncated
             "Table{" + val.row_count.to_text + " rows x [" + (prepared.join ", ") + "]}"
+    _ : Function -> "[Function]"
     _ -> val.to_display_text


### PR DESCRIPTION
### Pull Request Description

- Moved the row count out of the grid.
  - Shown for all cases.
- Added some of the JS wiring to do pages but currently hidden.
- Dropdown allowing the user to control the number of rows rendered.
- `Nothing` rendered as a italic light Nothing not just empty now.
- Function rendered as `[Function]`.
- Rounded corners on top to make it align more with look of panel.
- Dropdown for `Text.split` delimiter feed.

### Screenshots

![image](https://github.com/enso-org/enso/assets/4699705/6ca4d76d-f46e-4f78-8178-9daf6eaf7235)

![image](https://github.com/enso-org/enso/assets/4699705/01bf876b-5584-47c1-8ebf-c71a5955dfa1)

![image](https://github.com/enso-org/enso/assets/4699705/890aba2c-621d-4a7b-9599-db1d0a0de173)

![image](https://github.com/enso-org/enso/assets/4699705/8e4a79dd-0001-4b88-aa96-f527f31250f3)


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
