### PR TITLE
Ensure slow shutdown of LS always kicks off hooks

### DIFF
--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerController.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerController.scala
@@ -297,6 +297,9 @@ class LanguageServerController(
           s"Received client ($clientId) disconnect request during shutdown. Ignoring."
         )
 
+      case ShutDownServer =>
+        logger.debug(s"Received shutdown request during shutdown. Ignoring.")
+
       case m: StartServer =>
         // This instance has not yet been shut down. Retry
         context.parent.forward(Retry(m))

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerRegistry.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerRegistry.scala
@@ -88,7 +88,7 @@ class LanguageServerRegistry(
     case msg @ KillThemAll =>
       val killer = context.actorOf(
         LanguageServerKiller.props(
-          serverControllers.values.toList,
+          serverControllers,
           timeoutConfig.shutdownTimeout
         ),
         "language-server-killer"


### PR DESCRIPTION


### Pull Request Description

This change fixes the rather elusive bug where shutdown hooks could not be fired when shutdown was taking too long and termination was forced.

Under the circumstances described in detail in ticket #6515 there was a small chance that we could have a shutdown race condition. Essentially the messages received when client was disconnected and language server forced the termination could lead to language server not sending the public `ProjectClosed` message which triggers shutdown hook. Now we always do.

Also made sure that multiple `ProjectClosed` messages don't lead to firing multiple shutdown hooks, which was another possibility.

No tests as one would have to be able to introduce different delays in various message handlers to simulate the problem.
Having ability to do such chaos testing would be nice but it is beyond the scope of this ticket. 
I was able to reproduce the problem 100% with my specially crafted setup so I'm fairly confident about the change.

Closes #6515.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
