### PR TITLE
Fix logic for enabling dashboard

### DIFF
--- a/app/ide-desktop/lib/content/src/index.ts
+++ b/app/ide-desktop/lib/content/src/index.ts
@@ -187,7 +187,8 @@ class Main implements AppRunner {
         const isOpeningMainEntryPoint =
             contentConfig.OPTIONS.groups.startup.options.entry.value ===
             contentConfig.OPTIONS.groups.startup.options.entry.default
-        const isNotOpeningProject = contentConfig.OPTIONS.groups.startup.options.project.value === ''
+        const isNotOpeningProject =
+            contentConfig.OPTIONS.groups.startup.options.project.value === ''
         if (
             (isUsingAuthentication || isUsingNewDashboard) &&
             isOpeningMainEntryPoint &&

--- a/app/ide-desktop/lib/content/src/index.ts
+++ b/app/ide-desktop/lib/content/src/index.ts
@@ -187,7 +187,7 @@ class Main implements AppRunner {
         const isOpeningMainEntryPoint =
             contentConfig.OPTIONS.groups.startup.options.entry.value ===
             contentConfig.OPTIONS.groups.startup.options.entry.default
-        const isNotOpeningProject = contentConfig.OPTIONS.groups.startup.options.entry.value === ''
+        const isNotOpeningProject = contentConfig.OPTIONS.groups.startup.options.project.value === ''
         if (
             (isUsingAuthentication || isUsingNewDashboard) &&
             isOpeningMainEntryPoint &&


### PR DESCRIPTION
### Pull Request Description
Fixes regression introduced by #6671, preventing the dashboard from being opened because `startup.entry` is never the empty string

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
