### PR TITLE
Eliminate deadlock scenario during file edit/open/close requests

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -345,10 +345,7 @@ public class ExecutionService {
     if (module.isEmpty()) {
       module = context.createModuleForFile(path);
     }
-    module.ifPresent(
-        mod -> {
-          mod.setLiteralSource(contents);
-        });
+    module.ifPresent(mod -> mod.setLiteralSource(contents));
   }
 
   /**

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/CloseFileCmd.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/CloseFileCmd.scala
@@ -17,13 +17,13 @@ class CloseFileCmd(request: Api.CloseFileNotification) extends Command(None) {
     ec: ExecutionContext
   ): Future[Unit] =
     Future {
-      ctx.locking.acquireFileLock(request.path)
       ctx.locking.acquireReadCompilationLock()
+      ctx.locking.acquireFileLock(request.path)
       try {
         ctx.executionService.resetModuleSources(request.path)
       } finally {
-        ctx.locking.releaseReadCompilationLock()
         ctx.locking.releaseFileLock(request.path)
+        ctx.locking.releaseReadCompilationLock()
       }
     }
 

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/OpenFileCmd.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/command/OpenFileCmd.scala
@@ -17,16 +17,16 @@ class OpenFileCmd(request: Api.OpenFileNotification) extends Command(None) {
     ec: ExecutionContext
   ): Future[Unit] =
     Future {
-      ctx.locking.acquireFileLock(request.path)
       ctx.locking.acquireReadCompilationLock()
+      ctx.locking.acquireFileLock(request.path)
       try {
         ctx.executionService.setModuleSources(
           request.path,
           request.contents
         )
       } finally {
-        ctx.locking.releaseReadCompilationLock()
         ctx.locking.releaseFileLock(request.path)
+        ctx.locking.releaseReadCompilationLock()
       }
     }
 

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -230,7 +230,6 @@ final class EnsureCompiledJob(protected val files: Iterable[File])
     file: File
   )(implicit ctx: RuntimeContext): Option[Changeset[Rope]] = {
     ctx.locking.acquireFileLock(file)
-    ctx.locking.acquireReadCompilationLock()
     ctx.locking.acquirePendingEditsLock()
     try {
       val pendingEdits = ctx.state.pendingEdits.dequeue(file)
@@ -253,7 +252,6 @@ final class EnsureCompiledJob(protected val files: Iterable[File])
       Option.when(shouldExecute)(changeset)
     } finally {
       ctx.locking.releasePendingEditsLock()
-      ctx.locking.releaseReadCompilationLock()
       ctx.locking.releaseFileLock(file)
     }
   }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ExecuteJob.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/instrument/job/ExecuteJob.scala
@@ -26,8 +26,8 @@ class ExecuteJob(
 
   /** @inheritdoc */
   override def run(implicit ctx: RuntimeContext): Unit = {
-    ctx.locking.acquireContextLock(contextId)
     ctx.locking.acquireReadCompilationLock()
+    ctx.locking.acquireContextLock(contextId)
     val context = ctx.executionService.getContext
     val originalExecutionEnvironment =
       executionEnvironment.map(_ => context.getExecutionEnvironment)
@@ -48,8 +48,8 @@ class ExecuteJob(
       }
     } finally {
       originalExecutionEnvironment.foreach(context.setExecutionEnvironment)
-      ctx.locking.releaseReadCompilationLock()
       ctx.locking.releaseContextLock(contextId)
+      ctx.locking.releaseReadCompilationLock()
     }
     ctx.endpoint.sendToClient(Api.Response(Api.ExecutionComplete(contextId)))
     StartBackgroundProcessingJob.startBackgroundJobs()


### PR DESCRIPTION
### Pull Request Description

At the beginning of the execution `EnsureCompiledJob` acquired write compilation lock. When compiling individual modules it would then
- acquire file lock
- acquire read compilation lock

The second one was spurious since it already kept the write lock. This sequence meant however that `CloseFileCmd` or `OpenFileCmd` can lead to  a deadlock when requests come in close succession. This is because commands:
- acquire file lock
- acquire read compilation lock

So `EnsureCompiledJob` might have the (write) compilation lock but the commands could have file lock. And the second required lock for either the job or the command could never be acquired.

Flipping the order did the trick.

Partially solves #6841.

### Important Notes

For some reason we don't get updates for the newly added node, as illustrated in the screenshot, but that could be related to the close/open action. Will need to dig more.

![Screenshot from 2023-06-01 16-45-17](https://github.com/enso-org/enso/assets/292128/900aa9b3-b2b2-4e4d-93c8-267f92b79352)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
