### PR TITLE
Fix defect where constructor fields not show for `Value` constructors.

### DIFF
--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/IdExecutionService.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/IdExecutionService.java
@@ -20,7 +20,7 @@ import org.enso.logger.masking.MaskedString;
 import org.enso.pkg.QualifiedName;
 
 public interface IdExecutionService {
-  public static final String INSTRUMENT_ID = "id-value-extractor";
+  String INSTRUMENT_ID = "id-value-extractor";
 
   /**
    * Attach a new event node factory to observe identified nodes within given function.
@@ -222,7 +222,7 @@ public interface IdExecutionService {
           AtomConstructor atomConstructor = qualifiedAccessor.getAtomConstructor();
           moduleName = atomConstructor.getDefinitionScope().getModule().getName();
           typeName = atomConstructor.getType().getQualifiedName();
-          functionName = atomConstructor.getDisplayName();
+          functionName = atomConstructor.getName();
         }
         case EnsoRootNode ensoRootNode -> {
           moduleName = ensoRootNode.getModuleScope().getModule().getName();


### PR DESCRIPTION
### Pull Request Description

The `IdExecutionService` now uses `getName` not `getDisplayName` for atomConstructor.
`getDisplayName` adjusts the name if the name is `Value` or `Error`, which meant no parameters in IDE.

Before:
![image](https://github.com/enso-org/enso/assets/4699705/ddc564fe-3213-46ec-9684-ab718f8bb0bb)

Now:
![image](https://github.com/enso-org/enso/assets/4699705/59d3ece4-1148-44bb-8a13-7bc3db8dfca2)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
