### PR TITLE
Force `newDashboard` default on the CI-built packages.

### DIFF
--- a/app/gui/view/documentation/src/lib.rs
+++ b/app/gui/view/documentation/src/lib.rs
@@ -17,28 +17,26 @@
 //!
 //! [`Tailwind CSS`]: https://tailwindcss.com/
 
+#![recursion_limit = "1024"]
 // === Features ===
 #![feature(drain_filter)]
 #![feature(option_result_contains)]
 // === Standard Linter Configuration ===
 #![deny(non_ascii_idents)]
+#![warn(unsafe_code)]
 #![allow(clippy::bool_to_int_with_if)]
 #![allow(clippy::let_and_return)]
+// === Non-Standard Linter Configuration ===
 #![warn(missing_copy_implementations)]
 #![warn(missing_debug_implementations)]
 #![warn(missing_docs)]
 #![warn(trivial_casts)]
 #![warn(trivial_numeric_casts)]
-#![warn(unsafe_code)]
 #![warn(unused_import_braces)]
 #![warn(unused_qualifications)]
-#![recursion_limit = "1024"]
 
 use ensogl::prelude::*;
 use ensogl::system::web::traits::*;
-
-use graph_editor::component::visualization;
-use ide_view_graph_editor as graph_editor;
 
 use enso_frp as frp;
 use enso_suggestion_database::documentation_ir::EntryDocumentation;
@@ -55,15 +53,17 @@ use ensogl::Animation;
 use ensogl_component::shadow;
 use ensogl_derive_theme::FromTheme;
 use ensogl_hardcoded_theme::application::component_browser::documentation as theme;
+use graph_editor::component::visualization;
+use ide_view_graph_editor as graph_editor;
 use web::HtmlElement;
 use web::JsCast;
-
-pub mod html;
 
 
 // ==============
 // === Export ===
 // ==============
+
+pub mod html;
 
 pub use visualization::container::overlay;
 

--- a/build/base/src/fs.rs
+++ b/build/base/src/fs.rs
@@ -29,7 +29,8 @@ pub fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result {
 #[context("Failed to deserialize JSON from path: {}", path.as_ref().display())]
 pub fn read_json<T: DeserializeOwned>(path: impl AsRef<Path>) -> Result<T> {
     let contents = read_to_string(&path)?;
-    serde_json::from_str(&contents).with_context(|| format!("Failed to parse JSON from {}", path.as_ref().display()))
+    serde_json::from_str(&contents)
+        .with_context(|| format!("Failed to parse JSON from {}", path.as_ref().display()))
 }
 
 /// Serialize the data to JSON text and write it to the file.

--- a/build/base/src/fs.rs
+++ b/build/base/src/fs.rs
@@ -25,6 +25,13 @@ pub fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> Result {
     wrappers::write(&path, &contents)
 }
 
+/// Read the file file, deserializing JSON text into the data.
+#[context("Failed to deserialize JSON from path: {}", path.as_ref().display())]
+pub fn read_json<T: DeserializeOwned>(path: impl AsRef<Path>) -> Result<T> {
+    let contents = read_to_string(&path)?;
+    serde_json::from_str(&contents).with_context(|| format!("Failed to parse JSON from {}", path.as_ref().display()))
+}
+
 /// Serialize the data to JSON text and write it to the file.
 ///
 /// See [`write()`].

--- a/build/build/paths.yaml
+++ b/build/build/paths.yaml
@@ -18,6 +18,9 @@
       lib/:
         client/:
         content/:
+        content-config/:
+          src/:
+            config.json:
         icons/:
         project-manager/:
   build/:

--- a/build/build/src/project/gui.rs
+++ b/build/build/src/project/gui.rs
@@ -102,7 +102,7 @@ fn override_default_for_authentication(path: &crate::paths::generated::RepoRootA
         json_path.last().unwrap().to_string(),
         serde_json::Value::Bool(true),
     );
-    ide_ci::fs::write_json(path, &json);
+    ide_ci::fs::write_json(path, &json)?;
     Ok(())
 }
 

--- a/build/build/src/project/gui.rs
+++ b/build/build/src/project/gui.rs
@@ -85,8 +85,11 @@ impl IsWatcher<Gui> for Watcher {
     }
 }
 
+/// Override the default value of `newDashboard` in `config.json` to `true`.
 ///
-fn override_default_for_authentication(
+/// This is a temporary workaround. We want to enable the new dashboard by default in the CI-built
+/// IDE, but we don't want to enable it by default in the IDE built locally by developers.
+pub fn override_default_for_authentication(
     path: &crate::paths::generated::RepoRootAppIdeDesktopLibContentConfigSrcConfigJson,
 ) -> Result {
     let json_path = ["groups", "featurePreview", "options", "newDashboard", "value"];
@@ -128,6 +131,9 @@ impl IsTarget for Gui {
     ) -> BoxFuture<'static, Result<Self::Artifact>> {
         let WithDestination { inner, destination } = job;
         async move {
+            // TODO: [mwu]
+            //  This is a temporary workaround until https://github.com/enso-org/enso/issues/6662
+            //  is resolved.
             if ide_ci::actions::workflow::is_in_env() {
                 let path = &context.repo_root.app.ide_desktop.lib.content_config.src.config_json;
                 warn!("Overriding default for authentication in {}", path.display());

--- a/build/build/src/project/gui.rs
+++ b/build/build/src/project/gui.rs
@@ -85,23 +85,22 @@ impl IsWatcher<Gui> for Watcher {
     }
 }
 
-fn override_default_for_authentication(path: &crate::paths::generated::RepoRootAppIdeDesktopLibContentConfigSrcConfigJson) -> Result {
-    // The path in JSON is like groups.featurePreview.options.newDashboard.value.
-    // We want to switch that value to true.
+///
+fn override_default_for_authentication(
+    path: &crate::paths::generated::RepoRootAppIdeDesktopLibContentConfigSrcConfigJson,
+) -> Result {
     let json_path = ["groups", "featurePreview", "options", "newDashboard", "value"];
     let mut json = ide_ci::fs::read_json::<serde_json::Value>(path)?;
-    let mut current = json.as_object_mut().ok_or_else(|| anyhow!("Failed to find object in {:?}", path))?;
+    let mut current =
+        json.as_object_mut().ok_or_else(|| anyhow!("Failed to find object in {:?}", path))?;
     for key in &json_path[..json_path.len() - 1] {
         current = current
             .get_mut(*key)
-            .with_context(|| format!("Failed to find {:?} in {:?}", key, path))?
+            .with_context(|| format!("Failed to find {key:?} in {path:?}"))?
             .as_object_mut()
-            .with_context(|| format!("Failed to find object at {:?} in {:?}", key, path))?;
+            .with_context(|| format!("Failed to find object at {key:?} in {path:?}"))?;
     }
-    current.insert(
-        json_path.last().unwrap().to_string(),
-        serde_json::Value::Bool(true),
-    );
+    current.insert(json_path.last().unwrap().to_string(), serde_json::Value::Bool(true));
     ide_ci::fs::write_json(path, &json)?;
     Ok(())
 }
@@ -132,7 +131,7 @@ impl IsTarget for Gui {
             if ide_ci::actions::workflow::is_in_env() {
                 let path = &context.repo_root.app.ide_desktop.lib.content_config.src.config_json;
                 warn!("Overriding default for authentication in {}", path.display());
-                override_default_for_authentication(&path)?;
+                override_default_for_authentication(path)?;
             }
 
             let ide = ide_desktop_from_context(&context);

--- a/lib/rust/ensogl/component/spinner/src/lib.rs
+++ b/lib/rust/ensogl/component/spinner/src/lib.rs
@@ -1,6 +1,12 @@
 //! An animated spinner component that can be used to indicate that a process
 //! is running.
 
+// === Standard Linter Configuration ===
+#![deny(non_ascii_idents)]
+#![warn(unsafe_code)]
+#![allow(clippy::bool_to_int_with_if)]
+#![allow(clippy::let_and_return)]
+
 use ensogl_core::display::shape::*;
 use ensogl_core::prelude::*;
 


### PR DESCRIPTION
### Pull Request Description
As agreed with @sylwiabr this PR makes CI-built IDE packages have the new dashboard enabled by default.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
