### PR TITLE
Split CB documentation to smaller pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,8 @@
 - [A loading animation is now shown when opening and creating projects][6827],
   as the previous behaviour of showing a blank screen while the project was
   being loaded was potentially confusing to users.
+- [Performance and readability of documentation panel was improved][6893]. The
+  documentation is now split into separate pages, which are much smaller.
 
 [6279]: https://github.com/enso-org/enso/pull/6279
 [6421]: https://github.com/enso-org/enso/pull/6421
@@ -191,6 +193,7 @@
 [6474]: https://github.com/enso-org/enso/pull/6474
 [6844]: https://github.com/enso-org/enso/pull/6844
 [6827]: https://github.com/enso-org/enso/pull/6827
+[6893]: https://github.com/enso-org/enso/pull/6893
 
 #### EnsoGL (rendering engine)
 

--- a/app/gui/suggestion-database/src/documentation_ir.rs
+++ b/app/gui/suggestion-database/src/documentation_ir.rs
@@ -21,6 +21,17 @@ use std::cmp::Ordering;
 
 
 
+// ==============
+// === Errors ===
+// ==============
+
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, Eq, Fail, PartialEq)]
+#[fail(display = "Can't find parent module for entry with id {}", _0)]
+pub struct NoParentModule(entry::Id);
+
+
+
 // ==========================
 // === EntryDocumentation ===
 // ==========================
@@ -42,28 +53,35 @@ impl Default for EntryDocumentation {
     }
 }
 
+/// A link to the other documentation entry. It is used to connect documentation pages (for
+/// example, the module documentation with every type's documentation).
+#[derive(Debug)]
+pub struct LinkedDocPage {
+    /// The name of the liked entry. It is used to produce a unique ID for the link.
+    pub name: Rc<QualifiedName>,
+    /// The intermediate reprentation of the linked entry's documentation.
+    pub page: EntryDocumentation,
+}
+
 impl EntryDocumentation {
     /// Constructor.
-    pub fn new(db: &SuggestionDatabase, id: &entry::Id) -> Result<Self, NoSuchEntry> {
+    pub fn new(db: &SuggestionDatabase, id: &entry::Id) -> FallibleResult<Self> {
         let entry = db.lookup(*id);
         let result = match entry {
             Ok(entry) => match entry.kind {
-                Kind::Type => {
-                    let type_docs = TypeDocumentation::new(*id, &entry, db)?.into();
-                    Documentation::Type(type_docs).into()
-                }
+                Kind::Type => Self::type_docs(db, &entry, *id)?,
                 Kind::Module => {
-                    let module_docs = ModuleDocumentation::new(*id, &entry, db)?.into();
+                    let module_docs = ModuleDocumentation::new(*id, &entry, db)?;
                     Documentation::Module(module_docs).into()
                 }
                 Kind::Constructor => Self::constructor_docs(db, &entry)?,
                 Kind::Method => Self::method_docs(db, &entry)?,
                 Kind::Function => {
-                    let function_docs = FunctionDocumentation::from_entry(&entry).into();
+                    let function_docs = Function::from_entry(&entry);
                     Documentation::Function(function_docs).into()
                 }
                 Kind::Local => {
-                    let local_docs = LocalDocumentation::from_entry(&entry).into();
+                    let local_docs = LocalDocumentation::from_entry(&entry);
                     Documentation::Local(local_docs).into()
                 }
             },
@@ -75,24 +93,125 @@ impl EntryDocumentation {
         Ok(result)
     }
 
-    /// Qualified name of the function-like entry. See [`Documentation::function_name`].
-    pub fn function_name(&self) -> Option<&QualifiedName> {
-        match self {
-            EntryDocumentation::Docs(docs) => docs.function_name(),
-            _ => None,
-        }
-    }
-
     /// Create documentation for a hard-coded builtin entry.
     pub fn builtin(sections: impl IntoIterator<Item = &DocSection>) -> Self {
-        let sections = Rc::new(BuiltinDocumentation::from_doc_sections(sections.into_iter()));
+        let sections = BuiltinDocumentation::from_doc_sections(sections.into_iter());
         Self::Docs(Documentation::Builtin(sections))
     }
 
-    fn method_docs(
+    /// The list of links displayed on the documentation page.
+    pub fn linked_doc_pages(&self) -> Vec<LinkedDocPage> {
+        match self {
+            EntryDocumentation::Docs(docs) => match docs {
+                Documentation::Module(docs) => {
+                    let methods = docs.methods.iter().map(|method| LinkedDocPage {
+                        name: method.name.clone_ref(),
+                        page: Documentation::ModuleMethod {
+                            docs:        method.clone_ref(),
+                            module_docs: docs.clone_ref(),
+                        }
+                        .into(),
+                    });
+                    let types = docs.types.iter().map(|type_| LinkedDocPage {
+                        name: type_.name.clone_ref(),
+                        page: Documentation::Type {
+                            docs:        type_.clone_ref(),
+                            module_docs: docs.clone_ref(),
+                        }
+                        .into(),
+                    });
+                    methods.chain(types).collect()
+                }
+                Documentation::Type { docs, module_docs } => {
+                    let methods = docs.methods.iter().map(|method| LinkedDocPage {
+                        name: method.name.clone_ref(),
+                        page: Documentation::Method {
+                            docs:        method.clone_ref(),
+                            type_docs:   docs.clone_ref(),
+                            module_docs: module_docs.clone_ref(),
+                        }
+                        .into(),
+                    });
+                    let constructors = docs.constructors.iter().map(|constructor| LinkedDocPage {
+                        name: constructor.name.clone_ref(),
+                        page: Documentation::Constructor {
+                            docs:        constructor.clone_ref(),
+                            type_docs:   docs.clone_ref(),
+                            module_docs: module_docs.clone_ref(),
+                        }
+                        .into(),
+                    });
+                    let parent_module = LinkedDocPage {
+                        name: module_docs.name.clone_ref(),
+                        page: Documentation::Module(module_docs.clone_ref()).into(),
+                    };
+                    methods.chain(constructors).chain(iter::once(parent_module)).collect()
+                }
+                Documentation::Constructor { type_docs, module_docs, .. } => vec![LinkedDocPage {
+                    name: type_docs.name.clone_ref(),
+                    page: Documentation::Type {
+                        docs:        type_docs.clone_ref(),
+                        module_docs: module_docs.clone_ref(),
+                    }
+                    .into(),
+                }],
+                Documentation::Method { type_docs, module_docs, .. } => vec![LinkedDocPage {
+                    name: type_docs.name.clone_ref(),
+                    page: Documentation::Type {
+                        docs:        type_docs.clone_ref(),
+                        module_docs: module_docs.clone_ref(),
+                    }
+                    .into(),
+                }],
+                Documentation::ModuleMethod { module_docs, .. } => vec![LinkedDocPage {
+                    name: module_docs.name.clone_ref(),
+                    page: Documentation::Module(module_docs.clone_ref()).into(),
+                }],
+                Documentation::Function(_) => default(),
+                Documentation::Local(_) => default(),
+                Documentation::Builtin(_) => default(),
+            },
+            EntryDocumentation::Placeholder(_) => default(),
+        }
+    }
+
+    fn parent_module(
         db: &SuggestionDatabase,
         entry: &Entry,
-    ) -> Result<EntryDocumentation, NoSuchEntry> {
+        entry_id: entry::Id,
+    ) -> Result<ModuleDocumentation, NoParentModule> {
+        let defined_in = &entry.defined_in;
+        let parent_module = db.lookup_by_qualified_name(defined_in);
+        match parent_module {
+            Some((id, parent)) => match parent.kind {
+                Kind::Module => Ok(ModuleDocumentation::new(id, &parent, db)
+                    .map_err(|_| NoParentModule(entry_id))?),
+                _ => {
+                    error!(
+                        "Unexpected parent entry ({}) kind, expected Module.",
+                        entry.qualified_name()
+                    );
+                    Err(NoParentModule(entry_id))
+                }
+            },
+            None => {
+                error!("Parent module for entry {} not found.", entry.qualified_name());
+                Err(NoParentModule(entry_id))
+            }
+        }
+    }
+
+    fn type_docs(
+        db: &SuggestionDatabase,
+        entry: &Entry,
+        entry_id: entry::Id,
+    ) -> FallibleResult<EntryDocumentation> {
+        let module_docs = Self::parent_module(db, entry, entry_id)?;
+        let type_docs = TypeDocumentation::new(entry_id, entry, db)?;
+        Ok(Documentation::Type { docs: type_docs, module_docs }.into())
+    }
+
+    fn method_docs(db: &SuggestionDatabase, entry: &Entry) -> FallibleResult<EntryDocumentation> {
         let self_type = match &entry.self_type {
             Some(self_type) => self_type,
             None => {
@@ -100,26 +219,25 @@ impl EntryDocumentation {
                 return Ok(Placeholder::NoDocumentation.into());
             }
         };
-        let return_type = db.lookup_by_qualified_name(self_type);
-        match return_type {
-            Some((id, parent)) => {
-                let name = entry.qualified_name().into();
-                match parent.kind {
-                    Kind::Type => {
-                        let type_docs = TypeDocumentation::new(id, &parent, db)?.into();
-                        Ok(Documentation::Method { name, type_docs }.into())
-                    }
-                    Kind::Module => {
-                        let module_docs = ModuleDocumentation::new(id, &parent, db)?;
-                        let module_docs = module_docs.into();
-                        Ok(Documentation::ModuleMethod { name, module_docs }.into())
-                    }
-                    _ => {
-                        error!("Unexpected parent kind for method {}.", entry.qualified_name());
-                        Ok(Placeholder::NoDocumentation.into())
-                    }
+        let self_type = db.lookup_by_qualified_name(self_type);
+        match self_type {
+            Some((id, parent)) => match parent.kind {
+                Kind::Type => {
+                    let docs = Function::from_entry(entry);
+                    let type_docs = TypeDocumentation::new(id, &parent, db)?;
+                    let module_docs = Self::parent_module(db, &parent, id)?;
+                    Ok(Documentation::Method { docs, type_docs, module_docs }.into())
                 }
-            }
+                Kind::Module => {
+                    let docs = Function::from_entry(entry);
+                    let module_docs = ModuleDocumentation::new(id, &parent, db)?;
+                    Ok(Documentation::ModuleMethod { docs, module_docs }.into())
+                }
+                _ => {
+                    error!("Unexpected parent kind for method {}.", entry.qualified_name());
+                    Ok(Placeholder::NoDocumentation.into())
+                }
+            },
             None => {
                 error!("Parent entry for method {} not found.", entry.qualified_name());
                 Ok(Self::Placeholder(Placeholder::NoDocumentation))
@@ -130,15 +248,16 @@ impl EntryDocumentation {
     fn constructor_docs(
         db: &SuggestionDatabase,
         entry: &Entry,
-    ) -> Result<EntryDocumentation, NoSuchEntry> {
+    ) -> FallibleResult<EntryDocumentation> {
         let return_type = &entry.return_type;
         let return_type = db.lookup_by_qualified_name(return_type);
 
         match return_type {
             Some((id, parent)) => {
-                let name = entry.qualified_name().into();
-                let type_docs = TypeDocumentation::new(id, &parent, db)?.into();
-                Ok(Documentation::Constructor { name, type_docs }.into())
+                let docs = Function::from_entry(entry);
+                let type_docs = TypeDocumentation::new(id, &parent, db)?;
+                let module_docs = Self::parent_module(db, &parent, id)?;
+                Ok(Documentation::Constructor { docs, type_docs, module_docs }.into())
             }
             None => {
                 error!("No return type found for constructor {}.", entry.qualified_name());
@@ -166,30 +285,31 @@ pub enum Placeholder {
 #[derive(Debug, Clone, CloneRef, PartialEq)]
 #[allow(missing_docs)]
 pub enum Documentation {
-    Module(Rc<ModuleDocumentation>),
-    Type(Rc<TypeDocumentation>),
-    Constructor { name: Rc<QualifiedName>, type_docs: Rc<TypeDocumentation> },
-    Method { name: Rc<QualifiedName>, type_docs: Rc<TypeDocumentation> },
-    ModuleMethod { name: Rc<QualifiedName>, module_docs: Rc<ModuleDocumentation> },
-    Function(Rc<FunctionDocumentation>),
-    Local(Rc<LocalDocumentation>),
-    Builtin(Rc<BuiltinDocumentation>),
+    Module(ModuleDocumentation),
+    Type {
+        docs:        TypeDocumentation,
+        module_docs: ModuleDocumentation,
+    },
+    Constructor {
+        docs:        Function,
+        type_docs:   TypeDocumentation,
+        module_docs: ModuleDocumentation,
+    },
+    Method {
+        docs:        Function,
+        type_docs:   TypeDocumentation,
+        module_docs: ModuleDocumentation,
+    },
+    ModuleMethod {
+        docs:        Function,
+        module_docs: ModuleDocumentation,
+    },
+    Function(Function),
+    Local(LocalDocumentation),
+    Builtin(BuiltinDocumentation),
 }
 
-impl Documentation {
-    /// Qualified name of the documented function. Functions are part of the documentation for
-    /// the larger entity, e.g., constructor documentation is embedded into the type
-    /// documentation. The returned qualified name is used to scroll to the corresponding section in
-    /// a larger documentation page.
-    pub fn function_name(&self) -> Option<&QualifiedName> {
-        match self {
-            Documentation::Constructor { name, .. } => Some(name),
-            Documentation::Method { name, .. } => Some(name),
-            Documentation::ModuleMethod { name, .. } => Some(name),
-            _ => None,
-        }
-    }
-}
+
 
 // =========================
 // === TypeDocumentation ===
@@ -242,7 +362,7 @@ impl TypeDocumentation {
 // ===========================
 
 /// Documentation of the [`EntryKind::Module`] entries.
-#[derive(Debug, Clone, CloneRef, PartialEq)]
+#[derive(Debug, Clone, CloneRef, PartialEq, Eq)]
 #[allow(missing_docs)]
 pub struct ModuleDocumentation {
     pub name:     Rc<QualifiedName>,
@@ -266,38 +386,6 @@ impl ModuleDocumentation {
             methods: Methods::of_entry(id, db)?,
             examples,
         })
-    }
-}
-
-
-
-// =============================
-// === FunctionDocumentation ===
-// =============================
-
-/// Documentation of the [`EntryKind::Function`] entries.
-#[derive(Debug, Clone, CloneRef, PartialEq)]
-#[allow(missing_docs)]
-pub struct FunctionDocumentation {
-    pub name:      Rc<QualifiedName>,
-    pub arguments: Rc<Vec<Argument>>,
-    pub tags:      Tags,
-    pub synopsis:  Synopsis,
-    pub examples:  Examples,
-}
-
-impl FunctionDocumentation {
-    /// Constructor.
-    pub fn from_entry(entry: &Entry) -> Self {
-        let FilteredDocSections { tags, synopsis, examples } =
-            FilteredDocSections::new(entry.documentation.iter());
-        Self {
-            name: entry.qualified_name().into(),
-            arguments: entry.arguments.clone().into(),
-            tags,
-            synopsis,
-            examples,
-        }
     }
 }
 
@@ -422,7 +510,7 @@ impl Synopsis {
 // =============
 
 /// A list of types defined in the module.
-#[derive(Debug, Clone, CloneRef, PartialEq, Default, Deref)]
+#[derive(Debug, Clone, CloneRef, PartialEq, Eq, Default, Deref)]
 pub struct Types {
     list: SortedVec<TypeDocumentation>,
 }
@@ -663,8 +751,9 @@ mod tests {
     fn test_documentation_of_constructor() {
         let db = mock_db();
         let name = Rc::new(QualifiedName::from_text("Standard.Base.A.Foo").unwrap());
-        let type_docs = a_type().into();
-        let expected = Documentation::Constructor { name: name.clone(), type_docs };
+        let type_docs = a_type();
+        let docs = a_foo_constructor();
+        let expected = Documentation::Constructor { docs, type_docs, module_docs: module_docs() };
         assert_docs(&db, name, expected);
     }
 
@@ -676,23 +765,26 @@ mod tests {
         // === Type method ===
 
         let name = Rc::new(QualifiedName::from_text("Standard.Base.A.baz").unwrap());
-        let type_docs = a_type().into();
-        let expected = Documentation::Method { name: name.clone(), type_docs };
+        let type_docs = a_type();
+        let docs = a_baz_method();
+        let expected =
+            Documentation::Method { docs, type_docs, module_docs: module_docs().clone_ref() };
         assert_docs(&db, name, expected);
 
 
         // === Module method ===
 
         let name = Rc::new(QualifiedName::from_text("Standard.Base.module_method").unwrap());
-        let module_docs = module_docs().into();
-        let expected = Documentation::ModuleMethod { name: name.clone(), module_docs };
+        let module_docs = module_docs();
+        let docs = module_method_function();
+        let expected = Documentation::ModuleMethod { docs, module_docs };
         assert_docs(&db, name, expected);
     }
 
     #[test]
     fn test_documentation_of_module() {
         let db = mock_db();
-        let expected = Documentation::Module(Rc::new(module_docs()));
+        let expected = Documentation::Module(module_docs());
         let name = Rc::new(QualifiedName::from_text("Standard.Base").unwrap());
         assert_docs(&db, name, expected);
     }
@@ -703,7 +795,7 @@ mod tests {
 
         // === Type Standard.Base.A ===
 
-        let expected = Documentation::Type(Rc::new(a_type()));
+        let expected = Documentation::Type { docs: a_type(), module_docs: module_docs() };
         let name = QualifiedName::from_text("Standard.Base.A").unwrap();
         let (entry_id, _) = db.lookup_by_qualified_name(&name).unwrap();
         let docs = EntryDocumentation::new(&db, &entry_id).unwrap();
@@ -711,7 +803,7 @@ mod tests {
 
         // === Type Standard.Base.B ===
 
-        let expected = Documentation::Type(Rc::new(b_type()));
+        let expected = Documentation::Type { docs: b_type(), module_docs: module_docs() };
         let name = Rc::new(QualifiedName::from_text("Standard.Base.B").unwrap());
         assert_docs(&db, name, expected);
     }

--- a/app/gui/view/documentation/assets/input.css
+++ b/app/gui/view/documentation/assets/input.css
@@ -17,3 +17,7 @@ ul {
   list-style-type: disc;
   list-style-position: inside;
 }
+
+svg {
+  pointer-events: none;
+}

--- a/app/gui/view/documentation/src/html.rs
+++ b/app/gui/view/documentation/src/html.rs
@@ -161,7 +161,7 @@ fn render_type_documentation(docs: &TypeDocumentation, back_link: Option<BackLin
     let tags = section_content(list_of_tags(&docs.tags));
 
     let content = owned_html! {
-        : header(ICON_TYPE, type_header(name.name(), arguments_list(arguments), back_link.clone()));
+        : header(ICON_TYPE, type_header(name.name(), arguments_list(arguments), back_link.as_ref()));
         : &tags;
         : &synopsis;
         @ if methods_exist {
@@ -180,7 +180,7 @@ fn render_type_documentation(docs: &TypeDocumentation, back_link: Option<BackLin
 fn type_header<'a>(
     name: &'a str,
     arguments: impl Render + 'a,
-    back_link: Option<BackLink>,
+    back_link: Option<&'a BackLink>,
 ) -> Box<dyn Render + 'a> {
     box_html! {
         @ if let Some(BackLink { id, displayed }) = &back_link {
@@ -418,7 +418,7 @@ fn render_function_documentation(docs: &Function, back_link: Option<BackLink>) -
     let tags = section_content(list_of_tags(tags));
     let examples = section_content(list_of_examples(&docs.examples));
     let content = owned_html! {
-        : header(ICON_TYPE, function_header(name.name(), arguments_list(arguments), back_link.clone()));
+        : header(ICON_TYPE, function_header(name.name(), arguments_list(arguments), back_link.as_ref()));
         : &tags;
         : &synopsis;
         @ if examples_exist {
@@ -433,7 +433,7 @@ fn render_function_documentation(docs: &Function, back_link: Option<BackLink>) -
 fn function_header<'a>(
     name: &'a str,
     arguments: impl Render + 'a,
-    back_link: Option<BackLink>,
+    back_link: Option<&'a BackLink>,
 ) -> Box<dyn Render + 'a> {
     box_html! {
         @ if let Some(BackLink { id, displayed }) = &back_link {

--- a/app/gui/view/documentation/src/html.rs
+++ b/app/gui/view/documentation/src/html.rs
@@ -14,7 +14,6 @@ use enso_suggestion_database::documentation_ir::Documentation;
 use enso_suggestion_database::documentation_ir::EntryDocumentation;
 use enso_suggestion_database::documentation_ir::Examples;
 use enso_suggestion_database::documentation_ir::Function;
-use enso_suggestion_database::documentation_ir::FunctionDocumentation;
 use enso_suggestion_database::documentation_ir::LocalDocumentation;
 use enso_suggestion_database::documentation_ir::ModuleDocumentation;
 use enso_suggestion_database::documentation_ir::Placeholder;
@@ -62,14 +61,14 @@ fn svg_icon(content: &'static str) -> impl Render {
 
 /// Render entry documentation to HTML code with Tailwind CSS styles.
 #[profile(Detail)]
-pub fn render(docs: EntryDocumentation) -> String {
+pub fn render(docs: &EntryDocumentation) -> String {
     let html = match docs {
         EntryDocumentation::Placeholder(placeholder) => match placeholder {
             Placeholder::NoDocumentation => String::from("No documentation available."),
             Placeholder::VirtualComponentGroup { name } =>
-                render_virtual_component_group_docs(name),
+                render_virtual_component_group_docs(name.clone_ref()),
         },
-        EntryDocumentation::Docs(docs) => render_documentation(docs),
+        EntryDocumentation::Docs(docs) => render_documentation(docs.clone_ref()),
     };
     match validate_utf8(&html) {
         Ok(_) => html,
@@ -87,17 +86,33 @@ fn validate_utf8(s: &str) -> Result<&str, std::str::Utf8Error> {
 }
 
 fn render_documentation(docs: Documentation) -> String {
+    let back_link = match &docs {
+        Documentation::Constructor { type_docs, .. } => Some(BackLink {
+            displayed: type_docs.name.name().to_owned(),
+            id:        anchor_name(&type_docs.name),
+        }),
+        Documentation::Method { type_docs, .. } => Some(BackLink {
+            displayed: type_docs.name.name().to_owned(),
+            id:        anchor_name(&type_docs.name),
+        }),
+        Documentation::ModuleMethod { module_docs, .. } => Some(BackLink {
+            displayed: module_docs.name.name().to_owned(),
+            id:        anchor_name(&module_docs.name),
+        }),
+        Documentation::Type { module_docs, .. } => Some(BackLink {
+            displayed: module_docs.name.name().to_owned(),
+            id:        anchor_name(&module_docs.name),
+        }),
+        _ => None,
+    };
     match docs {
-        Documentation::Module(module_docs) => render_module_documentation(&module_docs, None),
-        Documentation::Type(type_docs) => render_type_documentation(&type_docs, None),
-        Documentation::Function(docs) => render_function_documentation(&docs),
+        Documentation::Module(module_docs) => render_module_documentation(&module_docs),
+        Documentation::Type { docs, .. } => render_type_documentation(&docs, back_link),
+        Documentation::Function(docs) => render_function_documentation(&docs, back_link),
         Documentation::Local(docs) => render_local_documentation(&docs),
-        Documentation::Constructor { type_docs, name } =>
-            render_type_documentation(&type_docs, Some(&name)),
-        Documentation::Method { type_docs, name } =>
-            render_type_documentation(&type_docs, Some(&name)),
-        Documentation::ModuleMethod { module_docs, name } =>
-            render_module_documentation(&module_docs, Some(&name)),
+        Documentation::Constructor { docs, .. } => render_function_documentation(&docs, back_link),
+        Documentation::Method { docs, .. } => render_function_documentation(&docs, back_link),
+        Documentation::ModuleMethod { docs, .. } => render_function_documentation(&docs, back_link),
         Documentation::Builtin(builtin_docs) => render_builtin_documentation(&builtin_docs),
     }
 }
@@ -112,6 +127,17 @@ fn render_virtual_component_group_docs(name: ImString) -> String {
     docs_content(content).into_string().unwrap()
 }
 
+/// An optional link to the parent entry (module or type), that is displayed in the documentation
+/// header. Pressing this link will switch the documentation to the parent entry, allowing
+/// bidirectional navigation.
+#[derive(Debug, Clone)]
+struct BackLink {
+    /// Displayed text.
+    displayed: String,
+    /// The unique ID of the link.
+    id:        String,
+}
+
 
 // === Types ===
 
@@ -122,23 +148,20 @@ fn render_virtual_component_group_docs(name: ImString) -> String {
 /// - Synopsis and a list of constructors.
 /// - Methods.
 /// - Examples.
-fn render_type_documentation(
-    docs: &TypeDocumentation,
-    function_name: Option<&QualifiedName>,
-) -> String {
+fn render_type_documentation(docs: &TypeDocumentation, back_link: Option<BackLink>) -> String {
     let methods_exist = !docs.methods.is_empty();
     let examples_exist = !docs.examples.is_empty();
     let name = &docs.name;
     let arguments = &docs.arguments;
     let synopsis = &docs.synopsis;
     let constructors = &docs.constructors;
-    let synopsis = section_content(type_synopsis(synopsis, constructors, function_name));
-    let methods = section_content(list_of_functions(&docs.methods, function_name));
+    let synopsis = section_content(type_synopsis(synopsis, constructors));
+    let methods = section_content(list_of_functions(&docs.methods));
     let examples = section_content(list_of_examples(&docs.examples));
     let tags = section_content(list_of_tags(&docs.tags));
 
     let content = owned_html! {
-        : header(ICON_TYPE, type_header(name.name(), arguments_list(arguments)));
+        : header(ICON_TYPE, type_header(name.name(), arguments_list(arguments), back_link.clone()));
         : &tags;
         : &synopsis;
         @ if methods_exist {
@@ -154,8 +177,18 @@ fn render_type_documentation(
 }
 
 /// A header for the type documentation.
-fn type_header<'a>(name: &'a str, arguments: impl Render + 'a) -> Box<dyn Render + 'a> {
+fn type_header<'a>(
+    name: &'a str,
+    arguments: impl Render + 'a,
+    back_link: Option<BackLink>,
+) -> Box<dyn Render + 'a> {
     box_html! {
+        @ if let Some(BackLink { id, displayed }) = &back_link {
+            a(id=id, class="text-2xl font-bold text-typeName hover:underline cursor-pointer") {
+                : displayed;
+            }
+            : " :: ";
+        }
         span(class="text-2xl font-bold text-typeName") {
             span { : name }
             span(class="opacity-34") { : &arguments }
@@ -176,7 +209,6 @@ fn methods_header() -> impl Render {
 fn type_synopsis<'a>(
     synopsis: &'a Synopsis,
     constructors: &'a Constructors,
-    function_name: Option<&'a QualifiedName>,
 ) -> Box<dyn Render + 'a> {
     box_html! {
         @ for p in synopsis.iter() {
@@ -189,86 +221,65 @@ fn type_synopsis<'a>(
         }
         ul(class="list-disc list-outside marker:text-typeName") {
             @ for method in constructors.iter() {
-                : single_constructor(method, function_name);
+                : single_constructor(method);
             }
         }
     }
 }
 
 /// A documentation for a single constructor in the list.
-fn single_constructor<'a>(
-    method: &'a Function,
-    function_name: Option<&'a QualifiedName>,
-) -> Box<dyn Render + 'a> {
-    let highlight = function_name.map(|n| n == &*method.name).unwrap_or(false);
+/// If the first [`DocSection`] is of type [`DocSection::Paragraph`], it is rendered on the first
+/// line, after the list of arguments.
+fn single_constructor<'a>(constructor: &'a Function) -> Box<dyn Render + 'a> {
+    let first = match &constructor.synopsis.as_ref()[..] {
+        [DocSection::Paragraph { body }, ..] => Some(body),
+        _ => None,
+    };
     box_html! {
-        li(id=anchor_name(&method.name)) {
-            span(class=labels!("text-typeName", "font-bold", "bg-yellow-100" => highlight)) {
+        li(id=anchor_name(&constructor.name), class="hover:underline cursor-pointer") {
+            span(class=labels!("text-typeName", "font-bold")) {
                 span(class="opacity-85") {
-                    : method.name.name();
+                    : constructor.name.name();
                 }
-                span(class="opacity-34") { : arguments_list(&method.arguments); }
+                span(class="opacity-34") { : arguments_list(&constructor.arguments); }
             }
-            : function_docs(method);
+            @ if let Some(first) = first {
+                span { : ", "; : Raw(first); }
+            }
         }
     }
 }
 
 /// A list of methods defined for the type.
-fn list_of_functions<'a>(
-    functions: &'a [Function],
-    function_name: Option<&'a QualifiedName>,
-) -> Box<dyn Render + 'a> {
+fn list_of_functions<'a>(functions: &'a [Function]) -> Box<dyn Render + 'a> {
     box_html! {
         ul(class="list-disc list-inside") {
             @ for f in functions.iter() {
-                : single_function(f, function_name);
+                : single_function(f);
             }
         }
     }
 }
 
 /// A documentation for a single method in the list.
-fn single_function<'a>(
-    function: &'a Function,
-    function_name: Option<&'a QualifiedName>,
-) -> Box<dyn Render + 'a> {
-    let highlight = function_name.map(|n| n == &*function.name).unwrap_or(false);
+/// If the first [`DocSection`] is of type [`DocSection::Paragraph`], it is rendered on the first
+/// line, after the list of arguments.
+fn single_function<'a>(function: &'a Function) -> Box<dyn Render + 'a> {
+    let first = match &function.synopsis.as_ref()[..] {
+        [DocSection::Paragraph { body }, ..] => Some(body),
+        _ => None,
+    };
     box_html! {
-        li(id=anchor_name(&function.name)) {
-            span(class=labels!("text-methodName", "font-semibold", "bg-yellow-100" => highlight)) {
+        li(id=anchor_name(&function.name), class="hover:underline cursor-pointer") {
+            span(class=labels!("text-methodName", "font-semibold")) {
                 span(class="opacity-85") {
                     : function.name.name();
                 }
                 span(class="opacity-34") { : arguments_list(&function.arguments); }
             }
-            : function_docs(function);
-        }
-    }
-}
-
-/// Synopsis of a function. If the first [`DocSection`] is of type
-/// [`DocSection::Paragraph`], it is rendered on the first line, after the list of arguments. All
-/// other sections are rendered as separate paragraphs below. Examples for the function are rendered
-/// below the main part of the documentation in a separate subsection.
-fn function_docs<'a>(constructor: &'a Function) -> Box<dyn Render + 'a> {
-    let (first, rest) = match &constructor.synopsis.as_ref()[..] {
-        [DocSection::Paragraph { body }, rest @ ..] => (Some(body), rest),
-        [_, rest @ ..] => (None, rest),
-        [] => (None, default()),
-    };
-    let tags = list_of_tags(&constructor.tags);
-    box_html! {
-        @ if let Some(first) = first {
-            span { : ", "; : Raw(first); }
-        }
-        : &tags;
-        @ for p in rest {
-            : paragraph(p);
-        }
-        @ if !constructor.examples.is_empty() {
-            h2(class="font-semibold") { : "Examples" }
-            : list_of_examples(&constructor.examples);
+            @ if let Some(first) = first {
+                span { : ", "; : Raw(first); }
+            }
         }
     }
 }
@@ -284,17 +295,14 @@ fn function_docs<'a>(constructor: &'a Function) -> Box<dyn Render + 'a> {
 /// - Types.
 /// - Functions.
 /// - Examples.
-fn render_module_documentation(
-    docs: &ModuleDocumentation,
-    function_name: Option<&QualifiedName>,
-) -> String {
+fn render_module_documentation(docs: &ModuleDocumentation) -> String {
     let types_exist = !docs.types.is_empty();
     let methods_exist = !docs.methods.is_empty();
     let examples_exist = !docs.examples.is_empty();
     let name = &docs.name;
     let synopsis = section_content(module_synopsis(&docs.synopsis));
     let types = section_content(list_of_types(&docs.types));
-    let methods = section_content(list_of_functions(&docs.methods, function_name));
+    let methods = section_content(list_of_functions(&docs.methods));
     let examples = section_content(list_of_examples(&docs.examples));
     let tags = section_content(list_of_tags(&docs.tags));
     let content = owned_html! {
@@ -331,7 +339,7 @@ fn list_of_types<'a>(types: &'a Types) -> Box<dyn Render + 'a> {
 /// A single type in the list.
 fn single_type<'a>(type_: &'a TypeDocumentation) -> Box<dyn Render + 'a> {
     box_html! {
-        li(id=anchor_name(&type_.name), class="text-typeName font-semibold") {
+        li(id=anchor_name(&type_.name), class="text-typeName font-semibold hover:underline cursor-pointer") {
             span(class="opacity-85") {
                 : type_.name.name();
             }
@@ -402,15 +410,15 @@ fn module_synopsis<'a>(synopsis: &'a Synopsis) -> Box<dyn Render + 'a> {
 // === Functions ===
 
 /// Render documentation of a function.
-fn render_function_documentation(docs: &FunctionDocumentation) -> String {
-    let FunctionDocumentation { name, arguments, synopsis, tags, .. } = docs;
+fn render_function_documentation(docs: &Function, back_link: Option<BackLink>) -> String {
+    let Function { name, arguments, synopsis, tags, .. } = docs;
 
     let examples_exist = !docs.examples.is_empty();
     let synopsis = section_content(function_synopsis(synopsis));
     let tags = section_content(list_of_tags(tags));
     let examples = section_content(list_of_examples(&docs.examples));
     let content = owned_html! {
-        : header(ICON_TYPE, function_header(name.name(), arguments_list(arguments)));
+        : header(ICON_TYPE, function_header(name.name(), arguments_list(arguments), back_link.clone()));
         : &tags;
         : &synopsis;
         @ if examples_exist {
@@ -422,8 +430,18 @@ fn render_function_documentation(docs: &FunctionDocumentation) -> String {
 }
 
 /// A header for the function documentation.
-fn function_header<'a>(name: &'a str, arguments: impl Render + 'a) -> Box<dyn Render + 'a> {
+fn function_header<'a>(
+    name: &'a str,
+    arguments: impl Render + 'a,
+    back_link: Option<BackLink>,
+) -> Box<dyn Render + 'a> {
     box_html! {
+        @ if let Some(BackLink { id, displayed }) = &back_link {
+            a(id=id, class="text-2xl font-bold text-typeName hover:underline cursor-pointer") {
+                : displayed;
+            }
+            : " :: ";
+        }
         span(class="text-2xl font-bold text-typeName") {
             span { : name }
             span(class="opacity-34") { : &arguments }

--- a/app/gui/view/documentation/src/lib.rs
+++ b/app/gui/view/documentation/src/lib.rs
@@ -40,6 +40,7 @@ use ensogl::system::web::traits::*;
 
 use enso_frp as frp;
 use enso_suggestion_database::documentation_ir::EntryDocumentation;
+use enso_suggestion_database::documentation_ir::LinkedDocPage;
 use ensogl::animation::physics::inertia::Spring;
 use ensogl::application::Application;
 use ensogl::data::color;
@@ -55,8 +56,6 @@ use ensogl_derive_theme::FromTheme;
 use ensogl_hardcoded_theme::application::component_browser::documentation as theme;
 use graph_editor::component::visualization;
 use ide_view_graph_editor as graph_editor;
-use web::HtmlElement;
-use web::JsCast;
 
 
 // ==============
@@ -110,6 +109,7 @@ pub struct Model {
     /// to EnsoGL shapes, and pass them to the DOM instead.
     overlay:        overlay::View,
     display_object: display::object::Instance,
+    event_handlers: Rc<RefCell<Vec<web::EventListenerHandle>>>,
 }
 
 impl Model {
@@ -150,7 +150,15 @@ impl Model {
         scene.dom.layers.node_searcher.manage(&inner_dom);
         scene.dom.layers.node_searcher.manage(&caption_dom);
 
-        Model { outer_dom, inner_dom, caption_dom, overlay, display_object }.init()
+        Model {
+            outer_dom,
+            inner_dom,
+            caption_dom,
+            overlay,
+            display_object,
+            event_handlers: default(),
+        }
+        .init()
     }
 
     fn init(self) -> Self {
@@ -173,17 +181,33 @@ impl Model {
     }
 
     /// Display the documentation and scroll to the qualified name if needed.
-    fn display_doc(&self, docs: EntryDocumentation) {
-        let anchor = docs.function_name().map(html::anchor_name);
-        let html = html::render(docs);
+    fn display_doc(&self, docs: EntryDocumentation, display_doc: &frp::Source<EntryDocumentation>) {
+        let linked_pages = docs.linked_doc_pages();
+        let html = html::render(&docs);
         self.inner_dom.dom().set_inner_html(&html);
-        if let Some(anchor) = anchor {
+        self.set_link_handlers(linked_pages, display_doc);
+        // Scroll to the top of the page.
+        self.inner_dom.dom().set_scroll_top(0);
+    }
+
+    /// Setup event handlers for links on the documentation page.
+    fn set_link_handlers(
+        &self,
+        linked_pages: Vec<LinkedDocPage>,
+        display_doc: &frp::Source<EntryDocumentation>,
+    ) {
+        let mut handlers = self.event_handlers.borrow_mut();
+        handlers.clear();
+        for page in linked_pages {
+            let content = page.page.clone_ref();
+            let anchor = html::anchor_name(&page.name);
             if let Some(element) = web::document.get_element_by_id(&anchor) {
-                let offset = element.dyn_ref::<HtmlElement>().map(|e| e.offset_top()).unwrap_or(0);
-                self.inner_dom.dom().set_scroll_top(offset);
+                let closure: web::JsEventHandler = web::Closure::new(f_!([display_doc, content] {
+                    display_doc.emit(content.clone_ref());
+                }));
+                let handler = web::add_event_listener(&element, "click", closure);
+                handlers.push(handler);
             }
-        } else {
-            self.inner_dom.dom().set_scroll_top(0);
         }
     }
 
@@ -300,7 +324,11 @@ impl View {
             docs <+ frp.display_documentation;
             display_delay.restart <+ frp.display_documentation.constant(DISPLAY_DELAY_MS);
             display_docs <- display_delay.on_expired.map2(&docs,|_,docs| docs.clone_ref());
-            eval display_docs((docs) model.display_doc(docs.clone_ref()));
+            display_docs_callback <- source();
+            display_docs <- any(&display_docs, &display_docs_callback);
+            eval display_docs([model, display_docs_callback]
+                (docs) model.display_doc(docs.clone_ref(), &display_docs_callback)
+            );
 
 
             // === Hovered item preview caption ===

--- a/app/gui/view/graph-editor/src/component/node/action_bar.rs
+++ b/app/gui/view/graph-editor/src/component/node/action_bar.rs
@@ -15,7 +15,6 @@ use ensogl_component::toggle_button::ToggleButton;
 use ensogl_hardcoded_theme::graph_editor::node::actions as theme;
 
 
-
 // ==============
 // === Export ===
 // ==============

--- a/app/gui/view/graph-editor/src/component/node/input/widget.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget.rs
@@ -60,6 +60,8 @@ use span_tree::node::Ref as SpanRef;
 use span_tree::TagValue;
 use text::index::Byte;
 
+
+
 pub(super) mod prelude {
     pub use super::ConfigContext;
     pub use super::Configuration;

--- a/lib/rust/data-structures/src/size_capped_vec_deque.rs
+++ b/lib/rust/data-structures/src/size_capped_vec_deque.rs
@@ -1,5 +1,6 @@
 //! A vector with a cap for its size. If the vector is full, adding a new element will remove
 //! an old one.
+
 use std::collections::VecDeque;
 
 

--- a/lib/rust/ensogl/core/src/application.rs
+++ b/lib/rust/ensogl/core/src/application.rs
@@ -106,7 +106,8 @@ impl Application {
         let data = &self.inner;
         let network = self.frp.network();
         enso_frp::extend! { network
-            eval self.display.default_scene.frp.focused ((t) data.show_system_cursor(!t));
+            app_focused <- self.display.default_scene.frp.focused.on_change();
+            eval app_focused((t) data.show_system_cursor(!t));
             frp.private.output.tooltip <+ frp.private.input.set_tooltip;
             eval_ frp.private.input.show_system_cursor(data.show_system_cursor(true));
             eval_ frp.private.input.hide_system_cursor(data.show_system_cursor(false));


### PR DESCRIPTION
### Pull Request Description

Now documentation for types, constructors and methods is displayed separately, with a links between pages.
It drastically improves the speed of documentation panel update (50-100x on my machine), and also provides more readable documentation.


https://github.com/enso-org/enso/assets/6566674/05c77560-162b-4396-bfa0-1e79eb6dcc5f

Before:

<img width="620" alt="Screenshot 2023-05-31 at 01 02 47" src="https://github.com/enso-org/enso/assets/6566674/045ad3fc-470b-44d6-b453-e63c06711d06">


After:

<img width="800" alt="Screenshot 2023-05-31 at 00 54 53" src="https://github.com/enso-org/enso/assets/6566674/cb76e757-66fa-4544-8ef9-80b0a54efe0b">

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
