### PR TITLE
Low-latency rendering with the desynchronized hint

### DIFF
--- a/lib/rust/web/src/lib.rs
+++ b/lib/rust/web/src/lib.rs
@@ -686,6 +686,8 @@ ops! { HtmlCanvasElementOps for HtmlCanvasElement
         fn get_webgl2_context(&self) -> Option<WebGl2RenderingContext> {
             let options = Object::new();
             Reflect::set(&options, &"antialias".into(), &false.into()).unwrap();
+            // See: https://developer.chrome.com/blog/desynchronized
+            Reflect::set(&options, &"desynchronized".into(), &true.into()).unwrap();
             let context = self.get_context_with_context_options("webgl2", &options).ok().flatten();
             context.and_then(|obj| obj.dyn_into::<WebGl2RenderingContext>().ok())
         }


### PR DESCRIPTION
### Pull Request Description

This PR adds `desynchronized` hint to the WebGL context which invokes a different code path that bypasses the [usual DOM update mechanism](https://docs.google.com/presentation/d/1boPxbgNrTU0ddsc144rcXayGA_WF53k96imRH8Mp34Y/edit#slide=id.p). To learn more, see: https://developer.chrome.com/blog/desynchronized/

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
