### PR TITLE
Workaround for `to_date_time` type errors

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
@@ -423,7 +423,8 @@ type Date
 
              example_to_time = Date.new 2020 2 3 . to_date_time Time_Of_Day.new Time_Zone.utc
     to_date_time : Time_Of_Day -> Time_Zone -> Date_Time
-    to_date_time self (time_of_day=Time_Of_Day.new) (zone=Time_Zone.system) = self.to_time_builtin time_of_day zone
+    to_date_time self (time_of_day=Time_Of_Day.new) (zone=Time_Zone.system) =
+        Time_Utils.make_zoned_date_time self time_of_day zone
 
     ## ALIAS Add Period
        Add the specified amount of time to this instant to get another date.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
@@ -499,7 +499,8 @@ type Date_Time
 
              example_at_zone = Date_Time.new 2020 . at_zone (Time_Zone.new -4)
     at_zone : Time_Zone -> Date_Time
-    at_zone self zone = @Builtin_Method "Date_Time.at_zone"
+    at_zone self zone =
+        Time_Utils.with_zone_same_instant self zone
 
     ## ALIAS Add Period, Add Duration
        Add the specified amount of time to this instant to produce a new instant.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
@@ -251,7 +251,8 @@ type Time_Of_Day
 
              example_to_time = Time_Of_Day.new 12 30 . to_time (Date.new 2020)
     to_date_time : Date -> Time_Zone -> Date_Time
-    to_date_time self date (zone=Time_Zone.system) = self.to_date_time_builtin date zone
+    to_date_time self date (zone=Time_Zone.system) =
+        Time_Utils.make_zoned_date_time date self zone
 
     ## ALIAS Add Duration
        Add the specified amount of time to this instant to get a new instant.

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoDate.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoDate.java
@@ -73,12 +73,6 @@ public final class EnsoDate implements TruffleObject {
     return date.getDayOfMonth();
   }
 
-  @Builtin.Method(name = "to_time_builtin", description = "Combine this day with time to create a point in time.")
-  @CompilerDirectives.TruffleBoundary
-  public EnsoDateTime toTime(EnsoTimeOfDay timeOfDay, EnsoTimeZone zone) {
-    return new EnsoDateTime(date.atTime(timeOfDay.asTime()).atZone(zone.asTimeZone()));
-  }
-
   @ExportMessage
   boolean isDate() {
     return true;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoDateTime.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoDateTime.java
@@ -182,12 +182,6 @@ public final class EnsoDateTime implements TruffleObject {
     return new EnsoDate(dateTime.toLocalDate());
   }
 
-  @Builtin.Method(description = "Return this datetime in the provided time zone.")
-  @CompilerDirectives.TruffleBoundary
-  public EnsoDateTime atZone(EnsoTimeZone zone) {
-    return new EnsoDateTime(dateTime.withZoneSameInstant(zone.asTimeZone()));
-  }
-
   @Builtin.Method(description = "Return this datetime to the datetime in the provided time zone.")
   @CompilerDirectives.TruffleBoundary
   public Text toText() {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoTimeOfDay.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoTimeOfDay.java
@@ -112,14 +112,6 @@ public final class EnsoTimeOfDay implements TruffleObject {
     return localTime.toSecondOfDay();
   }
 
-  @Builtin.Method(
-      name = "to_date_time_builtin",
-      description = "Combine this time of day with a date to create a point in time.")
-  @CompilerDirectives.TruffleBoundary
-  public EnsoDateTime toTime(EnsoDate date, EnsoTimeZone zone) {
-    return new EnsoDateTime(localTime.atDate(date.asDate()).atZone(zone.asTimeZone()));
-  }
-
   @Builtin.Method(description = "Return this datetime to the datetime in the provided time zone.")
   @CompilerDirectives.TruffleBoundary
   public Text toText() {

--- a/std-bits/base/src/main/java/org/enso/base/Time_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/Time_Utils.java
@@ -216,4 +216,9 @@ public class Time_Utils {
   public static ZonedDateTime make_zoned_date_time(LocalDate date, LocalTime time, ZoneId zone) {
     return ZonedDateTime.of(date, time, zone);
   }
+
+  /** Constructs a new time instant referring to the same moment in time but in a different time zone. */
+  public static ZonedDateTime with_zone_same_instant(ZonedDateTime dateTime, ZoneId zone) {
+    return dateTime.withZoneSameInstant(zone);
+  }
 }

--- a/std-bits/base/src/main/java/org/enso/base/Time_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/Time_Utils.java
@@ -7,11 +7,7 @@ import org.enso.base.time.Time_Of_Day_Utils;
 import org.enso.polyglot.common_utils.Core_Date_Utils;
 import org.graalvm.polyglot.Value;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.Period;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoUnit;
@@ -214,5 +210,10 @@ public class Time_Utils {
    */
   public static long months_between(LocalDate start, LocalDate end) {
     return ChronoUnit.MONTHS.between(start, end);
+  }
+
+  /** Constructs a Date_Time from a Date, Time_Of_Day and Zone. */
+  public static ZonedDateTime make_zoned_date_time(LocalDate date, LocalTime time, ZoneId zone) {
+    return ZonedDateTime.of(date, time, zone);
   }
 }

--- a/std-bits/base/src/main/java/org/enso/base/Time_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/Time_Utils.java
@@ -7,7 +7,12 @@ import org.enso.base.time.Time_Of_Day_Utils;
 import org.enso.polyglot.common_utils.Core_Date_Utils;
 import org.graalvm.polyglot.Value;
 
-import java.time.*;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoUnit;
@@ -15,7 +20,9 @@ import java.time.temporal.TemporalField;
 import java.time.temporal.WeekFields;
 import java.util.Locale;
 
-/** Utils for standard library operations on Time. */
+/**
+ * Utils for standard library operations on Time.
+ */
 public class Time_Utils {
   public enum AdjustOp {
     PLUS,
@@ -24,6 +31,7 @@ public class Time_Utils {
 
   /**
    * Creates a DateTimeFormatter from a format string, supporting building standard formats.
+   *
    * @param format format string
    * @param locale locale needed for custom formats
    * @return DateTimeFormatter
@@ -43,18 +51,20 @@ public class Time_Utils {
   /**
    * Creates a DateTimeFormatter from a format string, supporting building standard formats.
    * For Enso format, return the default output formatter.
+   *
    * @param format format string
    * @param locale locale needed for custom formats
    * @return DateTimeFormatter
    */
   public static DateTimeFormatter make_output_formatter(String format, Locale locale) {
     return format.equals("ENSO_ZONED_DATE_TIME")
-            ? Time_Utils.default_output_date_time_formatter()
-            : make_formatter(format, locale);
+        ? Time_Utils.default_output_date_time_formatter()
+        : make_formatter(format, locale);
   }
 
   /**
    * Given a format string, returns true if it is a format that is based on ISO date time.
+   *
    * @param format format string
    * @return True if format is based on ISO date time
    */
@@ -65,21 +75,26 @@ public class Time_Utils {
     };
   }
 
-  /** @return default Date Time formatter for parsing a Date_Time. */
+  /**
+   * @return default Date Time formatter for parsing a Date_Time.
+   */
   public static DateTimeFormatter default_zoned_date_time_formatter() {
     return Core_Date_Utils.defaultZonedDateTimeFormatter();
   }
 
-  /** @return default Date Time formatter for writing a Date_Time. */
+  /**
+   * @return default Date Time formatter for writing a Date_Time.
+   */
   public static DateTimeFormatter default_output_date_time_formatter() {
     return new DateTimeFormatterBuilder().append(DateTimeFormatter.ISO_LOCAL_DATE)
-            .appendLiteral(' ')
-            .append(DateTimeFormatter.ISO_LOCAL_TIME)
-            .toFormatter();
+        .appendLiteral(' ')
+        .append(DateTimeFormatter.ISO_LOCAL_TIME)
+        .toFormatter();
   }
 
   /**
    * Replace space with T in ISO date time string to make it compatible with ISO format.
+   *
    * @param dateString Raw date time string with either space or T as separator
    * @return ISO format date time string
    */
@@ -212,12 +227,16 @@ public class Time_Utils {
     return ChronoUnit.MONTHS.between(start, end);
   }
 
-  /** Constructs a Date_Time from a Date, Time_Of_Day and Zone. */
+  /**
+   * Constructs a Date_Time from a Date, Time_Of_Day and Zone.
+   */
   public static ZonedDateTime make_zoned_date_time(LocalDate date, LocalTime time, ZoneId zone) {
     return ZonedDateTime.of(date, time, zone);
   }
 
-  /** Constructs a new time instant referring to the same moment in time but in a different time zone. */
+  /**
+   * Constructs a new time instant referring to the same moment in time but in a different time zone.
+   */
   public static ZonedDateTime with_zone_same_instant(ZonedDateTime dateTime, ZoneId zone) {
     return dateTime.withZoneSameInstant(zone);
   }

--- a/test/Tests/src/Data/Time/Date_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Spec.enso
@@ -91,6 +91,13 @@ spec_with name create_new_date parse_date =
             time . nanosecond . should_equal 0
             time . zone . zone_id . should_equal Time_Zone.utc.zone_id
 
+        Test.specify "date-time conversion should work with interop values" <|
+            date = create_new_date 2000 12 21
+            time = Time_Of_Day.new 12 30 45
+            datetime = time.to_date_time date
+            datetime.date . should_equal date
+            datetime.time_of_day . should_equal time
+
         Test.specify "should convert to Json" <|
             date = create_new_date 2001 12 21
             date.to_json.should_equal <|

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -222,11 +222,11 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
 
         Test.specify "should allow to set an interop timezone" <|
             interop_tz = ZoneOffset.ofTotalSeconds 3600
-            dt0 = create_new_datetime 2020
+            dt0 = create_new_datetime 2020 (zone = Time_Zone.utc)
             dt1 = dt0.at_zone interop_tz
 
             dt1.zone . zone_id . should_equal interop_tz.zone_id
-            dt1.to_display_text . should_equal "2020-01-01 00:00:00 +01:00"
+            dt1.to_display_text . should_equal "2020-01-01 01:00:00 +01:00"
 
         Test.specify "should get time of day from offsed-based time" <|
             time = parse_datetime "1970-01-01T00:00:01+01:00" . time_of_day

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -220,6 +220,14 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . zone . zone_id . should_equal tz.zone_id
             time.to_display_text . should_equal "1970-01-01 03:00:00 Europe/Moscow"
 
+        Test.specify "should allow to set an interop timezone" <|
+            interop_tz = ZoneOffset.ofTotalSeconds 3600
+            dt0 = create_new_datetime 2020
+            dt1 = dt0.at_zone interop_tz
+
+            dt1.zone . zone_id . should_equal interop_tz.zone_id
+            dt1.to_display_text . should_equal "2020-01-01 00:00:00 +01:00"
+
         Test.specify "should get time of day from offsed-based time" <|
             time = parse_datetime "1970-01-01T00:00:01+01:00" . time_of_day
             time . hour . should_equal 0

--- a/test/Tests/src/Data/Time/Time_Of_Day_Spec.enso
+++ b/test/Tests/src/Data/Time/Time_Of_Day_Spec.enso
@@ -90,6 +90,13 @@ specWith name create_new_time parse_time =
             datetime . nanosecond . should_equal 0
             datetime . zone . zone_id . should_equal Time_Zone.utc.zone_id
 
+        Test.specify "date-time conversion should work with interop values" <|
+            date = Date.new 2000 12 21
+            time = create_new_time 12 30 45
+            datetime = date.to_date_time time
+            datetime.date . should_equal date
+            datetime.time_of_day . should_equal time
+
         Test.specify "should add time-based interval" <|
             time = create_new_time 0 + (Duration.new minutes=1)
             time . to_seconds . should_equal 60


### PR DESCRIPTION
### Pull Request Description

Related to #6912

It essentially solves it by removing any builtins that would take an EnsoDate/EnsoTimeOfDay/EnsoTimeZone and replacing them with Java utils that do the same operation.

This is not a proper solution - the builtin conversion is still invalid for the date/time types - but at this moment we may just no longer use the invalid conversion so it is much less of an issue. We still need to be aware of this if we want to introduce builtins taking date/time in the future.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
