### PR TITLE
Use Project Manager when on local backend

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/ide.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/ide.tsx
@@ -5,6 +5,8 @@ import * as backendModule from '../backend'
 import * as backendProvider from '../../providers/backend'
 import * as platformModule from '../../platform'
 
+import GLOBAL_CONFIG from '../../../../../../../../gui/config.yaml' assert { type: 'yaml' }
+
 // =================
 // === Constants ===
 // =================
@@ -68,6 +70,15 @@ function Ide(props: IdeProps) {
                     }
                 })()
                 const runNewProject = async () => {
+                    const engineConfig =
+                        backend.platform === platformModule.Platform.cloud
+                            ? {
+                                  rpcUrl: jsonAddress,
+                                  dataUrl: binaryAddress,
+                              }
+                            : {
+                                  projectManagerUrl: GLOBAL_CONFIG.projectManagerEndpoint,
+                              }
                     await appRunner?.runApp({
                         loader: {
                             assetsUrl: `${assetsRoot}dynamic-assets`,
@@ -75,8 +86,7 @@ function Ide(props: IdeProps) {
                             jsUrl: `${assetsRoot}pkg${JS_EXTENSION[backend.platform]}`,
                         },
                         engine: {
-                            rpcUrl: jsonAddress,
-                            dataUrl: binaryAddress,
+                            ...engineConfig,
                             preferredVersion: engineVersion,
                         },
                         startup: {


### PR DESCRIPTION
### Pull Request Description
Temporary workaround (?) while GUI still depends on the Project Manager for certain actions.
I think the issues should still be open (assuming the intent is still to move away from the old projects list), but maybe they should go in the backlog instead.

This fixes features relying on the Project Manager:
- the "open projects" view in the IDE (#6804)
- renaming projects from inside the IDE (#6756)

### Important Notes
- It has been brought up that the dashboard does `project/open`, and then the IDE does `project/open` again. It's possible to work around this on the dashboard side, but I'm not sure whether the added complexity is worth the performance improvements in avoiding opening the same project twice.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
