### PR TITLE
Clearly select single specialization with enum dispatch pattern

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNode.java
@@ -1,6 +1,7 @@
 package org.enso.interpreter.node.expression.builtin.meta;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.GenerateUncached;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -10,10 +11,10 @@ import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
-import org.enso.interpreter.epb.runtime.PolyglotProxy;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
+import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.error.PanicSentinel;
@@ -75,99 +76,13 @@ public abstract class TypeOfNode extends Node {
     return execute(value.getValue());
   }
 
-  @Specialization(
-      guards = {
-        "interop.hasArrayElements(proxy)",
-        "!interop.isString(proxy)", // R string value is an array and a string
-        "!types.hasType(proxy)",
-        "!interop.hasMetaObject(proxy)"
-      })
-  Object doPolyglotArray(
-      PolyglotProxy proxy,
-      @CachedLibrary(limit = "3") InteropLibrary interop,
-      @CachedLibrary(limit = "3") TypesLibrary types) {
-    return EnsoContext.get(this).getBuiltins().array();
-  }
-
-  @Specialization(
-      guards = {
-        "interop.isString(proxy)",
-        "!types.hasType(proxy)",
-        "!interop.hasMetaObject(proxy)"
-      })
-  Object doPolyglotString(
-      PolyglotProxy proxy,
-      @CachedLibrary(limit = "3") InteropLibrary interop,
-      @CachedLibrary(limit = "3") TypesLibrary types) {
-    return EnsoContext.get(this).getBuiltins().text();
-  }
-
-  @Specialization(
-      guards = {
-        "interop.isNumber(proxy)",
-        "!types.hasType(proxy)",
-        "!interop.hasMetaObject(proxy)"
-      })
-  Object doPolyglotNumber(
-      PolyglotProxy proxy,
-      @CachedLibrary(limit = "3") InteropLibrary interop,
-      @CachedLibrary(limit = "3") TypesLibrary types) {
-    Builtins builtins = EnsoContext.get(this).getBuiltins();
-    if (interop.fitsInInt(proxy)) {
-      return builtins.number().getInteger();
-    } else if (interop.fitsInDouble(proxy)) {
-      return builtins.number().getDecimal();
-    } else {
-      return EnsoContext.get(this).getBuiltins().number();
-    }
-  }
-
-  @Specialization(guards = {"findInterop(value, interop).isDateTime()"})
-  Object doDateTime(Object value, @CachedLibrary(limit = "3") InteropLibrary interop) {
-    return EnsoContext.get(this).getBuiltins().dateTime();
-  }
-
-  @Specialization(guards = {"findInterop(value, interop).isTimeZone()"})
-  Object doTimeZone(Object value, @CachedLibrary(limit = "3") InteropLibrary interop) {
-    EnsoContext ctx = EnsoContext.get(this);
-    return ctx.getBuiltins().timeZone();
-  }
-
-  @Specialization(guards = {"findInterop(value, interop).isDate()"})
-  Object doDate(Object value, @CachedLibrary(limit = "3") InteropLibrary interop) {
-    EnsoContext ctx = EnsoContext.get(this);
-    return ctx.getBuiltins().date();
-  }
-
-  @Specialization(guards = {"findInterop(value, interop).isTime()"})
-  Object doTime(Object value, @CachedLibrary(limit = "3") InteropLibrary interop) {
-    EnsoContext ctx = EnsoContext.get(this);
-    return ctx.getBuiltins().timeOfDay();
-  }
-
-  @Specialization(guards = "findInterop(value, interop).isDuration()")
-  Object doDuration(Object value, @CachedLibrary(limit = "3") InteropLibrary interop) {
-    EnsoContext ctx = EnsoContext.get(this);
-    return ctx.getBuiltins().duration();
-  }
-
-  @Specialization(
-      guards = {
-        "interop.hasMetaObject(value)",
-        "!types.hasType(value)",
-        "findInterop(value, interop).isNone()"
-      })
-  Object doMetaObject(
+  @Specialization(guards = {"!types.hasType(value)"})
+  Object withoutType(
       Object value,
       @CachedLibrary(limit = "3") InteropLibrary interop,
-      @CachedLibrary(limit = "3") TypesLibrary types) {
-    try {
-      return interop.getMetaObject(value);
-    } catch (UnsupportedMessageException e) {
-      CompilerDirectives.transferToInterpreter();
-      Builtins builtins = EnsoContext.get(this).getBuiltins();
-      throw new PanicException(builtins.error().makeCompileError("invalid meta object"), this);
-    }
+      @CachedLibrary(limit = "3") TypesLibrary types,
+      @Cached WithoutType delegate) {
+    return delegate.execute(value);
   }
 
   @Specialization(guards = {"types.hasType(value)", "!interop.isNumber(value)"})
@@ -176,61 +91,6 @@ public abstract class TypeOfNode extends Node {
       @CachedLibrary(limit = "3") InteropLibrary interop,
       @CachedLibrary(limit = "3") TypesLibrary types) {
     return types.getType(value);
-  }
-
-  static InteropType findInterop(Object value, InteropLibrary interop) {
-    return InteropType.find(value, interop);
-  }
-
-  enum InteropType {
-    NONE,
-    DATE_TIME,
-    TIME_ZONE,
-    DATE,
-    TIME,
-    DURATION;
-
-    static InteropType find(Object value, InteropLibrary interop) {
-      boolean time = interop.isTime(value);
-      boolean date = interop.isDate(value);
-      if (time) {
-        return date ? DATE_TIME : TIME;
-      }
-      if (date) {
-        return DATE;
-      }
-      if (interop.isTimeZone(value)) {
-        return TIME_ZONE;
-      }
-      if (interop.isDuration(value)) {
-        return DURATION;
-      }
-      return NONE;
-    }
-
-    boolean isDateTime() {
-      return this == DATE_TIME;
-    }
-
-    boolean isTimeZone() {
-      return this == TIME_ZONE;
-    }
-
-    boolean isTime() {
-      return this == TIME;
-    }
-
-    boolean isDate() {
-      return this == DATE;
-    }
-
-    boolean isDuration() {
-      return this == DURATION;
-    }
-
-    boolean isNone() {
-      return this == NONE;
-    }
   }
 
   @Fallback
@@ -242,5 +102,151 @@ public abstract class TypeOfNode extends Node {
             .error()
             .makeCompileError("unknown type_of for " + value),
         this);
+  }
+
+  @GenerateUncached
+  abstract static class WithoutType extends Node {
+    abstract Object execute(Object value);
+
+    @Specialization(guards = {"findInterop(value, interop).isArray()"})
+    Type doPolyglotArray(Object value, @CachedLibrary(limit = "3") InteropLibrary interop) {
+      return EnsoContext.get(this).getBuiltins().array();
+    }
+
+    @Specialization(guards = {"findInterop(value, interop).isString()"})
+    Type doPolyglotString(Object value, @CachedLibrary(limit = "3") InteropLibrary interop) {
+      return EnsoContext.get(this).getBuiltins().text();
+    }
+
+    @Specialization(guards = {"findInterop(value, interop).isNumber()"})
+    Type doPolyglotNumber(Object value, @CachedLibrary(limit = "3") InteropLibrary interop) {
+      Builtins builtins = EnsoContext.get(this).getBuiltins();
+      if (interop.fitsInInt(value)) {
+        return builtins.number().getInteger();
+      } else if (interop.fitsInDouble(value)) {
+        return builtins.number().getDecimal();
+      } else {
+        return EnsoContext.get(this).getBuiltins().number().getNumber();
+      }
+    }
+
+    @Specialization(guards = {"findInterop(value, interop).isDateTime()"})
+    Type doDateTime(Object value, @CachedLibrary(limit = "3") InteropLibrary interop) {
+      return EnsoContext.get(this).getBuiltins().dateTime();
+    }
+
+    @Specialization(guards = {"findInterop(value, interop).isTimeZone()"})
+    Type doTimeZone(Object value, @CachedLibrary(limit = "3") InteropLibrary interop) {
+      EnsoContext ctx = EnsoContext.get(this);
+      return ctx.getBuiltins().timeZone();
+    }
+
+    @Specialization(guards = {"findInterop(value, interop).isDate()"})
+    Type doDate(Object value, @CachedLibrary(limit = "3") InteropLibrary interop) {
+      EnsoContext ctx = EnsoContext.get(this);
+      return ctx.getBuiltins().date();
+    }
+
+    @Specialization(guards = {"findInterop(value, interop).isTime()"})
+    Type doTime(Object value, @CachedLibrary(limit = "3") InteropLibrary interop) {
+      EnsoContext ctx = EnsoContext.get(this);
+      return ctx.getBuiltins().timeOfDay();
+    }
+
+    @Specialization(guards = "findInterop(value, interop).isDuration()")
+    Type doDuration(Object value, @CachedLibrary(limit = "3") InteropLibrary interop) {
+      EnsoContext ctx = EnsoContext.get(this);
+      return ctx.getBuiltins().duration();
+    }
+
+    @Specialization(guards = {"findInterop(value, interop).isNone()"})
+    Object doMetaObject(Object value, @CachedLibrary(limit = "3") InteropLibrary interop) {
+      try {
+        return interop.getMetaObject(value);
+      } catch (UnsupportedMessageException e) {
+        CompilerDirectives.transferToInterpreter();
+        Builtins builtins = EnsoContext.get(this).getBuiltins();
+        throw new PanicException(builtins.error().makeCompileError("invalid meta object"), this);
+      }
+    }
+
+    static InteropType findInterop(Object value, InteropLibrary interop) {
+      return InteropType.find(value, interop);
+    }
+
+    enum InteropType {
+      NONE,
+      STRING,
+      NUMBER,
+      ARRAY,
+      DATE_TIME,
+      TIME_ZONE,
+      DATE,
+      TIME,
+      DURATION;
+
+      static InteropType find(Object value, InteropLibrary interop) {
+        if (interop.isString(value)) {
+          return STRING;
+        }
+        if (interop.isNumber(value)) {
+          return NUMBER;
+        }
+        if (interop.hasArrayElements(value)) {
+          return ARRAY;
+        }
+        boolean time = interop.isTime(value);
+        boolean date = interop.isDate(value);
+        if (time) {
+          return date ? DATE_TIME : TIME;
+        }
+        if (date) {
+          return DATE;
+        }
+        if (interop.isTimeZone(value)) {
+          return TIME_ZONE;
+        }
+        if (interop.isDuration(value)) {
+          return DURATION;
+        }
+        return NONE;
+      }
+
+      boolean isString() {
+        return this == STRING;
+      }
+
+      boolean isNumber() {
+        return this == NUMBER;
+      }
+
+      boolean isArray() {
+        return this == ARRAY;
+      }
+
+      boolean isDateTime() {
+        return this == DATE_TIME;
+      }
+
+      boolean isTimeZone() {
+        return this == TIME_ZONE;
+      }
+
+      boolean isTime() {
+        return this == TIME;
+      }
+
+      boolean isDate() {
+        return this == DATE;
+      }
+
+      boolean isDuration() {
+        return this == DURATION;
+      }
+
+      boolean isNone() {
+        return this == NONE;
+      }
+    }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNode.java
@@ -221,7 +221,7 @@ public abstract class TypeOfNode extends Node {
         if (interop.isDuration(value)) {
           return DURATION;
         }
-        if (interop.isMetaObject(value)) {
+        if (interop.hasMetaObject(value)) {
           return META_OBJECT;
         }
         return NONE;

--- a/test/Tests/src/Semantic/Case_Spec.enso
+++ b/test/Tests/src/Semantic/Case_Spec.enso
@@ -257,18 +257,17 @@ spec = Test.group "Pattern Matches" <|
             _ -> Test.fail "Expected to match on ArrayList type."
 
         case Meta.type_of list of
-            _ : Vector -> Test.fail "Expected to match in java.lang.Class case."
-            _ : Array -> Test.fail "Expected to match in java.lang.Class case."
-            _ : ArrayList -> Test.fail "Expected to match in java.lang.Class case."
-            _ : Class -> Nothing
-            _ : ArrayList -> Test.fail "Expected to match in java.lang.Class case."
+            _ : Vector -> Test.fail "Expected to match Array case."
+            _ : ArrayList -> Test.fail "Expected to match Array case."
+            _ : Class -> Test.fail "Expected to match Array case."
+            Array -> Nothing
+            _ -> Test.fail "Expected to match Array case."
 
         case Meta.type_of list of
-            Vector -> Test.fail "Expected to match on a polyglot symbol."
-            Array -> Test.fail "Expected to match on a polyglot symbol."
-            ArrayList -> Nothing
-            Class -> Test.fail "Expected to match on a polyglot symbol."
-            _ -> Test.fail "Expected to match on a polyglot symbol."
+            Vector -> Test.fail "Expected to match Array case."
+            Class -> Test.fail "Expected to match Array case."
+            Array -> Nothing
+            _ -> Test.fail "Expected to match Array case."
 
         # Tests a bug where array matching a polyglot Object[] array would fail if the same branch mis-matched earlier.
         foo x = case x of

--- a/test/Tests/src/Semantic/Meta_Spec.enso
+++ b/test/Tests/src/Semantic/Meta_Spec.enso
@@ -194,7 +194,8 @@ spec =
             list.add 123
             list_tpe = Meta.type_of list
             list_tpe . should_not_equal_type JObject
-            list_tpe . should_equal_type ArrayList
+            list_tpe . should_not_equal_type ArrayList
+            list_tpe . should_equal_type Array
 
             e = IOException.new "meh"
             e_tpe = Meta.type_of e


### PR DESCRIPTION
### Pull Request Description

Many of our specializations have complicated guards. They accept one alternative, but try to avoid others with negative checks. It is messy and problematic to keep consistency when expanding the guards. This PR proposes **enum dispatch pattern** instead. The algorithm to select a specialization is encoded in `find` method - whatever gets selected is the right `@Specialization`. No need for negative guards.

Since [a86fd22](https://github.com/enso-org/enso/pull/6819/commits/a86fd2272145b18acac8a2884d3d48dda13f6f20) the check of `types.hasType` is performed and if not, all the other operations are delegated to `WithoutType` node. That node can safely assume `value` doesn't have a type.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
