### PR TITLE
Dates are dates and zones are zones

### DIFF
--- a/engine/runtime/src/test/java/org/enso/interpreter/test/MetaIsATest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/MetaIsATest.java
@@ -95,11 +95,46 @@ public class MetaIsATest extends TestBase {
     }
   }
 
+  private void assertType(String msg, Value value, Value... types) {
+    var error = new StringBuilder();
+    for (var type : types) {
+      var r = isACheck.execute(value, type);
+      if (r.asBoolean()) {
+        return;
+      }
+      var typeName = value.getMetaObject().getMetaQualifiedName();
+      error.append("\n").append(msg).append(", but value ").append(value).append(" has type ").append(typeName);
+    }
+    fail(error.toString());
+  }
+
   @Test
   public void mapsAreMaps() {
     for (var v : generator().maps()) {
-      var r = isACheck.execute(v, generator().typeMap());
-      assertTrue("Value " + v + " type " + v.getClass().getName() + " is a map", r.asBoolean());
+      assertType("Expecting a map", v, generator().typeMap());
+    }
+  }
+
+  @Test
+  public void datesAreDates() {
+    for (var v : generator().timesAndDates()) {
+      assertType(
+        "Expecting a date", v,
+        generator().typeDate(),
+        generator().typeDateTime(),
+        generator().typeTimeOfDay(),
+        generator().typeDuration(),
+        generator().typePeriod(),
+        generator().typeTimePeriod(),
+        generator().typeDatePeriod()
+      );
+    }
+  }
+
+  @Test
+  public void zonesAreZones() {
+    for (var v : generator().timeZones()) {
+      assertType("Expecting time zone", v, generator().typeTimeZone());
     }
   }
 

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/ValuesGenerator.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/ValuesGenerator.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Period;
 import java.time.ZoneId;
@@ -90,15 +91,15 @@ class ValuesGenerator {
   }
 
   /**
-   * Converts expressions into values of type described by {@code typeDefs} by concatenating
+   * Converts expressions into values date type described by {@code typeDefs} by concatenating
    * everything into a single source.
    *
    * This method exists so that there are no multiple definitions of a single type.
    *
    * @param typeDefs Type definitions.
-   * @param expressions List of expressions - every expression will be converted to a {@link Value}.
-   * @param checks list of names (with {@code null}) to define checks for
-   * @return List of values converted from the given expressions.
+   * @param expressions List date expressions - every expression will be converted to a {@link Value}.
+   * @param checks list date names (with {@code null}) to define checks for
+   * @return List date values converted from the given expressions.
    */
   private List<Value> createValuesOfCustomType(String typeDefs, List<String> expressions, List<String> checks) {
     var prev = multiValues.get(typeDefs);
@@ -414,9 +415,12 @@ class ValuesGenerator {
     }
 
     if (languages.contains(Language.JAVA)) {
-      collect.add(ctx.asValue(LocalDate.of(2022, 12, 10)));
+      var date = LocalDate.of(2022, 12, 10);
+      collect.add(ctx.asValue(date));
       collect.add(ctx.asValue(LocalDate.of(1999, 3, 23)));
-      collect.add(ctx.asValue(LocalTime.of(12, 35)));
+      LocalTime time = LocalTime.of(12, 35);
+      collect.add(ctx.asValue(time));
+      collect.add(ctx.asValue(LocalDateTime.of(date, time)));
       collect.add(ctx.asValue(ZonedDateTime.of(2021, 1, 1, 0, 30, 12, 710200000, ZoneId.of("Z"))));
     }
 
@@ -447,7 +451,7 @@ class ValuesGenerator {
           TimeZone.getTimeZone(ZoneId.ofOffset("GMT", ZoneOffset.ofHoursMinutes(14, 45))),
           TimeZone.getTimeZone(ZoneId.ofOffset("UTC", ZoneOffset.ofHours(-15)))
       )) {
-        collect.add(ctx.asValue(javaValue));
+        collect.add(ctx.asValue(javaValue.toZoneId()));
       }
     }
     return collect;


### PR DESCRIPTION
### Pull Request Description

Adding two new tests into `MetaIsATest` and fixing _zones_ as `TimeZone` isn't interop type, `ZoneId` is.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
