### PR TITLE
sbt runEngineDistribution --debug to ease debuggging

### DIFF
--- a/project/DistributionPackage.scala
+++ b/project/DistributionPackage.scala
@@ -7,6 +7,8 @@ import sbt.util.{CacheStore, CacheStoreFactory, FileInfo, Tracked}
 
 import scala.sys.process._
 
+import org.enso.build.WithDebugCommand
+
 object DistributionPackage {
 
   /** File extensions. */
@@ -263,6 +265,10 @@ object DistributionPackage {
     all.add(enso.getAbsolutePath())
     all.addAll(args.asJava)
     pb.command(all)
+    if (args.contains("--debug")) {
+      all.remove("--debug")
+      pb.environment().put("JAVA_OPTS", WithDebugCommand.DEBUG_OPTION)
+    }
     pb.inheritIO()
     val p        = pb.start()
     val exitCode = p.waitFor()

--- a/project/WithDebugCommand.scala
+++ b/project/WithDebugCommand.scala
@@ -15,6 +15,8 @@ import sbt._
   * }}}
   */
 object WithDebugCommand {
+  val DEBUG_OPTION =
+    "-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5005,suspend=y";
 
   val truffleNoBackgroundCompilationOptions = Seq(
     "-Dpolyglot.engine.BackgroundCompilation=false"
@@ -78,9 +80,7 @@ object WithDebugCommand {
         else Seq()
       val debuggerOpts =
         if (debugFlags.contains(debuggerOption))
-          Seq(
-            "-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5005,suspend=y"
-          )
+          Seq(DEBUG_OPTION)
         else Seq()
       val javaOpts: Seq[String] = Seq(
         truffleNoBackgroundCompilationOptions,


### PR DESCRIPTION
### Pull Request Description

Adding `--debug` parameter to `runEngineDistribution` to allow debugging of the engine from inside of `sbt`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
- All code has been tested:
  - [x] Manual check in VSCode worked
