### PR TITLE
Import/export syntax error have more specific messages

### DIFF
--- a/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/TreeToIr.java
@@ -21,7 +21,8 @@ import org.enso.compiler.core.IR$Error$Syntax$UnexpectedDeclarationInType$;
 import org.enso.compiler.core.IR$Error$Syntax$UnexpectedExpression$;
 import org.enso.compiler.core.IR$Error$Syntax$InvalidEscapeSequence$;
 import org.enso.compiler.core.IR$Error$Syntax$EmptyParentheses$;
-import org.enso.compiler.core.IR$Error$Syntax$InvalidImport$;
+import org.enso.compiler.core.IR$Error$Syntax$InvalidImport;
+import org.enso.compiler.core.IR$Error$Syntax$InvalidExport;
 import org.enso.compiler.core.IR$Error$Syntax$Reason;
 import org.enso.compiler.core.IR$Error$Syntax$UnrecognizedToken$;
 import org.enso.compiler.core.IR$Error$Syntax$UnsupportedSyntax;
@@ -70,6 +71,7 @@ import org.enso.syntax2.TextElement;
 import org.enso.syntax2.Token;
 import org.enso.syntax2.Tree;
 
+import org.enso.syntax2.Tree.Invalid;
 import scala.Option;
 import scala.collection.immutable.LinearSeq;
 import scala.collection.immutable.List;
@@ -1525,8 +1527,22 @@ final class TreeToIr {
       meta(), diag()
       );
     } catch (SyntaxException err) {
-      return err.toError(IR$Error$Syntax$InvalidImport$.MODULE$);
+      if (err.where instanceof Invalid invalid) {
+        return err.toError(invalidImportReason(invalid.getError()));
+      } else {
+        return err.toError(invalidImportReason(null));
+      }
     }
+  }
+
+  private IR$Error$Syntax$Reason invalidImportReason(String msg) {
+    return new IR$Error$Syntax$InvalidImport(
+        Objects.requireNonNullElse(msg, "Imports must have a valid module path"));
+  }
+
+  private IR$Error$Syntax$Reason invalidExportReason(String msg) {
+    return new IR$Error$Syntax$InvalidExport(
+        Objects.requireNonNullElse(msg, "Exports must have a valid module path"));
   }
 
   @SuppressWarnings("unchecked")
@@ -1583,7 +1599,11 @@ final class TreeToIr {
         meta(), diag()
         );
     } catch (SyntaxException err) {
-      return err.toError(IR$Error$Syntax$InvalidImport$.MODULE$);
+      if (err.where instanceof Invalid invalid) {
+        return err.toError(invalidExportReason(invalid.getError()));
+      } else {
+        return err.toError(invalidExportReason(null));
+      }
     }
   }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/core/IR.scala
@@ -7803,9 +7803,18 @@ object IR {
           s"Cannot define a pattern outside a pattern context"
       }
 
-      case object InvalidImport extends Reason {
+      case class InvalidImport(
+        message: String = "Imports must have a valid module path"
+      ) extends Reason {
         override def explanation: String =
-          s"Imports must have a valid module path"
+          s"Invalid Import: $message"
+      }
+
+      case class InvalidExport(
+        message: String = "Exports must have a valid module path"
+      ) extends Reason {
+        override def explanation: String =
+          s"Invalid Export: $message"
       }
 
       case object InvalidStandaloneSignature extends Reason {

--- a/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
@@ -1,10 +1,12 @@
 package org.enso.compiler;
 
+import java.util.Objects;
 import org.enso.compiler.core.IR;
 import org.enso.compiler.core.IR$Error$Syntax;
 import org.enso.compiler.core.IR$Error$Syntax$InvalidEscapeSequence$;
 import org.enso.compiler.core.IR$Error$Syntax$Reason;
-import org.enso.compiler.core.IR$Error$Syntax$InvalidImport$;
+import org.enso.compiler.core.IR$Error$Syntax$InvalidImport;
+import org.enso.compiler.core.IR$Error$Syntax$InvalidExport;
 import org.enso.compiler.core.IR$Error$Syntax$UnexpectedExpression$;
 import org.enso.compiler.core.IR$Error$Syntax$UnrecognizedToken$;
 import org.enso.compiler.core.IR$Error$Syntax$UnsupportedSyntax;
@@ -144,40 +146,49 @@ public class ErrorCompilerTest extends CompilerTest {
     assertSingleSyntaxError(ir, IR$Error$Syntax$UnexpectedExpression$.MODULE$, "Unexpected expression", 0, 13);
   }
 
+
+  private IR$Error$Syntax$InvalidImport invalidImport(String msg) {
+    return new IR$Error$Syntax$InvalidImport(msg);
+  }
+
+  private IR$Error$Syntax$InvalidExport invalidExport(String msg) {
+    return new IR$Error$Syntax$InvalidExport(msg);
+  }
+
   @Test
   public void malformedImport3() throws Exception {
     var ir = parse("import Foo as Foo, Bar");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 14, 22);
+    assertSingleSyntaxError(ir, invalidImport("Expected identifier."), null, 14, 22);
   }
 
   @Test
   public void malformedImport4() throws Exception {
     var ir = parse("import Foo as Foo.Bar");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 14, 21);
+    assertSingleSyntaxError(ir, invalidImport("Expected identifier."), null, 14, 21);
   }
 
   @Test
   public void malformedImport5() throws Exception {
     var ir = parse("import Foo as");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 13, 13);
+    assertSingleSyntaxError(ir, invalidImport("Expected tokens."), null, 13, 13);
   }
 
   @Test
   public void malformedImport6() throws Exception {
     var ir = parse("import Foo as Bar.Baz");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 14, 21);
+    assertSingleSyntaxError(ir, invalidImport("Expected identifier."), null, 14, 21);
   }
 
   @Test
   public void malformedImport7() throws Exception {
     var ir = parse("import Foo hiding");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 7, 17);
+    assertSingleSyntaxError(ir, invalidImport("Expected qualified name."), null, 7, 17);
   }
 
   @Test
   public void malformedImport8() throws Exception {
     var ir = parse("import Foo hiding X,");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 7, 20);
+    assertSingleSyntaxError(ir, invalidImport("Malformed comma-delimited sequence."), null, 7, 20);
   }
 
   @Test
@@ -203,25 +214,25 @@ public class ErrorCompilerTest extends CompilerTest {
   @Test
   public void malformedImport11() throws Exception {
     var ir = parse("from import all");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 4, 4);
+    assertSingleSyntaxError(ir, invalidImport("Expected tokens."), null, 4, 4);
   }
 
   @Test
   public void malformedImport12() throws Exception {
     var ir = parse("from Foo import all hiding");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 26, 26);
+    assertSingleSyntaxError(ir, invalidImport("Expected tokens."), null, 26, 26);
   }
 
   @Test
   public void malformedImport13() throws Exception {
     var ir = parse("from Foo import all hiding X.Y");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 27, 30);
+    assertSingleSyntaxError(ir, invalidImport("Expected identifier."), null, 27, 30);
   }
 
   @Test
   public void malformedImport14() throws Exception {
     var ir = parse("from Foo import Some.Nested.Module.Path");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 16, 39);
+    assertSingleSyntaxError(ir, invalidImport("Expected identifier."), null, 16, 39);
   }
 
   @Test
@@ -239,55 +250,55 @@ public class ErrorCompilerTest extends CompilerTest {
   @Test
   public void malformedExport3() throws Exception {
     var ir = parse("export Foo as Foo, Bar");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 14, 22);
+    assertSingleSyntaxError(ir, invalidExport("Expected identifier."), null, 14, 22);
   }
 
   @Test
   public void malformedExport4() throws Exception {
     var ir = parse("export Foo as Foo.Bar");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 14, 21);
+    assertSingleSyntaxError(ir, invalidExport("Expected identifier."), null, 14, 21);
   }
 
   @Test
   public void malformedExport5() throws Exception {
     var ir = parse("export Foo as");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 13, 13);
+    assertSingleSyntaxError(ir, invalidExport("Expected tokens."), null, 13, 13);
   }
 
   @Test
   public void malformedExport6() throws Exception {
     var ir = parse("export Foo as Bar.Baz");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 14, 21);
+    assertSingleSyntaxError(ir, invalidExport("Expected identifier."), null, 14, 21);
   }
 
   @Test
   public void malformedExport7() throws Exception {
     var ir = parse("export Foo hiding");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 7, 17);
+    assertSingleSyntaxError(ir, invalidExport("Expected qualified name."), null, 7, 17);
   }
 
   @Test
   public void malformedExport8() throws Exception {
     var ir = parse("export Foo hiding X,");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 7, 20);
+    assertSingleSyntaxError(ir, invalidExport("Malformed comma-delimited sequence."), null, 7, 20);
   }
 
   @Test
   public void malformedExport9() throws Exception {
     var ir = parse("from export all");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 4, 4);
+    assertSingleSyntaxError(ir, invalidExport("Expected tokens."), null, 4, 4);
   }
 
   @Test
   public void malformedExport10() throws Exception {
     var ir = parse("from Foo export all hiding");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 26, 26);
+    assertSingleSyntaxError(ir, invalidExport("Expected tokens."), null, 26, 26);
   }
 
   @Test
   public void malformedExport11() throws Exception {
     var ir = parse("from Foo export all hiding X.Y");
-    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidImport$.MODULE$, "Imports must have a valid module path", 27, 30);
+    assertSingleSyntaxError(ir, invalidExport("Expected identifier."), null, 27, 30);
   }
 
   @Test
@@ -367,7 +378,9 @@ public class ErrorCompilerTest extends CompilerTest {
   ) {
     var errors = assertIR(ir, IR$Error$Syntax.class, 1);
     assertEquals(type, errors.head().reason());
-    assertEquals(msg, errors.head().message());
+    if (msg != null) {
+      assertEquals(msg, errors.head().message());
+    }
     assertEquals(new Location(start, end), errors.head().location().get().location());
   }
 


### PR DESCRIPTION
Fixes #6425

### Pull Request Description
Import and export syntax errors have more specific messages. For example, trying to compile this import:
```
from Standard.Table import Table as My_Table
```
now results in:
```
Compiler encountered errors:
tmp.enso[2:28-2:44]: Invalid Import: Expected identifier..
Aborting due to 1 errors and 0 warnings.
```
and before it was:
```
Compiler encountered errors:
tmp.enso[2:28-2:44]: Imports must have a valid module path.
Aborting due to 1 errors and 0 warnings.
```

There are more examples of these *better* error messages in [ErrorCompilerTest.java](https://github.com/enso-org/enso/pull/6808/files#diff-7097760cf88cf9ce8d83fb6a540241a28910b075f5cc449680cbcddf9ad24ebc)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
