### PR TITLE
Create execution context with id

### DIFF
--- a/app/gui/controller/engine-protocol/src/language_server.rs
+++ b/app/gui/controller/engine-protocol/src/language_server.rs
@@ -118,7 +118,7 @@ trait API {
     /// Create a new execution context. Return capabilities executionContext/canModify and
     /// executionContext/receivesUpdates containing freshly created ContextId
     #[MethodInput=CreateExecutionContextInput, rpc_name="executionContext/create"]
-    fn create_execution_context(&self) -> response::CreateExecutionContext;
+    fn create_execution_context(&self, context_id: ContextId) -> response::CreateExecutionContext;
 
     /// Destroy an execution context and free its resources.
     #[MethodInput=DestroyExecutionContextInput, rpc_name="executionContext/destroy"]

--- a/app/gui/controller/engine-protocol/src/language_server/tests.rs
+++ b/app/gui/controller/engine-protocol/src/language_server/tests.rs
@@ -373,9 +373,9 @@ fn test_execution_context() {
     let create_execution_context_response =
         response::CreateExecutionContext { context_id, can_modify, receives_updates };
     test_request(
-        |client| client.create_execution_context(),
+        |client| client.create_execution_context(&context_id),
         "executionContext/create",
-        json!({}),
+        json!({"contextId":"00000000-0000-0000-0000-000000000000"}),
         json!({
             "contextId" : "00000000-0000-0000-0000-000000000000",
             "canModify" : {

--- a/app/gui/src/controller/graph/executed.rs
+++ b/app/gui/src/controller/graph/executed.rs
@@ -97,12 +97,9 @@ pub struct Handle {
 impl Handle {
     /// Create handle for the executed graph that will be running the given method.
     #[profile(Task)]
-    pub async fn new(
-        project: model::Project,
-        method: MethodPointer,
-        context_id: model::execution_context::Id,
-    ) -> FallibleResult<Self> {
+    pub async fn new(project: model::Project, method: MethodPointer) -> FallibleResult<Self> {
         let graph = controller::Graph::new_method(&project, &method).await?;
+        let context_id = Uuid::new_v4();
         let execution = project.create_execution_context(method.clone(), context_id).await?;
         Ok(Self::new_internal(graph, project, execution))
     }
@@ -486,9 +483,7 @@ pub mod tests {
             let suggestion_db = self.graph.suggestion_db();
             model::project::test::expect_suggestion_db(&mut project, suggestion_db);
             let project = Rc::new(project);
-            Handle::new(project.clone_ref(), method, test::mock::data::CONTEXT_ID)
-                .boxed_local()
-                .expect_ok()
+            Handle::new(project.clone_ref(), method).boxed_local().expect_ok()
         }
     }
 

--- a/app/gui/src/controller/graph/executed.rs
+++ b/app/gui/src/controller/graph/executed.rs
@@ -97,9 +97,13 @@ pub struct Handle {
 impl Handle {
     /// Create handle for the executed graph that will be running the given method.
     #[profile(Task)]
-    pub async fn new(project: model::Project, method: MethodPointer) -> FallibleResult<Self> {
+    pub async fn new(
+        project: model::Project,
+        method: MethodPointer,
+        context_id: model::execution_context::Id,
+    ) -> FallibleResult<Self> {
         let graph = controller::Graph::new_method(&project, &method).await?;
-        let execution = project.create_execution_context(method.clone()).await?;
+        let execution = project.create_execution_context(method.clone(), context_id).await?;
         Ok(Self::new_internal(graph, project, execution))
     }
 
@@ -482,7 +486,9 @@ pub mod tests {
             let suggestion_db = self.graph.suggestion_db();
             model::project::test::expect_suggestion_db(&mut project, suggestion_db);
             let project = Rc::new(project);
-            Handle::new(project.clone_ref(), method).boxed_local().expect_ok()
+            Handle::new(project.clone_ref(), method, test::mock::data::CONTEXT_ID)
+                .boxed_local()
+                .expect_ok()
         }
     }
 

--- a/app/gui/src/controller/project.rs
+++ b/app/gui/src/controller/project.rs
@@ -131,7 +131,7 @@ impl Project {
         // clients that we currently do not support) that main module exists and contains main
         // method. Thus, we should be able to successfully create a graph controller for it.
         let main_module_text = controller::Text::new(&project, file_path).await?;
-        let main_graph = controller::ExecutedGraph::new(project, method).await?;
+        let main_graph = controller::ExecutedGraph::new(project, method, Uuid::new_v4()).await?;
 
         self.init_call_stack_from_metadata(&main_module_model, &main_graph).await;
         self.notify_about_compiling_process(&main_graph);

--- a/app/gui/src/controller/project.rs
+++ b/app/gui/src/controller/project.rs
@@ -131,7 +131,7 @@ impl Project {
         // clients that we currently do not support) that main module exists and contains main
         // method. Thus, we should be able to successfully create a graph controller for it.
         let main_module_text = controller::Text::new(&project, file_path).await?;
-        let main_graph = controller::ExecutedGraph::new(project, method, Uuid::new_v4()).await?;
+        let main_graph = controller::ExecutedGraph::new(project, method).await?;
 
         self.init_call_stack_from_metadata(&main_module_model, &main_graph).await;
         self.notify_about_compiling_process(&main_graph);

--- a/app/gui/src/model/execution_context/synchronized.rs
+++ b/app/gui/src/model/execution_context/synchronized.rs
@@ -66,10 +66,11 @@ impl ExecutionContext {
     pub fn create(
         language_server: Rc<language_server::Connection>,
         root_definition: language_server::MethodPointer,
+        id: model::execution_context::Id,
     ) -> impl Future<Output = FallibleResult<Self>> {
         async move {
             info!("Creating.");
-            let id = language_server.client.create_execution_context().await?.context_id;
+            let id = language_server.client.create_execution_context(&id).await?.context_id;
             let model = model::execution_context::Plain::new(root_definition);
             info!("Created. Id: {id}.");
             let this = Self { id, model, language_server };
@@ -415,7 +416,7 @@ pub mod test {
             let connection = language_server::Connection::new_mock_rc(ls_client);
             let mut test = TestWithLocalPoolExecutor::set_up();
             let method = data.main_method_pointer();
-            let context = ExecutionContext::create(connection, method);
+            let context = ExecutionContext::create(connection, method, data.context_id);
             let context = test.expect_completion(context).unwrap();
             Fixture { data, context, test }
         }
@@ -434,7 +435,7 @@ pub mod test {
         fn mock_create_destroy_calls(data: &MockData, ls: &mut language_server::MockClient) {
             let id = data.context_id;
             let result = Self::expected_creation_response(data);
-            expect_call!(ls.create_execution_context()    => Ok(result));
+            expect_call!(ls.create_execution_context(id)  => Ok(result));
             expect_call!(ls.destroy_execution_context(id) => Ok(()));
         }
 

--- a/app/gui/src/model/project.rs
+++ b/app/gui/src/model/project.rs
@@ -85,6 +85,7 @@ pub trait API: Debug {
     fn create_execution_context<'a>(
         &'a self,
         root_definition: language_server::MethodPointer,
+        context_id: model::execution_context::Id,
     ) -> BoxFuture<'a, FallibleResult<model::ExecutionContext>>;
 
     /// Set a new project name.
@@ -234,8 +235,10 @@ pub mod test {
         let ctx2 = ctx.clone_ref();
         project
             .expect_create_execution_context()
-            .withf_st(move |root_definition| root_definition == &ctx.current_method())
-            .returning_st(move |_root_definition| ready(Ok(ctx2.clone_ref())).boxed_local());
+            .withf_st(move |root_definition, _context_id| root_definition == &ctx.current_method())
+            .returning_st(move |_root_definition, _context_id| {
+                ready(Ok(ctx2.clone_ref())).boxed_local()
+            });
     }
 
     /// Sets up project root id expectation on the mock project, returning a given id.

--- a/app/gui/src/model/project/synchronized.rs
+++ b/app/gui/src/model/project/synchronized.rs
@@ -704,10 +704,10 @@ impl model::project::API for Project {
     fn create_execution_context(
         &self,
         root_definition: MethodPointer,
+        context_id: execution_context::Id,
     ) -> BoxFuture<FallibleResult<model::ExecutionContext>> {
         async move {
             let ls_rpc = self.language_server_rpc.clone_ref();
-            let context_id = Uuid::new_v4();
             let context =
                 execution_context::Synchronized::create(ls_rpc, root_definition, context_id);
             let context = Rc::new(context.await?);
@@ -930,7 +930,8 @@ mod test {
         assert!(result1.is_err());
 
         // Create execution context.
-        let execution = project.create_execution_context(context_data.main_method_pointer());
+        let execution = project
+            .create_execution_context(context_data.main_method_pointer(), context_data.context_id);
         let execution = test.expect_completion(execution).unwrap();
 
         // Now context is in registry.

--- a/app/gui/src/model/project/synchronized.rs
+++ b/app/gui/src/model/project/synchronized.rs
@@ -707,7 +707,9 @@ impl model::project::API for Project {
     ) -> BoxFuture<FallibleResult<model::ExecutionContext>> {
         async move {
             let ls_rpc = self.language_server_rpc.clone_ref();
-            let context = execution_context::Synchronized::create(ls_rpc, root_definition);
+            let context_id = Uuid::new_v4();
+            let context =
+                execution_context::Synchronized::create(ls_rpc, root_definition, context_id);
             let context = Rc::new(context.await?);
             self.execution_contexts.insert(context.clone_ref());
             let context: model::ExecutionContext = context;

--- a/app/gui/tests/language_server.rs
+++ b/app/gui/tests/language_server.rs
@@ -357,7 +357,9 @@ async fn binary_visualization_updates_test_hlp() {
     let module = project.module(module_path).await.unwrap();
     info!("Got module: {module:?}");
     let context_id = Uuid::new_v4();
-    let graph_executed = controller::ExecutedGraph::new(project, method, context_id).await.unwrap();
+    let execution_ctx = project.create_execution_context(method.clone(), context_id).await.unwrap();
+    let graph = controller::Graph::new_method(&project, &method).await.unwrap();
+    let graph_executed = controller::ExecutedGraph::new_internal(graph, project, execution_ctx);
 
     let the_node = graph_executed.graph().nodes().unwrap()[0].info.clone();
     graph_executed.graph().set_expression(the_node.id(), "10+20").unwrap();

--- a/app/gui/tests/language_server.rs
+++ b/app/gui/tests/language_server.rs
@@ -356,7 +356,8 @@ async fn binary_visualization_updates_test_hlp() {
     let module_qualified_name = project.qualified_module_name(&module_path);
     let module = project.module(module_path).await.unwrap();
     info!("Got module: {module:?}");
-    let graph_executed = controller::ExecutedGraph::new(project, method).await.unwrap();
+    let context_id = Uuid::new_v4();
+    let graph_executed = controller::ExecutedGraph::new(project, method, context_id).await.unwrap();
 
     let the_node = graph_executed.graph().nodes().unwrap()[0].info.clone();
     graph_executed.graph().set_expression(the_node.id(), "10+20").unwrap();

--- a/app/gui/tests/language_server.rs
+++ b/app/gui/tests/language_server.rs
@@ -95,7 +95,7 @@ async fn ls_text_protocol_test() {
     response.expect("Couldn't write yaml file.");
 
     // Setting execution context.
-    let execution_context = client.create_execution_context().await;
+    let execution_context = client.create_execution_context(&Uuid::new_v4()).await;
     let execution_context = execution_context.expect("Couldn't create execution context.");
     let execution_context_id = execution_context.context_id;
 

--- a/integration-test/tests/engine.rs
+++ b/integration-test/tests/engine.rs
@@ -53,7 +53,7 @@ async fn getting_component_groups() {
     let test = TestOnNewProjectControllersOnly::set_up().await;
     let ls_json_connection = test.project.json_rpc();
     let main_module = test.project.main_module().to_string();
-    let execution_ctx = ls_json_connection.create_execution_context().await.unwrap();
+    let execution_ctx = ls_json_connection.create_execution_context(&Uuid::new_v4()).await.unwrap();
     let frame = StackItem::ExplicitCall(ExplicitCall {
         method_pointer:                   MethodPointer {
             module:          main_module.clone(),


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

`executionContext/create` method has an optional `context_id` parameter. Supplying this argument makes the user's session more reproducible. I.e. this way the language server can recreate the user's session by recording the requests.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
