### PR TITLE
Disable authentication and newDashboard by default

### DIFF
--- a/app/ide-desktop/lib/content-config/src/config.json
+++ b/app/ide-desktop/lib/content-config/src/config.json
@@ -1,7 +1,7 @@
 {
   "options": {
     "authentication": {
-      "value": true,
+      "value": false,
       "description": "Determines whether user authentication is enabled. This option is always true when executed in the cloud."
     },
     "dataCollection": {
@@ -121,7 +121,7 @@
           "primary": false
         },
         "newDashboard": {
-          "value": true,
+          "value": false,
           "description": "Determines whether the new dashboard with cloud integration is enabled."
         },
         "profiling": {


### PR DESCRIPTION
### Pull Request Description

This PR sets `authentication` and `featurePreview.newDashboard` flags back to false until we fix problems with developers entrypoints access.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
