### PR TITLE
Skip internal field getters when building suggestions

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
@@ -94,6 +94,10 @@ final class SuggestionBuilder[A: IndexedSource](
             }
             val getters = members
               .flatMap(_.arguments)
+              .filterNot { argument =>
+                argument.name.name.startsWith(InternalPrefix) ||
+                argument.name.name.endsWith(InternalSuffix)
+              }
               .distinctBy(_.name.name)
               .map(buildGetter(module, tpName.name, _))
 
@@ -812,5 +816,8 @@ object SuggestionBuilder {
   }
 
   val Any: String = "Standard.Base.Any.Any"
+
+  private val InternalSuffix = "_internal"
+  private val InternalPrefix = "internal_"
 
 }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
@@ -2484,6 +2484,86 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
       )
     }
 
+    "build type with constructor with internal field" in {
+
+      val code =
+        """import Standard.Base.Data.Numbers
+          |
+          |type T
+          |    A a_internal internal_a x
+          |""".stripMargin
+      val module = code.preprocessModule
+
+      build(code, module) shouldEqual Tree.Root(
+        Vector(
+          ModuleNode,
+          Tree.Node(
+            Suggestion.Type(
+              externalId    = None,
+              module        = "Unnamed.Test",
+              name          = "T",
+              params        = Seq(),
+              returnType    = "Unnamed.Test.T",
+              parentType    = Some(SuggestionBuilder.Any),
+              documentation = None
+            ),
+            Vector()
+          ),
+          Tree.Node(
+            Suggestion.Constructor(
+              externalId = None,
+              module     = "Unnamed.Test",
+              name       = "A",
+              arguments = Seq(
+                Suggestion.Argument(
+                  "a_internal",
+                  SuggestionBuilder.Any,
+                  false,
+                  false,
+                  None
+                ),
+                Suggestion.Argument(
+                  "internal_a",
+                  SuggestionBuilder.Any,
+                  false,
+                  false,
+                  None
+                ),
+                Suggestion.Argument(
+                  "x",
+                  SuggestionBuilder.Any,
+                  false,
+                  false,
+                  None
+                )
+              ),
+              returnType    = "Unnamed.Test.T",
+              documentation = None,
+              annotations   = Seq()
+            ),
+            Vector()
+          ),
+          Tree.Node(
+            Suggestion.Method(
+              externalId = None,
+              module     = "Unnamed.Test",
+              name       = "x",
+              arguments = Seq(
+                Suggestion
+                  .Argument("self", "Unnamed.Test.T", false, false, None)
+              ),
+              selfType      = "Unnamed.Test.T",
+              returnType    = SuggestionBuilder.Any,
+              isStatic      = false,
+              documentation = None,
+              annotations   = Seq()
+            ),
+            Vector()
+          )
+        )
+      )
+    }
+
     "build Integer type" in {
 
       val code = "type Integer"


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #6900 

This is a follow-up to the discussion of the imports/exports meeting. 

Right now we have no control over the visibility of atom constructor arguments. One way to hide them is a convention of filtering getters by an `internal` prefix or suffix.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
