### PR TITLE
Fix scrollbars not being visible in fullscreen text visualisation. 

### DIFF
--- a/app/gui/view/graph-editor/src/builtin/visualization/native/text_visualization.rs
+++ b/app/gui/view/graph-editor/src/builtin/visualization/native/text_visualization.rs
@@ -42,7 +42,8 @@ use ensogl_component::grid_view::GridView;
 use ensogl_component::scrollbar;
 use ensogl_component::scrollbar::Scrollbar;
 use ensogl_hardcoded_theme as theme;
-
+use text_provider::BackendTextProvider;
+use text_provider::TextProvider;
 
 
 // =================
@@ -79,9 +80,6 @@ pub struct GridWindow {
     position: GridPosition,
     size:     GridSize,
 }
-
-use text_provider::BackendTextProvider;
-use text_provider::TextProvider;
 
 
 
@@ -164,19 +162,16 @@ impl<T: 'static> Model<T> {
         self.root.add_child(&self.scroll_bar_horizontal);
         self.root.add_child(&self.scroll_bar_vertical);
         self.scroll_bar_vertical.set_rotation_z(-90.0_f32.to_radians());
-
-        self.app.display.default_scene.layers.main.add(&self.scroll_bar_horizontal);
-        self.app.display.default_scene.layers.main.add(&self.scroll_bar_vertical);
     }
 
     fn set_size(&self, size: Vector2) {
-        self.scroll_bar_horizontal.set_y(-size.y / 2.0);
-        self.scroll_bar_horizontal.set_length(size.x);
         let scrollbar_width = scrollbar::WIDTH - scrollbar::PADDING;
-        self.scroll_bar_horizontal.modify_y(|y| *y += scrollbar_width / 2.0);
-        self.scroll_bar_vertical.set_x(size.x / 2.0);
+        let h_y = -size.y / 2.0 + scrollbar_width / 2.0;
+        self.scroll_bar_horizontal.set_y(h_y);
+        self.scroll_bar_horizontal.set_length(size.x);
+        let v_x = size.x / 2.0 - scrollbar_width / 2.0;
+        self.scroll_bar_vertical.set_x(v_x);
         self.scroll_bar_vertical.set_length(size.y);
-        self.scroll_bar_vertical.modify_x(|x| *x -= scrollbar_width / 2.0);
         let text_padding = Vector2::new(PADDING_TEXT, PADDING_TEXT);
         self.clipping_div.set_dom_size(size - 2.0 * text_padding);
         self.size.set(size);

--- a/app/gui/view/graph-editor/src/component/visualization/container.rs
+++ b/app/gui/view/graph-editor/src/component/visualization/container.rs
@@ -353,6 +353,7 @@ impl ContainerModel {
     fn init(self) -> Self {
         self.display_object.add_child(&self.drag_root);
         self.scene.layers.above_nodes.add(&self.action_bar);
+        self.scene.layers.panel.add(&self.fullscreen_view);
         self.update_shape_sizes(ViewState::default());
         self.init_corner_roundness();
         self.view.show_waiting_screen();


### PR DESCRIPTION
### Pull Request Description

Fixes #6855

Correctly sets the layers of the full-screen panel and the scrollbars. The full-screen panel needs to be in the `panel` layer, as it is fixed and above everything else.  The scrollbars in the text visualization should be placed together with their parents, so they are switched correctly between layers when enabling/disabling full-screen. Leaving their layer otherwise unspecified should not lead to occlusion issues, as all other elements in the text visualization are Dom elements, and therefore placed below EnsoGL elements.  

https://github.com/enso-org/enso/assets/1428930/db80c5b7-69fd-4bf5-84ab-c83664227059


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
