### PR TITLE
Infrastructure for debugging async tasks

### DIFF
--- a/app/gui/src/controller/graph/widget.rs
+++ b/app/gui/src/controller/graph/widget.rs
@@ -112,13 +112,18 @@ impl Controller {
 
         let out_widget_data = output.widget_data.clone_ref();
         let weak = Rc::downgrade(&model);
-        spawn_stream_handler(weak, manager_notifications, move |notification, model| {
-            let data = model.borrow_mut().handle_notification(notification);
-            if let Some(data) = data {
-                out_widget_data.emit(data);
-            }
-            std::future::ready(())
-        });
+        spawn_stream_handler(
+            "widget notifications",
+            weak,
+            manager_notifications,
+            move |notification, model| {
+                let data = model.borrow_mut().handle_notification(notification);
+                if let Some(data) = data {
+                    out_widget_data.emit(data);
+                }
+                std::future::ready(())
+            },
+        );
 
         Self { frp, model }
     }

--- a/app/gui/src/controller/ide.rs
+++ b/app/gui/src/controller/ide.rs
@@ -59,7 +59,7 @@ impl StatusNotificationPublisher {
     pub fn publish_event(&self, label: impl Into<String>) {
         let label = label.into();
         let notification = StatusNotification::Event { label };
-        executor::global::spawn(self.publisher.publish(notification));
+        executor::global::spawn("publish_event", self.publisher.publish(notification));
     }
 
     /// Publish a notification about new process (see [`StatusNotification::ProcessStarted`]).
@@ -71,7 +71,7 @@ impl StatusNotificationPublisher {
         let handle = self.next_process_handle.get();
         self.next_process_handle.set(handle + 1);
         let notification = StatusNotification::BackgroundTaskStarted { label, handle };
-        executor::global::spawn(self.publisher.publish(notification));
+        executor::global::spawn("publish_background_task", self.publisher.publish(notification));
         handle
     }
 
@@ -80,7 +80,7 @@ impl StatusNotificationPublisher {
     #[profile(Debug)]
     pub fn published_background_task_finished(&self, handle: BackgroundTaskHandle) {
         let notification = StatusNotification::BackgroundTaskFinished { handle };
-        executor::global::spawn(self.publisher.publish(notification));
+        self.publisher.notify(notification);
     }
 
     /// The asynchronous stream of published notifications.

--- a/app/gui/src/controller/project.rs
+++ b/app/gui/src/controller/project.rs
@@ -201,7 +201,7 @@ impl Project {
         let status_notifier = self.status_notifications.clone_ref();
         let compiling_process = status_notifier.publish_background_task(COMPILING_STDLIB_LABEL);
         let execution_ready = graph.when_ready();
-        executor::global::spawn(async move {
+        executor::global::spawn("notify_about_compiling_process", async move {
             if execution_ready.await.is_some() {
                 status_notifier.published_background_task_finished(compiling_process);
             } else {

--- a/app/gui/src/controller/searcher.rs
+++ b/app/gui/src/controller/searcher.rs
@@ -566,7 +566,10 @@ impl Searcher {
             if let Actions::Loaded { list } = &data.actions {
                 debug!("Update filtering.");
                 list.update_filtering(filter.pattern);
-                executor::global::spawn(self.notifier.publish(Notification::NewActionList));
+                executor::global::spawn(
+                    "new_action_list",
+                    self.notifier.publish(Notification::NewActionList),
+                );
             }
         }
         Ok(())
@@ -683,7 +686,7 @@ impl Searcher {
                 match self.ide.manage_projects() {
                     Ok(_) => {
                         let ide = self.ide.clone_ref();
-                        executor::global::spawn(async move {
+                        executor::global::spawn("execute project management action", async move {
                             // We checked that manage_projects returns Some just a moment ago, so
                             // unwrapping is safe.
                             let manage_projects = ide.manage_projects().unwrap();
@@ -923,7 +926,10 @@ impl Searcher {
             self.gather_actions_from_engine(this_type, None);
             self.data.borrow_mut().actions = Actions::Loading;
         }
-        executor::global::spawn(self.notifier.publish(Notification::NewActionList));
+        executor::global::spawn(
+            "new_action_list",
+            self.notifier.publish(Notification::NewActionList),
+        );
     }
 
     /// Get the typename of "this" value for current completion context. Returns `Future`, as the
@@ -958,7 +964,7 @@ impl Searcher {
         let graph = self.graph.graph();
         let position = self.my_utf16_location().span.into();
         let this = self.clone_ref();
-        executor::global::spawn(async move {
+        executor::global::spawn("gather_actions_from_engine", async move {
             let this_type = this_type.await;
             let is_static = this_type.is_some().then_some(false);
             info!("Requesting new suggestion list. Type of `self` is {this_type:?}.");

--- a/app/gui/src/controller/upload.rs
+++ b/app/gui/src/controller/upload.rs
@@ -193,7 +193,7 @@ impl NodeFromDroppedFileHandler {
     ) -> FallibleResult {
         let node = self.graph.add_node(Self::new_node_info(&file, position))?;
         let this = self.clone_ref();
-        executor::global::spawn(async move {
+        executor::global::spawn("create_node_and_start_uploading", async move {
             if let Err(err) = this.upload_file(node, file).await {
                 error!("Error while uploading file: {err}");
                 this.update_metadata(node, |md| md.error = Some(err.to_string()));

--- a/app/gui/src/controller/visualization/manager.rs
+++ b/app/gui/src/controller/visualization/manager.rs
@@ -379,7 +379,7 @@ impl Manager {
             };
             Some(())
         };
-        spawn(async move {
+        spawn("synchronize visualization", async move {
             task.await;
         });
     }
@@ -400,11 +400,12 @@ impl Manager {
                 let visualization_id = new_visualization.id;
                 let status = Status::Attached(new_visualization);
                 self.update_status(target, status);
-                spawn(update_receiver.for_each(move |data| {
+                let task = update_receiver.for_each(move |data| {
                     let notification = Notification::ValueUpdate { target, visualization_id, data };
                     let _ = notifier.unbounded_send(notification);
                     ready(())
-                }))
+                });
+                spawn("attach_visualization", task);
             }
             Err(error) => {
                 // TODO [mwu]

--- a/app/gui/src/ide.rs
+++ b/app/gui/src/ide.rs
@@ -61,7 +61,7 @@ impl Ide {
     }
 
     fn init(self) -> Self {
-        executor::global::spawn(self.alive_log_sending_loop());
+        executor::global::spawn("alive_log_sending_loop", self.alive_log_sending_loop());
         self
     }
 

--- a/app/gui/src/ide/initializer.rs
+++ b/app/gui/src/ide/initializer.rs
@@ -165,7 +165,7 @@ impl Initializer {
         let transport = WebSocket::new_opened(endpoint).await?;
         let mut project_manager = project_manager::Client::new(transport);
         project_manager.set_timeout(std::time::Duration::from_secs(PROJECT_MANAGER_TIMEOUT_SEC));
-        executor::global::spawn(project_manager.runner());
+        executor::global::spawn("project_manager", project_manager.runner());
         Ok(Rc::new(project_manager))
     }
 }

--- a/app/gui/src/lib.rs
+++ b/app/gui/src/lib.rs
@@ -181,7 +181,7 @@ pub fn main() {
     let executor = executor::setup_global_executor();
     EXECUTOR.with(move |global_executor| global_executor.replace(Some(executor)));
     let initializer = Initializer::new(config);
-    executor::global::spawn(async move {
+    executor::global::spawn("ide start", async move {
         let ide = initializer.start().await;
         ensogl::system::web::document
             .get_element_by_id("loader")

--- a/app/gui/src/model/execution_context.rs
+++ b/app/gui/src/model/execution_context.rs
@@ -95,7 +95,7 @@ pub struct ComputedValueInfoRegistry {
 impl ComputedValueInfoRegistry {
     fn emit(&self, update: ComputedValueExpressions) {
         let future = self.updates.publish(update);
-        executor::global::spawn(future);
+        executor::global::spawn("ComputedValueInfoRegistry::emit", future);
     }
 
     /// Store the information from the given update received from the Language Server.

--- a/app/gui/src/model/execution_context/synchronized.rs
+++ b/app/gui/src/model/execution_context/synchronized.rs
@@ -150,7 +150,7 @@ impl ExecutionContext {
                 if !self.model.is_ready.replace(true) {
                     info!("Context {} Became ready", self.id);
                     let this = self.clone();
-                    executor::global::spawn(async move {
+                    executor::global::spawn("execution_context ready", async move {
                         this.load_component_groups().await;
                     });
                 },
@@ -354,7 +354,7 @@ impl Drop for ExecutionContext {
     fn drop(&mut self) {
         let id = self.id;
         let ls = self.language_server.clone_ref();
-        executor::global::spawn(async move {
+        executor::global::spawn("execution_context drop", async move {
             let result = ls.client.destroy_execution_context(&id).await;
             if result.is_err() {
                 error!("Error when destroying Execution Context: {result:?}.");

--- a/app/gui/src/presenter/graph.rs
+++ b/app/gui/src/presenter/graph.rs
@@ -824,20 +824,25 @@ impl Graph {
         use crate::controller::graph::Notification;
         let graph_notifications = self.model.controller.subscribe();
         let weak = Rc::downgrade(&self.model);
-        spawn_stream_handler(weak, graph_notifications, move |notification, _model| {
-            debug!("Received controller notification {notification:?}");
-            match notification {
-                executed::Notification::Graph(graph) => match graph {
-                    Notification::Invalidate => update_view.emit(()),
-                    Notification::PortsUpdate => update_view.emit(()),
-                },
-                executed::Notification::ComputedValueInfo(expressions) =>
-                    update_expressions.emit(expressions),
-                executed::Notification::EnteredStack(_)
-                | executed::Notification::ExitedStack(_) => update_view.emit(()),
-            }
-            std::future::ready(())
-        })
+        spawn_stream_handler(
+            "graph_presenter notifications",
+            weak,
+            graph_notifications,
+            move |notification, _model| {
+                debug!("Received controller notification {notification:?}");
+                match notification {
+                    executed::Notification::Graph(graph) => match graph {
+                        Notification::Invalidate => update_view.emit(()),
+                        Notification::PortsUpdate => update_view.emit(()),
+                    },
+                    executed::Notification::ComputedValueInfo(expressions) =>
+                        update_expressions.emit(expressions),
+                    executed::Notification::EnteredStack(_)
+                    | executed::Notification::ExitedStack(_) => update_view.emit(()),
+                }
+                std::future::ready(())
+            },
+        )
     }
 }
 

--- a/app/gui/src/presenter/searcher.rs
+++ b/app/gui/src/presenter/searcher.rs
@@ -358,12 +358,17 @@ impl Searcher {
 
         let weak_model = Rc::downgrade(&model);
         let notifications = model.controller.subscribe();
-        spawn_stream_handler(weak_model, notifications, move |notification, _| {
-            match notification {
-                Notification::NewActionList => action_list_changed.emit(()),
-            };
-            std::future::ready(())
-        });
+        spawn_stream_handler(
+            "searcher presenter notifications",
+            weak_model,
+            notifications,
+            move |notification, _| {
+                match notification {
+                    Notification::NewActionList => action_list_changed.emit(()),
+                };
+                std::future::ready(())
+            },
+        );
 
         Self { model, _network: network }
     }

--- a/app/gui/src/tests.rs
+++ b/app/gui/src/tests.rs
@@ -27,7 +27,7 @@ fn failure_to_open_project_is_reported() {
     let mut fixture = TestWithMockedTransport::set_up(&transport);
     fixture.run_test(async move {
         let project_manager = Rc::new(project_manager::Client::new(transport));
-        executor::global::spawn(project_manager.runner());
+        executor::global::spawn("project_manager", project_manager.runner());
         let name = ProjectName::new_unchecked(crate::constants::DEFAULT_PROJECT_NAME.to_owned());
         let project_to_open = ProjectToOpen::Name(name);
         let initializer =

--- a/app/gui/src/transport/web.rs
+++ b/app/gui/src/transport/web.rs
@@ -467,7 +467,7 @@ mod tests {
         }));
 
         // Spawn task to process events stream.
-        executor::global::spawn(handler);
+        executor::global::spawn("websockets handler", handler);
 
         // Close socket after some delay.
         web::sleep(Duration::from_secs(20)).await;

--- a/app/gui/tests/language_server.rs
+++ b/app/gui/tests/language_server.rs
@@ -260,7 +260,7 @@ async fn file_events() {
     let mut stream = client.events();
     let _executor = enso_executor::setup_global_executor();
 
-    executor::global::spawn(client.runner());
+    executor::global::spawn("client", client.runner());
 
     let client_id = uuid::Uuid::default();
     let session = client.init_protocol_connection(&client_id).await;

--- a/app/gui/tests/project_manager.rs
+++ b/app/gui/tests/project_manager.rs
@@ -29,7 +29,7 @@ mod tests {
         let client = Client::new(ws);
         let _executor = enso_executor::setup_global_executor();
 
-        executor::global::spawn(client.runner());
+        executor::global::spawn("client", client.runner());
 
         let name = ProjectName::new_unchecked("TestProject");
         let creation = client.create_project(&name, &None, &None, &Install);

--- a/lib/rust/executor/Cargo.toml
+++ b/lib/rust/executor/Cargo.toml
@@ -10,3 +10,9 @@ futures = { version = "0.3.1" }
 enso-prelude = { path = "../prelude" }
 ensogl-core = { path = "../ensogl/core" }
 enso-profiler = { path = "../profiler" }
+
+[features]
+# Uncommend the next line to enable debug logging for running async tasks.
+# See crate documentation to learn more.
+# default = ["debug"]
+debug = []

--- a/lib/rust/executor/src/test_utils.rs
+++ b/lib/rust/executor/src/test_utils.rs
@@ -38,7 +38,7 @@ impl TestWithLocalPoolExecutor {
     where Task: Future<Output = ()> + 'static {
         self.running_task_count.set(self.running_task_count.get() + 1);
         let running_tasks_clone = self.running_task_count.clone_ref();
-        spawn(async move {
+        spawn("TestWithLocalPoolExecutor::run_task", async move {
             task.await;
             running_tasks_clone.set(running_tasks_clone.get() - 1);
         });

--- a/lib/rust/notification/src/lib.rs
+++ b/lib/rust/notification/src/lib.rs
@@ -76,6 +76,6 @@ where
     /// Use global executor to publish a message.
     pub fn notify(&self, message: Message) {
         let notify = self.publish(message);
-        executor::global::spawn(notify);
+        executor::global::spawn("notify", notify);
     }
 }


### PR DESCRIPTION
### Pull Request Description

This code adds simple infrastructure for debugging asynchronous tasks running on our global executor. When the `enso-executor/debug` feature is enabled, the executor logs each task's start and finish and preserves a list of currently running tasks in a HashMap. 

I wrote this code while working on an investigation in #6321.

`executor::global::spawn` and `executor::global::spawn_stream_handler` require an additional parameter - the name of the task that will be logged - when the `debug` feature is enabled.


https://github.com/enso-org/enso/assets/6566674/68c9bc1d-ba26-4cb5-b0ef-4c38ae69f2c0



### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
