### PR TITLE
Do not adjust node position when created under mouse cursor.

### DIFF
--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -3710,6 +3710,8 @@ mod tests {
     }
 
     #[test]
+    // The alignment is disabled for mouse-oriented node placement. See [`new_node_position`] docs.
+    #[ignore]
     fn test_magnet_alignment_when_adding_node_by_shortcut() {
         test_magnet_alignment_when_adding_node(move_mouse_and_add_node_by_shortcut);
     }

--- a/app/gui/view/graph-editor/src/new_node_position.rs
+++ b/app/gui/view/graph-editor/src/new_node_position.rs
@@ -31,6 +31,10 @@ pub mod free_place_finder;
 /// Return a position for a newly created node. The position is calculated by establishing a
 /// reference position and then aligning it to existing nodes.
 ///
+/// **Note** The aligning nodes is currently disabled for nodes which were created under mouse
+/// position (including dropping an edge), as it turned out to be confusing for users. It may be
+/// brought back once the algorithm will be improved.
+///
 /// The reference position is chosen from among:
 ///  - the position of a source node of the dropped edge (if available),
 ///  - the bottom-most selected node (if available),
@@ -63,7 +67,7 @@ pub fn new_node_position(
         AddNodeEvent => default(),
         StartCreationEvent | ClickingButton if some_nodes_are_selected =>
             under_selected_nodes(graph_editor),
-        StartCreationEvent => at_mouse_aligned_to_close_nodes(graph_editor, mouse_position),
+        StartCreationEvent => mouse_position,
         ClickingButton => {
             let pos = on_ray(graph_editor, screen_center, Vector2(0.0, -1.0)).unwrap();
             magnet_alignment(graph_editor, pos, HorizontallyAndVertically)

--- a/app/gui/view/graph-editor/src/new_node_position.rs
+++ b/app/gui/view/graph-editor/src/new_node_position.rs
@@ -68,8 +68,7 @@ pub fn new_node_position(
             let pos = on_ray(graph_editor, screen_center, Vector2(0.0, -1.0)).unwrap();
             magnet_alignment(graph_editor, pos, HorizontallyAndVertically)
         }
-        DroppingEdge { endpoint } =>
-            at_mouse_aligned_to_source_node(graph_editor, endpoint.node_id, mouse_position),
+        DroppingEdge { endpoint } => mouse_position,
         StartCreationFromPortEvent { endpoint } => under(graph_editor, endpoint.node_id),
     }
 }

--- a/app/gui/view/graph-editor/src/new_node_position.rs
+++ b/app/gui/view/graph-editor/src/new_node_position.rs
@@ -33,7 +33,8 @@ pub mod free_place_finder;
 ///
 /// **Note** The aligning nodes is currently disabled for nodes which were created under mouse
 /// position (including dropping an edge), as it turned out to be confusing for users. It may be
-/// brought back once the algorithm will be improved.
+/// brought back once the algorithm will be improved (the [`at_mouse_aligned_to_close_nodes`]
+/// function)
 ///
 /// The reference position is chosen from among:
 ///  - the position of a source node of the dropped edge (if available),
@@ -72,7 +73,7 @@ pub fn new_node_position(
             let pos = on_ray(graph_editor, screen_center, Vector2(0.0, -1.0)).unwrap();
             magnet_alignment(graph_editor, pos, HorizontallyAndVertically)
         }
-        DroppingEdge { endpoint } => mouse_position,
+        DroppingEdge { .. } => mouse_position,
         StartCreationFromPortEvent { endpoint } => under(graph_editor, endpoint.node_id),
     }
 }


### PR DESCRIPTION
### Pull Request Description

Fixes #7064 

Because our position adjusting mechanism was very confusing for users, especially on edge drops, this PR disables this adjusting for the cases where node is about to be put under the mouse pointer.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
