### PR TITLE
Throw panic on "no currying for conversions"

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Common.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Common.enso
@@ -324,6 +324,31 @@ type No_Such_Conversion
     to_display_text self = "Could not find a conversion from `"+self.that.to_display_text+"` to `"+self.target.to_display_text+"`."
 
 @Builtin_Type
+type No_Conversion_Currying
+    ## PRIVATE
+       An error that occurs when an attempt is made to curry a conversion function.
+
+       Arguments:
+       - has_this: true, when `this` argument is present
+       - has_that: true, when `that` argument is present
+       - conversion: the conversion that was attempted.
+    Error has_this has_that conversion
+
+    ## PRIVATE
+       Convert the No_Conversion_Currying error to a human-readable format.
+    to_display_text : Text
+    to_display_text self =
+      case self.has_this of
+          True ->
+              case self.has_that of
+                    True -> "Conversion currying is not supported."
+                    False -> "Conversion currying without `that` argument is not supported."
+          False ->
+              case self.has_that of
+                  True -> "Conversion currying without `this` argument is not supported."
+                  False -> "Conversion currying without `this` and `that` arguments is not supported."
+
+@Builtin_Type
 type Forbidden_Operation
     ## PRIVATE
        An error that occurs when the action is not allowed to perform the operation in the given context.

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InvokeCallableNode.java
@@ -224,8 +224,8 @@ public abstract class InvokeCallableNode extends BaseNode {
           callerFrame, state, conversion, selfArgument, thatArgument, arguments);
     } else {
       CompilerDirectives.transferToInterpreter();
-      throw new RuntimeException(
-          "Conversion currying without `this` or `that` argument is not supported.");
+      var ctx = EnsoContext.get(this);
+      throw new PanicException(ctx.getBuiltins().error().makeNoConversionCurrying(canApplyThis, canApplyThat, conversion), this);
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/NoConversionCurrying.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/error/NoConversionCurrying.java
@@ -1,0 +1,19 @@
+package org.enso.interpreter.node.expression.builtin.error;
+
+import org.enso.interpreter.dsl.BuiltinType;
+import org.enso.interpreter.node.expression.builtin.UniquelyConstructibleBuiltin;
+
+import java.util.List;
+
+@BuiltinType
+public class NoConversionCurrying extends UniquelyConstructibleBuiltin {
+  @Override
+  protected String getConstructorName() {
+    return "Error";
+  }
+
+  @Override
+  protected List<String> getConstructorParamNames() {
+    return List.of("has_this", "has_that", "conversion");
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Error.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Error.java
@@ -25,6 +25,7 @@ public class Error {
   private final UninitializedState uninitializedState;
   private final NoSuchMethod noSuchMethod;
   private final NoSuchConversion noSuchConversion;
+  private final NoConversionCurrying noConversionCurrying;
   private final ModuleNotInPackageError moduleNotInPackageError;
   private final ArithmeticError arithmeticError;
   private final InvalidArrayIndex invalidArrayIndex;
@@ -60,6 +61,7 @@ public class Error {
     uninitializedState = builtins.getBuiltinType(UninitializedState.class);
     noSuchMethod = builtins.getBuiltinType(NoSuchMethod.class);
     noSuchConversion = builtins.getBuiltinType(NoSuchConversion.class);
+    noConversionCurrying = builtins.getBuiltinType(NoConversionCurrying.class);
     moduleNotInPackageError = builtins.getBuiltinType(ModuleNotInPackageError.class);
     arithmeticError = builtins.getBuiltinType(ArithmeticError.class);
     invalidArrayIndex = builtins.getBuiltinType(InvalidArrayIndex.class);
@@ -134,6 +136,11 @@ public class Error {
 
   public Atom makeInvalidConversionTarget(Object target) {
     return invalidConversionTarget.newInstance(target);
+  }
+
+  public Atom makeNoConversionCurrying(
+      boolean hasThis, boolean hasThat, UnresolvedConversion conversion) {
+    return noConversionCurrying.newInstance(hasThis, hasThat, conversion);
   }
 
   /**

--- a/test/Tests/src/Semantic/Conversion_Spec.enso
+++ b/test/Tests/src/Semantic/Conversion_Spec.enso
@@ -112,4 +112,7 @@ spec =
             meta_from.rename "foo" 123 . should_equal "foo called"
             meta_from.rename "foo" . should_equal .foo
 
+        Test.specify "should not allow currying" <|
+            Panic.recover Any (Foo.from) . catch Any .to_display_text . should_equal "Conversion currying without `that` argument is not supported."
+
 main = Test_Suite.run_main spec


### PR DESCRIPTION
### Pull Request Description

Previously, a `RuntimeException` would be thrown when an attempt would be made to curry a conversion function. That is problematic for IDE where `executionFailed` means we can't enter functions due to lack of method pointers info.

Closes #6897.

![Screenshot from 2023-06-02 20-31-03](https://github.com/enso-org/enso/assets/292128/a6c77544-2c47-425c-8ce0-982d837dda5b)


### Important Notes

A more generic solution that allows to recover from execution failures will need a follow up.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
