### PR TITLE
Improvements that significantly reduce the chances of request timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -826,6 +826,7 @@
 - [Improve and colorize compiler's diagnostic messages][6931]
 - [Execute some runtime commands synchronously to avoid race conditions][6998]
 - [Scala 2.13.11 update][7010]
+- [Improve parallel execution of commands and jobs in Language Server][7042]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -944,6 +945,7 @@
 [6931]: https://github.com/enso-org/enso/pull/6931
 [6998]: https://github.com/enso-org/enso/pull/6998
 [7010]: https://github.com/enso-org/enso/pull/7010
+[7042]: https://github.com/enso-org/enso/pull/7042
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -291,7 +291,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: LogLevel) {
     .option(RuntimeOptions.LOG_MASKING, Masking.isMaskingEnabled.toString)
     .option(RuntimeOptions.EDITION_OVERRIDE, Info.currentEdition)
     .option(
-      RuntimeServerInfo.JOB_PARALLELISM_OPTION,
+      RuntimeOptions.JOB_PARALLELISM,
       Runtime.getRuntime.availableProcessors().toString
     )
     .option(RuntimeOptions.PREINITIALIZE, "js")

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
@@ -48,6 +48,11 @@ public class RuntimeOptions {
               INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION)
           .build();
 
+  public static final String JOB_PARALLELISM = interpreterOptionName("jobParallelism");
+  public static final OptionKey<Integer> JOB_PARALLELISM_KEY = new OptionKey<>(1);
+  public static final OptionDescriptor JOB_PARALLELISM_DESCRIPTOR =
+      OptionDescriptor.newBuilder(JOB_PARALLELISM_KEY, JOB_PARALLELISM).build();
+
   public static final String ENABLE_PROJECT_SUGGESTIONS = optionName("enableProjectSuggestions");
   public static final OptionKey<Boolean> ENABLE_PROJECT_SUGGESTIONS_KEY = new OptionKey<>(true);
   private static final OptionDescriptor ENABLE_PROJECT_SUGGESTIONS_DESCRIPTOR =
@@ -127,6 +132,7 @@ public class RuntimeOptions {
               LANGUAGE_HOME_OVERRIDE_DESCRIPTOR,
               EDITION_OVERRIDE_DESCRIPTOR,
               INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION_DESCRIPTOR,
+              JOB_PARALLELISM_DESCRIPTOR,
               DISABLE_IR_CACHES_DESCRIPTOR,
               PREINITIALIZE_DESCRIPTOR,
               WAIT_FOR_PENDING_SERIALIZATION_JOBS_DESCRIPTOR,

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeServerInfo.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeServerInfo.java
@@ -8,9 +8,5 @@ public class RuntimeServerInfo {
   public static final String URI = "enso://runtime-server";
   public static final String INSTRUMENT_NAME = "enso-runtime-server";
   public static final String ENABLE_OPTION = INSTRUMENT_NAME + ".enable";
-
-  public static final String JOB_PARALLELISM_OPTION = INSTRUMENT_NAME + ".jobParallelism";
-  public static final OptionKey<Integer> JOB_PARALLELISM_KEY = new OptionKey<>(1);
-  public static final OptionDescriptor JOB_PARALLELISM_DESCRIPTOR =
-      OptionDescriptor.newBuilder(JOB_PARALLELISM_KEY, JOB_PARALLELISM_OPTION).build();
+  public static final OptionKey<String> ENABLE_OPTION_KEY = new OptionKey<>("");
 }

--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeServerInfo.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeServerInfo.java
@@ -1,6 +1,5 @@
 package org.enso.polyglot;
 
-import org.graalvm.options.OptionDescriptor;
 import org.graalvm.options.OptionKey;
 
 /** Container for Runtime Server related constants. */

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/SetExecutionEnvironmentCommand.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/SetExecutionEnvironmentCommand.java
@@ -43,7 +43,7 @@ public class SetExecutionEnvironmentCommand extends Command {
       Runtime$Api$ExecutionEnvironment executionEnvironment, UUID contextId, RuntimeContext ctx) {
     var logger = ctx.executionService().getLogger();
     var contextLockTimestamp = ctx.locking().acquireContextLock(contextId);
-    ctx.locking().acquireWriteCompilationLock();
+    var writeLockTimestamp = ctx.locking().acquireWriteCompilationLock();
 
     try {
       Stack<InstrumentFrame> stack = ctx.contextManager().getStack(contextId);
@@ -56,10 +56,15 @@ public class SetExecutionEnvironmentCommand extends Command {
       reply(new Runtime$Api$SetExecutionEnvironmentResponse(contextId), ctx);
     } finally {
       ctx.locking().releaseWriteCompilationLock();
+      logger.log(
+          Level.FINEST,
+          "Kept write compilation lock [SetExecutionEnvironmentCommand] for "
+              + (System.currentTimeMillis() - writeLockTimestamp)
+              + " milliseconds");
       ctx.locking().releaseContextLock(contextId);
       logger.log(
           Level.FINEST,
-          "Kept context lock [UpsertVisualisationJob] for "
+          "Kept context lock [SetExecutionEnvironmentCommand] for "
               + (System.currentTimeMillis() - contextLockTimestamp)
               + " milliseconds");
     }

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/SetExecutionEnvironmentCommand.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/SetExecutionEnvironmentCommand.java
@@ -2,7 +2,6 @@ package org.enso.interpreter.instrument.command;
 
 import java.util.UUID;
 import java.util.logging.Level;
-
 import org.enso.interpreter.instrument.CacheInvalidation;
 import org.enso.interpreter.instrument.InstrumentFrame;
 import org.enso.interpreter.instrument.execution.RuntimeContext;

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/SerializeModuleJob.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/SerializeModuleJob.java
@@ -29,7 +29,7 @@ public final class SerializeModuleJob extends BackgroundJob<Void> {
             .getEnvironment()
             .getOptions()
             .get(RuntimeOptions.USE_GLOBAL_IR_CACHE_LOCATION_KEY);
-    ctx.locking().acquireWriteCompilationLock();
+    var writeLockTimestamp = ctx.locking().acquireWriteCompilationLock();
     try {
       ctx.executionService()
           .getContext()
@@ -50,6 +50,13 @@ public final class SerializeModuleJob extends BackgroundJob<Void> {
               });
     } finally {
       ctx.locking().releaseWriteCompilationLock();
+      ctx.executionService()
+          .getLogger()
+          .log(
+              Level.FINEST,
+              "Kept write compilation lock [SetExecutionEnvironmentCommand] for "
+                  + (System.currentTimeMillis() - writeLockTimestamp)
+                  + " milliseconds");
     }
     return null;
   }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/CloseFileCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/CloseFileCmd.scala
@@ -3,6 +3,8 @@ package org.enso.interpreter.instrument.command
 import org.enso.interpreter.instrument.execution.RuntimeContext
 import org.enso.polyglot.runtime.Runtime.Api
 
+import java.util.logging.Level
+
 /** A command that closes a file.
   *
   * @param request a request for a service
@@ -11,16 +13,29 @@ class CloseFileCmd(request: Api.CloseFileNotification)
     extends SynchronousCommand(None) {
 
   override def executeSynchronously(implicit ctx: RuntimeContext): Unit = {
-    ctx.locking.acquireReadCompilationLock()
-    ctx.locking.acquireFileLock(request.path)
-    ctx.locking.acquirePendingEditsLock()
+    val logger                    = ctx.executionService.getLogger
+    val readLockTimestamp         = ctx.locking.acquireReadCompilationLock()
+    val fileLockTimestamp         = ctx.locking.acquireFileLock(request.path)
+    val pendingEditsLockTimestamp = ctx.locking.acquirePendingEditsLock()
     try {
       ctx.state.pendingEdits.dequeue(request.path)
       ctx.executionService.resetModuleSources(request.path)
     } finally {
       ctx.locking.releasePendingEditsLock()
+      logger.log(
+        Level.FINEST,
+        "Kept pending edits lock [CloseFileCmd] for " + (System.currentTimeMillis - pendingEditsLockTimestamp) + " milliseconds"
+      )
       ctx.locking.releaseFileLock(request.path)
+      logger.log(
+        Level.FINEST,
+        "Kept file lock [CloseFileCmd] for " + (System.currentTimeMillis - fileLockTimestamp) + " milliseconds"
+      )
       ctx.locking.releaseReadCompilationLock()
+      logger.log(
+        Level.FINEST,
+        "Kept read compilation lock [CloseFileCmd] for " + (System.currentTimeMillis - readLockTimestamp) + " milliseconds"
+      )
     }
   }
 

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/DestroyContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/DestroyContextCmd.scala
@@ -4,6 +4,7 @@ import org.enso.interpreter.instrument.execution.RuntimeContext
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.polyglot.runtime.Runtime.Api.RequestId
 
+import java.util.logging.Level
 import scala.concurrent.{ExecutionContext, Future}
 
 /** A command that destroys the specified execution context.
@@ -34,13 +35,18 @@ class DestroyContextCmd(
   }
 
   private def removeContext()(implicit ctx: RuntimeContext): Unit = {
+    val logger = ctx.executionService.getLogger
     ctx.jobControlPlane.abortJobs(request.contextId)
-    ctx.locking.acquireContextLock(request.contextId)
+    val lockTimestamp = ctx.locking.acquireContextLock(request.contextId)
     try {
       ctx.contextManager.destroy(request.contextId)
       reply(Api.DestroyContextResponse(request.contextId))
     } finally {
       ctx.locking.releaseContextLock(request.contextId)
+      logger.log(
+        Level.FINEST,
+        s"Kept context lock [DestroyContextCmd] for ${System.currentTimeMillis() - lockTimestamp} milliseconds"
+      )
       ctx.locking.removeContextLock(request.contextId)
     }
   }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/ModifyVisualisationCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/ModifyVisualisationCmd.scala
@@ -4,11 +4,13 @@ import org.enso.interpreter.instrument.execution.RuntimeContext
 import org.enso.interpreter.instrument.job.{
   EnsureCompiledJob,
   ExecuteJob,
+  Job,
   UpsertVisualisationJob
 }
 import org.enso.polyglot.runtime.Runtime.Api
-import org.enso.polyglot.runtime.Runtime.Api.RequestId
+import org.enso.polyglot.runtime.Runtime.Api.ExpressionId
 
+import java.util.logging.Level
 import scala.concurrent.{ExecutionContext, Future}
 
 /** A command that modifies a visualisation.
@@ -17,7 +19,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * @param request a request for a service
   */
 class ModifyVisualisationCmd(
-  maybeRequestId: Option[RequestId],
+  maybeRequestId: Option[Api.RequestId],
   request: Api.ModifyVisualisation
 ) extends AsynchronousCommand(maybeRequestId) {
 
@@ -26,8 +28,9 @@ class ModifyVisualisationCmd(
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {
-    val contextId = request.visualisationConfig.executionContextId
-    ctx.locking.acquireContextLock(contextId)
+    val logger        = ctx.executionService.getLogger
+    val contextId     = request.visualisationConfig.executionContextId
+    val lockTimestamp = ctx.locking.acquireContextLock(contextId)
     try {
       if (doesContextExist) {
         modifyVisualisation()
@@ -36,6 +39,10 @@ class ModifyVisualisationCmd(
       }
     } finally {
       ctx.locking.releaseContextLock(contextId)
+      logger.log(
+        Level.FINEST,
+        s"Kept context lock [UpsertVisualisationJob] for ${System.currentTimeMillis() - lockTimestamp} milliseconds"
+      )
     }
   }
 
@@ -43,11 +50,22 @@ class ModifyVisualisationCmd(
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {
-    val maybeVisualisation = ctx.contextManager.getVisualisationById(
+    val exisitingVisualisation = ctx.contextManager.getVisualisationById(
       request.visualisationConfig.executionContextId,
       request.visualisationId
     )
-    maybeVisualisation match {
+    val visualisationPresent: Option[ExpressionId] =
+      exisitingVisualisation.map(_.expressionId).orElse {
+        val jobFilter = (job: Job[_]) =>
+          job match {
+            case upsert: UpsertVisualisationJob
+                if upsert.getVisualizationId() == request.visualisationId =>
+              Some(upsert.key)
+            case _ => None
+          }
+        ctx.jobControlPlane.jobInProgress(jobFilter)
+      }
+    visualisationPresent match {
       case None =>
         Future {
           ctx.endpoint.sendToClient(
@@ -55,14 +73,16 @@ class ModifyVisualisationCmd(
           )
         }
 
-      case Some(visualisation) =>
+      case Some(expressionId) =>
+        ctx.endpoint.sendToClient(
+          Api.Response(maybeRequestId, Api.VisualisationModified())
+        )
         val maybeFutureExecutable =
           ctx.jobProcessor.run(
             new UpsertVisualisationJob(
               maybeRequestId,
-              Api.VisualisationModified(),
               request.visualisationId,
-              visualisation.expressionId,
+              expressionId,
               request.visualisationConfig
             )
           )
@@ -96,6 +116,10 @@ class ModifyVisualisationCmd(
         Api.ContextNotExistError(request.visualisationConfig.executionContextId)
       )
     }
+  }
+
+  override def toString: String = {
+    "ModifyVisualisationCmd(visualizationId: " + request.visualisationId + ")"
   }
 
 }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RenameProjectCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RenameProjectCmd.scala
@@ -33,9 +33,9 @@ class RenameProjectCmd(
     } yield ()
 
   private def doRename(implicit ctx: RuntimeContext): Unit = {
-    ctx.locking.acquireWriteCompilationLock()
+    val logger             = ctx.executionService.getLogger
+    val writeLockTimestamp = ctx.locking.acquireWriteCompilationLock()
     try {
-      val logger = ctx.executionService.getLogger
       logger.log(
         Level.FINE,
         s"Renaming project [old:${request.namespace}.${request.oldName},new:${request.namespace}.${request.newName}]..."
@@ -76,6 +76,11 @@ class RenameProjectCmd(
       )
     } finally {
       ctx.locking.releaseWriteCompilationLock()
+      logger.log(
+        Level.FINEST,
+        "Kept write compilation lock [RenameProjectCmd] for " + (System.currentTimeMillis - writeLockTimestamp) + " milliseconds"
+      )
+
     }
   }
 

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/CommandExecutionEngine.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/CommandExecutionEngine.scala
@@ -20,7 +20,9 @@ class CommandExecutionEngine(interpreterContext: InterpreterContext)
       .get(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION_KEY)
       .booleanValue()
 
-  private val locking = new ReentrantLocking
+  private val locking = new ReentrantLocking(
+    interpreterContext.executionService.getLogger
+  )
 
   private val executionState = new ExecutionState()
 

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobControlPlane.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobControlPlane.scala
@@ -32,5 +32,5 @@ trait JobControlPlane {
 
   /** Finds the first in-progress job satisfying the `filter` condition
     */
-  def jobInProgress[T](filter: Job[_] => Option[T]): Option[T]
+  def jobInProgress[T](filter: PartialFunction[Job[_], Option[T]]): Option[T]
 }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobControlPlane.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobControlPlane.scala
@@ -29,4 +29,8 @@ trait JobControlPlane {
     * already running.
     */
   def startBackgroundJobs(): Boolean
+
+  /** Finds the first in-progress job satisfying the `filter` condition
+    */
+  def jobInProgress[T](filter: Job[_] => Option[T]): Option[T]
 }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
@@ -187,4 +187,11 @@ final class JobExecutionEngine(
     delayedBackgroundJobsQueue.forEach(job => runBackground(job))
     delayedBackgroundJobsQueue.clear()
   }
+
+  override def jobInProgress[T](filter: Job[_] => Option[T]): Option[T] = {
+    val allJobs = runningJobsRef.get()
+    allJobs
+      .find(runningJob => filter(runningJob.job).nonEmpty)
+      .flatMap(runningJob => filter(runningJob.job))
+  }
 }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/Locking.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/Locking.scala
@@ -19,7 +19,9 @@ trait Locking {
     */
   def removeFileLock(file: File): Unit
 
-  /** Acquires a compilation write lock.
+  /** Acquires a compilation write lock and returns a timestamp when it succeeded.
+    *
+    * @return timestamp of when the lock was acquired
     */
   def acquireWriteCompilationLock(): Long
 
@@ -27,7 +29,9 @@ trait Locking {
     */
   def releaseWriteCompilationLock(): Unit
 
-  /** Acquires a compilation read lock.
+  /** Acquires a compilation read lock and returns a timestamp when it succeeded.
+    *
+    * @return timestamp of when the lock was acquired
     */
   def acquireReadCompilationLock(): Long
 
@@ -35,7 +39,9 @@ trait Locking {
     */
   def releaseReadCompilationLock(): Unit
 
-  /** Acquires a pending edits lock.
+  /** Acquires a pending edits lock and returns a timestamp when it succeeded.
+    *
+    * @return timestamp of when the lock was acquired
     */
   def acquirePendingEditsLock(): Long
 
@@ -56,9 +62,10 @@ trait Locking {
     */
   def releaseContextLock(contextId: UUID): Unit
 
-  /** Acquires a file lock.
+  /** Acquires a file lock and returns a timestamp when it succeeded.
     *
     * @param file a file to lock
+    * @return timestamp of when the lock was acquired
     */
   def acquireFileLock(file: File): Long
 

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/Locking.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/Locking.scala
@@ -21,7 +21,7 @@ trait Locking {
 
   /** Acquires a compilation write lock.
     */
-  def acquireWriteCompilationLock(): Unit
+  def acquireWriteCompilationLock(): Long
 
   /** Releases a compilation write lock.
     */
@@ -29,7 +29,7 @@ trait Locking {
 
   /** Acquires a compilation read lock.
     */
-  def acquireReadCompilationLock(): Unit
+  def acquireReadCompilationLock(): Long
 
   /** Releases a compilation read lock.
     */
@@ -37,17 +37,18 @@ trait Locking {
 
   /** Acquires a pending edits lock.
     */
-  def acquirePendingEditsLock(): Unit
+  def acquirePendingEditsLock(): Long
 
   /** Releases a pending edits lock.
     */
   def releasePendingEditsLock(): Unit
 
-  /** Acquires a context lock.
+  /** Acquires a context lock and returns a timestamp when it succeeded.
     *
     * @param contextId a context to lock
+    * @return timestamp of when the lock was acquired
     */
-  def acquireContextLock(contextId: UUID): Unit
+  def acquireContextLock(contextId: UUID): Long
 
   /** Releases a context lock.
     *
@@ -59,7 +60,7 @@ trait Locking {
     *
     * @param file a file to lock
     */
-  def acquireFileLock(file: File): Unit
+  def acquireFileLock(file: File): Long
 
   /** Releases a file lock.
     *

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/ReentrantLocking.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/ReentrantLocking.scala
@@ -1,13 +1,16 @@
 package org.enso.interpreter.instrument.execution
 
+import com.oracle.truffle.api.TruffleLogger
+
 import java.io.File
 import java.util.UUID
 import java.util.concurrent.locks.{Lock, ReentrantLock, ReentrantReadWriteLock}
+import java.util.logging.Level
 
 /** Provides locking capabilities for the runtime server. Ir uses reentrant
   * locks.
   */
-class ReentrantLocking extends Locking {
+class ReentrantLocking(logger: TruffleLogger) extends Locking {
 
   private val compilationLock = new ReentrantReadWriteLock(true)
 
@@ -72,42 +75,55 @@ class ReentrantLocking extends Locking {
   }
 
   /** @inheritdoc */
-  override def acquireWriteCompilationLock(): Unit =
-    compilationLock.writeLock().lockInterruptibly()
+  override def acquireWriteCompilationLock(): Long = {
+    logLockAcquisition(compilationLock.writeLock(), "write compilation")
+  }
 
   /** @inheritdoc */
   override def releaseWriteCompilationLock(): Unit =
     compilationLock.writeLock().unlock()
 
   /** @inheritdoc */
-  override def acquireReadCompilationLock(): Unit =
-    compilationLock.readLock().lockInterruptibly()
+  override def acquireReadCompilationLock(): Long = {
+    logLockAcquisition(compilationLock.readLock(), "read compilation")
+  }
 
   /** @inheritdoc */
   override def releaseReadCompilationLock(): Unit =
     compilationLock.readLock().unlock()
 
   /** @inheritdoc */
-  override def acquirePendingEditsLock(): Unit =
-    pendingEditsLock.lock()
+  override def acquirePendingEditsLock(): Long = {
+    logLockAcquisition(pendingEditsLock, "pending edit")
+  }
 
   /** @inheritdoc */
   override def releasePendingEditsLock(): Unit =
     pendingEditsLock.unlock()
 
   /** @inheritdoc */
-  override def acquireContextLock(contextId: UUID): Unit =
-    getContextLock(contextId).lockInterruptibly()
+  override def acquireContextLock(contextId: UUID): Long = {
+    logLockAcquisition(getContextLock(contextId), s"$contextId context")
+  }
 
   /** @inheritdoc */
   override def releaseContextLock(contextId: UUID): Unit =
     getContextLock(contextId).unlock()
 
   /** @inheritdoc */
-  override def acquireFileLock(file: File): Unit =
-    getFileLock(file).lockInterruptibly()
+  override def acquireFileLock(file: File): Long = {
+    logLockAcquisition(getFileLock(file), "file")
+  }
 
   /** @inheritdoc */
   override def releaseFileLock(file: File): Unit = getFileLock(file).unlock()
+
+  private def logLockAcquisition(lock: Lock, msg: String): Long = {
+    val now = System.currentTimeMillis()
+    lock.lockInterruptibly()
+    val now2 = System.currentTimeMillis()
+    logger.log(Level.FINEST, s"Waited ${now2 - now} for the $msg lock")
+    now2
+  }
 
 }

--- a/engine/runtime-instrument-runtime-server/src/main/java/org/enso/interpreter/instrument/RuntimeServerInstrument.java
+++ b/engine/runtime-instrument-runtime-server/src/main/java/org/enso/interpreter/instrument/RuntimeServerInstrument.java
@@ -142,8 +142,7 @@ public class RuntimeServerInstrument extends TruffleInstrument {
   protected OptionDescriptors getOptionDescriptors() {
     return OptionDescriptors.create(
         Arrays.asList(
-            OptionDescriptor.newBuilder(new OptionKey<>(""), RuntimeServerInfo.ENABLE_OPTION)
-                .build(),
-            RuntimeServerInfo.JOB_PARALLELISM_DESCRIPTOR));
+            OptionDescriptor.newBuilder(RuntimeServerInfo.ENABLE_OPTION_KEY, RuntimeServerInfo.ENABLE_OPTION)
+                .build()));
   }
 }

--- a/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -1605,7 +1605,8 @@ class RuntimeVisualizationsTest
         )
       )
     )
-    context.receiveN(1) should contain theSameElementsAs Seq(
+    context.receiveN(2) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.VisualisationAttached()),
       Api.Response(requestId, Api.ModuleNotFound("Test.Undefined"))
     )
   }
@@ -1766,7 +1767,8 @@ class RuntimeVisualizationsTest
         )
       )
     )
-    context.receiveN(1) should contain theSameElementsAs Seq(
+    context.receiveN(2) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.VisualisationAttached()),
       Api.Response(
         requestId,
         Api.VisualisationExpressionFailed(

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -45,7 +45,6 @@ import org.enso.pkg.PackageManager;
 import org.enso.pkg.QualifiedName;
 import org.enso.polyglot.LanguageInfo;
 import org.enso.polyglot.RuntimeOptions;
-import org.enso.polyglot.RuntimeServerInfo;
 import org.graalvm.options.OptionKey;
 import scala.jdk.javaapi.OptionConverters;
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -462,8 +462,10 @@ public class EnsoContext {
 
   /** The job parallelism or 1 */
   public int getJobParallelism() {
-    var n = getOption(RuntimeServerInfo.JOB_PARALLELISM_KEY);
-    return n == null ? 1 : n.intValue();
+    var n = getOption(RuntimeOptions.JOB_PARALLELISM_KEY);
+    var base = n == null ? 1 : n.intValue();
+    var optimal = Math.round(base * 0.5);
+    return optimal < 1 ? 1 : (int) optimal;
   }
 
   /**


### PR DESCRIPTION
### Pull Request Description

Request Timeouts started plaguing IDE due to numerous `executionContext/***Visualization` requests. While caused by a bug they revealed a bigger problem in the Language Server when serving large amounts of requests:
1) Long and short lived jobs are fighting for various locks. Lock contention leads to some jobs waiting for a longer than desired leading to unexpected request timeouts. Increasing timeout value is just delaying the problem.
2) Requests coming from IDE are served almost instantly and handled by various commands. Commands can issue further jobs that serve request. We apparently have and always had a single-thread thread pool for serving such jobs, leading to immediate thread starvation.

Both reasons increase the chances of Request Timeouts when dealing with a large number of requests. For 2) I noticed that while we used to set the `enso-runtime-server.jobParallelism` option descriptor key to some machine-dependent value (most likely > 1), the value set would **only** be available for instrumentation. `JobExecutionEngine` where it is actually used would always get the default, i.e. a single-threaded ThreadPool. This means that this option descriptor was simply misused since its introduction. Moved that option to runtime options so that it can be set and retrieved during normal operation.

Adding parallelism intensified problem 1), because now we could execute multiple jobs and they would compete for resources. It also revealed a scenario for a yet another deadlock scenario, due to invalid order of lock acquisition. See `ExecuteJob` vs `UpsertVisualisationJob` order for details.

Still, a number of requests would continue to randomly timeout due to lock contention. It became apparent that
`Attach/Modify/Detach-VisualisationCmd` should not wait until a triggered `UpsertVisualisationJob` sends a response to the client; long and short lived jobs will always compete for resources and we cannot guarantee that they will not timeout that way. That is why the response is sent immediately from the command handler and not from the job executed after it.

This brings another problematic scenario:
1. `AttachVisualisationCmd` is executed, response sent to the client, `UpsertVisualisationJob` scheduled.
2. In the meantime `ModifyVisualisationCmd` comes and fails; command cannot find the visualization that will only be added by `UpsertVisualisationJob`, which might have not yet been scheduled to run.

Remedied that by checking visualisation-related jobs that are still in progress. It also allowed for cancelling jobs which results wouldn't be used anyway (`ModifyVisualisationCmd` sends its own `UpsertVisualisationJob`). This is not a theoretical scenario, it happened frequently on IDE startup.

This change does not fully solve the rather problematic setup of numerous locks, which are requested by short and long lived jobs. A better design should still be investigated. But it significantly reduces the chances of Request Timeouts which IDE had to deal with.

With this change I haven't been able to experience Request Timeouts for relatively modest projects anymore.

I added the possibility of logging wait times for locks to better investigate further problems.

Closes #7005 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
