### PR TITLE
Do not return getters from global completion response

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/search/SearchProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/search/SearchProtocol.scala
@@ -86,7 +86,7 @@ object SearchProtocol {
           .dropNullValues
 
       case conversion: Suggestion.Conversion =>
-        Encoder[Suggestion.Method]
+        Encoder[Suggestion.DefinedMethod]
           .apply(conversionToMethod(conversion))
           .deepMerge(
             Json.obj(CodecField.Type -> SuggestionType.Method.asJson)
@@ -94,7 +94,7 @@ object SearchProtocol {
           .dropNullValues
 
       case getter: Suggestion.Getter =>
-        Encoder[Suggestion.Method]
+        Encoder[Suggestion.DefinedMethod]
           .apply(getterToMethod(getter))
           .deepMerge(
             Json.obj(CodecField.Type -> SuggestionType.Method.asJson)
@@ -126,7 +126,7 @@ object SearchProtocol {
 
   private def conversionToMethod(
     conversion: Suggestion.Conversion
-  ): Suggestion.Method = {
+  ): Suggestion.DefinedMethod = {
     val arg = Suggestion.Argument(
       Suggestion.Kind.Conversion.From,
       conversion.selfType,
@@ -148,7 +148,9 @@ object SearchProtocol {
     )
   }
 
-  private def getterToMethod(getter: Suggestion.Getter): Suggestion.Method =
+  private def getterToMethod(
+    getter: Suggestion.Getter
+  ): Suggestion.DefinedMethod =
     Suggestion.DefinedMethod(
       getter.externalId,
       getter.module,

--- a/engine/language-server/src/test/scala/org/enso/languageserver/search/Suggestions.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/search/Suggestions.scala
@@ -49,7 +49,18 @@ object Suggestions {
     annotations   = Seq("a")
   )
 
-  val method: Suggestion.Method = Suggestion.Method(
+  val getter: Suggestion.Getter = Suggestion.Getter(
+    externalId    = None,
+    module        = "local.Test.Main",
+    name          = "a",
+    arguments     = Vector(),
+    selfType      = "MyType",
+    returnType    = "Any",
+    documentation = None,
+    annotations   = Seq()
+  )
+
+  val method: Suggestion.DefinedMethod = Suggestion.DefinedMethod(
     externalId = Some(UUID.fromString("ea9d7734-26a7-4f65-9dd9-c648eaf57d63")),
     module     = "local.Test.Main",
     name       = "foo",
@@ -89,7 +100,7 @@ object Suggestions {
     documentation = None
   )
 
-  val methodOnAny: Suggestion.Method = Suggestion.Method(
+  val methodOnAny: Suggestion.DefinedMethod = Suggestion.DefinedMethod(
     externalId = Some(UUID.fromString("6cfe1538-5df7-42e4-bf55-64f8ac2ededa")),
     module     = "Standard.Base.Any.Extensions",
     name       = "<<",
@@ -104,7 +115,7 @@ object Suggestions {
     annotations   = Seq()
   )
 
-  val methodOnNumber: Suggestion.Method = Suggestion.Method(
+  val methodOnNumber: Suggestion.DefinedMethod = Suggestion.DefinedMethod(
     externalId = Some(UUID.fromString("33b426aa-2f74-42c0-9032-1159b5386eac")),
     module     = "Standard.Base.Data.Number.Extensions",
     name       = "asin",
@@ -118,7 +129,7 @@ object Suggestions {
     annotations   = Seq()
   )
 
-  val methodOnInteger: Suggestion.Method = Suggestion.Method(
+  val methodOnInteger: Suggestion.DefinedMethod = Suggestion.DefinedMethod(
     externalId = Some(UUID.fromString("2849c0f0-3c27-44df-abcb-5c163dd7ac91")),
     module     = "Standard.Builtins.Main",
     name       = "+",
@@ -136,6 +147,7 @@ object Suggestions {
     module,
     tpe,
     constructor,
+    getter,
     method,
     function,
     local,

--- a/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
@@ -762,10 +762,10 @@ class SuggestionsHandlerSpec
               inserted(0),
               inserted(1),
               inserted(2),
-              inserted(6),
               inserted(7),
               inserted(8),
-              inserted(3)
+              inserted(9),
+              inserted(4)
             )
           )
         )
@@ -773,7 +773,7 @@ class SuggestionsHandlerSpec
 
     "search entries by self type" taggedAs Retry in withDb {
       (config, repo, _, _, handler) =>
-        val (_, Seq(_, _, _, methodId, _, _, methodOnAnyId, _, _)) =
+        val (_, Seq(_, _, _, getterId, methodId, _, _, methodOnAnyId, _, _)) =
           Await.result(repo.insertAll(Suggestions.all), Timeout)
         handler ! SearchProtocol.Completion(
           file       = mkModulePath(config, "Main.enso"),
@@ -787,7 +787,7 @@ class SuggestionsHandlerSpec
         expectMsg(
           SearchProtocol.CompletionResult(
             1L,
-            Seq(methodId, methodOnAnyId)
+            Seq(getterId, methodId, methodOnAnyId)
           )
         )
     }
@@ -796,7 +796,7 @@ class SuggestionsHandlerSpec
       (config, repo, _, _, handler) =>
         val (
           _,
-          Seq(_, _, _, _, _, _, anyMethodId, numberMethodId, integerMethodId)
+          Seq(_, _, _, _, _, _, _, anyMethodId, numberMethodId, integerMethodId)
         ) =
           Await.result(repo.insertAll(Suggestions.all), Timeout)
 
@@ -819,7 +819,7 @@ class SuggestionsHandlerSpec
 
     "search entries for any" taggedAs Retry in withDb {
       (config, repo, _, _, handler) =>
-        val (_, Seq(_, _, _, _, _, _, anyMethodId, _, _)) =
+        val (_, Seq(_, _, _, _, _, _, _, anyMethodId, _, _)) =
           Await.result(repo.insertAll(Suggestions.all), Timeout)
 
         handler ! SearchProtocol.Completion(
@@ -841,7 +841,7 @@ class SuggestionsHandlerSpec
 
     "search entries by return type" taggedAs Retry in withDb {
       (config, repo, _, _, handler) =>
-        val (_, Seq(_, _, _, _, functionId, _, _, _, _)) =
+        val (_, Seq(_, _, _, _, _, functionId, _, _, _, _)) =
           Await.result(repo.insertAll(Suggestions.all), Timeout)
         handler ! SearchProtocol.Completion(
           file       = mkModulePath(config, "Main.enso"),
@@ -862,7 +862,7 @@ class SuggestionsHandlerSpec
 
     "search entries by tags" taggedAs Retry in withDb {
       (config, repo, _, _, handler) =>
-        val (_, Seq(_, _, _, _, _, localId, _, _, _)) =
+        val (_, Seq(_, _, _, _, _, _, localId, _, _, _)) =
           Await.result(repo.insertAll(Suggestions.all), Timeout)
         handler ! SearchProtocol.Completion(
           file       = mkModulePath(config, "Main.enso"),
@@ -1089,7 +1089,7 @@ class SuggestionsHandlerSpec
       )
 
     val method: Suggestion.Method =
-      Suggestion.Method(
+      Suggestion.DefinedMethod(
         externalId    = Some(UUID.randomUUID()),
         module        = "Test.Main",
         name          = "main",

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/ExportedSymbol.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/ExportedSymbol.scala
@@ -43,7 +43,6 @@ object ExportedSymbol {
       case s: Suggestion.Type        => Some(Type(s.module, s.name))
       case s: Suggestion.Constructor => Some(Constructor(s.module, s.name))
       case s: Suggestion.Method      => Some(Method(s.module, s.name))
-      case _: Suggestion.Conversion  => None
       case _: Suggestion.Function    => None
       case _: Suggestion.Local       => None
     }

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
@@ -161,7 +161,7 @@ class RuntimeSuggestionUpdatesTest
               ),
               Tree.Node(
                 Api.SuggestionUpdate(
-                  Suggestion.Method(
+                  Suggestion.DefinedMethod(
                     None,
                     moduleName,
                     "main",
@@ -211,7 +211,7 @@ class RuntimeSuggestionUpdatesTest
             Vector(
               Tree.Node(
                 Api.SuggestionUpdate(
-                  Suggestion.Method(
+                  Suggestion.DefinedMethod(
                     None,
                     moduleName,
                     "main",
@@ -283,7 +283,7 @@ class RuntimeSuggestionUpdatesTest
             Vector(
               Tree.Node(
                 Api.SuggestionUpdate(
-                  Suggestion.Method(
+                  Suggestion.DefinedMethod(
                     None,
                     moduleName,
                     "main",
@@ -375,7 +375,7 @@ class RuntimeSuggestionUpdatesTest
             Vector(
               Tree.Node(
                 Api.SuggestionUpdate(
-                  Suggestion.Method(
+                  Suggestion.DefinedMethod(
                     None,
                     moduleName,
                     "main",
@@ -475,7 +475,7 @@ class RuntimeSuggestionUpdatesTest
             Vector(
               Tree.Node(
                 Api.SuggestionUpdate(
-                  Suggestion.Method(
+                  Suggestion.DefinedMethod(
                     None,
                     moduleName,
                     "main",
@@ -541,7 +541,7 @@ class RuntimeSuggestionUpdatesTest
               ),
               Tree.Node(
                 Api.SuggestionUpdate(
-                  Suggestion.Method(
+                  Suggestion.DefinedMethod(
                     None,
                     moduleName,
                     "foo",
@@ -602,7 +602,7 @@ class RuntimeSuggestionUpdatesTest
             Vector(
               Tree.Node(
                 Api.SuggestionUpdate(
-                  Suggestion.Method(
+                  Suggestion.DefinedMethod(
                     None,
                     moduleName,
                     "foo",
@@ -715,7 +715,7 @@ class RuntimeSuggestionUpdatesTest
               ),
               Tree.Node(
                 Api.SuggestionUpdate(
-                  Suggestion.Method(
+                  Suggestion.DefinedMethod(
                     None,
                     moduleName,
                     "main",
@@ -773,7 +773,7 @@ class RuntimeSuggestionUpdatesTest
               ),
               Tree.Node(
                 Api.SuggestionUpdate(
-                  Suggestion.Method(
+                  Suggestion.DefinedMethod(
                     None,
                     "Enso_Test.Foo.Main",
                     "main",
@@ -871,7 +871,7 @@ class RuntimeSuggestionUpdatesTest
               ),
               Tree.Node(
                 Api.SuggestionUpdate(
-                  Suggestion.Method(
+                  Suggestion.DefinedMethod(
                     None,
                     moduleName,
                     "main",
@@ -906,7 +906,7 @@ class RuntimeSuggestionUpdatesTest
               ),
               Tree.Node(
                 Api.SuggestionUpdate(
-                  Suggestion.Method(
+                  Suggestion.DefinedMethod(
                     None,
                     moduleName,
                     "overloaded",
@@ -933,7 +933,7 @@ class RuntimeSuggestionUpdatesTest
               ),
               Tree.Node(
                 Api.SuggestionUpdate(
-                  Suggestion.Method(
+                  Suggestion.DefinedMethod(
                     None,
                     moduleName,
                     "overloaded",
@@ -1080,7 +1080,7 @@ class RuntimeSuggestionUpdatesTest
               ),
               Tree.Node(
                 Api.SuggestionUpdate(
-                  Suggestion.Method(
+                  Suggestion.Getter(
                     None,
                     "Enso_Test.Test.A",
                     "a",
@@ -1096,7 +1096,6 @@ class RuntimeSuggestionUpdatesTest
                     ),
                     "Enso_Test.Test.A.MyType",
                     ConstantsGen.ANY,
-                    false,
                     None,
                     Seq()
                   ),
@@ -1106,7 +1105,7 @@ class RuntimeSuggestionUpdatesTest
               ),
               Tree.Node(
                 Api.SuggestionUpdate(
-                  Suggestion.Method(
+                  Suggestion.DefinedMethod(
                     None,
                     "Enso_Test.Test.A",
                     "fortytwo",
@@ -1131,7 +1130,7 @@ class RuntimeSuggestionUpdatesTest
               ),
               Tree.Node(
                 Api.SuggestionUpdate(
-                  Suggestion.Method(
+                  Suggestion.DefinedMethod(
                     None,
                     "Enso_Test.Test.A",
                     "hello",
@@ -1189,7 +1188,7 @@ class RuntimeSuggestionUpdatesTest
               ),
               Tree.Node(
                 Api.SuggestionUpdate(
-                  Suggestion.Method(
+                  Suggestion.DefinedMethod(
                     None,
                     moduleName,
                     "main",

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
@@ -69,7 +69,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "foo",
@@ -101,7 +101,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           DoccedModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "foo",
@@ -132,7 +132,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "foo",
@@ -169,7 +169,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           DoccedModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "foo",
@@ -200,7 +200,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "foo",
@@ -233,7 +233,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "foo",
@@ -271,7 +271,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "foo",
@@ -310,7 +310,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "foo",
@@ -343,7 +343,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "foo",
@@ -406,7 +406,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "foo",
@@ -452,7 +452,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "bar",
@@ -515,7 +515,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "bar",
@@ -563,7 +563,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "apply",
@@ -650,7 +650,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "apply",
@@ -760,7 +760,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "foo",
@@ -805,7 +805,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "foo",
@@ -851,7 +851,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "foo",
@@ -909,7 +909,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "a",
@@ -933,7 +933,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
                 Suggestion.Argument("a", "Number", false, false, None)
               ),
               returnType    = "Unnamed.Test.MyType",
-              sourceType    = "Number",
+              selfType      = "Number",
               documentation = Some(" My conversion")
             ),
             Vector()
@@ -991,7 +991,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "a",
@@ -1047,7 +1047,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "x",
@@ -1072,7 +1072,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
                   .Argument("opt", "Unnamed.Test.MyMaybe", false, false, None)
               ),
               returnType    = "Unnamed.Test.MyType",
-              sourceType    = "Unnamed.Test.MyMaybe",
+              selfType      = "Unnamed.Test.MyMaybe",
               documentation = Some(" My conversion method")
             ),
             Vector()
@@ -1094,7 +1094,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId    = None,
               module        = "Unnamed.Test",
               name          = "main",
@@ -1145,7 +1145,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId    = None,
               module        = "Unnamed.Test",
               name          = "main",
@@ -1210,7 +1210,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId    = None,
               module        = "Unnamed.Test",
               name          = "main",
@@ -1273,7 +1273,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId    = None,
               module        = "Unnamed.Test",
               name          = "main",
@@ -1330,7 +1330,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId    = None,
               module        = "Unnamed.Test",
               name          = "main",
@@ -1385,7 +1385,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId    = None,
               module        = "Unnamed.Test",
               name          = "main",
@@ -1432,7 +1432,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId    = None,
               module        = "Unnamed.Test",
               name          = "main",
@@ -1493,7 +1493,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId    = None,
               module        = "Unnamed.Test",
               name          = "main",
@@ -1553,7 +1553,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId    = None,
               module        = "Unnamed.Test",
               name          = "main",
@@ -1599,7 +1599,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId    = None,
               module        = "Unnamed.Test",
               name          = "main",
@@ -1631,7 +1631,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
       )
     }
 
-    "build atom simple" in {
+    "build type simple" in {
 
       val code =
         """type MyType
@@ -1671,7 +1671,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "a",
@@ -1681,14 +1681,13 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.MyType",
               returnType    = SuggestionBuilder.Any,
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "b",
@@ -1698,7 +1697,6 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.MyType",
               returnType    = SuggestionBuilder.Any,
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
@@ -1708,14 +1706,14 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
       )
     }
 
-    "build atom with documentation" in {
+    "build type with documentation" in {
 
       val code =
         """## Module doc
           |
           |## My sweet type
           |type Mtp
-          |    ## My sweet atom
+          |    ## My sweet type
           |    MyType a b""".stripMargin
       val module = code.preprocessModule
 
@@ -1746,13 +1744,13 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
                   .Argument("b", SuggestionBuilder.Any, false, false, None)
               ),
               returnType    = "Unnamed.Test.Mtp",
-              documentation = Some(" My sweet atom"),
+              documentation = Some(" My sweet type"),
               annotations   = Seq()
             ),
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "a",
@@ -1762,14 +1760,13 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.Mtp",
               returnType    = SuggestionBuilder.Any,
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "b",
@@ -1779,7 +1776,6 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.Mtp",
               returnType    = SuggestionBuilder.Any,
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
@@ -1789,7 +1785,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
       )
     }
 
-    "build type simple" in {
+    "build type with two constructors" in {
 
       val code =
         """type Maybe
@@ -1840,7 +1836,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "a",
@@ -1850,7 +1846,6 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.Maybe",
               returnType    = SuggestionBuilder.Any,
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
@@ -1860,7 +1855,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
       )
     }
 
-    "build type with documentation" in {
+    "build type with documentation and two constructors" in {
 
       val code =
         """## Module doc
@@ -1916,7 +1911,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "a",
@@ -1926,7 +1921,6 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.Maybe",
               returnType    = SuggestionBuilder.Any,
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
@@ -1990,7 +1984,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "empty",
@@ -2064,7 +2058,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "a",
@@ -2074,14 +2068,13 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.Maybe",
               returnType    = SuggestionBuilder.Any,
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "map",
@@ -2188,7 +2181,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "x",
@@ -2198,7 +2191,6 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.T",
               returnType    = "Unnamed.Test.S",
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
@@ -2267,7 +2259,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "a",
@@ -2277,14 +2269,13 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.S",
               returnType    = SuggestionBuilder.Any,
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "b",
@@ -2294,14 +2285,13 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.S",
               returnType    = SuggestionBuilder.Any,
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "c",
@@ -2311,7 +2301,6 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.S",
               returnType    = SuggestionBuilder.Any,
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
@@ -2368,7 +2357,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "x",
@@ -2378,7 +2367,6 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.T",
               returnType    = "Standard.Base.Data.Numbers.Number",
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
@@ -2447,7 +2435,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "x",
@@ -2457,14 +2445,13 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.E",
               returnType    = "a",
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "y",
@@ -2474,7 +2461,6 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.E",
               returnType    = "b",
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
@@ -2544,7 +2530,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "x",
@@ -2554,7 +2540,6 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.T",
               returnType    = SuggestionBuilder.Any,
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
@@ -2628,7 +2613,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
       )
     }
 
-    "build module with simple atom" in {
+    "build module with simple type" in {
       val code =
         """type MyType
           |    MkMyType a b
@@ -2669,7 +2654,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "a",
@@ -2679,14 +2664,13 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.MyType",
               returnType    = SuggestionBuilder.Any,
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "b",
@@ -2696,14 +2680,13 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.MyType",
               returnType    = SuggestionBuilder.Any,
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId    = None,
               module        = "Unnamed.Test",
               name          = "main",
@@ -2720,7 +2703,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
       )
     }
 
-    "build module with an atom named as module" in {
+    "build module with a type named as module" in {
       val code =
         """type Test
           |    Mk_Test a
@@ -2759,7 +2742,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "a",
@@ -2769,14 +2752,13 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.Test",
               returnType    = SuggestionBuilder.Any,
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId    = None,
               module        = "Unnamed.Test",
               name          = "main",
@@ -2859,7 +2841,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.Getter(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "a",
@@ -2869,14 +2851,13 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
               ),
               selfType      = "Unnamed.Test.A",
               returnType    = "Standard.Base.Any.Any",
-              isStatic      = false,
               documentation = None,
               annotations   = Seq()
             ),
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               None,
               "Unnamed.Test",
               "quux",
@@ -2901,7 +2882,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "quux",
@@ -2925,7 +2906,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId    = None,
               module        = "Unnamed.Test",
               name          = "main",
@@ -2986,7 +2967,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "quux",
@@ -3011,7 +2992,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "quux",
@@ -3035,7 +3016,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId    = None,
               module        = "Unnamed.Test",
               name          = "main",
@@ -3067,7 +3048,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId =
                 Some(UUID.fromString("4083ce56-a5e5-4ecd-bf45-37ddf0b58456")),
               module        = "Unnamed.Test",
@@ -3102,7 +3083,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId    = None,
               module        = "Unnamed.Test",
               name          = "main",
@@ -3157,7 +3138,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
         Vector(
           ModuleNode,
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId    = None,
               module        = "Unnamed.Test",
               name          = "main",
@@ -3210,7 +3191,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
             Vector()
           ),
           Tree.Node(
-            Suggestion.Method(
+            Suggestion.DefinedMethod(
               externalId = None,
               module     = "Unnamed.Test",
               name       = "foo",
@@ -3240,7 +3221,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
       val module      = code.preprocessModule
       val suggestions = build(code, module)
       val fooSuggestion = suggestions.collectFirst {
-        case s: Suggestion.Method if s.name == "foo" => s
+        case s: Suggestion.DefinedMethod if s.name == "foo" => s
       }
       val fooArg = fooSuggestion.get.arguments(1)
       fooArg.reprType shouldEqual "Unnamed.Test.My_Tp"
@@ -3259,7 +3240,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
       val module      = code.preprocessModule
       val suggestions = build(code, module)
       val method = suggestions.collectFirst {
-        case s: Suggestion.Method if s.name == "trim" => s
+        case s: Suggestion.DefinedMethod if s.name == "trim" => s
       }
       method.get.arguments.size shouldEqual 3
       val arg1 = method.get.arguments(1)

--- a/lib/scala/searcher/src/bench/scala/org/enso/searcher/sql/SuggestionRandom.scala
+++ b/lib/scala/searcher/src/bench/scala/org/enso/searcher/sql/SuggestionRandom.scala
@@ -19,6 +19,7 @@ object SuggestionRandom {
       case Suggestion.Kind.Module      => nextSuggestionModule()
       case Suggestion.Kind.Type        => nextSuggestionType()
       case Suggestion.Kind.Constructor => nextSuggestionConstructor()
+      case Suggestion.Kind.Getter      => nextSuggestionGetter()
       case Suggestion.Kind.Method      => nextSuggestionMethod()
       case Suggestion.Kind.Conversion  => nextSuggestionMethod()
       case Suggestion.Kind.Function    => nextSuggestionFunction()
@@ -54,8 +55,20 @@ object SuggestionRandom {
       annotations   = Seq()
     )
 
+  def nextSuggestionGetter(): Suggestion.Getter =
+    Suggestion.Getter(
+      externalId    = optional(UUID.randomUUID()),
+      module        = "Test.Main",
+      name          = nextString(),
+      arguments     = Seq(),
+      selfType      = nextString(),
+      returnType    = nextString(),
+      documentation = optional(nextString()),
+      annotations   = Seq()
+    )
+
   def nextSuggestionMethod(): Suggestion.Method =
-    Suggestion.Method(
+    Suggestion.DefinedMethod(
       externalId    = optional(UUID.randomUUID()),
       module        = "Test.Main",
       name          = nextString(),
@@ -101,12 +114,13 @@ object SuggestionRandom {
     )
 
   def nextKind(): Suggestion.Kind =
-    Random.nextInt(5) match {
+    Random.nextInt(6) match {
       case 0 => Suggestion.Kind.Module
       case 1 => Suggestion.Kind.Constructor
-      case 2 => Suggestion.Kind.Method
-      case 3 => Suggestion.Kind.Function
-      case 4 => Suggestion.Kind.Local
+      case 2 => Suggestion.Kind.Getter
+      case 3 => Suggestion.Kind.Method
+      case 4 => Suggestion.Kind.Function
+      case 5 => Suggestion.Kind.Local
       case x => throw new NoSuchElementException(s"nextKind: $x")
     }
 

--- a/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlSuggestionsRepo.scala
+++ b/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlSuggestionsRepo.scala
@@ -1051,7 +1051,7 @@ final class SqlSuggestionsRepo(val db: SqlDatabase)(implicit
             toUUID(suggestion.externalIdLeast, suggestion.externalIdMost),
           module        = suggestion.module,
           arguments     = Seq(),
-          selfType    = suggestion.selfType,
+          selfType      = suggestion.selfType,
           returnType    = suggestion.returnType,
           documentation = suggestion.documentation,
           reexport      = suggestion.reexport

--- a/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlSuggestionsRepo.scala
+++ b/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlSuggestionsRepo.scala
@@ -744,6 +744,9 @@ final class SqlSuggestionsRepo(val db: SqlDatabase)(implicit
       .filterOpt(module) { case (row, value) =>
         row.scopeStartLine === ScopeColumn.EMPTY || row.module === value
       }
+      .filterIf(selfTypes.isEmpty) { row =>
+        row.kind =!= SuggestionKind.GETTER
+      }
       .filterIf(selfTypes.nonEmpty) { row =>
         row.selfType.inSet(selfTypes) &&
         (row.kind =!= SuggestionKind.CONSTRUCTOR)
@@ -844,7 +847,36 @@ final class SqlSuggestionsRepo(val db: SqlDatabase)(implicit
           scopeEndOffset   = ScopeColumn.EMPTY,
           reexport         = reexport
         )
-      case Suggestion.Method(
+      case Suggestion.Getter(
+            expr,
+            module,
+            name,
+            _,
+            selfType,
+            returnType,
+            doc,
+            _,
+            reexport
+          ) =>
+        SuggestionRow(
+          id               = None,
+          externalIdLeast  = expr.map(_.getLeastSignificantBits),
+          externalIdMost   = expr.map(_.getMostSignificantBits),
+          kind             = SuggestionKind.GETTER,
+          module           = module,
+          name             = name,
+          selfType         = selfType,
+          returnType       = returnType,
+          parentType       = None,
+          isStatic         = false,
+          documentation    = doc,
+          scopeStartLine   = ScopeColumn.EMPTY,
+          scopeStartOffset = ScopeColumn.EMPTY,
+          scopeEndLine     = ScopeColumn.EMPTY,
+          scopeEndOffset   = ScopeColumn.EMPTY,
+          reexport         = reexport
+        )
+      case Suggestion.DefinedMethod(
             expr,
             module,
             name,
@@ -986,8 +1018,21 @@ final class SqlSuggestionsRepo(val db: SqlDatabase)(implicit
           annotations   = Seq(),
           reexport      = suggestion.reexport
         )
+      case SuggestionKind.GETTER =>
+        Suggestion.Getter(
+          externalId =
+            toUUID(suggestion.externalIdLeast, suggestion.externalIdMost),
+          module        = suggestion.module,
+          name          = suggestion.name,
+          arguments     = Seq(),
+          selfType      = suggestion.selfType,
+          returnType    = suggestion.returnType,
+          documentation = suggestion.documentation,
+          annotations   = Seq(),
+          reexport      = suggestion.reexport
+        )
       case SuggestionKind.METHOD =>
-        Suggestion.Method(
+        Suggestion.DefinedMethod(
           externalId =
             toUUID(suggestion.externalIdLeast, suggestion.externalIdMost),
           module        = suggestion.module,
@@ -1006,7 +1051,7 @@ final class SqlSuggestionsRepo(val db: SqlDatabase)(implicit
             toUUID(suggestion.externalIdLeast, suggestion.externalIdMost),
           module        = suggestion.module,
           arguments     = Seq(),
-          sourceType    = suggestion.selfType,
+          selfType    = suggestion.selfType,
           returnType    = suggestion.returnType,
           documentation = suggestion.documentation,
           reexport      = suggestion.reexport

--- a/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/Tables.scala
+++ b/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/Tables.scala
@@ -60,10 +60,11 @@ object SuggestionKind {
   val MODULE: Byte      = 0
   val TYPE: Byte        = 1
   val CONSTRUCTOR: Byte = 2
-  val METHOD: Byte      = 3
-  val FUNCTION: Byte    = 4
-  val LOCAL: Byte       = 5
-  val CONVERSION: Byte  = 6
+  val GETTER: Byte      = 3
+  val METHOD: Byte      = 4
+  val FUNCTION: Byte    = 5
+  val LOCAL: Byte       = 6
+  val CONVERSION: Byte  = 7
 
   /** Create a database suggestion kind.
     *
@@ -75,6 +76,7 @@ object SuggestionKind {
       case Suggestion.Kind.Module      => MODULE
       case Suggestion.Kind.Type        => TYPE
       case Suggestion.Kind.Constructor => CONSTRUCTOR
+      case Suggestion.Kind.Getter      => GETTER
       case Suggestion.Kind.Method      => METHOD
       case Suggestion.Kind.Conversion  => CONVERSION
       case Suggestion.Kind.Function    => FUNCTION
@@ -86,6 +88,7 @@ object SuggestionKind {
       case MODULE      => Suggestion.Kind.Module
       case TYPE        => Suggestion.Kind.Type
       case CONSTRUCTOR => Suggestion.Kind.Constructor
+      case GETTER      => Suggestion.Kind.Getter
       case METHOD      => Suggestion.Kind.Method
       case FUNCTION    => Suggestion.Kind.Function
       case LOCAL       => Suggestion.Kind.Local
@@ -223,7 +226,7 @@ object SuggestionRowUniqueIndex {
     val suggestionName = suggestion match {
       case conversion: Suggestion.Conversion =>
         NameColumn.conversionMethodName(
-          conversion.sourceType,
+          conversion.selfType,
           conversion.returnType
         )
       case _ => suggestion.name
@@ -285,5 +288,5 @@ object SuggestionsVersion extends TableQuery(new SuggestionsVersionTable(_))
 object SchemaVersion extends TableQuery(new SchemaVersionTable(_)) {
 
   /** The current schema version. */
-  val CurrentVersion: Long = 10
+  val CurrentVersion: Long = 11
 }

--- a/lib/scala/searcher/src/test/scala/org/enso/searcher/sql/SuggestionsRepoTest.scala
+++ b/lib/scala/searcher/src/test/scala/org/enso/searcher/sql/SuggestionsRepoTest.scala
@@ -69,26 +69,16 @@ class SuggestionsRepoTest
       thrown.version shouldEqual wrongSchemaVersion
     }
 
-    "insert all suggestions" taggedAs Retry in withRepo { repo =>
-      val suggestions = Seq(
-        suggestion.module,
-        suggestion.tpe,
-        suggestion.constructor,
-        suggestion.method,
-        suggestion.instanceMethod,
-        suggestion.conversion,
-        suggestion.function,
-        suggestion.local
-      )
+    "insert all suggestions111" taggedAs Retry in withRepo { repo =>
       val action =
         for {
           v1        <- repo.currentVersion
-          (v2, ids) <- repo.insertAll(suggestions)
+          (v2, ids) <- repo.insertAll(suggestion.all)
           all       <- repo.selectAllSuggestions
         } yield (ids, all, v1, v2)
 
       val (ids, entries, v1, v2) = Await.result(action, Timeout)
-      val expectedEntries        = ids.zip(suggestions).map(SuggestionEntry.tupled)
+      val expectedEntries        = ids.zip(suggestion.all).map(SuggestionEntry.tupled)
       entries should contain theSameElementsAs expectedEntries
       v1 should not equal v2
     }
@@ -96,32 +86,12 @@ class SuggestionsRepoTest
     "get all suggestions" taggedAs Retry in withRepo { repo =>
       val action =
         for {
-          _ <- repo.insertAll(
-            Seq(
-              suggestion.module,
-              suggestion.tpe,
-              suggestion.constructor,
-              suggestion.method,
-              suggestion.instanceMethod,
-              suggestion.conversion,
-              suggestion.function,
-              suggestion.local
-            )
-          )
+          _   <- repo.insertAll(suggestion.all)
           all <- repo.getAll
         } yield all._2
 
       val suggestions = Await.result(action, Timeout).map(_.suggestion)
-      suggestions should contain theSameElementsAs Seq(
-        suggestion.module,
-        suggestion.tpe,
-        suggestion.constructor,
-        suggestion.method,
-        suggestion.instanceMethod,
-        suggestion.conversion,
-        suggestion.function,
-        suggestion.local
-      )
+      suggestions should contain theSameElementsAs suggestion.all
     }
 
     "fail to insertAll duplicate suggestion" taggedAs Retry in withRepo {
@@ -160,17 +130,7 @@ class SuggestionsRepoTest
 
     "remove suggestions by module names" taggedAs Retry in withRepo { repo =>
       val action = for {
-        (_, idsIns) <- repo.insertAll(
-          Seq(
-            suggestion.module,
-            suggestion.tpe,
-            suggestion.constructor,
-            suggestion.method,
-            suggestion.conversion,
-            suggestion.function,
-            suggestion.local
-          )
-        )
+        (_, idsIns) <- repo.insertAll(suggestion.all)
         (_, idsRem) <- repo.removeModules(Seq(suggestion.constructor.module))
       } yield (idsIns, idsRem)
 
@@ -181,17 +141,7 @@ class SuggestionsRepoTest
     "remove suggestions by empty module names" taggedAs Retry in withRepo {
       repo =>
         val action = for {
-          (v1, _) <- repo.insertAll(
-            Seq(
-              suggestion.module,
-              suggestion.tpe,
-              suggestion.constructor,
-              suggestion.method,
-              suggestion.conversion,
-              suggestion.function,
-              suggestion.local
-            )
-          )
+          (v1, _) <- repo.insertAll(suggestion.all)
           (v2, removed) <- repo.removeModules(Seq())
         } yield (v1, v2, removed)
 
@@ -1494,8 +1444,20 @@ class SuggestionsRepoTest
         annotations   = Seq()
       )
 
-    val method: Suggestion.Method =
-      Suggestion.Method(
+    val getter: Suggestion.Getter =
+      Suggestion.Getter(
+        externalId    = Some(UUID.randomUUID()),
+        module        = "local.Test.Main",
+        name          = "a",
+        arguments     = Seq(),
+        selfType      = "Standard.Builtins.Pair",
+        returnType    = "Standard.Builtins.IO",
+        documentation = None,
+        annotations   = Seq()
+      )
+
+    val method: Suggestion.DefinedMethod =
+      Suggestion.DefinedMethod(
         externalId    = Some(UUID.randomUUID()),
         module        = "local.Test.Main",
         name          = "main",
@@ -1507,8 +1469,8 @@ class SuggestionsRepoTest
         annotations   = Seq()
       )
 
-    val instanceMethod: Suggestion.Method =
-      Suggestion.Method(
+    val instanceMethod: Suggestion.DefinedMethod =
+      Suggestion.DefinedMethod(
         externalId    = Some(UUID.randomUUID()),
         module        = "local.Test.Main",
         name          = "foo",
@@ -1525,7 +1487,7 @@ class SuggestionsRepoTest
         externalId    = Some(UUID.randomUUID()),
         module        = "local.Test.Main",
         arguments     = Seq(),
-        sourceType    = "local.Test.Main.Foo",
+        selfType      = "local.Test.Main.Foo",
         returnType    = "local.Test.Main.Bar",
         documentation = None
       )
@@ -1556,5 +1518,18 @@ class SuggestionsRepoTest
         ),
         documentation = Some("Some bazz")
       )
+
+    val all: Seq[Suggestion] = Seq(
+      module,
+      tpe,
+      constructor,
+      getter,
+      method,
+      instanceMethod,
+      conversion,
+      function,
+      local
+    )
+
   }
 }

--- a/lib/scala/searcher/src/test/scala/org/enso/searcher/sql/SuggestionsRepoTest.scala
+++ b/lib/scala/searcher/src/test/scala/org/enso/searcher/sql/SuggestionsRepoTest.scala
@@ -141,7 +141,7 @@ class SuggestionsRepoTest
     "remove suggestions by empty module names" taggedAs Retry in withRepo {
       repo =>
         val action = for {
-          (v1, _) <- repo.insertAll(suggestion.all)
+          (v1, _)       <- repo.insertAll(suggestion.all)
           (v2, removed) <- repo.removeModules(Seq())
         } yield (v1, v2, removed)
 


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #6936 

Changelog:
- add: new suggestion type Getter that is not exposed to the api
- update: do not return suggestion of type getter when doing a global search (without specifying self types)

Private suggestions and modules mentioned in the issue will be filtered out after we finish the work on the new (refined) exports algorithm.

### Important Notes

![2023-06-09-205327_1088x612_scrot](https://github.com/enso-org/enso/assets/357683/c6b16894-ada0-4ea9-abe8-5efc41949787)


<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
