### PR TITLE
Filter suggestion constructors when searching by self type

### DIFF
--- a/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlSuggestionsRepo.scala
+++ b/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlSuggestionsRepo.scala
@@ -745,7 +745,8 @@ final class SqlSuggestionsRepo(val db: SqlDatabase)(implicit
         row.scopeStartLine === ScopeColumn.EMPTY || row.module === value
       }
       .filterIf(selfTypes.nonEmpty) { row =>
-        row.selfType.inSet(selfTypes)
+        row.selfType.inSet(selfTypes) &&
+        (row.kind =!= SuggestionKind.CONSTRUCTOR)
       }
       .filterOpt(returnType) { case (row, value) =>
         row.returnType === value

--- a/lib/scala/searcher/src/test/scala/org/enso/searcher/sql/SuggestionsRepoTest.scala
+++ b/lib/scala/searcher/src/test/scala/org/enso/searcher/sql/SuggestionsRepoTest.scala
@@ -970,6 +970,32 @@ class SuggestionsRepoTest
       res should contain theSameElementsAs Seq(id).flatten
     }
 
+    "search suggestion by self type excluding constructors" taggedAs Retry in withRepo {
+      repo =>
+        val constructorSelfType =
+          Suggestion.SelfType(suggestion.constructor).toSeq
+        val action = for {
+          _ <- repo.insert(suggestion.module)
+          _ <- repo.insert(suggestion.tpe)
+          _ <- repo.insert(suggestion.constructor)
+          _ <- repo.insert(suggestion.method)
+          _ <- repo.insert(suggestion.conversion)
+          _ <- repo.insert(suggestion.function)
+          _ <- repo.insert(suggestion.local)
+          res <- repo.search(
+            None,
+            constructorSelfType,
+            None,
+            None,
+            None,
+            None
+          )
+        } yield res._2
+
+        val res = Await.result(action, Timeout)
+        res.isEmpty shouldEqual true
+    }
+
     "search suggestion by return type" taggedAs Retry in withRepo { repo =>
       val action = for {
         _   <- repo.insert(suggestion.module)


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #6627

Changelog:
- update: search method excludes constructors when searched by the self type

### Important Notes

Component Browser doesn't show the `Between` constructor when called on the `Range` node.

![2023-05-23-172446_1203x865_scrot](https://github.com/enso-org/enso/assets/357683/a2553c46-6a0e-4842-ba91-7c2b76c56c6d)


<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
