### PR TITLE
Temporarily disable macOS signing and notarization

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -590,7 +590,6 @@ jobs:
           APPLEIDPASS: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
           CSC_IDENTITY_AUTO_DISCOVERY: "true"
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CODE_SIGNING_CERT_PASSWORD }}
-          CSC_LINK: ${{ secrets.APPLE_CODE_SIGNING_CERT }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: failure() && runner.os == 'Windows'
         name: List files if failed (Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -625,7 +625,6 @@ jobs:
           APPLEIDPASS: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
           CSC_IDENTITY_AUTO_DISCOVERY: "true"
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CODE_SIGNING_CERT_PASSWORD }}
-          CSC_LINK: ${{ secrets.APPLE_CODE_SIGNING_CERT }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: failure() && runner.os == 'Windows'
         name: List files if failed (Windows)

--- a/app/gui/src/controller/searcher.rs
+++ b/app/gui/src/controller/searcher.rs
@@ -3,8 +3,11 @@
 use crate::model::traits::*;
 use crate::prelude::*;
 
+use crate::controller::graph::executed::Handle;
 use crate::controller::graph::FailedToCreateNode;
 use crate::controller::searcher::component::group;
+use crate::model::execution_context::QualifiedMethodPointer;
+use crate::model::execution_context::Visualization;
 use crate::model::module::NodeEditStatus;
 use crate::model::module::NodeMetadata;
 use crate::model::suggestion_database;
@@ -36,10 +39,8 @@ pub mod breadcrumbs;
 pub mod component;
 pub mod input;
 
-use crate::controller::graph::executed::Handle;
-use crate::model::execution_context::QualifiedMethodPointer;
-use crate::model::execution_context::Visualization;
 pub use action::Action;
+
 
 
 // =================

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -193,10 +193,13 @@ pub fn expose_os_specific_signing_secret(os: OS, step: Step) -> Step {
                 &crate::ide::web::env::WIN_CSC_KEY_PASSWORD,
             ),
         OS::MacOS => step
-            .with_secret_exposed_as(
-                secret::APPLE_CODE_SIGNING_CERT,
-                &crate::ide::web::env::CSC_LINK,
-            )
+            // This temporarily disables notarization and code signing.
+            // Should be uncommented, once https://github.com/enso-org/enso/issues/7091 is
+            // addressed.
+            // .with_secret_exposed_as(
+            //     secret::APPLE_CODE_SIGNING_CERT,
+            //     &crate::ide::web::env::CSC_LINK,
+            // )
             .with_secret_exposed_as(
                 secret::APPLE_CODE_SIGNING_CERT_PASSWORD,
                 &crate::ide::web::env::CSC_KEY_PASSWORD,


### PR DESCRIPTION
MacOS builds are now failing, because Apple started rejecting us.
It should be reinstated, when #7091  is addressed.

### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
