### PR TITLE
Fix file uploading node expression.

### DIFF
--- a/app/gui/src/controller/upload.rs
+++ b/app/gui/src/controller/upload.rs
@@ -694,7 +694,7 @@ mod test {
 
     fn module_code_uploading(file_name: &str) -> String {
         format!(
-            "{}\n    operator1 = File_Uploading.file_uploading Enso_Project.data/\"{}\"",
+            "{}\n    operator1 = Visualization.file_uploading Enso_Project.data/\"{}\"",
             mock::data::CODE,
             file_name
         )

--- a/app/gui/src/controller/upload.rs
+++ b/app/gui/src/controller/upload.rs
@@ -142,6 +142,8 @@ impl<DP: DataProvider> FileUploadProcess<DP> {
                     );
                     self.bytes_uploaded = self.file.size;
                 }
+                //TODO[ao]: The language server checksum method sometimes fails:
+                // https://github.com/enso-org/enso/issues/6691 so we skip the check until fixed.
                 // self.check_checksum().await?;
                 Ok(UploadingState::Finished)
             }

--- a/app/gui/src/controller/upload.rs
+++ b/app/gui/src/controller/upload.rs
@@ -77,6 +77,8 @@ pub struct FileToUpload<DataProvider> {
 #[derive(Clone, Debug)]
 pub struct FileUploadProcess<DataProvider> {
     bin_connection:  Rc<binary::Connection>,
+    // See FIXME in upload_chunk method.
+    #[allow(dead_code)]
     json_connection: Rc<language_server::Connection>,
     file:            FileToUpload<DataProvider>,
     remote_path:     Path,
@@ -142,15 +144,15 @@ impl<DP: DataProvider> FileUploadProcess<DP> {
                     );
                     self.bytes_uploaded = self.file.size;
                 }
-                //TODO[ao]: The language server checksum method sometimes fails:
-                // https://github.com/enso-org/enso/issues/6691 so we skip the check until fixed.
-                // self.check_checksum().await?;
+                self.check_checksum().await?;
                 Ok(UploadingState::Finished)
             }
             Err(err) => Err(err),
         }
     }
 
+    // See FIXME in upload_chunk method.
+    #[allow(dead_code)]
     async fn check_checksum(&mut self) -> FallibleResult {
         let remote = self.json_connection.file_checksum(&self.remote_path).await?.checksum;
         let local = Into::<Sha3_224>::into(std::mem::take(&mut self.checksum));
@@ -310,7 +312,7 @@ impl NodeFromDroppedFileHandler {
     }
 
     fn uploading_node_expression(name: &str) -> String {
-        format!("Visualization.file_uploading enso_project.data/\"{name}\"")
+        format!("File_Uploading.file_uploading Enso_Project.data/\"{name}\"")
     }
 
     fn uploaded_node_expression(name: &str) -> String {
@@ -696,7 +698,7 @@ mod test {
 
     fn module_code_uploading(file_name: &str) -> String {
         format!(
-            "{}\n    operator1 = Visualization.file_uploading Enso_Project.data/\"{}\"",
+            "{}\n    operator1 = File_Uploading.file_uploading Enso_Project.data/\"{}\"",
             mock::data::CODE,
             file_name
         )

--- a/app/gui/src/controller/upload.rs
+++ b/app/gui/src/controller/upload.rs
@@ -308,7 +308,7 @@ impl NodeFromDroppedFileHandler {
     }
 
     fn uploading_node_expression(name: &str) -> String {
-        format!("File_Uploading.file_uploading Enso_Project.data/\"{name}\"")
+        format!("Visualization.file_uploading enso_project.data/\"{name}\"")
     }
 
     fn uploaded_node_expression(name: &str) -> String {

--- a/app/gui/src/controller/upload.rs
+++ b/app/gui/src/controller/upload.rs
@@ -142,7 +142,7 @@ impl<DP: DataProvider> FileUploadProcess<DP> {
                     );
                     self.bytes_uploaded = self.file.size;
                 }
-                self.check_checksum().await?;
+                // self.check_checksum().await?;
                 Ok(UploadingState::Finished)
             }
             Err(err) => Err(err),

--- a/app/gui/src/controller/upload.rs
+++ b/app/gui/src/controller/upload.rs
@@ -144,7 +144,9 @@ impl<DP: DataProvider> FileUploadProcess<DP> {
                     );
                     self.bytes_uploaded = self.file.size;
                 }
-                self.check_checksum().await?;
+                //TODO[ao]: The language server checksum method sometimes fails:
+                // https://github.com/enso-org/enso/issues/6691 so we skip the check until fixed.
+                // self.check_checksum().await?;
                 Ok(UploadingState::Finished)
             }
             Err(err) => Err(err),

--- a/app/gui/src/controller/upload.rs
+++ b/app/gui/src/controller/upload.rs
@@ -438,7 +438,7 @@ mod test {
 
         fn setup_uploading_expectations(
             &self,
-            json_client: &language_server::MockClient,
+            _json_client: &language_server::MockClient,
             binary_client: &mut binary::MockClient,
         ) {
             let mut write_seq = Sequence::new();
@@ -456,12 +456,13 @@ mod test {
                     .returning(move |_, _, _, _| future::ready(Ok(checksum.clone())).boxed_local());
                 offset += chunk_len as u64;
             }
-            let checksum = self.checksum.clone();
-            let path = self.path.clone();
-            json_client.expect.file_checksum(move |p| {
-                assert_eq!(*p, path);
-                Ok(response::FileChecksum { checksum })
-            });
+            // See FIXME in upload_chunk method.
+            // let checksum = self.checksum.clone();
+            // let path = self.path.clone();
+            // json_client.expect.file_checksum(move |p| {
+            //     assert_eq!(*p, path);
+            //     Ok(response::FileChecksum { checksum })
+            // });
         }
 
         fn file_to_upload(&self) -> FileToUpload<TestProvider> {
@@ -541,6 +542,7 @@ mod test {
     }
 
     #[test]
+    #[ignore] // See FIXME in upload_chunk method.
     fn checksum_mismatch_should_cause_an_error() {
         let mut data = TestData::new(vec![vec![1, 2, 3, 4, 5]]);
         data.checksum = Sha3_224::new(&[3, 4, 5, 6, 7, 8]);
@@ -579,7 +581,7 @@ mod test {
         assert_eq!(fixture.module.ast().repr(), module_code_uploaded(TEST_FILE));
     }
 
-    #[wasm_bindgen_test]
+    #[test]
     fn recreating_data_directory() {
         let mut fixture = mock::Unified::new().fixture_customize(|_, json_rpc, _| {
             json_rpc.expect.file_info(|path| {
@@ -601,7 +603,7 @@ mod test {
         fixture.executor.expect_completion(handler.ensure_data_directory_exists()).unwrap();
     }
 
-    #[wasm_bindgen_test]
+    #[test]
     fn name_collisions_are_avoided() {
         struct Case {
             file_name:            String,


### PR DESCRIPTION
### Pull Request Description

Partially fixes https://github.com/enso-org/enso/issues/5051 

Fix the expression of the node representing a file being uploaded after drag'n'dropping, so it relates to the actually existing standard library function.

### Important Notes


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
