### PR TITLE
Never return null from InteropLibrary calls

### DIFF
--- a/engine/runtime-with-polyglot/src/test/java/org/enso/interpreter/test/InsightForEnsoTest.java
+++ b/engine/runtime-with-polyglot/src/test/java/org/enso/interpreter/test/InsightForEnsoTest.java
@@ -49,6 +49,7 @@ public class InsightForEnsoTest {
             print(`${ctx.name} at ${ctx.source.name}:${ctx.line}:`);
             let dump = "";
             for (let p in frame) {
+                frame.unknown // used to yield NullPointerException
                 dump += ` ${p}=${frame[p]}`;
             }
             print(dump);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/DebugLocalScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/DebugLocalScope.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 import org.enso.interpreter.EnsoLanguage;
 import org.enso.interpreter.node.EnsoRootNode;
 import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.error.DataflowError;
 
 /**
  * This class serves as a basic support for debugging with Chrome inspector. Currently, only
@@ -180,11 +181,8 @@ public class DebugLocalScope implements TruffleObject {
   @ExportMessage
   Object readMember(String member) {
     FramePointer framePtr = allBindings.get(member);
-    if (framePtr == null) {
-      return null;
-    } else {
-      return getValue(frame, framePtr);
-    }
+    var value = getValue(frame, framePtr);
+    return value != null ? value : DataflowError.UNINITIALIZED;
   }
 
   @ExportMessage


### PR DESCRIPTION
### Pull Request Description

Preventing `NullPointerException` from debugger and GraalVM Insight.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
