### PR TITLE
Revert "Show spinner when opening/creating a project (#6321)"

### DIFF
--- a/app/gui/src/controller/ide.rs
+++ b/app/gui/src/controller/ide.rs
@@ -5,8 +5,6 @@
 
 use crate::prelude::*;
 
-use crate::config::ProjectToOpen;
-
 use double_representation::name::project;
 use mockall::automock;
 use parser::Parser;
@@ -104,7 +102,9 @@ impl StatusNotificationPublisher {
 /// used internally in code.
 #[derive(Copy, Clone, Debug)]
 pub enum Notification {
-    /// User opened a new or existing project.
+    /// User created a new project. The new project is opened in IDE.
+    NewProjectCreated,
+    /// User opened an existing project.
     ProjectOpened,
     /// User closed the project.
     ProjectClosed,
@@ -118,12 +118,10 @@ pub enum Notification {
 
 // === Errors ===
 
-/// Error raised when a project with given name or ID was not found.
+#[allow(missing_docs)]
 #[derive(Clone, Debug, Fail)]
-#[fail(display = "Project '{}' was not found.", project)]
-pub struct ProjectNotFound {
-    project: ProjectToOpen,
-}
+#[fail(display = "Project with name \"{}\" not found.", 0)]
+struct ProjectNotFound(String);
 
 
 // === Managing API ===
@@ -133,16 +131,11 @@ pub struct ProjectNotFound {
 /// It is a separate trait, because those methods  are not supported in some environments (see also
 /// [`API::manage_projects`]).
 pub trait ManagingProjectAPI {
-    /// Create a new project and open it in the IDE.
+    /// Create a new unnamed project and open it in the IDE.
     ///
-    /// `name` is an optional project name. It overrides the name of the template if given.
     /// `template` is an optional project template name. Available template names are defined in
     /// `lib/scala/pkg/src/main/scala/org/enso/pkg/Template.scala`.
-    fn create_new_project(
-        &self,
-        name: Option<String>,
-        template: Option<project::Template>,
-    ) -> BoxFuture<FallibleResult>;
+    fn create_new_project(&self, template: Option<project::Template>) -> BoxFuture<FallibleResult>;
 
     /// Return a list of existing projects.
     fn list_projects(&self) -> BoxFuture<FallibleResult<Vec<ProjectMetadata>>>;
@@ -157,41 +150,15 @@ pub trait ManagingProjectAPI {
     /// and then for the project opening.
     fn open_project_by_name(&self, name: String) -> BoxFuture<FallibleResult> {
         async move {
-            let project_id = self.find_project(&ProjectToOpen::Name(name.into())).await?;
-            self.open_project(project_id).await
-        }
-        .boxed_local()
-    }
-
-    /// Open a project by name or ID. If no project with the given name exists, it will be created.
-    fn open_or_create_project(&self, project_to_open: ProjectToOpen) -> BoxFuture<FallibleResult> {
-        async move {
-            match self.find_project(&project_to_open).await {
-                Ok(project_id) => self.open_project(project_id).await,
-                Err(error) =>
-                    if let ProjectToOpen::Name(name) = project_to_open {
-                        info!("Attempting to create project with name '{name}'.");
-                        self.create_new_project(Some(name.to_string()), None).await
-                    } else {
-                        Err(error)
-                    },
+            let projects = self.list_projects().await?;
+            let mut projects = projects.into_iter();
+            let project = projects.find(|project| project.name.as_ref() == name);
+            let uuid = project.map(|project| project.id);
+            if let Some(uuid) = uuid {
+                self.open_project(uuid).await
+            } else {
+                Err(ProjectNotFound(name).into())
             }
-        }
-        .boxed_local()
-    }
-
-    /// Find a project by name or ID.
-    fn find_project<'a: 'c, 'b: 'c, 'c>(
-        &'a self,
-        project_to_open: &'b ProjectToOpen,
-    ) -> BoxFuture<'c, FallibleResult<Uuid>> {
-        async move {
-            self.list_projects()
-                .await?
-                .into_iter()
-                .find(|project_metadata| project_to_open.matches(project_metadata))
-                .map(|metadata| metadata.id)
-                .ok_or_else(|| ProjectNotFound { project: project_to_open.clone() }.into())
         }
         .boxed_local()
     }

--- a/app/gui/src/controller/searcher.rs
+++ b/app/gui/src/controller/searcher.rs
@@ -679,6 +679,33 @@ impl Searcher {
                 Mode::NewNode { .. } => self.add_example(&example).map(Some),
                 _ => Err(CannotExecuteWhenEditingNode.into()),
             },
+            Action::ProjectManagement(action) => {
+                match self.ide.manage_projects() {
+                    Ok(_) => {
+                        let ide = self.ide.clone_ref();
+                        executor::global::spawn(async move {
+                            // We checked that manage_projects returns Some just a moment ago, so
+                            // unwrapping is safe.
+                            let manage_projects = ide.manage_projects().unwrap();
+                            let result = match action {
+                                action::ProjectManagement::CreateNewProject =>
+                                    manage_projects.create_new_project(None),
+                                action::ProjectManagement::OpenProject { id, .. } =>
+                                    manage_projects.open_project(*id),
+                            };
+                            if let Err(err) = result.await {
+                                error!("Error when creating new project: {err}");
+                            }
+                        });
+                        Ok(None)
+                    }
+                    Err(err) => Err(NotSupported {
+                        action_label: Action::ProjectManagement(action).to_string(),
+                        reason:       err,
+                    }
+                    .into()),
+                }
+            }
         }
     }
 
@@ -974,6 +1001,12 @@ impl Searcher {
         let mut actions = action::ListWithSearchResultBuilder::new();
         let (libraries_icon, default_icon) =
             action::hardcoded::ICONS.with(|i| (i.libraries.clone_ref(), i.default.clone_ref()));
+        if should_add_additional_entries && self.ide.manage_projects().is_ok() {
+            let mut root_cat = actions.add_root_category("Projects", default_icon.clone_ref());
+            let category = root_cat.add_category("Projects", default_icon.clone_ref());
+            let create_project = action::ProjectManagement::CreateNewProject;
+            category.add_action(Action::ProjectManagement(create_project));
+        }
         let mut libraries_root_cat =
             actions.add_root_category("Libraries", libraries_icon.clone_ref());
         if should_add_additional_entries {

--- a/app/gui/src/controller/searcher/action.rs
+++ b/app/gui/src/controller/searcher/action.rs
@@ -66,6 +66,14 @@ impl Suggestion {
 /// Action of adding example code.
 pub type Example = Rc<model::suggestion_database::Example>;
 
+/// A variants of project management actions. See also [`Action`].
+#[allow(missing_docs)]
+#[derive(Clone, CloneRef, Debug, Eq, PartialEq)]
+pub enum ProjectManagement {
+    CreateNewProject,
+    OpenProject { id: Immutable<Uuid>, name: ImString },
+}
+
 /// A single action on the Searcher list. See also `controller::searcher::Searcher` docs.
 #[derive(Clone, CloneRef, Debug, PartialEq)]
 pub enum Action {
@@ -76,6 +84,8 @@ pub enum Action {
     /// Add to the current module a new function with example code, and a new node in
     /// current scene calling that function.
     Example(Example),
+    /// The project management operation: creating or opening, projects.
+    ProjectManagement(ProjectManagement),
     // In the future, other action types will be added (like module/method management, etc.).
 }
 
@@ -91,6 +101,10 @@ impl Display for Action {
             Self::Suggestion(Suggestion::Hardcoded(suggestion)) =>
                 Display::fmt(&suggestion.name, f),
             Self::Example(example) => write!(f, "Example: {}", example.name),
+            Self::ProjectManagement(ProjectManagement::CreateNewProject) =>
+                write!(f, "New Project"),
+            Self::ProjectManagement(ProjectManagement::OpenProject { name, .. }) =>
+                Display::fmt(name, f),
         }
     }
 }

--- a/app/gui/src/ide.rs
+++ b/app/gui/src/ide.rs
@@ -2,7 +2,6 @@
 
 use crate::prelude::*;
 
-use crate::config::ProjectToOpen;
 use crate::presenter::Presenter;
 
 use analytics::AnonymousData;
@@ -91,11 +90,6 @@ impl Ide {
             }
         }
     }
-
-    /// Open a project by name or ID. If no project with the given name exists, it will be created.
-    pub fn open_or_create_project(&self, project: ProjectToOpen) {
-        self.presenter.open_or_create_project(project)
-    }
 }
 
 /// A reduced version of [`Ide`] structure, representing an application which failed to initialize.
@@ -106,6 +100,7 @@ impl Ide {
 pub struct FailedIde {
     pub view: ide_view::root::View,
 }
+
 
 /// The Path of the module initially opened after opening project in IDE.
 pub fn initial_module_path(project: &model::Project) -> model::module::Path {

--- a/app/gui/src/integration_test.rs
+++ b/app/gui/src/integration_test.rs
@@ -83,10 +83,7 @@ impl Fixture {
         let project_management =
             controller.manage_projects().expect("Cannot access Managing Project API");
 
-        project_management
-            .create_new_project(None, None)
-            .await
-            .expect("Failed to create new project");
+        project_management.create_new_project(None).await.expect("Failed to create new project");
     }
 
     /// After returning, the IDE is in a state with the project opened and ready to work

--- a/app/gui/src/presenter.rs
+++ b/app/gui/src/presenter.rs
@@ -4,16 +4,13 @@
 
 use crate::prelude::*;
 
-use crate::config::ProjectToOpen;
 use crate::controller::ide::StatusNotification;
 use crate::executor::global::spawn_stream_handler;
 use crate::presenter;
 
 use enso_frp as frp;
-use ensogl::system::js;
 use ide_view as view;
 use ide_view::graph_editor::SharedHashMap;
-use std::time::Duration;
 
 
 // ==============
@@ -29,19 +26,6 @@ pub use code::Code;
 pub use graph::Graph;
 pub use project::Project;
 pub use searcher::Searcher;
-
-
-
-// =================
-// === Constants ===
-// =================
-
-/// We don't know how long opening the project will take, but we still want to show a fake
-/// progress indicator for the user. This constant represents how long the spinner will run for in
-/// milliseconds.
-const OPEN_PROJECT_SPINNER_TIME_MS: u64 = 5_000;
-/// The interval in milliseconds at which we should increase the spinner
-const OPEN_PROJECT_SPINNER_UPDATE_PERIOD_MS: u64 = 10;
 
 
 
@@ -110,15 +94,15 @@ impl Model {
     #[profile(Task)]
     pub fn open_project(&self, project_name: String) {
         let controller = self.controller.clone_ref();
-        crate::executor::global::spawn(with_progress_indicator(|| async move {
+        crate::executor::global::spawn(async move {
             if let Ok(managing_api) = controller.manage_projects() {
                 if let Err(err) = managing_api.open_project_by_name(project_name).await {
                     error!("Cannot open project by name: {err}.");
                 }
             } else {
-                warn!("Project Manager API not available, cannot open project.");
+                warn!("Project opening failed: no ProjectManagingAPI available.");
             }
-        }));
+        });
     }
 
     /// Create a new project. `template` is an optional name of the project template passed to the
@@ -129,10 +113,9 @@ impl Model {
         if let Ok(template) =
             template.map(double_representation::name::project::Template::from_text).transpose()
         {
-            crate::executor::global::spawn(with_progress_indicator(|| async move {
+            crate::executor::global::spawn(async move {
                 if let Ok(managing_api) = controller.manage_projects() {
-                    if let Err(err) = managing_api.create_new_project(None, template.clone()).await
-                    {
+                    if let Err(err) = managing_api.create_new_project(template.clone()).await {
                         if let Some(template) = template {
                             error!("Could not create new project from template {template}: {err}.");
                         } else {
@@ -140,66 +123,13 @@ impl Model {
                         }
                     }
                 } else {
-                    warn!("Project Manager API not available, cannot create project.");
+                    warn!("Project creation failed: no ProjectManagingAPI available.");
                 }
-            }))
+            })
         } else if let Some(template) = template {
             error!("Invalid project template name: {template}");
         };
     }
-
-    /// Open a project by name or ID. If no project with the given name exists, it will be created.
-    #[profile(Task)]
-    fn open_or_create_project(&self, project: ProjectToOpen) {
-        let controller = self.controller.clone_ref();
-        crate::executor::global::spawn(with_progress_indicator(|| async move {
-            if let Ok(managing_api) = controller.manage_projects() {
-                if let Err(error) = managing_api.open_or_create_project(project).await {
-                    error!("Cannot open or create project. {error}");
-                }
-            } else {
-                warn!("Project Manager API not available, cannot open or create project.");
-            }
-        }));
-    }
-}
-
-/// Show a full-screen spinner for the exact duration of the specified function.
-async fn with_progress_indicator<F, T>(f: F)
-where
-    F: FnOnce() -> T,
-    T: Future<Output = ()>, {
-    // TODO[ss]: Use a safer variant of getting the JS app. This one gets a variable from JS, casts
-    // it to a type, etc. Somewhere in EnsoGL we might already have some logic for getting the JS
-    // app and throwing an error if it's not defined.
-    let Ok(app) = js::app() else { return error!("Failed to get JavaScript EnsoGL app.") };
-    app.show_progress_indicator(0.0);
-
-    let (finished_tx, finished_rx) = futures::channel::oneshot::channel();
-    let spinner_progress = futures::stream::unfold(0, |time| async move {
-        enso_web::sleep(Duration::from_millis(OPEN_PROJECT_SPINNER_UPDATE_PERIOD_MS)).await;
-        let new_time = time + OPEN_PROJECT_SPINNER_UPDATE_PERIOD_MS;
-        if new_time < OPEN_PROJECT_SPINNER_TIME_MS {
-            let progress = new_time as f32 / OPEN_PROJECT_SPINNER_TIME_MS as f32;
-            Some((progress, new_time))
-        } else {
-            None
-        }
-    })
-    .take_until(finished_rx);
-    executor::global::spawn(spinner_progress.for_each(|progress| async move {
-        let Ok(app) = js::app() else { return error!("Failed to get JavaScript EnsoGL app.") };
-        app.show_progress_indicator(progress);
-    }));
-
-    f().await;
-
-    // This fails when the spinner progressed until the end before the function got completed
-    // and therefore the receiver got dropped, so we'll ignore the result.
-    let _ = finished_tx.send(());
-
-    let Ok(app) = js::app() else { return error!("Failed to get JavaScript EnsoGL app.") };
-    app.hide_progress_indicator();
 }
 
 
@@ -235,13 +165,6 @@ impl Presenter {
             let root_frp = &model.view.frp;
             root_frp.switch_view_to_project <+ welcome_view_frp.create_project.constant(());
             root_frp.switch_view_to_project <+ welcome_view_frp.open_project.constant(());
-
-            eval root_frp.selected_project ([model] (project) {
-                if let Some(project) = project {
-                    model.close_project();
-                    model.open_project(project.name.to_string());
-                }
-            });
         }
 
         Self { model, network }.init()
@@ -251,6 +174,7 @@ impl Presenter {
     fn init(self) -> Self {
         self.setup_status_bar_notification_handler();
         self.setup_controller_notification_handler();
+        self.model.clone_ref().setup_and_display_new_project();
         executor::global::spawn(self.clone_ref().set_projects_list_on_welcome_screen());
         self
     }
@@ -290,7 +214,8 @@ impl Presenter {
         let weak = Rc::downgrade(&self.model);
         spawn_stream_handler(weak, stream, move |notification, model| {
             match notification {
-                controller::ide::Notification::ProjectOpened =>
+                controller::ide::Notification::NewProjectCreated
+                | controller::ide::Notification::ProjectOpened =>
                     model.setup_and_display_new_project(),
                 controller::ide::Notification::ProjectClosed => {
                     model.close_project();
@@ -313,11 +238,6 @@ impl Presenter {
                 }
             }
         }
-    }
-
-    /// Open a project by name or ID. If no project with the given name exists, it will be created.
-    pub fn open_or_create_project(&self, project: ProjectToOpen) {
-        self.model.open_or_create_project(project)
     }
 }
 

--- a/app/gui/src/presenter/searcher/provider.rs
+++ b/app/gui/src/presenter/searcher/provider.rs
@@ -133,6 +133,7 @@ impl ide_view::searcher::DocumentationProvider for Action {
                 Some(doc.unwrap_or_else(|| Self::doc_placeholder_for(&suggestion)))
             }
             Action::Example(example) => Some(example.documentation_html.clone()),
+            Action::ProjectManagement(_) => None,
         }
     }
 }

--- a/app/gui/view/src/project.rs
+++ b/app/gui/view/src/project.rs
@@ -567,7 +567,7 @@ impl View {
             // === Project Dialog ===
 
             eval_ frp.show_project_list  (model.show_project_list());
-            project_chosen <- project_list.frp.selected_project.constant(());
+            project_chosen   <- project_list.grid.entry_selected.constant(());
             mouse_down       <- scene.mouse.frp_deprecated.down.constant(());
             clicked_on_bg    <- mouse_down.filter(f_!(scene.mouse.target.get().is_background()));
             should_be_closed <- any(frp.hide_project_list,project_chosen,clicked_on_bg);

--- a/app/gui/view/src/root.rs
+++ b/app/gui/view/src/root.rs
@@ -6,7 +6,6 @@
 
 use ensogl::prelude::*;
 
-use engine_protocol::project_manager::ProjectMetadata;
 use enso_frp as frp;
 use ensogl::application;
 use ensogl::application::Application;
@@ -39,12 +38,11 @@ pub struct Model {
     status_bar:     crate::status_bar::View,
     welcome_view:   crate::welcome_screen::View,
     project_view:   Rc<CloneCell<Option<crate::project::View>>>,
-    frp:            Frp,
 }
 
 impl Model {
     /// Constuctor.
-    pub fn new(app: &Application, frp: &Frp) -> Self {
+    pub fn new(app: &Application) -> Self {
         let app = app.clone_ref();
         let display_object = display::object::Instance::new();
         let state = Rc::new(CloneCell::new(State::WelcomeScreen));
@@ -53,9 +51,8 @@ impl Model {
         let welcome_view = app.new_view::<crate::welcome_screen::View>();
         let project_view = Rc::new(CloneCell::new(None));
         display_object.add_child(&welcome_view);
-        let frp = frp.clone_ref();
 
-        Self { app, display_object, state, status_bar, welcome_view, project_view, frp }
+        Self { app, display_object, status_bar, welcome_view, project_view, state }
     }
 
     /// Switch displayed view from Project View to Welcome Screen. Project View will not be
@@ -85,10 +82,6 @@ impl Model {
     fn init_project_view(&self) {
         if self.project_view.get().is_none() {
             let view = self.app.new_view::<crate::project::View>();
-            let project_list_frp = &view.project_list().frp;
-            frp::extend! { network
-                self.frp.source.selected_project <+ project_list_frp.selected_project;
-            }
             self.project_view.set(Some(view));
         }
     }
@@ -108,8 +101,6 @@ ensogl::define_endpoints! {
         switch_view_to_welcome_screen(),
     }
     Output {
-        /// The selected project in the project list
-        selected_project (Option<ProjectMetadata>),
     }
 }
 
@@ -137,8 +128,8 @@ impl Deref for View {
 impl View {
     /// Constuctor.
     pub fn new(app: &Application) -> Self {
+        let model = Model::new(app);
         let frp = Frp::new();
-        let model = Model::new(app, &frp);
         let network = &frp.network;
         let style = StyleWatchFrp::new(&app.display.default_scene.style_sheet);
         let offset_y = style.get_number(ensogl_hardcoded_theme::application::status_bar::offset_y);

--- a/build-config.yaml
+++ b/build-config.yaml
@@ -1,6 +1,6 @@
 # Options intended to be common for all developers.
 
-wasm-size-limit: 15.87 MiB
+wasm-size-limit: 15.85 MiB
 
 required-versions:
   # NB. The Rust version is pinned in rust-toolchain.toml.

--- a/integration-test/tests/engine.rs
+++ b/integration-test/tests/engine.rs
@@ -33,7 +33,7 @@ impl TestOnNewProjectControllersOnly {
         let initializer = enso_gui::Initializer::new(config);
         let error_msg = "Couldn't open project.";
         let ide = initializer.initialize_ide_controller().await.expect(error_msg);
-        ide.manage_projects().unwrap().create_new_project(None, None).await.unwrap();
+        ide.manage_projects().unwrap().create_new_project(None).await.unwrap();
         let project = ide.current_project().unwrap();
         Self { _ide: ide, project, _executor: executor }
     }

--- a/lib/rust/ensogl/pack/js/src/runner/index.ts
+++ b/lib/rust/ensogl/pack/js/src/runner/index.ts
@@ -426,9 +426,10 @@ export class App {
 
     /** Show a spinner. The displayed progress is constant. */
     showProgressIndicator(progress: number) {
-        if (this.progressIndicator == null) {
-            this.progressIndicator = new wasm.ProgressIndicator(this.config)
+        if (this.progressIndicator) {
+            this.hideProgressIndicator()
         }
+        this.progressIndicator = new wasm.ProgressIndicator(this.config)
         this.progressIndicator.set(progress)
     }
 


### PR DESCRIPTION
This reverts commit 341f1275e062e9621c6f8632cf7c5558be8a2f5e. The revert is due that spinner breaks project opening using new dashboard. 

New PR with fixed feature should be QA using new dashboard which can be enabled with `-authentication` and `-feature-preview.new-dashboard` flags

@Procrat 

### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
