### PR TITLE
Fix GPU performance tool panic

### DIFF
--- a/lib/rust/ensogl/core/src/display/world.rs
+++ b/lib/rust/ensogl/core/src/display/world.rs
@@ -560,22 +560,25 @@ impl WorldData {
         {
             if let Some(gpu_perf_results) = &gpu_perf_results {
                 for result in gpu_perf_results {
-                    // The monitor is not updated yet, so the last sample is from the previous
-                    // frame.
-                    let frame_offset = result.frame_offset - 1;
-                    if frame_offset == 0 {
-                        let stats_data = &mut self.stats.borrow_mut().stats_data;
-                        stats_data.gpu_time = Some(result.total);
-                        stats_data.cpu_and_idle_time = Some(stats_data.frame_time - result.total);
-                    } else {
-                        // The last sampler stored in monitor is from 2 frames ago, as the last
-                        // frame stats are not submitted yet.
-                        let sampler_offset = result.frame_offset - 2;
-                        self.stats_monitor.with_last_nth_sample(sampler_offset, |sample| {
-                            sample.gpu_time = Some(result.total);
-                            sample.cpu_and_idle_time = Some(sample.frame_time - result.total);
-                        });
-                        self.stats_monitor.redraw_historical_data(sampler_offset);
+                    if result.frame_offset > 0 {
+                        // The monitor is not updated yet, so the last sample is from the previous
+                        // frame.
+                        let frame_offset = result.frame_offset - 1;
+                        if frame_offset == 0 {
+                            let stats_data = &mut self.stats.borrow_mut().stats_data;
+                            stats_data.gpu_time = Some(result.total);
+                            stats_data.cpu_and_idle_time =
+                                Some(stats_data.frame_time - result.total);
+                        } else {
+                            // The last sampler stored in monitor is from 2 frames ago, as the last
+                            // frame stats are not submitted yet.
+                            let sampler_offset = result.frame_offset - 2;
+                            self.stats_monitor.with_last_nth_sample(sampler_offset, |sample| {
+                                sample.gpu_time = Some(result.total);
+                                sample.cpu_and_idle_time = Some(sample.frame_time - result.total);
+                            });
+                            self.stats_monitor.redraw_historical_data(sampler_offset);
+                        }
                     }
                 }
             }

--- a/lib/rust/ensogl/core/src/display/world.rs
+++ b/lib/rust/ensogl/core/src/display/world.rs
@@ -560,6 +560,8 @@ impl WorldData {
         {
             if let Some(gpu_perf_results) = &gpu_perf_results {
                 for result in gpu_perf_results {
+                    // If run in the first frame, the results can be reported with frame offset
+                    // being 0. In such a case, we are ignoring it.
                     if result.frame_offset > 0 {
                         // The monitor is not updated yet, so the last sample is from the previous
                         // frame.


### PR DESCRIPTION
### Pull Request Description

Sometimes in the first frame the GPU perf tool panics. This is because we are overflowing subtraction. This PR fixes it.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
