### PR TITLE
fix: Remove race in MultiProgress write/flush

### DIFF
--- a/build/ci_utils/src/log.rs
+++ b/build/ci_utils/src/log.rs
@@ -2,6 +2,7 @@ use crate::prelude::*;
 use tracing_subscriber::prelude::*;
 
 use crate::global;
+
 use std::io;
 use std::sync::Once;
 use tracing::span::Attributes;

--- a/build/ci_utils/src/log.rs
+++ b/build/ci_utils/src/log.rs
@@ -70,8 +70,7 @@ pub fn setup_logging() -> Result {
             .with_default_directive(LevelFilter::TRACE.into())
             .from_env_lossy();
 
-        let progress_bar = global::multi_progress_bar();
-        let progress_bar_writer = IndicatifWriter::new(progress_bar);
+        let progress_bar_writer = IndicatifWriter::new();
 
         tracing::subscriber::set_global_default(
             Registry::default().with(MyLayer).with(
@@ -101,16 +100,14 @@ pub fn setup_logging() -> Result {
 ///
 /// To avoid this, the writer suspends the progress bars when writing logs.
 #[derive(Clone, Debug)]
-struct IndicatifWriter {
-    progress_bar: indicatif::MultiProgress,
-}
+struct IndicatifWriter;
 
 
 // === Main `impl` ===
 
 impl IndicatifWriter {
-    pub fn new(progress_bar: indicatif::MultiProgress) -> Self {
-        Self { progress_bar }
+    pub fn new() -> Self {
+        Self
     }
 }
 
@@ -119,11 +116,11 @@ impl IndicatifWriter {
 
 impl std::io::Write for IndicatifWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.progress_bar.suspend(|| io::stderr().write(buf))
+        global::with_suspend_multi_progress_bar(|| io::stderr().write(buf))
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        self.progress_bar.suspend(|| io::stderr().flush())
+        global::with_suspend_multi_progress_bar(|| io::stderr().flush())
     }
 }
 


### PR DESCRIPTION
### Pull Request Description

`MultiProgress` write/flush requires the progress bar be suspended. The previous impl caused a deadlock because the `MultiProgress` bar contains an `RwLock` and was also stored in a `Mutex` (meaning we could acquire the outer lock then be blocked on acquiring the inner lock). This change ensures that we always acquire the `Mutex` before getting a handle to the `MultiProgress`, making the deadlock impossible.
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] ~~Unit tests have been written where possible.~~
  - [ ] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
