### PR TITLE
Eliminate race condition for edit/close/open cmds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -816,6 +816,7 @@
 - [Upgrade GraalVM to 22.3.1 JDK17][6750]
 - [Ascribed types are checked during runtime][6790]
 - [Improve and colorize compiler's diagnostic messages][6931]
+- [Execute some runtime commands synchronously to avoid race conditions][6998]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -931,6 +932,7 @@
 [6780]: https://github.com/enso-org/enso/pull/6780
 [6790]: https://github.com/enso-org/enso/pull/6790
 [6931]: https://github.com/enso-org/enso/pull/6931
+[6998]: https://github.com/enso-org/enso/pull/6998
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/AsynchronousCommand.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/AsynchronousCommand.scala
@@ -15,7 +15,7 @@ abstract class AsynchronousCommand(maybeRequestId: Option[RequestId])
     extends Command(maybeRequestId) {
   type Result[T] = Future[T]
 
-  override def execute(implicit
+  final override def execute(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Result[Completion] = {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/AsynchronousCommand.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/AsynchronousCommand.scala
@@ -1,0 +1,64 @@
+package org.enso.interpreter.instrument.command
+
+import com.oracle.truffle.api.TruffleLogger
+import org.enso.interpreter.instrument.execution.Completion.{Done, Interrupted}
+import org.enso.interpreter.instrument.execution.{Completion, RuntimeContext}
+import org.enso.interpreter.runtime.control.ThreadInterruptedException
+import org.enso.polyglot.runtime.Runtime.Api.RequestId
+
+import java.util.logging.Level
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success}
+
+abstract class AsynchronousCommand(maybeRequestId: Option[RequestId])
+    extends Command(maybeRequestId) {
+  type Result[T] = Future[T]
+
+  override def execute(implicit
+    ctx: RuntimeContext,
+    ec: ExecutionContext
+  ): Result[Completion] = {
+    val logger = ctx.executionService.getLogger
+    for {
+      _ <- Future {
+        logger.log(Level.FINE, s"Executing command asynchronously: $this...")
+      }
+      result <- mapFailures(logger, executeAsynchronously(ctx, ec))
+      _      <- Future { logger.log(Level.FINE, s"Command $this finished.") }
+    } yield result
+  }
+
+  private def mapFailures(logger: TruffleLogger, result: Future[Unit])(implicit
+    ex: ExecutionContext
+  ): Future[Completion] = {
+    result.transformWith[Completion] {
+      case Success(()) =>
+        Future.successful(Done)
+
+      case Failure(_: InterruptedException | _: ThreadInterruptedException) =>
+        Future.successful[Completion](Interrupted)
+
+      case Failure(NonFatal(ex)) =>
+        logger.log(
+          Level.SEVERE,
+          s"An error occurred during execution of $this command",
+          ex
+        )
+        Future.failed[Completion](ex)
+
+      case Failure(ex) =>
+        logger.log(
+          Level.SEVERE,
+          s"An error occurred during execution of $this command",
+          ex
+        )
+        Future.failed[Completion](ex)
+    }
+  }
+
+  def executeAsynchronously(implicit
+    ctx: RuntimeContext,
+    ec: ExecutionContext
+  ): Future[Unit]
+}

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/AttachVisualisationCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/AttachVisualisationCmd.scala
@@ -15,10 +15,10 @@ import scala.concurrent.{ExecutionContext, Future}
 class AttachVisualisationCmd(
   maybeRequestId: Option[RequestId],
   request: Api.AttachVisualisation
-) extends Command(maybeRequestId) {
+) extends AsynchronousCommand(maybeRequestId) {
 
   /** @inheritdoc */
-  override def execute(implicit
+  override def executeAsynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/CloseFileCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/CloseFileCmd.scala
@@ -3,28 +3,25 @@ package org.enso.interpreter.instrument.command
 import org.enso.interpreter.instrument.execution.RuntimeContext
 import org.enso.polyglot.runtime.Runtime.Api
 
-import scala.concurrent.{ExecutionContext, Future}
-
 /** A command that closes a file.
   *
   * @param request a request for a service
   */
-class CloseFileCmd(request: Api.CloseFileNotification) extends Command(None) {
+class CloseFileCmd(request: Api.CloseFileNotification)
+    extends SynchronousCommand(None) {
 
-  /** @inheritdoc */
-  override def execute(implicit
-    ctx: RuntimeContext,
-    ec: ExecutionContext
-  ): Future[Unit] =
-    Future {
-      ctx.locking.acquireReadCompilationLock()
-      ctx.locking.acquireFileLock(request.path)
-      try {
-        ctx.executionService.resetModuleSources(request.path)
-      } finally {
-        ctx.locking.releaseFileLock(request.path)
-        ctx.locking.releaseReadCompilationLock()
-      }
+  override def executeSynchronously(implicit ctx: RuntimeContext): Unit = {
+    ctx.locking.acquireReadCompilationLock()
+    ctx.locking.acquireFileLock(request.path)
+    ctx.locking.acquirePendingEditsLock()
+    try {
+      ctx.state.pendingEdits.dequeue(request.path)
+      ctx.executionService.resetModuleSources(request.path)
+    } finally {
+      ctx.locking.releasePendingEditsLock()
+      ctx.locking.releaseFileLock(request.path)
+      ctx.locking.releaseReadCompilationLock()
     }
+  }
 
 }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/Command.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/Command.scala
@@ -1,21 +1,26 @@
 package org.enso.interpreter.instrument.command
 
-import org.enso.interpreter.instrument.execution.RuntimeContext
+import org.enso.interpreter.instrument.execution.{Completion, RuntimeContext}
 import org.enso.polyglot.runtime.Runtime.{Api, ApiResponse}
 import org.enso.polyglot.runtime.Runtime.Api.RequestId
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext}
 
 /** Base command trait that encapsulates a function request. Uses
   * [[RuntimeContext]] to perform a request.
   */
 abstract class Command(maybeRequestId: Option[RequestId]) {
 
+  type Result[_]
+
   /** Executes a request.
     *
     * @param ctx contains suppliers of services to perform a request
     */
-  def execute(implicit ctx: RuntimeContext, ec: ExecutionContext): Future[Unit]
+  def execute(implicit
+    ctx: RuntimeContext,
+    ec: ExecutionContext
+  ): Result[Completion]
 
   override def toString: String = this.getClass.getSimpleName
 

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/CreateContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/CreateContextCmd.scala
@@ -14,10 +14,10 @@ import scala.concurrent.{ExecutionContext, Future}
 class CreateContextCmd(
   maybeRequestId: Option[RequestId],
   request: Api.CreateContextRequest
-) extends Command(maybeRequestId) {
+) extends AsynchronousCommand(maybeRequestId) {
 
   /** @inheritdoc */
-  override def execute(implicit
+  override def executeAsynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] =

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/DeserializeLibrarySuggestionsCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/DeserializeLibrarySuggestionsCmd.scala
@@ -13,10 +13,10 @@ import scala.concurrent.{ExecutionContext, Future}
 class DeserializeLibrarySuggestionsCmd(
   maybeRequestId: Option[Api.RequestId],
   request: Api.DeserializeLibrarySuggestions
-) extends Command(maybeRequestId) {
+) extends AsynchronousCommand(maybeRequestId) {
 
   /** @inheritdoc */
-  override def execute(implicit
+  override def executeAsynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/DestroyContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/DestroyContextCmd.scala
@@ -14,10 +14,10 @@ import scala.concurrent.{ExecutionContext, Future}
 class DestroyContextCmd(
   maybeRequestId: Option[RequestId],
   request: Api.DestroyContextRequest
-) extends Command(maybeRequestId) {
+) extends AsynchronousCommand(maybeRequestId) {
 
   /** @inheritdoc */
-  override def execute(implicit
+  override def executeAsynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] =

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/DetachVisualisationCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/DetachVisualisationCmd.scala
@@ -15,10 +15,10 @@ import scala.concurrent.{ExecutionContext, Future}
 class DetachVisualisationCmd(
   maybeRequestId: Option[RequestId],
   request: Api.DetachVisualisation
-) extends Command(maybeRequestId) {
+) extends AsynchronousCommand(maybeRequestId) {
 
   /** @inheritdoc */
-  override def execute(implicit
+  override def executeAsynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/EditFileCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/EditFileCmd.scala
@@ -11,13 +11,14 @@ import scala.concurrent.{ExecutionContext, Future}
   *
   * @param request a request for editing
   */
-class EditFileCmd(request: Api.EditFileNotification) extends Command(None) {
+class EditFileCmd(request: Api.EditFileNotification)
+    extends AsynchronousCommand(None) {
 
   /** Executes a request.
     *
     * @param ctx contains suppliers of services to perform a request
     */
-  override def execute(implicit
+  override def executeAsynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/GetComponentGroupsCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/GetComponentGroupsCmd.scala
@@ -12,10 +12,10 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 class GetComponentGroupsCmd(
   maybeRequestId: Option[RequestId]
-) extends Command(maybeRequestId) {
+) extends AsynchronousCommand(maybeRequestId) {
 
   /** @inheritdoc */
-  override def execute(implicit
+  override def executeAsynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = Future {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/GetTypeGraphCommand.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/GetTypeGraphCommand.scala
@@ -8,10 +8,10 @@ import org.enso.polyglot.runtime.Runtime.Api.RequestId
 import scala.concurrent.{ExecutionContext, Future}
 
 class GetTypeGraphCommand(maybeRequestId: Option[RequestId])
-    extends Command(maybeRequestId) {
+    extends AsynchronousCommand(maybeRequestId) {
 
   /** @inheritdoc */
-  override def execute(implicit
+  override def executeAsynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = Future {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/InterruptContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/InterruptContextCmd.scala
@@ -14,10 +14,10 @@ import scala.concurrent.{ExecutionContext, Future}
 class InterruptContextCmd(
   maybeRequestId: Option[RequestId],
   request: Api.InterruptContextRequest
-) extends Command(maybeRequestId) {
+) extends AsynchronousCommand(maybeRequestId) {
 
   /** @inheritdoc */
-  override def execute(implicit
+  override def executeAsynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] =

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/InvalidateModulesIndexCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/InvalidateModulesIndexCmd.scala
@@ -13,13 +13,13 @@ import scala.concurrent.{ExecutionContext, Future}
 class InvalidateModulesIndexCmd(
   maybeRequestId: Option[Api.RequestId],
   val request: Api.InvalidateModulesIndexRequest
-) extends Command(maybeRequestId) {
+) extends AsynchronousCommand(maybeRequestId) {
 
   /** Executes a request.
     *
     * @param ctx contains suppliers of services to perform a request
     */
-  override def execute(implicit
+  override def executeAsynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/ModifyVisualisationCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/ModifyVisualisationCmd.scala
@@ -19,10 +19,10 @@ import scala.concurrent.{ExecutionContext, Future}
 class ModifyVisualisationCmd(
   maybeRequestId: Option[RequestId],
   request: Api.ModifyVisualisation
-) extends Command(maybeRequestId) {
+) extends AsynchronousCommand(maybeRequestId) {
 
   /** @inheritdoc */
-  override def execute(implicit
+  override def executeAsynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/OpenFileCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/OpenFileCmd.scala
@@ -3,31 +3,27 @@ package org.enso.interpreter.instrument.command
 import org.enso.interpreter.instrument.execution.RuntimeContext
 import org.enso.polyglot.runtime.Runtime.Api
 
-import scala.concurrent.{ExecutionContext, Future}
-
 /** A command that opens a file.
   *
   * @param request a request for a service
   */
-class OpenFileCmd(request: Api.OpenFileNotification) extends Command(None) {
+class OpenFileCmd(request: Api.OpenFileNotification)
+    extends SynchronousCommand(None) {
 
   /** @inheritdoc */
-  override def execute(implicit
-    ctx: RuntimeContext,
-    ec: ExecutionContext
-  ): Future[Unit] =
-    Future {
-      ctx.locking.acquireReadCompilationLock()
-      ctx.locking.acquireFileLock(request.path)
-      try {
-        ctx.executionService.setModuleSources(
-          request.path,
-          request.contents
-        )
-      } finally {
-        ctx.locking.releaseFileLock(request.path)
-        ctx.locking.releaseReadCompilationLock()
-      }
+  override def executeSynchronously(implicit
+    ctx: RuntimeContext
+  ): Unit = {
+    ctx.locking.acquireReadCompilationLock()
+    ctx.locking.acquireFileLock(request.path)
+    try {
+      ctx.executionService.setModuleSources(
+        request.path,
+        request.contents
+      )
+    } finally {
+      ctx.locking.releaseFileLock(request.path)
+      ctx.locking.releaseReadCompilationLock()
     }
-
+  }
 }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/PopContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/PopContextCmd.scala
@@ -16,10 +16,10 @@ import scala.concurrent.{ExecutionContext, Future}
 class PopContextCmd(
   maybeRequestId: Option[RequestId],
   request: Api.PopContextRequest
-) extends Command(maybeRequestId) {
+) extends AsynchronousCommand(maybeRequestId) {
 
   /** @inheritdoc */
-  override def execute(implicit
+  override def executeAsynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] =

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/PushContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/PushContextCmd.scala
@@ -15,10 +15,10 @@ import scala.concurrent.{ExecutionContext, Future}
 class PushContextCmd(
   maybeRequestId: Option[RequestId],
   request: Api.PushContextRequest
-) extends Command(maybeRequestId) {
+) extends AsynchronousCommand(maybeRequestId) {
 
   /** @inheritdoc */
-  override def execute(implicit
+  override def executeAsynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] =

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
@@ -17,10 +17,10 @@ import scala.jdk.CollectionConverters._
 class RecomputeContextCmd(
   maybeRequestId: Option[RequestId],
   request: Api.RecomputeContextRequest
-) extends Command(maybeRequestId) {
+) extends AsynchronousCommand(maybeRequestId) {
 
   /** @inheritdoc */
-  override def execute(implicit
+  override def executeAsynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] =

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RenameProjectCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RenameProjectCmd.scala
@@ -20,10 +20,10 @@ import scala.concurrent.{ExecutionContext, Future}
 class RenameProjectCmd(
   maybeRequestId: Option[Api.RequestId],
   request: Api.RenameProject
-) extends Command(maybeRequestId) {
+) extends AsynchronousCommand(maybeRequestId) {
 
   /** @inheritdoc */
-  override def execute(implicit
+  override def executeAsynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] =

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/SetExpressionValueCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/SetExpressionValueCmd.scala
@@ -12,13 +12,13 @@ import scala.concurrent.{ExecutionContext, Future}
   * @param request a request for the update
   */
 class SetExpressionValueCmd(request: Api.SetExpressionValueNotification)
-    extends Command(None) {
+    extends AsynchronousCommand(None) {
 
   /** Executes a request.
     *
     * @param ctx contains suppliers of services to perform a request
     */
-  override def execute(implicit
+  override def executeAsynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/StartBackgroundProcessingCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/StartBackgroundProcessingCmd.scala
@@ -12,10 +12,10 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 final class StartBackgroundProcessingCmd(
   maybeRequestId: Option[Api.RequestId]
-) extends Command(maybeRequestId) {
+) extends AsynchronousCommand(maybeRequestId) {
 
   /** @inheritdoc */
-  override def execute(implicit
+  override def executeAsynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/SynchronousCommand.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/SynchronousCommand.scala
@@ -1,0 +1,41 @@
+package org.enso.interpreter.instrument.command
+
+import org.enso.interpreter.instrument.execution.{Completion, RuntimeContext}
+import org.enso.interpreter.instrument.execution.Completion.{Done, Interrupted}
+import org.enso.interpreter.runtime.control.ThreadInterruptedException
+import org.enso.polyglot.runtime.Runtime.Api.RequestId
+
+import java.util.logging.Level
+import scala.concurrent.ExecutionContext
+
+abstract class SynchronousCommand(maybeRequestId: Option[RequestId])
+    extends Command(maybeRequestId) {
+  type Result[T] = T
+
+  override def execute(implicit
+    ctx: RuntimeContext,
+    ec: ExecutionContext
+  ): Result[Completion] = {
+    val logger = ctx.executionService.getLogger
+    logger.log(Level.FINE, s"Executing command synchronously: $this...")
+    try {
+      executeSynchronously
+      Done
+    } catch {
+      case _: InterruptedException | _: ThreadInterruptedException =>
+        Interrupted
+      case ex: Throwable =>
+        logger.log(
+          Level.SEVERE,
+          s"An error occurred during execution of $this command",
+          ex
+        )
+        Done
+    } finally {
+      logger.log(Level.FINE, s"Command $this finished.")
+    }
+  }
+
+  def executeSynchronously(implicit ctx: RuntimeContext): Unit
+
+}

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/SynchronousCommand.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/SynchronousCommand.scala
@@ -12,7 +12,7 @@ abstract class SynchronousCommand(maybeRequestId: Option[RequestId])
     extends Command(maybeRequestId) {
   type Result[T] = T
 
-  override def execute(implicit
+  final override def execute(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Result[Completion] = {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/CommandProcessor.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/CommandProcessor.scala
@@ -2,8 +2,6 @@ package org.enso.interpreter.instrument.execution
 
 import org.enso.interpreter.instrument.command.Command
 
-import scala.concurrent.Future
-
 /** Defines a uniform interface to execute commands.
   */
 trait CommandProcessor {
@@ -11,9 +9,10 @@ trait CommandProcessor {
   /** Invokes a command with the provided context.
     *
     * @param cmd a command to execute
-    * @return a future signaling the completion of computations
+    * @return if the command is asynchronous, a future signaling the completion of computations,
+    *         a signal indicating the completion otherwise
     */
-  def invoke(cmd: Command): Future[Completion]
+  def invoke(cmd: Command): cmd.Result[Completion]
 
   /** Stops the command processor.
     */


### PR DESCRIPTION
### Pull Request Description

There was an inherent race condition between edit, close & open commands which could not be prevented solely using locks. `EditFileCmd` triggered `EnsureCompiledJob` which was applying edits collected over time. At the same `CloseFileCmd` and `OpenFileCmd` were executed asynchronously and required locks on compilation unit  and file lock.

Additionally, open file was resetting the module's runtime source irrespective of any edits that could already have been applied with the asynchronous execution in `EnsureCompiledJob`. This was visible especially during early manipulation of the project when open/close was performed due to a bug in IDE (#6843).

Now commands can be run either synchronously or asynchronously. Only that way can we ensure that `close` & `open` commands finish by the time any editions are being applied to module's sources.

Closes #6841.

### Important Notes

In the given video, `"foo"` would be greyed out because it would never be part of the module's (runtime) sources. Therefore no IR would be generated for it or instrumentation, meaning it would be present in `expressionUpdates` information necessary for IDE.

[Kazam_screencast_00014.webm](https://github.com/enso-org/enso/assets/292128/226a17b8-729a-415a-803f-003a9695b2f1)


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
