### PR TITLE
Don't instrument function bodies

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/function/StatementNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/function/StatementNode.java
@@ -1,14 +1,11 @@
 package org.enso.interpreter.node.callable.function;
 
-import com.oracle.truffle.api.Assumption;
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.StandardTags;
 import com.oracle.truffle.api.instrumentation.Tag;
 import com.oracle.truffle.api.source.SourceSection;
 import org.enso.interpreter.node.ClosureRootNode;
 import org.enso.interpreter.node.ExpressionNode;
-import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.tag.AvoidIdInstrumentationTag;
 
 /**

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -1755,7 +1755,7 @@ class IrToTruffle(
       location: Option[IdentifiedLocation],
       binding: Boolean = false
     ): CreateFunctionNode = {
-      val bodyBuilder = new BuildFunctionBody(arguments, body, None, binding)
+      val bodyBuilder = new BuildFunctionBody(arguments, body, None, false)
       val fnRootNode = ClosureRootNode.build(
         language,
         scope,


### PR DESCRIPTION
### Pull Request Description

Function bodies cannot be instrumented even if the function is right inside a binding. Consider a scenario when a function is assigned to a variable and then applied to a `map` method of a really large vector. The instrumentation will render execution extremely slow.

Alternatively we would still support instrumenting function bodies in this limited case but take into account the number of times function is actually called.

Closes #7070

### Important Notes

![Screenshot from 2023-06-21 17-20-52](https://github.com/enso-org/enso/assets/292128/57e7809b-b731-4f04-8a01-dceedb6b73d3)


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
