### PR TITLE
Refactor `create_database_table` into `Connection.create_table` and `select_into_database_table`, implement `Set`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -477,6 +477,8 @@
 - [Added execution control to `Table.write` and various bug fixes.][6835]
 - [Implemented `Table.add_row_number`.][6890]
 - [Handling edge cases in rounding.][6922]
+- [Split `Table.create_database_table` into `Connection.create_table` and
+  `Table.select_into_database_table`.][6925]
 
 [debug-shortcuts]:
   https://github.com/enso-org/enso/blob/develop/app/gui/docs/product/shortcuts.md#debug
@@ -693,6 +695,7 @@
 [6835]: https://github.com/enso-org/enso/pull/6835
 [6890]: https://github.com/enso-org/enso/pull/6890
 [6922]: https://github.com/enso-org/enso/pull/6922
+[6925]: https://github.com/enso-org/enso/pull/6925
 
 #### Enso Compiler
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Map.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Map.enso
@@ -70,7 +70,7 @@ type Map key value
              import Standard.Base.Data.Map.Map
 
              example_from_vector = Map.from_vector [["A", 1], ["B", 2]]
-    from_vector : Vector Any -> Boolean -> Map
+    from_vector : Vector Any -> Boolean -> Map ! Illegal_Argument
     from_vector vec allow_duplicates=False =
         vec.fold Map.empty m-> el-> if el.length != 2 then Error.throw (Illegal_Argument.Error "`Map.from_vector` encountered an invalid value. Each value in the vector has to be a key-value pair - it must have exactly 2 elements.") else
             key = el.at 0

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Map.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Map.enso
@@ -58,11 +58,11 @@ type Map key value
 
        Arguments:
        - vec: A vector of key-value pairs (2 element vectors).
-       - allow_duplicates: A flag which specifies if duplicate keys on the input
-         vector are allowed. By default, set to `False`, meaning that if two
-         entries in the vector share the same key, an `Illegal_Argument.Error`
-         will be thrown. If set to `True`, the last entry with a given key will
-         be kept.
+       - error_on_duplicates: A flag which specifies if duplicate keys on the
+         input vector should result in an error. By default, set to `True`,
+         meaning that if two entries in the vector share the same key, an
+         `Illegal_Argument` error is raised. If set to `False`, the last entry
+         with a given key will be kept.
 
        > Example
          Building a map containing two key-value pairs.
@@ -71,11 +71,11 @@ type Map key value
 
              example_from_vector = Map.from_vector [["A", 1], ["B", 2]]
     from_vector : Vector Any -> Boolean -> Map ! Illegal_Argument
-    from_vector vec allow_duplicates=False =
+    from_vector vec error_on_duplicates=True =
         vec.fold Map.empty m-> el-> if el.length != 2 then Error.throw (Illegal_Argument.Error "`Map.from_vector` encountered an invalid value. Each value in the vector has to be a key-value pair - it must have exactly 2 elements.") else
             key = el.at 0
             value = el.at 1
-            if allow_duplicates || (m.contains_key key . not) then m.insert key value else
+            if error_on_duplicates.not || (m.contains_key key . not) then m.insert key value else
                 Error.throw (Illegal_Argument.Error "`Map.from_vector` encountered duplicate key: "+key.to_display_text)
 
     ## Returns True iff the Map is empty, i.e., does not have any entries.
@@ -264,7 +264,7 @@ type Map key value
     transform self function =
         func_pairs = p -> function (p.at 0) (p.at 1)
         vec_transformed = self.to_vector.map func_pairs
-        new_map = Map.from_vector vec_transformed allow_duplicates=False
+        new_map = Map.from_vector vec_transformed error_on_duplicates=True
         new_map.catch Illegal_Argument error->
             case error.message.starts_with "`Map.from_vector` encountered duplicate key" of
                 True ->

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Set.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Set.enso
@@ -64,6 +64,7 @@ type Set
         other_map = other.underlying_map
         new_map = self.underlying_map.to_vector.fold Map.empty m-> el->
             if other_map.contains_key el then m.insert el True else m
+        Set.Value new_map
 
     ## ALIAS Difference
        Computes a set difference.
@@ -75,6 +76,7 @@ type Set
         other_map = other.underlying_map
         new_map = self.underlying_map.to_vector.fold Map.empty m-> el->
             if other_map.contains_key el then m else m.insert el True
+        Set.Value new_map
 
     ## PRIVATE
     to_text : Text

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Set.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Set.enso
@@ -29,10 +29,10 @@ type Set
          `True` it will raise an `Illegal_Argument` if duplicate elements are
          encountered.
     from_vector : Vector Any -> Boolean -> Set ! Illegal_Argument
-    from_vector (vector : Vector) (error_on_duplicates : Boolean = True) =
+    from_vector (vector : Vector) (error_on_duplicates : Boolean = False) =
         pairs_array = Array_Proxy.new vector.length (i-> [vector.at i, Nothing])
         pairs = Vector.from_polyglot_array pairs_array
-        map = Map.from_vector pairs allow_duplicates
+        map = Map.from_vector pairs error_on_duplicates=error_on_duplicates
         Set.Value map
 
     ## Constructs an empty set.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Set.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Set.enso
@@ -17,7 +17,7 @@ from project.Data.Boolean import Boolean, True, False
    An unordered collection of unique values.
 type Set
     ## PRIVATE
-    Value (underlying_map : Map Any Boolean)
+    Value (underlying_map : Map Any Nothing)
 
     ## Constructs a new set from a vector.
 
@@ -29,7 +29,7 @@ type Set
          an `Illegal_Argument` if duplicate elements are encountered.
     from_vector : Vector Any -> Boolean -> Set ! Illegal_Argument
     from_vector (vector : Vector) (allow_duplicates : Boolean = True) =
-        pairs_array = Array_Proxy.new vector.length (i-> [vector.at i, True])
+        pairs_array = Array_Proxy.new vector.length (i-> [vector.at i, Nothing])
         pairs = Vector.from_polyglot_array pairs_array
         map = Map.from_vector pairs allow_duplicates
         Set.Value map
@@ -62,7 +62,7 @@ type Set
        Adds a value to this set.
     insert : Any -> Set
     insert self value =
-        new_map = self.underlying_map.insert value True
+        new_map = self.underlying_map.insert value Nothing
         Set.Value new_map
 
     ## Creates a union of the two sets.
@@ -75,7 +75,7 @@ type Set
     intersection self (other : Set) =
         other_map = other.underlying_map
         new_map = self.underlying_map.keys.fold Map.empty m-> el->
-            if other_map.contains_key el then m.insert el True else m
+            if other_map.contains_key el then m.insert el Nothing else m
         Set.Value new_map
 
     ## Computes a set difference.
@@ -86,7 +86,7 @@ type Set
     difference self (other : Set) =
         other_map = other.underlying_map
         new_map = self.underlying_map.keys.fold Map.empty m-> el->
-            if other_map.contains_key el then m else m.insert el True
+            if other_map.contains_key el then m else m.insert el Nothing
         Set.Value new_map
 
     ## PRIVATE

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Set.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Set.enso
@@ -23,12 +23,13 @@ type Set
 
        Arguments:
        - vector: the vector of elements to add to the set.
-       - allow_duplicates: specifies if duplicate elements in the input are
-         allowed. Defaults to `True`, meaning that the last occurrence of each
-         duplicated element is added to the set. If set to `False` it will raise
-         an `Illegal_Argument` if duplicate elements are encountered.
+       - error_on_duplicates: specifies if duplicate elements in the input
+         should result in an error. Defaults to `False`, meaning that the last
+         occurrence of each duplicated element is retained in the set. If set to
+         `True` it will raise an `Illegal_Argument` if duplicate elements are
+         encountered.
     from_vector : Vector Any -> Boolean -> Set ! Illegal_Argument
-    from_vector (vector : Vector) (allow_duplicates : Boolean = True) =
+    from_vector (vector : Vector) (error_on_duplicates : Boolean = True) =
         pairs_array = Array_Proxy.new vector.length (i-> [vector.at i, Nothing])
         pairs = Vector.from_polyglot_array pairs_array
         map = Map.from_vector pairs allow_duplicates
@@ -68,7 +69,9 @@ type Set
     ## Creates a union of the two sets.
     union : Set -> Set
     union self (other : Set) =
-        Set.from_vector (self.to_vector + other.to_vector)
+        start_map = self.underlying_map
+        new_map = other.to_vector.fold start_map m-> el-> m.insert el Nothing
+        Set.Value new_map
 
     ## Creates an intersection of the two sets.
     intersection : Set -> Set

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Set.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Set.enso
@@ -1,0 +1,81 @@
+import project.Any.Any
+import project.Data.Array_Proxy.Array_Proxy
+import project.Data.Map.Map
+import project.Data.Numbers.Integer
+import project.Data.Vector.Vector
+import project.Data.Text.Extensions
+import project.Data.Text.Text
+import project.Errors.Illegal_Argument.Illegal_Argument
+import project.Nothing.Nothing
+import project.Panic.Panic
+
+from project.Data.Boolean import Boolean, True, False
+
+## UNSTABLE
+   An unordered collection of unique values.
+type Set
+    ## PRIVATE
+    Value (underlying_map : Map Any Boolean)
+
+    ## Constructs a new set from a vector.
+
+       Arguments:
+       - vector: the vector of elements to add to the set.
+       - allow_duplicates: specifies if duplicate elements in the input are
+         allowed. Defaults to `True`, meaning that the last occurrence of each
+         duplicated element is added to the set. If set to `False` it will raise
+         an `Illegal_Argument` if duplicate elements are encountered.
+    from_vector : Vector Any -> Boolean -> Set ! Illegal_Argument
+    from_vector (vector : Vector) (allow_duplicates : Boolean = True) =
+        pairs_array = Array_Proxy.new vector.length (i-> [vector.at i, True])
+        pairs = Vector.from_polyglot_array pairs_array
+        map = Map.from_vector pairs allow_duplicates
+        Set.Value map
+
+    ## Returns a vector containing all elements of this set.
+    to_vector : Vector
+    to_vector self = self.underlying_map.keys
+
+    ## Returns the number of elements in this set.
+    size : Integer
+    size self = self.underlying_map.size
+
+    ## Checks if this set contains a given value.
+    contains : Any -> Boolean
+    contains self value = self.underlying_map.contains_key value
+
+    ## ALIAS Add
+       Adds a value to this set.
+    insert : Any -> Set
+    insert self value =
+        new_map = self.self.underlying_map.insert value True
+        Set.Value new_map
+
+    ## ALIAS Union
+       Creates a union of the two sets.
+    + : Set -> Set
+    + self (other : Set) =
+        Set.from_vector (self.to_vector + other.to_vector)
+
+    ## ALIAS Intersection
+       Creates an intersection of the two sets.
+    & : Set -> Set
+    & self (other : Set) =
+        other_map = other.underlying_map
+        new_map = self.underlying_map.to_vector.fold Map.empty m-> el->
+            if other_map.contains_key el then m.insert el True else m
+
+    ## ALIAS Difference
+       Computes a set difference.
+
+       Returns the set that contains all elements of this set that are not in
+       the other set.
+    - : Set -> Set
+    - self (other : Set) =
+        other_map = other.underlying_map
+        new_map = self.underlying_map.to_vector.fold Map.empty m-> el->
+            if other_map.contains_key el then m else m.insert el True
+
+    ## PRIVATE
+    to_text : Text
+    to_text self = self.to_vector.join ", " "Set{" "}"

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Set.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Set.enso
@@ -2,6 +2,7 @@ import project.Any.Any
 import project.Data.Array_Proxy.Array_Proxy
 import project.Data.Map.Map
 import project.Data.Numbers.Integer
+import project.Data.Ordering.Ordering
 import project.Data.Vector.Vector
 import project.Data.Text.Extensions
 import project.Data.Text.Text
@@ -32,6 +33,10 @@ type Set
         map = Map.from_vector pairs allow_duplicates
         Set.Value map
 
+    ## Constructs an empty set.
+    empty : Set
+    empty = Set.Value Map.empty
+
     ## Returns a vector containing all elements of this set.
     to_vector : Vector
     to_vector self = self.underlying_map.keys
@@ -39,6 +44,14 @@ type Set
     ## Returns the number of elements in this set.
     size : Integer
     size self = self.underlying_map.size
+
+    ## Checks if the set is empty.
+    is_empty : Boolean
+    is_empty self = self.underlying_map.is_empty
+
+    ## Checks if the set is not empty.
+    not_empty : Boolean
+    not_empty self = self.underlying_map.not_empty
 
     ## Checks if this set contains a given value.
     contains : Any -> Boolean
@@ -81,3 +94,15 @@ type Set
     ## PRIVATE
     to_text : Text
     to_text self = self.to_vector.join ", " "Set{" "}"
+
+## PRIVATE
+type Set_Comparator
+    ## PRIVATE
+    compare x y =
+        if x.size != y.size then Nothing else
+            if (x - y).is_empty then Ordering.Equal else Nothing
+
+    ## PRIVATE
+    hash x =
+        vec = x.to_vector.sort . remove_warnings
+        Comparable.from vec . hash vec

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Set.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Set.enso
@@ -2,6 +2,7 @@ import project.Any.Any
 import project.Data.Array_Proxy.Array_Proxy
 import project.Data.Map.Map
 import project.Data.Numbers.Integer
+import project.Data.Ordering.Comparable
 import project.Data.Ordering.Ordering
 import project.Data.Vector.Vector
 import project.Data.Text.Extensions
@@ -61,33 +62,30 @@ type Set
        Adds a value to this set.
     insert : Any -> Set
     insert self value =
-        new_map = self.self.underlying_map.insert value True
+        new_map = self.underlying_map.insert value True
         Set.Value new_map
 
-    ## ALIAS Union
-       Creates a union of the two sets.
-    + : Set -> Set
-    + self (other : Set) =
+    ## Creates a union of the two sets.
+    union : Set -> Set
+    union self (other : Set) =
         Set.from_vector (self.to_vector + other.to_vector)
 
-    ## ALIAS Intersection
-       Creates an intersection of the two sets.
-    & : Set -> Set
-    & self (other : Set) =
+    ## Creates an intersection of the two sets.
+    intersection : Set -> Set
+    intersection self (other : Set) =
         other_map = other.underlying_map
-        new_map = self.underlying_map.to_vector.fold Map.empty m-> el->
+        new_map = self.underlying_map.keys.fold Map.empty m-> el->
             if other_map.contains_key el then m.insert el True else m
         Set.Value new_map
 
-    ## ALIAS Difference
-       Computes a set difference.
+    ## Computes a set difference.
 
        Returns the set that contains all elements of this set that are not in
        the other set.
-    - : Set -> Set
-    - self (other : Set) =
+    difference : Set -> Set
+    difference self (other : Set) =
         other_map = other.underlying_map
-        new_map = self.underlying_map.to_vector.fold Map.empty m-> el->
+        new_map = self.underlying_map.keys.fold Map.empty m-> el->
             if other_map.contains_key el then m else m.insert el True
         Set.Value new_map
 
@@ -100,7 +98,7 @@ type Set_Comparator
     ## PRIVATE
     compare x y =
         if x.size != y.size then Nothing else
-            if (x - y).is_empty then Ordering.Equal else Nothing
+            if (x.difference y).is_empty then Ordering.Equal else Nothing
 
     ## PRIVATE
     hash x =

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Main.enso
@@ -4,6 +4,7 @@ import project.Data.Boolean
 import project.Data.List.List
 import project.Data.Numbers
 import project.Data.Map.Map
+import project.Data.Set.Set
 import project.Data.Text.Text
 import project.Data.Vector.Vector
 import project.Error.Error
@@ -36,6 +37,7 @@ export project.Any.Any
 export project.Data.Array.Array
 export project.Data.List.List
 export project.Data.Map.Map
+export project.Data.Set.Set
 export project.Data.Text.Text
 export project.Data.Vector.Vector
 export project.Error.Error

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -162,7 +162,7 @@ type Connection
                 case self.dialect.is_probably_a_query query of
                     True -> result
                     False ->
-                        Error.throw (Table_Not_Found.Error query sql_error treated_as_query=True)
+                        Error.throw (Table_Not_Found.Error query sql_error treated_as_query=True extra_message="")
         SQL_Query.Raw_SQL raw_sql -> handle_sql_errors <|
             self.jdbc_connection.ensure_query_has_no_holes raw_sql . if_not_error <|
                 columns = self.fetch_columns raw_sql Statement_Setter.null
@@ -177,7 +177,7 @@ type Connection
                 columns = self.fetch_columns statement statement_setter
                 Database_Table_Module.make_table self name columns ctx
             result.catch SQL_Error sql_error->
-                Error.throw (Table_Not_Found.Error name sql_error treated_as_query=False)
+                Error.throw (Table_Not_Found.Error name sql_error treated_as_query=False extra_message="")
 
     ## PRIVATE
        Execute the query and load the results into memory as a Table.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -9,6 +9,7 @@ from Standard.Base.Metadata.Choice import Option
 import Standard.Base.Metadata.Display
 
 import Standard.Table.Data.Table.Table as Materialized_Table
+import Standard.Table.Data.Type.Value_Type.Value_Type
 
 import project.Data.SQL_Query.SQL_Query
 import project.Data.SQL_Statement.SQL_Statement
@@ -192,6 +193,43 @@ type Connection
         self.query query . read max_rows=limit
 
     ## PRIVATE
+       Creates a new empty table in the database.
+
+       Arguments:
+       - table_name: the name of the table to create. If not provided, a random
+         name will be generated for temporary tables. If `temporary=False`, then
+         a name must be provided.
+       - structure: the structure of the table. This can be provided as a vector
+         of pairs of column names and types or an existing `Table` to copy the
+         structure from it. Note that if a `Table` is provided, only its column
+         structure is inherited - no table content is copied.
+       - primary_key: the names of the columns to use as the primary key. The
+         first column from the table is used by default. If it is set to
+         `Nothing` or an empty vector, no primary key will be created.
+       - temporary: if set to `True`, the table will be temporary, meaning that
+         it will be dropped once the `connection` is closed. Defaults to
+         `False`.
+       - on_problems: the behavior to use when encountering non-fatal problems.
+         Defaults to reporting them as warning.
+
+       ! Error Conditions
+
+         - If a table with the given name already exists, then a
+           `Table_Already_Exists` error is raised.
+         - If a column type is not supported and is coerced to a similar
+           supported type, an `Inexact_Type_Coercion` problem is reported
+           according to the `on_problems` setting.
+         - If a column type is not supported and there is no replacement (e.g.
+           native Enso types), an `Unsupported_Type` error is raised.
+         - If the provided primary key columns are not present in table
+           structure provided, `Missing_Input_Columns` error is raised.
+         - An `SQL_Error` may be reported if there is a failure on the database
+           side.
+    create_table : Text|Nothing -> Table | Vector (Pair Text Value_Type) -> Boolean -> Boolean -> Problem_Behavior -> Table ! Table_Already_Exists
+    create_table (table_name : Text | Nothing = Nothing) (structure : Vector | Table | Materialized_Table) (primary_key : Vector Text = first_column_in_structure structure) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
+        create_table_structure connection table_name structure primary_key temporary allow_existing on_problems
+
+    ## PRIVATE
        Internal read function for a statement with optional types.
 
        Arguments:
@@ -260,3 +298,8 @@ make_table_name_selector : Connection -> Widget
 make_table_name_selector connection =
     tables_to_display = connection.tables.at "Name" . to_vector
     Single_Choice display=Display.Always values=(tables_to_display.map t-> Option t t.pretty)
+
+## PRIVATE
+first_column_in_structure structure = case structure of
+    _ : Vector -> structure.first.first
+    _ -> structure.columns_names.first

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -14,7 +14,7 @@ import Standard.Table.Data.Type.Value_Type.Value_Type
 import project.Data.SQL_Query.SQL_Query
 import project.Data.SQL_Statement.SQL_Statement
 import project.Data.SQL_Type.SQL_Type
-import project.Data.Table.Table
+import project.Data.Table.Table as Database_Table
 import project.Data.Table as Database_Table_Module
 import project.Internal.IR.Context.Context
 import project.Internal.IR.SQL_Expression.SQL_Expression
@@ -24,7 +24,8 @@ import project.Internal.Statement_Setter.Statement_Setter
 
 from project.Internal.Result_Set import read_column, result_set_to_table
 from project.Internal.JDBC_Connection import handle_sql_errors
-from project.Errors import SQL_Error, Table_Not_Found
+from project.Errors import SQL_Error, Table_Not_Found, Table_Already_Exists
+from project.Internal.Upload_Table import create_table_structure
 
 polyglot java import java.lang.UnsupportedOperationException
 polyglot java import java.util.UUID
@@ -153,7 +154,7 @@ type Connection
          - If provided with a `Table_Name` or a text short-hand and the table is
            not found, a `Table_Not_Found` error is raised.
     @query make_table_name_selector
-    query : Text | SQL_Query -> Text -> Table ! Table_Not_Found | SQL_Error
+    query : Text | SQL_Query -> Text -> Database_Table ! Table_Not_Found | SQL_Error
     query self query alias="" = case query of
         _ : Text ->
             result = self.query alias=alias <|
@@ -188,7 +189,7 @@ type Connection
          If supplied as `Text`, the name is checked against the `tables` list to determine if it is a table or a query.
        - limit: the maximum number of rows to return.
     @query make_table_name_selector
-    read : Text | SQL_Query -> Integer | Nothing -> Materialized_Table
+    read : Text | SQL_Query -> Integer | Nothing -> Materialized_Table ! Table_Not_Found
     read self query limit=Nothing =
         self.query query . read max_rows=limit
 
@@ -230,9 +231,9 @@ type Connection
            structure provided, `Missing_Input_Columns` error is raised.
          - An `SQL_Error` may be reported if there is a failure on the database
            side.
-    create_table : Text|Nothing -> Table | Vector (Pair Text Value_Type) -> Boolean -> Boolean -> Problem_Behavior -> Table ! Table_Already_Exists
-    create_table (table_name : Text | Nothing = Nothing) (structure : Vector | Table | Materialized_Table) (primary_key : Vector Text = first_column_in_structure structure) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
-        create_table_structure connection table_name structure primary_key temporary allow_existing on_problems
+    create_table : Text|Nothing -> Vector (Pair Text Value_Type) | Database_Table | Materialized_Table -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists
+    create_table (table_name : Text | Nothing = Nothing) (structure : Vector | Database_Table | Materialized_Table) (primary_key : Vector Text = first_column_in_structure structure) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
+        create_table_structure self table_name structure primary_key temporary allow_existing on_problems
 
     ## PRIVATE
        Internal read function for a statement with optional types.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -232,7 +232,7 @@ type Connection
          - An `SQL_Error` may be reported if there is a failure on the database
            side.
     create_table : Text|Nothing -> Vector (Pair Text Value_Type) | Database_Table | Materialized_Table -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists
-    create_table (table_name : Text | Nothing = Nothing) (structure : Vector | Database_Table | Materialized_Table) (primary_key : Vector Text = first_column_in_structure structure) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
+    create_table self (table_name : Text | Nothing = Nothing) (structure : Vector | Database_Table | Materialized_Table) (primary_key : Vector Text = [first_column_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
         created_table_name = create_table_structure self table_name structure primary_key temporary allow_existing on_problems
         self.query (SQL_Query.Table_Name created_table_name)
 
@@ -309,4 +309,4 @@ make_table_name_selector connection =
 ## PRIVATE
 first_column_in_structure structure = case structure of
     _ : Vector -> structure.first.first
-    _ -> structure.columns_names.first
+    _ -> structure.column_names.first

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -231,8 +231,8 @@ type Connection
            structure provided, `Missing_Input_Columns` error is raised.
          - An `SQL_Error` may be reported if there is a failure on the database
            side.
-    create_table : Text|Nothing -> Vector (Pair Text Value_Type) | Database_Table | Materialized_Table -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists
-    create_table self (table_name : Text | Nothing = Nothing) (structure : Vector | Database_Table | Materialized_Table) (primary_key : Vector Text = [first_column_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
+    create_table : Text|Nothing -> Vector (Pair Text Value_Type) | Database_Table | Materialized_Table -> Vector Text | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists
+    create_table self (table_name : Text | Nothing = Nothing) (structure : Vector | Database_Table | Materialized_Table) (primary_key : (Vector Text | Nothing) = [first_column_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
         created_table_name = create_table_structure self table_name structure primary_key temporary allow_existing on_problems
         self.query (SQL_Query.Table_Name created_table_name)
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -233,7 +233,8 @@ type Connection
            side.
     create_table : Text|Nothing -> Vector (Pair Text Value_Type) | Database_Table | Materialized_Table -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists
     create_table (table_name : Text | Nothing = Nothing) (structure : Vector | Database_Table | Materialized_Table) (primary_key : Vector Text = first_column_in_structure structure) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
-        create_table_structure self table_name structure primary_key temporary allow_existing on_problems
+        created_table_name = create_table_structure self table_name structure primary_key temporary allow_existing on_problems
+        self.query (SQL_Query.Table_Name created_table_name)
 
     ## PRIVATE
        Internal read function for a statement with optional types.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -193,7 +193,8 @@ type Connection
         self.query query . read max_rows=limit
 
     ## PRIVATE
-       Creates a new empty table in the database.
+       Creates a new empty table in the database and returns a query referencing
+       the new table.
 
        Arguments:
        - table_name: the name of the table to create. If not provided, a random
@@ -209,6 +210,10 @@ type Connection
        - temporary: if set to `True`, the table will be temporary, meaning that
          it will be dropped once the `connection` is closed. Defaults to
          `False`.
+       - allow_existing: Defaults to `False`, meaning that if the table with the
+         provided name already exists, an error will be raised. If set to `True`,
+         the existing table will be returned instead. Note that the existing
+         table is not guaranteed to have the same structure as the one provided.
        - on_problems: the behavior to use when encountering non-fatal problems.
          Defaults to reporting them as warning.
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Update_Action.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Update_Action.enso
@@ -1,0 +1,14 @@
+type Update_Action
+    ## Records are appended but if cause a primary key clash will fail.
+    Insert
+
+    ## Just update the existing records. Unmatched columns are left unchanged.
+       Errors if any record is not matched in the target table.
+    Update
+
+    ## Append the records to the new table if not found.
+       Updates existing records to the new values. Unmatched columns are left unchanged.
+    Update_Or_Insert
+
+    ## Appends new records, updates existing records, removes records not in the target table
+    Align_Records

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Errors.enso
@@ -126,14 +126,23 @@ type Table_Not_Found
          for the table was executed.
        - treated_as_query: Whether the table name was treated as a raw query
          string.
-    Error (name:Text) (related_query_error:SQL_Error) (treated_as_query:Boolean)
+       - extra_message: An extra message to append.
+    Error (name:Text) (related_query_error:SQL_Error|Nothing) (treated_as_query:Boolean) (extra_message:Text)
 
     ## PRIVATE
        Pretty print the table not found error.
     to_display_text : Text
-    to_display_text self = case self.treated_as_query of
-        True -> "The name " + self.name + " was treated as a query, but the query failed with the following error: " + self.related_query_error.to_display_text + "; if you want to force to use that as a table name, wrap it in `SQL_Query.Table_Name`."
-        False -> "Table " + self.name + " was not found in the database."
+    to_display_text self =
+        base_repr = case self.treated_as_query of
+            True -> "The name " + self.name + " was treated as a query, but the query failed with the following error: " + self.related_query_error.to_display_text + "; if you want to force to use that as a table name, wrap it in `SQL_Query.Table_Name`."
+            False -> "Table " + self.name + " was not found in the database."
+        base_repr + self.extra_message
+
+    ## PRIVATE
+       Creates a copy of this error with a changed `extra_message`.
+    with_changed_extra_message : Table_Not_Found
+    with_changed_extra_message self new_extra_message =
+        Table_Not_Found.Error self.name self.related_query_error self.treated_as_query new_extra_message
 
 type Table_Already_Exists
     ## PRIVATE

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Database_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Database_Table.enso
@@ -9,7 +9,7 @@ import project.Connection.Connection.Connection
 import project.Data.Table.Table
 import project.Data.Update_Action.Update_Action
 from project.Errors import all
-from project.Internal.Result_Set import result_set_to_table
+from project.Extensions.Upload_Default_Helpers import default_key_columns
 from project.Internal.Upload_Table import all
 
 ## Creates a new database table from this table.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Database_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Database_Table.enso
@@ -49,9 +49,7 @@ from project.Internal.Upload_Table import all
 @primary_key Widget_Helpers.make_column_name_vector_selector
 Table.select_into_database_table : Connection -> Text|Nothing -> Vector Text | Nothing -> Boolean -> Problem_Behavior -> Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
 Table.select_into_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False on_problems=Problem_Behavior.Report_Warning = Panic.recover SQL_Error <|
-    Panic.recover SQL_Error <|
-        connection.jdbc_connection.run_within_transaction <|
-            upload_database_table self connection table_name primary_key temporary on_problems
+    upload_database_table self connection table_name primary_key temporary on_problems
 
 ## Updates the target table with the contents of this table.
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Database_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Database_Table.enso
@@ -1,0 +1,90 @@
+from Standard.Base import all
+import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
+
+import Standard.Table.Internal.Widget_Helpers
+from Standard.Table.Errors import all
+from Standard.Table import Column_Selector
+
+import project.Connection.Connection.Connection
+import project.Data.Table.Table
+import project.Data.Update_Action.Update_Action
+from project.Errors import all
+from project.Internal.Result_Set import result_set_to_table
+from project.Internal.Upload_Table import all
+
+## Creates a new database table from this table.
+
+   Arguments:
+   - connection: the database connection to use. The table will be created in
+     the database and schema associated with this connection.
+   - table_name: the name of the table to create. If not provided, a random name
+     will be generated for temporary tables. If `temporary=False`, then a name
+     must be provided.
+   - primary_key: the names of the columns to use as the primary key. The first
+     column from the table is used by default. If it is set to `Nothing` or an
+     empty vector, no primary key will be created.
+   - temporary: if set to `True`, the table will be temporary, meaning that it
+     will be dropped once the `connection` is closed. Defaults to `False`.
+   - on_problems: the behavior to use when encountering non-fatal problems.
+     Defaults to reporting them as warning.
+
+   ! Error Conditions
+
+     - If a table with the given name already exists, then a
+       `Table_Already_Exists` error is raised.
+     - If a column type is not supported and is coerced to a similar supported
+       type, an `Inexact_Type_Coercion` problem is reported according to the
+       `on_problems` setting.
+     - If a column type is not supported and there is no replacement (e.g.
+       native Enso types), an `Unsupported_Type` error is raised.
+     - If the provided primary key columns are not present in the source table,
+       `Missing_Input_Columns` error is raised.
+     - If the selected primary key columns are not unique, a
+       `Non_Unique_Primary_Key` error is raised.
+     - An `SQL_Error` may be reported if there is a failure on the database
+       side.
+
+     If an error has been raised, the table is not created (that may not always
+     apply to `SQL_Error`).
+@primary_key Widget_Helpers.make_column_name_vector_selector
+Table.select_into_database_table : Connection -> Text|Nothing -> Vector Text | Nothing -> Boolean -> Problem_Behavior -> Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
+Table.select_into_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False on_problems=Problem_Behavior.Report_Warning = Panic.recover SQL_Error <|
+    Panic.recover SQL_Error <|
+        connection.jdbc_connection.run_within_transaction <|
+            upload_database_table self connection table_name primary_key temporary on_problems
+
+## Updates the target table with the contents of this table.
+
+   Arguments:
+   - connection: the database connection of the target table.
+   - table_name: the name of the table to update.
+   - update_action: specifies the update strategy - how to handle existing new
+     and missing rows.
+   - key_columns: the names of the columns to use identify correlate rows from
+     the source table with rows in the target table. This key is used to
+     determine if a row from the source table exists in the target or is a new
+     one.
+   - error_on_missing_columns: if set to `False` (the default), any columns
+     missing from the source table will be left unchanged or initialized with
+     the default value if inserting. If a missing column has no default value,
+     this will trigger a `SQL_Error`. If set to `True`, any columns missing from
+     the source will cause an error.
+    - on_problems: the behavior to use when encountering non-fatal problems.
+
+   ! Error Conditions
+
+     - If `key_columns` are not present in either the source or target tables, a
+       `Missing_Input_Columns` error is raised.
+     - If the target table does not exist, a `Table_Not_Found` error is raised.
+     - If `error_on_missing_columns` is set to `True` and a column is missing
+       from the source table, a `Missing_Input_Columns` error is raised.
+     - If the source table contains columns that are not present in the target
+       table, an `Unmatched_Columns` error is raised.
+     - If a column in the source table has a type that cannot be trivially
+       widened to the corresponding column in the target table, a
+       `Column_Type_Mismatch` error is raised.
+
+     If any error was raised, the data in the target table is not modified.
+Table.update_database_table : Connection -> Text -> Update_Action -> Vector Text-> Boolean -> Table ! Table_Not_Found | Unmatched_Columns | Missing_Input_Columns | Column_Type_Mismatch | SQL_Error | Illegal_Argument
+Table.update_database_table connection (table_name : Text) (update_action : Update_Action = Update_Action.Update_Or_Insert) (key_columns : Vector = default_key_columns connection table_name) (error_on_missing_columns : Boolean = False) =
+    common_update_table self connection table_name update_action key_columns error_on_missing_columns

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Default_Helpers.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Default_Helpers.enso
@@ -3,6 +3,8 @@ import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 from Standard.Table import Column_Selector
 
+from project.Internal.Result_Set import result_set_to_table
+
 ## PRIVATE
 default_key_columns connection table_name =
     keys = get_primary_key connection table_name

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Default_Helpers.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Default_Helpers.enso
@@ -1,0 +1,35 @@
+from Standard.Base import all
+import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
+
+from Standard.Table import Column_Selector
+
+## PRIVATE
+default_key_columns connection table_name =
+    keys = get_primary_key connection table_name
+    keys.catch Any _->
+        Error.throw (Illegal_Argument.Error "Could not determine the primary key for table "+table_name+". Please provide it explicitly.")
+
+## PRIVATE
+
+   This method may not work correctly with temporary tables, possibly resulting
+   in `SQL_Error` as such tables may not be found.
+
+   ! Temporary Tables in SQLite
+
+     The temporary tables in SQLite live in a `temp` database. There is a bug in
+     how JDBC retrieves primary keys - it only queries the `sqlite_schema` table
+     which contains schemas of only permanent tables.
+
+     Ideally, we should provide a custom implementation for SQLite that will
+     UNION both `sqlite_schema` and `temp.sqlite_schema` tables to get results
+     for both temporary and permanent tables.
+
+     TODO [RW] fix keys for SQLite temporary tables and test it
+get_primary_key connection table_name =
+    connection.jdbc_connection.with_connection java_connection->
+        rs = java_connection.getMetaData.getPrimaryKeys Nothing Nothing table_name
+        keys_table = result_set_to_table rs connection.dialect.make_column_fetcher_for_type
+        # The names of the columns are sometimes lowercase and sometimes uppercase, so we do a case insensitive select first.
+        selected = keys_table.select_columns [Column_Selector.By_Name "COLUMN_NAME", Column_Selector.By_Name "KEY_SEQ"] reorder=True
+        key_column_names = selected.order_by 1 . at 0 . to_vector
+        if key_column_names.is_empty then Nothing else key_column_names

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_In_Memory_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_In_Memory_Table.enso
@@ -10,7 +10,7 @@ import project.Connection.Connection.Connection
 import project.Data.Table.Table as Database_Table
 import project.Data.Update_Action.Update_Action
 from project.Errors import all
-from project.Internal.Result_Set import result_set_to_table
+from project.Extensions.Upload_Default_Helpers import default_key_columns
 from project.Internal.Upload_Table import all
 
 ## Creates a new database table from this in-memory table.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_In_Memory_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_In_Memory_Table.enso
@@ -50,9 +50,7 @@ from project.Internal.Upload_Table import all
 @primary_key Widget_Helpers.make_column_name_vector_selector
 Table.select_into_database_table : Connection -> Text|Nothing -> Vector Text | Nothing -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
 Table.select_into_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False on_problems=Problem_Behavior.Report_Warning =
-    Panic.recover SQL_Error <|
-        connection.jdbc_connection.run_within_transaction <|
-            upload_in_memory_table self connection table_name primary_key temporary on_problems
+    upload_in_memory_table self connection table_name primary_key temporary on_problems
 
 ## Updates the target table with the contents of this table.
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_In_Memory_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_In_Memory_Table.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
-import Standard.Table.Data.Table.Table as In_Memory_Table
+import Standard.Table.Data.Table.Table
 import Standard.Table.Internal.Widget_Helpers
 from Standard.Table.Errors import all
 from Standard.Table import Column_Selector
@@ -48,8 +48,8 @@ from project.Internal.Upload_Table import all
      If an error has been raised, the table is not created (that may not always
      apply to `SQL_Error`).
 @primary_key Widget_Helpers.make_column_name_vector_selector
-In_Memory_Table.select_into_database_table : Connection -> Text|Nothing -> Vector Text | Nothing -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
-In_Memory_Table.select_into_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False on_problems=Problem_Behavior.Report_Warning =
+Table.select_into_database_table : Connection -> Text|Nothing -> Vector Text | Nothing -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
+Table.select_into_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False on_problems=Problem_Behavior.Report_Warning =
     Panic.recover SQL_Error <|
         connection.jdbc_connection.run_within_transaction <|
             upload_in_memory_table self connection table_name primary_key temporary on_problems
@@ -131,8 +131,8 @@ Database_Table.select_into_database_table self connection table_name=Nothing pri
        `Column_Type_Mismatch` error is raised.
 
      If any error was raised, the data in the target table is not modified.
-In_Memory_Table.update_database_table : Connection -> Text -> Update_Action -> Vector Text-> Boolean -> Database_Table ! Table_Not_Found | Unmatched_Columns | Missing_Input_Columns | Column_Type_Mismatch | SQL_Error | Illegal_Argument
-In_Memory_Table.update_database_table connection (table_name : Text) (update_action : Update_Action = Update_Action.Update_Or_Insert) (key_columns : Vector = default_key_columns connection table_name) (error_on_missing_columns : Boolean = False) =
+Table.update_database_table : Connection -> Text -> Update_Action -> Vector Text-> Boolean -> Database_Table ! Table_Not_Found | Unmatched_Columns | Missing_Input_Columns | Column_Type_Mismatch | SQL_Error | Illegal_Argument
+Table.update_database_table connection (table_name : Text) (update_action : Update_Action = Update_Action.Update_Or_Insert) (key_columns : Vector = default_key_columns connection table_name) (error_on_missing_columns : Boolean = False) =
     common_update_table self connection table_name update_action key_columns error_on_missing_columns
 
 ## Updates the target table with the contents of this table.
@@ -170,34 +170,3 @@ In_Memory_Table.update_database_table connection (table_name : Text) (update_act
 Database_Table.update_database_table : Connection -> Text -> Update_Action -> Vector Text-> Boolean -> Database_Table ! Table_Not_Found | Unmatched_Columns | Missing_Input_Columns | Column_Type_Mismatch | SQL_Error | Illegal_Argument
 Database_Table.update_database_table connection (table_name : Text) (update_action : Update_Action = Update_Action.Update_Or_Insert) (key_columns : Vector = default_key_columns connection table_name) (error_on_missing_columns : Boolean = False) =
     common_update_table self connection table_name update_action key_columns error_on_missing_columns
-
-## PRIVATE
-default_key_columns connection table_name =
-    keys = get_primary_key connection table_name
-    keys.catch Any _->
-        Error.throw (Illegal_Argument.Error "Could not determine the primary key for table "+table_name+". Please provide it explicitly.")
-
-## PRIVATE
-
-   This method may not work correctly with temporary tables, possibly resulting
-   in `SQL_Error` as such tables may not be found.
-
-   ! Temporary Tables in SQLite
-
-     The temporary tables in SQLite live in a `temp` database. There is a bug in
-     how JDBC retrieves primary keys - it only queries the `sqlite_schema` table
-     which contains schemas of only permanent tables.
-
-     Ideally, we should provide a custom implementation for SQLite that will
-     UNION both `sqlite_schema` and `temp.sqlite_schema` tables to get results
-     for both temporary and permanent tables.
-
-     TODO [RW] fix keys for SQLite temporary tables and test it
-get_primary_key connection table_name =
-    connection.jdbc_connection.with_connection java_connection->
-        rs = java_connection.getMetaData.getPrimaryKeys Nothing Nothing table_name
-        keys_table = result_set_to_table rs connection.dialect.make_column_fetcher_for_type
-        # The names of the columns are sometimes lowercase and sometimes uppercase, so we do a case insensitive select first.
-        selected = keys_table.select_columns [Column_Selector.By_Name "COLUMN_NAME", Column_Selector.By_Name "KEY_SEQ"] reorder=True
-        key_column_names = selected.order_by 1 . at 0 . to_vector
-        if key_column_names.is_empty then Nothing else key_column_names

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_In_Memory_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_In_Memory_Table.enso
@@ -54,47 +54,6 @@ Table.select_into_database_table self connection table_name=Nothing primary_key=
         connection.jdbc_connection.run_within_transaction <|
             upload_in_memory_table self connection table_name primary_key temporary on_problems
 
-## Creates a new database table from this table.
-
-   Arguments:
-   - connection: the database connection to use. The table will be created in
-     the database and schema associated with this connection.
-   - table_name: the name of the table to create. If not provided, a random name
-     will be generated for temporary tables. If `temporary=False`, then a name
-     must be provided.
-   - primary_key: the names of the columns to use as the primary key. The first
-     column from the table is used by default. If it is set to `Nothing` or an
-     empty vector, no primary key will be created.
-   - temporary: if set to `True`, the table will be temporary, meaning that it
-     will be dropped once the `connection` is closed. Defaults to `False`.
-   - on_problems: the behavior to use when encountering non-fatal problems.
-     Defaults to reporting them as warning.
-
-   ! Error Conditions
-
-     - If a table with the given name already exists, then a
-       `Table_Already_Exists` error is raised.
-     - If a column type is not supported and is coerced to a similar supported
-       type, an `Inexact_Type_Coercion` problem is reported according to the
-       `on_problems` setting.
-     - If a column type is not supported and there is no replacement (e.g.
-       native Enso types), an `Unsupported_Type` error is raised.
-     - If the provided primary key columns are not present in the source table,
-       `Missing_Input_Columns` error is raised.
-     - If the selected primary key columns are not unique, a
-       `Non_Unique_Primary_Key` error is raised.
-     - An `SQL_Error` may be reported if there is a failure on the database
-       side.
-
-     If an error has been raised, the table is not created (that may not always
-     apply to `SQL_Error`).
-@primary_key Widget_Helpers.make_column_name_vector_selector
-Database_Table.select_into_database_table : Connection -> Text|Nothing -> Vector Text | Nothing -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
-Database_Table.select_into_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False on_problems=Problem_Behavior.Report_Warning = Panic.recover SQL_Error <|
-    Panic.recover SQL_Error <|
-        connection.jdbc_connection.run_within_transaction <|
-            upload_database_table self connection table_name primary_key temporary on_problems
-
 ## Updates the target table with the contents of this table.
 
    Arguments:
@@ -133,40 +92,4 @@ Database_Table.select_into_database_table self connection table_name=Nothing pri
      If any error was raised, the data in the target table is not modified.
 Table.update_database_table : Connection -> Text -> Update_Action -> Vector Text-> Boolean -> Database_Table ! Table_Not_Found | Unmatched_Columns | Missing_Input_Columns | Column_Type_Mismatch | SQL_Error | Illegal_Argument
 Table.update_database_table connection (table_name : Text) (update_action : Update_Action = Update_Action.Update_Or_Insert) (key_columns : Vector = default_key_columns connection table_name) (error_on_missing_columns : Boolean = False) =
-    common_update_table self connection table_name update_action key_columns error_on_missing_columns
-
-## Updates the target table with the contents of this table.
-
-   Arguments:
-   - connection: the database connection of the target table.
-   - table_name: the name of the table to update.
-   - update_action: specifies the update strategy - how to handle existing new
-     and missing rows.
-   - key_columns: the names of the columns to use identify correlate rows from
-     the source table with rows in the target table. This key is used to
-     determine if a row from the source table exists in the target or is a new
-     one.
-   - error_on_missing_columns: if set to `False` (the default), any columns
-     missing from the source table will be left unchanged or initialized with
-     the default value if inserting. If a missing column has no default value,
-     this will trigger a `SQL_Error`. If set to `True`, any columns missing from
-     the source will cause an error.
-    - on_problems: the behavior to use when encountering non-fatal problems.
-
-   ! Error Conditions
-
-     - If `key_columns` are not present in either the source or target tables, a
-       `Missing_Input_Columns` error is raised.
-     - If the target table does not exist, a `Table_Not_Found` error is raised.
-     - If `error_on_missing_columns` is set to `True` and a column is missing
-       from the source table, a `Missing_Input_Columns` error is raised.
-     - If the source table contains columns that are not present in the target
-       table, an `Unmatched_Columns` error is raised.
-     - If a column in the source table has a type that cannot be trivially
-       widened to the corresponding column in the target table, a
-       `Column_Type_Mismatch` error is raised.
-
-     If any error was raised, the data in the target table is not modified.
-Database_Table.update_database_table : Connection -> Text -> Update_Action -> Vector Text-> Boolean -> Database_Table ! Table_Not_Found | Unmatched_Columns | Missing_Input_Columns | Column_Type_Mismatch | SQL_Error | Illegal_Argument
-Database_Table.update_database_table connection (table_name : Text) (update_action : Update_Action = Update_Action.Update_Or_Insert) (key_columns : Vector = default_key_columns connection table_name) (error_on_missing_columns : Boolean = False) =
     common_update_table self connection table_name update_action key_columns error_on_missing_columns

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
@@ -133,6 +133,9 @@ Database_Table.create_database_table self connection table_name=Nothing primary_
     upload_status.if_not_error <|
         connection.query (SQL_Query.Table_Name effective_table_name)
 
+In_Memory_Table.update_database_table : Connection -> Text -> (Vector Text) | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
+In_Memory_Table.update_database_table connection (table_name : Text) update_action
+
 ## PRIVATE
    Ensures that provided primary key columns are present in the table and that
    there are no duplicates.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
@@ -132,9 +132,9 @@ Database_Table.create_database_table self connection table_name=Nothing primary_
        `Column_Type_Mismatch` error is raised.
 
      If any error was raised, the data in the target table is not modified.
-In_Memory_Table.update_database_table : Connection -> Text -> Update_Action -> Vector Text-> Boolean -> Problem_Behavior -> Database_Table ! Table_Not_Found | Unmatched_Columns | Missing_Input_Columns | Column_Type_Mismatch | SQL_Error | Illegal_Argument
-In_Memory_Table.update_database_table connection (table_name : Text) (update_action : Update_Action = Update_Action.Update_Or_Insert) (key_columns : Vector = default_key_columns connection table_name) (error_on_missing_columns : Boolean = False) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
-    common_update_table self source_table connection table_name update_action key_columns error_on_missing_columns on_problems
+In_Memory_Table.update_database_table : Connection -> Text -> Update_Action -> Vector Text-> Boolean -> Database_Table ! Table_Not_Found | Unmatched_Columns | Missing_Input_Columns | Column_Type_Mismatch | SQL_Error | Illegal_Argument
+In_Memory_Table.update_database_table connection (table_name : Text) (update_action : Update_Action = Update_Action.Update_Or_Insert) (key_columns : Vector = default_key_columns connection table_name) (error_on_missing_columns : Boolean = False) =
+    common_update_table self source_table connection table_name update_action key_columns error_on_missing_columns
 
 ## Updates the target table with the contents of this table.
 
@@ -168,9 +168,9 @@ In_Memory_Table.update_database_table connection (table_name : Text) (update_act
        `Column_Type_Mismatch` error is raised.
 
      If any error was raised, the data in the target table is not modified.
-Database_Table.update_database_table : Connection -> Text -> Update_Action -> Vector Text-> Boolean -> Problem_Behavior -> Database_Table ! Table_Not_Found | Unmatched_Columns | Missing_Input_Columns | Column_Type_Mismatch | SQL_Error | Illegal_Argument
-Database_Table.update_database_table connection (table_name : Text) (update_action : Update_Action = Update_Action.Update_Or_Insert) (key_columns : Vector = default_key_columns connection table_name) (error_on_missing_columns : Boolean = False) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
-    common_update_table self source_table connection table_name update_action key_columns error_on_missing_columns on_problems
+Database_Table.update_database_table : Connection -> Text -> Update_Action -> Vector Text-> Boolean -> Database_Table ! Table_Not_Found | Unmatched_Columns | Missing_Input_Columns | Column_Type_Mismatch | SQL_Error | Illegal_Argument
+Database_Table.update_database_table connection (table_name : Text) (update_action : Update_Action = Update_Action.Update_Or_Insert) (key_columns : Vector = default_key_columns connection table_name) (error_on_missing_columns : Boolean = False) =
+    common_update_table self source_table connection table_name update_action key_columns error_on_missing_columns
 
 ## PRIVATE
 default_key_columns connection table_name =

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
@@ -23,9 +23,6 @@ from project.Internal.Upload_Table import all
      empty vector, no primary key will be created.
    - temporary: if set to `True`, the table will be temporary, meaning that it
      will be dropped once the `connection` is closed. Defaults to `False`.
-   - structure_only: if set to `True`, the created table will inherit the
-     structure (column names and types) of the source table, but no rows will be
-     inserted. Defaults to `False`.
    - on_problems: the behavior to use when encountering non-fatal problems.
      Defaults to reporting them as warning.
 
@@ -47,11 +44,11 @@ from project.Internal.Upload_Table import all
 
      If an error has been raised, the table is not created (that may not always
      apply to `SQL_Error`).
-In_Memory_Table.select_into_database_table : Connection -> Text|Nothing -> (Vector Text) | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
-In_Memory_Table.select_into_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False structure_only=False on_problems=Problem_Behavior.Report_Warning =
+In_Memory_Table.select_into_database_table : Connection -> Text|Nothing -> (Vector Text) | Nothing -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
+In_Memory_Table.select_into_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False on_problems=Problem_Behavior.Report_Warning =
     Panic.recover SQL_Error <|
         connection.jdbc_connection.run_within_transaction <|
-            upload_in_memory_table source_table connection table_name primary_key temporary structure_only on_problems
+            upload_in_memory_table source_table connection table_name primary_key temporary on_problems
 
 ## Creates a new database table from this table.
 
@@ -66,9 +63,6 @@ In_Memory_Table.select_into_database_table self connection table_name=Nothing pr
      empty vector, no primary key will be created.
    - temporary: if set to `True`, the table will be temporary, meaning that it
      will be dropped once the `connection` is closed. Defaults to `False`.
-   - structure_only: if set to `True`, the created table will inherit the
-     structure (column names and types) of the source table, but no rows will be
-     inserted. Defaults to `False`.
    - on_problems: the behavior to use when encountering non-fatal problems.
      Defaults to reporting them as warning.
 
@@ -90,11 +84,11 @@ In_Memory_Table.select_into_database_table self connection table_name=Nothing pr
 
      If an error has been raised, the table is not created (that may not always
      apply to `SQL_Error`).
-Database_Table.select_into_database_table : Connection -> Text|Nothing -> (Vector Text) | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
-Database_Table.select_into_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False structure_only=False on_problems=Problem_Behavior.Report_Warning = Panic.recover SQL_Error <|
+Database_Table.select_into_database_table : Connection -> Text|Nothing -> (Vector Text) | Nothing -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
+Database_Table.select_into_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False on_problems=Problem_Behavior.Report_Warning = Panic.recover SQL_Error <|
     Panic.recover SQL_Error <|
         connection.jdbc_connection.run_within_transaction <|
-            upload_database_table source_table connection table_name primary_key temporary structure_only on_problems
+            upload_database_table source_table connection table_name primary_key temporary on_problems
 
 ## Updates the target table with the contents of this table.
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
@@ -47,8 +47,8 @@ from project.Internal.Upload_Table import all
 
      If an error has been raised, the table is not created (that may not always
      apply to `SQL_Error`).
-In_Memory_Table.create_database_table : Connection -> Text|Nothing -> (Vector Text) | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
-In_Memory_Table.create_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False structure_only=False on_problems=Problem_Behavior.Report_Warning =
+In_Memory_Table.select_into_database_table : Connection -> Text|Nothing -> (Vector Text) | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
+In_Memory_Table.select_into_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False structure_only=False on_problems=Problem_Behavior.Report_Warning =
     Panic.recover SQL_Error <|
         connection.jdbc_connection.run_within_transaction <|
             upload_in_memory_table source_table connection table_name primary_key temporary structure_only on_problems
@@ -90,8 +90,8 @@ In_Memory_Table.create_database_table self connection table_name=Nothing primary
 
      If an error has been raised, the table is not created (that may not always
      apply to `SQL_Error`).
-Database_Table.create_database_table : Connection -> Text|Nothing -> (Vector Text) | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
-Database_Table.create_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False structure_only=False on_problems=Problem_Behavior.Report_Warning = Panic.recover SQL_Error <|
+Database_Table.select_into_database_table : Connection -> Text|Nothing -> (Vector Text) | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
+Database_Table.select_into_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False structure_only=False on_problems=Problem_Behavior.Report_Warning = Panic.recover SQL_Error <|
     Panic.recover SQL_Error <|
         connection.jdbc_connection.run_within_transaction <|
             upload_database_table source_table connection table_name primary_key temporary structure_only on_problems

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
@@ -3,11 +3,13 @@ import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 import Standard.Table.Data.Table.Table as In_Memory_Table
 from Standard.Table.Errors import all
+from Standard.Table import Column_Selector
 
 import project.Connection.Connection.Connection
 import project.Data.Table.Table as Database_Table
 import project.Data.Update_Action.Update_Action
 from project.Errors import all
+from project.Internal.Result_Set import result_set_to_table
 from project.Internal.Upload_Table import all
 
 ## Creates a new database table from this in-memory table.
@@ -48,7 +50,7 @@ In_Memory_Table.select_into_database_table : Connection -> Text|Nothing -> (Vect
 In_Memory_Table.select_into_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False on_problems=Problem_Behavior.Report_Warning =
     Panic.recover SQL_Error <|
         connection.jdbc_connection.run_within_transaction <|
-            upload_in_memory_table source_table connection table_name primary_key temporary on_problems
+            upload_in_memory_table self connection table_name primary_key temporary on_problems
 
 ## Creates a new database table from this table.
 
@@ -88,7 +90,7 @@ Database_Table.select_into_database_table : Connection -> Text|Nothing -> (Vecto
 Database_Table.select_into_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False on_problems=Problem_Behavior.Report_Warning = Panic.recover SQL_Error <|
     Panic.recover SQL_Error <|
         connection.jdbc_connection.run_within_transaction <|
-            upload_database_table source_table connection table_name primary_key temporary on_problems
+            upload_database_table self connection table_name primary_key temporary on_problems
 
 ## Updates the target table with the contents of this table.
 
@@ -128,7 +130,7 @@ Database_Table.select_into_database_table self connection table_name=Nothing pri
      If any error was raised, the data in the target table is not modified.
 In_Memory_Table.update_database_table : Connection -> Text -> Update_Action -> Vector Text-> Boolean -> Database_Table ! Table_Not_Found | Unmatched_Columns | Missing_Input_Columns | Column_Type_Mismatch | SQL_Error | Illegal_Argument
 In_Memory_Table.update_database_table connection (table_name : Text) (update_action : Update_Action = Update_Action.Update_Or_Insert) (key_columns : Vector = default_key_columns connection table_name) (error_on_missing_columns : Boolean = False) =
-    common_update_table self source_table connection table_name update_action key_columns error_on_missing_columns
+    common_update_table self connection table_name update_action key_columns error_on_missing_columns
 
 ## Updates the target table with the contents of this table.
 
@@ -164,7 +166,7 @@ In_Memory_Table.update_database_table connection (table_name : Text) (update_act
      If any error was raised, the data in the target table is not modified.
 Database_Table.update_database_table : Connection -> Text -> Update_Action -> Vector Text-> Boolean -> Database_Table ! Table_Not_Found | Unmatched_Columns | Missing_Input_Columns | Column_Type_Mismatch | SQL_Error | Illegal_Argument
 Database_Table.update_database_table connection (table_name : Text) (update_action : Update_Action = Update_Action.Update_Or_Insert) (key_columns : Vector = default_key_columns connection table_name) (error_on_missing_columns : Boolean = False) =
-    common_update_table self source_table connection table_name update_action key_columns error_on_missing_columns
+    common_update_table self connection table_name update_action key_columns error_on_missing_columns
 
 ## PRIVATE
 default_key_columns connection table_name =

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
@@ -2,6 +2,7 @@ from Standard.Base import all
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 import Standard.Table.Data.Table.Table as In_Memory_Table
+import Standard.Table.Internal.Widget_Helpers
 from Standard.Table.Errors import all
 from Standard.Table import Column_Selector
 
@@ -46,6 +47,7 @@ from project.Internal.Upload_Table import all
 
      If an error has been raised, the table is not created (that may not always
      apply to `SQL_Error`).
+@primary_key Widget_Helpers.make_column_name_vector_selector
 In_Memory_Table.select_into_database_table : Connection -> Text|Nothing -> (Vector Text) | Nothing -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
 In_Memory_Table.select_into_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False on_problems=Problem_Behavior.Report_Warning =
     Panic.recover SQL_Error <|
@@ -86,6 +88,7 @@ In_Memory_Table.select_into_database_table self connection table_name=Nothing pr
 
      If an error has been raised, the table is not created (that may not always
      apply to `SQL_Error`).
+@primary_key Widget_Helpers.make_column_name_vector_selector
 Database_Table.select_into_database_table : Connection -> Text|Nothing -> (Vector Text) | Nothing -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
 Database_Table.select_into_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False on_problems=Problem_Behavior.Report_Warning = Panic.recover SQL_Error <|
     Panic.recover SQL_Error <|

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
@@ -48,7 +48,7 @@ from project.Internal.Upload_Table import all
      If an error has been raised, the table is not created (that may not always
      apply to `SQL_Error`).
 @primary_key Widget_Helpers.make_column_name_vector_selector
-In_Memory_Table.select_into_database_table : Connection -> Text|Nothing -> (Vector Text) | Nothing -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
+In_Memory_Table.select_into_database_table : Connection -> Text|Nothing -> Vector Text | Nothing -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
 In_Memory_Table.select_into_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False on_problems=Problem_Behavior.Report_Warning =
     Panic.recover SQL_Error <|
         connection.jdbc_connection.run_within_transaction <|
@@ -89,7 +89,7 @@ In_Memory_Table.select_into_database_table self connection table_name=Nothing pr
      If an error has been raised, the table is not created (that may not always
      apply to `SQL_Error`).
 @primary_key Widget_Helpers.make_column_name_vector_selector
-Database_Table.select_into_database_table : Connection -> Text|Nothing -> (Vector Text) | Nothing -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
+Database_Table.select_into_database_table : Connection -> Text|Nothing -> Vector Text | Nothing -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
 Database_Table.select_into_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False on_problems=Problem_Behavior.Report_Warning = Panic.recover SQL_Error <|
     Panic.recover SQL_Error <|
         connection.jdbc_connection.run_within_transaction <|

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
@@ -3,13 +3,14 @@ from Standard.Base.Random import random_uuid
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 import Standard.Table.Data.Table.Table as In_Memory_Table
+from Standard.Table import Aggregate_Column, Match_Columns
 from Standard.Table.Errors import all
-from Standard.Table import Aggregate_Column
 
 import project.Connection.Connection.Connection
 import project.Data.SQL_Query.SQL_Query
 import project.Data.SQL_Statement.SQL_Statement
 import project.Data.Table.Table as Database_Table
+import project.Data.Update_Action.Update_Action
 import project.Internal.IR.Query.Query
 import project.Internal.IR.SQL_Expression.SQL_Expression
 from project.Errors import all
@@ -133,8 +134,80 @@ Database_Table.create_database_table self connection table_name=Nothing primary_
     upload_status.if_not_error <|
         connection.query (SQL_Query.Table_Name effective_table_name)
 
-In_Memory_Table.update_database_table : Connection -> Text -> (Vector Text) | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
-In_Memory_Table.update_database_table connection (table_name : Text) update_action
+# TODO get primary key? does not work for temporary tables. So just fail on the default then with a descriptive error that needs explicit?
+# TODO if match_columns=By_Position, how do we handle key_columns? I guess we join on whatever the column matched in the source? so we need to clarify that columns are specified in terms of target names? not sure if positional matching is a good idea at all
+
+## TODO
+
+   Arguments:
+   - connection: the database connection of the target table.
+   - table_name: the name of the table to update.
+   - update_action: specifies the update strategy - how to handle existing new
+     and missing rows.
+   - key_columns: the names of the columns to use identify correlate rows from
+     the source table with rows in the target table. This key is used to
+     determine if a row from the source table exists in the target or is a new
+     one.
+   - match_columns: specifies how columns of the source table are matched to
+     columns of the target table. By default, columns are matched by their name.
+   - error_on_missing_columns: if set to `False` (the default), any columns
+     missing from the source table will be left unchanged or initialized with
+     the default value if inserting. If a missing column has no default value,
+     this will trigger a `SQL_Error`. If set to `True`, any columns missing from
+     the source will cause an error.
+   - create_table_if_missing: if set to `True`, the target table will be created
+     if it does not exist. By default, the table is assumed to exist and if it
+     does not, an error is reported.
+
+   ! Error Conditions
+
+     - TODO: key_columns not resolving
+     - TODO: table does not exist
+     - TODO: missing columns in source (and error_on_missing_columns)
+     - TODO: extra columns detected in source (always error)
+In_Memory_Table.update_database_table : Connection -> Text -> Update_Action -> (Vector Text) | Nothing -> Match_Columns -> Boolean -> Boolean -> Problem_Behavior -> Database_Table
+In_Memory_Table.update_database_table connection (table_name : Text) (update_action : Update_Action = Update_Action.Update_Or_Insert) (key_columns : (Vector | Nothing) = Nothing) (match_columns : Match_Columns = Match_Columns.By_Name) (error_on_missing_columns : Boolean = False) (create_table_if_missing : Boolean = False) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
+    connection.jdbc_connection.run_within_transaction <|
+        tmp_table = upload_table self connection Nothing temporary=True
+        resulting_table = append_existing_table
+        connection.drop_table tmp_table.name
+        resulting_table
+
+## TODO
+
+   Arguments:
+   - connection: the database connection of the target table.
+   - table_name: the name of the table to update.
+   - update_action: specifies the update strategy - how to handle existing new
+     and missing rows.
+   - key_columns: the names of the columns to use identify correlate rows from
+     the source table with rows in the target table. This key is used to
+     determine if a row from the source table exists in the target or is a new
+     one.
+   - match_columns: specifies how columns of the source table are matched to
+     columns of the target table. By default, columns are matched by their name.
+   - error_on_missing_columns: if set to `False` (the default), any columns
+     missing from the source table will be left unchanged or initialized with
+     the default value if inserting. If a missing column has no default value,
+     this will trigger a `SQL_Error`. If set to `True`, any columns missing from
+     the source will cause an error.
+   - create_table_if_missing: if set to `True`, the target table will be created
+     if it does not exist. By default, the table is assumed to exist and if it
+     does not, an error is reported.
+
+   ! Error Conditions
+
+     - TODO: key_columns not resolving
+     - TODO: table does not exist
+     - TODO: missing columns in source (and error_on_missing_columns)
+     - TODO: extra columns detected in source (always error)
+Database_Table.update_database_table : Connection -> Text -> Update_Action -> (Vector Text) | Nothing -> Match_Columns -> Boolean -> Boolean -> Problem_Behavior -> Database_Table
+Database_Table.update_database_table connection (table_name : Text) (update_action : Update_Action = Update_Action.Update_Or_Insert) (key_columns : (Vector | Nothing) = Nothing) (match_columns : Match_Columns = Match_Columns.By_Name) (error_on_missing_columns : Boolean = False) (create_table_if_missing : Boolean = False) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
+    connection.jdbc_connection.run_within_transaction <|
+        tmp_table = copy_table self connection Nothing temporary=True
+        resulting_table = append_existing_table
+        connection.drop_table tmp_table.name
+        resulting_table
 
 ## PRIVATE
    Ensures that provided primary key columns are present in the table and that

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Extensions/Upload_Table.enso
@@ -1,19 +1,14 @@
 from Standard.Base import all
-from Standard.Base.Random import random_uuid
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 import Standard.Table.Data.Table.Table as In_Memory_Table
-from Standard.Table import Aggregate_Column, Match_Columns
 from Standard.Table.Errors import all
 
 import project.Connection.Connection.Connection
-import project.Data.SQL_Query.SQL_Query
-import project.Data.SQL_Statement.SQL_Statement
 import project.Data.Table.Table as Database_Table
 import project.Data.Update_Action.Update_Action
-import project.Internal.IR.Query.Query
-import project.Internal.IR.SQL_Expression.SQL_Expression
 from project.Errors import all
+from project.Internal.Upload_Table import all
 
 ## Creates a new database table from this in-memory table.
 
@@ -53,26 +48,10 @@ from project.Errors import all
      If an error has been raised, the table is not created (that may not always
      apply to `SQL_Error`).
 In_Memory_Table.create_database_table : Connection -> Text|Nothing -> (Vector Text) | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
-In_Memory_Table.create_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False structure_only=False on_problems=Problem_Behavior.Report_Warning = Panic.recover SQL_Error <|
-    resolved_primary_key = resolve_primary_key self primary_key
-    effective_table_name = resolve_effective_table_name table_name temporary
-    create_table_statement = prepare_create_table_statement connection effective_table_name self.columns resolved_primary_key temporary on_problems
-
-    ## `create_table_statement.if_not_error` is used to ensure that if there are
-       any dataflow errors up to this point, we want to propagate them and not
-       continue. Otherwise, they could 'leak' to `Panic.rethrow` and be wrongly
-       raised as panics.
-    upload_status = create_table_statement.if_not_error <|
-        translate_known_upload_errors self connection resolved_primary_key <|
-            connection.jdbc_connection.run_within_transaction <|
-                Panic.rethrow <| connection.execute_update create_table_statement
-                if structure_only.not then
-                    insert_template = make_batched_insert_template connection effective_table_name self.column_names
-                    statement_setter = connection.dialect.get_statement_setter
-                    Panic.rethrow <| connection.jdbc_connection.batch_insert insert_template statement_setter self default_batch_size
-
-    upload_status.if_not_error <|
-        connection.query (SQL_Query.Table_Name effective_table_name)
+In_Memory_Table.create_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False structure_only=False on_problems=Problem_Behavior.Report_Warning =
+    Panic.recover SQL_Error <|
+        connection.jdbc_connection.run_within_transaction <|
+            upload_in_memory_table source_table connection table_name primary_key temporary structure_only on_problems
 
 ## Creates a new database table from this table.
 
@@ -113,31 +92,51 @@ In_Memory_Table.create_database_table self connection table_name=Nothing primary
      apply to `SQL_Error`).
 Database_Table.create_database_table : Connection -> Text|Nothing -> (Vector Text) | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists | Inexact_Type_Coercion | Missing_Input_Columns | Non_Unique_Primary_Key | SQL_Error | Illegal_Argument
 Database_Table.create_database_table self connection table_name=Nothing primary_key=[self.columns.first.name] temporary=False structure_only=False on_problems=Problem_Behavior.Report_Warning = Panic.recover SQL_Error <|
-    resolved_primary_key = resolve_primary_key self primary_key
-    effective_table_name = resolve_effective_table_name table_name temporary
-    create_table_statement = prepare_create_table_statement connection effective_table_name self.columns resolved_primary_key temporary on_problems
-    connection_check = if self.connection.jdbc_connection == connection.jdbc_connection then True else
-        Error.throw (Unsupported_Database_Operation.Error "The Database table to be uploaded must be coming from the same connection as the connection on which the new table is being created. Cross-connection uploads are currently not supported. To work around this, you can first `.read` the table into memory and then upload it from memory to a different connection.")
+    Panic.recover SQL_Error <|
+        connection.jdbc_connection.run_within_transaction <|
+            upload_database_table source_table connection table_name primary_key temporary structure_only on_problems
 
-    upload_status = connection_check.if_not_error <| create_table_statement.if_not_error <|
-        translate_known_upload_errors self connection resolved_primary_key <|
-            connection.jdbc_connection.run_within_transaction <|
-                Panic.rethrow <| connection.execute_update create_table_statement
-                if structure_only.not then
-                    ## We need to ensure that the columns in this statement are matching
-                       positionally the columns in `create_table_statement`. But we
-                       create both from the same table, so that is guaranteed.
-                    copy_into_statement = connection.dialect.generate_sql <|
-                        Query.Insert_From_Select effective_table_name self.to_select_query
-                    Panic.rethrow <| connection.execute_update copy_into_statement
+## Updates the target table with the contents of this table.
 
-    upload_status.if_not_error <|
-        connection.query (SQL_Query.Table_Name effective_table_name)
+   Arguments:
+   - connection: the database connection of the target table.
+   - table_name: the name of the table to update.
+   - update_action: specifies the update strategy - how to handle existing new
+     and missing rows.
+   - key_columns: the names of the columns to use identify correlate rows from
+     the source table with rows in the target table. This key is used to
+     determine if a row from the source table exists in the target or is a new
+     one. The key can be an empty list if the action is `Insert` - then all rows
+     are treated as new (but the Database may still reject them with `SQL_Error`
+     if they violate an integrity constraint).
+   - error_on_missing_columns: if set to `False` (the default), any columns
+     missing from the source table will be left unchanged or initialized with
+     the default value if inserting. If a missing column has no default value,
+     this will trigger a `SQL_Error`. If set to `True`, any columns missing from
+     the source will cause an error.
+    - on_problems: the behavior to use when encountering non-fatal problems.
 
-# TODO get primary key? does not work for temporary tables. So just fail on the default then with a descriptive error that needs explicit?
-# TODO if match_columns=By_Position, how do we handle key_columns? I guess we join on whatever the column matched in the source? so we need to clarify that columns are specified in terms of target names? not sure if positional matching is a good idea at all
+   ! Error Conditions
 
-## TODO
+     - If `key_columns` are not present in either the source or target tables, a
+       `Missing_Input_Columns` error is raised.
+     - If no `key_columns` are specified and the `update_action` is other than
+       `Insert`, an `Illegal_Argument` error is raised.
+     - If the target table does not exist, a `Table_Not_Found` error is raised.
+     - If `error_on_missing_columns` is set to `True` and a column is missing
+       from the source table, a `Missing_Input_Columns` error is raised.
+     - If the source table contains columns that are not present in the target
+       table, an `Unmatched_Columns` error is raised.
+     - If a column in the source table has a type that cannot be trivially
+       widened to the corresponding column in the target table, a
+       `Column_Type_Mismatch` error is raised.
+
+     If any error was raised, the data in the target table is not modified.
+In_Memory_Table.update_database_table : Connection -> Text -> Update_Action -> Vector Text-> Boolean -> Problem_Behavior -> Database_Table ! Table_Not_Found | Unmatched_Columns | Missing_Input_Columns | Column_Type_Mismatch | SQL_Error | Illegal_Argument
+In_Memory_Table.update_database_table connection (table_name : Text) (update_action : Update_Action = Update_Action.Update_Or_Insert) (key_columns : Vector = default_key_columns connection table_name) (error_on_missing_columns : Boolean = False) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
+    common_update_table self source_table connection table_name update_action key_columns error_on_missing_columns on_problems
+
+## Updates the target table with the contents of this table.
 
    Arguments:
    - connection: the database connection of the target table.
@@ -148,143 +147,58 @@ Database_Table.create_database_table self connection table_name=Nothing primary_
      the source table with rows in the target table. This key is used to
      determine if a row from the source table exists in the target or is a new
      one.
-   - match_columns: specifies how columns of the source table are matched to
-     columns of the target table. By default, columns are matched by their name.
    - error_on_missing_columns: if set to `False` (the default), any columns
      missing from the source table will be left unchanged or initialized with
      the default value if inserting. If a missing column has no default value,
      this will trigger a `SQL_Error`. If set to `True`, any columns missing from
      the source will cause an error.
-   - create_table_if_missing: if set to `True`, the target table will be created
-     if it does not exist. By default, the table is assumed to exist and if it
-     does not, an error is reported.
+    - on_problems: the behavior to use when encountering non-fatal problems.
 
    ! Error Conditions
 
-     - TODO: key_columns not resolving
-     - TODO: table does not exist
-     - TODO: missing columns in source (and error_on_missing_columns)
-     - TODO: extra columns detected in source (always error)
-In_Memory_Table.update_database_table : Connection -> Text -> Update_Action -> (Vector Text) | Nothing -> Match_Columns -> Boolean -> Boolean -> Problem_Behavior -> Database_Table
-In_Memory_Table.update_database_table connection (table_name : Text) (update_action : Update_Action = Update_Action.Update_Or_Insert) (key_columns : (Vector | Nothing) = Nothing) (match_columns : Match_Columns = Match_Columns.By_Name) (error_on_missing_columns : Boolean = False) (create_table_if_missing : Boolean = False) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
-    connection.jdbc_connection.run_within_transaction <|
-        tmp_table = upload_table self connection Nothing temporary=True
-        resulting_table = append_existing_table
-        connection.drop_table tmp_table.name
-        resulting_table
+     - If `key_columns` are not present in either the source or target tables, a
+       `Missing_Input_Columns` error is raised.
+     - If the target table does not exist, a `Table_Not_Found` error is raised.
+     - If `error_on_missing_columns` is set to `True` and a column is missing
+       from the source table, a `Missing_Input_Columns` error is raised.
+     - If the source table contains columns that are not present in the target
+       table, an `Unmatched_Columns` error is raised.
+     - If a column in the source table has a type that cannot be trivially
+       widened to the corresponding column in the target table, a
+       `Column_Type_Mismatch` error is raised.
 
-## TODO
-
-   Arguments:
-   - connection: the database connection of the target table.
-   - table_name: the name of the table to update.
-   - update_action: specifies the update strategy - how to handle existing new
-     and missing rows.
-   - key_columns: the names of the columns to use identify correlate rows from
-     the source table with rows in the target table. This key is used to
-     determine if a row from the source table exists in the target or is a new
-     one.
-   - match_columns: specifies how columns of the source table are matched to
-     columns of the target table. By default, columns are matched by their name.
-   - error_on_missing_columns: if set to `False` (the default), any columns
-     missing from the source table will be left unchanged or initialized with
-     the default value if inserting. If a missing column has no default value,
-     this will trigger a `SQL_Error`. If set to `True`, any columns missing from
-     the source will cause an error.
-   - create_table_if_missing: if set to `True`, the target table will be created
-     if it does not exist. By default, the table is assumed to exist and if it
-     does not, an error is reported.
-
-   ! Error Conditions
-
-     - TODO: key_columns not resolving
-     - TODO: table does not exist
-     - TODO: missing columns in source (and error_on_missing_columns)
-     - TODO: extra columns detected in source (always error)
-Database_Table.update_database_table : Connection -> Text -> Update_Action -> (Vector Text) | Nothing -> Match_Columns -> Boolean -> Boolean -> Problem_Behavior -> Database_Table
-Database_Table.update_database_table connection (table_name : Text) (update_action : Update_Action = Update_Action.Update_Or_Insert) (key_columns : (Vector | Nothing) = Nothing) (match_columns : Match_Columns = Match_Columns.By_Name) (error_on_missing_columns : Boolean = False) (create_table_if_missing : Boolean = False) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
-    connection.jdbc_connection.run_within_transaction <|
-        tmp_table = copy_table self connection Nothing temporary=True
-        resulting_table = append_existing_table
-        connection.drop_table tmp_table.name
-        resulting_table
+     If any error was raised, the data in the target table is not modified.
+Database_Table.update_database_table : Connection -> Text -> Update_Action -> Vector Text-> Boolean -> Problem_Behavior -> Database_Table ! Table_Not_Found | Unmatched_Columns | Missing_Input_Columns | Column_Type_Mismatch | SQL_Error | Illegal_Argument
+Database_Table.update_database_table connection (table_name : Text) (update_action : Update_Action = Update_Action.Update_Or_Insert) (key_columns : Vector = default_key_columns connection table_name) (error_on_missing_columns : Boolean = False) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
+    common_update_table self source_table connection table_name update_action key_columns error_on_missing_columns on_problems
 
 ## PRIVATE
-   Ensures that provided primary key columns are present in the table and that
-   there are no duplicates.
-resolve_primary_key table primary_key = case primary_key of
-    Nothing -> Nothing
-    _ : Vector -> if primary_key.is_empty then Nothing else
-        table.select_columns primary_key reorder=True . column_names
+default_key_columns connection table_name =
+    keys = get_primary_key connection table_name
+    keys.catch Any _->
+        Error.throw (Illegal_Argument.Error "Could not determine the primary key for table "+table_name+". Please provide it explicitly.")
 
 ## PRIVATE
-   Inspects any `SQL_Error` thrown and replaces it with a more precise error
-   type when available.
-translate_known_upload_errors source_table connection primary_key ~action =
-    handler caught_panic =
-        error_mapper = connection.dialect.get_error_mapper
-        sql_error = caught_panic.payload
-        case error_mapper.is_primary_key_violation sql_error of
-            True -> raise_duplicated_primary_key_error source_table primary_key caught_panic
-            False -> Panic.throw caught_panic
-    Panic.catch SQL_Error action handler
 
-## PRIVATE
-   Creates a `Non_Unique_Primary_Key` error containing information about an
-   example group violating the uniqueness constraint.
-raise_duplicated_primary_key_error source_table primary_key original_panic =
-    agg = source_table.aggregate [Aggregate_Column.Count]+(primary_key.map Aggregate_Column.Group_By)
-    filtered = agg.filter column=0 (Filter_Condition.Greater than=1)
-    materialized = filtered.read max_rows=1
-    case materialized.row_count == 0 of
-        ## If we couldn't find a duplicated key, we give up the translation and
-           rethrow the original panic containing the SQL error. This could
-           happen if the constraint violation is on some non-trivial key, like
-           case insensitive.
-        True -> Panic.throw original_panic
-        False ->
-            row = materialized.first_row.to_vector
-            example_count = row.first
-            example_entry = row.drop 1
-            Error.throw (Non_Unique_Primary_Key.Error primary_key example_entry example_count)
+   This method may not work correctly with temporary tables, possibly resulting
+   in `SQL_Error` as such tables may not be found.
 
+   ! Temporary Tables in SQLite
 
-## PRIVATE
-   Creates a statement that will create a table with structure determined by the
-   provided columns.
+     The temporary tables in SQLite live in a `temp` database. There is a bug in
+     how JDBC retrieves primary keys - it only queries the `sqlite_schema` table
+     which contains schemas of only permanent tables.
 
-   The `primary_key` columns must be present in `columns`, but it is the
-   responsibility of the caller to ensure that, otherwise the generated
-   statement will be invalid.
-prepare_create_table_statement : Connection -> Text -> Vector -> Vector Text -> Boolean -> Problem_Behavior -> SQL_Statement
-prepare_create_table_statement connection table_name columns primary_key temporary on_problems =
-    type_mapping = connection.dialect.get_type_mapping
-    column_descriptors = columns.map column->
-        name = column.name
-        value_type = column.value_type
-        sql_type = type_mapping.value_type_to_sql value_type on_problems
-        sql_type_text = type_mapping.sql_type_to_text sql_type
-        Pair.new name sql_type_text
-    connection.dialect.generate_sql <|
-        Query.Create_Table table_name column_descriptors primary_key temporary
+     Ideally, we should provide a custom implementation for SQLite that will
+     UNION both `sqlite_schema` and `temp.sqlite_schema` tables to get results
+     for both temporary and permanent tables.
 
-## PRIVATE
-   Generates a random table name if it was nothing, if it is allowed (temporary=True).
-resolve_effective_table_name table_name temporary = case table_name of
-    Nothing -> if temporary then "temporary-table-"+random_uuid else
-        Error.throw (Illegal_Argument.Error "A name must be provided when creating a non-temporary table.")
-    _ : Text -> table_name
-
-## PRIVATE
-   The recommended batch size seems to be between 50 and 100.
-   See: https://docs.oracle.com/cd/E18283_01/java.112/e16548/oraperf.htm#:~:text=batch%20sizes%20in%20the%20general%20range%20of%2050%20to%20100
-default_batch_size = 100
-
-## PRIVATE
-make_batched_insert_template : Connection -> Text -> Vector (Vector Text) -> SQL_Query
-make_batched_insert_template connection table_name column_names =
-    # We add Nothing as placeholders, they will be replaced with the actual values later.
-    pairs = column_names.map name->[name, SQL_Expression.Constant Nothing]
-    query = connection.dialect.generate_sql <| Query.Insert table_name pairs
-    template = query.prepare.first
-    template
+     TODO [RW] fix keys for SQLite temporary tables and test it
+get_primary_key connection table_name =
+    connection.jdbc_connection.with_connection java_connection->
+        rs = java_connection.getMetaData.getPrimaryKeys Nothing Nothing table_name
+        keys_table = result_set_to_table rs connection.dialect.make_column_fetcher_for_type
+        # The names of the columns are sometimes lowercase and sometimes uppercase, so we do a case insensitive select first.
+        selected = keys_table.select_columns [Column_Selector.By_Name "COLUMN_NAME", Column_Selector.By_Name "KEY_SEQ"] reorder=True
+        key_column_names = selected.order_by 1 . at 0 . to_vector
+        if key_column_names.is_empty then Nothing else key_column_names

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/In_Transaction.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/In_Transaction.enso
@@ -1,0 +1,22 @@
+from Standard.Base import all
+from project.Errors.Common import Uninitialized_State
+import Standard.Base.Runtime.State
+
+## PRIVATE
+type In_Transaction
+    ## PRIVATE
+       Checks if a transaction is currently being run.
+    is_in_transaction : Boolean
+    is_in_transaction =
+        Panic.catch Uninitialized_State (State.get In_Transaction) (_->False)
+
+    ## PRIVATE
+       Executes the provided action marking as being run within a transaction.
+    mark_running_in_transaction ~action =
+        State.run In_Transaction True action
+
+    ## PRIVATE
+       Runs the provided action, failing if the call is not made from within a
+       transaction.
+    ensure_in_transaction ~action =
+        if is_in_transaction then action else Error.throw (Illegal_State.Error "`ensure_in_transaction` called outside of a transaction.")

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/In_Transaction.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/In_Transaction.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
-from project.Errors.Common import Uninitialized_State
+from Standard.Base.Errors.Common import Uninitialized_State
+import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Runtime.State
 
 ## PRIVATE
@@ -19,4 +20,4 @@ type In_Transaction
        Runs the provided action, failing if the call is not made from within a
        transaction.
     ensure_in_transaction ~action =
-        if is_in_transaction then action else Error.throw (Illegal_State.Error "`ensure_in_transaction` called outside of a transaction.")
+        if In_Transaction.is_in_transaction then action else Error.throw (Illegal_State.Error "`ensure_in_transaction` called outside of a transaction.")

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/JDBC_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/JDBC_Connection.enso
@@ -11,6 +11,7 @@ import project.Data.SQL_Statement.SQL_Statement
 import project.Data.SQL_Type.SQL_Type
 import project.Data.Table.Table as Database_Table
 import project.Internal.Statement_Setter.Statement_Setter
+import project.Internal.In_Transaction.In_Transaction
 
 from project.Errors import SQL_Error, SQL_Timeout
 
@@ -140,13 +141,15 @@ type JDBC_Connection
        take precedence over the original panic that caused that rollback.
     run_within_transaction : Any -> Any
     run_within_transaction self ~action =
+        if In_Transaction.is_in_transaction then
+            Panic.throw (Illegal_State.Error "`run_within_transaction` is executed within an existing transaction. Nesting transactions is not allowed as its semantics are unclear.")
         self.run_without_autocommit <|
             self.with_connection java_connection->
                 handle_panic caught_panic =
                     java_connection.rollback
                     Panic.throw caught_panic
                 result = Panic.catch Any handler=handle_panic <|
-                    action
+                    In_Transaction.mark_running_in_transaction action
                 java_connection.commit
                 result
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
@@ -135,7 +135,8 @@ type Postgres_Connection
     read : Text | SQL_Query -> Integer | Nothing -> Materialized_Table
     read self query limit=Nothing = self.connection.read query limit
 
-    ## Creates a new empty table in the database.
+    ## Creates a new empty table in the database and returns a query referencing
+       the new table.
 
        Arguments:
        - table_name: the name of the table to create. If not provided, a random
@@ -151,6 +152,10 @@ type Postgres_Connection
        - temporary: if set to `True`, the table will be temporary, meaning that
          it will be dropped once the `connection` is closed. Defaults to
          `False`.
+       - allow_existing: Defaults to `False`, meaning that if the table with the
+         provided name already exists, an error will be raised. If set to `True`,
+         the existing table will be returned instead. Note that the existing
+         table is not guaranteed to have the same structure as the one provided.
        - on_problems: the behavior to use when encountering non-fatal problems.
          Defaults to reporting them as warning.
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
@@ -174,7 +174,7 @@ type Postgres_Connection
          - An `SQL_Error` may be reported if there is a failure on the database
            side.
     create_table : Text|Nothing -> Vector (Pair Text Value_Type) | Database_Table | Materialized_Table -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists
-    create_table (table_name : Text | Nothing = Nothing) (structure : Vector | Database_Table | Materialized_Table) (primary_key : Vector Text = first_column_in_structure structure) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
+    create_table self (table_name : Text | Nothing = Nothing) (structure : Vector | Database_Table | Materialized_Table) (primary_key : Vector Text = [first_column_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
         self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
 
     ## ADVANCED

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
@@ -173,8 +173,8 @@ type Postgres_Connection
            structure provided, `Missing_Input_Columns` error is raised.
          - An `SQL_Error` may be reported if there is a failure on the database
            side.
-    create_table : Text|Nothing -> Vector (Pair Text Value_Type) | Database_Table | Materialized_Table -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists
-    create_table self (table_name : Text | Nothing = Nothing) (structure : Vector | Database_Table | Materialized_Table) (primary_key : Vector Text = [first_column_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
+    create_table : Text|Nothing -> Vector (Pair Text Value_Type) | Database_Table | Materialized_Table -> Vector Text | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists
+    create_table self (table_name : Text | Nothing = Nothing) (structure : Vector | Database_Table | Materialized_Table) (primary_key : (Vector Text | Nothing) = [first_column_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
         self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
 
     ## ADVANCED

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
@@ -105,12 +105,22 @@ type Postgres_Connection
     tables self name_like=Nothing database=self.database schema=Nothing types=self.dialect.default_table_types all_fields=False =
         self.connection.tables name_like database schema types all_fields
 
-    ## Set up a query returning a Table object, which can be used to work with data within the database or load it into memory.
+    ## Set up a query returning a Table object, which can be used to work with
+       data within the database or load it into memory.
 
        Arguments:
        - query: name of the table or sql statement to query.
-         If supplied as `Text`, the name is checked against the `tables` list to determine if it is a table or a query.
+         If supplied as `Text`, the name is checked against the `tables` list to
+         determine if it is a table or a query.
        - alias: optionally specify a friendly alias for the query.
+
+       ! Error Conditions
+
+         - If provided with a `Raw_SQL` query or `Text` that looks like a query, if
+           any SQL error occurs when executing the query, a `SQL_Error` error is
+           raised.
+         - If provided with a `Table_Name` or a text short-hand and the table is
+           not found, a `Table_Not_Found` error is raised.
     @query make_table_name_selector
     query : Text | SQL_Query -> Text -> Database_Table
     query self query alias="" = self.connection.query query alias
@@ -124,6 +134,42 @@ type Postgres_Connection
     @query make_table_name_selector
     read : Text | SQL_Query -> Integer | Nothing -> Materialized_Table
     read self query limit=Nothing = self.connection.read query limit
+
+    ## Creates a new empty table in the database.
+
+       Arguments:
+       - table_name: the name of the table to create. If not provided, a random
+         name will be generated for temporary tables. If `temporary=False`, then
+         a name must be provided.
+       - structure: the structure of the table. This can be provided as a vector
+         of pairs of column names and types or an existing `Table` to copy the
+         structure from it. Note that if a `Table` is provided, only its column
+         structure is inherited - no table content is copied.
+       - primary_key: the names of the columns to use as the primary key. The
+         first column from the table is used by default. If it is set to
+         `Nothing` or an empty vector, no primary key will be created.
+       - temporary: if set to `True`, the table will be temporary, meaning that
+         it will be dropped once the `connection` is closed. Defaults to
+         `False`.
+       - on_problems: the behavior to use when encountering non-fatal problems.
+         Defaults to reporting them as warning.
+
+       ! Error Conditions
+
+         - If a table with the given name already exists, then a
+           `Table_Already_Exists` error is raised.
+         - If a column type is not supported and is coerced to a similar
+           supported type, an `Inexact_Type_Coercion` problem is reported
+           according to the `on_problems` setting.
+         - If a column type is not supported and there is no replacement (e.g.
+           native Enso types), an `Unsupported_Type` error is raised.
+         - If the provided primary key columns are not present in table
+           structure provided, `Missing_Input_Columns` error is raised.
+         - An `SQL_Error` may be reported if there is a failure on the database
+           side.
+    create_table : Text|Nothing -> Table | Vector (Pair Text Value_Type) -> Boolean -> Boolean -> Problem_Behavior -> Table ! Table_Already_Exists
+    create_table (table_name : Text | Nothing = Nothing) (structure : Vector | Table | Materialized_Table) (primary_key : Vector Text = first_column_in_structure structure) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
+        self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
 
     ## ADVANCED
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
@@ -6,6 +6,7 @@ from Standard.Base.Metadata.Choice import Option
 import Standard.Base.Metadata.Display
 
 import Standard.Table.Data.Table.Table as Materialized_Table
+import Standard.Table.Data.Type.Value_Type.Value_Type
 
 import project.Connection.Connection.Connection
 import project.Data.Dialect
@@ -17,8 +18,8 @@ import project.Internal.IR.Query.Query
 import project.Internal.JDBC_Connection
 import project.Internal.SQL_Type_Reference.SQL_Type_Reference
 
-from project.Connection.Connection import make_table_types_selector, make_schema_selector, make_table_name_selector
-from project.Errors import SQL_Error
+from project.Connection.Connection import make_table_types_selector, make_schema_selector, make_table_name_selector, first_column_in_structure
+from project.Errors import SQL_Error, Table_Not_Found, Table_Already_Exists
 from project.Internal.Result_Set import read_column
 
 type Postgres_Connection
@@ -122,7 +123,7 @@ type Postgres_Connection
          - If provided with a `Table_Name` or a text short-hand and the table is
            not found, a `Table_Not_Found` error is raised.
     @query make_table_name_selector
-    query : Text | SQL_Query -> Text -> Database_Table
+    query : Text | SQL_Query -> Text -> Database_Table ! Table_Not_Found
     query self query alias="" = self.connection.query query alias
 
     ## Execute the query and load the results into memory as a Table.
@@ -132,7 +133,7 @@ type Postgres_Connection
          If supplied as `Text`, the name is checked against the `tables` list to determine if it is a table or a query.
        - limit: the maximum number of rows to return.
     @query make_table_name_selector
-    read : Text | SQL_Query -> Integer | Nothing -> Materialized_Table
+    read : Text | SQL_Query -> Integer | Nothing -> Materialized_Table ! Table_Not_Found
     read self query limit=Nothing = self.connection.read query limit
 
     ## Creates a new empty table in the database and returns a query referencing
@@ -172,8 +173,8 @@ type Postgres_Connection
            structure provided, `Missing_Input_Columns` error is raised.
          - An `SQL_Error` may be reported if there is a failure on the database
            side.
-    create_table : Text|Nothing -> Table | Vector (Pair Text Value_Type) -> Boolean -> Boolean -> Problem_Behavior -> Table ! Table_Already_Exists
-    create_table (table_name : Text | Nothing = Nothing) (structure : Vector | Table | Materialized_Table) (primary_key : Vector Text = first_column_in_structure structure) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
+    create_table : Text|Nothing -> Vector (Pair Text Value_Type) | Database_Table | Materialized_Table -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists
+    create_table (table_name : Text | Nothing = Nothing) (structure : Vector | Database_Table | Materialized_Table) (primary_key : Vector Text = first_column_in_structure structure) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
         self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
 
     ## ADVANCED

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
@@ -99,12 +99,22 @@ type SQLite_Connection
     tables self name_like=Nothing database=self.database schema=Nothing types=self.dialect.default_table_types all_fields=False =
         self.connection.tables name_like database schema types all_fields
 
-    ## Set up a query returning a Table object, which can be used to work with data within the database or load it into memory.
+    ## Set up a query returning a Table object, which can be used to work with
+       data within the database or load it into memory.
 
        Arguments:
        - query: name of the table or sql statement to query.
-         If supplied as `Text`, the name is checked against the `tables` list to determine if it is a table or a query.
+         If supplied as `Text`, the name is checked against the `tables` list to
+         determine if it is a table or a query.
        - alias: optionally specify a friendly alias for the query.
+
+       ! Error Conditions
+
+         - If provided with a `Raw_SQL` query or `Text` that looks like a query, if
+           any SQL error occurs when executing the query, a `SQL_Error` error is
+           raised.
+         - If provided with a `Table_Name` or a text short-hand and the table is
+           not found, a `Table_Not_Found` error is raised.
     @query make_table_name_selector
     query : Text | SQL_Query -> Text -> Database_Table
     query self query alias="" = self.connection.query query alias
@@ -118,6 +128,42 @@ type SQLite_Connection
     @query make_table_name_selector
     read : Text | SQL_Query -> Integer | Nothing -> Materialized_Table
     read self query limit=Nothing = self.connection.read query limit
+
+    ## Creates a new empty table in the database.
+
+       Arguments:
+       - table_name: the name of the table to create. If not provided, a random
+         name will be generated for temporary tables. If `temporary=False`, then
+         a name must be provided.
+       - structure: the structure of the table. This can be provided as a vector
+         of pairs of column names and types or an existing `Table` to copy the
+         structure from it. Note that if a `Table` is provided, only its column
+         structure is inherited - no table content is copied.
+       - primary_key: the names of the columns to use as the primary key. The
+         first column from the table is used by default. If it is set to
+         `Nothing` or an empty vector, no primary key will be created.
+       - temporary: if set to `True`, the table will be temporary, meaning that
+         it will be dropped once the `connection` is closed. Defaults to
+         `False`.
+       - on_problems: the behavior to use when encountering non-fatal problems.
+         Defaults to reporting them as warning.
+
+       ! Error Conditions
+
+         - If a table with the given name already exists, then a
+           `Table_Already_Exists` error is raised.
+         - If a column type is not supported and is coerced to a similar
+           supported type, an `Inexact_Type_Coercion` problem is reported
+           according to the `on_problems` setting.
+         - If a column type is not supported and there is no replacement (e.g.
+           native Enso types), an `Unsupported_Type` error is raised.
+         - If the provided primary key columns are not present in table
+           structure provided, `Missing_Input_Columns` error is raised.
+         - An `SQL_Error` may be reported if there is a failure on the database
+           side.
+    create_table : Text|Nothing -> Table | Vector (Pair Text Value_Type) -> Boolean -> Boolean -> Problem_Behavior -> Table ! Table_Already_Exists
+    create_table (table_name : Text | Nothing = Nothing) (structure : Vector | Table | Materialized_Table) (primary_key : Vector Text = first_column_in_structure structure) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
+        self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
 
     ## ADVANCED
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
@@ -167,8 +167,8 @@ type SQLite_Connection
            structure provided, `Missing_Input_Columns` error is raised.
          - An `SQL_Error` may be reported if there is a failure on the database
            side.
-    create_table : Text|Nothing -> Vector (Pair Text Value_Type) | Database_Table | Materialized_Table -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists
-    create_table self (table_name : Text | Nothing = Nothing) (structure : Vector | Database_Table | Materialized_Table) (primary_key : Vector Text = [first_column_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
+    create_table : Text|Nothing -> Vector (Pair Text Value_Type) | Database_Table | Materialized_Table -> Vector Text | Nothing -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists
+    create_table self (table_name : Text | Nothing = Nothing) (structure : Vector | Database_Table | Materialized_Table) (primary_key : (Vector Text | Nothing) = [first_column_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
         self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
 
     ## ADVANCED

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
@@ -168,7 +168,7 @@ type SQLite_Connection
          - An `SQL_Error` may be reported if there is a failure on the database
            side.
     create_table : Text|Nothing -> Vector (Pair Text Value_Type) | Database_Table | Materialized_Table -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists
-    create_table (table_name : Text | Nothing = Nothing) (structure : Vector | Database_Table | Materialized_Table) (primary_key : Vector Text = first_column_in_structure structure) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
+    create_table self (table_name : Text | Nothing = Nothing) (structure : Vector | Database_Table | Materialized_Table) (primary_key : Vector Text = [first_column_in_structure structure]) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
         self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
 
     ## ADVANCED

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
@@ -129,7 +129,8 @@ type SQLite_Connection
     read : Text | SQL_Query -> Integer | Nothing -> Materialized_Table
     read self query limit=Nothing = self.connection.read query limit
 
-    ## Creates a new empty table in the database.
+    ## Creates a new empty table in the database and returns a query referencing
+       the new table.
 
        Arguments:
        - table_name: the name of the table to create. If not provided, a random
@@ -145,6 +146,10 @@ type SQLite_Connection
        - temporary: if set to `True`, the table will be temporary, meaning that
          it will be dropped once the `connection` is closed. Defaults to
          `False`.
+       - allow_existing: Defaults to `False`, meaning that if the table with the
+         provided name already exists, an error will be raised. If set to `True`,
+         the existing table will be returned instead. Note that the existing
+         table is not guaranteed to have the same structure as the one provided.
        - on_problems: the behavior to use when encountering non-fatal problems.
          Defaults to reporting them as warning.
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
@@ -6,6 +6,7 @@ from Standard.Base.Metadata.Choice import Option
 import Standard.Base.Metadata.Display
 
 import Standard.Table.Data.Table.Table as Materialized_Table
+import Standard.Table.Data.Type.Value_Type.Value_Type
 
 import project.Connection.Connection.Connection
 import project.Data.SQL_Query.SQL_Query
@@ -17,8 +18,8 @@ import project.Internal.IR.Query.Query
 import project.Internal.JDBC_Connection
 import project.Internal.SQL_Type_Reference.SQL_Type_Reference
 
-from project.Connection.Connection import make_table_types_selector, make_schema_selector, make_table_name_selector
-from project.Errors import SQL_Error
+from project.Connection.Connection import make_table_types_selector, make_schema_selector, make_table_name_selector, first_column_in_structure
+from project.Errors import SQL_Error, Table_Not_Found, Table_Already_Exists
 
 type SQLite_Connection
     ## PRIVATE
@@ -116,7 +117,7 @@ type SQLite_Connection
          - If provided with a `Table_Name` or a text short-hand and the table is
            not found, a `Table_Not_Found` error is raised.
     @query make_table_name_selector
-    query : Text | SQL_Query -> Text -> Database_Table
+    query : Text | SQL_Query -> Text -> Database_Table ! Table_Not_Found
     query self query alias="" = self.connection.query query alias
 
     ## Execute the query and load the results into memory as a Table.
@@ -126,7 +127,7 @@ type SQLite_Connection
          If supplied as `Text`, the name is checked against the `tables` list to determine if it is a table or a query.
        - limit: the maximum number of rows to return.
     @query make_table_name_selector
-    read : Text | SQL_Query -> Integer | Nothing -> Materialized_Table
+    read : Text | SQL_Query -> Integer | Nothing -> Materialized_Table ! Table_Not_Found
     read self query limit=Nothing = self.connection.read query limit
 
     ## Creates a new empty table in the database and returns a query referencing
@@ -166,8 +167,8 @@ type SQLite_Connection
            structure provided, `Missing_Input_Columns` error is raised.
          - An `SQL_Error` may be reported if there is a failure on the database
            side.
-    create_table : Text|Nothing -> Table | Vector (Pair Text Value_Type) -> Boolean -> Boolean -> Problem_Behavior -> Table ! Table_Already_Exists
-    create_table (table_name : Text | Nothing = Nothing) (structure : Vector | Table | Materialized_Table) (primary_key : Vector Text = first_column_in_structure structure) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
+    create_table : Text|Nothing -> Vector (Pair Text Value_Type) | Database_Table | Materialized_Table -> Boolean -> Boolean -> Problem_Behavior -> Database_Table ! Table_Already_Exists
+    create_table (table_name : Text | Nothing = Nothing) (structure : Vector | Database_Table | Materialized_Table) (primary_key : Vector Text = first_column_in_structure structure) (temporary : Boolean = False) (allow_existing : Boolean = False) (on_problems:Problem_Behavior = Problem_Behavior.Report_Warning) =
         self.connection.create_table table_name structure primary_key temporary allow_existing on_problems
 
     ## ADVANCED

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload_Table.enso
@@ -24,12 +24,12 @@ create_table_structure connection table_name structure primary_key temporary all
             if allow_existing then Nothing else Error.throw (Table_Already_Exists.Error table_name)
         False ->
             effective_table_name = resolve_effective_table_name table_name temporary
-            # TODO fix this structure not necessarily being a Table
-            # TODO migrate select into to use this method
+            aligned_structure = align_structure structure
             resolved_primary_key = resolve_primary_key structure primary_key
-            create_table_statement = prepare_create_table_statement connection effective_table_name self.columns resolved_primary_key temporary on_problems
-            create_table_statement.if_not_error <|
+            create_table_statement = prepare_create_table_statement connection effective_table_name aligned_structure resolved_primary_key temporary on_problems
+            update_result = create_table_statement.if_not_error <|
                 connection.execute_update create_table_statement
+            update_result.if_not_error
 
 ## PRIVATE
    A helper that can upload a table from any backend to a database.
@@ -45,8 +45,9 @@ upload_table source_table connection table_name primary_key temporary on_problem
 
 ## PRIVATE
    It should be run within a transaction.
-upload_in_memory_table source_table connection table_name primary_key temporary structure_only on_problems =
+upload_in_memory_table source_table connection table_name primary_key temporary on_problems =
     In_Transaction.ensure_in_transaction <|
+
         resolved_primary_key = resolve_primary_key self primary_key
         effective_table_name = resolve_effective_table_name table_name temporary
         create_table_statement = prepare_create_table_statement connection effective_table_name self.columns resolved_primary_key temporary on_problems
@@ -58,17 +59,17 @@ upload_in_memory_table source_table connection table_name primary_key temporary 
         upload_status = create_table_statement.if_not_error <|
             translate_known_upload_errors self connection resolved_primary_key <|
                 Panic.rethrow <| connection.execute_update create_table_statement
-                if structure_only.not then
-                    insert_template = make_batched_insert_template connection effective_table_name self.column_names
-                    statement_setter = connection.dialect.get_statement_setter
-                    Panic.rethrow <| connection.jdbc_connection.batch_insert insert_template statement_setter self default_batch_size
+
+                insert_template = make_batched_insert_template connection effective_table_name self.column_names
+                statement_setter = connection.dialect.get_statement_setter
+                Panic.rethrow <| connection.jdbc_connection.batch_insert insert_template statement_setter self default_batch_size
 
         upload_status.if_not_error <|
             connection.query (SQL_Query.Table_Name effective_table_name)
 
 ## PRIVATE
    It should be run within a transaction.
-upload_database_table source_table connection table_name primary_key temporary structure_only on_problems =
+upload_database_table source_table connection table_name primary_key temporary on_problems =
     In_Transaction.ensure_in_transaction <|
         resolved_primary_key = resolve_primary_key self primary_key
         effective_table_name = resolve_effective_table_name table_name temporary
@@ -79,13 +80,13 @@ upload_database_table source_table connection table_name primary_key temporary s
         upload_status = connection_check.if_not_error <| create_table_statement.if_not_error <|
             translate_known_upload_errors self connection resolved_primary_key <|
                 Panic.rethrow <| connection.execute_update create_table_statement
-                if structure_only.not then
-                    ## We need to ensure that the columns in this statement are matching
-                       positionally the columns in `create_table_statement`. But we
-                       create both from the same table, so that is guaranteed.
-                    copy_into_statement = connection.dialect.generate_sql <|
-                        Query.Insert_From_Select effective_table_name self.to_select_query
-                    Panic.rethrow <| connection.execute_update copy_into_statement
+
+                ## We need to ensure that the columns in this statement are matching
+                   positionally the columns in `create_table_statement`. But we
+                   create both from the same table, so that is guaranteed.
+                copy_into_statement = connection.dialect.generate_sql <|
+                    Query.Insert_From_Select effective_table_name self.to_select_query
+                Panic.rethrow <| connection.execute_update copy_into_statement
 
         upload_status.if_not_error <|
             connection.query (SQL_Query.Table_Name effective_table_name)
@@ -93,10 +94,17 @@ upload_database_table source_table connection table_name primary_key temporary s
 ## PRIVATE
    Ensures that provided primary key columns are present in the table and that
    there are no duplicates.
-resolve_primary_key table primary_key = case primary_key of
+resolve_primary_key structure primary_key = case primary_key of
     Nothing -> Nothing
     _ : Vector -> if primary_key.is_empty then Nothing else
-        table.select_columns primary_key reorder=True . column_names
+        validated = primary_key.map key->
+            if key.is_a Text then key else
+                Error.throw (Illegal_Argument.Error "Primary key must be a vector of column names.")
+        validated.if_not_error <|
+            column_names = Set.from_vector (structure.map .first)
+            missing_columns = (Set.from_vector primary_key) - column_names
+            if missing_columns.not_empty then Error.throw (Missing_Input_Columns.Error missing_columns.to_vector) else
+                primary_key
 
 ## PRIVATE
    Inspects any `SQL_Error` thrown and replaces it with a more precise error
@@ -129,6 +137,18 @@ raise_duplicated_primary_key_error source_table primary_key original_panic =
             example_entry = row.drop 1
             Error.throw (Non_Unique_Primary_Key.Error primary_key example_entry example_count)
 
+## PRIVATE
+align_structure : Table | Vector (Pair Text Value_Type) -> Vector (Pair Text Value_Type)
+align_structure table_or_columns = case table_or_columns of
+    _ : Vector -> table_or_columns.map pair->
+        if pair.length != 2 then Error.throw (Illegal_Argument.Error "The structure must be an existing Table or vector of pairs.") else
+            name = pair.first
+            value_type = pair.second
+            if name . is_a Text . not then Error.throw (Illegal_Argument.Error "Column names must be a Text. Instead, got a: "+name.to_display_text+".") else
+                if value_type . is_a Value_Type . not then Error.throw (Illegal_Argument.Error "Column value types must be a Value_Type. Instead, got a: "+value_type.to_display_text+".") else
+                    pair
+    _ -> table_or_columns.columns.map column->
+        Pair.new column.name column.value_type
 
 ## PRIVATE
    Creates a statement that will create a table with structure determined by the
@@ -140,9 +160,9 @@ raise_duplicated_primary_key_error source_table primary_key original_panic =
 prepare_create_table_statement : Connection -> Text -> Vector -> Vector Text -> Boolean -> Problem_Behavior -> SQL_Statement
 prepare_create_table_statement connection table_name columns primary_key temporary on_problems =
     type_mapping = connection.dialect.get_type_mapping
-    column_descriptors = columns.map column->
-        name = column.name
-        value_type = column.value_type
+    column_descriptors = columns.map pair->
+        name = pair.first
+        value_type = pair.second
         sql_type = type_mapping.value_type_to_sql value_type on_problems
         sql_type_text = type_mapping.sql_type_to_text sql_type
         Pair.new name sql_type_text

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload_Table.enso
@@ -1,0 +1,185 @@
+from Standard.Base import all
+from Standard.Base.Random import random_uuid
+import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
+
+import Standard.Table.Data.Table.Table as In_Memory_Table
+from Standard.Table import Aggregate_Column
+from Standard.Table.Errors import all
+
+import project.Connection.Connection.Connection
+import project.Data.SQL_Query.SQL_Query
+import project.Data.SQL_Statement.SQL_Statement
+import project.Data.Table.Table as Database_Table
+import project.Data.Update_Action.Update_Action
+import project.Internal.In_Transaction.In_Transaction
+import project.Internal.IR.Query.Query
+import project.Internal.IR.SQL_Expression.SQL_Expression
+from project.Errors import all
+
+## PRIVATE
+   A helper that can upload a table from any backend to a database.
+   It should be run within a transaction.
+upload_table source_table connection table_name primary_key temporary structure_only on_problems =
+    case source_table of
+        _ : In_Memory_Table ->
+            upload_in_memory_table source_table connection table_name primary_key temporary structure_only on_problems
+        _ : Database_Table ->
+            upload_database_table source_table connection table_name primary_key temporary structure_only on_problems
+        _ ->
+            Panic.throw <| Illegal_Argument.Error ("Unsupported table type: " + Meta.get_qualified_type_name source_table)
+
+## PRIVATE
+   It should be run within a transaction.
+upload_in_memory_table source_table connection table_name primary_key temporary structure_only on_problems =
+    In_Transaction.ensure_in_transaction <|
+        resolved_primary_key = resolve_primary_key self primary_key
+        effective_table_name = resolve_effective_table_name table_name temporary
+        create_table_statement = prepare_create_table_statement connection effective_table_name self.columns resolved_primary_key temporary on_problems
+
+        ## `create_table_statement.if_not_error` is used to ensure that if there are
+           any dataflow errors up to this point, we want to propagate them and not
+           continue. Otherwise, they could 'leak' to `Panic.rethrow` and be wrongly
+           raised as panics.
+        upload_status = create_table_statement.if_not_error <|
+            translate_known_upload_errors self connection resolved_primary_key <|
+                Panic.rethrow <| connection.execute_update create_table_statement
+                if structure_only.not then
+                    insert_template = make_batched_insert_template connection effective_table_name self.column_names
+                    statement_setter = connection.dialect.get_statement_setter
+                    Panic.rethrow <| connection.jdbc_connection.batch_insert insert_template statement_setter self default_batch_size
+
+        upload_status.if_not_error <|
+            connection.query (SQL_Query.Table_Name effective_table_name)
+
+## PRIVATE
+   It should be run within a transaction.
+upload_database_table source_table connection table_name primary_key temporary structure_only on_problems =
+    In_Transaction.ensure_in_transaction <|
+        resolved_primary_key = resolve_primary_key self primary_key
+        effective_table_name = resolve_effective_table_name table_name temporary
+        create_table_statement = prepare_create_table_statement connection effective_table_name self.columns resolved_primary_key temporary on_problems
+        connection_check = if self.connection.jdbc_connection == connection.jdbc_connection then True else
+            Error.throw (Unsupported_Database_Operation.Error "The Database table to be uploaded must be coming from the same connection as the connection on which the new table is being created. Cross-connection uploads are currently not supported. To work around this, you can first `.read` the table into memory and then upload it from memory to a different connection.")
+
+        upload_status = connection_check.if_not_error <| create_table_statement.if_not_error <|
+            translate_known_upload_errors self connection resolved_primary_key <|
+                Panic.rethrow <| connection.execute_update create_table_statement
+                if structure_only.not then
+                    ## We need to ensure that the columns in this statement are matching
+                       positionally the columns in `create_table_statement`. But we
+                       create both from the same table, so that is guaranteed.
+                    copy_into_statement = connection.dialect.generate_sql <|
+                        Query.Insert_From_Select effective_table_name self.to_select_query
+                    Panic.rethrow <| connection.execute_update copy_into_statement
+
+        upload_status.if_not_error <|
+            connection.query (SQL_Query.Table_Name effective_table_name)
+
+## PRIVATE
+   Ensures that provided primary key columns are present in the table and that
+   there are no duplicates.
+resolve_primary_key table primary_key = case primary_key of
+    Nothing -> Nothing
+    _ : Vector -> if primary_key.is_empty then Nothing else
+        table.select_columns primary_key reorder=True . column_names
+
+## PRIVATE
+   Inspects any `SQL_Error` thrown and replaces it with a more precise error
+   type when available.
+translate_known_upload_errors source_table connection primary_key ~action =
+    handler caught_panic =
+        error_mapper = connection.dialect.get_error_mapper
+        sql_error = caught_panic.payload
+        case error_mapper.is_primary_key_violation sql_error of
+            True -> raise_duplicated_primary_key_error source_table primary_key caught_panic
+            False -> Panic.throw caught_panic
+    Panic.catch SQL_Error action handler
+
+## PRIVATE
+   Creates a `Non_Unique_Primary_Key` error containing information about an
+   example group violating the uniqueness constraint.
+raise_duplicated_primary_key_error source_table primary_key original_panic =
+    agg = source_table.aggregate [Aggregate_Column.Count]+(primary_key.map Aggregate_Column.Group_By)
+    filtered = agg.filter column=0 (Filter_Condition.Greater than=1)
+    materialized = filtered.read max_rows=1
+    case materialized.row_count == 0 of
+        ## If we couldn't find a duplicated key, we give up the translation and
+           rethrow the original panic containing the SQL error. This could
+           happen if the constraint violation is on some non-trivial key, like
+           case insensitive.
+        True -> Panic.throw original_panic
+        False ->
+            row = materialized.first_row.to_vector
+            example_count = row.first
+            example_entry = row.drop 1
+            Error.throw (Non_Unique_Primary_Key.Error primary_key example_entry example_count)
+
+
+## PRIVATE
+   Creates a statement that will create a table with structure determined by the
+   provided columns.
+
+   The `primary_key` columns must be present in `columns`, but it is the
+   responsibility of the caller to ensure that, otherwise the generated
+   statement will be invalid.
+prepare_create_table_statement : Connection -> Text -> Vector -> Vector Text -> Boolean -> Problem_Behavior -> SQL_Statement
+prepare_create_table_statement connection table_name columns primary_key temporary on_problems =
+    type_mapping = connection.dialect.get_type_mapping
+    column_descriptors = columns.map column->
+        name = column.name
+        value_type = column.value_type
+        sql_type = type_mapping.value_type_to_sql value_type on_problems
+        sql_type_text = type_mapping.sql_type_to_text sql_type
+        Pair.new name sql_type_text
+    connection.dialect.generate_sql <|
+        Query.Create_Table table_name column_descriptors primary_key temporary
+
+## PRIVATE
+   Generates a random table name if it was nothing, if it is allowed (temporary=True).
+resolve_effective_table_name table_name temporary = case table_name of
+    Nothing -> if temporary then "temporary-table-"+random_uuid else
+        Error.throw (Illegal_Argument.Error "A name must be provided when creating a non-temporary table.")
+    _ : Text -> table_name
+
+## PRIVATE
+   The recommended batch size seems to be between 50 and 100.
+   See: https://docs.oracle.com/cd/E18283_01/java.112/e16548/oraperf.htm#:~:text=batch%20sizes%20in%20the%20general%20range%20of%2050%20to%20100
+default_batch_size = 100
+
+## PRIVATE
+make_batched_insert_template : Connection -> Text -> Vector (Vector Text) -> SQL_Query
+make_batched_insert_template connection table_name column_names =
+    # We add Nothing as placeholders, they will be replaced with the actual values later.
+    pairs = column_names.map name->[name, SQL_Expression.Constant Nothing]
+    query = connection.dialect.generate_sql <| Query.Insert table_name pairs
+    template = query.prepare.first
+    template
+
+## PRIVATE
+common_update_table source_table connection table_name update_action key_columns error_on_missing_columns on_problems =
+    Panic.recover SQL_Error <|
+        connection.jdbc_connection.run_within_transaction <|
+            target_table = connection.query (SQL_Query.Table_Name table_name)
+            # We catch the `Table_Not_Found` error and handle it specially, if the error was different, it will just get passed through further.
+            handle_error = target_table.catch Table_Not_Found error->
+                # Rethrow the error with more info.
+                msg_suffix = " Use `Connection.create_table` to create a table before trying to append to it."
+                new_error = error.with_changed_extra_message msg_suffix
+                Error.throw new_error
+            if target_table.is_error then handle_error else
+                tmp_table_name = "temporary-source-table-"+random_uuid
+                tmp_table = upload_table source_table connection tmp_table_name key_columns temporary=True structure_only=False on_problems=Problem_Behavior.Report_Error
+                tmp_table.if_not_error <|
+                    resulting_table = append_to_existing_table
+                    connection.drop_table tmp_table.name
+                    resulting_table
+
+## PRIVATE
+append_to_existing_table source_table target_table update_action key_columns error_on_missing_columns =
+    source_columns = Set.from_vector source_table.column_names
+    target_columns = Set.from_vector target_table.column_names
+    extra_columns = source_columns - target_columns
+    if extra_columns.not_empty then Error.throw (Unmatched_Columns.Error extra_columns) else
+        missing_columns = target_columns - source_columns
+        if missing_columns.not_empty && error_on_missing_columns then Error.throw (Missing_Input_Columns.Error missing_columns "the source table") else
+            Error.throw "TODO: Implement the actual update logic."

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload_Table.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 from Standard.Base.Random import random_uuid
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
+import Standard.Base.Errors.Illegal_State.Illegal_State
 
 import Standard.Table.Data.Table.Table as In_Memory_Table
 import Standard.Table.Data.Type.Value_Type.Value_Type
@@ -215,6 +216,6 @@ append_to_existing_table source_table target_table update_action key_columns err
     if extra_columns.not_empty then Error.throw (Unmatched_Columns.Error extra_columns) else
         missing_columns = target_columns.difference source_columns
         if missing_columns.not_empty && error_on_missing_columns then Error.throw (Missing_Input_Columns.Error missing_columns "the source table") else
-            # TODO
+            # TODO [RW] to be finished in follow up PR
             _ = [update_action, key_columns]
-            Error.throw "TODO: Implement the actual update logic."
+            Error.throw (Illegal_State.Error "TODO: Not implemented yet.")

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload_Table.enso
@@ -18,6 +18,8 @@ from project.Connection.Connection import all_known_table_names
 from project.Errors import all
 
 ## PRIVATE
+   Creates a new database table with the provided structure and returns the name
+   of the created table.
 create_table_structure connection table_name structure primary_key temporary allow_existing on_problems =
     case table_name.is_nothing.not && all_known_table_names connection . contains table_name of
         True ->
@@ -29,7 +31,8 @@ create_table_structure connection table_name structure primary_key temporary all
             create_table_statement = prepare_create_table_statement connection effective_table_name aligned_structure resolved_primary_key temporary on_problems
             update_result = create_table_statement.if_not_error <|
                 connection.execute_update create_table_statement
-            update_result.if_not_error
+            update_result.if_not_error <|
+                effective_table_name
 
 ## PRIVATE
    A helper that can upload a table from any backend to a database.
@@ -47,49 +50,43 @@ upload_table source_table connection table_name primary_key temporary on_problem
    It should be run within a transaction.
 upload_in_memory_table source_table connection table_name primary_key temporary on_problems =
     In_Transaction.ensure_in_transaction <|
+        created_table_name = create_table_structure connection table_name structure=source_table primary_key temporary=temporary allow_existing=False on_problems=on_problems
 
-        resolved_primary_key = resolve_primary_key self primary_key
-        effective_table_name = resolve_effective_table_name table_name temporary
-        create_table_statement = prepare_create_table_statement connection effective_table_name self.columns resolved_primary_key temporary on_problems
-
-        ## `create_table_statement.if_not_error` is used to ensure that if there are
+        ## `created_table_name.if_not_error` is used to ensure that if there are
            any dataflow errors up to this point, we want to propagate them and not
            continue. Otherwise, they could 'leak' to `Panic.rethrow` and be wrongly
            raised as panics.
-        upload_status = create_table_statement.if_not_error <|
+        upload_status = created_table_name.if_not_error <|
             translate_known_upload_errors self connection resolved_primary_key <|
                 Panic.rethrow <| connection.execute_update create_table_statement
 
-                insert_template = make_batched_insert_template connection effective_table_name self.column_names
+                insert_template = make_batched_insert_template connection created_table_name self.column_names
                 statement_setter = connection.dialect.get_statement_setter
                 Panic.rethrow <| connection.jdbc_connection.batch_insert insert_template statement_setter self default_batch_size
 
         upload_status.if_not_error <|
-            connection.query (SQL_Query.Table_Name effective_table_name)
+            connection.query (SQL_Query.Table_Name created_table_name)
 
 ## PRIVATE
    It should be run within a transaction.
 upload_database_table source_table connection table_name primary_key temporary on_problems =
     In_Transaction.ensure_in_transaction <|
-        resolved_primary_key = resolve_primary_key self primary_key
-        effective_table_name = resolve_effective_table_name table_name temporary
-        create_table_statement = prepare_create_table_statement connection effective_table_name self.columns resolved_primary_key temporary on_problems
-        connection_check = if self.connection.jdbc_connection == connection.jdbc_connection then True else
+        connection_check = if source_table.connection.jdbc_connection == connection.jdbc_connection then True else
             Error.throw (Unsupported_Database_Operation.Error "The Database table to be uploaded must be coming from the same connection as the connection on which the new table is being created. Cross-connection uploads are currently not supported. To work around this, you can first `.read` the table into memory and then upload it from memory to a different connection.")
 
-        upload_status = connection_check.if_not_error <| create_table_statement.if_not_error <|
-            translate_known_upload_errors self connection resolved_primary_key <|
-                Panic.rethrow <| connection.execute_update create_table_statement
+        connection_check.if_not_error <|
+            created_table_name = create_table_structure connection table_name structure=source_table primary_key temporary=temporary allow_existing=False on_problems=on_problems
+            upload_status = created_table_name.if_not_error <|
+                translate_known_upload_errors self connection resolved_primary_key <|
+                    ## We need to ensure that the columns in this statement are matching
+                       positionally the columns in `create_table_statement`. But we
+                       create both from the same table, so that is guaranteed.
+                    copy_into_statement = connection.dialect.generate_sql <|
+                        Query.Insert_From_Select created_table_name self.to_select_query
+                    Panic.rethrow <| connection.execute_update copy_into_statement
 
-                ## We need to ensure that the columns in this statement are matching
-                   positionally the columns in `create_table_statement`. But we
-                   create both from the same table, so that is guaranteed.
-                copy_into_statement = connection.dialect.generate_sql <|
-                    Query.Insert_From_Select effective_table_name self.to_select_query
-                Panic.rethrow <| connection.execute_update copy_into_statement
-
-        upload_status.if_not_error <|
-            connection.query (SQL_Query.Table_Name effective_table_name)
+            upload_status.if_not_error <|
+                connection.query (SQL_Query.Table_Name created_table_name)
 
 ## PRIVATE
    Ensures that provided primary key columns are present in the table and that

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload_Table.enso
@@ -3,6 +3,7 @@ from Standard.Base.Random import random_uuid
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 import Standard.Table.Data.Table.Table as In_Memory_Table
+import Standard.Table.Data.Type.Value_Type.Value_Type
 from Standard.Table import Aggregate_Column
 from Standard.Table.Errors import all
 
@@ -23,11 +24,11 @@ from project.Errors import all
 create_table_structure connection table_name structure primary_key temporary allow_existing on_problems =
     case table_name.is_nothing.not && all_known_table_names connection . contains table_name of
         True ->
-            if allow_existing then Nothing else Error.throw (Table_Already_Exists.Error table_name)
+            if allow_existing then table_name else Error.throw (Table_Already_Exists.Error table_name)
         False ->
             effective_table_name = resolve_effective_table_name table_name temporary
             aligned_structure = align_structure structure
-            resolved_primary_key = resolve_primary_key structure primary_key
+            resolved_primary_key = resolve_primary_key aligned_structure primary_key
             create_table_statement = prepare_create_table_statement connection effective_table_name aligned_structure resolved_primary_key temporary on_problems
             update_result = create_table_statement.if_not_error <|
                 connection.execute_update create_table_statement
@@ -50,19 +51,18 @@ upload_table source_table connection table_name primary_key temporary on_problem
    It should be run within a transaction.
 upload_in_memory_table source_table connection table_name primary_key temporary on_problems =
     In_Transaction.ensure_in_transaction <|
-        created_table_name = create_table_structure connection table_name structure=source_table primary_key temporary=temporary allow_existing=False on_problems=on_problems
+        created_table_name = create_table_structure connection table_name structure=source_table primary_key=primary_key temporary=temporary allow_existing=False on_problems=on_problems
+        column_names = source_table.column_names
 
         ## `created_table_name.if_not_error` is used to ensure that if there are
            any dataflow errors up to this point, we want to propagate them and not
            continue. Otherwise, they could 'leak' to `Panic.rethrow` and be wrongly
            raised as panics.
         upload_status = created_table_name.if_not_error <|
-            translate_known_upload_errors self connection resolved_primary_key <|
-                Panic.rethrow <| connection.execute_update create_table_statement
-
-                insert_template = make_batched_insert_template connection created_table_name self.column_names
+            translate_known_upload_errors source_table connection primary_key <|
+                insert_template = make_batched_insert_template connection created_table_name column_names
                 statement_setter = connection.dialect.get_statement_setter
-                Panic.rethrow <| connection.jdbc_connection.batch_insert insert_template statement_setter self default_batch_size
+                Panic.rethrow <| connection.jdbc_connection.batch_insert insert_template statement_setter source_table default_batch_size
 
         upload_status.if_not_error <|
             connection.query (SQL_Query.Table_Name created_table_name)
@@ -75,14 +75,15 @@ upload_database_table source_table connection table_name primary_key temporary o
             Error.throw (Unsupported_Database_Operation.Error "The Database table to be uploaded must be coming from the same connection as the connection on which the new table is being created. Cross-connection uploads are currently not supported. To work around this, you can first `.read` the table into memory and then upload it from memory to a different connection.")
 
         connection_check.if_not_error <|
-            created_table_name = create_table_structure connection table_name structure=source_table primary_key temporary=temporary allow_existing=False on_problems=on_problems
+            created_table_name = create_table_structure connection table_name structure=source_table primary_key=primary_key temporary=temporary allow_existing=False on_problems=on_problems
             upload_status = created_table_name.if_not_error <|
-                translate_known_upload_errors self connection resolved_primary_key <|
-                    ## We need to ensure that the columns in this statement are matching
-                       positionally the columns in `create_table_statement`. But we
-                       create both from the same table, so that is guaranteed.
+                translate_known_upload_errors source_table connection primary_key <|
+                    ## We need to ensure that the columns in this statement are
+                       matching positionally the columns in the newly created
+                       table. But we create both from the same source table, so
+                       that is guaranteed.
                     copy_into_statement = connection.dialect.generate_sql <|
-                        Query.Insert_From_Select created_table_name self.to_select_query
+                        Query.Insert_From_Select created_table_name source_table.to_select_query
                     Panic.rethrow <| connection.execute_update copy_into_statement
 
             upload_status.if_not_error <|
@@ -99,7 +100,7 @@ resolve_primary_key structure primary_key = case primary_key of
                 Error.throw (Illegal_Argument.Error "Primary key must be a vector of column names.")
         validated.if_not_error <|
             column_names = Set.from_vector (structure.map .first)
-            missing_columns = (Set.from_vector primary_key) - column_names
+            missing_columns = (Set.from_vector primary_key).difference column_names
             if missing_columns.not_empty then Error.throw (Missing_Input_Columns.Error missing_columns.to_vector) else
                 primary_key
 
@@ -135,7 +136,7 @@ raise_duplicated_primary_key_error source_table primary_key original_panic =
             Error.throw (Non_Unique_Primary_Key.Error primary_key example_entry example_count)
 
 ## PRIVATE
-align_structure : Table | Vector (Pair Text Value_Type) -> Vector (Pair Text Value_Type)
+align_structure : Database_Table | In_Memory_Table | Vector (Pair Text Value_Type) -> Vector (Pair Text Value_Type)
 align_structure table_or_columns = case table_or_columns of
     _ : Vector -> table_or_columns.map pair->
         if pair.length != 2 then Error.throw (Illegal_Argument.Error "The structure must be an existing Table or vector of pairs.") else
@@ -210,8 +211,10 @@ common_update_table source_table connection table_name update_action key_columns
 append_to_existing_table source_table target_table update_action key_columns error_on_missing_columns =
     source_columns = Set.from_vector source_table.column_names
     target_columns = Set.from_vector target_table.column_names
-    extra_columns = source_columns - target_columns
+    extra_columns = source_columns.difference target_columns
     if extra_columns.not_empty then Error.throw (Unmatched_Columns.Error extra_columns) else
-        missing_columns = target_columns - source_columns
+        missing_columns = target_columns.difference source_columns
         if missing_columns.not_empty && error_on_missing_columns then Error.throw (Missing_Input_Columns.Error missing_columns "the source table") else
+            # TODO
+            _ = [update_action, key_columns]
             Error.throw "TODO: Implement the actual update logic."

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload_Table.enso
@@ -14,17 +14,32 @@ import project.Data.Update_Action.Update_Action
 import project.Internal.In_Transaction.In_Transaction
 import project.Internal.IR.Query.Query
 import project.Internal.IR.SQL_Expression.SQL_Expression
+from project.Connection.Connection import all_known_table_names
 from project.Errors import all
+
+## PRIVATE
+create_table_structure connection table_name structure primary_key temporary allow_existing on_problems =
+    case table_name.is_nothing.not && all_known_table_names connection . contains table_name of
+        True ->
+            if allow_existing then Nothing else Error.throw (Table_Already_Exists.Error table_name)
+        False ->
+            effective_table_name = resolve_effective_table_name table_name temporary
+            # TODO fix this structure not necessarily being a Table
+            # TODO migrate select into to use this method
+            resolved_primary_key = resolve_primary_key structure primary_key
+            create_table_statement = prepare_create_table_statement connection effective_table_name self.columns resolved_primary_key temporary on_problems
+            create_table_statement.if_not_error <|
+                connection.execute_update create_table_statement
 
 ## PRIVATE
    A helper that can upload a table from any backend to a database.
    It should be run within a transaction.
-upload_table source_table connection table_name primary_key temporary structure_only on_problems =
+upload_table source_table connection table_name primary_key temporary on_problems =
     case source_table of
         _ : In_Memory_Table ->
-            upload_in_memory_table source_table connection table_name primary_key temporary structure_only on_problems
+            upload_in_memory_table source_table connection table_name primary_key temporary on_problems
         _ : Database_Table ->
-            upload_database_table source_table connection table_name primary_key temporary structure_only on_problems
+            upload_database_table source_table connection table_name primary_key temporary on_problems
         _ ->
             Panic.throw <| Illegal_Argument.Error ("Unsupported table type: " + Meta.get_qualified_type_name source_table)
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload_Table.enso
@@ -38,19 +38,25 @@ create_table_structure connection table_name structure primary_key temporary all
 
 ## PRIVATE
    A helper that can upload a table from any backend to a database.
-   It should be run within a transaction.
-upload_table source_table connection table_name primary_key temporary on_problems =
+   It should be run within a transaction and wrapped in `handle_upload_errors`.
+internal_upload_table source_table connection table_name primary_key temporary on_problems =
     case source_table of
         _ : In_Memory_Table ->
-            upload_in_memory_table source_table connection table_name primary_key temporary on_problems
+            internal_upload_in_memory_table source_table connection table_name primary_key temporary on_problems
         _ : Database_Table ->
-            upload_database_table source_table connection table_name primary_key temporary on_problems
+            internal_upload_database_table source_table connection table_name primary_key temporary on_problems
         _ ->
             Panic.throw <| Illegal_Argument.Error ("Unsupported table type: " + Meta.get_qualified_type_name source_table)
 
 ## PRIVATE
-   It should be run within a transaction.
 upload_in_memory_table source_table connection table_name primary_key temporary on_problems =
+    Panic.recover SQL_Error <| handle_upload_errors <|
+        connection.jdbc_connection.run_within_transaction <|
+            internal_upload_in_memory_table source_table connection table_name primary_key temporary on_problems
+
+## PRIVATE
+   It should be run within a transaction and wrapped in `handle_upload_errors`.
+internal_upload_in_memory_table source_table connection table_name primary_key temporary on_problems =
     In_Transaction.ensure_in_transaction <|
         created_table_name = create_table_structure connection table_name structure=source_table primary_key=primary_key temporary=temporary allow_existing=False on_problems=on_problems
         column_names = source_table.column_names
@@ -60,7 +66,7 @@ upload_in_memory_table source_table connection table_name primary_key temporary 
            continue. Otherwise, they could 'leak' to `Panic.rethrow` and be wrongly
            raised as panics.
         upload_status = created_table_name.if_not_error <|
-            translate_known_upload_errors source_table connection primary_key <|
+            internal_translate_known_upload_errors source_table connection primary_key <|
                 insert_template = make_batched_insert_template connection created_table_name column_names
                 statement_setter = connection.dialect.get_statement_setter
                 Panic.rethrow <| connection.jdbc_connection.batch_insert insert_template statement_setter source_table default_batch_size
@@ -69,8 +75,14 @@ upload_in_memory_table source_table connection table_name primary_key temporary 
             connection.query (SQL_Query.Table_Name created_table_name)
 
 ## PRIVATE
-   It should be run within a transaction.
 upload_database_table source_table connection table_name primary_key temporary on_problems =
+    Panic.recover SQL_Error <| handle_upload_errors <|
+        connection.jdbc_connection.run_within_transaction <|
+            internal_upload_database_table source_table connection table_name primary_key temporary on_problems
+
+## PRIVATE
+   It should be run within a transaction and wrapped in `handle_upload_errors`.
+internal_upload_database_table source_table connection table_name primary_key temporary on_problems =
     In_Transaction.ensure_in_transaction <|
         connection_check = if source_table.connection.jdbc_connection == connection.jdbc_connection then True else
             Error.throw (Unsupported_Database_Operation.Error "The Database table to be uploaded must be coming from the same connection as the connection on which the new table is being created. Cross-connection uploads are currently not supported. To work around this, you can first `.read` the table into memory and then upload it from memory to a different connection.")
@@ -78,7 +90,7 @@ upload_database_table source_table connection table_name primary_key temporary o
         connection_check.if_not_error <|
             created_table_name = create_table_structure connection table_name structure=source_table primary_key=primary_key temporary=temporary allow_existing=False on_problems=on_problems
             upload_status = created_table_name.if_not_error <|
-                translate_known_upload_errors source_table connection primary_key <|
+                internal_translate_known_upload_errors source_table connection primary_key <|
                     ## We need to ensure that the columns in this statement are
                        matching positionally the columns in the newly created
                        table. But we create both from the same source table, so
@@ -106,16 +118,31 @@ resolve_primary_key structure primary_key = case primary_key of
                 primary_key
 
 ## PRIVATE
-   Inspects any `SQL_Error` thrown and replaces it with a more precise error
-   type when available.
-translate_known_upload_errors source_table connection primary_key ~action =
+   Inspects any `SQL_Error` thrown and replaces it with an error recipe, that is
+   converted into a proper error in an outer layer.
+
+   The special handling is needed, because computing the
+   `Non_Unique_Primary_Key` error may need to perform a SQL query that must be
+   run outside of the just-failed transaction.
+internal_translate_known_upload_errors source_table connection primary_key ~action =
     handler caught_panic =
         error_mapper = connection.dialect.get_error_mapper
         sql_error = caught_panic.payload
         case error_mapper.is_primary_key_violation sql_error of
-            True -> raise_duplicated_primary_key_error source_table primary_key caught_panic
+            True -> Panic.throw (Non_Unique_Primary_Key_Recipe.Recipe source_table primary_key caught_panic)
             False -> Panic.throw caught_panic
     Panic.catch SQL_Error action handler
+
+## PRIVATE
+handle_upload_errors ~action =
+    Panic.catch Non_Unique_Primary_Key_Recipe action caught_panic->
+        recipe = caught_panic.payload
+        raise_duplicated_primary_key_error recipe.source_table recipe.primary_key recipe.original_panic
+
+## PRIVATE
+type Non_Unique_Primary_Key_Recipe
+    ## PRIVATE
+    Recipe source_table primary_key original_panic
 
 ## PRIVATE
    Creates a `Non_Unique_Primary_Key` error containing information about an
@@ -191,7 +218,7 @@ make_batched_insert_template connection table_name column_names =
 
 ## PRIVATE
 common_update_table source_table connection table_name update_action key_columns error_on_missing_columns =
-    Panic.recover SQL_Error <|
+    Panic.recover SQL_Error <| handle_upload_errors <|
         connection.jdbc_connection.run_within_transaction <|
             target_table = connection.query (SQL_Query.Table_Name table_name)
             # We catch the `Table_Not_Found` error and handle it specially, if the error was different, it will just get passed through further.
@@ -202,7 +229,7 @@ common_update_table source_table connection table_name update_action key_columns
                 Error.throw new_error
             if target_table.is_error then handle_error else
                 tmp_table_name = "temporary-source-table-"+random_uuid
-                tmp_table = upload_table source_table connection tmp_table_name key_columns temporary=True structure_only=False on_problems=Problem_Behavior.Report_Error
+                tmp_table = internal_upload_table source_table connection tmp_table_name key_columns temporary=True structure_only=False on_problems=Problem_Behavior.Report_Error
                 tmp_table.if_not_error <|
                     resulting_table = append_to_existing_table tmp_table target_table update_action key_columns error_on_missing_columns
                     connection.drop_table tmp_table.name

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload_Table.enso
@@ -156,7 +156,7 @@ make_batched_insert_template connection table_name column_names =
     template
 
 ## PRIVATE
-common_update_table source_table connection table_name update_action key_columns error_on_missing_columns on_problems =
+common_update_table source_table connection table_name update_action key_columns error_on_missing_columns =
     Panic.recover SQL_Error <|
         connection.jdbc_connection.run_within_transaction <|
             target_table = connection.query (SQL_Query.Table_Name table_name)
@@ -170,7 +170,7 @@ common_update_table source_table connection table_name update_action key_columns
                 tmp_table_name = "temporary-source-table-"+random_uuid
                 tmp_table = upload_table source_table connection tmp_table_name key_columns temporary=True structure_only=False on_problems=Problem_Behavior.Report_Error
                 tmp_table.if_not_error <|
-                    resulting_table = append_to_existing_table
+                    resulting_table = append_to_existing_table tmp_table target_table update_action key_columns error_on_missing_columns
                     connection.drop_table tmp_table.name
                     resulting_table
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Main.enso
@@ -9,7 +9,8 @@ import project.Connection.SQLite_Details.In_Memory
 import project.Connection.SQLite_Format.SQLite_Format
 import project.Connection.SSL_Mode.SSL_Mode
 import project.Data.SQL_Query.SQL_Query
-import project.Extensions.Upload_Table
+import project.Extensions.Upload_Database_Table
+import project.Extensions.Upload_In_Memory_Table
 
 from project.Connection.Postgres_Details.Postgres_Details import Postgres
 from project.Connection.SQLite_Details.SQLite_Details import SQLite
@@ -25,7 +26,8 @@ export project.Connection.SQLite_Details.In_Memory
 export project.Connection.SQLite_Format.SQLite_Format
 export project.Connection.SSL_Mode.SSL_Mode
 export project.Data.SQL_Query.SQL_Query
-export project.Extensions.Upload_Table
+export project.Extensions.Upload_Database_Table
+export project.Extensions.Upload_In_Memory_Table
 
 from project.Connection.Postgres_Details.Postgres_Details export Postgres
 from project.Connection.SQLite_Details.SQLite_Details export SQLite

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Type/Storage.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Type/Storage.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Errors.Common.Index_Out_Of_Bounds
+import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Errors.Illegal_State.Illegal_State
 
 import Standard.Table.Data.Type.Value_Type.Value_Type
@@ -50,6 +51,7 @@ closest_storage_type value_type = case value_type of
     Value_Type.Date_Time _ -> DateTimeType.INSTANCE
     Value_Type.Time -> TimeOfDayType.INSTANCE
     Value_Type.Mixed -> AnyObjectType.INSTANCE
+    _ -> Error.throw (Illegal_Argument.Error "Columns of type "+value_type.to_display_text+" are currently not supported in the in-memory backend.")
 
 ## PRIVATE
    Converts a value type to an in-memory storage type, possibly approximating it

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -174,7 +174,7 @@ type Table_Column_Helper
             _ -> [selectors]
         selected_columns = vector.map resolve_selector . flatten
         if reorder then selected_columns.distinct on=_.name else
-            map = Map.from_vector (selected_columns.map column-> [column.name, True]) allow_duplicates=True
+            map = Map.from_vector (selected_columns.map column-> [column.name, True]) error_on_duplicates=False
             self.internal_columns.filter column-> map.contains_key column.name
 
     ## PRIVATE

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
@@ -171,7 +171,7 @@ limit_data limit data = case limit of
         bounds = case data.fold_with_index (Extreme.Value first first first first) update_extreme of
             Extreme.Value min_x max_x min_y max_y ->  [min_x, max_x, min_y, max_y]
             _ -> []
-        extreme = Map.from_vector bounds allow_duplicates=True . values
+        extreme = Map.from_vector bounds error_on_duplicates=False . values
 
         if limit <= extreme.length then extreme.take (First limit) else
             extreme + data.take (Index_Sub_Range.Sample (limit - extreme.length))

--- a/test/Table_Tests/src/Common_Table_Operations/Conversion_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Conversion_Spec.enso
@@ -383,11 +383,11 @@ spec setup =
                 r1 = t.cast "X" Value_Type.Decimal
                 r1.should_fail_with Illegal_Argument
 
-                r2 = t.cast Value_Type.Binary
+                r2 = t.cast "X" Value_Type.Binary
                 r2.should_fail_with Illegal_Argument
 
                 # this is not supposed to be supported, but still needs a friendly message
-                r3 = t.cast (Value_Type.Unsupported_Data_Type "foobar" "foobar")
+                r3 = t.cast "X" (Value_Type.Unsupported_Data_Type "foobar" "foobar")
                 r3.should_fail_with Illegal_Argument
 
     Test.group prefix+"Simple variant of Table/Column.parse in all backends" <|

--- a/test/Table_Tests/src/Common_Table_Operations/Conversion_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Conversion_Spec.enso
@@ -128,6 +128,10 @@ spec setup =
             c3.value_type . should_equal (Value_Type.Integer Bits.Bits_32)
             c3.to_vector . should_equal [1, 2, 3]
 
+            c4 = c.cast Value_Type.Byte
+            c4.value_type . should_equal Value_Type.Byte
+            c4.to_vector . should_equal [1, 2, 3]
+
         Test.specify "should allow to cast a floating point column to integer" <|
             t = table_builder [["X", [1.0001, 2.25, 4.0]]]
             c = t.at "X" . cast Value_Type.Integer
@@ -370,6 +374,21 @@ spec setup =
                 c7.to_vector . should_equal ((nulls 6) + [Date_Time.new 2020, Date_Time.new 2023 12 15 19 25, Nothing] + (nulls 4))
                 w7 = Problems.expect_warning Conversion_Failure c7
                 w7.affected_rows_count . should_equal 6+3+1
+
+        if setup.is_database.not then
+            Test.specify "should fail if there is no conversion available for a given type" <|
+                t = table_builder [["X", [1, 2, 3]]]
+
+                # currently unsupported
+                r1 = t.cast "X" Value_Type.Decimal
+                r1.should_fail_with Illegal_Argument
+
+                r2 = t.cast Value_Type.Binary
+                r2.should_fail_with Illegal_Argument
+
+                # this is not supposed to be supported, but still needs a friendly message
+                r3 = t.cast (Value_Type.Unsupported_Data_Type "foobar" "foobar")
+                r3.should_fail_with Illegal_Argument
 
     Test.group prefix+"Simple variant of Table/Column.parse in all backends" <|
         Test.specify "should be able to parse simple integers" <|

--- a/test/Table_Tests/src/Database/Common_Spec.enso
+++ b/test/Table_Tests/src/Database/Common_Spec.enso
@@ -18,7 +18,7 @@ spec prefix connection =
     tables_to_clean = Vector.new_builder
     upload prefix data temporary=True =
         name = Name_Generator.random_name prefix
-        table = data.create_database_table connection name temporary=temporary primary_key=Nothing
+        table = data.select_into_database_table connection name temporary=temporary primary_key=Nothing
         tables_to_clean.append table.name
         table
 

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -57,7 +57,7 @@ postgres_specific_spec connection db_name setup =
         connection.execute_update 'CREATE VIEW "'+vinfo+'" AS SELECT "A" FROM "'+tinfo+'";'
 
         temporary_table = Name_Generator.random_name "TemporaryTable"
-        (Table.new [["X", [1, 2, 3]]]).create_database_table connection temporary_table temporary=True
+        (Table.new [["X", [1, 2, 3]]]).select_into_database_table connection temporary_table temporary=True
 
         Test.specify "should be able to list table types" <|
             table_types = connection.table_types
@@ -202,7 +202,7 @@ run_tests connection db_name =
         name = Name_Generator.random_name "table_"+ix.to_text
 
         in_mem_table = Table.new columns
-        in_mem_table.create_database_table connection name primary_key=Nothing temporary=True
+        in_mem_table.select_into_database_table connection name primary_key=Nothing temporary=True
     materialize = .read
 
     Common_Spec.spec prefix connection
@@ -210,9 +210,9 @@ run_tests connection db_name =
     common_selection = Common_Table_Operations.Main.Test_Selection.Config supports_case_sensitive_columns=True order_by_unicode_normalization_by_default=True take_drop=False allows_mixed_type_comparisons=False fixed_length_text_columns=True
     aggregate_selection = Common_Table_Operations.Aggregate_Spec.Test_Selection.Config first_last_row_order=False aggregation_problems=False
     agg_in_memory_table = (enso_project.data / "data.csv") . read
-    agg_table = agg_in_memory_table.create_database_table connection (Name_Generator.random_name "Agg1") primary_key=Nothing temporary=True
+    agg_table = agg_in_memory_table.select_into_database_table connection (Name_Generator.random_name "Agg1") primary_key=Nothing temporary=True
     tables.append agg_table.name
-    empty_agg_table = (agg_in_memory_table.take (First 0)).create_database_table connection (Name_Generator.random_name "Agg_Empty") primary_key=Nothing temporary=True
+    empty_agg_table = (agg_in_memory_table.take (First 0)).select_into_database_table connection (Name_Generator.random_name "Agg_Empty") primary_key=Nothing temporary=True
     tables.append empty_agg_table.name
 
     setup = Common_Table_Operations.Main.Test_Setup.Config prefix agg_table empty_agg_table table_builder materialize is_database=True test_selection=common_selection aggregate_test_selection=aggregate_selection

--- a/test/Table_Tests/src/Database/Redshift_Spec.enso
+++ b/test/Table_Tests/src/Database/Redshift_Spec.enso
@@ -45,7 +45,7 @@ run_tests connection =
         name = Name_Generator.random_name "table_"+ix.to_text
 
         in_mem_table = Table.new columns
-        in_mem_table.create_database_table connection name primary_key=Nothing temporary=True
+        in_mem_table.select_into_database_table connection name primary_key=Nothing temporary=True
     materialize = .read
 
     Common_Spec.spec prefix connection
@@ -54,9 +54,9 @@ run_tests connection =
     common_selection = Common_Table_Operations.Main.Test_Selection.Config supports_case_sensitive_columns=True order_by_unicode_normalization_by_default=True take_drop=False allows_mixed_type_comparisons=False
     aggregate_selection = Common_Table_Operations.Aggregate_Spec.Test_Selection.Config first_last_row_order=False aggregation_problems=False date_support=False
     agg_in_memory_table = (enso_project.data / "data.csv") . read
-    agg_table = agg_in_memory_table.create_database_table connection (Name_Generator.random_name "Agg1") primary_key=Nothing temporary=True
+    agg_table = agg_in_memory_table.select_into_database_table connection (Name_Generator.random_name "Agg1") primary_key=Nothing temporary=True
     tables.append agg_table.name
-    empty_agg_table = (agg_in_memory_table.take (First 0)).create_database_table connection (Name_Generator.random_name "Agg_Empty") primary_key=Nothing temporary=True
+    empty_agg_table = (agg_in_memory_table.take (First 0)).select_into_database_table connection (Name_Generator.random_name "Agg_Empty") primary_key=Nothing temporary=True
     tables.append empty_agg_table.name
 
     setup = Common_Table_Operations.Main.Test_Setup.Config prefix agg_table empty_agg_table table_builder materialize is_database=True test_selection=common_selection aggregate_test_selection=aggregate_selection

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -42,7 +42,7 @@ sqlite_specific_spec prefix connection =
         connection.execute_update 'CREATE VIEW "'+vinfo+'" AS SELECT "A" FROM "'+tinfo+'";'
 
         temporary_table = Name_Generator.random_name "TemporaryTable"
-        (Table.new [["X", [1, 2, 3]]]).create_database_table connection temporary_table temporary=True
+        (Table.new [["X", [1, 2, 3]]]).select_into_database_table connection temporary_table temporary=True
 
         Test.specify "should be able to list table types" <|
             table_types = connection.table_types
@@ -126,7 +126,7 @@ sqlite_spec connection prefix =
         name = Name_Generator.random_name "table_"+ix.to_text
 
         in_mem_table = Table.new columns
-        in_mem_table.create_database_table connection name primary_key=Nothing
+        in_mem_table.select_into_database_table connection name primary_key=Nothing
     materialize = .read
 
     Common_Spec.spec prefix connection
@@ -144,8 +144,8 @@ sqlite_spec connection prefix =
          the missing statistics.
     aggregate_selection = Common_Table_Operations.Aggregate_Spec.Test_Selection.Config advanced_stats=False text_shortest_longest=False first_last=False first_last_row_order=False multi_distinct=False aggregation_problems=False nan=False date_support=False
     agg_in_memory_table = (enso_project.data / "data.csv") . read
-    agg_table = agg_in_memory_table.create_database_table connection (Name_Generator.random_name "Agg1") primary_key=Nothing temporary=True
-    empty_agg_table = (agg_in_memory_table.take (First 0)).create_database_table connection (Name_Generator.random_name "Agg_Empty") primary_key=Nothing temporary=True
+    agg_table = agg_in_memory_table.select_into_database_table connection (Name_Generator.random_name "Agg1") primary_key=Nothing temporary=True
+    empty_agg_table = (agg_in_memory_table.take (First 0)).select_into_database_table connection (Name_Generator.random_name "Agg_Empty") primary_key=Nothing temporary=True
 
     setup = Common_Table_Operations.Main.Test_Setup.Config prefix agg_table empty_agg_table table_builder materialize is_database=True test_selection=common_selection aggregate_test_selection=aggregate_selection
     Common_Table_Operations.Main.spec setup
@@ -211,7 +211,7 @@ spec =
         Test.specify 'should not duplicate warnings' <|
             c = Database.connect (SQLite In_Memory)
             t0 = Table.new [["X", ["a", "bc", "def"]]]
-            t1 = t0.create_database_table c "Tabela"
+            t1 = t0.select_into_database_table c "Tabela"
             t2 = t1.cast "X" (Value_Type.Char size=1)
             Warning.get_all t2 . length . should_equal 1
 

--- a/test/Table_Tests/src/Database/Types/SQLite_Type_Mapping_Spec.enso
+++ b/test/Table_Tests/src/Database/Types/SQLite_Type_Mapping_Spec.enso
@@ -5,7 +5,8 @@ from Standard.Table import Aggregate_Column, Value_Type, Table
 from Standard.Table.Errors import Invalid_Value_Type, Inexact_Type_Coercion
 
 import Standard.Database.Data.Dialect
-import Standard.Database.Extensions.Upload_Table
+import Standard.Database.Extensions.Upload_Database_Table
+import Standard.Database.Extensions.Upload_In_Memory_Table
 import Standard.Database.Internal.SQLite.SQLite_Type_Mapping
 from Standard.Database import Database, SQLite, In_Memory, SQL_Query
 from Standard.Database.Errors import Unsupported_Database_Operation

--- a/test/Table_Tests/src/Database/Types/SQLite_Type_Mapping_Spec.enso
+++ b/test/Table_Tests/src/Database/Types/SQLite_Type_Mapping_Spec.enso
@@ -103,7 +103,7 @@ spec =
 
         Test.specify "does not support creating tables with date/time values" <|
             t = Table.new [["a", [Date.now]], ["b", [Time_Of_Day.now]], ["c", [Date_Time.now]]]
-            r1 = t.create_database_table connection temporary=True
+            r1 = t.select_into_database_table connection temporary=True
             r1.should_fail_with Unsupported_Database_Operation
 
         Test.specify "should be able to infer types for all supported operations" <|

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -7,7 +7,7 @@ from Standard.Table.Errors import Missing_Input_Columns
 from Standard.Database import all
 from Standard.Database.Errors import all
 from Standard.Database.Internal.Result_Set import result_set_to_table
-from Standard.Database.Extensions.Upload_Table import get_primary_key
+from Standard.Database.Extensions.Upload_Default_Helpers import get_primary_key
 
 from Standard.Test import Test, Test_Suite, Problems
 import Standard.Test.Extensions

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -236,6 +236,18 @@ spec make_new_connection prefix persistent_connector=True =
             r4.should_fail_with Non_Unique_Primary_Key
             r4.catch . clashing_primary_key . should_equal [1, 'a']
 
+        Test.specify "should fail if the target table already exists" <|
+            name = Name_Generator.random_name "table-already-exists"
+            db_table = connection.create_table name [["X", Value_Type.Integer]] temporary=True
+            t = Table.new ["Y", ['a', 'b']]
+            r1 = t.select_into_database_table connection name temporary=True
+            r1.should_fail_with Table_Already_Exists
+            r2 = t.select_into_database_table connection name temporary=False
+            r2.should_fail_with Table_Already_Exists
+
+            db_table.column_names . should_equal ["X"]
+            db_table.at "X" . to_vector . should_equal []
+
     Test.group prefix+"Persisting a Database Table (query)" <|
         Test.specify "should be able to create a persistent copy of a DB table" <|
             t = Table.new [["X", [1, 2, 3]], ["Y", ['a', 'b', 'c']], ["Z", [1.0, 2.0, 3.0]]]
@@ -342,7 +354,20 @@ spec make_new_connection prefix persistent_connector=True =
             r1.should_fail_with Unsupported_Database_Operation
             r1.catch.message . should_contain "same connection"
 
-    test_table_append table_builder =
+        Test.specify "should fail if the target table already exists" <|
+            name = Name_Generator.random_name "table-already-exists"
+            db_table = connection.create_table name [["X", Value_Type.Integer]] temporary=True
+            t = Table.new ["Y", ['a', 'b']]
+            db_table_2 = t.select_into_database_table connection temporary=True
+            r1 = db_table_2.select_into_database_table connection name temporary=True
+            r1.should_fail_with Table_Already_Exists
+            r2 = db_table_2.select_into_database_table connection name temporary=False
+            r2.should_fail_with Table_Already_Exists
+
+            db_table.column_names . should_equal ["X"]
+            db_table.at "X" . to_vector . should_equal []
+
+    test_table_append source_table_builder target_table_builder =
         Test.specify "should be able to append new rows to a table" <|
             Nothing
 
@@ -394,11 +419,11 @@ spec make_new_connection prefix persistent_connector=True =
         Test.specify "should fail if some of key_columns do not exist in either table" <|
             Nothing
 
-        Test.specify "by default, should fail if the target table does not exist" <|
-            Nothing
-
-        Test.specify "should allow to create the target table if it does not exist, but make it temporary and attach a warning" <|
-            Nothing
+        Test.specify "should fail if the target table does not exist" <|
+            t = source_table_builder ["X", [1, 2, 3], "Y", ['a', 'b', 'c']]
+            nonexistent_name = Name_Generator.random_name "nonexistent-table"
+            r1 = t.update_database_table connection nonexistent_name
+            r1.should_fail_with Table_Not_Found
 
         Test.specify "should report a meaningful error when the primary key could not be determined" <|
             # TODO temporary (only SQLite?)
@@ -411,16 +436,14 @@ spec make_new_connection prefix persistent_connector=True =
             # TODO how do we define compatibility? I assume we allow type widening, but not narrowing
             Nothing
 
+    table_builder name_prefix args =
+        in_memory_table = Table.new args
+        in_memory_table.select_into_database_table connection (Name_Generator.random_name name_prefix) temporary=True
+    Test.group "Appending an in-memory table to a Database table" pending="TODO" <|
+        test_table_append Table.new (table_builder "target-table")
 
-    Test.group "Appending an in-memory table to a Database table" <|
-        table_builder = Table.new
-        test_table_append table_builder
-
-    Test.group "Appending a Database table to a Database table" <|
-        table_builder args =
-            in_memory_table = Table.new args
-            in_memory_table.select_into_database_table connection (Name_Generator.random_name "source-table") temporary=True
-        test_table_append table_builder
+    Test.group "Appending a Database table to a Database table" pending="TODO" <|
+        test_table_append (table_builder "source-table") (table_builder "target-table")
 
 
 ## PRIVATE

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -217,11 +217,6 @@ spec make_new_connection prefix persistent_connector=True =
             r1 = in_memory_table.select_into_database_table connection (Name_Generator.random_name "primary-key-4") primary_key=["X", "nonexistent"]
             r1.should_fail_with Missing_Input_Columns
 
-            db_table_2 = in_memory_table.select_into_database_table connection (Name_Generator.random_name "primary-key-5") primary_key=["X", "X"]
-            Panic.with_finalizer (connection.drop_table db_table_2.name) <|
-                # The primary key may be: [X] or [X, X].
-                get_primary_key connection db_table_2.name . should_contain_the_same_elements_as ["X"]
-
         Test.specify "should fail if the primary key is not unique" <|
             t1 = Table.new [["X", [1, 2, 1]], ["Y", ['b', 'b', 'a']]]
             r1 = t1.select_into_database_table connection (Name_Generator.random_name "primary-key-6") temporary=True primary_key=["X"]

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -68,13 +68,13 @@ spec make_new_connection prefix persistent_connector=True =
 
         Test.specify "should fail if the table already exists" <|
             name = Name_Generator.random_name "table-already-exists 1"
-            r0 = connection.create_table name structure=[["X", Value_Type.Integer], ["Y", Value_Type.Char]] temporary=True
+            connection.create_table name structure=[["X", Value_Type.Integer], ["Y", Value_Type.Char]] temporary=True
             r1 = connection.create_table name structure=[["X", Value_Type.Integer], ["Y", Value_Type.Char]] temporary=True
             r1.should_fail_with Table_Already_Exists
 
         Test.specify "should not fail if the table exists, if `allow_existing=True`, even if the structure does not match" <|
             name = Name_Generator.random_name "table-already-exists 2"
-            r0 = connection.create_table name structure=[["X", Value_Type.Integer], ["Y", Value_Type.Char]] temporary=True
+            connection.create_table name structure=[["X", Value_Type.Integer], ["Y", Value_Type.Char]] temporary=True
             r1 = connection.create_table name structure=[["Z", Value_Type.Float]] temporary=True allow_existing=True
             r1.column_names . should_equal ["X", "Y"]
 
@@ -103,7 +103,7 @@ spec make_new_connection prefix persistent_connector=True =
             Test.specify "should drop the temporary table after the connection is closed" <|
                 name = Name_Generator.random_name "temporary_table 2"
                 tmp_connection = make_new_connection Nothing
-                db_table = tmp_connection.create_table name [["X", Value_Type.Integer]] temporary=True
+                tmp_connection.create_table name [["X", Value_Type.Integer]] temporary=True
                 tmp_connection.query (SQL_Query.Table_Name name) . column_names . should_equal ["X"]
                 tmp_connection.close
                 connection.query (SQL_Query.Table_Name name) . should_fail_with Table_Not_Found
@@ -111,7 +111,7 @@ spec make_new_connection prefix persistent_connector=True =
             Test.specify "should preserve the regular table after the connection is closed" <|
                 name = Name_Generator.random_name "persistent_table 2"
                 tmp_connection = make_new_connection Nothing
-                db_table = tmp_connection.create_table name [["X", Value_Type.Integer]] temporary=False
+                tmp_connection.create_table name [["X", Value_Type.Integer]] temporary=False
                 Panic.with_finalizer (connection.drop_table name) <|
                     t1 = tmp_connection.query (SQL_Query.Table_Name name)
                     t1.column_names . should_equal ["X"]
@@ -122,7 +122,8 @@ spec make_new_connection prefix persistent_connector=True =
                     t2.at "X" . value_type . is_integer . should_be_true
 
         Test.specify "should be able to specify a primary key" <|
-            db_table = connection.create_table structure=[["X", Value_Type.Integer], ["Y", Value_Type.Char], ["Z", Value_Type.Integer], ["W", Value_Type.Float]] primary_key=["Y", "Z"] temporary=True
+            name = Name_Generator.random_name "primary_key 1"
+            db_table = connection.create_table table_name=name structure=[["X", Value_Type.Integer], ["Y", Value_Type.Char], ["Z", Value_Type.Integer], ["W", Value_Type.Float]] primary_key=["Y", "Z"] temporary=False
             Panic.with_finalizer (connection.drop_table db_table.name) <|
                 get_primary_key connection db_table.name . should_equal ["Y", "Z"]
 
@@ -218,7 +219,8 @@ spec make_new_connection prefix persistent_connector=True =
 
             db_table_2 = in_memory_table.select_into_database_table connection (Name_Generator.random_name "primary-key-5") primary_key=["X", "X"]
             Panic.with_finalizer (connection.drop_table db_table_2.name) <|
-                get_primary_key connection db_table_2.name . should_equal ["X"]
+                # The primary key may be: [X] or [X, X].
+                get_primary_key connection db_table_2.name . should_contain_the_same_elements_as ["X"]
 
         Test.specify "should fail if the primary key is not unique" <|
             t1 = Table.new [["X", [1, 2, 1]], ["Y", ['b', 'b', 'a']]]
@@ -244,7 +246,7 @@ spec make_new_connection prefix persistent_connector=True =
         Test.specify "should fail if the target table already exists" <|
             name = Name_Generator.random_name "table-already-exists"
             db_table = connection.create_table name [["X", Value_Type.Integer]] temporary=True
-            t = Table.new ["Y", ['a', 'b']]
+            t = Table.new [["Y", ['a', 'b']]]
             r1 = t.select_into_database_table connection name temporary=True
             r1.should_fail_with Table_Already_Exists
             r2 = t.select_into_database_table connection name temporary=False
@@ -362,7 +364,7 @@ spec make_new_connection prefix persistent_connector=True =
         Test.specify "should fail if the target table already exists" <|
             name = Name_Generator.random_name "table-already-exists"
             db_table = connection.create_table name [["X", Value_Type.Integer]] temporary=True
-            t = Table.new ["Y", ['a', 'b']]
+            t = Table.new [["Y", ['a', 'b']]]
             db_table_2 = t.select_into_database_table connection temporary=True
             r1 = db_table_2.select_into_database_table connection name temporary=True
             r1.should_fail_with Table_Already_Exists
@@ -374,7 +376,12 @@ spec make_new_connection prefix persistent_connector=True =
 
     test_table_append source_table_builder target_table_builder =
         Test.specify "should be able to append new rows to a table" <|
-            Nothing
+            dest = target_table_builder [["X", [1, 2, 3]], ["Y", ['a', 'b', 'c']]] primary_key=["X"]
+            src = source_table_builder [["X", [4, 5, 6]], ["Y", ['d', 'e', 'f']]]
+            result = src.update_database_table connection dest.name
+            result.column_names . should_equal ["X", "Y"]
+            result.at "X" . to_vector . should_equal [1, 2, 3, 4, 5, 6]
+            result.at "Y" . to_vector . should_equal ['a', 'b', 'c', 'd', 'e', 'f']
 
         Test.specify "should error if new rows clash with existing ones and mode is Insert, target table should remain unchanged" <|
             Nothing
@@ -441,15 +448,14 @@ spec make_new_connection prefix persistent_connector=True =
             # TODO how do we define compatibility? I assume we allow type widening, but not narrowing
             Nothing
 
-    table_builder name_prefix args =
+    table_builder name_prefix args primary_key=[] =
         in_memory_table = Table.new args
-        in_memory_table.select_into_database_table connection (Name_Generator.random_name name_prefix) temporary=True
+        in_memory_table.select_into_database_table connection (Name_Generator.random_name name_prefix) temporary=True primary_key=primary_key
     Test.group "Appending an in-memory table to a Database table" pending="TODO" <|
         test_table_append Table.new (table_builder "target-table")
 
     Test.group "Appending a Database table to a Database table" pending="TODO" <|
         test_table_append (table_builder "source-table") (table_builder "target-table")
-
 
 ## PRIVATE
    Creates a mock column containing `values`.

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 from Standard.Table import all
 from Standard.Table.Errors import Missing_Input_Columns
@@ -66,12 +67,13 @@ spec make_new_connection prefix persistent_connector=True =
             db_table.row_count . should_equal 0
 
         Test.specify "should fail if the table already exists" <|
-            name = Name_Generator.random_name "table"
+            name = Name_Generator.random_name "table-already-exists 1"
             r0 = connection.create_table name structure=[["X", Value_Type.Integer], ["Y", Value_Type.Char]] temporary=True
             r1 = connection.create_table name structure=[["X", Value_Type.Integer], ["Y", Value_Type.Char]] temporary=True
             r1.should_fail_with Table_Already_Exists
 
         Test.specify "should not fail if the table exists, if `allow_existing=True`, even if the structure does not match" <|
+            name = Name_Generator.random_name "table-already-exists 2"
             r0 = connection.create_table name structure=[["X", Value_Type.Integer], ["Y", Value_Type.Char]] temporary=True
             r1 = connection.create_table name structure=[["Z", Value_Type.Float]] temporary=True allow_existing=True
             r1.column_names . should_equal ["X", "Y"]
@@ -110,7 +112,6 @@ spec make_new_connection prefix persistent_connector=True =
                 name = Name_Generator.random_name "persistent_table 2"
                 tmp_connection = make_new_connection Nothing
                 db_table = tmp_connection.create_table name [["X", Value_Type.Integer]] temporary=False
-                name = db_table.name
                 Panic.with_finalizer (connection.drop_table name) <|
                     t1 = tmp_connection.query (SQL_Query.Table_Name name)
                     t1.column_names . should_equal ["X"]
@@ -135,6 +136,10 @@ spec make_new_connection prefix persistent_connector=True =
 
         Test.specify "should not allow creating a table without columns" <|
             r1 = connection.create_table structure=[] temporary=True
+            r1.should_fail_with Illegal_Argument
+
+        Test.specify "should check types of primary key" <|
+            r1 = connection.create_table structure=[["X", Value_Type.Integer]] primary_key=[0] temporary=True
             r1.should_fail_with Illegal_Argument
 
     Test.group prefix+"Uploading an in-memory Table" <|
@@ -211,7 +216,7 @@ spec make_new_connection prefix persistent_connector=True =
             r1 = in_memory_table.select_into_database_table connection (Name_Generator.random_name "primary-key-4") primary_key=["X", "nonexistent"]
             r1.should_fail_with Missing_Input_Columns
 
-            db_table_2 = in_memory_table.select_into_database_table connection (Name_Generator.random_name "primary-key-5") primary_key=["X", 0]
+            db_table_2 = in_memory_table.select_into_database_table connection (Name_Generator.random_name "primary-key-5") primary_key=["X", "X"]
             Panic.with_finalizer (connection.drop_table db_table_2.name) <|
                 get_primary_key connection db_table_2.name . should_equal ["X"]
 

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -34,28 +34,120 @@ spec make_new_connection prefix persistent_connector=True =
     connection = make_new_connection Nothing
     Test.group prefix+"Creating an empty table" <|
         Test.specify "should allow to specify the column names and types" <|
-            Nothing
+            t = connection.create_table structure=[["X", Value_Type.Integer], ["Y", Value_Type.Char]] temporary=True
+            t.column_names . should_equal ["X", "Y"]
+            t.at "X" . to_vector . should_equal []
+            t.at "X" . value_type . is_integer . should_be_true
+            t.at "Y" . to_vector . should_equal []
+            t.at "Y" . value_type . is_text . should_be_true
+            t.row_count . should_equal 0
 
         Test.specify "should allow to inherit the structure of an existing in-memory table" <|
-            Nothing
+            t = Table.new [["X", [1, 2]], ["Y", ['a', 'b']]]
+            db_table = connection.create_table structure=t temporary=True
+            db_table.column_names . should_equal ["X", "Y"]
+            db_table.at "X" . to_vector . should_equal []
+            db_table.at "X" . value_type . is_integer . should_be_true
+            db_table.at "Y" . to_vector . should_equal []
+            db_table.at "Y" . value_type . is_text . should_be_true
+            db_table.row_count . should_equal 0
 
         Test.specify "should allow to inherit the structure of an existing Database table" <|
-            Nothing
+            t = Table.new [["X", [1, 2]], ["Y", ['a', 'b']]]
+            input_db_table = t.select_into_database_table connection (Name_Generator.random_name "input_table") temporary=True
+            input_db_table.at "X" . to_vector . should_equal [1, 2]
+
+            db_table = connection.create_table structure=input_db_table temporary=True
+            db_table.column_names . should_equal ["X", "Y"]
+            db_table.at "X" . to_vector . should_equal []
+            db_table.at "X" . value_type . is_integer . should_be_true
+            db_table.at "Y" . to_vector . should_equal []
+            db_table.at "Y" . value_type . is_text . should_be_true
+            db_table.row_count . should_equal 0
 
         Test.specify "should fail if the table already exists" <|
-            Nothing
+            name = Name_Generator.random_name "table"
+            r0 = connection.create_table name structure=[["X", Value_Type.Integer], ["Y", Value_Type.Char]] temporary=True
+            r1 = connection.create_table name structure=[["X", Value_Type.Integer], ["Y", Value_Type.Char]] temporary=True
+            r1.should_fail_with Table_Already_Exists
 
-        Test.specify "should not fail if the table exists, if `if_not_exists=True`, even if the structure does not match" <|
-            Nothing
+        Test.specify "should not fail if the table exists, if `allow_existing=True`, even if the structure does not match" <|
+            r0 = connection.create_table name structure=[["X", Value_Type.Integer], ["Y", Value_Type.Char]] temporary=True
+            r1 = connection.create_table name structure=[["Z", Value_Type.Float]] temporary=True allow_existing=True
+            r1.column_names . should_equal ["X", "Y"]
 
-        Test.specify "should drop the temporary table after the connection is closed" <|
-            Nothing
+        Test.specify "should include the created table in the tables directory" <|
+            name = Name_Generator.random_name "persistent_table 1"
+            db_table = connection.create_table name structure=[["X", Value_Type.Integer], ["Y", Value_Type.Char]] temporary=False
+            Panic.with_finalizer (connection.drop_table db_table.name) <|
+                db_table.column_names . should_equal ["X", "Y"]
+                db_table.at "X" . to_vector . should_equal []
 
-        Test.specify "should preserve the regular table after the connection is closed" <|
-            Nothing
+                connection.tables.at "Name" . to_vector . should_contain name
+                connection.query name . column_names . should_equal ["X", "Y"]
+                connection.query name . at "X" . to_vector . should_equal []
+
+        Test.specify "should include the temporary table in the tables directory" <|
+            name = Name_Generator.random_name "temporary_table 1"
+            db_table = connection.create_table name structure=[["X", Value_Type.Integer], ["Y", Value_Type.Char]] temporary=True
+            db_table.column_names . should_equal ["X", "Y"]
+            db_table.at "X" . to_vector . should_equal []
+
+            connection.tables.at "Name" . to_vector . should_contain name
+            connection.query name . column_names . should_equal ["X", "Y"]
+            connection.query name . at "X" . to_vector . should_equal []
+
+        if persistent_connector then
+            Test.specify "should drop the temporary table after the connection is closed" <|
+                name = Name_Generator.random_name "temporary_table 2"
+                tmp_connection = make_new_connection Nothing
+                db_table = tmp_connection.create_table name [["X", Value_Type.Integer]] temporary=True
+                tmp_connection.query (SQL_Query.Table_Name name) . column_names . should_equal ["X"]
+                tmp_connection.close
+                connection.query (SQL_Query.Table_Name name) . should_fail_with Table_Not_Found
+
+            Test.specify "should preserve the regular table after the connection is closed" <|
+                name = Name_Generator.random_name "persistent_table 2"
+                tmp_connection = make_new_connection Nothing
+                db_table = tmp_connection.create_table name [["X", Value_Type.Integer]] temporary=False
+                name = db_table.name
+                Panic.with_finalizer (connection.drop_table name) <|
+                    t1 = tmp_connection.query (SQL_Query.Table_Name name)
+                    t1.column_names . should_equal ["X"]
+                    t1.at "X" . value_type . is_integer . should_be_true
+                    tmp_connection.close
+                    t2 = connection.query (SQL_Query.Table_Name name)
+                    t2.column_names . should_equal ["X"]
+                    t2.at "X" . value_type . is_integer . should_be_true
+
+        Test.specify "should be able to specify a primary key" <|
+            db_table = connection.create_table structure=[["X", Value_Type.Integer], ["Y", Value_Type.Char], ["Z", Value_Type.Integer], ["W", Value_Type.Float]] primary_key=["Y", "Z"] temporary=True
+            Panic.with_finalizer (connection.drop_table db_table.name) <|
+                get_primary_key connection db_table.name . should_equal ["Y", "Z"]
+
+        Test.specify "should ensure that primary key columns specified are valid" <|
+            r1 = connection.create_table structure=[["X", Value_Type.Integer]] primary_key=["Y"] temporary=True
+            r1.should_fail_with Missing_Input_Columns
+
+            t = Table.new [["X", [1, 2, 3]]]
+            r2 = connection.create_table structure=t primary_key=["Y"] temporary=True
+            r2.should_fail_with Missing_Input_Columns
+
+        Test.specify "should not allow creating a table without columns" <|
+            r1 = connection.create_table structure=[] temporary=True
+            r1.should_fail_with Illegal_Argument
 
     Test.group prefix+"Uploading an in-memory Table" <|
         in_memory_table = Table.new [["X", [1, 2, 3]], ["Y", ['a', 'b', 'c']]]
+        Test.specify "should create a database table with the same contents as the source" <|
+            db_table = in_memory_table.select_into_database_table connection temporary=True
+            db_table.column_names . should_equal ["X", "Y"]
+            db_table.at "X" . to_vector . should_equal [1, 2, 3]
+            db_table.at "Y" . to_vector . should_equal ['a', 'b', 'c']
+            db_table.at "X" . value_type . is_integer . should_be_true
+            db_table.at "Y" . value_type . is_text . should_be_true
+            db_table.row_count . should_equal 3
+
         Test.specify "should include the created table in the tables directory" <|
             db_table = in_memory_table.select_into_database_table connection (Name_Generator.random_name "permanent_table 1") temporary=False
             Panic.with_finalizer (connection.drop_table db_table.name) <|
@@ -88,7 +180,7 @@ spec make_new_connection prefix persistent_connector=True =
                     tmp_connection.close
                     connection.query (SQL_Query.Table_Name name) . at "X" . to_vector . should_equal [1, 2, 3]
 
-        Test.specify "should rollback the table creation if select_into_database_table fails" <|
+        Test.specify "should not create any table if upload fails" <|
             normal_column = Column.from_vector "Y" ((100+0).up_to (100+1000)).to_vector
             exploding_column = make_mock_column "X" (0.up_to 1000).to_vector 512
             exploding_table = Table.new [normal_column, exploding_column]

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -227,6 +227,58 @@ spec make_new_connection prefix persistent_connector=True =
             r1.should_fail_with Unsupported_Database_Operation
             r1.catch.message . should_contain "same connection"
 
+    test_table_append table_builder =
+        Test.specify "should be able to append new rows to a table" <|
+            Nothing
+
+        Test.specify "should be able to update existing rows in a table" <|
+            Nothing
+
+        Test.specify "should upsert by default (update existing rows, insert new rows)" <|
+            Nothing
+
+        Test.specify "should allow to align an existing table with a source (upsert + delete rows missing from source)" <|
+            Nothing
+
+        Test.specify "should be able to detect the primary key of a table for row correlation" <|
+            Nothing
+
+        Test.specify "should fail if the key is not unique in the unique table" <|
+            Nothing
+
+        Test.specify "should fail if the key causes update of multiple values (it's not unique in the target table)" <|
+            Nothing
+
+        Test.specify "should fail if the source table contains columns not present in the target (data loss)" <|
+            Nothing
+
+        Test.specify "by default should keep columns missing from source as-is and use defaults when inserting" <|
+            Nothing
+
+        Test.specify "should fail if the source table is missing some columns and the column in the target has no default value" <|
+            Nothing
+
+        Test.specify "should fail if the source table is missing some columns, if asked to" <|
+            Nothing
+
+        Test.specify "TODO mapping of primary key columns - wrong name TODO" <|
+            Nothing
+
+        Test.specify "should fail if types of columns are not compatible" <|
+            # TODO how do we define compatibility? I assume we allow type widening, but not narrowing
+            Nothing
+
+
+    Test.group "Appending an in-memory table to a Database table" <|
+        table_builder = Table.new
+        test_table_append table_builder
+
+    Test.group "Appending a Database table to a Database table" <|
+        table_builder args =
+            in_memory_table = Table.new args
+            in_memory_table.create_database_table connection (Name_Generator.random_name "source-table") temporary=True
+        test_table_append table_builder
+
 
 ## PRIVATE
    Creates a mock column containing `values`.

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -32,10 +32,32 @@ main = Test_Suite.run_main <|
      database, so features relying on persistence cannot really be tested.
 spec make_new_connection prefix persistent_connector=True =
     connection = make_new_connection Nothing
+    Test.group prefix+"Creating an empty table" <|
+        Test.specify "should allow to specify the column names and types" <|
+            Nothing
+
+        Test.specify "should allow to inherit the structure of an existing in-memory table" <|
+            Nothing
+
+        Test.specify "should allow to inherit the structure of an existing Database table" <|
+            Nothing
+
+        Test.specify "should fail if the table already exists" <|
+            Nothing
+
+        Test.specify "should not fail if the table exists, if `if_not_exists=True`, even if the structure does not match" <|
+            Nothing
+
+        Test.specify "should drop the temporary table after the connection is closed" <|
+            Nothing
+
+        Test.specify "should preserve the regular table after the connection is closed" <|
+            Nothing
+
     Test.group prefix+"Uploading an in-memory Table" <|
         in_memory_table = Table.new [["X", [1, 2, 3]], ["Y", ['a', 'b', 'c']]]
         Test.specify "should include the created table in the tables directory" <|
-            db_table = in_memory_table.create_database_table connection (Name_Generator.random_name "permanent_table 1") temporary=False
+            db_table = in_memory_table.select_into_database_table connection (Name_Generator.random_name "permanent_table 1") temporary=False
             Panic.with_finalizer (connection.drop_table db_table.name) <|
                 db_table.at "X" . to_vector . should_equal [1, 2, 3]
 
@@ -43,7 +65,7 @@ spec make_new_connection prefix persistent_connector=True =
                 connection.query db_table.name . at "X" . to_vector . should_equal [1, 2, 3]
 
         Test.specify "should include the temporary table in the tables directory" <|
-            db_table = in_memory_table.create_database_table connection (Name_Generator.random_name "temporary_table 1") temporary=True
+            db_table = in_memory_table.select_into_database_table connection (Name_Generator.random_name "temporary_table 1") temporary=True
             db_table.at "X" . to_vector . should_equal [1, 2, 3]
             connection.tables.at "Name" . to_vector . should_contain db_table.name
             connection.query db_table.name . at "X" . to_vector . should_equal [1, 2, 3]
@@ -51,7 +73,7 @@ spec make_new_connection prefix persistent_connector=True =
         if persistent_connector then
             Test.specify "should drop the temporary table after the connection is closed" <|
                 tmp_connection = make_new_connection Nothing
-                db_table = in_memory_table.create_database_table tmp_connection (Name_Generator.random_name "temporary_table 2") temporary=True
+                db_table = in_memory_table.select_into_database_table tmp_connection (Name_Generator.random_name "temporary_table 2") temporary=True
                 name = db_table.name
                 tmp_connection.query (SQL_Query.Table_Name name) . at "X" . to_vector . should_equal [1, 2, 3]
                 tmp_connection.close
@@ -59,66 +81,66 @@ spec make_new_connection prefix persistent_connector=True =
 
             Test.specify "should preserve the regular table after the connection is closed" <|
                 tmp_connection = make_new_connection Nothing
-                db_table = in_memory_table.create_database_table tmp_connection (Name_Generator.random_name "permanent_table 1") temporary=False
+                db_table = in_memory_table.select_into_database_table tmp_connection (Name_Generator.random_name "permanent_table 1") temporary=False
                 name = db_table.name
                 Panic.with_finalizer (connection.drop_table name) <|
                     tmp_connection.query (SQL_Query.Table_Name name) . at "X" . to_vector . should_equal [1, 2, 3]
                     tmp_connection.close
                     connection.query (SQL_Query.Table_Name name) . at "X" . to_vector . should_equal [1, 2, 3]
 
-        Test.specify "should rollback the table creation if create_database_table fails" <|
+        Test.specify "should rollback the table creation if select_into_database_table fails" <|
             normal_column = Column.from_vector "Y" ((100+0).up_to (100+1000)).to_vector
             exploding_column = make_mock_column "X" (0.up_to 1000).to_vector 512
             exploding_table = Table.new [normal_column, exploding_column]
             name = Name_Generator.random_name "rolling-back-table"
             connection.query (SQL_Query.Table_Name name) . should_fail_with Table_Not_Found
             Test.expect_panic_with matcher=ExplodingStoragePayload <|
-                exploding_table.create_database_table connection name temporary=False primary_key=Nothing
+                exploding_table.select_into_database_table connection name temporary=False primary_key=Nothing
             connection.query (SQL_Query.Table_Name name) . should_fail_with Table_Not_Found
 
         Test.specify "should set a primary key for the table" <|
             t1 = Table.new [["X", [1, 2, 3]], ["Y", ['a', 'b', 'c']], ["Z", [1.0, 2.0, 3.0]]]
-            db_table_1 = t1.create_database_table connection (Name_Generator.random_name "primary-key-1") primary_key=["Y", "X"]
+            db_table_1 = t1.select_into_database_table connection (Name_Generator.random_name "primary-key-1") primary_key=["Y", "X"]
             Panic.with_finalizer (connection.drop_table db_table_1.name) <|
                 db_table_1.at "X" . to_vector . should_equal [1, 2, 3]
                 get_primary_key connection db_table_1.name . should_equal ["Y", "X"]
 
-            db_table_2 = t1.create_database_table connection (Name_Generator.random_name "primary-key-2")
+            db_table_2 = t1.select_into_database_table connection (Name_Generator.random_name "primary-key-2")
             Panic.with_finalizer (connection.drop_table db_table_2.name) <|
                 db_table_2.at "X" . to_vector . should_equal [1, 2, 3]
                 get_primary_key connection db_table_2.name . should_equal ["X"]
 
-            db_table_3 = t1.create_database_table connection (Name_Generator.random_name "primary-key-3") primary_key=Nothing
+            db_table_3 = t1.select_into_database_table connection (Name_Generator.random_name "primary-key-3") primary_key=Nothing
             Panic.with_finalizer (connection.drop_table db_table_3.name) <|
                 db_table_3.at "X" . to_vector . should_equal [1, 2, 3]
                 get_primary_key connection db_table_3.name . should_equal Nothing
 
         Test.specify "should ensure that primary key columns are valid" <|
-            r1 = in_memory_table.create_database_table connection (Name_Generator.random_name "primary-key-4") primary_key=["X", "nonexistent"]
+            r1 = in_memory_table.select_into_database_table connection (Name_Generator.random_name "primary-key-4") primary_key=["X", "nonexistent"]
             r1.should_fail_with Missing_Input_Columns
 
-            db_table_2 = in_memory_table.create_database_table connection (Name_Generator.random_name "primary-key-5") primary_key=["X", 0]
+            db_table_2 = in_memory_table.select_into_database_table connection (Name_Generator.random_name "primary-key-5") primary_key=["X", 0]
             Panic.with_finalizer (connection.drop_table db_table_2.name) <|
                 get_primary_key connection db_table_2.name . should_equal ["X"]
 
         Test.specify "should fail if the primary key is not unique" <|
             t1 = Table.new [["X", [1, 2, 1]], ["Y", ['b', 'b', 'a']]]
-            r1 = t1.create_database_table connection (Name_Generator.random_name "primary-key-6") temporary=True primary_key=["X"]
+            r1 = t1.select_into_database_table connection (Name_Generator.random_name "primary-key-6") temporary=True primary_key=["X"]
             r1.should_fail_with Non_Unique_Primary_Key
             e1 = r1.catch
             e1.clashing_primary_key . should_equal [1]
             e1.clashing_example_row_count . should_equal 2
             e1.to_display_text . should_equal "The primary key [X] is not unique. The key [1] corresponds to 2 rows."
 
-            r2 = t1.create_database_table connection (Name_Generator.random_name "primary-key-6") temporary=True primary_key=["Y"]
+            r2 = t1.select_into_database_table connection (Name_Generator.random_name "primary-key-6") temporary=True primary_key=["Y"]
             r2.should_fail_with Non_Unique_Primary_Key
             r2.catch . clashing_primary_key . should_equal ['b']
 
-            r3 = t1.create_database_table connection (Name_Generator.random_name "primary-key-7") temporary=True primary_key=["X", "Y"]
+            r3 = t1.select_into_database_table connection (Name_Generator.random_name "primary-key-7") temporary=True primary_key=["X", "Y"]
             r3.at "X" . to_vector . should_equal [1, 2, 1]
 
             t2 = Table.new [["X", [1, 2, 1]], ["Y", ['a', 'b', 'a']]]
-            r4 = t2.create_database_table connection (Name_Generator.random_name "primary-key-7") temporary=True primary_key=["X", "Y"]
+            r4 = t2.select_into_database_table connection (Name_Generator.random_name "primary-key-7") temporary=True primary_key=["X", "Y"]
             r4.should_fail_with Non_Unique_Primary_Key
             r4.catch . clashing_primary_key . should_equal [1, 'a']
 
@@ -126,9 +148,9 @@ spec make_new_connection prefix persistent_connector=True =
         Test.specify "should be able to create a persistent copy of a DB table" <|
             t = Table.new [["X", [1, 2, 3]], ["Y", ['a', 'b', 'c']], ["Z", [1.0, 2.0, 3.0]]]
             tmp_connection = make_new_connection Nothing
-            db_table = t.create_database_table tmp_connection (Name_Generator.random_name "source-table") temporary=True
+            db_table = t.select_into_database_table tmp_connection (Name_Generator.random_name "source-table") temporary=True
 
-            copied_table = db_table.create_database_table tmp_connection (Name_Generator.random_name "copied-table") temporary=False
+            copied_table = db_table.select_into_database_table tmp_connection (Name_Generator.random_name "copied-table") temporary=False
             name = copied_table.name
             Panic.with_finalizer (connection.drop_table name) <|
                 copied_table.at "X" . value_type . is_integer . should_be_true
@@ -144,14 +166,14 @@ spec make_new_connection prefix persistent_connector=True =
         Test.specify "should be able to persist a complex query with generated columns, joins etc." <|
             t1 = Table.new [["X", [1, 1, 2]], ["Y", [1, 2, 3]]]
 
-            db_table_1 = t1.create_database_table connection (Name_Generator.random_name "source-table-1") temporary=True primary_key=Nothing
+            db_table_1 = t1.select_into_database_table connection (Name_Generator.random_name "source-table-1") temporary=True primary_key=Nothing
 
             db_table_2 = db_table_1.set "[Y] + 100 * [X]" "C1" . set '"constant_text"' "C2"
             db_table_3 = db_table_1.aggregate [Aggregate_Column.Group_By "X", Aggregate_Column.Sum "[Y]*[Y]" "C3"] . set "[X] + 1" "X"
 
             db_table_4 = db_table_2.join db_table_3 join_kind=Join_Kind.Left_Outer
 
-            copied_table = db_table_4.create_database_table connection (Name_Generator.random_name "copied-table") temporary=True primary_key=Nothing
+            copied_table = db_table_4.select_into_database_table connection (Name_Generator.random_name "copied-table") temporary=True primary_key=Nothing
             copied_table.column_names . should_equal ["X", "Y", "C1", "C2", "Right X", "C3"]
             copied_table.at "X" . to_vector . should_equal [1, 1, 2]
             copied_table.at "C1" . to_vector . should_equal [101, 102, 203]
@@ -169,10 +191,10 @@ spec make_new_connection prefix persistent_connector=True =
         Test.specify "should be able to create a temporary copy of a query" <|
             tmp_connection = make_new_connection Nothing
             t = Table.new [["X", [1, 2, 3]], ["Y", [4, 5, 6]]]
-            db_table = t.create_database_table tmp_connection (Name_Generator.random_name "source-table") temporary=True
+            db_table = t.select_into_database_table tmp_connection (Name_Generator.random_name "source-table") temporary=True
             db_table_2 = db_table.set "[X] + 100 * [Y]" "computed"
 
-            copied_table = db_table_2.create_database_table tmp_connection (Name_Generator.random_name "copied-table") temporary=True
+            copied_table = db_table_2.select_into_database_table tmp_connection (Name_Generator.random_name "copied-table") temporary=True
             name = copied_table.name
 
             copied_table_accessed = tmp_connection.query name
@@ -184,33 +206,33 @@ spec make_new_connection prefix persistent_connector=True =
 
         Test.specify "should be able to specify a primary key" <|
             t = Table.new [["X", [1, 2, 3]], ["Y", ['a', 'b', 'c']]]
-            db_table = t.create_database_table connection (Name_Generator.random_name "source-table") temporary=True
-            db_table_2 = db_table.create_database_table connection (Name_Generator.random_name "copied-table") primary_key=["X"]
+            db_table = t.select_into_database_table connection (Name_Generator.random_name "source-table") temporary=True
+            db_table_2 = db_table.select_into_database_table connection (Name_Generator.random_name "copied-table") primary_key=["X"]
             Panic.with_finalizer (connection.drop_table db_table_2.name) <|
                 get_primary_key connection db_table_2.name . should_equal ["X"]
 
         Test.specify "should ensure that primary key columns are valid" <|
             t = Table.new [["X", [1, 2, 3]], ["Y", ['a', 'b', 'c']]]
-            db_table = t.create_database_table connection (Name_Generator.random_name "source-table") temporary=True
-            r1 = db_table.create_database_table connection (Name_Generator.random_name "copied-table") temporary=True primary_key=["nonexistent"]
+            db_table = t.select_into_database_table connection (Name_Generator.random_name "source-table") temporary=True
+            r1 = db_table.select_into_database_table connection (Name_Generator.random_name "copied-table") temporary=True primary_key=["nonexistent"]
             r1.should_fail_with Missing_Input_Columns
 
         Test.specify "should fail when the primary key is not unique" <|
             t = Table.new [["X", [1, 2, 1]], ["Y", ['b', 'b', 'a']]]
-            db_table = t.create_database_table connection (Name_Generator.random_name "source-table") temporary=True primary_key=Nothing
+            db_table = t.select_into_database_table connection (Name_Generator.random_name "source-table") temporary=True primary_key=Nothing
             Problems.assume_no_problems db_table
 
-            r1 = db_table.create_database_table connection (Name_Generator.random_name "copied-table") temporary=True primary_key=["X"]
+            r1 = db_table.select_into_database_table connection (Name_Generator.random_name "copied-table") temporary=True primary_key=["X"]
             r1.should_fail_with Non_Unique_Primary_Key
             e1 = r1.catch
             e1.clashing_primary_key . should_equal [1]
             e1.clashing_example_row_count . should_equal 2
 
             t2 = Table.new [["X", [1, 3, 1, 2, 3, 2, 2, 2, 0]], ["Y", ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']]]
-            db_table_2 = t2.create_database_table connection (Name_Generator.random_name "source-table-2") temporary=True primary_key=Nothing
+            db_table_2 = t2.select_into_database_table connection (Name_Generator.random_name "source-table-2") temporary=True primary_key=Nothing
             Problems.assume_no_problems db_table_2
 
-            r2 = db_table_2.create_database_table connection (Name_Generator.random_name "copied-table-2") temporary=True primary_key=["X"]
+            r2 = db_table_2.select_into_database_table connection (Name_Generator.random_name "copied-table-2") temporary=True primary_key=["X"]
             r2.should_fail_with Non_Unique_Primary_Key
             e2 = r2.catch
             e2.clashing_primary_key.length . should_equal 1
@@ -221,10 +243,10 @@ spec make_new_connection prefix persistent_connector=True =
 
         Test.specify "will not allow to upload tables across connections" <|
             t = Table.new [["X", [1, 2, 1]], ["Y", ['b', 'b', 'a']]]
-            db_table = t.create_database_table connection (Name_Generator.random_name "source-table") temporary=True primary_key=Nothing
+            db_table = t.select_into_database_table connection (Name_Generator.random_name "source-table") temporary=True primary_key=Nothing
 
             connection_2 = make_new_connection Nothing
-            r1 = db_table.create_database_table connection_2 (Name_Generator.random_name "copied-table") temporary=True primary_key=Nothing
+            r1 = db_table.select_into_database_table connection_2 (Name_Generator.random_name "copied-table") temporary=True primary_key=Nothing
             r1.should_fail_with Unsupported_Database_Operation
             r1.catch.message . should_contain "same connection"
 
@@ -305,7 +327,7 @@ spec make_new_connection prefix persistent_connector=True =
     Test.group "Appending a Database table to a Database table" <|
         table_builder args =
             in_memory_table = Table.new args
-            in_memory_table.create_database_table connection (Name_Generator.random_name "source-table") temporary=True
+            in_memory_table.select_into_database_table connection (Name_Generator.random_name "source-table") temporary=True
         test_table_append table_builder
 
 

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -6,6 +6,7 @@ from Standard.Table.Errors import Missing_Input_Columns
 from Standard.Database import all
 from Standard.Database.Errors import all
 from Standard.Database.Internal.Result_Set import result_set_to_table
+from Standard.Database.Extensions.Upload_Table import get_primary_key
 
 from Standard.Test import Test, Test_Suite, Problems
 import Standard.Test.Extensions
@@ -231,6 +232,12 @@ spec make_new_connection prefix persistent_connector=True =
         Test.specify "should be able to append new rows to a table" <|
             Nothing
 
+        Test.specify "should error if new rows clash with existing ones and mode is Insert, target table should remain unchanged" <|
+            Nothing
+
+        Test.specify "should use the target table primary key for the key by default" <|
+            Nothing
+
         Test.specify "should be able to update existing rows in a table" <|
             Nothing
 
@@ -241,6 +248,12 @@ spec make_new_connection prefix persistent_connector=True =
             Nothing
 
         Test.specify "should be able to detect the primary key of a table for row correlation" <|
+            Nothing
+
+        Test.specify "should allow specifying no key in Insert mode" <|
+            Nothing
+
+        Test.specify "should fail if no key is specified in other modes" <|
             Nothing
 
         Test.specify "should fail if the key is not unique in the unique table" <|
@@ -261,7 +274,20 @@ spec make_new_connection prefix persistent_connector=True =
         Test.specify "should fail if the source table is missing some columns, if asked to" <|
             Nothing
 
-        Test.specify "TODO mapping of primary key columns - wrong name TODO" <|
+        Test.specify "should fail if some of key_columns do not exist in either table" <|
+            Nothing
+
+        Test.specify "by default, should fail if the target table does not exist" <|
+            Nothing
+
+        Test.specify "should allow to create the target table if it does not exist, but make it temporary and attach a warning" <|
+            Nothing
+
+        Test.specify "should report a meaningful error when the primary key could not be determined" <|
+            # TODO temporary (only SQLite?)
+            Nothing
+
+            # TODO non-existent target
             Nothing
 
         Test.specify "should fail if types of columns are not compatible" <|
@@ -287,27 +313,3 @@ spec make_new_connection prefix persistent_connector=True =
 make_mock_column name values exploding_index =
     storage = ExplodingStorage.new values.to_array exploding_index
     Column.from_storage name storage
-
-## PRIVATE
-
-   This method may not work correctly with temporary tables, possibly resulting
-   in `SQL_Error` as such tables may not be found.
-
-   ! Temporary Tables in SQLite
-
-     The temporary tables in SQLite live in a `temp` database. There is a bug in
-     how JDBC retrieves primary keys - it only queries the `sqlite_schema` table
-     which contains schemas of only permanent tables. For now, we just adapt to
-     it and check primary keys for non-temporary tables only. If we ever want to
-     use the primary key information in the actual product, we will likely need
-     to reimplement this by ourselves and UNION both `sqlite_schema` and
-     `temp.sqlite_schema` tables to get results for both temporary and permanent
-     tables.
-get_primary_key connection table_name =
-    connection.jdbc_connection.with_connection java_connection->
-        rs = java_connection.getMetaData.getPrimaryKeys Nothing Nothing table_name
-        keys_table = result_set_to_table rs connection.dialect.make_column_fetcher_for_type
-        # The names of the columns are sometimes lowercase and sometimes uppercase, so we do a case insensitive select first.
-        selected = keys_table.select_columns [Column_Selector.By_Name "COLUMN_NAME", Column_Selector.By_Name "KEY_SEQ"] reorder=True
-        key_column_names = selected.order_by 1 . at 0 . to_vector
-        if key_column_names.is_empty then Nothing else key_column_names

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -247,6 +247,9 @@ spec make_new_connection prefix persistent_connector=True =
         Test.specify "should allow to align an existing table with a source (upsert + delete rows missing from source)" <|
             Nothing
 
+        Test.specify "should allow to use a transformed table, with computed fields, as a source" <|
+            Nothing
+
         Test.specify "should be able to detect the primary key of a table for row correlation" <|
             Nothing
 

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -383,70 +383,11 @@ spec make_new_connection prefix persistent_connector=True =
             result.at "X" . to_vector . should_equal [1, 2, 3, 4, 5, 6]
             result.at "Y" . to_vector . should_equal ['a', 'b', 'c', 'd', 'e', 'f']
 
-        Test.specify "should error if new rows clash with existing ones and mode is Insert, target table should remain unchanged" <|
-            Nothing
-
-        Test.specify "should use the target table primary key for the key by default" <|
-            Nothing
-
-        Test.specify "should be able to update existing rows in a table" <|
-            Nothing
-
-        Test.specify "should upsert by default (update existing rows, insert new rows)" <|
-            Nothing
-
-        Test.specify "should allow to align an existing table with a source (upsert + delete rows missing from source)" <|
-            Nothing
-
-        Test.specify "should allow to use a transformed table, with computed fields, as a source" <|
-            Nothing
-
-        Test.specify "should be able to detect the primary key of a table for row correlation" <|
-            Nothing
-
-        Test.specify "should allow specifying no key in Insert mode" <|
-            Nothing
-
-        Test.specify "should fail if no key is specified in other modes" <|
-            Nothing
-
-        Test.specify "should fail if the key is not unique in the unique table" <|
-            Nothing
-
-        Test.specify "should fail if the key causes update of multiple values (it's not unique in the target table)" <|
-            Nothing
-
-        Test.specify "should fail if the source table contains columns not present in the target (data loss)" <|
-            Nothing
-
-        Test.specify "by default should keep columns missing from source as-is and use defaults when inserting" <|
-            Nothing
-
-        Test.specify "should fail if the source table is missing some columns and the column in the target has no default value" <|
-            Nothing
-
-        Test.specify "should fail if the source table is missing some columns, if asked to" <|
-            Nothing
-
-        Test.specify "should fail if some of key_columns do not exist in either table" <|
-            Nothing
-
         Test.specify "should fail if the target table does not exist" <|
             t = source_table_builder ["X", [1, 2, 3], "Y", ['a', 'b', 'c']]
             nonexistent_name = Name_Generator.random_name "nonexistent-table"
             r1 = t.update_database_table connection nonexistent_name
             r1.should_fail_with Table_Not_Found
-
-        Test.specify "should report a meaningful error when the primary key could not be determined" <|
-            # TODO temporary (only SQLite?)
-            Nothing
-
-            # TODO non-existent target
-            Nothing
-
-        Test.specify "should fail if types of columns are not compatible" <|
-            # TODO how do we define compatibility? I assume we allow type widening, but not narrowing
-            Nothing
 
     table_builder name_prefix args primary_key=[] =
         in_memory_table = Table.new args

--- a/test/Table_Tests/src/In_Memory/Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Spec.enso
@@ -12,7 +12,8 @@ from Standard.Table.Errors import Invalid_Output_Column_Names, Duplicate_Output_
 
 import Standard.Visualization
 
-import Standard.Database.Extensions.Upload_Table
+import Standard.Database.Extensions.Upload_Database_Table
+import Standard.Database.Extensions.Upload_In_Memory_Table
 from Standard.Database import Database, SQLite, In_Memory
 
 from Standard.Test import Test, Test_Suite, Problems

--- a/test/Table_Tests/src/In_Memory/Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Spec.enso
@@ -854,7 +854,7 @@ spec =
             t.join 42 . should_fail_with Type_Error
 
             db_connection = Database.connect (SQLite In_Memory)
-            db_table = (Table.new [["Y", [4, 5, 6]]]).create_database_table db_connection "test"
+            db_table = (Table.new [["Y", [4, 5, 6]]]).select_into_database_table db_connection "test"
 
             r = t.join db_table
             r.should_fail_with Illegal_Argument

--- a/test/Tests/src/Data/Map_Spec.enso
+++ b/test/Tests/src/Data/Map_Spec.enso
@@ -250,7 +250,7 @@ spec =
             m1.should_fail_with Illegal_Argument
             m1.catch.message . should_equal "`Map.from_vector` encountered duplicate key: 0"
 
-            m2 = Map.from_vector vec allow_duplicates=True
+            m2 = Map.from_vector vec error_on_duplicates=False
             Problems.assume_no_problems m2
             m2.get 0 . should_equal 1
             m2.get 3 . should_equal -5

--- a/test/Tests/src/Data/Map_Spec.enso
+++ b/test/Tests/src/Data/Map_Spec.enso
@@ -1,8 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Errors.No_Such_Key.No_Such_Key
-import Standard.Base.Data.Time.Date_Time.Date_Time
-from Standard.Base.Data.Map import Map
 
 from Standard.Test import Test, Test_Suite, Problems
 import Standard.Test.Extensions

--- a/test/Tests/src/Data/Set_Spec.enso
+++ b/test/Tests/src/Data/Set_Spec.enso
@@ -20,7 +20,7 @@ spec =
             s1.size . should_equal 3
             s1.to_vector.sort . should_equal [1, 2, 3]
 
-            r2 = Set.from_vector [1, 2, 2] allow_duplicates=False
+            r2 = Set.from_vector [1, 2, 2] error_on_duplicates=True
             r2.should_fail_with Illegal_Argument
 
         Test.specify "should allow checking contains" <|

--- a/test/Tests/src/Data/Set_Spec.enso
+++ b/test/Tests/src/Data/Set_Spec.enso
@@ -1,6 +1,9 @@
 from Standard.Base import all
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
+from Standard.Test import Test, Test_Suite, Problems
+import Standard.Test.Extensions
+
 spec =
     Test.group "Enso Set" <|
         Test.specify "should allow checking for emptiness" <|
@@ -32,12 +35,13 @@ spec =
             s2 = Set.from_vector [2, 3]
             s3 = Set.from_vector [3, 4]
 
-            (s1 + s2).to_vector.sort . should_equal [1, 2, 3]
-            (s1 + s3).to_vector.sort . should_equal [1, 2, 3, 4]
-            (s1 & s2).to_vector.sort . should_equal [2]
-            (s1 & s3).to_vector.sort . should_equal []
-            (s1 - s2).to_vector.sort . should_equal [1]
-            (s1 - s3).to_vector.sort . should_equal [1, 2]
+            (s1.union s2).to_vector.sort . should_equal [1, 2, 3]
+            (s1.union s3).to_vector.sort . should_equal [1, 2, 3, 4]
+            (s1.intersection s2).to_vector.sort . should_equal [2]
+            (s1.intersection s3).to_vector . should_equal []
+            (s1.difference s2).to_vector.sort . should_equal [1]
+            (s1.difference s3).to_vector.sort . should_equal [1, 2]
+            (s1.difference s1).to_vector . should_equal []
 
         Test.specify "should allow to check for equality of two sets" <|
             s1 = Set.from_vector [1, 2]
@@ -47,3 +51,5 @@ spec =
             (s1 == s2) . should_be_true
             (s1 == s1) . should_be_true
             (s1 == s3) . should_be_false
+
+main = Test_Suite.run_main spec

--- a/test/Tests/src/Data/Set_Spec.enso
+++ b/test/Tests/src/Data/Set_Spec.enso
@@ -1,0 +1,49 @@
+from Standard.Base import all
+import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
+
+spec =
+    Test.group "Enso Set" <|
+        Test.specify "should allow checking for emptiness" <|
+            empty_map = Set.empty
+            non_empty = Set.empty . insert "foo"
+            empty_map.is_empty . should_be_true
+            non_empty.is_empty . should_be_false
+
+            empty_map.not_empty . should_be_false
+            non_empty.not_empty . should_be_true
+
+        Test.specify "should be constructed from a vector" <|
+            s1 = Set.from_vector [1, 2, 3, 2]
+            s1.size . should_equal 3
+            s1.to_vector.sort . should_equal [1, 2, 3]
+
+            r2 = Set.from_vector [1, 2, 2] allow_duplicates=False
+            r2.should_fail_with Illegal_Argument
+
+        Test.specify "should allow checking contains" <|
+            s1 = Set.from_vector [1, 2, 3, 2]
+            s1.contains 1 . should_be_true
+            s1.contains 2 . should_be_true
+            s1.contains 3 . should_be_true
+            s1.contains 4 . should_be_false
+
+        Test.specify "should allow to compute a union, intersection and difference" <|
+            s1 = Set.from_vector [1, 2]
+            s2 = Set.from_vector [2, 3]
+            s3 = Set.from_vector [3, 4]
+
+            (s1 + s2).to_vector.sort . should_equal [1, 2, 3]
+            (s1 + s3).to_vector.sort . should_equal [1, 2, 3, 4]
+            (s1 & s2).to_vector.sort . should_equal [2]
+            (s1 & s3).to_vector.sort . should_equal []
+            (s1 - s2).to_vector.sort . should_equal [1]
+            (s1 - s3).to_vector.sort . should_equal [1, 2]
+
+        Test.specify "should allow to check for equality of two sets" <|
+            s1 = Set.from_vector [1, 2]
+            s2 = Set.from_vector [2, 1, 1]
+            s3 = Set.from_vector [1, 2, 3]
+
+            (s1 == s2) . should_be_true
+            (s1 == s1) . should_be_true
+            (s1 == s3) . should_be_false

--- a/test/Tests/src/Main.enso
+++ b/test/Tests/src/Main.enso
@@ -43,10 +43,11 @@ import project.Data.Ordering.Vector_Lexicographic_Order_Spec
 import project.Data.Pair_Spec
 import project.Data.Problems_Spec
 import project.Data.Range_Spec
+import project.Data.Regression_Spec
+import project.Data.Set_Spec
+import project.Data.Statistics_Spec
 import project.Data.Time.Spec as Time_Spec
 import project.Data.Vector_Spec
-import project.Data.Statistics_Spec
-import project.Data.Regression_Spec
 
 import project.Data.Text_Spec
 import project.Data.Text.Text_Sub_Range_Spec
@@ -106,6 +107,7 @@ main = Test_Suite.run_main <|
     List_Spec.spec
     Locale_Spec.spec
     Map_Spec.spec
+    Set_Spec.spec
     Maybe_Spec.spec
     Meta_Spec.spec
     Meta_Location_Spec.spec

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -24,7 +24,7 @@ type Foo
 
 visualization_spec connection =
     in_mem = Table.new [["A", ['a', 'a', 'a']], ["B", [2, 2, 3]], ["C", [3, 5, 6]]]
-    t = in_mem.create_database_table connection "T" primary_key=Nothing temporary=True
+    t = in_mem.select_into_database_table connection "T" primary_key=Nothing temporary=True
 
     make_json header data all_rows ixes_header ixes =
         p_header      = ["header", header]


### PR DESCRIPTION
### Pull Request Description

First part for #6498 - refactoring of the upload infrastructure, in preparation for `update_database_table`.

Implemented a `Set` data structure which was long needed.

The APIs are added and an initial implementation is created, but it is not complete - but it has grown significantly already so the remaining implementation will be done as a separate PR.

Adds some basic ability for a function to ensure that it is only executed from within a transaction.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
