### PR TITLE
Don't swallow exceptions in RuntimeServerTest

### DIFF
--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -19,6 +19,7 @@ import org.scalatest.matchers.should.Matchers
 import java.io.{ByteArrayOutputStream, File}
 import java.nio.file.{Files, Path, Paths}
 import java.util.UUID
+import org.apache.commons.io.output.TeeOutputStream
 
 @scala.annotation.nowarn("msg=multiarg infix syntax")
 class RuntimeServerTest
@@ -67,8 +68,8 @@ class RuntimeServerTest
             .getAbsolutePath
         )
         .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
-        .logHandler(logOut)
-        .out(out)
+        .logHandler(new TeeOutputStream(logOut, System.err))
+        .out(new TeeOutputStream(out, System.err))
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()
     )

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
@@ -116,6 +116,9 @@ final class JobExecutionEngine(
         case NonFatal(ex) =>
           logger.log(Level.SEVERE, s"Error executing $job", ex)
           promise.failure(ex)
+        case err: Throwable =>
+          logger.log(Level.SEVERE, s"Error executing $job", err)
+          throw err
       } finally {
         runningJobsRef.updateAndGet(_.filterNot(_.id == jobId))
       }


### PR DESCRIPTION
### Pull Request Description

While working on #6903 I realized that `LinkageError` from `Compiler` is silently swallowed by the `RuntimeServerTest`. Avoiding that by using `TeeOutputStream` and always printing out to `stderr`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
