### PR TITLE
Add cloud dashboard to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,11 +156,14 @@
   <kbd>cmd</kbd>+<kbd>alt</kbd>+<kbd>t</kbd>/<kbd>r</kbd>.
 - [Fixed a bug where selecting a nested breadcrumb would cause the order of
   breadcrumbs to change incorrectly.][6617]
+- [Cloud Dashboard, which supersedes the startup screen][6279]. Features also
+  added in various other PRs.
 
+[6279]: https://github.com/enso-org/enso/pull/6279
 [6421]: https://github.com/enso-org/enso/pull/6421
 [6530]: https://github.com/enso-org/enso/pull/6530
-[6620]: https://github.com/enso-org/enso/pull/6620
 [6617]: https://github.com/enso-org/enso/pull/6617
+[6620]: https://github.com/enso-org/enso/pull/6620
 
 #### EnsoGL (rendering engine)
 
@@ -217,17 +220,16 @@
 
 [3857]: https://github.com/enso-org/enso/pull/3857
 [3985]: https://github.com/enso-org/enso/pull/3985
-[4047]: https://github.com/enso-org/enso/pull/4047
 [4003]: https://github.com/enso-org/enso/pull/4003
+[4047]: https://github.com/enso-org/enso/pull/4047
 [5895]: https://github.com/enso-org/enso/pull/5895
-[5895]: https://github.com/enso-org/enso/pull/6130
 [6035]: https://github.com/enso-org/enso/pull/6035
 [6097]: https://github.com/enso-org/enso/pull/6097
-[6097]: https://github.com/enso-org/enso/pull/6341
+[6130]: https://github.com/enso-org/enso/pull/6130
 [6366]: https://github.com/enso-org/enso/pull/6366
-[6487]: https://github.com/enso-org/enso/pull/6487
 [6341]: https://github.com/enso-org/enso/pull/6341
 [6470]: https://github.com/enso-org/enso/pull/6470
+[6487]: https://github.com/enso-org/enso/pull/6487
 [6512]: https://github.com/enso-org/enso/pull/6512
 
 #### Enso Standard Library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,8 +156,10 @@
   <kbd>cmd</kbd>+<kbd>alt</kbd>+<kbd>t</kbd>/<kbd>r</kbd>.
 - [Fixed a bug where selecting a nested breadcrumb would cause the order of
   breadcrumbs to change incorrectly.][6617]
-- [Cloud Dashboard, which supersedes the startup screen][6279]. Features also
-  added in various other PRs.
+- [Cloud dashboard, which supersedes the startup screen][6279]. Features also
+  added in various other PRs. The new dashboard includes tables for projects,
+  folders, files and secrets, a list of templates from which new projects can be
+  created, a user menu, and a search bar.
 
 [6279]: https://github.com/enso-org/enso/pull/6279
 [6421]: https://github.com/enso-org/enso/pull/6421


### PR DESCRIPTION
### Pull Request Description
- Adds the cloud dashboard to the changelog
- Fixes broken links in changelog

### Important Notes
The specific issue to link to for the "cloud dashboard" feature can be changed.
I think adding all relevant commits to the changelog would be unnecessary clutter - especially as the cloud dashboard is still being changed/getting new features relatively frequently.
(Also, it shouldn't be relevant news for end users as they are almost certainly not using the cloud dashboard yet.)
Of course, once the cloud dashboard is officially released, each feature PR should get its own changelog entry.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
