### PR TITLE
fix dragging out edge from node output

### DIFF
--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -2669,8 +2669,8 @@ impl GraphEditor {
             cannot_interact <- input.set_read_only || out.has_detached_edge;
             cannot_interact <- all(cannot_interact, init)._0();
             can_create_new_edge <- cannot_interact.not();
-            can_create_on_output <- can_create_new_edge.sample(&touch.output_port.selected);
-            can_create_on_input <- can_create_new_edge.sample(&touch.input_port.selected);
+            can_create_on_output <- can_create_new_edge.sample(&touch.output_port.down);
+            can_create_on_input <- can_create_new_edge.sample(&touch.input_port.down);
 
             // Attach detached edge to node port when clicking or releasing on node port.
             port_output_mouse_up <- out.hover_node_output.sample(&mouse.up_primary).unwrap();
@@ -2685,9 +2685,9 @@ impl GraphEditor {
             ).unwrap();
 
             // Create new detached edge when clicking on node port.
-            state.set_detached_edge <+ touch.output_port.selected.gate(&can_create_on_output)
+            state.set_detached_edge <+ touch.output_port.down.gate(&can_create_on_output)
                 .map(|source| DetachedEdge::new_source(*source));
-            state.set_detached_edge <+ touch.input_port.selected.gate(&can_create_on_input)
+            state.set_detached_edge <+ touch.input_port.down.gate(&can_create_on_input)
                 .filter(f!([model] (t) !model.is_node_connected_at_input(t.node_id,t.port)))
                 .map(|target| DetachedEdge::new_target(*target));
         }


### PR DESCRIPTION
### Pull Request Description

Fixes #7102

The edge can now again be created both by clicking or dragging the output port.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
