### PR TITLE
Empty editions are not parsed as NaN

### DIFF
--- a/lib/scala/pkg/src/test/scala/org/enso/pkg/ConfigSpec.scala
+++ b/lib/scala/pkg/src/test/scala/org/enso/pkg/ConfigSpec.scala
@@ -94,7 +94,7 @@ class ConfigSpec
       serialized should include("edition: '2020.1'")
     }
 
-    "correctly de-serialize missing edition" in {
+    "correctly parse empty edition field" in {
       val config =
         """name: FooBar
           |edition:

--- a/lib/scala/pkg/src/test/scala/org/enso/pkg/ConfigSpec.scala
+++ b/lib/scala/pkg/src/test/scala/org/enso/pkg/ConfigSpec.scala
@@ -93,6 +93,16 @@ class ConfigSpec
       val serialized = parsed.toYaml
       serialized should include("edition: '2020.1'")
     }
+
+    "correctly de-serialize missing edition" in {
+      val config =
+        """name: FooBar
+          |edition:
+          |""".stripMargin
+      val parsed = Config.fromYaml(config).get
+
+      parsed.edition shouldBe None
+    }
   }
 
   "Component groups" should {


### PR DESCRIPTION
### Pull Request Description

Empty edition (null value) was parsed as NaN, which was confusing. This change correctly detects the case before trying different fallback mechanisms.

Addresses invalid warning mentioned in #6806.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
