### PR TITLE
Small fixes from book club.

### DIFF
--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -99,7 +99,13 @@ class TableVisualization extends Visualization {
             } else if (params.value === '') {
                 return '<span style="color:grey; font-style: italic;">Empty</span>'
             }
-            return params.value.toString()
+            return params.value
+                .toString()
+                .replace(
+                    /[&<"'>]/g,
+                    m =>
+                        ({ '&': '&amp;', '<': '&lt;', '"': '&quot;', "'": '&#39;', '>': '&gt;' }[m])
+                )
         }
 
         if (!this.tabElem) {
@@ -146,6 +152,7 @@ class TableVisualization extends Visualization {
                     cellRenderer: cellRenderer,
                 },
                 onColumnResized: e => this.lockColumnSize(e),
+                suppressFieldDotNotation: true,
             }
             this.agGrid = new agGrid.Grid(tabElem, this.agGridOptions)
         }

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -91,6 +91,11 @@ class TableVisualization extends Visualization {
             return content
         }
 
+        function escapeHTML(str) {
+            const mapping = { '&': '&amp;', '<': '&lt;', '"': '&quot;', "'": '&#39;', '>': '&gt;' }
+            return str.replace(/[&<>"']/g, m => mapping[m])
+        }
+
         function cellRenderer(params) {
             if (params.value === null) {
                 return '<span style="color:grey; font-style: italic;">Nothing</span>'
@@ -99,13 +104,7 @@ class TableVisualization extends Visualization {
             } else if (params.value === '') {
                 return '<span style="color:grey; font-style: italic;">Empty</span>'
             }
-            return params.value
-                .toString()
-                .replace(
-                    /[&<"'>]/g,
-                    m =>
-                        ({ '&': '&amp;', '<': '&lt;', '"': '&quot;', "'": '&#39;', '>': '&gt;' }[m])
-                )
+            return escapeHTML(params.value.toString())
         }
 
         if (!this.tabElem) {

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
@@ -149,9 +149,10 @@ list_directory directory name_filter=Nothing recursive=False =
    - uri: The URI to fetch.
    - method: The HTTP method to use. Defaults to `GET`.
    - headers: The headers to send with the request. Defaults to an empty vector.
-   - parse:  If successful should the body be parsed to an Enso native object.
+   - try_auto_parse:  If successful should the body be attempted to be parsed to
+     an Enso native object.
 fetch : (URI | Text) -> HTTP_Method -> Vector (Header | Pair Text Text) -> Boolean -> Any
-fetch uri method=HTTP_Method.Get headers=[] parse=True =
+fetch uri method=HTTP_Method.Get headers=[] try_auto_parse=True =
     parsed_headers = headers . map h-> case h of
         _ : Vector -> Header.new (h.at 0) (h.at 1)
         _ : Pair -> Header.new (h.at 0) (h.at 1)
@@ -162,7 +163,8 @@ fetch uri method=HTTP_Method.Get headers=[] parse=True =
     response = HTTP.new.request request
 
     if response.code.is_success.not then Error.throw (Request_Error.Error "Status Code" ("Request failed with status code: " + response.code.to_text + ". " + response.body.decode_as_text)) else
-        if parse then response.decode if_unsupported=response else response
+        if try_auto_parse.not then response else
+            response.decode if_unsupported=response . catch handler=(_->response)
 
 ## ALIAS Download, HTTP Get
    Fetches from the URI and returns the response, parsing the body if the
@@ -172,7 +174,8 @@ fetch uri method=HTTP_Method.Get headers=[] parse=True =
    Arguments:
    - method: The HTTP method to use. Defaults to `GET`.
    - headers: The headers to send with the request. Defaults to an empty vector.
-   - parse:  If successful should the body be parsed to an Enso native object.
+   - try_auto_parse:  If successful should the body be attempted to be parsed to
+     an Enso native object.
 URI.fetch : HTTP_Method -> Vector (Header | Pair Text Text) -> Boolean -> Any
-URI.fetch self method=HTTP_Method.Get headers=[] parse=True =
-    Data.fetch self method headers parse
+URI.fetch self method=HTTP_Method.Get headers=[] try_auto_parse=True =
+    Data.fetch self method headers try_auto_parse

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
@@ -156,7 +156,8 @@ type Array
     # For compatibility with Vector
     #
 
-    ## Sort the array.
+    ## ALIAS order_by
+       Sort the array.
 
        Arguments:
        - order: The order in which the array elements are sorted.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
@@ -1144,7 +1144,7 @@ round_min_long = -99999999999999
 
 ## PRIVATE
    Restrict rounding decimal_places parameter.
-check_decimal_places : Integer -> Function -> Any ! Illegal_Argument
+check_decimal_places : Integer -> Any -> Any ! Illegal_Argument
 check_decimal_places decimal_places ~action =
     if decimal_places >= round_min_decimal_places && decimal_places <= round_max_decimal_places then action else
         msg = "round: decimal_places must be between " + round_min_decimal_places.to_text + " and " + round_max_decimal_places.to_text + " (inclusive), but was " + decimal_places.to_text

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
@@ -271,6 +271,7 @@ type Number
          Convert the value 5000 to a string.
 
              5000.format "#,##0"
+    @locale Locale.default_widget
     format : Text -> Locale -> Text
     format self format locale=Locale.default =
         symbols = DecimalFormatSymbols.new locale.java_locale

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
@@ -1142,7 +1142,7 @@ round_min_long = -99999999999999
 
 ## PRIVATE
    Restrict rounding decimal_places parameter.
-check_decimal_places : Integer -> Function
+check_decimal_places : Integer -> Function -> Any ! Illegal_Argument
 check_decimal_places decimal_places ~action =
     if decimal_places >= round_min_decimal_places && decimal_places <= round_max_decimal_places then action else
         msg = "round: decimal_places must be between " + round_min_decimal_places.to_text + " and " + round_max_decimal_places.to_text + " (inclusive), but was " + decimal_places.to_text
@@ -1150,7 +1150,7 @@ check_decimal_places decimal_places ~action =
 
 ## PRIVATE
    Restrict allowed range of input to rounding methods.
-check_round_input : Number -> Function
+check_round_input : Number -> Function -> Any ! Illegal_Argument
 check_round_input n ~action =
     if n >= round_min_long && n <= round_max_long then action else
         msg = "Error: `round` can only accept values between " + round_min_long.to_text + " and " + round_max_long.to_text + " (inclusive), but was " + n.to_text

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
@@ -1,3 +1,4 @@
+import project.Any.Any
 import project.Data.Text.Text
 import project.Data.Locale.Locale
 import project.Errors.Common.Arithmetic_Error

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text.enso
@@ -61,6 +61,8 @@ type Text
         Text_Utils.equals_ignore_case self that locale.java_locale
 
     ## ADVANCED
+       PRIVATE
+       UNSTABLE
        Unifies the case of all letters in the text, generating a key which can be
        used to perform case-insensitive comparisons.
     @locale Locale.default_widget

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text.enso
@@ -55,15 +55,15 @@ type Text
          ACCENT). Therefore:
 
              (('É' . equals_ignore_case 'é') && ('é' . equals_ignore_case 'e\u0301')) == True
+    @locale Locale.default_widget
     equals_ignore_case : Text -> Locale -> Boolean
     equals_ignore_case self that locale=Locale.default =
         Text_Utils.equals_ignore_case self that locale.java_locale
 
     ## ADVANCED
-       PRIVATE
-       UNSTABLE
        Unifies the case of all letters in the text, generating a key which can be
        used to perform case-insensitive comparisons.
+    @locale Locale.default_widget
     to_case_insensitive_key : Locale -> Text
     to_case_insensitive_key self locale=Locale.default =
         Text_Utils.case_insensitive_key self locale.java_locale
@@ -77,6 +77,7 @@ type Text
          Checking how "a" orders in relation to "b".
 
              "a".compare_to_ignore_case "b"
+    @locale Locale.default_widget
     compare_to_ignore_case : Text -> Locale -> Ordering
     compare_to_ignore_case self that locale=Locale.default =
         if that.is_nothing then Error.throw (Type_Error.Error Text that "that") else

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -1035,6 +1035,7 @@ Text.drop self range=(Index_Sub_Range.First 1) =
          from Standard.Base import all
 
          example_case_with_locale = "i".to_case Upper (Locale.new "tr") == "İ"
+@locale Locale.default_widget
 Text.to_case : Case -> Locale -> Text
 Text.to_case self case_option=Case.Lower locale=Locale.default = case case_option of
     Case.Lower -> UCharacter.toLowerCase locale.java_locale self
@@ -1391,6 +1392,7 @@ Text.last_index_of self term="" start=-1 case_sensitivity=Case_Sensitivity.Sensi
      Parse the text "7.6" into a decimal number.
 
          "7.6".parse_decimal
+@locale Locale.default_widget
 Text.parse_decimal : Locale | Nothing -> Decimal ! Number_Parse_Error
 Text.parse_decimal self locale=Nothing = Decimal.parse self locale
 
@@ -1570,6 +1572,7 @@ Text.parse_date self format=Nothing = Date.parse self format
 
          example_parse =
             "06 of May 2020 at 04:30AM".parse_date_time "dd 'of' MMMM yyyy 'at' hh:mma"
+@locale Locale.default_widget
 Text.parse_date_time : Text | Nothing -> Locale -> Date_Time ! Time_Error
 Text.parse_date_time self format=Nothing locale=Locale.default = Date_Time.parse self format locale
 
@@ -1638,6 +1641,7 @@ Text.parse_date_time self format=Nothing locale=Locale.default = Date_Time.parse
          import Standard.Base.Data.Text.Extensions
 
          example_parse = "4:30AM".parse_time_of_day "h:mma"
+@locale Locale.default_widget
 Text.parse_time_of_day : Text | Nothing -> Locale -> Time_Of_Day ! Time_Error
 Text.parse_time_of_day self format=Nothing locale=Locale.default = Time_Of_Day.parse self format locale
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Text_Ordering.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Text_Ordering.enso
@@ -38,6 +38,7 @@ type Text_Ordering
        Arguments:
        - sort_digits_as_numbers: Sort digits in the text as numbers. Setting
          this to `True` results in a "Natural" ordering.
+    @locale Locale.default_widget
     Case_Insensitive (locale:Locale=Locale.default) (sort_digits_as_numbers:Boolean=False)
 
     ## PRIVATE

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -866,7 +866,8 @@ type Vector a
     second : Any ! Index_Out_Of_Bounds
     second self = self.at 1
 
-    ## Sort the vector.
+    ## ALIAS order_by
+       Sort the vector.
 
        Arguments:
        - order: The order in which the vector elements are sorted.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
@@ -109,6 +109,7 @@ type File_Format
         Single_Choice display=Display.Always values=(all_types.map n->(Option (make_name n) (File_Format.constructor_code n)))
 
 type Plain_Text_Format
+    @encoding Encoding.default_widget
     Plain_Text (encoding:Encoding=Encoding.utf_8)
 
     ## PRIVATE

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
@@ -735,8 +735,7 @@ type Column
     rename self name = self.naming_helpers.ensure_name_is_valid name <|
         Column.Value name self.connection self.sql_type_reference self.expression self.context
 
-    ## UNSTABLE
-
+    ## ALIAS order_by
        Sorts the column according to the specified rules.
 
        Arguments:

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
@@ -233,6 +233,7 @@ type Column
 
        Returns a column with results of comparing this column's elements against
        `other`.
+    @locale Locale.default_widget
     equals_ignore_case : Column | Any -> Locale -> Column
     equals_ignore_case self other locale=Locale.default =
         Value_Type.expect_text self <|
@@ -1050,6 +1051,7 @@ type Column
                 self.internal_do_cast type on_problems
 
     ## Formatting values is not supported in database columns.
+    @locale Locale.default_widget
     format : Text | Column -> Locale -> Column ! Illegal_Argument
     format self format=Nothing locale=Locale.default =
         _ = [format, locale]

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
@@ -692,7 +692,8 @@ type Column
             False -> is_blank
         result.rename new_name
 
-    ## Returns a new column where missing values have been replaced with the
+    ## ALIAS if_nothing
+       Returns a new column where missing values have been replaced with the
        provided default.
     fill_nothing : Column | Any -> Column
     fill_nothing self default =
@@ -702,7 +703,8 @@ type Column
             op_result = self.make_binary_op "FILL_NULL" default new_name
             adapt_unified_column op_result common_type
 
-    ## Returns a new column where empty Text values have been replaced with the
+    ## ALIAS if_empty
+       Returns a new column where empty Text values have been replaced with the
        provided default.
 
        Arguments:

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
@@ -753,7 +753,7 @@ type Column
              column.sort Sort_Direction.Descending
     sort : Sort_Direction -> Column
     sort self order=Sort_Direction.Ascending =
-        self.to_table.order_by (Sort_Column.Index 0 order) . at 0
+        self.to_table.order_by [Sort_Column.Index 0 order] . at 0
 
     ## UNSTABLE
        Creates a new Column with the specified range of rows from the input

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -595,7 +595,7 @@ type Table
          In the call below, assuming that the table of `t1` contains rows for
          numbers 1, 2, ..., 10, will return rows starting from 6 and not an empty
          result as one could expect if the limit was applied before the filters.
-             t1 = table.order_by ([Sort_Column.Name "A"]) . limit 5
+             t1 = table.order_by [Sort_Column.Name "A"] . limit 5
              t2 = t1.filter 'A' (Greater than=5)
              t2.read
     limit : Integer -> Table

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -1350,14 +1350,14 @@ type Table
        value field.
 
        Arguments:
-       - id_fields: Set of fields to remain as columns. These values will be
+       - key_columns: Set of fields to remain as columns. These values will be
          repeated for each data field that is pivoted.
-       - name_field: The name of the field that will contain the names of the
-         pivoted fields. If this name is already in use, it will be renamed
-         with a numeric suffix.
-       - value_field: The name of the field that will contain the values of the
-         pivoted fields. If this name is already in use, it will be renamed
-         with a numeric suffix.
+       - attribute_column_name: The name of the field that will contain the
+         names of the pivoted fields. If this name is already in use, it will be
+         renamed with a numeric suffix.
+       - value_column_name: The name of the field that will contain the values
+         of the pivoted fields. If this name is already in use, it will be
+         renamed with a numeric suffix.
        - on_problems: Specifies how to handle problems if they occur, reporting
          them as warnings by default.
 
@@ -1373,12 +1373,12 @@ type Table
          - If any column names in the new table are clashing, a
            `Duplicate_Output_Column_Names` is reported according to the
            `on_problems` setting.
-    @id_fields Widget_Helpers.make_column_name_vector_selector
+    @key_columns Widget_Helpers.make_column_name_vector_selector
     transpose : Vector (Integer | Text | Column_Selector) | Text | Integer -> Text -> Text -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Duplicate_Output_Column_Names
-    transpose self id_fields=[] (name_field="Name") (value_field="Value") (error_on_missing_columns=True) (on_problems = Report_Warning) =
+    transpose self key_columns=[] (attribute_column_name="Name") (value_column_name="Value") (error_on_missing_columns=True) (on_problems = Report_Warning) =
         ## Avoid unused arguments warning. We cannot rename arguments to `_`,
            because we need to keep the API consistent with the in-memory table.
-        _ = [id_fields, name_field, value_field, error_on_missing_columns, on_problems]
+        _ = [key_columns, attribute_column_name, value_column_name, error_on_missing_columns, on_problems]
         msg = "Transposing columns is not supported in database tables, the table has to be materialized first with `read`."
         Error.throw (Unsupported_Database_Operation.Error msg)
 
@@ -1399,7 +1399,7 @@ type Table
 
        ! Error Conditions
 
-         - If a column in `group_by` or `name_field` is not in the input table,
+         - If a column in `group_by` or `name_column` is not in the input table,
            a `Missing_Input_Columns` is raised as a dataflow error.
          - If a column selector in `values` given as a `Text` and it does not
            match any columns in the input table nor is it a valid expression, an

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -452,7 +452,7 @@ type Table
              people.filter "age" (age -> (age%10 == 0))
     @column Widget_Helpers.make_column_name_selector
     filter : (Column | Text | Integer) -> (Filter_Condition|(Any->Boolean)) -> Problem_Behavior -> Table ! No_Such_Column | Index_Out_Of_Bounds | Invalid_Value_Type
-    filter self column filter=(Filter_Condition.Is_True) on_problems=Report_Warning = case column of
+    filter self column filter=(Filter_Condition.Equal True) on_problems=Report_Warning = case column of
        _ : Column ->
            mask filter_column = case Helpers.check_integrity self filter_column of
                False ->

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -1373,6 +1373,24 @@ type Table
          - If any column names in the new table are clashing, a
            `Duplicate_Output_Column_Names` is reported according to the
            `on_problems` setting.
+
+       ? Example Transpose Operation
+
+         Input Table `table`:
+
+            A | Name    | Country
+           ---|---------|---------
+            A | Example | France
+            B | Another | Germany
+
+         Result `table.transpose ['A'] 'Attribute' 'Value'`:
+
+            A | Attribute | Value
+           ---|-----------|---------
+            A | Name      | Example
+            A | Country   | France
+            B | Name      | Another
+            B | Country   | Germany
     @key_columns Widget_Helpers.make_column_name_vector_selector
     transpose : Vector (Integer | Text | Column_Selector) | Text | Integer -> Text -> Text -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Duplicate_Output_Column_Names
     transpose self key_columns=[] (attribute_column_name="Name") (value_column_name="Value") (error_on_missing_columns=True) (on_problems = Report_Warning) =
@@ -1414,6 +1432,21 @@ type Table
              an `Unquoted_Delimiter`
            - If there are more than 10 issues with a single column,
              an `Additional_Warnings`.
+
+       ? Example Cross Tab Operation
+
+         Input Table `table`:
+
+            A | B       | C
+           ---|---------|---------
+            A | Name    | Example
+            A | Country | France
+
+         Result `table.cross_tab ['A'] 'B' (Aggregate_Column.First 'C')`:
+
+            A | Name    | Country
+           ---|---------|---------
+            A | Example | France
     @group_by Widget_Helpers.make_column_name_vector_selector
     @name_column Widget_Helpers.make_column_name_selector
     @values (Widget_Helpers.make_aggregate_column_selector include_group_by=False)

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -1378,19 +1378,19 @@ type Table
 
          Input Table `table`:
 
-            A | Name    | Country
-           ---|---------|---------
-            A | Example | France
-            B | Another | Germany
+            Id | Name    | Country
+           ----|---------|---------
+            A  | Example | France
+            B  | Another | Germany
 
-         Result `table.transpose ['A'] 'Attribute' 'Value'`:
+         Result `table.transpose ['Id'] 'Attribute' 'Value'`:
 
-            A | Attribute | Value
-           ---|-----------|---------
-            A | Name      | Example
-            A | Country   | France
-            B | Name      | Another
-            B | Country   | Germany
+            Id | Attribute | Value
+           ----|-----------|---------
+            A  | Name      | Example
+            A  | Country   | France
+            B  | Name      | Another
+            B  | Country   | Germany
     @key_columns Widget_Helpers.make_column_name_vector_selector
     transpose : Vector (Integer | Text | Column_Selector) | Text | Integer -> Text -> Text -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Duplicate_Output_Column_Names
     transpose self key_columns=[] (attribute_column_name="Name") (value_column_name="Value") (error_on_missing_columns=True) (on_problems = Report_Warning) =
@@ -1437,16 +1437,16 @@ type Table
 
          Input Table `table`:
 
-            A | B       | C
-           ---|---------|---------
-            A | Name    | Example
-            A | Country | France
+            Id | B       | C
+           ----|---------|---------
+            A  | Name    | Example
+            A  | Country | France
 
-         Result `table.cross_tab ['A'] 'B' (Aggregate_Column.First 'C')`:
+         Result `table.cross_tab ['Id'] 'B' (Aggregate_Column.First 'C')`:
 
-            A | Name    | Country
-           ---|---------|---------
-            A | Example | France
+            Id | Name    | Country
+           ----|---------|---------
+            A  | Example | France
     @group_by Widget_Helpers.make_column_name_vector_selector
     @name_column Widget_Helpers.make_column_name_selector
     @values (Widget_Helpers.make_aggregate_column_selector include_group_by=False)

--- a/distribution/lib/Standard/Searcher/0.0.0-dev/src/Data_Science.enso
+++ b/distribution/lib/Standard/Searcher/0.0.0-dev/src/Data_Science.enso
@@ -52,7 +52,7 @@
 
          example_sort =
              table = Examples.inventory_table
-             table.order_by ([Sort_Column.Name "total_stock", Sort_Column.Name "sold_stock" Sort_Direction.Descending])
+             table.order_by [Sort_Column.Name "total_stock", Sort_Column.Name "sold_stock" Sort_Direction.Descending]
 
    > Example
      Compute the number of transactions that each item has participated in, as

--- a/distribution/lib/Standard/Searcher/0.0.0-dev/src/Data_Science/Transform.enso
+++ b/distribution/lib/Standard/Searcher/0.0.0-dev/src/Data_Science/Transform.enso
@@ -31,7 +31,7 @@
 
          example_sort =
             table = Examples.inventory_table
-            table.order_by ([Sort_Column.Name "price" Sort_Direction.Descending])
+            table.order_by [Sort_Column.Name "price" Sort_Direction.Descending]
 
    > Example
      Add two columns to each other.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Aggregate_Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Aggregate_Column.enso
@@ -149,7 +149,7 @@ type Aggregate_Column
          not missing value returned.
        - order_by: required for database tables. Specifies how to order the
          results within the group.
-    First (column:Text|Integer|Column|Any=0) (new_name:Text|Nothing=Nothing) (ignore_nothing:Boolean=True) (order_by:(Text | Sort_Column | Vector (Text | Sort_Column) | Nothing)=Nothing) # Column needed because of 6866
+    First (column:Text|Integer|Column|Any=0) (new_name:Text|Nothing=Nothing) (ignore_nothing:Boolean=True) (order_by:(Text | Vector (Text | Sort_Column) | Nothing)=Nothing) # Column needed because of 6866
 
     ## Creates a new column with the last value in each group. If no rows,
        evaluates to `Nothing`.
@@ -162,7 +162,7 @@ type Aggregate_Column
          not missing value returned.
        - order_by: required for database tables. Specifies how to order the
          results within the group.
-    Last (column:Text|Integer|Column|Any=0) (new_name:Text|Nothing=Nothing) (ignore_nothing:Boolean=True) (order_by:(Text | Sort_Column | Vector (Text | Sort_Column) | Nothing)=Nothing) # Column needed because of 6866
+    Last (column:Text|Integer|Column|Any=0) (new_name:Text|Nothing=Nothing) (ignore_nothing:Boolean=True) (order_by:(Text | Vector (Text | Sort_Column) | Nothing)=Nothing) # Column needed because of 6866
 
     ## Creates a new column with the maximum value in each group. If no rows,
        evaluates to `Nothing`.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -904,7 +904,7 @@ type Column
             _ -> self.is_nothing
         result.rename new_name
 
-    ## ALIAS Fill Missing
+    ## ALIAS Fill Missing, if_nothing
 
        Returns a new column where missing values have been replaced with the
        provided default.
@@ -936,7 +936,7 @@ type Column
             col = Java_Column.new new_name new_st
             Column.Value col
 
-    ## ALIAS Fill Empty
+    ## ALIAS Fill Empty, if_empty
 
        Returns a new column where empty Text values have been replaced with the
        provided default.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -180,6 +180,7 @@ type Column
 
        Returns a column with results of comparing this column's elements against
        `other`.
+    @locale Locale.default_widget
     equals_ignore_case : Column | Any -> Locale -> Column
     equals_ignore_case self other locale=Locale.default =
         ## TODO currently this always runs the fallback which is slow due to the

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -1666,8 +1666,7 @@ type Column
     info : Table
     info self = self.to_table.info
 
-    ## UNSTABLE
-
+    ## ALIAS order_by
        Sorts the column according to the specified rules.
 
        Arguments:

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column_Vector_Extensions.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column_Vector_Extensions.enso
@@ -53,7 +53,7 @@ Column.compute_bulk self statistics=[Statistic.Count, Statistic.Sum] =
    Arguments:
    - statistic: Statistic to calculate.
    - name: Name of the new column.
-Column.running : Statistic -> Column
+Column.running : Statistic -> Text -> Column
 Column.running self statistic=Statistic.Count name=statistic.to_text+" "+self.name =
     data = Statistic.running self.to_vector statistic
     Column.from_vector name data

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Data_Formatter.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Data_Formatter.enso
@@ -129,6 +129,7 @@ type Data_Formatter
 
        Arguments:
        - locale: The locale to use when parsing dates and times.
+    @datetime_locale Locale.default_widget
     with_locale : Locale -> Data_Formatter
     with_locale self datetime_locale = self.clone datetime_locale=datetime_locale
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Join_Condition.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Join_Condition.enso
@@ -23,6 +23,7 @@ type Join_Condition
         - left: A name or index of a column in the left table.
         - right: A name or index of a column in the right table.
         - locale: The locale to use for case insensitive comparisons.
+    @locale Locale.default_widget
     Equals_Ignore_Case (left : Text | Integer) (right : Text | Integer = left) (locale : Locale = Locale.default)
 
     ## Correlates rows from the two tables if the `left` element fits between

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1260,7 +1260,7 @@ type Table
             _ : Date_Range -> Column.from_vector (new_name.if_nothing "Date Range") column.to_vector
             _ -> Error.throw (Illegal_Argument.Error "Unsupported type for `Table.set`.")
 
-        if resolved.length != self.row_count then Error.throw (Illegal_Argument.Error "The length of the column does not match the number of rows in the table.") else
+        if resolved.length != self.row_count then Error.throw (Row_Count_Mismatch.Error self.row_count resolved.length) else
             renamed = case new_name of
                Nothing -> resolved
                _ : Text -> resolved.rename new_name
@@ -1762,19 +1762,19 @@ type Table
 
          Input Table `table`:
 
-            A | Name    | Country
-           ---|---------|---------
-            A | Example | France
-            B | Another | Germany
+            Id | Name    | Country
+           ----|---------|---------
+            A  | Example | France
+            B  | Another | Germany
 
-         Result `table.transpose ['A'] 'Attribute' 'Value'`:
+         Result `table.transpose ['Id'] 'Attribute' 'Value'`:
 
-            A | Attribute | Value
-           ---|-----------|---------
-            A | Name      | Example
-            A | Country   | France
-            B | Name      | Another
-            B | Country   | Germany
+            Id | Attribute | Value
+           ----|-----------|---------
+            A  | Name      | Example
+            A  | Country   | France
+            B  | Name      | Another
+            B  | Country   | Germany
     @key_columns Widget_Helpers.make_column_name_vector_selector
     transpose : Vector (Integer | Text | Column_Selector) | Text | Integer -> Text -> Text -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Duplicate_Output_Column_Names
     transpose self (key_columns = []) (attribute_column_name="Name") (value_column_name="Value") (error_on_missing_columns=True) (on_problems = Report_Warning) =
@@ -1834,16 +1834,16 @@ type Table
 
          Input Table `table`:
 
-            A | B       | C
-           ---|---------|---------
-            A | Name    | Example
-            A | Country | France
+            Id | B       | C
+           ----|---------|---------
+            A  | Name    | Example
+            A  | Country | France
 
-         Result `table.cross_tab ['A'] 'B' (Aggregate_Column.First 'C')`:
+         Result `table.cross_tab ['Id'] 'B' (Aggregate_Column.First 'C')`:
 
-            A | Name    | Country
-           ---|---------|---------
-            A | Example | France
+            Id | Name    | Country
+           ----|---------|---------
+            A  | Example | France
     @group_by Widget_Helpers.make_column_name_vector_selector
     @name_column Widget_Helpers.make_column_name_selector
     @values (Widget_Helpers.make_aggregate_column_selector include_group_by=False)

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1078,7 +1078,7 @@ type Table
              people.filter "age" (age -> (age%10 == 0))
     @column Widget_Helpers.make_column_name_selector
     filter : (Column | Text | Integer) -> (Filter_Condition|(Any->Boolean)) -> Problem_Behavior -> Table ! No_Such_Column | Index_Out_Of_Bounds | Invalid_Value_Type
-    filter self column filter=(Filter_Condition.Is_True) on_problems=Report_Warning = case column of
+    filter self column filter=(Filter_Condition.Equal True) on_problems=Report_Warning = case column of
         _ : Column ->
             mask filter_column = Table.Value (self.java_table.mask filter_column.java_column)
             case filter of

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1259,18 +1259,20 @@ type Table
             _ : Range -> Column.from_vector (new_name.if_nothing "Range") column.to_vector
             _ : Date_Range -> Column.from_vector (new_name.if_nothing "Date Range") column.to_vector
             _ -> Error.throw (Illegal_Argument.Error "Unsupported type for `Table.set`.")
-        renamed = case new_name of
-           Nothing -> resolved
-           _ : Text -> resolved.rename new_name
-        check_add_mode = case set_mode of
-            Set_Mode.Add_Or_Update -> True
-            Set_Mode.Add -> if self.java_table.getColumnByName renamed.name . is_nothing then True else
-                Error.throw (Existing_Column.Error renamed.name)
-            Set_Mode.Update -> if self.java_table.getColumnByName renamed.name . is_nothing . not then True else
-                Error.throw (Missing_Column.Error renamed.name)
 
-        check_add_mode.if_not_error <|
-            Table.Value (self.java_table.addOrReplaceColumn renamed.java_column)
+        if resolved.length != self.row_count then Error.throw (Illegal_Argument.Error "The length of the column does not match the number of rows in the table.") else
+            renamed = case new_name of
+               Nothing -> resolved
+               _ : Text -> resolved.rename new_name
+            check_add_mode = case set_mode of
+                Set_Mode.Add_Or_Update -> True
+                Set_Mode.Add -> if self.java_table.getColumnByName renamed.name . is_nothing then True else
+                    Error.throw (Existing_Column.Error renamed.name)
+                Set_Mode.Update -> if self.java_table.getColumnByName renamed.name . is_nothing . not then True else
+                    Error.throw (Missing_Column.Error renamed.name)
+
+            check_add_mode.if_not_error <|
+                Table.Value (self.java_table.addOrReplaceColumn renamed.java_column)
 
     ## Given an expression, create a derived column where each value is the
        result of evaluating the expression for the row.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1732,14 +1732,14 @@ type Table
        value field.
 
        Arguments:
-       - id_fields: Set of fields to remain as columns. These values will be
+       - key_columns: Set of fields to remain as columns. These values will be
          repeated for each data field that is pivoted.
-       - name_field: The name of the field that will contain the names of the
-         pivoted fields. If this name is already in use, it will be renamed
-         with a numeric suffix.
-       - value_field: The name of the field that will contain the values of the
-         pivoted fields. If this name is already in use, it will be renamed
-         with a numeric suffix.
+       - attribute_column_name: The name of the field that will contain the
+         names of the pivoted fields. If this name is already in use, it will be
+         renamed with a numeric suffix.
+       - value_column_name: The name of the field that will contain the values
+         of the pivoted fields. If this name is already in use, it will be
+         renamed with a numeric suffix.
        - on_problems: Specifies how to handle problems if they occur, reporting
          them as warnings by default.
 
@@ -1755,14 +1755,14 @@ type Table
          - If any column names in the new table are clashing, a
            `Duplicate_Output_Column_Names` is reported according to the
            `on_problems` setting.
-    @id_fields Widget_Helpers.make_column_name_vector_selector
+    @key_columns Widget_Helpers.make_column_name_vector_selector
     transpose : Vector (Integer | Text | Column_Selector) | Text | Integer -> Text -> Text -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Duplicate_Output_Column_Names
-    transpose self (id_fields = []) (name_field="Name") (value_field="Value") (error_on_missing_columns=True) (on_problems = Report_Warning) =
+    transpose self (key_columns = []) (attribute_column_name="Name") (value_column_name="Value") (error_on_missing_columns=True) (on_problems = Report_Warning) =
         columns_helper = self.columns_helper
         unique = Unique_Name_Strategy.new
         problem_builder = Problem_Builder.new error_on_missing_columns=error_on_missing_columns
 
-        id_columns = columns_helper.select_columns_helper id_fields False problem_builder
+        id_columns = columns_helper.select_columns_helper key_columns False problem_builder
 
         selected_names = Map.from_vector (id_columns.map column-> [column.name, True])
 
@@ -1772,7 +1772,7 @@ type Table
         java_id = id_columns.map .java_column
 
         unique.mark_used (id_columns.map .name)
-        result = Table.Value (Java_Table.transpose java_id.to_array java_data.to_array (unique.make_unique name_field) (unique.make_unique value_field))
+        result = Table.Value (Java_Table.transpose java_id.to_array java_data.to_array (unique.make_unique attribute_column_name) (unique.make_unique value_column_name))
         problem_builder.report_unique_name_strategy unique
 
         problem_builder.attach_problems_after on_problems result
@@ -1794,7 +1794,7 @@ type Table
 
        ! Error Conditions
 
-         - If a column in `group_by` or `name_field` is not in the input table,
+         - If a column in `group_by` or `name_column` is not in the input table,
            a `Missing_Input_Columns` is raised as a dataflow error.
          - If a column selector in `values` given as a `Text` and it does not
            match any columns in the input table nor is it a valid expression, an

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1757,6 +1757,24 @@ type Table
          - If any column names in the new table are clashing, a
            `Duplicate_Output_Column_Names` is reported according to the
            `on_problems` setting.
+
+       ? Example Transpose Operation
+
+         Input Table `table`:
+
+            A | Name    | Country
+           ---|---------|---------
+            A | Example | France
+            B | Another | Germany
+
+         Result `table.transpose ['A'] 'Attribute' 'Value'`:
+
+            A | Attribute | Value
+           ---|-----------|---------
+            A | Name      | Example
+            A | Country   | France
+            B | Name      | Another
+            B | Country   | Germany
     @key_columns Widget_Helpers.make_column_name_vector_selector
     transpose : Vector (Integer | Text | Column_Selector) | Text | Integer -> Text -> Text -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Missing_Input_Columns | Duplicate_Output_Column_Names
     transpose self (key_columns = []) (attribute_column_name="Name") (value_column_name="Value") (error_on_missing_columns=True) (on_problems = Report_Warning) =
@@ -1811,6 +1829,21 @@ type Table
              an `Unquoted_Delimiter`
            - If there are more than 10 issues with a single column,
              an `Additional_Warnings`.
+
+       ? Example Cross Tab Operation
+
+         Input Table `table`:
+
+            A | B       | C
+           ---|---------|---------
+            A | Name    | Example
+            A | Country | France
+
+         Result `table.cross_tab ['A'] 'B' (Aggregate_Column.First 'C')`:
+
+            A | Name    | Country
+           ---|---------|---------
+            A | Example | France
     @group_by Widget_Helpers.make_column_name_vector_selector
     @name_column Widget_Helpers.make_column_name_selector
     @values (Widget_Helpers.make_aggregate_column_selector include_group_by=False)

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Delimited/Delimited_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Delimited/Delimited_Format.enso
@@ -8,6 +8,8 @@ import project.Delimited.Quote_Style.Quote_Style
 import project.Internal.Delimited_Reader
 import project.Internal.Delimited_Writer
 
+from Standard.Base.Widget_Helpers import make_delimiter_selector
+
 ## Read delimited files such as CSVs into a Table.
 type Delimited_Format
     ## Read delimited files such as CSVs into a Table.
@@ -49,6 +51,8 @@ type Delimited_Format
          character if it anywhere else than at the beginning of the line. This
          option is only applicable for read mode and does not affect writing. It
          defaults to `Nothing` which means that comments are disabled.
+    @delimiter make_delimiter_selector
+    @encoding Encoding.default_widget
     Delimited (delimiter:Text=',') (encoding:Encoding=Encoding.utf_8) (skip_rows:Integer=0) (row_limit:Integer|Nothing=Nothing) (quote_style:Quote_Style=Quote_Style.With_Quotes) (headers:Boolean|Infer=Infer) (value_formatter:Data_Formatter|Nothing=Data_Formatter.Value) (keep_invalid_rows:Boolean=True) (line_endings:Line_Ending_Style|Infer=Infer) (comment_character:Text|Nothing=Nothing)
 
     ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -398,7 +398,7 @@ filter_blank_rows table when_any treat_nans_as_blank =
             merge = if when_any then (||) else (&&)
             missing_mask = cols.map (_.is_blank treat_nans_as_blank) . reduce merge
             non_missing_mask = missing_mask.not
-            table.filter non_missing_mask
+            table.filter non_missing_mask Filter_Condition.Is_True
         False -> table
 
 ## PRIVATE

--- a/test/Table_Tests/src/Common_Table_Operations/Cross_Tab_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Cross_Tab_Spec.enso
@@ -104,7 +104,7 @@ spec setup =
             t1.at "z Count" . to_vector . should_equal [2]
             t1.at "z Sum" . to_vector . should_equal [17]
 
-        Test.specify "should fail if name_field is not found" <|
+        Test.specify "should fail if name_column is not found" <|
             err1 = table.cross_tab [] "Name"
             err1.should_fail_with Missing_Input_Columns
             err1.catch.criteria . should_equal ["Name"]

--- a/test/Table_Tests/src/Common_Table_Operations/Order_By_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Order_By_Spec.enso
@@ -56,19 +56,19 @@ spec setup =
             t1.at "gamma" . to_vector . should_equal [4, 3, 2, 1]
 
         Test.specify "should work with single Sort_Column" <|
-            t1 = table.order_by (Sort_Column.Name "alpha")
+            t1 = table.order_by [Sort_Column.Name "alpha"]
             t1.at "alpha" . to_vector . should_equal [0, 1, 2, 3]
             t1.at "gamma" . to_vector . should_equal [4, 3, 2, 1]
 
-            t2 = t1.order_by (Sort_Column.Name "alpha" Sort_Direction.Descending)
+            t2 = t1.order_by [Sort_Column.Name "alpha" Sort_Direction.Descending]
             t2.at "alpha" . to_vector . should_equal [3, 2, 1, 0]
             t2.at "gamma" . to_vector . should_equal [1, 2, 3, 4]
 
-            t3 = table.order_by (Sort_Column.Index 0)
+            t3 = table.order_by [Sort_Column.Index 0]
             t3.at "alpha" . to_vector . should_equal [0, 1, 2, 3]
             t3.at "gamma" . to_vector . should_equal [4, 3, 2, 1]
 
-            t4 = t3.order_by (Sort_Column.Index 0 Sort_Direction.Descending)
+            t4 = t3.order_by [Sort_Column.Index 0 Sort_Direction.Descending]
             t4.at "alpha" . to_vector . should_equal [3, 2, 1, 0]
             t4.at "gamma" . to_vector . should_equal [1, 2, 3, 4]
 

--- a/test/Table_Tests/src/Common_Table_Operations/Transpose_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Transpose_Spec.enso
@@ -24,7 +24,7 @@ spec setup =
 
         Test.specify "should allow custom names" <|
             t = table_builder [["Key", ["x", "y", "z"]], ["Value", [1, 2, 3]], ["Another", [10, Nothing, 20]], ["Yet Another", [Nothing, "Hello", "World"]]]
-            t1 = t.transpose name_field="Key" value_field="Object"
+            t1 = t.transpose attribute_column_name="Key" value_column_name="Object"
             t1.row_count . should_equal 12
             t1.column_count . should_equal 2
             t1.at "Key" . to_vector . should_equal ["Key", "Value", "Another", "Yet Another", "Key", "Value", "Another", "Yet Another", "Key", "Value", "Another", "Yet Another"]
@@ -96,19 +96,19 @@ spec setup =
         Test.specify "should warn on column name clashes" <|
             t1 = table_builder [["X", ["x", "y", "z"]], ["Y", [1, 2, 3]], ["Z", [10, Nothing, 20]]]
 
-            action1 = t1.transpose ["X", "Y", "Z"] name_field="Y" value_field="Z" on_problems=_
+            action1 = t1.transpose ["X", "Y", "Z"] attribute_column_name="Y" value_column_name="Z" on_problems=_
             tester1 table =
                 table.column_names . should_equal ["X", "Y", "Z", "Y 1", "Z 1"]
             problems1 = [Duplicate_Output_Column_Names.Error ["Y", "Z"]]
             Problems.test_problem_handling action1 problems1 tester1
 
-            action2 = t1.transpose ["X"] name_field="F" value_field="F" on_problems=_
+            action2 = t1.transpose ["X"] attribute_column_name="F" value_column_name="F" on_problems=_
             tester2 table =
                 table.column_names . should_equal ["X", "F", "F 1"]
             problems2 = [Duplicate_Output_Column_Names.Error ["F"]]
             Problems.test_problem_handling action2 problems2 tester2
 
             # No clash with the columns that are removed by transpose.
-            t2 = t1.transpose ["X"] name_field="Y" value_field="Z" on_problems=Problem_Behavior.Report_Error
+            t2 = t1.transpose ["X"] attribute_column_name="Y" value_column_name="Z" on_problems=Problem_Behavior.Report_Error
             Problems.assume_no_problems t2
             t2.column_names . should_equal ["X", "Y", "Z"]

--- a/test/Table_Tests/src/In_Memory/Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Spec.enso
@@ -8,7 +8,7 @@ from Standard.Table import Table, Column, Sort_Column, Column_Selector, Aggregat
 import Standard.Table.Main as Table_Module
 from Standard.Table.Data.Aggregate_Column.Aggregate_Column import all hiding First, Last
 import Standard.Table.Data.Type.Value_Type.Value_Type
-from Standard.Table.Errors import Invalid_Output_Column_Names, Duplicate_Output_Column_Names, No_Input_Columns_Selected, Missing_Input_Columns, No_Such_Column, Floating_Point_Equality, Invalid_Value_Type
+from Standard.Table.Errors import Invalid_Output_Column_Names, Duplicate_Output_Column_Names, No_Input_Columns_Selected, Missing_Input_Columns, No_Such_Column, Floating_Point_Equality, Invalid_Value_Type, Row_Count_Mismatch
 
 import Standard.Visualization
 
@@ -880,10 +880,10 @@ spec =
             t = Table.new [["X", [1, 2, 3]]]
 
             c = Column.from_vector "Column" [10, 20]
-            t.set c . should_fail_with Illegal_Argument
-            t.set [10, 20] . should_fail_with Illegal_Argument
-            t.set (100.up_to 102) . should_fail_with Illegal_Argument
-            t.set ((Date.new 2020 1 1).up_to (Date.new 2020 1 3)) . should_fail_with Illegal_Argument
+            t.set c . should_fail_with Row_Count_Mismatch
+            t.set [10, 20] . should_fail_with Row_Count_Mismatch
+            t.set (100.up_to 102) . should_fail_with Row_Count_Mismatch
+            t.set ((Date.new 2020 1 1).up_to (Date.new 2020 1 3)) . should_fail_with Row_Count_Mismatch
 
 main = Test_Suite.run_main spec
 

--- a/test/Table_Tests/src/In_Memory/Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Spec.enso
@@ -860,6 +860,31 @@ spec =
             r.should_fail_with Illegal_Argument
             r.catch.message . contains "cross-backend" . should_be_true
 
+    Test.group "[In-Memory-specific] Table.set" <|
+        Test.specify "should allow using vector and range for a new column" <|
+            t = Table.new [["X", [1, 2, 3]]]
+
+            t_vec = t.set [10, 20, 30]
+            t_vec.column_names.should_equal ["X", "Vector"]
+            t_vec.at "Vector" . to_vector . should_equal [10, 20, 30]
+
+            t_range = t.set (100.up_to 103)
+            t_range.column_names.should_equal ["X", "Range"]
+            t_range.at "Range" . to_vector . should_equal [100, 101, 102]
+
+            t_date_range = t.set ((Date.new 2020 1 1).up_to (Date.new 2020 1 4))
+            t_date_range.column_names.should_equal ["X", "Date Range"]
+            t_date_range.at "Date Range" . to_vector . should_equal [Date.new 2020 1 1, Date.new 2020 1 2, Date.new 2020 1 3]
+
+        Test.specify "should fail if there is a length mismatch on a new column" <|
+            t = Table.new [["X", [1, 2, 3]]]
+
+            c = Column.from_vector "Column" [10, 20]
+            t.set c . should_fail_with Illegal_Argument
+            t.set [10, 20] . should_fail_with Illegal_Argument
+            t.set (100.up_to 102) . should_fail_with Illegal_Argument
+            t.set ((Date.new 2020 1 1).up_to (Date.new 2020 1 3)) . should_fail_with Illegal_Argument
+
 main = Test_Suite.run_main spec
 
 ## JS indexes months form 0, so we need to subtract 1.

--- a/test/Visualization_Tests/src/SQL_Spec.enso
+++ b/test/Visualization_Tests/src/SQL_Spec.enso
@@ -12,7 +12,7 @@ visualization_spec connection =
     t = connection.query (SQL_Query.Table_Name "T")
     Test.group "SQL Visualization" <|
         Test.specify "should provide type metadata for interpolations" <|
-            q = t.filter ((t.at "B" == 2) && (t.at "A" == True)) . at "C"
+            q = t.filter ((t.at "B" == 2) && (t.at "A" == True)) Filter_Condition.Is_True . at "C"
             vis = Visualization.prepare_visualization q
             int_param = JS_Object.from_pairs [["value", 2], ["enso_type", "Standard.Base.Data.Numbers.Integer"]]
             str_param = JS_Object.from_pairs [["value", True], ["enso_type", "Standard.Base.Data.Boolean.Boolean"]]


### PR DESCRIPTION
### Pull Request Description

- Add the missing dropdowns for `Locale` and `Encoding`.
- Correct a few mismatched type signatures.
- Adjust `order_by` calls with a single `Sort_Column` to call in a Vector.
- Adjust parameter names for `transpose`.
- Fix for the table viz: escape HTML and `suppressFieldDotNotation`.
- Use `Filter_Condition.Equal True` for the default filter.
- Adjust `Data.fetch` to return the response on success when parse fails. Rename `parse` to `try_auto_parse`.
- Add various aliases for methods.
- Add tests for `Table.set` when using a `Vector`, `Range` or `Date_Range`.
- Add check for mismatched length on `Table.set`.

![image](https://github.com/enso-org/enso/assets/4699705/23ea0ba3-2b05-4af8-afd9-f35b55446c24)

![image](https://github.com/enso-org/enso/assets/4699705/8b0253e6-e9e8-490a-9607-0da51ab5a215)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
