### PR TITLE
Make sure Enso FrameDescriptors have non-null default value

### DIFF
--- a/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/IncrementalUpdatesTest.java
+++ b/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/IncrementalUpdatesTest.java
@@ -110,7 +110,7 @@ public class IncrementalUpdatesTest {
     var result = sendUpdatesWhenFunctionBodyIsChangedBySettingValue("4", ConstantsGen.INTEGER, "4", "x", null, LiteralNode.class);
     assertTrue("Execution succeeds: " + result, result.head().payload() instanceof Runtime$Api$ExecutionComplete);
     assertEquals("Error is printed as a result",
-      List.newBuilder().addOne("(Error: (Uninitialized_State.Error Nothing))"), context.consumeOut()
+      List.newBuilder().addOne("(Error: Uninitialized value)"), context.consumeOut()
     );
   }
 

--- a/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/IncrementalUpdatesTest.java
+++ b/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/IncrementalUpdatesTest.java
@@ -16,7 +16,7 @@ import org.enso.polyglot.runtime.Runtime$Api$BackgroundJobsStartedNotification;
 import org.enso.polyglot.runtime.Runtime$Api$CreateContextRequest;
 import org.enso.polyglot.runtime.Runtime$Api$CreateContextResponse;
 import org.enso.polyglot.runtime.Runtime$Api$EditFileNotification;
-import org.enso.polyglot.runtime.Runtime$Api$ExecutionFailed;
+import org.enso.polyglot.runtime.Runtime$Api$ExecutionComplete;
 import org.enso.polyglot.runtime.Runtime$Api$ExpressionUpdates;
 import org.enso.polyglot.runtime.Runtime$Api$InitializedNotification;
 import org.enso.polyglot.runtime.Runtime$Api$MethodCall;
@@ -107,8 +107,11 @@ public class IncrementalUpdatesTest {
 
   @Test
   public void sendNotANumberChange() {
-    var failed = sendUpdatesWhenFunctionBodyIsChangedBySettingValue("4", ConstantsGen.INTEGER, "4", "x", null, LiteralNode.class);
-    assertTrue("Execution failed: " + failed, failed.head().payload() instanceof Runtime$Api$ExecutionFailed);
+    var result = sendUpdatesWhenFunctionBodyIsChangedBySettingValue("4", ConstantsGen.INTEGER, "4", "x", null, LiteralNode.class);
+    assertTrue("Execution succeeds: " + result, result.head().payload() instanceof Runtime$Api$ExecutionComplete);
+    assertEquals("Error is printed as a result",
+      List.newBuilder().addOne("(Error: (Uninitialized_State.Error Nothing))"), context.consumeOut()
+    );
   }
 
   private static String extractPositions(String code, String chars, Map<Character, int[]> beginAndLength) {

--- a/engine/runtime-with-polyglot/src/test/java/org/enso/interpreter/test/InsightForEnsoTest.java
+++ b/engine/runtime-with-polyglot/src/test/java/org/enso/interpreter/test/InsightForEnsoTest.java
@@ -85,5 +85,10 @@ public class InsightForEnsoTest {
       assertNotEquals("Step two: " + msgs, -1, msgs.indexOf("n=4 v=5 acc=function"));
       assertNotEquals("3rd step: " + msgs, -1, msgs.indexOf("n=3 v=20 acc=function"));
       assertNotEquals("4th step: " + msgs, -1, msgs.indexOf("n=2 v=60 acc=function"));
+
+      assertNotEquals(
+        "Uninitialized variables are seen as JavaScript null: " + msgs,
+        -1, msgs.indexOf("n=null v=null acc=function")
+      );
     }
 }

--- a/engine/runtime-with-polyglot/src/test/java/org/enso/interpreter/test/InsightForEnsoTest.java
+++ b/engine/runtime-with-polyglot/src/test/java/org/enso/interpreter/test/InsightForEnsoTest.java
@@ -1,0 +1,89 @@
+package org.enso.interpreter.test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.function.Function;
+import org.enso.polyglot.RuntimeOptions;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Language;
+import org.graalvm.polyglot.Source;
+import org.junit.After;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Before;
+import org.junit.Test;
+
+public class InsightForEnsoTest {
+    private Context ctx;
+    private AutoCloseable insightHandle;
+    private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    @Before
+    public void initContext() throws Exception {
+        this.ctx = Context.newBuilder()
+                .allowExperimentalOptions(true)
+                .option(
+                        RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
+                        Paths.get("../../distribution/component").toFile().getAbsolutePath()
+                )
+                .logHandler(OutputStream.nullOutputStream())
+                .allowExperimentalOptions(true)
+                .allowIO(true)
+                .out(out)
+                .allowAllAccess(true)
+                .build();
+
+        var engine = ctx.getEngine();
+        Map<String, Language> langs = engine.getLanguages();
+        assertNotNull("Enso found: " + langs, langs.get("enso"));
+
+        @SuppressWarnings("unchecked")
+        var fn = (Function<Source,AutoCloseable>) engine.getInstruments().get("insight").lookup(Function.class);
+        assertNotNull(fn);
+
+        var insightScript = Source.newBuilder("js", """
+        insight.on('enter', (ctx, frame) => {
+            print(`${ctx.name} at ${ctx.source.name}:${ctx.line}:`);
+            let dump = "";
+            for (let p in frame) {
+                dump += ` ${p}=${frame[p]}`;
+            }
+            print(dump);
+        }, {
+            roots : true
+        });
+        """, "trace.js").build();
+        this.insightHandle = fn.apply(insightScript);
+    }
+
+    @After
+    public void disposeContext() throws Exception {
+        this.insightHandle.close();
+        this.ctx.close();
+    }
+
+    @Test
+    public void computeFactorial() throws Exception {
+      var code = Source.newBuilder("enso", """
+      fac n =
+          acc n v = if n <= 1 then v else
+            @Tail_Call acc n-1 n*v
+
+          acc n 1
+      """, "factorial.enso").build();
+
+      var m = ctx.eval(code);
+      var fac = m.invokeMember("eval_expression", "fac");
+      var res = fac.execute(5);
+      assertEquals(120, res.asInt());
+
+      var msgs = out.toString();
+      assertNotEquals("Step one: " + msgs, -1, msgs.indexOf("n=5 v=1 acc=function"));
+      assertNotEquals("Step two: " + msgs, -1, msgs.indexOf("n=4 v=5 acc=function"));
+      assertNotEquals("3rd step: " + msgs, -1, msgs.indexOf("n=3 v=20 acc=function"));
+      assertNotEquals("4th step: " + msgs, -1, msgs.indexOf("n=2 v=60 acc=function"));
+    }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -1,16 +1,9 @@
 package org.enso.interpreter.runtime;
 
-import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.TruffleFile;
-import com.oracle.truffle.api.TruffleLanguage;
-import com.oracle.truffle.api.TruffleLanguage.Env;
-import com.oracle.truffle.api.TruffleLogger;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnknownIdentifierException;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
-import com.oracle.truffle.api.nodes.Node;
-import com.oracle.truffle.api.object.Shape;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStream;
@@ -20,9 +13,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.StreamSupport;
+
 import org.enso.compiler.Compiler;
 import org.enso.compiler.PackageRepository;
 import org.enso.compiler.data.CompilerConfig;
@@ -32,7 +24,6 @@ import org.enso.editions.LibraryName;
 import org.enso.interpreter.EnsoLanguage;
 import org.enso.interpreter.OptionsHelper;
 import org.enso.interpreter.instrument.NotificationHandler;
-import org.enso.interpreter.runtime.Module;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.scope.TopLevelScope;
@@ -48,6 +39,17 @@ import org.enso.polyglot.LanguageInfo;
 import org.enso.polyglot.RuntimeOptions;
 import org.enso.polyglot.RuntimeServerInfo;
 import org.graalvm.options.OptionKey;
+
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.TruffleFile;
+import com.oracle.truffle.api.TruffleLanguage;
+import com.oracle.truffle.api.TruffleLanguage.Env;
+import com.oracle.truffle.api.TruffleLogger;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.object.Shape;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.StreamSupport;
+
 import scala.jdk.javaapi.OptionConverters;
 
 /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -1,23 +1,28 @@
 package org.enso.interpreter.runtime;
 
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.TruffleFile;
+import com.oracle.truffle.api.TruffleLanguage;
+import com.oracle.truffle.api.TruffleLanguage.Env;
+import com.oracle.truffle.api.TruffleLogger;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnknownIdentifierException;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.object.Shape;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
-
+import java.util.stream.StreamSupport;
 import org.enso.compiler.Compiler;
 import org.enso.compiler.PackageRepository;
 import org.enso.compiler.data.CompilerConfig;
@@ -27,6 +32,7 @@ import org.enso.editions.LibraryName;
 import org.enso.interpreter.EnsoLanguage;
 import org.enso.interpreter.OptionsHelper;
 import org.enso.interpreter.instrument.NotificationHandler;
+import org.enso.interpreter.runtime.Module;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.scope.TopLevelScope;
@@ -42,17 +48,6 @@ import org.enso.polyglot.LanguageInfo;
 import org.enso.polyglot.RuntimeOptions;
 import org.enso.polyglot.RuntimeServerInfo;
 import org.graalvm.options.OptionKey;
-
-import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
-import com.oracle.truffle.api.TruffleFile;
-import com.oracle.truffle.api.TruffleLanguage;
-import com.oracle.truffle.api.TruffleLanguage.Env;
-import com.oracle.truffle.api.TruffleLogger;
-import com.oracle.truffle.api.nodes.Node;
-import com.oracle.truffle.api.object.Shape;
-import java.util.concurrent.ExecutorService;
-import java.util.stream.StreamSupport;
-
 import scala.jdk.javaapi.OptionConverters;
 
 /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Error.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Error.java
@@ -1,31 +1,9 @@
 package org.enso.interpreter.runtime.builtin;
 
 import com.oracle.truffle.api.CompilerDirectives;
-import static com.oracle.truffle.api.CompilerDirectives.transferToInterpreterAndInvalidate;
-import org.enso.interpreter.node.expression.builtin.error.ArithmeticError;
-import org.enso.interpreter.node.expression.builtin.error.ArityError;
-import org.enso.interpreter.node.expression.builtin.error.CaughtPanic;
-import org.enso.interpreter.node.expression.builtin.error.CompileError;
-import org.enso.interpreter.node.expression.builtin.error.ForbiddenOperation;
-import org.enso.interpreter.node.expression.builtin.error.IncomparableValues;
-import org.enso.interpreter.node.expression.builtin.error.IndexOutOfBounds;
-import org.enso.interpreter.node.expression.builtin.error.InexhaustivePatternMatch;
-import org.enso.interpreter.node.expression.builtin.error.InvalidArrayIndex;
-import org.enso.interpreter.node.expression.builtin.error.InvalidConversionTarget;
-import org.enso.interpreter.node.expression.builtin.error.ModuleDoesNotExist;
-import org.enso.interpreter.node.expression.builtin.error.ModuleNotInPackageError;
-import org.enso.interpreter.node.expression.builtin.error.NoConversionCurrying;
-import org.enso.interpreter.node.expression.builtin.error.NoSuchConversion;
+import org.enso.interpreter.node.expression.builtin.error.*;
 import org.enso.interpreter.node.expression.builtin.error.NoSuchField;
 import org.enso.interpreter.node.expression.builtin.error.NoSuchMethod;
-import org.enso.interpreter.node.expression.builtin.error.NotInvokable;
-import org.enso.interpreter.node.expression.builtin.error.NumberParseError;
-import org.enso.interpreter.node.expression.builtin.error.Panic;
-import org.enso.interpreter.node.expression.builtin.error.SyntaxError;
-import org.enso.interpreter.node.expression.builtin.error.TypeError;
-import org.enso.interpreter.node.expression.builtin.error.Unimplemented;
-import org.enso.interpreter.node.expression.builtin.error.UninitializedState;
-import org.enso.interpreter.node.expression.builtin.error.UnsupportedArgumentTypes;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.UnresolvedConversion;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
@@ -33,7 +11,8 @@ import org.enso.interpreter.runtime.callable.atom.Atom;
 import org.enso.interpreter.runtime.data.Array;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.data.text.Text;
-import org.enso.interpreter.runtime.error.DataflowError;
+
+import static com.oracle.truffle.api.CompilerDirectives.transferToInterpreterAndInvalidate;
 
 /** Container for builtin Error types */
 public final class Error {
@@ -63,7 +42,6 @@ public final class Error {
   private final ForbiddenOperation forbiddenOperation;
 
   private final Unimplemented unimplemented;
-  private final DataflowError dataFlowErrorUninitializedValue;
 
   @CompilerDirectives.CompilationFinal private Atom arithmeticErrorShiftTooBig;
 
@@ -73,7 +51,7 @@ public final class Error {
   private static final Text divideByZeroMessage = Text.create("Cannot divide by zero.");
 
   /** Creates builders for error Atom Constructors. */
-  Error(Builtins builtins, EnsoContext context) {
+  public Error(Builtins builtins, EnsoContext context) {
     this.context = context;
     syntaxError = builtins.getBuiltinType(SyntaxError.class);
     typeError = builtins.getBuiltinType(TypeError.class);
@@ -99,8 +77,6 @@ public final class Error {
     caughtPanic = builtins.getBuiltinType(CaughtPanic.class);
     forbiddenOperation = builtins.getBuiltinType(ForbiddenOperation.class);
     unimplemented = builtins.getBuiltinType(Unimplemented.class);
-    dataFlowErrorUninitializedValue =
-        DataflowError.withoutTrace(makeUninitializedStateError(builtins.nothing()), null);
   }
 
   public Atom makeSyntaxError(Object message) {
@@ -123,7 +99,7 @@ public final class Error {
     return inexhaustivePatternMatch.newInstance(message);
   }
 
-  public final Atom makeUninitializedStateError(Object key) {
+  public Atom makeUninitializedStateError(Object key) {
     return uninitializedState.newInstance(key);
   }
 
@@ -266,9 +242,5 @@ public final class Error {
 
   public Atom makeNumberParseError(String message) {
     return numberParseError.newInstance(Text.create(message));
-  }
-
-  public DataflowError dataFlowErrorUninitializedValue() {
-    return dataFlowErrorUninitializedValue;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/DataflowError.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/DataflowError.java
@@ -9,6 +9,7 @@ import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.Node;
+import java.util.Objects;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
@@ -21,7 +22,10 @@ import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
  */
 @ExportLibrary(InteropLibrary.class)
 @ExportLibrary(TypesLibrary.class)
-public class DataflowError extends AbstractTruffleException {
+public final class DataflowError extends AbstractTruffleException {
+  /** Signals (local) values that haven't yet been initialized */
+  public static final DataflowError UNINITIALIZED = new DataflowError(null, (Node) null);
+
   private final Object payload;
 
   /**
@@ -34,6 +38,7 @@ public class DataflowError extends AbstractTruffleException {
    * @return a new dataflow error
    */
   public static DataflowError withoutTrace(Object payload, Node location) {
+    assert payload != null;
     DataflowError result = new DataflowError(payload, location);
     TruffleStackTrace.fillIn(result);
     return result;
@@ -50,6 +55,7 @@ public class DataflowError extends AbstractTruffleException {
    * @return a new dataflow error
    */
   public static DataflowError withTrace(Object payload, AbstractTruffleException prototype) {
+    assert payload != null;
     return new DataflowError(payload, prototype);
   }
 
@@ -69,7 +75,7 @@ public class DataflowError extends AbstractTruffleException {
    * @return the payload object
    */
   public Object getPayload() {
-    return payload;
+    return payload != null ? payload : "Uninitialized value";
   }
 
   /**
@@ -78,18 +84,17 @@ public class DataflowError extends AbstractTruffleException {
    * @return a string representation of this object
    */
   @Override
+  @TruffleBoundary
   public String toString() {
-    return "Error:" + getPayload().toString();
+    return "Error:" + Objects.toString(getPayload());
   }
 
   @ExportMessage
   @TruffleBoundary
-  public String toDisplayString(
-      boolean allowSideEffects,
-      @CachedLibrary(limit = "3") InteropLibrary displays,
-      @CachedLibrary(limit = "3") InteropLibrary strings) {
+  public String toDisplayString(boolean allowSideEffects) {
     try {
-      return "(Error: " + strings.asString(displays.toDisplayString(payload)) + ")";
+      var iop = InteropLibrary.getUncached();
+      return "(Error: " + iop.asString(iop.toDisplayString(getPayload())) + ")";
     } catch (UnsupportedMessageException e) {
       return "Error";
     }
@@ -108,6 +113,11 @@ public class DataflowError extends AbstractTruffleException {
   @ExportMessage
   boolean isException() {
     return true;
+  }
+
+  @ExportMessage
+  boolean isNull() {
+    return payload == null;
   }
 
   @ExportMessage

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/scope/LocalScope.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/scope/LocalScope.scala
@@ -8,6 +8,7 @@ import org.enso.compiler.pass.analyse.AliasAnalysis.Graph.{
   Scope => AliasScope
 }
 import org.enso.compiler.pass.analyse.{AliasAnalysis, DataflowAnalysis}
+import org.enso.interpreter.runtime.EnsoContext
 import org.enso.interpreter.runtime.scope.LocalScope.{
   internalSlots,
   monadicStateSlotName
@@ -162,6 +163,18 @@ class LocalScope(
         )
       assert(localFrameSlotIdxs(definition.id) == returnedFrameIdx)
     }
+    val ctx =
+      try {
+        EnsoContext.get(null)
+      } catch {
+        case _: RuntimeException => null
+      }
+    val defValue = if (ctx != null) {
+      ctx.getBuiltins().error().dataFlowErrorUninitializedValue()
+    } else {
+      0L;
+    }
+    descriptorBuilder.defaultValue(defValue)
     val frameDescriptor = descriptorBuilder.build()
     assert(
       internalSlots.length + localFrameSlotIdxs.size == frameDescriptor.getNumberOfSlots

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/scope/LocalScope.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/scope/LocalScope.scala
@@ -168,6 +168,7 @@ class LocalScope(
         EnsoContext.get(null)
       } catch {
         case _: RuntimeException => null
+        case _: AssertionError => null
       }
     val defValue = if (ctx != null) {
       ctx.getBuiltins().error().dataFlowErrorUninitializedValue()

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/scope/LocalScope.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/scope/LocalScope.scala
@@ -8,7 +8,7 @@ import org.enso.compiler.pass.analyse.AliasAnalysis.Graph.{
   Scope => AliasScope
 }
 import org.enso.compiler.pass.analyse.{AliasAnalysis, DataflowAnalysis}
-import org.enso.interpreter.runtime.EnsoContext
+import org.enso.interpreter.runtime.error.DataflowError
 import org.enso.interpreter.runtime.scope.LocalScope.{
   internalSlots,
   monadicStateSlotName
@@ -163,19 +163,7 @@ class LocalScope(
         )
       assert(localFrameSlotIdxs(definition.id) == returnedFrameIdx)
     }
-    val ctx =
-      try {
-        EnsoContext.get(null)
-      } catch {
-        case _: RuntimeException => null
-        case _: AssertionError => null
-      }
-    val defValue = if (ctx != null) {
-      ctx.getBuiltins().error().dataFlowErrorUninitializedValue()
-    } else {
-      0L;
-    }
-    descriptorBuilder.defaultValue(defValue)
+    descriptorBuilder.defaultValue(DataflowError.UNINITIALIZED)
     val frameDescriptor = descriptorBuilder.build()
     assert(
       internalSlots.length + localFrameSlotIdxs.size == frameDescriptor.getNumberOfSlots

--- a/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
@@ -84,6 +84,21 @@ public class ExecCompilerTest {
   }
 
   @Test
+  public void testRecursiveDefinition() throws Exception {
+    var module = ctx.eval("enso", """
+    from Standard.Base import all
+
+    run prefix =
+        op = if False then 42 else prefix+op
+        op
+    """);
+    var run = module.invokeMember("eval_expression", "run");
+    var error = run.execute("Nope: ");
+    assertTrue("We get an error value back", error.isException());
+    assertEquals("(Error: (Uninitialized_State.Error Nothing))", error.toString());
+  }
+
+  @Test
   public void testInvalidEnsoProjectRef() throws Exception {
     var module =
         ctx.eval(

--- a/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
@@ -6,9 +6,12 @@ import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.PolyglotException;
 import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 public class ExecCompilerTest {
   private static Context ctx;
@@ -64,6 +67,20 @@ public class ExecCompilerTest {
     } catch (PolyglotException ex) {
         assertEquals("Syntax error: Unexpected expression.", ex.getMessage());
     }
+  }
+
+  @Test
+  public void testSelfAssignment() throws Exception {
+    var module = ctx.eval("enso", """
+    from Standard.Base.Errors.Common import all
+    run value =
+        meta1 = meta1
+        meta1
+    """);
+    var run = module.invokeMember("eval_expression", "run");
+    var error = run.execute(-1);
+    assertTrue("We get an error value back", error.isException());
+    assertEquals("(Error: (Uninitialized_State.Error Nothing))", error.toString());
   }
 
   @Test

--- a/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
@@ -80,7 +80,8 @@ public class ExecCompilerTest {
     var run = module.invokeMember("eval_expression", "run");
     var error = run.execute(-1);
     assertTrue("We get an error value back", error.isException());
-    assertEquals("(Error: (Uninitialized_State.Error Nothing))", error.toString());
+    assertTrue("The error value also represents null", error.isNull());
+    assertEquals("(Error: Uninitialized value)", error.toString());
   }
 
   @Test
@@ -95,7 +96,8 @@ public class ExecCompilerTest {
     var run = module.invokeMember("eval_expression", "run");
     var error = run.execute("Nope: ");
     assertTrue("We get an error value back", error.isException());
-    assertEquals("(Error: (Uninitialized_State.Error Nothing))", error.toString());
+    assertTrue("The error value also represents null", error.isNull());
+    assertEquals("(Error: Uninitialized value)", error.toString());
   }
 
   @Test


### PR DESCRIPTION
### Pull Request Description

Solves runtime problems with self assigned statements like `x = x` by making sure the initial value of each variable is initialized to non-null.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
