### PR TITLE
Missing conversion of hash key in EqualsNode

### DIFF
--- a/engine/runtime/src/test/java/org/enso/interpreter/test/HashCodeTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/HashCodeTest.java
@@ -1,13 +1,9 @@
 package org.enso.interpreter.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import com.oracle.truffle.api.interop.InteropLibrary;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.enso.interpreter.node.expression.builtin.interop.syntax.HostValueToEnsoNode;
 import org.enso.interpreter.node.expression.builtin.meta.EqualsNode;
 import org.enso.interpreter.node.expression.builtin.meta.HashCodeNode;
@@ -16,12 +12,15 @@ import org.enso.interpreter.runtime.EnsoContext;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
 import org.junit.AfterClass;
-import org.junit.Before;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
 import org.junit.experimental.theories.DataPoints;
 import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
+
+import com.oracle.truffle.api.interop.InteropLibrary;
 
 @RunWith(Theories.class)
 public class HashCodeTest extends TestBase {

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/ValuesGenerator.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/ValuesGenerator.java
@@ -13,6 +13,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -576,6 +577,15 @@ class ValuesGenerator {
       )) {
         collect.add(v("maps-" + expr, imports, expr, "Map").type());
       }
+    }
+    if (languages.contains(Language.JAVA)) {
+      collect.add(ctx.asValue(Collections.emptyMap()));
+      collect.add(ctx.asValue(Collections.singletonMap("A", 1)));
+      var map = new HashMap<String,Integer>();
+      map.put("A", 1);
+      map.put("B", 2);
+      map.put("C", 3);
+      collect.add(ctx.asValue(map));
     }
     return collect;
   }


### PR DESCRIPTION
### Pull Request Description

Expanding `ValuesGenerator` to cover also hosted Java maps (to cover #6682 issues) made me realize the `HashCodeTest` and `EqualsTest` are failing to convert keys to supported Enso values.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
