### PR TITLE
Prevent default only of some shortcuts.

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/dashboard.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/dashboard.tsx
@@ -97,7 +97,6 @@ const EXPERIMENTAL = {
 
 /** The `id` attribute of the element into which the IDE will be rendered. */
 const IDE_ELEMENT_ID = 'root'
-const IDE_SCENE_CLASS = 'scene'
 /** The `localStorage` key under which the ID of the current directory is stored. */
 const DIRECTORY_STACK_KEY = `${common.PRODUCT_NAME.toLowerCase()}-dashboard-directory-stack`
 
@@ -332,13 +331,9 @@ function Dashboard(props: DashboardProps) {
     const switchToIdeTab = react.useCallback(() => {
         setTab(Tab.ide)
         const ideElement = document.getElementById(IDE_ELEMENT_ID)
-        const ideScene = document.getElementsByClassName(IDE_SCENE_CLASS)[0]
         if (ideElement) {
             ideElement.style.top = ''
             ideElement.style.display = 'absolute'
-            if (ideScene) {
-                ideScene.focus()
-            }
         }
     }, [])
 
@@ -346,13 +341,9 @@ function Dashboard(props: DashboardProps) {
         setTab(Tab.dashboard)
         doRefresh()
         const ideElement = document.getElementById(IDE_ELEMENT_ID)
-        const ideScene = document.getElementsByClassName(IDE_SCENE_CLASS)[0]
         if (ideElement) {
             ideElement.style.top = '-100vh'
             ideElement.style.display = 'fixed'
-            if (ideScene) {
-                ideScene.blur()
-            }
         }
     }, [])
 

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/dashboard.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/dashboard.tsx
@@ -97,6 +97,7 @@ const EXPERIMENTAL = {
 
 /** The `id` attribute of the element into which the IDE will be rendered. */
 const IDE_ELEMENT_ID = 'root'
+const IDE_SCENE_CLASS = 'scene'
 /** The `localStorage` key under which the ID of the current directory is stored. */
 const DIRECTORY_STACK_KEY = `${common.PRODUCT_NAME.toLowerCase()}-dashboard-directory-stack`
 
@@ -331,9 +332,13 @@ function Dashboard(props: DashboardProps) {
     const switchToIdeTab = react.useCallback(() => {
         setTab(Tab.ide)
         const ideElement = document.getElementById(IDE_ELEMENT_ID)
+        const ideScene = document.getElementsByClassName(IDE_SCENE_CLASS)[0]
         if (ideElement) {
             ideElement.style.top = ''
             ideElement.style.display = 'absolute'
+            if (ideScene) {
+                ideScene.focus()
+            }
         }
     }, [])
 
@@ -341,9 +346,13 @@ function Dashboard(props: DashboardProps) {
         setTab(Tab.dashboard)
         doRefresh()
         const ideElement = document.getElementById(IDE_ELEMENT_ID)
+        const ideScene = document.getElementsByClassName(IDE_SCENE_CLASS)[0]
         if (ideElement) {
             ideElement.style.top = '-100vh'
             ideElement.style.display = 'fixed'
+            if (ideScene) {
+                ideScene.blur()
+            }
         }
     }, [])
 

--- a/lib/rust/ensogl/core/src/display/scene.rs
+++ b/lib/rust/ensogl/core/src/display/scene.rs
@@ -339,7 +339,6 @@ impl Dom {
         let root = web::document.create_div_or_panic();
         let layers = DomLayers::new(&root);
         root.set_class_name("scene");
-        root.set_attribute_or_warn("tabIndex", "0");
         root.set_style_or_warn("height", "100vh");
         root.set_style_or_warn("width", "100vw");
         root.set_style_or_warn("display", "block");
@@ -878,7 +877,7 @@ impl SceneData {
         let mouse =
             Mouse::new(&frp, &dom.root, &variables, &display_mode, &pointer_target_registry);
         let disable_context_menu = Rc::new(web::ignore_context_menu(&dom.root));
-        let keyboard = Keyboard::new(&dom.root);
+        let keyboard = Keyboard::new(&web::window);
         let network = &frp.network;
         let extensions = Extensions::default();
         let bg_color_var = style_sheet.var("application.background");

--- a/lib/rust/ensogl/core/src/display/scene.rs
+++ b/lib/rust/ensogl/core/src/display/scene.rs
@@ -310,16 +310,10 @@ pub struct Keyboard {
 }
 
 impl Keyboard {
-    pub fn new() -> Self {
+    pub fn new(target: &web::EventTarget) -> Self {
         let frp = enso_frp::io::keyboard::Keyboard::default();
-        let bindings = Rc::new(enso_frp::io::keyboard::DomBindings::new(&frp));
+        let bindings = Rc::new(enso_frp::io::keyboard::DomBindings::new(target, &frp));
         Self { frp, bindings }
-    }
-}
-
-impl Default for Keyboard {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -345,9 +339,11 @@ impl Dom {
         let root = web::document.create_div_or_panic();
         let layers = DomLayers::new(&root);
         root.set_class_name("scene");
+        root.set_attribute_or_warn("tabIndex", "0");
         root.set_style_or_warn("height", "100vh");
         root.set_style_or_warn("width", "100vw");
         root.set_style_or_warn("display", "block");
+        root.set_style_or_warn("outline", "none");
         let root = web::dom::WithKnownShape::new(&root);
         Self { root, layers }
     }
@@ -882,7 +878,7 @@ impl SceneData {
         let mouse =
             Mouse::new(&frp, &dom.root, &variables, &display_mode, &pointer_target_registry);
         let disable_context_menu = Rc::new(web::ignore_context_menu(&dom.root));
-        let keyboard = Keyboard::new();
+        let keyboard = Keyboard::new(&dom.root);
         let network = &frp.network;
         let extensions = Extensions::default();
         let bg_color_var = style_sheet.var("application.background");

--- a/lib/rust/frp/src/io/js.rs
+++ b/lib/rust/frp/src/io/js.rs
@@ -71,9 +71,6 @@ impl Listener {
 /// https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
 fn event_listener_options() -> enso_web::AddEventListenerOptions {
     let mut options = enso_web::AddEventListenerOptions::new();
-    // We listen for events in capture phase, so we can decide ourself if it should be passed
-    // further.
-    // options.capture(true);
     // We want to prevent default action on wheel events, thus listener cannot be passive.
     options.passive(false);
     options

--- a/lib/rust/frp/src/io/js.rs
+++ b/lib/rust/frp/src/io/js.rs
@@ -26,38 +26,41 @@ pub struct Listener {
 
 impl Listener {
     /// Constructor.
-    pub fn new<T: 'static>(event_type: impl Str, callback: Closure<dyn FnMut(T)>) -> Self {
-        let window = &web::window;
+    pub fn new<T: 'static>(
+        target: &EventTarget,
+        event_type: impl Str,
+        callback: Closure<dyn FnMut(T)>,
+    ) -> Self {
         let event_type = event_type.as_ref();
         let options = event_listener_options();
-        let handle = web::add_event_listener_with_options(window, event_type, callback, &options);
+        let handle = web::add_event_listener_with_options(target, event_type, callback, &options);
         Self { _handle: handle }
     }
 }
 
 impl Listener {
     /// Creates a new key down event listener.
-    pub fn new_key_down<F>(f: F) -> Self
+    pub fn new_key_down<F>(target: &EventTarget, f: F) -> Self
     where F: KeyboardEventCallback {
         let boxed = Box::new(f);
         let closure = Closure::<dyn KeyboardEventCallback>::wrap(boxed);
-        Self::new("keydown", closure)
+        Self::new(target, "keydown", closure)
     }
 
     /// Creates a new key up event listener.
-    pub fn new_key_up<F>(f: F) -> Self
+    pub fn new_key_up<F>(target: &EventTarget, f: F) -> Self
     where F: KeyboardEventCallback {
         let boxed = Box::new(f);
         let closure = Closure::<dyn KeyboardEventCallback>::wrap(boxed);
-        Self::new("keyup", closure)
+        Self::new(target, "keyup", closure)
     }
 
     /// Creates a blur event listener.
-    pub fn new_blur<F>(f: F) -> Self
+    pub fn new_blur<F>(target: &EventTarget, f: F) -> Self
     where F: EventCallback {
         let boxed = Box::new(f);
         let closure = Closure::<dyn EventCallback>::wrap(boxed);
-        Self::new("blur", closure)
+        Self::new(target, "blur", closure)
     }
 }
 
@@ -70,7 +73,7 @@ fn event_listener_options() -> enso_web::AddEventListenerOptions {
     let mut options = enso_web::AddEventListenerOptions::new();
     // We listen for events in capture phase, so we can decide ourself if it should be passed
     // further.
-    options.capture(true);
+    // options.capture(true);
     // We want to prevent default action on wheel events, thus listener cannot be passive.
     options.passive(false);
     options

--- a/lib/rust/frp/src/io/keyboard.rs
+++ b/lib/rust/frp/src/io/keyboard.rs
@@ -419,11 +419,13 @@ impl Default for Keyboard {
 }
 
 
+// =======================
+// === BrowserShortcut ===
+// =======================
 
-// ===================
-// === DomBindings ===
-// ===================
-
+/// A handy structure used for defining shortcuts used by the browser in some special way
+/// (for example reload page or add bookmark). We want to prevent default actions on such shortcuts.
+/// See also [`BROWSER_SHORTCUTS`].
 struct BrowserShortcut {
     code:  &'static str,
     ctrl:  bool,
@@ -450,12 +452,19 @@ impl BrowserShortcut {
     }
 }
 
+/// A list of shortcuts with special browser action, on which we want to call `prevent_default`.
 const BROWSER_SHORTCUTS: &[BrowserShortcut] =
     &[BrowserShortcut::new("Tab"), BrowserShortcut::ctrl("R"), BrowserShortcut::ctrl_shift("D")];
 
 fn is_browser_shortcut(event: &KeyboardEvent) -> bool {
     BROWSER_SHORTCUTS.iter().any(|shortcut| shortcut.matches(event))
 }
+
+
+
+// ===================
+// === DomBindings ===
+// ===================
 
 /// A handle of listener emitting events on bound FRP graph.
 ///

--- a/lib/rust/frp/src/io/keyboard.rs
+++ b/lib/rust/frp/src/io/keyboard.rs
@@ -4,11 +4,12 @@ use crate::prelude::*;
 
 use crate as frp;
 use crate::io::js::Listener;
-
 use crate::web;
+
 use enso_web::KeyboardEvent;
 use inflector::Inflector;
 use unicode_segmentation::UnicodeSegmentation;
+
 
 
 // ============


### PR DESCRIPTION
### Pull Request Description

Before, we prevented default on every keyboard event, making usage of HTML inputs impossible (both on the dashboard and inside visualizations).

### Important Notes

The list of shortcuts was based on comments in #6364 (where the `preventDefault` was introduced).

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
