### PR TITLE
Detect and override hooks of the same kind

### DIFF
--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ShutdownHookActivator.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ShutdownHookActivator.scala
@@ -36,8 +36,9 @@ class ShutdownHookActivator[F[+_, +_]: Exec: CovariantFlatMap]
     scheduled: List[UUID] = Nil
   ): Receive = {
     case RegisterShutdownHook(projectId, hook) =>
-      val realHook = hook.asInstanceOf[ShutdownHook[F]]
-      val updated  = hooks.updated(projectId, realHook :: hooks(projectId))
+      val realHook    = hook.asInstanceOf[ShutdownHook[F]]
+      val uniqueHooks = hooks(projectId).filter(!_.isSameKind(realHook))
+      val updated     = hooks.updated(projectId, realHook :: uniqueHooks)
       context.become(running(updated, scheduled))
 
     case ProjectClosed(projectId) =>

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/shutdown/ShutdownHook.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/shutdown/ShutdownHook.scala
@@ -9,4 +9,7 @@ trait ShutdownHook[F[+_, +_]] {
     */
   def execute(): F[Nothing, Unit]
 
+  /** Checks if the provided `hook`` refers to the same kind of action as `this`` */
+  def isSameKind(hook: ShutdownHook[F]): Boolean
+
 }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/MoveProjectDirCmd.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/MoveProjectDirCmd.scala
@@ -47,4 +47,17 @@ class MoveProjectDirCmd[F[+_, +_]: CovariantFlatMap: ErrorChannel](
     )
   }
 
+  /** Returns the project ID to which this hook refers to */
+  def getProjectId(): UUID =
+    projectId
+
+  /** @inheritdoc */
+  override def isSameKind(hook: ShutdownHook[F]): Boolean = {
+    hook match {
+      case cmd: MoveProjectDirCmd[_] =>
+        projectId == cmd.getProjectId()
+      case _ =>
+        false
+    }
+  }
 }


### PR DESCRIPTION
### Pull Request Description

This change ensures that we can have at most one hook of the same action during shutdown.
Verified the change on a real project.

Closes #6767.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
