### PR TITLE
Display Initializing project... message when initializing project

### DIFF
--- a/app/gui/view/graph-editor/src/component/breadcrumbs/project_name.rs
+++ b/app/gui/view/graph-editor/src/component/breadcrumbs/project_name.rs
@@ -30,7 +30,7 @@ use parser::Parser;
 // This is a default value for the project name when it is created. The project name should
 // always be initialized externally for the current project. If this value is visible in the UI,
 // it was not set to the correct project name due to some bug.
-const UNINITIALIZED_PROJECT_NAME: &str = "Project Name Uninitialized";
+const UNINITIALIZED_PROJECT_NAME: &str = "Initializing project...";
 /// Default line height for project names.
 pub const LINE_HEIGHT: f32 = TEXT_SIZE * 1.5;
 


### PR DESCRIPTION
### Pull Request Description

The current `"Project Name Uninitialized"` seems a bit scary. Why not display text describing what's really happening?

![Initializing project...](https://github.com/enso-org/enso/assets/26887752/b852ccdc-b1e4-4d3d-aa40-9e23e18ef43c)

Isn't `Initializing project...` better?


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides.
- All code has been tested:
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
