### PR TITLE
Fix dashboard top bar resizing behavior

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/topBar.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/topBar.tsx
@@ -44,82 +44,77 @@ function TopBar(props: TopBarProps) {
 
     return (
         <div className="flex mb-2 h-8">
-            <div className="flex text-primary">
-                {platform === platformModule.Platform.desktop && (
-                    <div className="bg-gray-100 rounded-full flex flex-row flex-nowrap p-1.5">
-                        <button
-                            onClick={() => {
-                                setBackendPlatform(platformModule.Platform.desktop)
-                            }}
-                            className={`${
-                                backend.platform === platformModule.Platform.desktop
-                                    ? 'bg-white shadow-soft'
-                                    : 'opacity-50'
-                            } rounded-full px-1.5 py-1`}
-                        >
-                            {svg.COMPUTER_ICON}
-                        </button>
-                        <button
-                            onClick={() => {
-                                setBackendPlatform(platformModule.Platform.cloud)
-                            }}
-                            className={`${
-                                backend.platform === platformModule.Platform.cloud
-                                    ? 'bg-white shadow-soft'
-                                    : 'opacity-50'
-                            } rounded-full px-1.5 py-1`}
-                        >
-                            {svg.CLOUD_ICON}
-                        </button>
-                    </div>
-                )}
-                <div
-                    className={`flex items-center bg-label rounded-full pl-1
-                                pr-2.5 mx-2 ${projectName ? 'cursor-pointer' : 'opacity-50'}`}
-                    onClick={toggleTab}
-                >
-                    <span
-                        className={`opacity-50 overflow-hidden transition-width nowrap ${
-                            tab === dashboard.Tab.dashboard ? 'm-2 w-16' : 'w-0'
-                        }`}
-                    >
-                        {projectName ?? 'Dashboard'}
-                    </span>
-                    <div className="bg-white shadow-soft rounded-full px-1.5 py-1">
-                        {svg.BARS_ICON}
-                    </div>
-                    <span
-                        className={`opacity-50 overflow-hidden transition-width nowrap ${
-                            tab === dashboard.Tab.ide ? 'm-2 w-16' : 'w-0'
-                        }`}
-                    >
-                        {projectName ?? 'No project open'}
-                    </span>
-                </div>
-                <div className="flex items-center bg-label rounded-full px-2 w-140 max-w-2xl">
-                    <div>{svg.MAGNIFYING_GLASS_ICON}</div>
-                    <input
-                        type="text"
-                        placeholder="Click here or start typing to search for projects, data connectors, users, and more ..."
-                        value={query}
-                        onChange={event => {
-                            setQuery(event.target.value)
+            {platform === platformModule.Platform.desktop && (
+                <div className="bg-gray-100 rounded-full flex flex-row flex-nowrap p-1.5">
+                    <button
+                        onClick={() => {
+                            setBackendPlatform(platformModule.Platform.desktop)
                         }}
-                        className="flex-1 mx-2 bg-transparent"
-                    />
+                        className={`${
+                            backend.platform === platformModule.Platform.desktop
+                                ? 'bg-white shadow-soft'
+                                : 'opacity-50'
+                        } rounded-full px-1.5 py-1`}
+                    >
+                        {svg.COMPUTER_ICON}
+                    </button>
+                    <button
+                        onClick={() => {
+                            setBackendPlatform(platformModule.Platform.cloud)
+                        }}
+                        className={`${
+                            backend.platform === platformModule.Platform.cloud
+                                ? 'bg-white shadow-soft'
+                                : 'opacity-50'
+                        } rounded-full px-1.5 py-1`}
+                    >
+                        {svg.CLOUD_ICON}
+                    </button>
                 </div>
+            )}
+            <div
+                className={`flex items-center bg-label rounded-full pl-1
+                                pr-2.5 mx-2 ${projectName ? 'cursor-pointer' : 'opacity-50'}`}
+                onClick={toggleTab}
+            >
+                <span
+                    className={`opacity-50 overflow-hidden transition-width nowrap ${
+                        tab === dashboard.Tab.dashboard ? 'm-2 w-16' : 'w-0'
+                    }`}
+                >
+                    {projectName ?? 'Dashboard'}
+                </span>
+                <div className="bg-white shadow-soft rounded-full px-1.5 py-1">{svg.BARS_ICON}</div>
+                <span
+                    className={`opacity-50 overflow-hidden transition-width nowrap ${
+                        tab === dashboard.Tab.ide ? 'm-2 w-16' : 'w-0'
+                    }`}
+                >
+                    {projectName ?? 'No project open'}
+                </span>
             </div>
-            <div className="grow" />
+            <div className="grow flex items-center bg-label rounded-full px-2">
+                <div>{svg.MAGNIFYING_GLASS_ICON}</div>
+                <input
+                    type="text"
+                    placeholder="Click here or start typing to search for projects, data connectors, users, and more ..."
+                    value={query}
+                    onChange={event => {
+                        setQuery(event.target.value)
+                    }}
+                    className="flex-1 mx-2 bg-transparent"
+                />
+            </div>
             <a
                 href="https://discord.gg/enso"
                 target="_blank"
                 className="flex items-center bg-help rounded-full px-2.5 text-white mx-2"
             >
-                <span>help chat</span>
+                <span className="whitespace-nowrap">help chat</span>
                 <div className="ml-2">{svg.SPEECH_BUBBLE_ICON}</div>
             </a>
             {/* User profile and menu. */}
-            <div className="transform">
+            <div className="transform w-8">
                 <div
                     onClick={event => {
                         event.stopPropagation()


### PR DESCRIPTION
### Pull Request Description
Fixes [cloud-v2/#435](https://github.com/enso-org/cloud-v2/issues/435)

### Important Notes
The search bar has been changed to occupy all remaining width, intentionally diverging from the Figma design.
(This isn't a limitation, just a design decision, and can be changed to follow the Figma design exactly)

### Screenshots
Very narrow screen:
![image](https://github.com/enso-org/enso/assets/4046547/5253dcf5-7d42-4e32-91f3-f1ba550feccd)
![image](https://github.com/enso-org/enso/assets/4046547/1c64e106-2949-40b9-aed2-b299d8f0eedd)
"Very narrow" in this case means <520px so I don't think it's an issue
Narrow screen:
![image](https://github.com/enso-org/enso/assets/4046547/07c0b733-fb00-4a97-aaff-9bd8bbfdf9f2)
Wide screen:
![image](https://github.com/enso-org/enso/assets/4046547/65f1c0d6-cdfb-4aac-82a8-edd765a23aee)


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
