### PR TITLE
Only send suggestions updates when type changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -756,6 +756,7 @@
 - [Warning.get_all returns only unique warnings][6372]
 - [Reimplement `enso_project` as a proper builtin][6352]
 - [Limit number of reported warnings per value][6577]
+- [Suggestions are updated only when the type of the expression changes][6755]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -866,6 +867,7 @@
 [6372]: https://github.com/enso-org/enso/pull/6372
 [6352]: https://github.com/enso-org/enso/pull/6352
 [6577]: https://github.com/enso-org/enso/pull/6577
+[6755]: https://github.com/enso-org/enso/pull/6755
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/search/SuggestionsHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/search/SuggestionsHandler.scala
@@ -265,6 +265,7 @@ final class SuggestionsHandler(
         updates.map(u => (u.expressionId, u.expressionType))
       )
       val types = updates.toSeq
+        .filter(_.typeChanged)
         .flatMap(update => update.expressionType.map(update.expressionId -> _))
       suggestionsRepo
         .updateAll(types)

--- a/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
@@ -64,6 +64,7 @@ class ContextEventsListenerSpec
               Some(methodPointer),
               Vector(),
               false,
+              true,
               Api.ExpressionUpdate.Payload.Value()
             )
           )
@@ -100,6 +101,7 @@ class ContextEventsListenerSpec
               None,
               Vector(),
               false,
+              true,
               Api.ExpressionUpdate.Payload.DataflowError(
                 Seq(Suggestions.function.externalId.get)
               )
@@ -139,6 +141,7 @@ class ContextEventsListenerSpec
               None,
               Vector(),
               false,
+              false,
               Api.ExpressionUpdate.Payload.Panic("Method failure", Seq())
             )
           )
@@ -177,6 +180,7 @@ class ContextEventsListenerSpec
             None,
             Vector(),
             false,
+            false,
             Api.ExpressionUpdate.Payload.Value()
           )
         )
@@ -190,6 +194,7 @@ class ContextEventsListenerSpec
             None,
             None,
             Vector(),
+            false,
             false,
             Api.ExpressionUpdate.Payload.Value()
           )

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -375,6 +375,7 @@ object Runtime {
       methodCall: Option[MethodPointer],
       profilingInfo: Vector[ProfilingInfo],
       fromCache: Boolean,
+      typeChanged: Boolean,
       payload: ExpressionUpdate.Payload
     )
     object ExpressionUpdate {

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -367,6 +367,8 @@ object Runtime {
       * expression
       * @param fromCache whether or not the value for this expression came
       * from the cache
+      * @param typeChanged whether or not the type of the value or method definition
+      * has changed from the one that was cached, if any
       * @param payload an extra information about the computed value
       */
     case class ExpressionUpdate(

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
@@ -1363,7 +1363,9 @@ class RuntimeErrorsTest
         Api.ExpressionUpdate.Payload.Panic(
           "MyError2",
           Seq(xId)
-        )
+        ),
+        builtin     = false,
+        typeChanged = false
       ),
       TestMessages.panic(
         contextId,
@@ -1371,7 +1373,9 @@ class RuntimeErrorsTest
         Api.ExpressionUpdate.Payload.Panic(
           "MyError2",
           Seq(xId)
-        )
+        ),
+        builtin     = false,
+        typeChanged = false
       ),
       TestMessages.panic(
         contextId,
@@ -1379,7 +1383,9 @@ class RuntimeErrorsTest
         Api.ExpressionUpdate.Payload.Panic(
           "MyError2",
           Seq(xId)
-        )
+        ),
+        builtin     = false,
+        typeChanged = false
       ),
       context.executionComplete(contextId)
     )
@@ -1492,10 +1498,14 @@ class RuntimeErrorsTest
         contextId,
         xId,
         ConstantsGen.INTEGER,
-        Api.MethodPointer(moduleName, moduleName, "foo")
+        Api.MethodPointer(moduleName, moduleName, "foo"),
+        fromCache   = false,
+        typeChanged = true
       ),
-      TestMessages.update(contextId, yId, ConstantsGen.INTEGER),
-      TestMessages.update(contextId, mainResId, ConstantsGen.NOTHING),
+      TestMessages
+        .update(contextId, yId, ConstantsGen.INTEGER, typeChanged = true),
+      TestMessages
+        .update(contextId, mainResId, ConstantsGen.NOTHING, typeChanged = true),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("3")
@@ -1667,9 +1677,12 @@ class RuntimeErrorsTest
         contextId,
         xId,
         ConstantsGen.INTEGER,
-        Api.MethodPointer(moduleName, moduleName, "foo")
+        Api.MethodPointer(moduleName, moduleName, "foo"),
+        fromCache   = false,
+        typeChanged = true
       ),
-      TestMessages.update(contextId, yId, ConstantsGen.INTEGER),
+      TestMessages
+        .update(contextId, yId, ConstantsGen.INTEGER, typeChanged = true),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("3")

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeExecutionEnvironmentTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeExecutionEnvironmentTest.scala
@@ -221,6 +221,7 @@ class RuntimeExecutionEnvironmentTest
               Some(IF_ENABLED_METH_PTR),
               Vector(Api.ProfilingInfo.ExecutionTime(0)),
               false,
+              true,
               Api.ExpressionUpdate.Payload.Value()
             )
           )
@@ -320,6 +321,7 @@ class RuntimeExecutionEnvironmentTest
               Some(IF_ENABLED_METH_PTR),
               Vector(Api.ProfilingInfo.ExecutionTime(0)),
               false,
+              true,
               Api.ExpressionUpdate.Payload.Value()
             )
           )

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -133,7 +133,11 @@ class RuntimeServerTest
 
       object Update {
 
-        def mainX(contextId: UUID, fromCache: Boolean = false): Api.Response =
+        def mainX(
+          contextId: UUID,
+          fromCache: Boolean   = false,
+          typeChanged: Boolean = true
+        ): Api.Response =
           Api.Response(
             Api.ExpressionUpdates(
               contextId,
@@ -144,6 +148,7 @@ class RuntimeServerTest
                   None,
                   Vector(Api.ProfilingInfo.ExecutionTime(0)),
                   fromCache,
+                  typeChanged,
                   Api.ExpressionUpdate.Payload.Value()
                 )
               )
@@ -157,6 +162,7 @@ class RuntimeServerTest
             None,
             Vector(),
             true,
+            false,
             Api.ExpressionUpdate.Payload.Pending(None, None)
           )
 
@@ -167,12 +173,14 @@ class RuntimeServerTest
             None,
             Vector(),
             true,
+            false,
             Api.ExpressionUpdate.Payload.Pending(None, None)
           )
 
         def mainY(
           contextId: UUID,
-          fromCache: Boolean = false
+          fromCache: Boolean   = false,
+          typeChanged: Boolean = true
         ): Api.Response =
           Api.Response(
             Api.ExpressionUpdates(
@@ -190,13 +198,18 @@ class RuntimeServerTest
                   ),
                   Vector(Api.ProfilingInfo.ExecutionTime(0)),
                   fromCache,
+                  typeChanged,
                   Api.ExpressionUpdate.Payload.Value()
                 )
               )
             )
           )
 
-        def mainZ(contextId: UUID, fromCache: Boolean = false): Api.Response =
+        def mainZ(
+          contextId: UUID,
+          fromCache: Boolean   = false,
+          typeChanged: Boolean = true
+        ): Api.Response =
           Api.Response(
             Api.ExpressionUpdates(
               contextId,
@@ -207,13 +220,18 @@ class RuntimeServerTest
                   None,
                   Vector(Api.ProfilingInfo.ExecutionTime(0)),
                   fromCache,
+                  typeChanged,
                   Api.ExpressionUpdate.Payload.Value()
                 )
               )
             )
           )
 
-        def fooY(contextId: UUID, fromCache: Boolean = false): Api.Response =
+        def fooY(
+          contextId: UUID,
+          fromCache: Boolean   = false,
+          typeChanged: Boolean = true
+        ): Api.Response =
           Api.Response(
             Api.ExpressionUpdates(
               contextId,
@@ -224,13 +242,18 @@ class RuntimeServerTest
                   None,
                   Vector(Api.ProfilingInfo.ExecutionTime(0)),
                   fromCache,
+                  typeChanged,
                   Api.ExpressionUpdate.Payload.Value()
                 )
               )
             )
           )
 
-        def fooZ(contextId: UUID, fromCache: Boolean = false): Api.Response =
+        def fooZ(
+          contextId: UUID,
+          fromCache: Boolean   = false,
+          typeChanged: Boolean = true
+        ): Api.Response =
           Api.Response(
             Api.ExpressionUpdates(
               contextId,
@@ -241,6 +264,7 @@ class RuntimeServerTest
                   None,
                   Vector(Api.ProfilingInfo.ExecutionTime(0)),
                   fromCache,
+                  typeChanged,
                   Api.ExpressionUpdate.Payload.Value()
                 )
               )
@@ -293,6 +317,7 @@ class RuntimeServerTest
                   ),
                   Vector(Api.ProfilingInfo.ExecutionTime(0)),
                   false,
+                  true,
                   Api.ExpressionUpdate.Payload.Value()
                 )
               )
@@ -316,6 +341,7 @@ class RuntimeServerTest
                   ),
                   Vector(Api.ProfilingInfo.ExecutionTime(0)),
                   false,
+                  true,
                   Api.ExpressionUpdate.Payload.Value()
                 )
               )
@@ -376,9 +402,9 @@ class RuntimeServerTest
     context.receiveNIgnoreStdLib(6) should contain theSameElementsAs Seq(
       Api.Response(Api.BackgroundJobsStartedNotification()),
       Api.Response(requestId, Api.PushContextResponse(contextId)),
-      context.Main.Update.mainX(contextId),
-      context.Main.Update.mainY(contextId),
-      context.Main.Update.mainZ(contextId),
+      context.Main.Update.mainX(contextId, typeChanged = true),
+      context.Main.Update.mainY(contextId, typeChanged = true),
+      context.Main.Update.mainZ(contextId, typeChanged = true),
       context.executionComplete(contextId)
     )
 
@@ -1157,8 +1183,10 @@ class RuntimeServerTest
     )
     context.receiveN(4) should contain theSameElementsAs Seq(
       TestMessages.pending(contextId, fooX, fooRes, mainFoo, mainRes),
-      TestMessages.update(contextId, fooX, ConstantsGen.INTEGER),
-      TestMessages.update(contextId, fooRes, ConstantsGen.INTEGER),
+      TestMessages
+        .update(contextId, fooX, ConstantsGen.INTEGER, typeChanged = false),
+      TestMessages
+        .update(contextId, fooRes, ConstantsGen.INTEGER, typeChanged = false),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("5")
@@ -1167,12 +1195,15 @@ class RuntimeServerTest
     context.send(Api.Request(requestId, Api.PopContextRequest(contextId)))
     context.receiveN(4) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PopContextResponse(contextId)),
-      TestMessages.update(contextId, mainRes, ConstantsGen.NOTHING),
+      TestMessages
+        .update(contextId, mainRes, ConstantsGen.NOTHING, typeChanged = false),
       TestMessages.update(
         contextId,
         mainFoo,
         ConstantsGen.INTEGER,
-        Api.MethodPointer(moduleName, moduleName, "foo")
+        Api.MethodPointer(moduleName, moduleName, "foo"),
+        fromCache   = false,
+        typeChanged = false
       ),
       context.executionComplete(contextId)
     )
@@ -1284,9 +1315,12 @@ class RuntimeServerTest
         contextId,
         mainFoo,
         ConstantsGen.INTEGER,
-        Api.MethodPointer(moduleName, moduleName, "foo")
+        Api.MethodPointer(moduleName, moduleName, "foo"),
+        fromCache   = false,
+        typeChanged = false
       ),
-      TestMessages.update(contextId, mainRes, ConstantsGen.NOTHING),
+      TestMessages
+        .update(contextId, mainRes, ConstantsGen.NOTHING, typeChanged = false),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("6")
@@ -1352,8 +1386,9 @@ class RuntimeServerTest
     context.send(Api.Request(requestId, Api.PopContextRequest(contextId)))
     context.receiveN(4) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PopContextResponse(contextId)),
-      TestMessages.update(contextId, idMain, ConstantsGen.INTEGER),
-      context.Main.Update.mainY(contextId, fromCache = true),
+      TestMessages
+        .update(contextId, idMain, ConstantsGen.INTEGER, typeChanged = false),
+      context.Main.Update.mainY(contextId, fromCache                 = true),
       context.executionComplete(contextId)
     )
 
@@ -1437,8 +1472,14 @@ class RuntimeServerTest
     context.receiveN(5) should contain theSameElementsAs Seq(
       TestMessages.pending(contextId, idResult, idPrintln, idMain),
       TestMessages.update(contextId, idResult, ConstantsGen.TEXT),
-      TestMessages.update(contextId, idPrintln, ConstantsGen.NOTHING),
-      TestMessages.update(contextId, idMain, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        idPrintln,
+        ConstantsGen.NOTHING,
+        typeChanged = false
+      ),
+      TestMessages
+        .update(contextId, idMain, ConstantsGen.NOTHING, typeChanged = false),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("Hi")
@@ -1536,8 +1577,10 @@ class RuntimeServerTest
         ConstantsGen.INTEGER,
         Api.MethodPointer(moduleName, ConstantsGen.NUMBER, "x")
       ),
-      TestMessages.update(contextId, idMainP, ConstantsGen.NOTHING),
-      TestMessages.update(contextId, idMain, ConstantsGen.NOTHING),
+      TestMessages
+        .update(contextId, idMainP, ConstantsGen.NOTHING, typeChanged = false),
+      TestMessages
+        .update(contextId, idMain, ConstantsGen.NOTHING, typeChanged = false),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("4")
@@ -1563,10 +1606,14 @@ class RuntimeServerTest
         contextId,
         idMainA,
         ConstantsGen.INTEGER,
-        Api.MethodPointer(moduleName, numberTypeName, "x")
+        Api.MethodPointer(moduleName, numberTypeName, "x"),
+        fromCache   = false,
+        typeChanged = false
       ),
-      TestMessages.update(contextId, idMainP, ConstantsGen.NOTHING),
-      TestMessages.update(contextId, idMain, ConstantsGen.NOTHING),
+      TestMessages
+        .update(contextId, idMainP, ConstantsGen.NOTHING, typeChanged = false),
+      TestMessages
+        .update(contextId, idMain, ConstantsGen.NOTHING, typeChanged = false),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("5")
@@ -1592,10 +1639,14 @@ class RuntimeServerTest
         contextId,
         idMainA,
         ConstantsGen.INTEGER,
-        Api.MethodPointer(moduleName, moduleName, "pie")
+        Api.MethodPointer(moduleName, moduleName, "pie"),
+        fromCache   = false,
+        typeChanged = true
       ),
-      TestMessages.update(contextId, idMainP, ConstantsGen.NOTHING),
-      TestMessages.update(contextId, idMain, ConstantsGen.NOTHING),
+      TestMessages
+        .update(contextId, idMainP, ConstantsGen.NOTHING, typeChanged = false),
+      TestMessages
+        .update(contextId, idMain, ConstantsGen.NOTHING, typeChanged = false),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("3")
@@ -1621,10 +1672,14 @@ class RuntimeServerTest
         contextId,
         idMainA,
         ConstantsGen.INTEGER,
-        Api.MethodPointer(moduleName, moduleName, "uwu")
+        Api.MethodPointer(moduleName, moduleName, "uwu"),
+        fromCache   = false,
+        typeChanged = true
       ),
-      TestMessages.update(contextId, idMainP, ConstantsGen.NOTHING),
-      TestMessages.update(contextId, idMain, ConstantsGen.NOTHING),
+      TestMessages
+        .update(contextId, idMainP, ConstantsGen.NOTHING, typeChanged = false),
+      TestMessages
+        .update(contextId, idMain, ConstantsGen.NOTHING, typeChanged = false),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("7")
@@ -1652,8 +1707,10 @@ class RuntimeServerTest
         ConstantsGen.TEXT,
         Api.MethodPointer(moduleName, moduleName, "hie")
       ),
-      TestMessages.update(contextId, idMainP, ConstantsGen.NOTHING),
-      TestMessages.update(contextId, idMain, ConstantsGen.NOTHING),
+      TestMessages
+        .update(contextId, idMainP, ConstantsGen.NOTHING, typeChanged = false),
+      TestMessages
+        .update(contextId, idMain, ConstantsGen.NOTHING, typeChanged = false),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("hie!")
@@ -1679,10 +1736,14 @@ class RuntimeServerTest
         contextId,
         idMainA,
         ConstantsGen.TEXT,
-        Api.MethodPointer(moduleName, moduleName, "hie")
+        Api.MethodPointer(moduleName, moduleName, "hie"),
+        fromCache   = false,
+        typeChanged = true
       ),
-      TestMessages.update(contextId, idMainP, ConstantsGen.NOTHING),
-      TestMessages.update(contextId, idMain, ConstantsGen.NOTHING),
+      TestMessages
+        .update(contextId, idMainP, ConstantsGen.NOTHING, typeChanged = false),
+      TestMessages
+        .update(contextId, idMain, ConstantsGen.NOTHING, typeChanged = false),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("Hello!")
@@ -1794,24 +1855,30 @@ class RuntimeServerTest
         id1,
         ConstantsGen.INTEGER,
         Api.MethodPointer(moduleName, ConstantsGen.NUMBER, "overloaded"),
-        fromCache = true
+        fromCache   = true,
+        typeChanged = true
       ),
       TestMessages.update(
         contextId,
         id2,
         ConstantsGen.INTEGER,
-        Api.MethodPointer(moduleName, ConstantsGen.TEXT, "overloaded")
+        Api.MethodPointer(moduleName, ConstantsGen.TEXT, "overloaded"),
+        fromCache   = false,
+        typeChanged = false
       ),
       TestMessages.update(
         contextId,
         id3,
         ConstantsGen.INTEGER,
-        Api.MethodPointer(moduleName, ConstantsGen.NUMBER, "overloaded")
+        Api.MethodPointer(moduleName, ConstantsGen.NUMBER, "overloaded"),
+        fromCache   = false,
+        typeChanged = false
       ),
       TestMessages.update(
         contextId,
         idMain,
-        ConstantsGen.NOTHING
+        ConstantsGen.NOTHING,
+        typeChanged = false
       ),
       context.executionComplete(contextId)
     )
@@ -1839,25 +1906,31 @@ class RuntimeServerTest
         contextId,
         id2,
         ConstantsGen.INTEGER,
-        Api.MethodPointer(moduleName, ConstantsGen.TEXT, "overloaded")
+        Api.MethodPointer(moduleName, ConstantsGen.TEXT, "overloaded"),
+        fromCache   = false,
+        typeChanged = false
       ),
       TestMessages.update(
         contextId,
         id3,
         ConstantsGen.INTEGER,
-        Api.MethodPointer(moduleName, ConstantsGen.NUMBER, "overloaded")
+        Api.MethodPointer(moduleName, ConstantsGen.NUMBER, "overloaded"),
+        fromCache   = false,
+        typeChanged = false
       ),
       TestMessages.update(
         contextId,
         idMain,
-        ConstantsGen.NOTHING
+        ConstantsGen.NOTHING,
+        typeChanged = false
       ),
       TestMessages.update(
         contextId,
         id1,
         ConstantsGen.INTEGER,
         Api.MethodPointer(moduleName, ConstantsGen.NUMBER, "overloaded"),
-        fromCache = true
+        fromCache   = true,
+        typeChanged = true
       ),
       context.executionComplete(contextId)
     )
@@ -1885,25 +1958,32 @@ class RuntimeServerTest
         contextId,
         id2,
         ConstantsGen.INTEGER,
-        Api.MethodPointer(moduleName, ConstantsGen.TEXT, "overloaded")
+        Api.MethodPointer(moduleName, ConstantsGen.TEXT, "overloaded"),
+        fromCache   = false,
+        typeChanged = false
       ),
       TestMessages.update(
         contextId,
         id3,
         ConstantsGen.INTEGER,
-        Api.MethodPointer(moduleName, ConstantsGen.NUMBER, "overloaded")
+        Api.MethodPointer(moduleName, ConstantsGen.NUMBER, "overloaded"),
+        fromCache   = false,
+        typeChanged = false
       ),
       TestMessages.update(
         contextId,
         idMain,
-        ConstantsGen.NOTHING
+        ConstantsGen.NOTHING,
+        fromCache   = false,
+        typeChanged = false
       ),
       TestMessages.update(
         contextId,
         id1,
         ConstantsGen.INTEGER,
         Api.MethodPointer(moduleName, ConstantsGen.NUMBER, "overloaded"),
-        fromCache = true
+        fromCache   = true,
+        typeChanged = true
       ),
       context.executionComplete(contextId)
     )
@@ -2229,7 +2309,12 @@ class RuntimeServerTest
     )
     context.receiveN(3) shouldEqual Seq(
       TestMessages.pending(contextId, idMain),
-      TestMessages.update(contextId, idMain, ConstantsGen.INTEGER_BUILTIN),
+      TestMessages.update(
+        contextId,
+        idMain,
+        ConstantsGen.INTEGER_BUILTIN,
+        typeChanged = false
+      ),
       context.executionComplete(contextId)
     )
   }
@@ -2289,8 +2374,10 @@ class RuntimeServerTest
     context.send(Api.Request(requestId, Api.PopContextRequest(contextId)))
     context.receiveN(4) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PopContextResponse(contextId)),
-      TestMessages.update(contextId, idMain, ConstantsGen.INTEGER),
-      context.Main.Update.mainY(contextId, fromCache = true),
+      TestMessages
+        .update(contextId, idMain, ConstantsGen.INTEGER, typeChanged = false),
+      context.Main.Update
+        .mainY(contextId, fromCache = true, typeChanged = true),
       context.executionComplete(contextId)
     )
 
@@ -2475,8 +2562,10 @@ class RuntimeServerTest
     context.receiveNIgnorePendingExpressionUpdates(
       3
     ) should contain theSameElementsAs Seq(
-      TestMessages.update(contextId, idText, ConstantsGen.TEXT),
-      TestMessages.update(contextId, idRes, ConstantsGen.NOTHING),
+      TestMessages
+        .update(contextId, idText, ConstantsGen.TEXT, typeChanged = false),
+      TestMessages
+        .update(contextId, idRes, ConstantsGen.NOTHING, typeChanged = false),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List(prompt2)
@@ -2592,9 +2681,9 @@ class RuntimeServerTest
         context.Main.idFooY,
         context.Main.idFooZ
       ),
-      context.Main.Update.mainX(contextId),
-      context.Main.Update.mainY(contextId),
-      context.Main.Update.mainZ(contextId),
+      context.Main.Update.mainX(contextId, typeChanged = false),
+      context.Main.Update.mainY(contextId, typeChanged = false),
+      context.Main.Update.mainZ(contextId, typeChanged = false),
       context.executionComplete(contextId)
     )
   }
@@ -2652,7 +2741,7 @@ class RuntimeServerTest
     context.receiveN(4) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.RecomputeContextResponse(contextId)),
       TestMessages.pending(contextId, context.Main.idMainZ),
-      context.Main.Update.mainZ(contextId),
+      context.Main.Update.mainZ(contextId, typeChanged = false),
       context.executionComplete(contextId)
     )
   }
@@ -2718,9 +2807,9 @@ class RuntimeServerTest
         context.Main.idFooY,
         context.Main.idFooZ
       ),
-      context.Main.Update.mainX(contextId),
-      context.Main.Update.mainY(contextId),
-      context.Main.Update.mainZ(contextId),
+      context.Main.Update.mainX(contextId, typeChanged = false),
+      context.Main.Update.mainY(contextId, typeChanged = false),
+      context.Main.Update.mainZ(contextId, typeChanged = false),
       context.executionComplete(contextId)
     )
     context.languageContext.getExecutionEnvironment.getName shouldEqual Api.ExecutionEnvironment
@@ -4142,14 +4231,16 @@ class RuntimeServerTest
     val renameProjectResponses = context.receiveN(6)
     renameProjectResponses should contain allOf (
       Api.Response(requestId, Api.ProjectRenamed("Enso_Test", "Foo")),
-      context.Main.Update.mainX(contextId),
+      context.Main.Update.mainX(contextId, typeChanged = false),
       TestMessages.update(
         contextId,
         context.Main.idMainY,
         ConstantsGen.INTEGER,
-        Api.MethodPointer("Enso_Test.Foo.Main", ConstantsGen.NUMBER, "foo")
+        Api.MethodPointer("Enso_Test.Foo.Main", ConstantsGen.NUMBER, "foo"),
+        fromCache   = false,
+        typeChanged = true
       ),
-      context.Main.Update.mainZ(contextId),
+      context.Main.Update.mainZ(contextId, typeChanged = false),
       context.executionComplete(contextId)
     )
     renameProjectResponses.collect {
@@ -4193,14 +4284,16 @@ class RuntimeServerTest
         context.Main.idFooY,
         context.Main.idFooZ
       ),
-      context.Main.Update.mainX(contextId),
+      context.Main.Update.mainX(contextId, typeChanged = false),
       TestMessages.update(
         contextId,
         context.Main.idMainY,
         ConstantsGen.INTEGER,
-        Api.MethodPointer("Enso_Test.Foo.Main", ConstantsGen.NUMBER, "foo")
+        Api.MethodPointer("Enso_Test.Foo.Main", ConstantsGen.NUMBER, "foo"),
+        fromCache   = false,
+        typeChanged = false
       ),
-      context.Main.Update.mainZ(contextId),
+      context.Main.Update.mainZ(contextId, typeChanged = false),
       context.executionComplete(contextId)
     )
   }
@@ -4250,14 +4343,16 @@ class RuntimeServerTest
     val renameProjectResponses = context.receiveN(6)
     renameProjectResponses should contain allOf (
       Api.Response(requestId, Api.ProjectRenamed("Enso_Test", "Foo")),
-      context.Main.Update.mainX(contextId),
+      context.Main.Update.mainX(contextId, typeChanged = false),
       TestMessages.update(
         contextId,
         context.Main.idMainY,
         ConstantsGen.INTEGER,
-        Api.MethodPointer("Enso_Test.Foo.Main", ConstantsGen.NUMBER, "foo")
+        Api.MethodPointer("Enso_Test.Foo.Main", ConstantsGen.NUMBER, "foo"),
+        fromCache   = false,
+        typeChanged = true
       ),
-      context.Main.Update.mainZ(contextId),
+      context.Main.Update.mainZ(contextId, typeChanged = false),
       context.executionComplete(contextId)
     )
     renameProjectResponses.collect {
@@ -4292,7 +4387,8 @@ class RuntimeServerTest
         context.Main.idMainY,
         ConstantsGen.INTEGER,
         Api.MethodPointer("Enso_Test.Foo.Main", ConstantsGen.NUMBER, "foo"),
-        fromCache = true
+        fromCache   = true,
+        typeChanged = true
       ),
       context.executionComplete(contextId)
     )
@@ -4647,9 +4743,15 @@ class RuntimeServerTest
         y,
         ConstantsGen.INTEGER_BUILTIN,
         Api.MethodPointer(moduleName, moduleName, "inc"),
-        fromCache = true
+        fromCache   = true,
+        typeChanged = true
       ),
-      TestMessages.update(contextId, res, ConstantsGen.INTEGER_BUILTIN),
+      TestMessages.update(
+        contextId,
+        res,
+        ConstantsGen.INTEGER_BUILTIN,
+        typeChanged = false
+      ),
       context.executionComplete(contextId)
     )
 
@@ -4683,7 +4785,12 @@ class RuntimeServerTest
     )
     context.receiveN(3) should contain theSameElementsAs Seq(
       TestMessages.pending(contextId, `inc_res`, `y_inc`, y, res),
-      TestMessages.update(contextId, `inc_res`, ConstantsGen.INTEGER_BUILTIN),
+      TestMessages.update(
+        contextId,
+        `inc_res`,
+        ConstantsGen.INTEGER_BUILTIN,
+        typeChanged = false
+      ),
       context.executionComplete(contextId)
     )
 
@@ -4691,15 +4798,32 @@ class RuntimeServerTest
     context.send(Api.Request(requestId, Api.PopContextRequest(contextId)))
     context.receiveN(6) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PopContextResponse(contextId)),
-      TestMessages.update(contextId, `y_inc`, Constants.UNRESOLVED_SYMBOL),
-      TestMessages.update(contextId, `y_x`, ConstantsGen.INTEGER_BUILTIN),
+      TestMessages.update(
+        contextId,
+        `y_inc`,
+        Constants.UNRESOLVED_SYMBOL,
+        typeChanged = false
+      ),
+      TestMessages.update(
+        contextId,
+        `y_x`,
+        ConstantsGen.INTEGER_BUILTIN,
+        typeChanged = false
+      ),
       TestMessages.update(
         contextId,
         y,
         ConstantsGen.INTEGER_BUILTIN,
-        Api.MethodPointer(moduleName, moduleName, "inc")
+        Api.MethodPointer(moduleName, moduleName, "inc"),
+        fromCache   = false,
+        typeChanged = false
       ),
-      TestMessages.update(contextId, res, ConstantsGen.INTEGER_BUILTIN),
+      TestMessages.update(
+        contextId,
+        res,
+        ConstantsGen.INTEGER_BUILTIN,
+        typeChanged = false
+      ),
       context.executionComplete(contextId)
     )
   }
@@ -4771,7 +4895,8 @@ class RuntimeServerTest
     )
     context.receiveNIgnoreStdLib(3) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.SetExecutionEnvironmentResponse(contextId)),
-      TestMessages.update(contextId, idX, ConstantsGen.TEXT),
+      TestMessages
+        .update(contextId, idX, ConstantsGen.TEXT, typeChanged = false),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("Hello World!")

--- a/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -123,7 +123,11 @@ class RuntimeVisualizationsTest
 
       object Update {
 
-        def mainX(contextId: UUID, fromCache: Boolean = false): Api.Response =
+        def mainX(
+          contextId: UUID,
+          fromCache: Boolean   = false,
+          typeChanged: Boolean = true
+        ): Api.Response =
           Api.Response(
             Api.ExpressionUpdates(
               contextId,
@@ -134,13 +138,18 @@ class RuntimeVisualizationsTest
                   None,
                   Vector(Api.ProfilingInfo.ExecutionTime(0)),
                   fromCache,
+                  typeChanged,
                   Api.ExpressionUpdate.Payload.Value()
                 )
               )
             )
           )
 
-        def mainY(contextId: UUID, fromCache: Boolean = false): Api.Response =
+        def mainY(
+          contextId: UUID,
+          fromCache: Boolean   = false,
+          typeChanged: Boolean = true
+        ): Api.Response =
           Api.Response(
             Api.ExpressionUpdates(
               contextId,
@@ -157,13 +166,18 @@ class RuntimeVisualizationsTest
                   ),
                   Vector(Api.ProfilingInfo.ExecutionTime(0)),
                   fromCache,
+                  typeChanged,
                   Api.ExpressionUpdate.Payload.Value()
                 )
               )
             )
           )
 
-        def mainZ(contextId: UUID, fromCache: Boolean = false): Api.Response =
+        def mainZ(
+          contextId: UUID,
+          fromCache: Boolean   = false,
+          typeChanged: Boolean = true
+        ): Api.Response =
           Api.Response(
             Api.ExpressionUpdates(
               contextId,
@@ -174,13 +188,18 @@ class RuntimeVisualizationsTest
                   None,
                   Vector(Api.ProfilingInfo.ExecutionTime(0)),
                   fromCache,
+                  typeChanged,
                   Api.ExpressionUpdate.Payload.Value()
                 )
               )
             )
           )
 
-        def fooY(contextId: UUID, fromCache: Boolean = false): Api.Response =
+        def fooY(
+          contextId: UUID,
+          fromCache: Boolean   = false,
+          typeChanged: Boolean = true
+        ): Api.Response =
           Api.Response(
             Api.ExpressionUpdates(
               contextId,
@@ -191,13 +210,18 @@ class RuntimeVisualizationsTest
                   None,
                   Vector(Api.ProfilingInfo.ExecutionTime(0)),
                   fromCache,
+                  typeChanged,
                   Api.ExpressionUpdate.Payload.Value()
                 )
               )
             )
           )
 
-        def fooZ(contextId: UUID, fromCache: Boolean = false): Api.Response =
+        def fooZ(
+          contextId: UUID,
+          fromCache: Boolean   = false,
+          typeChanged: Boolean = true
+        ): Api.Response =
           Api.Response(
             Api.ExpressionUpdates(
               contextId,
@@ -208,6 +232,7 @@ class RuntimeVisualizationsTest
                   None,
                   Vector(Api.ProfilingInfo.ExecutionTime(0)),
                   fromCache,
+                  typeChanged,
                   Api.ExpressionUpdate.Payload.Value()
                 )
               )
@@ -936,8 +961,18 @@ class RuntimeVisualizationsTest
 
     val editFileResponse = context.receiveNIgnorePendingExpressionUpdates(4)
     editFileResponse should contain allOf (
-      TestMessages.update(contextId, context.Main.idFooY, ConstantsGen.INTEGER),
-      TestMessages.update(contextId, context.Main.idFooZ, ConstantsGen.INTEGER),
+      TestMessages.update(
+        contextId,
+        context.Main.idFooY,
+        ConstantsGen.INTEGER,
+        typeChanged = false
+      ),
+      TestMessages.update(
+        contextId,
+        context.Main.idFooZ,
+        ConstantsGen.INTEGER,
+        typeChanged = false
+      ),
       context.executionComplete(contextId)
     )
     val Some(data3) = editFileResponse.collectFirst {
@@ -963,8 +998,8 @@ class RuntimeVisualizationsTest
     )
     popContextResponses should contain allOf (
       Api.Response(requestId, Api.PopContextResponse(contextId)),
-      context.Main.Update.mainY(contextId),
-      context.Main.Update.mainZ(contextId),
+      context.Main.Update.mainY(contextId, typeChanged = false),
+      context.Main.Update.mainZ(contextId, typeChanged = false),
       context.executionComplete(contextId)
     )
 
@@ -2128,7 +2163,9 @@ class RuntimeVisualizationsTest
       TestMessages.panic(
         contextId,
         idMain,
-        Api.ExpressionUpdate.Payload.Panic("42 (Integer)", Seq(idMain))
+        Api.ExpressionUpdate.Payload.Panic("42 (Integer)", Seq(idMain)),
+        builtin     = false,
+        typeChanged = false
       ),
       Api.Response(
         Api.VisualisationEvaluationFailed(

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
@@ -80,6 +80,7 @@ class RecomputeContextCmd(
           None,
           Vector.empty,
           true,
+          false,
           Api.ExpressionUpdate.Payload.Pending(None, None)
         )
       }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -339,6 +339,7 @@ final class EnsureCompiledJob(protected val files: Iterable[File])
         None,
         Vector.empty,
         true,
+        false,
         Api.ExpressionUpdate.Payload.Pending(None, None)
       )
     }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -386,6 +386,7 @@ object ProgramExecutionSupport {
                   Api.ProfilingInfo.ExecutionTime(e.getNanoTimeElapsed)
                 }.toVector,
                 value.wasCached(),
+                value.isTypeChanged() || value.isFunctionCallChanged(),
                 payload
               )
             )

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/TestMessages.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/TestMessages.scala
@@ -69,7 +69,8 @@ object TestMessages {
     * @param contextId an identifier of the context
     * @param expressionId an identifier of the expression
     * @param expressionType a type of the expression
-    * @param fromCache whether or not the value for this expression came
+    * @param fromCache whether or not the value for this expression came from cache
+    * @param typeChanged a flag indicating whether the the type of expression has changed
     * @param methodPointer method pointer
     * @param payload the update payload
     * @return the expression update response
@@ -124,6 +125,7 @@ object TestMessages {
     * @param methodPointer a pointer to the method definition
     * @param fromCache whether or not the value for this expression came
     * from the cache
+    * @param typeChanged a flag indicating whether the the type of expression has changed
     * @return the expression update response
     */
   def update(
@@ -202,6 +204,7 @@ object TestMessages {
     * @param methodPointer a pointer to the method definition
     * @param fromCache whether or not the value for this expression came
     * from the cache
+    * @param typeChanged a flag indicating whether the the type of expression has changed
     * @param payload the error payload
     * @return the expression update response
     */
@@ -229,6 +232,7 @@ object TestMessages {
     * @param methodPointerOpt a pointer to the method definition
     * @param fromCache whether or not the value for this expression came
     * from the cache
+    * @param typeChanged a flag indicating whether the the type of expression has changed
     * @param payload the error payload
     * @return the expression update response
     */
@@ -370,6 +374,7 @@ object TestMessages {
     * @param methodPointer a pointer to the method definition
     * @param payload the error payload
     * @param builtin a flag indicating what is the type of Panic (a builtin Panic type or stdlib Panic)
+    * @param typeChanged a flag indicating whether the the type of expression has changed
     * @return the expression update response
     */
   private def panicBuilder(

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/TestMessages.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/TestMessages.scala
@@ -28,6 +28,7 @@ object TestMessages {
             None,
             Vector(Api.ProfilingInfo.ExecutionTime(0)),
             false,
+            true,
             Api.ExpressionUpdate.Payload.Value()
           )
         )
@@ -56,6 +57,7 @@ object TestMessages {
             None,
             Vector(Api.ProfilingInfo.ExecutionTime(0)),
             false,
+            true,
             Api.ExpressionUpdate.Payload.Value()
           )
         )
@@ -77,6 +79,7 @@ object TestMessages {
     expressionId: UUID,
     expressionType: String,
     fromCache: Boolean                       = false,
+    typeChanged: Boolean                     = true,
     methodPointer: Option[Api.MethodPointer] = None,
     payload: Api.ExpressionUpdate.Payload    = Api.ExpressionUpdate.Payload.Value()
   ): Api.Response =
@@ -90,6 +93,7 @@ object TestMessages {
             methodPointer,
             Vector(Api.ProfilingInfo.ExecutionTime(0)),
             fromCache,
+            typeChanged,
             payload
           )
         )
@@ -110,7 +114,7 @@ object TestMessages {
     expressionType: String,
     methodPointer: Api.MethodPointer
   ): Api.Response =
-    update(contextId, expressionId, expressionType, methodPointer, false)
+    update(contextId, expressionId, expressionType, methodPointer, false, true)
 
   /** Create an update response.
     *
@@ -127,7 +131,8 @@ object TestMessages {
     expressionId: UUID,
     expressionType: String,
     methodPointer: Api.MethodPointer,
-    fromCache: Boolean
+    fromCache: Boolean,
+    typeChanged: Boolean
   ): Api.Response =
     Api.Response(
       Api.ExpressionUpdates(
@@ -139,6 +144,7 @@ object TestMessages {
             Some(methodPointer),
             Vector(Api.ProfilingInfo.ExecutionTime(0)),
             fromCache,
+            typeChanged,
             Api.ExpressionUpdate.Payload.Value()
           )
         )
@@ -162,6 +168,7 @@ object TestMessages {
       expressionId,
       None,
       false,
+      true,
       payload
     )
 
@@ -184,6 +191,7 @@ object TestMessages {
       expressionId,
       methodPointer,
       false,
+      true,
       payload
     )
 
@@ -202,6 +210,7 @@ object TestMessages {
     expressionId: UUID,
     methodPointer: Api.MethodPointer,
     fromCache: Boolean,
+    typeChanged: Boolean,
     payload: Api.ExpressionUpdate.Payload
   ): Api.Response =
     errorBuilder(
@@ -209,6 +218,7 @@ object TestMessages {
       expressionId,
       Some(methodPointer),
       fromCache,
+      typeChanged,
       payload
     )
 
@@ -227,6 +237,7 @@ object TestMessages {
     expressionId: UUID,
     methodPointerOpt: Option[Api.MethodPointer],
     fromCache: Boolean,
+    typeChanged: Boolean,
     payload: Api.ExpressionUpdate.Payload
   ): Api.Response =
     Api.Response(
@@ -239,6 +250,7 @@ object TestMessages {
             methodPointerOpt,
             Vector(Api.ProfilingInfo.ExecutionTime(0)),
             fromCache,
+            typeChanged,
             payload
           )
         )
@@ -257,7 +269,7 @@ object TestMessages {
     expressionId: UUID,
     payload: Api.ExpressionUpdate.Payload
   ): Api.Response =
-    panicBuilder(contextId, expressionId, None, payload, false)
+    panicBuilder(contextId, expressionId, None, payload, false, true)
 
   /** Create a panic update response.
     *
@@ -273,7 +285,16 @@ object TestMessages {
     payload: Api.ExpressionUpdate.Payload,
     builtin: Boolean
   ): Api.Response =
-    panicBuilder(contextId, expressionId, None, payload, builtin)
+    panicBuilder(contextId, expressionId, None, payload, builtin, true)
+
+  def panic(
+    contextId: UUID,
+    expressionId: UUID,
+    payload: Api.ExpressionUpdate.Payload,
+    builtin: Boolean,
+    typeChanged: Boolean
+  ): Api.Response =
+    panicBuilder(contextId, expressionId, None, payload, builtin, typeChanged)
 
   /** Create a panic update response.
     *
@@ -291,7 +312,14 @@ object TestMessages {
     payload: Api.ExpressionUpdate.Payload,
     builtin: Boolean
   ): Api.Response =
-    panicBuilder(contextId, expressionId, Some(methodPointer), payload, builtin)
+    panicBuilder(
+      contextId,
+      expressionId,
+      Some(methodPointer),
+      payload,
+      builtin,
+      true
+    )
 
   /** Create a panic update response.
     *
@@ -309,7 +337,31 @@ object TestMessages {
     payload: Api.ExpressionUpdate.Payload,
     builtin: Option[String]
   ): Api.Response =
-    panicBuilder(contextId, expressionId, Some(methodPointer), payload, builtin)
+    panicBuilder(
+      contextId,
+      expressionId,
+      Some(methodPointer),
+      payload,
+      builtin,
+      true
+    )
+
+  def panic(
+    contextId: UUID,
+    expressionId: UUID,
+    methodPointer: Api.MethodPointer,
+    payload: Api.ExpressionUpdate.Payload,
+    builtin: Option[String],
+    typeChanged: Boolean
+  ): Api.Response =
+    panicBuilder(
+      contextId,
+      expressionId,
+      Some(methodPointer),
+      payload,
+      builtin,
+      typeChanged
+    )
 
   /** Create a panic update response.
     *
@@ -325,7 +377,8 @@ object TestMessages {
     expressionId: UUID,
     methodPointer: Option[Api.MethodPointer],
     payload: Api.ExpressionUpdate.Payload,
-    builtin: Boolean
+    builtin: Boolean,
+    typeChanged: Boolean
   ): Api.Response = panicBuilder(
     contextId,
     expressionId,
@@ -333,7 +386,8 @@ object TestMessages {
     payload,
     Some(
       if (builtin) ConstantsGen.PANIC_BUILTIN else ConstantsGen.PANIC
-    )
+    ),
+    typeChanged
   )
 
   private def panicBuilder(
@@ -341,7 +395,8 @@ object TestMessages {
     expressionId: UUID,
     methodPointer: Option[Api.MethodPointer],
     payload: Api.ExpressionUpdate.Payload,
-    builtin: Option[String]
+    builtin: Option[String],
+    typeChanged: Boolean
   ): Api.Response =
     Api.Response(
       Api.ExpressionUpdates(
@@ -353,6 +408,7 @@ object TestMessages {
             methodPointer,
             Vector(Api.ProfilingInfo.ExecutionTime(0)),
             false,
+            typeChanged,
             payload
           )
         )
@@ -379,6 +435,7 @@ object TestMessages {
             None,
             Vector(),
             true,
+            false,
             Api.ExpressionUpdate.Payload.Pending(None, None)
           )
         }


### PR DESCRIPTION
### Pull Request Description

The change adds an additional field to `ExpressionUpdates` messages sent by `ProgramExecutionSupport` to indicate if the type of value (or its method pointer) has changed and therefore would potentially require a suggestions' update.

Prior to #3729 that check was done during the instrumentation. However we still want to continue to support "pending expression" functionality therefore `SuggestionsHandler` will use the additional information to filter only the required expression updates.

Most of the changes are related to adapting our tests to the new field.

Closes #6706.

### Important Notes

The associated project now loads and navigates smoothly. 
Also attaching a screenshot from the project that illustrates that pending functionality continues to work:
[Kazam_screencast_00006.webm](https://github.com/enso-org/enso/assets/292128/35918841-f84f-4e1c-b1b0-40e45d97e111)


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- ~[ ] The documentation has been updated, if necessary.~
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
