### PR TITLE
CB/input area focus exclusivity.

### DIFF
--- a/app/gui/view/component-browser/component-list-panel/grid/src/lib.rs
+++ b/app/gui/view/component-browser/component-list-panel/grid/src/lib.rs
@@ -622,6 +622,8 @@ impl component::Frp<Model> for Frp {
         let entry_style = entry::Style::from_theme(network, style_frp);
         let colors = entry::style::Colors::from_theme(network, style_frp);
         let selection_colors = entry::style::SelectionColors::from_theme(network, style_frp);
+        let focus_in = model.on_event::<ensogl_core::event::FocusIn>();
+        let focus_out = model.on_event::<ensogl_core::event::FocusOut>();
         frp::extend! { network
             // === Active and Hovered Entry ===
 
@@ -753,8 +755,9 @@ impl component::Frp<Model> for Frp {
 
             // === Focus propagation ===
 
+            is_focused <- bool(&focus_out, &focus_in);
             // The underlying grid should handle keyboard events only when any element is active.
-            grid.deprecated_set_focus <+ out.focused && out.is_active;
+            grid.deprecated_set_focus <+ is_focused && out.is_active;
         }
 
         // Set the proper number of columns so we can set column widths.

--- a/app/gui/view/component-browser/component-list-panel/src/lib.rs
+++ b/app/gui/view/component-browser/component-list-panel/src/lib.rs
@@ -51,6 +51,7 @@ use crate::navigator::Navigator as SectionNavigator;
 use enso_frp as frp;
 use ensogl_core::application::frp::API;
 use ensogl_core::application::Application;
+use ensogl_core::control::io::mouse;
 use ensogl_core::data::bounding_box::BoundingBox;
 use ensogl_core::data::color;
 use ensogl_core::define_endpoints_2;
@@ -377,10 +378,8 @@ impl component::Frp<Model> for Frp {
                 model.is_hovered(pos, style)
             })).gate(&is_visible).on_change();
             output.is_hovered <+ is_hovered;
-            // TODO[ib] Temporary solution for focus, we grab keyboard events if the
-            //   component browser is visible. The proper implementation is tracked in
-            //   https://www.pivotaltracker.com/story/show/180872763
-            model.grid.deprecated_set_focus <+ is_visible;
+            let mouse_down = model.on_event::<mouse::Down>();
+            eval_ mouse_down (model.grid.focus());
 
             on_hover_end <- is_hovered.on_false();
             model.grid.unhover_element <+ on_hover_end;

--- a/app/gui/view/graph-editor/src/component/node.rs
+++ b/app/gui/view/graph-editor/src/component/node.rs
@@ -673,9 +673,13 @@ impl Node {
             let background_press = model.background.on_event::<mouse::Down>();
             let input_press = model.input.on_event::<mouse::Down>();
             input_as_background_press <- input_press.gate(&input.set_edit_ready_mode);
+            // When editing, clicks focus the `Text` component and set the cursor position.
+            background_as_input_press <- background_press.gate(&model.input.editing);
+            model.input.mouse_down <+_ background_as_input_press;
+            background_press <- background_press.gate_not(&model.input.editing);
             any_background_press <- any(&background_press, &input_as_background_press);
             any_primary_press <- any_background_press.filter(mouse::event::is_primary);
-            out.background_press <+ any_primary_press.constant(());
+            out.background_press <+_ any_primary_press;
 
 
             // === Selection ===

--- a/app/gui/view/graph-editor/src/component/node/input/area.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/area.rs
@@ -172,12 +172,13 @@ impl Model {
             self.display_object.remove_child(&self.widget_tree);
             self.display_object.add_child(&self.edit_mode_label);
             self.edit_mode_label.set_cursor_at_mouse_position();
+            self.edit_mode_label.focus();
         } else {
             self.display_object.remove_child(&self.edit_mode_label);
             self.display_object.add_child(&self.widget_tree);
             self.edit_mode_label.set_content("");
+            self.edit_mode_label.blur();
         }
-        self.edit_mode_label.deprecated_set_focus(edit_mode_active);
     }
 
     #[profile(Debug)]
@@ -355,6 +356,10 @@ ensogl::define_endpoints! {
         /// `set_expression` instead. In case the usage type is set to None, ports still may be
         /// colored if the definition type was present.
         set_expression_usage_type (ast::Id,Option<Type>),
+
+        /// Signal a mouse click in the input area. The click position will be determined by the
+        /// current pointer position, and the cursor position will be updated in the text area.
+        mouse_down (),
     }
 
     Output {
@@ -451,6 +456,10 @@ impl Area {
             label_hovered <- reacts_to_hover && frp.output.body_hover;
             model.edit_mode_label.set_hover <+ label_hovered && set_editing;
             hovered_body_pointer <- label_hovered.map(f!((t) model.body_hover_pointer_style(t)));
+
+            // === Edit Mode Focus ===
+
+            eval_ frp.input.mouse_down (model.edit_mode_label.focus());
 
             // === Port Hover ===
 

--- a/lib/rust/ensogl/component/text/src/component/text.rs
+++ b/lib/rust/ensogl/component/text/src/component/text.rs
@@ -363,6 +363,7 @@ ensogl_core::define_endpoints_2! {
 impl Text {
     fn init(self) -> Self {
         self.init_hover();
+        self.init_focus();
         self.init_single_line_mode();
         self.init_cursors();
         self.init_selections();
@@ -384,6 +385,21 @@ impl Text {
             hovered <- any(&input.set_hover,&hovered);
             out.hovered <+ hovered;
             out.pointer_style <+ out.hovered.map(|h| h.then_or_default(cursor::Style::cursor));
+        }
+    }
+
+    fn init_focus(&self) {
+        let network = self.frp.network();
+        let input = &self.frp.input;
+
+        let focus_in = self.on_event::<ensogl_core::event::FocusIn>();
+        let focus_out = self.on_event::<ensogl_core::event::FocusOut>();
+
+        frp::extend! { network
+            // The `shortcut` API uses the old focus API. By forwarding the new API to the old API
+            // here, the text component is compatible with either.
+            input.deprecated_focus <+_ focus_in;
+            input.deprecated_defocus <+_ focus_out;
         }
     }
 


### PR DESCRIPTION
### Pull Request Description

When the CB is clicked, it takes focus from the node input area. When the node input area is clicked, it takes focus back. Only the focused component responds to keyboard events.

[vokoscreenNG-2023-06-15_09-28-25.webm](https://github.com/enso-org/enso/assets/1047859/c03393ff-e3b2-4322-9dbb-55870c2fccab)

Implements main functionality of #5337. Fixes #6124.

### Important Notes

- The `shortcut` API now schedules its event handlers through a `microtask`, so that any other (directly-connected) handlers of the same events will run first. This supports setting conditions (such as `focused`) before they are evaluated by the shortcut handler, which is important to be able to do reliably because the `shortcut` pointer events unconditionally, and some external handler must determine whether they belong to the component in question.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] ~Unit tests have been written where possible.~
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
