### PR TITLE
Improve TCO in the presence of warnings

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/dispatch/CallOptimiserNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/dispatch/CallOptimiserNode.java
@@ -5,6 +5,7 @@ import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import org.enso.interpreter.runtime.callable.CallerInfo;
 import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.error.Warning;
 import org.enso.interpreter.runtime.state.State;
 
 /**
@@ -33,6 +34,7 @@ public abstract class CallOptimiserNode extends Node {
    * @param callerInfo the caller info to pass to the function
    * @param state the state to pass to the function
    * @param arguments the arguments to {@code callable}
+   * @param warnings warnings associated with the callable, null if empty
    * @return the result of executing {@code callable} using {@code arguments}
    */
   public abstract Object executeDispatch(
@@ -40,5 +42,6 @@ public abstract class CallOptimiserNode extends Node {
       Function callable,
       CallerInfo callerInfo,
       State state,
-      Object[] arguments);
+      Object[] arguments,
+      Warning[] warnings);
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/dispatch/CurryNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/dispatch/CurryNode.java
@@ -133,7 +133,7 @@ public class CurryNode extends BaseNode {
           return value;
         }
       } else {
-        var evaluatedVal = loopingCall.executeDispatch(frame, function, callerInfo, state, arguments);
+        var evaluatedVal = loopingCall.executeDispatch(frame, function, callerInfo, state, arguments, null);
 
         return this.oversaturatedCallableNode.execute(
             evaluatedVal, frame, state, oversaturatedArguments);
@@ -154,7 +154,7 @@ public class CurryNode extends BaseNode {
     return switch (getTailStatus()) {
       case TAIL_DIRECT -> directCall.executeCall(frame, function, callerInfo, state, arguments);
       case TAIL_LOOP -> throw new TailCallException(function, callerInfo, arguments);
-      default -> loopingCall.executeDispatch(frame, function, callerInfo, state, arguments);
+      default -> loopingCall.executeDispatch(frame, function, callerInfo, state, arguments, null);
     };
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/dispatch/IndirectCurryNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/dispatch/IndirectCurryNode.java
@@ -92,7 +92,7 @@ public abstract class IndirectCurryNode extends Node {
           return value;
         }
       } else {
-        var evaluatedVal = loopingCall.executeDispatch(frame, function, callerInfo, state, arguments);
+        var evaluatedVal = loopingCall.executeDispatch(frame, function, callerInfo, state, arguments, null);
 
         return oversaturatedCallableNode.execute(
             evaluatedVal,
@@ -129,7 +129,7 @@ public abstract class IndirectCurryNode extends Node {
       case TAIL_LOOP:
         throw new TailCallException(function, callerInfo, arguments);
       default:
-        return loopingCall.executeDispatch(frame, function, callerInfo, state, arguments);
+        return loopingCall.executeDispatch(frame, function, callerInfo, state, arguments, null);
     }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/dispatch/SimpleCallOptimiserNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/dispatch/SimpleCallOptimiserNode.java
@@ -9,6 +9,7 @@ import org.enso.interpreter.node.callable.ExecuteCallNodeGen;
 import org.enso.interpreter.runtime.callable.CallerInfo;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.control.TailCallException;
+import org.enso.interpreter.runtime.error.Warning;
 import org.enso.interpreter.runtime.state.State;
 
 /**
@@ -40,6 +41,7 @@ public class SimpleCallOptimiserNode extends CallOptimiserNode {
    * @param callerInfo the caller info to pass to the function
    * @param state the state to pass to the function
    * @param arguments the arguments to {@code function}
+   * @param warnings warnings associated with the callable, null if empty
    * @return the result of executing {@code function} using {@code arguments}
    */
   @Override
@@ -48,7 +50,8 @@ public class SimpleCallOptimiserNode extends CallOptimiserNode {
       Function function,
       CallerInfo callerInfo,
       State state,
-      Object[] arguments) {
+      Object[] arguments,
+      Warning[] warnings) {
     try {
       return executeCallNode.executeCall(frame, function, callerInfo, state, arguments);
     } catch (TailCallException e) {
@@ -65,7 +68,7 @@ public class SimpleCallOptimiserNode extends CallOptimiserNode {
         }
       }
       return next.executeDispatch(
-          frame, e.getFunction(), e.getCallerInfo(), state, e.getArguments());
+          frame, e.getFunction(), e.getCallerInfo(), state, e.getArguments(), e.getWarnings());
     }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/thunk/ThunkExecutorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/thunk/ThunkExecutorNode.java
@@ -67,7 +67,7 @@ public abstract class ThunkExecutorNode extends Node {
         return callNode.call(Function.ArgumentsHelper.buildArguments(function, state));
       } catch (TailCallException e) {
         return loopingCallOptimiserNode.executeDispatch(
-            frame, e.getFunction(), e.getCallerInfo(), state, e.getArguments());
+            frame, e.getFunction(), e.getCallerInfo(), state, e.getArguments(), e.getWarnings());
       }
     }
   }
@@ -89,7 +89,7 @@ public abstract class ThunkExecutorNode extends Node {
             function.getCallTarget(), Function.ArgumentsHelper.buildArguments(function, state));
       } catch (TailCallException e) {
         return loopingCallOptimiserNode.executeDispatch(
-            frame, e.getFunction(), e.getCallerInfo(), state, e.getArguments());
+            frame, e.getFunction(), e.getCallerInfo(), state, e.getArguments(), e.getWarnings());
       }
     }
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/ordering/SortVectorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/ordering/SortVectorNode.java
@@ -811,8 +811,8 @@ public abstract class SortVectorNode extends Node {
       Object yConverted;
       if (hasCustomOnFunc) {
         // onFunc cannot have `self` argument, we assume it has just one argument.
-        xConverted = callNode.executeDispatch(null, onFunc.get(x), null, state, new Object[]{x});
-        yConverted = callNode.executeDispatch(null, onFunc.get(y), null, state, new Object[]{y});
+        xConverted = callNode.executeDispatch(null, onFunc.get(x), null, state, new Object[]{x}, null);
+        yConverted = callNode.executeDispatch(null, onFunc.get(y), null, state, new Object[]{y}, null);
       } else {
         xConverted = x;
         yConverted = y;
@@ -823,7 +823,7 @@ public abstract class SortVectorNode extends Node {
       } else {
         args = new Object[] {xConverted, yConverted};
       }
-      Object res = callNode.executeDispatch(null, compareFunc.get(xConverted), null, state, args);
+      Object res = callNode.executeDispatch(null, compareFunc.get(xConverted), null, state, args, null);
       if (res == less) {
         return ascending ? -1 : 1;
       } else if (res == equal) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -636,7 +636,8 @@ public final class Module implements TruffleObject {
           eval.getFunction(),
           callerInfo,
           context.emptyState(),
-          new Object[] {builtins.debug(), Text.create(expr)});
+          new Object[] {builtins.debug(), Text.create(expr)},
+          null);
     }
 
     private static Object generateDocs(Module module, EnsoContext context) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/control/TailCallException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/control/TailCallException.java
@@ -3,6 +3,7 @@ package org.enso.interpreter.runtime.control;
 import com.oracle.truffle.api.nodes.ControlFlowException;
 import org.enso.interpreter.runtime.callable.CallerInfo;
 import org.enso.interpreter.runtime.callable.function.Function;
+import org.enso.interpreter.runtime.error.Warning;
 
 /**
  * Used to model the switch of control-flow from standard stack-based execution to looping.
@@ -13,18 +14,38 @@ public class TailCallException extends ControlFlowException {
   private final Function function;
   private final CallerInfo callerInfo;
   private final Object[] arguments;
+  private final Warning[] warnings;
 
   /**
    * Creates a new exception containing the necessary data to continue computation.
    *
    * @param function the function to execute in a loop
-   * @param state the state to pass to the function
+   * @param callerInfo the caller execution context
    * @param arguments the arguments to {@code function}
    */
   public TailCallException(Function function, CallerInfo callerInfo, Object[] arguments) {
     this.function = function;
     this.callerInfo = callerInfo;
     this.arguments = arguments;
+    this.warnings = null;
+  }
+
+  private TailCallException(
+      Function function, CallerInfo callerInfo, Object[] arguments, Warning[] warnings) {
+    this.function = function;
+    this.callerInfo = callerInfo;
+    this.arguments = arguments;
+    this.warnings = warnings;
+  }
+
+  /**
+   * Creates a new exception containing the necessary data to continue computation.
+   *
+   * @param origin the original tail call exception
+   * @param warnings warnings to be associated with the tail call exception
+   */
+  public TailCallException(TailCallException origin, Warning[] warnings) {
+    this(origin.getFunction(), origin.getCallerInfo(), origin.getArguments(), warnings);
   }
 
   /**
@@ -52,5 +73,14 @@ public class TailCallException extends ControlFlowException {
    */
   public CallerInfo getCallerInfo() {
     return callerInfo;
+  }
+
+  /**
+   * Gets the warnings that should be appended to the result of calling the function.
+   *
+   * @return the warnings to be appended to the result of the call, or null if empty
+   */
+  public Warning[] getWarnings() {
+    return warnings;
   }
 }

--- a/test/Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Tests/src/Semantic/Warnings_Spec.enso
@@ -437,6 +437,7 @@ spec = Test.group "Dataflow Warnings" <|
         result_non_tail . should_equal 6
         Warning.get_all result_non_tail . map .value . should_equal ["Foo"]
 
+    Test.specify "should not break TCO when warnings are attached to arguments" <|
         vec = Vector.new 10000 (i-> i+1)
         elem1 = Warning.attach "WARNING1" 998
         vec.contains 998 . should_equal True

--- a/test/Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Tests/src/Semantic/Warnings_Spec.enso
@@ -437,4 +437,19 @@ spec = Test.group "Dataflow Warnings" <|
         result_non_tail . should_equal 6
         Warning.get_all result_non_tail . map .value . should_equal ["Foo"]
 
+        vec = Vector.new 10000 (i-> i+1)
+        elem1 = Warning.attach "WARNING1" 998
+        vec.contains 998 . should_equal True
+        res1 = vec.contains elem1
+        res1 . should_equal True
+        Warning.get_all res1 . map .value . should_equal ["WARNING1"]
+
+        elem2 = Warning.attach "WARNING2" 9988
+        vec.contains 9988 . should_equal True
+        vec.contains elem2 . should_equal True
+
+        res2 = vec.contains elem2
+        res2 . should_equal True
+        Warning.get_all res2 . map .value . should_equal ["WARNING2"]
+
 main = Test_Suite.run_main spec

--- a/test/Tests/src/Semantic/Warnings_Spec.enso
+++ b/test/Tests/src/Semantic/Warnings_Spec.enso
@@ -442,12 +442,12 @@ spec = Test.group "Dataflow Warnings" <|
         elem1 = Warning.attach "WARNING1" 998
         vec.contains 998 . should_equal True
         res1 = vec.contains elem1
-        res1 . should_equal True
+        res1 . should_be_true
         Warning.get_all res1 . map .value . should_equal ["WARNING1"]
 
         elem2 = Warning.attach "WARNING2" 9988
-        vec.contains 9988 . should_equal True
-        vec.contains elem2 . should_equal True
+        vec.contains 9988 . should_be_true
+        vec.contains elem2 . should_be_true
 
         res2 = vec.contains elem2
         res2 . should_equal True


### PR DESCRIPTION
### Pull Request Description

Partially revert https://github.com/enso-org/enso/pull/6849, which introduced a regression in TCO in the presence of warnings. Rather than modifying the tail call status, `TailCallException` now propagates the extracted warnings and appends them to the final result. 

Closes #7093 

### Important Notes

Compared to the previous attempt we don't pay the penalty of adding the warnings or even checking for them because it is being dealt in a separate specialization.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

~~- [ ] The documentation has been updated, if necessary.~~
~~- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  ~~- [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
