### PR TITLE
Empty input in REPL does not throw NPE

### DIFF
--- a/engine/runner/src/main/scala/org/enso/runner/Repl.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Repl.scala
@@ -130,7 +130,9 @@ case class Repl(replIO: ReplIO) extends SessionManager {
         case EndOfInput =>
           continueRunning = false
         case Line(line) =>
-          if (line == ":list" || line == ":l") {
+          if (line.isEmpty) {
+            // nop
+          } else if (line == ":list" || line == ":l") {
             val bindings = executor.listBindings()
             bindings.foreach { case (varName, value) =>
               replIO.println(s"$varName = $value")

--- a/engine/runtime/src/main/java/org/enso/interpreter/EnsoLanguage.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/EnsoLanguage.java
@@ -209,12 +209,12 @@ public final class EnsoLanguage extends TruffleLanguage<EnsoContext> {
    * will be returned.
    *
    * @param request request for inline parsing
-   * @throws Exception if the compiler failed to parse
+   * @throws InlineParsingException if the compiler failed to parse
    * @return An {@link ExecutableNode} representing an AST fragment if the request contains
    *   syntactically correct Enso source, {@code null} otherwise.
    */
   @Override
-  protected ExecutableNode parse(InlineParsingRequest request) throws Exception {
+  protected ExecutableNode parse(InlineParsingRequest request) throws InlineParsingException {
     if (request.getLocation().getRootNode() instanceof EnsoRootNode ensoRootNode) {
       var context = EnsoContext.get(request.getLocation());
       Tree inlineExpr = context.getCompiler().parseInline(request.getSource());

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/EvalNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/EvalNode.java
@@ -67,7 +67,7 @@ public abstract class EvalNode extends BaseNode {
         InlineContext.fromJava(
             localScope, moduleScope, getTailStatus(), context.getCompilerConfig());
     ExpressionNode expr =
-        context.getCompiler().runInline(expression, inlineContext).getOrElse(null);
+        context.getCompiler().runInline(expression, inlineContext).getOrElse(() -> null);
     if (expr == null) {
       throw new RuntimeException("Invalid code passed to `eval`: " + expression);
     }


### PR DESCRIPTION
### Pull Request Description

Fix for an annoying NullPointerException thrown when an empty line is fed to REPL, i.e., when one just presses Enter. Now, you can press Enter, creating as many blank prompts, as you want:
![image](https://github.com/enso-org/enso/assets/14013887/8f38e210-da5c-46a0-b5f1-1a5da9e62584)


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [X] Unit tests have been written where possible.
  - [X] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
