### PR TITLE
Only initialise visualisation chooser if it is used.

### DIFF
--- a/app/gui/view/graph-editor/src/component/visualization/container.rs
+++ b/app/gui/view/graph-editor/src/component/visualization/container.rs
@@ -569,10 +569,8 @@ impl Container {
             selected_definition <- action_bar.visualisation_selection.map(f!([registry](path)
                 path.as_ref().and_then(|path| registry.definition_from_path(path))
             ));
-            action_bar.hide_icons <+ selected_definition.constant(());
+            action_bar.set_vis_input_type <+ frp.set_vis_input_type;
             frp.source.vis_input_type <+ frp.set_vis_input_type;
-            let chooser = &model.action_bar.visualization_chooser();
-            chooser.frp.set_vis_input_type <+ frp.set_vis_input_type;
         }
 
 

--- a/app/gui/view/graph-editor/src/component/visualization/container/action_bar.rs
+++ b/app/gui/view/graph-editor/src/component/visualization/container/action_bar.rs
@@ -389,7 +389,7 @@ impl ActionBar {
 
             mouse_out_no_menu <- any_component_out.gate_not(&visualization_chooser.menu_visible);
             remote_click      <- visualization_chooser.menu_closed.gate_not(&any_hovered);
-            hide              <- any(mouse_out_no_menu,remote_click,on_selection);
+            hide              <- any(mouse_out_no_menu,remote_click, on_selection);
             eval_ hide (model.hide());
 
 

--- a/app/gui/view/graph-editor/src/component/visualization/container/action_bar.rs
+++ b/app/gui/view/graph-editor/src/component/visualization/container/action_bar.rs
@@ -414,7 +414,10 @@ impl ActionBar {
            // === Visualisation Chooser ===
 
             // Note: we only want to update the chooser if it is visible, or when it becomes
-            // visible. Thus we avoid many simultaneous updates during initialisation.
+            // visible. During startup we get the type information for every node, and propagate
+            // this information to the chooser. By delaying the creation of UI list elements until
+            // the chooser is visible, we can avoid creating a lot of UI elements that are never
+            // used.
 
             visible <- any(&frp.show_icons, &any_component_over);
             hidden <- any(&frp.hide_icons, &hide);

--- a/app/gui/view/graph-editor/src/component/visualization/container/action_bar.rs
+++ b/app/gui/view/graph-editor/src/component/visualization/container/action_bar.rs
@@ -373,8 +373,7 @@ impl ActionBar {
             eval_ frp.show_icons ( model.show() );
 
             visualization_chooser.input.set_selected <+ frp.input.set_selected_visualization;
-            frp.source.visualisation_selection <+ visualization_chooser.chosen_entry;
-            on_selection <- visualization_chooser.chosen_entry.constant(());
+
 
             // === Mouse Interactions ===
 
@@ -389,9 +388,14 @@ impl ActionBar {
 
             mouse_out_no_menu <- any_component_out.gate_not(&visualization_chooser.menu_visible);
             remote_click      <- visualization_chooser.menu_closed.gate_not(&any_hovered);
-            hide              <- any(mouse_out_no_menu,remote_click, on_selection);
+            hide              <- any(mouse_out_no_menu,remote_click);
             eval_ hide (model.hide());
 
+            // The action bar does not allow to deselect the visualisation, so we prohibit these
+            // events, which can occur on re-initialization.
+            has_selection <- visualization_chooser.chosen_entry.is_some();
+            frp.source.visualisation_selection
+                <+ visualization_chooser.chosen_entry.gate(&has_selection);
 
             let reset_position_icon = &model.icons.reset_position_icon.events_deprecated;
             let reset_position_icon_down = reset_position_icon.mouse_down_primary.clone_ref();


### PR DESCRIPTION
### Pull Request Description

Re-introduce a feature that was removed with #6638: only initialize visualization choosers when they are visible. This avoids initializing lots of invisible UI elements at the same time when opening a project.  


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
