### PR TITLE
Increase engine timeout for visualisations.

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/TimingsConfig.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/TimingsConfig.scala
@@ -39,5 +39,5 @@ class TimingsConfig(
 }
 
 object TimingsConfig {
-  def default(): TimingsConfig = new TimingsConfig(10.seconds)
+  def default(): TimingsConfig = new TimingsConfig(20.seconds)
 }


### PR DESCRIPTION
### Pull Request Description

Follow on to discussion https://github.com/enso-org/enso/issues/6724#issuecomment-1570239589

Increases the timeout for the engine, as we are hitting it too often for larger datasets.



### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
