### PR TITLE
Link to new 101 tutorial and not deprecated one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ always trust the results you get.
     <b>Watch Tutorials</b><br/>
     <ul>
         <li><a href="https://github.com/enso-org/enso/blob/develop/app/gui/docs/product/shortcuts.md">Enso keyboard shortcuts</a></li>
-        <li><a href="https://youtu.be/3f6FE1dgMNw?list=PLk8NuufOVK01GhaObYr1_gqeASlkj2um0">Enso 101</a></li>
+        <li><a href="https://youtu.be/_Twh45PI_vU&list=PLk8NuufOVK01GhaObYr1_gqeASlkj2um0">Enso 101</a></li>
         <li><a href="https://youtu.be/hFxugfGbvGI?list=PLk8NuufOVK01GhaObYr1_gqeASlkj2um0">Analyze trams data</a></li>
         <li><a href="https://youtu.be/gXnojGR6wOI?list=PLk8NuufOVK01GhaObYr1_gqeASlkj2um0">Analyze GitHub Stargazers data</a></li>
         <li><a href="https://www.youtube.com/playlist?list=PLk8NuufOVK01GhaObYr1_gqeASlkj2um0">... other tutorials</a></li>


### PR DESCRIPTION
### Pull Request Description

The link to Enso 101 in the README pointed to the deprecated tutorial, causing confusion.

### Important Notes

Only the URL has been changed to point to the updated tutorial that now match the 2023.1.1 release.

### Checklist

No code change.
