### PR TITLE
Set suggestion reexports when serializing the library

### DIFF
--- a/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
@@ -535,6 +535,13 @@ class SuggestionsHandlerSpec
             ),
             Tree.Node(
               Api.SuggestionUpdate(
+                Suggestions.tpe,
+                Api.SuggestionAction.Add()
+              ),
+              Vector()
+            ),
+            Tree.Node(
+              Api.SuggestionUpdate(
                 Suggestions.constructor,
                 Api.SuggestionAction.Add()
               ),
@@ -599,6 +606,10 @@ class SuggestionsHandlerSpec
                   Suggestions.module.module
                 ),
                 ExportedSymbol.Type(
+                  Suggestions.tpe.module,
+                  Suggestions.tpe.name
+                ),
+                ExportedSymbol.Constructor(
                   Suggestions.constructor.module,
                   Suggestions.constructor.name
                 ),
@@ -618,7 +629,7 @@ class SuggestionsHandlerSpec
           Tree.Root(Vector())
         )
 
-        val updates2 = Seq(1L, 2L, 3L).map { id =>
+        val updates2 = Seq(1L, 2L, 3L, 4L).map { id =>
           SearchProtocol.SuggestionsDatabaseUpdate.Modify(
             id,
             reexport = Some(fieldUpdate(exportUpdateAdd.exports.module))
@@ -643,6 +654,10 @@ class SuggestionsHandlerSpec
                   Suggestions.module.module
                 ),
                 ExportedSymbol.Type(
+                  Suggestions.tpe.module,
+                  Suggestions.tpe.name
+                ),
+                ExportedSymbol.Constructor(
                   Suggestions.constructor.module,
                   Suggestions.constructor.name
                 ),
@@ -662,7 +677,7 @@ class SuggestionsHandlerSpec
           Tree.Root(Vector())
         )
 
-        val updates3 = Seq(1L, 2L, 3L).map { id =>
+        val updates3 = Seq(1L, 2L, 3L, 4L).map { id =>
           SearchProtocol.SuggestionsDatabaseUpdate.Modify(
             id,
             reexport = Some(fieldRemove)

--- a/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
@@ -598,7 +598,7 @@ class SuggestionsHandlerSpec
                 ExportedSymbol.Module(
                   Suggestions.module.module
                 ),
-                ExportedSymbol.Atom(
+                ExportedSymbol.Type(
                   Suggestions.constructor.module,
                   Suggestions.constructor.name
                 ),
@@ -642,7 +642,7 @@ class SuggestionsHandlerSpec
                 ExportedSymbol.Module(
                   Suggestions.module.module
                 ),
-                ExportedSymbol.Atom(
+                ExportedSymbol.Type(
                   Suggestions.constructor.module,
                   Suggestions.constructor.name
                 ),

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/SuggestionsHandlerEventsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/SuggestionsHandlerEventsTest.scala
@@ -500,11 +500,14 @@ class SuggestionsHandlerEventsTest extends BaseServerTest with FlakySpec {
               ModuleExports(
                 "Foo.Bar",
                 ListSet(
-                  ExportedSymbol
-                    .Type(
-                      Suggestions.constructor.module,
-                      Suggestions.constructor.name
-                    )
+                  ExportedSymbol.Type(
+                    Suggestions.tpe.module,
+                    Suggestions.tpe.name
+                  ),
+                  ExportedSymbol.Constructor(
+                    Suggestions.constructor.module,
+                    Suggestions.constructor.name
+                  )
                 )
               ),
               Api.ExportsAction.Add()
@@ -519,6 +522,14 @@ class SuggestionsHandlerEventsTest extends BaseServerTest with FlakySpec {
             "method" : "search/suggestionsDatabaseUpdates",
             "params" : {
               "updates" : [
+                {
+                  "type" : "Modify",
+                  "id" : 1,
+                  "reexport" : {
+                    "tag" : "Set",
+                    "value" : "Foo.Bar"
+                  }
+                },
                 {
                   "type" : "Modify",
                   "id" : 2,

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/SuggestionsHandlerEventsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/SuggestionsHandlerEventsTest.scala
@@ -501,7 +501,7 @@ class SuggestionsHandlerEventsTest extends BaseServerTest with FlakySpec {
                 "Foo.Bar",
                 ListSet(
                   ExportedSymbol
-                    .Atom(
+                    .Type(
                       Suggestions.constructor.module,
                       Suggestions.constructor.name
                     )

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/ExportedSymbol.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/ExportedSymbol.scala
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
       name  = "exportedModule"
     ),
     new JsonSubTypes.Type(
-      value = classOf[ExportedSymbol.Atom],
+      value = classOf[ExportedSymbol.Type],
       name  = "exportedAtom"
     ),
     new JsonSubTypes.Type(
@@ -28,26 +28,65 @@ sealed trait ExportedSymbol {
 }
 object ExportedSymbol {
 
+  /** Create [[ExportedSymbol]] from [[Suggestion]].
+    *
+    * @param suggestion the suggestion to convert
+    * @return the corresponding [[ExportedSymbol]]
+    */
+  def fromSuggestion(suggestion: Suggestion): Option[ExportedSymbol] =
+    suggestion match {
+      case s: Suggestion.Module      => Some(Module(s.module))
+      case s: Suggestion.Type        => Some(Type(s.module, s.name))
+      case s: Suggestion.Constructor => Some(Constructor(s.module, s.name))
+      case s: Suggestion.Method      => Some(Method(s.module, s.name))
+      case _: Suggestion.Conversion  => None
+      case _: Suggestion.Function    => None
+      case _: Suggestion.Local       => None
+    }
+
+  /** Create an exported symbol of the suggestion module.
+    *
+    * @param suggestion the suggestion to convert
+    * @return the corresponding [[ExportedSymbol.Module]]
+    */
+  def suggestionModule(suggestion: Suggestion): ExportedSymbol.Module =
+    ExportedSymbol.Module(suggestion.module)
+
   /** The module symbol.
     *
     * @param module the module name
     */
   case class Module(module: String) extends ExportedSymbol {
 
+    /** @inheritdoc */
     override def name: String =
       module
 
+    /** @inheritdoc */
     override def kind: Suggestion.Kind =
       Suggestion.Kind.Module
   }
 
-  /** The atom symbol.
+  /** The type symbol.
     *
     * @param module the module defining this atom
-    * @param name the atom name
+    * @param name the type name
     */
-  case class Atom(module: String, name: String) extends ExportedSymbol {
+  case class Type(module: String, name: String) extends ExportedSymbol {
 
+    /** @inheritdoc */
+    override def kind: Suggestion.Kind =
+      Suggestion.Kind.Type
+  }
+
+  /** The constructor symbol.
+    *
+    * @param module the module where this constructor is defined
+    * @param name the constructor name
+    */
+  case class Constructor(module: String, name: String) extends ExportedSymbol {
+
+    /** @inheritdoc */
     override def kind: Suggestion.Kind =
       Suggestion.Kind.Constructor
   }
@@ -59,6 +98,7 @@ object ExportedSymbol {
     */
   case class Method(module: String, name: String) extends ExportedSymbol {
 
+    /** @inheritdoc */
     override def kind: Suggestion.Kind =
       Suggestion.Kind.Method
   }

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/ExportedSymbol.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/ExportedSymbol.scala
@@ -11,7 +11,11 @@ import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
     ),
     new JsonSubTypes.Type(
       value = classOf[ExportedSymbol.Type],
-      name  = "exportedAtom"
+      name  = "exportedType"
+    ),
+    new JsonSubTypes.Type(
+      value = classOf[ExportedSymbol.Constructor],
+      name  = "exportedConstructor"
     ),
     new JsonSubTypes.Type(
       value = classOf[ExportedSymbol.Method],

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/Suggestion.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/Suggestion.scala
@@ -46,6 +46,9 @@ sealed trait Suggestion extends ToLogString {
   def name:          String
   def returnType:    String
   def documentation: Option[String]
+
+  /** Set the reexport field of the suggestion. */
+  def withReexport(reexport: Option[String]): Suggestion
 }
 
 object Suggestion {
@@ -221,6 +224,10 @@ object Suggestion {
       module
 
     /** @inheritdoc */
+    override def withReexport(reexport: Option[String]): Module =
+      copy(reexport = reexport)
+
+    /** @inheritdoc */
     override def toLogString(shouldMask: Boolean): String =
       s"Module(module=$module,name=$name,documentation=" +
       (if (shouldMask) documentation.map(_ => STUB) else documentation) +
@@ -249,6 +256,10 @@ object Suggestion {
     reexport: Option[String] = None
   ) extends Suggestion
       with ToLogString {
+
+    /** @inheritdoc */
+    override def withReexport(reexport: Option[String]): Type =
+      copy(reexport = reexport)
 
     /** @inheritdoc */
     override def toLogString(shouldMask: Boolean): String =
@@ -284,6 +295,10 @@ object Suggestion {
     reexport: Option[String] = None
   ) extends Suggestion
       with ToLogString {
+
+    /** @inheritdoc */
+    override def withReexport(reexport: Option[String]): Constructor =
+      copy(reexport = reexport)
 
     /** @inheritdoc */
     override def toLogString(shouldMask: Boolean): String =
@@ -324,6 +339,10 @@ object Suggestion {
       with ToLogString {
 
     /** @inheritdoc */
+    override def withReexport(reexport: Option[String]): Method =
+      copy(reexport = reexport)
+
+    /** @inheritdoc */
     override def toLogString(shouldMask: Boolean): String =
       "Method(" +
       s"module=$module," +
@@ -356,6 +375,10 @@ object Suggestion {
     documentation: Option[String],
     reexport: Option[String] = None
   ) extends Suggestion {
+
+    /** @inheritdoc */
+    override def withReexport(reexport: Option[String]): Conversion =
+      copy(reexport = reexport)
 
     /** @inheritdoc */
     override def name: String =
@@ -395,6 +418,10 @@ object Suggestion {
       with ToLogString {
 
     /** @inheritdoc */
+    override def withReexport(reexport: Option[String]): Function =
+      this
+
+    /** @inheritdoc */
     override def toLogString(shouldMask: Boolean): String =
       "Function(" +
       s"externalId=$externalId," +
@@ -424,6 +451,10 @@ object Suggestion {
     scope: Scope,
     documentation: Option[String]
   ) extends Suggestion {
+
+    /** @inheritdoc */
+    override def withReexport(reexport: Option[String]): Local =
+      this
 
     /** @inheritdoc */
     override def toLogString(shouldMask: Boolean): String =

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
@@ -1151,7 +1151,7 @@ class RuntimeSuggestionUpdatesTest
               ModuleExports(
                 "Enso_Test.Test.Main",
                 Set(
-                  ExportedSymbol.Atom("Enso_Test.Test.A", "MkA"),
+                  ExportedSymbol.Type("Enso_Test.Test.A", "MkA"),
                   ExportedSymbol.Method("Enso_Test.Test.A", "hello")
                 )
               ),
@@ -1259,7 +1259,7 @@ class RuntimeSuggestionUpdatesTest
             Api.ExportsUpdate(
               ModuleExports(
                 "Enso_Test.Test.Main",
-                Set(ExportedSymbol.Atom("Enso_Test.Test.A", "MkA"))
+                Set(ExportedSymbol.Type("Enso_Test.Test.A", "MkA"))
               ),
               Api.ExportsAction.Remove()
             )

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
@@ -1014,7 +1014,7 @@ class RuntimeSuggestionUpdatesTest
       )
     )
     context.receiveNIgnoreExpressionUpdates(
-      5
+      6
     ) should contain theSameElementsAs Seq(
       Api.Response(Api.BackgroundJobsStartedNotification()),
       Api.Response(requestId, Api.PushContextResponse(contextId)),
@@ -1151,7 +1151,8 @@ class RuntimeSuggestionUpdatesTest
               ModuleExports(
                 "Enso_Test.Test.Main",
                 Set(
-                  ExportedSymbol.Type("Enso_Test.Test.A", "MkA"),
+                  ExportedSymbol.Type("Enso_Test.Test.A", "MyType"),
+                  ExportedSymbol.Constructor("Enso_Test.Test.A", "MkA"),
                   ExportedSymbol.Method("Enso_Test.Test.A", "hello")
                 )
               ),
@@ -1190,6 +1191,7 @@ class RuntimeSuggestionUpdatesTest
           )
         )
       ),
+      Api.Response(Api.AnalyzeModuleInScopeJobFinished()),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("Hello World!")
@@ -1210,7 +1212,7 @@ class RuntimeSuggestionUpdatesTest
       )
     )
     context.receiveNIgnoreExpressionUpdates(
-      3
+      2
     ) should contain theSameElementsAs Seq(
       Api.Response(
         Api.SuggestionsDatabaseModuleUpdateNotification(
@@ -1228,7 +1230,6 @@ class RuntimeSuggestionUpdatesTest
           updates = Tree.Root(Vector())
         )
       ),
-      Api.Response(Api.AnalyzeModuleInScopeJobFinished()),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("Hello World!")
@@ -1259,7 +1260,10 @@ class RuntimeSuggestionUpdatesTest
             Api.ExportsUpdate(
               ModuleExports(
                 "Enso_Test.Test.Main",
-                Set(ExportedSymbol.Type("Enso_Test.Test.A", "MkA"))
+                Set(
+                  ExportedSymbol.Type("Enso_Test.Test.A", "MyType"),
+                  ExportedSymbol.Constructor("Enso_Test.Test.A", "MkA")
+                )
               ),
               Api.ExportsAction.Remove()
             )

--- a/engine/runtime/src/main/java/org/enso/compiler/context/ExportsMap.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/context/ExportsMap.java
@@ -1,0 +1,61 @@
+package org.enso.compiler.context;
+
+import org.enso.pkg.QualifiedName;
+import org.enso.polyglot.ExportedSymbol;
+import org.enso.polyglot.ModuleExports;
+import org.enso.polyglot.Suggestion;
+import scala.Option;
+import scala.runtime.BoxedUnit;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class ExportsMap {
+
+  private static final String MODULE_MAIN = "Main";
+  private static final String TYPE_SUFFIX = "type";
+
+  private final Map<ExportedSymbol, QualifiedName> exportsMap;
+
+  public ExportsMap() {
+    this.exportsMap = new HashMap<>();
+  }
+
+  public ExportsMap(Map<ExportedSymbol, QualifiedName> exportsMap) {
+    this.exportsMap = exportsMap;
+  }
+
+  public void add(ExportedSymbol symbol, QualifiedName moduleName) {
+    exportsMap.merge(symbol, moduleName, ExportsMap::getShortest);
+  }
+
+  public void addAll(QualifiedName moduleName, ModuleExports moduleExports) {
+    moduleExports
+        .symbols()
+        .foreach(
+            symbol -> {
+              add(symbol, moduleName);
+              return BoxedUnit.UNIT;
+            });
+  }
+
+  public QualifiedName get(ExportedSymbol symbol) {
+    return exportsMap.get(symbol);
+  }
+
+  public QualifiedName get(Suggestion suggestion) {
+    return ExportedSymbol.fromSuggestion(suggestion)
+        .flatMap(symbol -> Option.apply(exportsMap.get(symbol)))
+        .getOrElse(() -> exportsMap.get(ExportedSymbol.suggestionModule(suggestion)));
+  }
+
+  private static QualifiedName getShortest(QualifiedName name1, QualifiedName name2) {
+    return length(name1) <= length(name2) ? name1 : name2;
+  }
+
+  private static int length(QualifiedName qualifiedName) {
+    QualifiedName name =
+        qualifiedName.item().equals(TYPE_SUFFIX) ? qualifiedName.getParent().get() : qualifiedName;
+    return name.item().equals(MODULE_MAIN) ? name.path().length() : name.path().length() + 1;
+  }
+}

--- a/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
@@ -2,7 +2,7 @@ package org.enso.compiler
 
 import com.oracle.truffle.api.TruffleLogger
 import com.oracle.truffle.api.source.Source
-import org.enso.compiler.context.SuggestionBuilder
+import org.enso.compiler.context.{ExportsBuilder, ExportsMap, SuggestionBuilder}
 import org.enso.compiler.core.IR
 import org.enso.compiler.pass.analyse.BindingAnalysis
 import org.enso.editions.LibraryName
@@ -233,48 +233,76 @@ final class SerializationManager(
             throw e
         }
 
-      try {
-        val suggestions = new util.ArrayList[Suggestion]()
-        compiler.packageRepository
-          .getModulesForLibrary(libraryName)
-          .flatMap { module =>
-            SuggestionBuilder(module, compiler)
-              .build(module.getName, module.getIr)
-              .toVector
-              .filter(Suggestion.isGlobal)
-          }
-          .foreach(suggestions.add)
-        val cachedSuggestions =
-          new SuggestionsCache.CachedSuggestions(
-            libraryName,
-            new SuggestionsCache.Suggestions(suggestions),
-            compiler.packageRepository
-              .getPackageForLibraryJava(libraryName)
-              .map(_.listSourcesJava())
-          )
-        new SuggestionsCache(libraryName)
-          .save(cachedSuggestions, compiler.context, useGlobalCacheLocations)
-          .isPresent
-      } catch {
-        case e: NotSerializableException =>
-          logger.log(
-            Level.SEVERE,
-            s"Could not serialize suggestions [$libraryName].",
-            e
-          )
-          throw e
-        case e: Throwable =>
-          logger.log(
-            Level.SEVERE,
-            s"Serialization of suggestions `$libraryName` failed: ${e.getMessage}`",
-            e
-          )
-          throw e
-      }
+      doSerializeLibrarySuggestions(libraryName, useGlobalCacheLocations)
 
       result
     } finally {
       finishSerializing(libraryName.toQualifiedName)
+    }
+  }
+
+  private def doSerializeLibrarySuggestions(
+    libraryName: LibraryName,
+    useGlobalCacheLocations: Boolean
+  ): Boolean = {
+    val exportsBuilder = new ExportsBuilder
+    val exportsMap     = new ExportsMap
+    val suggestions    = new util.ArrayList[Suggestion]()
+
+    try {
+      val libraryModules =
+        compiler.packageRepository.getModulesForLibrary(libraryName)
+      libraryModules
+        .flatMap { module =>
+          val suggestions = SuggestionBuilder(module, compiler)
+            .build(module.getName, module.getIr)
+            .toVector
+            .filter(Suggestion.isGlobal)
+          val exports = exportsBuilder.build(module.getName, module.getIr)
+          exportsMap.addAll(module.getName, exports)
+          suggestions
+        }
+        .map { suggestion =>
+          val reexport = Option(exportsMap.get(suggestion)).map(_.toString)
+          reexport.foreach { v =>
+            if (
+              Suggestion.isGlobal(suggestion) && !suggestion
+                .isInstanceOf[Suggestion.Module]
+            ) {
+              println(
+                s"[$v] ${suggestion.getClass.getSimpleName}:${suggestion.name}"
+              )
+            }
+          }
+          suggestion.withReexport(reexport)
+        }
+        .foreach(suggestions.add)
+      val cachedSuggestions =
+        new SuggestionsCache.CachedSuggestions(
+          libraryName,
+          new SuggestionsCache.Suggestions(suggestions),
+          compiler.packageRepository
+            .getPackageForLibraryJava(libraryName)
+            .map(_.listSourcesJava())
+        )
+      new SuggestionsCache(libraryName)
+        .save(cachedSuggestions, compiler.context, useGlobalCacheLocations)
+        .isPresent
+    } catch {
+      case e: NotSerializableException =>
+        logger.log(
+          Level.SEVERE,
+          s"Could not serialize suggestions [$libraryName].",
+          e
+        )
+        throw e
+      case e: Throwable =>
+        logger.log(
+          Level.SEVERE,
+          s"Serialization of suggestions `$libraryName` failed: ${e.getMessage}`",
+          e
+        )
+        throw e
     }
   }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
@@ -264,16 +264,6 @@ final class SerializationManager(
         }
         .map { suggestion =>
           val reexport = Option(exportsMap.get(suggestion)).map(_.toString)
-          reexport.foreach { v =>
-            if (
-              Suggestion.isGlobal(suggestion) && !suggestion
-                .isInstanceOf[Suggestion.Module]
-            ) {
-              println(
-                s"[$v] ${suggestion.getClass.getSimpleName}:${suggestion.name}"
-              )
-            }
-          }
           suggestion.withReexport(reexport)
         }
         .foreach(suggestions.add)

--- a/engine/runtime/src/main/scala/org/enso/compiler/context/ExportsBuilder.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/ExportsBuilder.scala
@@ -19,8 +19,10 @@ final class ExportsBuilder {
       .collect {
         case BindingsMap.ResolvedMethod(module, method) =>
           ExportedSymbol.Method(module.getName.toString, method.name)
+        case BindingsMap.ResolvedType(module, tp) =>
+          ExportedSymbol.Type(module.getName.toString, tp.name)
         case BindingsMap.ResolvedConstructor(tp, cons) =>
-          ExportedSymbol.Atom(tp.module.getName.toString, cons.name)
+          ExportedSymbol.Type(tp.module.getName.toString, cons.name)
         case BindingsMap.ResolvedModule(module) =>
           ExportedSymbol.Module(module.getName.toString)
       }

--- a/engine/runtime/src/main/scala/org/enso/compiler/context/ExportsBuilder.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/ExportsBuilder.scala
@@ -22,7 +22,7 @@ final class ExportsBuilder {
         case BindingsMap.ResolvedType(module, tp) =>
           ExportedSymbol.Type(module.getName.toString, tp.name)
         case BindingsMap.ResolvedConstructor(tp, cons) =>
-          ExportedSymbol.Type(tp.module.getName.toString, cons.name)
+          ExportedSymbol.Constructor(tp.module.getName.toString, cons.name)
         case BindingsMap.ResolvedModule(module) =>
           ExportedSymbol.Module(module.getName.toString)
       }

--- a/engine/runtime/src/main/scala/org/enso/compiler/data/BindingsMap.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/data/BindingsMap.scala
@@ -16,9 +16,7 @@ import scala.annotation.unused
 
 /** A utility structure for resolving symbols in a given module.
   *
-  * @param constructors the types defined in the current module
-  * @param polyglotSymbols the polyglot symbols imported into the scope
-  * @param moduleMethods the methods defined with current module as `this`
+  * @param definedEntities the list of entities defined in the current module
   * @param currentModule the module holding these bindings
   */
 


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #6613 

Changelog
- feat: during the library serialization, build the exports map and set the reexport field of the suggestion

### Important Notes

IDE does not create additional imports for re-exported symbols.

![2023-05-18-192739_2019x828_scrot](https://github.com/enso-org/enso/assets/357683/5ef20dfe-d6a5-4935-a759-4af10b0817a5)


<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
