### PR TITLE
Send `executionComplete` response only on success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -845,6 +845,7 @@
 - [Improve parallel execution of commands and jobs in Language Server][7042]
 - [Added retries when executing GraalVM updater][7079]
 - [Add method call info for infix operators][7090]
+- [`executionComplete` response is sent on successful execution only][7143]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -967,6 +968,7 @@
 [7042]: https://github.com/enso-org/enso/pull/7042
 [7079]: https://github.com/enso-org/enso/pull/7079
 [7090]: https://github.com/enso-org/enso/pull/7090
+[7143]: https://github.com/enso-org/enso/pull/7143
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/docs/language-server/protocol-language-server.md
+++ b/docs/language-server/protocol-language-server.md
@@ -51,6 +51,7 @@ transport formats, please look [here](./protocol-architecture).
   - [`TextEdit`](#textedit)
   - [`DiagnosticType`](#diagnostictype)
   - [`StackTraceElement`](#stacktraceelement)
+  - [`ExecutionResult`](#executionresult)
   - [`Diagnostic`](#diagnostic)
   - [`SHA3-224`](#sha3-224)
   - [`FileEdit`](#fileedit)
@@ -1157,6 +1158,12 @@ interface StackTraceElement {
   location?: Range;
 }
 ```
+
+### `ExecutionResult`
+
+An execution result object is produced as a result of an execution attempt.
+Compared to `Diagnostic` object it can also represent a critical failure
+information.
 
 ### `Diagnostic`
 
@@ -3796,15 +3803,22 @@ None
 
 ### `executionContext/executionFailed`
 
-Sent from the server to the client to inform about a critical failure when
+Sent from the server to the client to inform about a failure when
 attempting to execute a context.
 
-When the [`executionContext/executionStatus`](#executioncontextexecutionstatus)
-notifies about potential problems in the code found by compiler, or the errors
-during runtime, this message signals about the errors in the logic or the
-implementation. It can be a compiler crash, an attempt to execute an empty
+The [`executionContext/executionStatus`](#executioncontextexecutionstatus)
+notifies about potential problems in the code found by compiler which did
+not prevent the execution from completing successfully.
+This message signals about the non-critical errors during runtime, or critical
+failures in the logic or the implementation.
+A critical failure can be a compiler crash, an attempt to execute an empty
 stack, an error location a method or a module when issuing a
 [`executionContext/push`](#executioncontextpush) command.
+
+`executionContext/executionFailed` and
+[`executionContext/executionComplete`](#executioncontextexecutioncomplete)
+messages are mutually exclusive, indicating a failed or a successful
+execution, respectively.
 
 - **Type:** Notification
 - **Direction:** Server -> Client
@@ -3821,14 +3835,9 @@ stack, an error location a method or a module when issuing a
   contextId: ContextId;
 
   /**
-   * The error message.
+   * The details of the failed execution.
    */
-  message: String;
-
-  /**
-   * The location of a file producing the error.
-   */
-  path?: Path;
+  result: ExecutionResult;
 }
 ```
 
@@ -3840,6 +3849,11 @@ None
 
 Sent from the server to the client to inform about the successful execution of a
 context.
+
+`executionContext/executionFailed` and
+[`executionContext/executionComplete`](#executioncontextexecutioncomplete)
+messages are mutually exclusive, indicating a failed or a successful
+execution, respectively.
 
 - **Type:** Notification
 - **Direction:** Server -> Client

--- a/docs/language-server/protocol-language-server.md
+++ b/docs/language-server/protocol-language-server.md
@@ -3803,22 +3803,21 @@ None
 
 ### `executionContext/executionFailed`
 
-Sent from the server to the client to inform about a failure when
-attempting to execute a context.
+Sent from the server to the client to inform about a failure when attempting to
+execute a context.
 
 The [`executionContext/executionStatus`](#executioncontextexecutionstatus)
-notifies about potential problems in the code found by compiler which did
-not prevent the execution from completing successfully.
-This message signals about the non-critical errors during runtime, or critical
-failures in the logic or the implementation.
-A critical failure can be a compiler crash, an attempt to execute an empty
-stack, an error location a method or a module when issuing a
+notifies about potential problems in the code found by compiler which did not
+prevent the execution from completing successfully. This message signals about
+the non-critical errors during runtime, or critical failures in the logic or the
+implementation. A critical failure can be a compiler crash, an attempt to
+execute an empty stack, an error location a method or a module when issuing a
 [`executionContext/push`](#executioncontextpush) command.
 
 `executionContext/executionFailed` and
 [`executionContext/executionComplete`](#executioncontextexecutioncomplete)
-messages are mutually exclusive, indicating a failed or a successful
-execution, respectively.
+messages are mutually exclusive, indicating a failed or a successful execution,
+respectively.
 
 - **Type:** Notification
 - **Direction:** Server -> Client
@@ -3852,8 +3851,8 @@ context.
 
 `executionContext/executionFailed` and
 [`executionContext/executionComplete`](#executioncontextexecutioncomplete)
-messages are mutually exclusive, indicating a failed or a successful
-execution, respectively.
+messages are mutually exclusive, indicating a failed or a successful execution,
+respectively.
 
 - **Type:** Notification
 - **Direction:** Server -> Client

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/RuntimeFailureMapper.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/RuntimeFailureMapper.scala
@@ -71,7 +71,7 @@ final class RuntimeFailureMapper(contentRootManager: ContentRootManager) {
   ): (Option[File], String) = {
     result match {
       case ExecutionResult.Diagnostic(
-            DiagnosticType.Error(),
+            DiagnosticType.Error,
             message,
             file,
             _,
@@ -117,9 +117,9 @@ final class RuntimeFailureMapper(contentRootManager: ContentRootManager) {
     kind: Api.DiagnosticType
   ): ContextRegistryProtocol.ExecutionDiagnosticKind =
     kind match {
-      case Api.DiagnosticType.Error() =>
+      case Api.DiagnosticType.Error =>
         ContextRegistryProtocol.ExecutionDiagnosticKind.Error
-      case Api.DiagnosticType.Warning() =>
+      case Api.DiagnosticType.Warning =>
         ContextRegistryProtocol.ExecutionDiagnosticKind.Warning
     }
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/RuntimeFailureMapper.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/RuntimeFailureMapper.scala
@@ -11,6 +11,8 @@ import org.enso.languageserver.protocol.json.ErrorApi._
 import org.enso.languageserver.runtime.ExecutionApi._
 import org.enso.polyglot.runtime.Runtime.Api
 import cats.implicits._
+import org.enso.polyglot.runtime.Runtime.Api.{DiagnosticType, ExecutionResult}
+
 import java.io.File
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -55,12 +57,34 @@ final class RuntimeFailureMapper(contentRootManager: ContentRootManager) {
     * @return the registry protocol representation fo the diagnostic message
     */
   def toProtocolFailure(
-    error: Api.ExecutionResult.Failure
+    result: Api.ExecutionResult
   )(implicit
     ec: ExecutionContext
-  ): Future[ContextRegistryProtocol.ExecutionFailure] =
-    for (path <- findRelativePath(error.file))
-      yield ContextRegistryProtocol.ExecutionFailure(error.message, path)
+  ): Future[ContextRegistryProtocol.ExecutionFailure] = {
+    val (file, msg) = fromExecutionResultToError(result)
+    for (path <- findRelativePath(file))
+      yield ContextRegistryProtocol.ExecutionFailure(msg, path)
+  }
+
+  private def fromExecutionResultToError(
+    result: Api.ExecutionResult
+  ): (Option[File], String) = {
+    result match {
+      case ExecutionResult.Diagnostic(
+            DiagnosticType.Error(),
+            message,
+            file,
+            _,
+            _,
+            _
+          ) =>
+        (file, message.getOrElse("unknown error"))
+      case ExecutionResult.Failure(msg, path) =>
+        (path, msg)
+      case _ =>
+        (None, s"internal error, got $result instead of an error")
+    }
+  }
 
   /** Convert the runtime diagnostic message to the context registry protocol
     * representation.

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -1,6 +1,10 @@
 package org.enso.polyglot.runtime
 
-import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
+import com.fasterxml.jackson.annotation.{
+  JsonIgnoreProperties,
+  JsonSubTypes,
+  JsonTypeInfo
+}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.cbor.CBORFactory
 import com.fasterxml.jackson.module.scala.{
@@ -855,10 +859,19 @@ object Runtime {
         )
       )
     )
-    sealed trait DiagnosticType
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    sealed trait DiagnosticType {
+
+      /** Checks if this diagnostic type represents an error. */
+      def isError(): Boolean
+    }
     object DiagnosticType {
-      case class Error()   extends DiagnosticType
-      case class Warning() extends DiagnosticType
+      case class Error() extends DiagnosticType {
+        override def isError(): Boolean = true
+      }
+      case class Warning() extends DiagnosticType {
+        override def isError(): Boolean = false
+      }
     }
 
     /** The element in the stack trace.
@@ -898,7 +911,15 @@ object Runtime {
         )
       )
     )
-    sealed trait ExecutionResult extends ToLogString
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    sealed trait ExecutionResult extends ToLogString {
+
+      /** Checks if this result represents a critical failure. * */
+      def isFailure: Boolean
+
+      /** Checks if this result represents a non-critical error. * */
+      def isError: Boolean
+    }
     object ExecutionResult {
 
       /** A diagnostic object produced as a compilation outcome, like error or
@@ -930,6 +951,10 @@ object Runtime {
           s"expressionId=$expressionId," +
           s"stack=${stack.map(_.toLogString(shouldMask))}" +
           ")"
+
+        override def isFailure: Boolean = false
+
+        override def isError: Boolean = kind.isError()
       }
 
       case object Diagnostic {
@@ -998,6 +1023,10 @@ object Runtime {
           s"Failure(message=$message,file=" +
           file.map(f => MaskedPath(f.toPath).toLogString(shouldMask)) +
           ")"
+
+        override def isFailure: Boolean = true
+
+        override def isError: Boolean = true
       }
 
     }
@@ -1088,22 +1117,22 @@ object Runtime {
         ")"
     }
 
-    /** Signals about the critical failure during the context execution.
+    /** Signals about the failure during the context execution.
       *
       * @param contextId the context's id
-      * @param failure the error description
+      * @param result the result of the execution
       */
     final case class ExecutionFailed(
       contextId: ContextId,
-      failure: ExecutionResult.Failure
+      result: ExecutionResult
     ) extends ApiNotification
         with ToLogString {
 
       /** @inheritdoc */
       override def toLogString(shouldMask: Boolean): String =
         "ExecutionFailed(" +
-        s"contextId=$contextId,failure=" +
-        failure.toLogString(shouldMask) +
+        s"contextId=$contextId,result=" +
+        result.toLogString(shouldMask) +
         ")"
     }
 

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -170,9 +170,9 @@ final class EnsureCompiledJob(protected val files: Iterable[File])
       .diagnostics
     val diagnostics = pass.collect {
       case warn: IR.Warning =>
-        createDiagnostic(Api.DiagnosticType.Warning(), module, warn)
+        createDiagnostic(Api.DiagnosticType.Warning, module, warn)
       case error: IR.Error =>
-        createDiagnostic(Api.DiagnosticType.Error(), module, error)
+        createDiagnostic(Api.DiagnosticType.Error, module, error)
     }
     sendDiagnosticUpdates(diagnostics)
     getCompilationStatus(diagnostics)
@@ -433,7 +433,7 @@ final class EnsureCompiledJob(protected val files: Iterable[File])
   private def getCompilationStatus(
     diagnostics: Iterable[Api.ExecutionResult.Diagnostic]
   ): CompilationStatus =
-    if (diagnostics.exists(_.kind == Api.DiagnosticType.Error()))
+    if (diagnostics.exists(_.isError))
       CompilationStatus.Error
     else
       CompilationStatus.Success

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
@@ -224,15 +224,26 @@ class RuntimeAsyncCommandsTest
       Api.Request(requestId, Api.InterruptContextRequest(contextId))
     )
     context.receiveNIgnoreExpressionUpdates(
-      3
+      4
     ) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.InterruptContextResponse(contextId)),
       Api.Response(
-        Api.ExecutionFailed(
+        Api.ExecutionUpdate(
           contextId,
-          Api.ExecutionResult
-            .Failure("Execution of function main interrupted.", None)
+          Seq(
+            Api.ExecutionResult.Diagnostic(
+              Api.DiagnosticType.Warning,
+              Some("Execution of function main interrupted."),
+              None,
+              None,
+              None,
+              Vector()
+            )
+          )
         )
+      ),
+      Api.Response(
+        Api.ExecutionComplete(contextId)
       ),
       Api.Response(Api.BackgroundJobsStartedNotification())
     )

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
@@ -224,7 +224,7 @@ class RuntimeAsyncCommandsTest
       Api.Request(requestId, Api.InterruptContextRequest(contextId))
     )
     context.receiveNIgnoreExpressionUpdates(
-      4
+      3
     ) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.InterruptContextResponse(contextId)),
       Api.Response(
@@ -234,8 +234,7 @@ class RuntimeAsyncCommandsTest
             .Failure("Execution of function main interrupted.", None)
         )
       ),
-      Api.Response(Api.BackgroundJobsStartedNotification()),
-      context.executionComplete(contextId)
+      Api.Response(Api.BackgroundJobsStartedNotification())
     )
   }
 }

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -4012,7 +4012,7 @@ class RuntimeServerTest
           Api.ExecutionResult.Failure("Module Unnamed.Main not found.", None)
         )
       ),
-      context.executionComplete(contextId)
+      Api.Response(Api.BackgroundJobsStartedNotification())
     )
   }
 
@@ -4064,7 +4064,7 @@ class RuntimeServerTest
           )
         )
       ),
-      context.executionComplete(contextId)
+      Api.Response(Api.BackgroundJobsStartedNotification())
     )
   }
 
@@ -4116,7 +4116,7 @@ class RuntimeServerTest
           )
         )
       ),
-      context.executionComplete(contextId)
+      Api.Response(Api.BackgroundJobsStartedNotification())
     )
   }
 
@@ -4159,33 +4159,30 @@ class RuntimeServerTest
         )
       )
     )
-    context.receiveN(4) should contain theSameElementsAs Seq(
+    context.receiveN(3) should contain theSameElementsAs Seq(
       Api.Response(Api.BackgroundJobsStartedNotification()),
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       Api.Response(
-        Api.ExecutionUpdate(
+        Api.ExecutionFailed(
           contextId,
-          Seq(
-            Api.ExecutionResult.Diagnostic.error(
-              "Not_Invokable.Error",
-              Some(mainFile),
-              Some(model.Range(model.Position(0, 7), model.Position(0, 19))),
-              None,
-              Vector(
-                Api.StackTraceElement(
-                  "Main.main",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(0, 7), model.Position(0, 19))
-                  ),
-                  None
-                )
+          Api.ExecutionResult.Diagnostic.error(
+            "Not_Invokable.Error",
+            Some(mainFile),
+            Some(model.Range(model.Position(0, 7), model.Position(0, 19))),
+            None,
+            Vector(
+              Api.StackTraceElement(
+                "Main.main",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(0, 7), model.Position(0, 19))
+                ),
+                None
               )
             )
           )
         )
-      ),
-      context.executionComplete(contextId)
+      )
     )
   }
 
@@ -4233,29 +4230,27 @@ class RuntimeServerTest
       Api.Response(Api.BackgroundJobsStartedNotification()),
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       Api.Response(
-        Api.ExecutionUpdate(
+        Api.ExecutionFailed(
           contextId,
-          Seq(
-            Api.ExecutionResult.Diagnostic.error(
-              "Type error: expected a function, but got 42.",
-              Some(mainFile),
-              Some(model.Range(model.Position(1, 7), model.Position(1, 19))),
-              None,
-              Vector(
-                Api.StackTraceElement(
-                  "Main.main",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(1, 7), model.Position(1, 19))
-                  ),
-                  None
-                )
+          Api.ExecutionResult.Diagnostic.error(
+            "Type error: expected a function, but got 42.",
+            Some(mainFile),
+            Some(model.Range(model.Position(1, 7), model.Position(1, 19))),
+            None,
+            Vector(
+              Api.StackTraceElement(
+                "Main.main",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(1, 7), model.Position(1, 19))
+                ),
+                None
               )
             )
           )
         )
       ),
-      context.executionComplete(contextId)
+      Api.Response(Api.BackgroundJobsStartedNotification())
     )
   }
 
@@ -4298,41 +4293,38 @@ class RuntimeServerTest
         )
       )
     )
-    context.receiveN(4) should contain theSameElementsAs Seq(
+    context.receiveN(3) should contain theSameElementsAs Seq(
       Api.Response(Api.BackgroundJobsStartedNotification()),
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       Api.Response(
-        Api.ExecutionUpdate(
+        Api.ExecutionFailed(
           contextId,
-          Seq(
-            Api.ExecutionResult.Diagnostic.error(
-              "No_Such_Method.Error",
-              Some(mainFile),
-              Some(model.Range(model.Position(2, 14), model.Position(2, 23))),
-              None,
-              Vector(
-                Api.StackTraceElement(
-                  "Main.bar",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(2, 14), model.Position(2, 23))
-                  ),
-                  None
+          Api.ExecutionResult.Diagnostic.error(
+            "No_Such_Method.Error",
+            Some(mainFile),
+            Some(model.Range(model.Position(2, 14), model.Position(2, 23))),
+            None,
+            Vector(
+              Api.StackTraceElement(
+                "Main.bar",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(2, 14), model.Position(2, 23))
                 ),
-                Api.StackTraceElement(
-                  "Main.main",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(0, 7), model.Position(0, 16))
-                  ),
-                  None
-                )
+                None
+              ),
+              Api.StackTraceElement(
+                "Main.main",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(0, 7), model.Position(0, 16))
+                ),
+                None
               )
             )
           )
         )
-      ),
-      context.executionComplete(contextId)
+      )
     )
   }
 
@@ -4380,37 +4372,35 @@ class RuntimeServerTest
       Api.Response(Api.BackgroundJobsStartedNotification()),
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       Api.Response(
-        Api.ExecutionUpdate(
+        Api.ExecutionFailed(
           contextId,
-          Seq(
-            Api.ExecutionResult.Diagnostic.error(
-              "Method `+` of type Function could not be found.",
-              Some(mainFile),
-              Some(model.Range(model.Position(3, 14), model.Position(3, 23))),
-              None,
-              Vector(
-                Api.StackTraceElement(
-                  "Main.bar",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(3, 14), model.Position(3, 23))
-                  ),
-                  None
+          Api.ExecutionResult.Diagnostic.error(
+            "Method `+` of type Function could not be found.",
+            Some(mainFile),
+            Some(model.Range(model.Position(3, 14), model.Position(3, 23))),
+            None,
+            Vector(
+              Api.StackTraceElement(
+                "Main.bar",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(3, 14), model.Position(3, 23))
                 ),
-                Api.StackTraceElement(
-                  "Main.main",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(1, 7), model.Position(1, 16))
-                  ),
-                  None
-                )
+                None
+              ),
+              Api.StackTraceElement(
+                "Main.main",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(1, 7), model.Position(1, 16))
+                ),
+                None
               )
             )
           )
         )
       ),
-      context.executionComplete(contextId)
+      Api.Response(Api.BackgroundJobsStartedNotification())
     )
   }
 
@@ -4453,41 +4443,38 @@ class RuntimeServerTest
         )
       )
     )
-    context.receiveN(4) should contain theSameElementsAs Seq(
+    context.receiveN(3) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       Api.Response(
-        Api.ExecutionUpdate(
+        Api.ExecutionFailed(
           contextId,
-          Seq(
-            Api.ExecutionResult.Diagnostic.error(
-              "Type_Error.Error",
-              Some(mainFile),
-              Some(model.Range(model.Position(2, 10), model.Position(2, 15))),
-              None,
-              Vector(
-                Api.StackTraceElement(
-                  "Main.bar",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(2, 10), model.Position(2, 15))
-                  ),
-                  None
+          Api.ExecutionResult.Diagnostic.error(
+            "Type_Error.Error",
+            Some(mainFile),
+            Some(model.Range(model.Position(2, 10), model.Position(2, 15))),
+            None,
+            Vector(
+              Api.StackTraceElement(
+                "Main.bar",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(2, 10), model.Position(2, 15))
                 ),
-                Api.StackTraceElement(
-                  "Main.main",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(0, 7), model.Position(0, 18))
-                  ),
-                  None
-                )
+                None
+              ),
+              Api.StackTraceElement(
+                "Main.main",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(0, 7), model.Position(0, 18))
+                ),
+                None
               )
             )
           )
         )
       ),
-      Api.Response(Api.BackgroundJobsStartedNotification()),
-      context.executionComplete(contextId)
+      Api.Response(Api.BackgroundJobsStartedNotification())
     )
   }
 
@@ -4531,41 +4518,38 @@ class RuntimeServerTest
         )
       )
     )
-    context.receiveNIgnoreStdLib(4) should contain theSameElementsAs Seq(
+    context.receiveNIgnoreStdLib(3) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       Api.Response(
-        Api.ExecutionUpdate(
+        Api.ExecutionFailed(
           contextId,
-          Seq(
-            Api.ExecutionResult.Diagnostic.error(
-              "Type error: expected `str` to be Text, but got Integer.",
-              Some(mainFile),
-              Some(model.Range(model.Position(3, 10), model.Position(3, 15))),
-              None,
-              Vector(
-                Api.StackTraceElement(
-                  "Main.bar",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(3, 10), model.Position(3, 15))
-                  ),
-                  None
+          Api.ExecutionResult.Diagnostic.error(
+            "Type error: expected `str` to be Text, but got Integer.",
+            Some(mainFile),
+            Some(model.Range(model.Position(3, 10), model.Position(3, 15))),
+            None,
+            Vector(
+              Api.StackTraceElement(
+                "Main.bar",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(3, 10), model.Position(3, 15))
                 ),
-                Api.StackTraceElement(
-                  "Main.main",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(1, 7), model.Position(1, 18))
-                  ),
-                  None
-                )
+                None
+              ),
+              Api.StackTraceElement(
+                "Main.main",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(1, 7), model.Position(1, 18))
+                ),
+                None
               )
             )
           )
         )
       ),
-      Api.Response(Api.BackgroundJobsStartedNotification()),
-      context.executionComplete(contextId)
+      Api.Response(Api.BackgroundJobsStartedNotification())
     )
   }
 
@@ -4609,33 +4593,30 @@ class RuntimeServerTest
         )
       )
     )
-    context.receiveNIgnoreStdLib(4) should contain theSameElementsAs Seq(
+    context.receiveNIgnoreStdLib(3) should contain theSameElementsAs Seq(
       Api.Response(Api.BackgroundJobsStartedNotification()),
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       Api.Response(
-        Api.ExecutionUpdate(
+        Api.ExecutionFailed(
           contextId,
-          Seq(
-            Api.ExecutionResult.Diagnostic.error(
-              "No_Such_Method.Error",
-              Some(mainFile),
-              Some(model.Range(model.Position(2, 7), model.Position(2, 16))),
-              None,
-              Vector(
-                Api.StackTraceElement(
-                  "Main.main",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(2, 7), model.Position(2, 16))
-                  ),
-                  None
-                )
+          Api.ExecutionResult.Diagnostic.error(
+            "No_Such_Method.Error",
+            Some(mainFile),
+            Some(model.Range(model.Position(2, 7), model.Position(2, 16))),
+            None,
+            Vector(
+              Api.StackTraceElement(
+                "Main.main",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(2, 7), model.Position(2, 16))
+                ),
+                None
               )
             )
           )
         )
-      ),
-      context.executionComplete(contextId)
+      )
     )
   }
 
@@ -4680,33 +4661,30 @@ class RuntimeServerTest
         )
       )
     )
-    context.receiveNIgnoreStdLib(4) should contain theSameElementsAs Seq(
+    context.receiveNIgnoreStdLib(3) should contain theSameElementsAs Seq(
       Api.Response(Api.BackgroundJobsStartedNotification()),
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       Api.Response(
-        Api.ExecutionUpdate(
+        Api.ExecutionFailed(
           contextId,
-          Seq(
-            Api.ExecutionResult.Diagnostic.error(
-              "Method `pi` of type Number.type could not be found.",
-              Some(mainFile),
-              Some(model.Range(model.Position(3, 7), model.Position(3, 16))),
-              None,
-              Vector(
-                Api.StackTraceElement(
-                  "Main.main",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(3, 7), model.Position(3, 16))
-                  ),
-                  None
-                )
+          Api.ExecutionResult.Diagnostic.error(
+            "Method `pi` of type Number.type could not be found.",
+            Some(mainFile),
+            Some(model.Range(model.Position(3, 7), model.Position(3, 16))),
+            None,
+            Vector(
+              Api.StackTraceElement(
+                "Main.main",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(3, 7), model.Position(3, 16))
+                ),
+                None
               )
             )
           )
         )
-      ),
-      context.executionComplete(contextId)
+      )
     )
   }
 
@@ -4759,57 +4737,54 @@ class RuntimeServerTest
         )
       )
     )
-    context.receiveN(4) should contain theSameElementsAs Seq(
+    context.receiveN(3) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       Api.Response(
-        Api.ExecutionUpdate(
+        Api.ExecutionFailed(
           contextId,
-          Seq(
-            Api.ExecutionResult.Diagnostic.error(
-              "Type_Error.Error",
-              Some(mainFile),
-              Some(model.Range(model.Position(10, 8), model.Position(10, 17))),
-              None,
-              Vector(
-                Api.StackTraceElement(
-                  "Main.baz",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(10, 8), model.Position(10, 17))
-                  ),
-                  None
+          Api.ExecutionResult.Diagnostic.error(
+            "Type_Error.Error",
+            Some(mainFile),
+            Some(model.Range(model.Position(10, 8), model.Position(10, 17))),
+            None,
+            Vector(
+              Api.StackTraceElement(
+                "Main.baz",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(10, 8), model.Position(10, 17))
                 ),
-                Api.StackTraceElement(
-                  "Main.bar",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(7, 8), model.Position(7, 11))
-                  ),
-                  None
+                None
+              ),
+              Api.StackTraceElement(
+                "Main.bar",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(7, 8), model.Position(7, 11))
                 ),
-                Api.StackTraceElement(
-                  "Main.foo",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(4, 8), model.Position(4, 11))
-                  ),
-                  None
+                None
+              ),
+              Api.StackTraceElement(
+                "Main.foo",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(4, 8), model.Position(4, 11))
                 ),
-                Api.StackTraceElement(
-                  "Main.main",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(1, 4), model.Position(1, 7))
-                  ),
-                  None
-                )
+                None
+              ),
+              Api.StackTraceElement(
+                "Main.main",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(1, 4), model.Position(1, 7))
+                ),
+                None
               )
             )
           )
         )
       ),
-      Api.Response(Api.BackgroundJobsStartedNotification()),
-      context.executionComplete(contextId)
+      Api.Response(Api.BackgroundJobsStartedNotification())
     )
   }
 
@@ -4863,57 +4838,54 @@ class RuntimeServerTest
         )
       )
     )
-    context.receiveNIgnoreStdLib(4) should contain theSameElementsAs Seq(
+    context.receiveNIgnoreStdLib(3) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       Api.Response(
-        Api.ExecutionUpdate(
+        Api.ExecutionFailed(
           contextId,
-          Seq(
-            Api.ExecutionResult.Diagnostic.error(
-              "Type error: expected `that` to be Number, but got Function.",
-              Some(mainFile),
-              Some(model.Range(model.Position(11, 8), model.Position(11, 17))),
-              None,
-              Vector(
-                Api.StackTraceElement(
-                  "Main.baz",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(11, 8), model.Position(11, 17))
-                  ),
-                  None
+          Api.ExecutionResult.Diagnostic.error(
+            "Type error: expected `that` to be Number, but got Function.",
+            Some(mainFile),
+            Some(model.Range(model.Position(11, 8), model.Position(11, 17))),
+            None,
+            Vector(
+              Api.StackTraceElement(
+                "Main.baz",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(11, 8), model.Position(11, 17))
                 ),
-                Api.StackTraceElement(
-                  "Main.bar",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(8, 8), model.Position(8, 11))
-                  ),
-                  None
+                None
+              ),
+              Api.StackTraceElement(
+                "Main.bar",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(8, 8), model.Position(8, 11))
                 ),
-                Api.StackTraceElement(
-                  "Main.foo",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(5, 8), model.Position(5, 11))
-                  ),
-                  None
+                None
+              ),
+              Api.StackTraceElement(
+                "Main.foo",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(5, 8), model.Position(5, 11))
                 ),
-                Api.StackTraceElement(
-                  "Main.main",
-                  Some(mainFile),
-                  Some(
-                    model.Range(model.Position(2, 4), model.Position(2, 7))
-                  ),
-                  None
-                )
+                None
+              ),
+              Api.StackTraceElement(
+                "Main.main",
+                Some(mainFile),
+                Some(
+                  model.Range(model.Position(2, 4), model.Position(2, 7))
+                ),
+                None
               )
             )
           )
         )
       ),
-      Api.Response(Api.BackgroundJobsStartedNotification()),
-      context.executionComplete(contextId)
+      Api.Response(Api.BackgroundJobsStartedNotification())
     )
   }
 

--- a/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -1206,7 +1206,7 @@ class RuntimeVisualizationsTest
         )
       )
     )
-    context.receiveN(4) should contain theSameElementsAs Seq(
+    context.receiveN(3) should contain theSameElementsAs Seq(
       Api.Response(Api.BackgroundJobsStartedNotification()),
       Api.Response(requestId, Api.VisualizationAttached()),
       Api.Response(
@@ -1214,8 +1214,7 @@ class RuntimeVisualizationsTest
           contextId,
           Api.ExecutionResult.Failure("Execution stack is empty.", None)
         )
-      ),
-      context.executionComplete(contextId)
+      )
     )
 
     // push main


### PR DESCRIPTION
### Pull Request Description

`executionFailed` instead is sent when an evaulation finishes with a a critical failure or a non-critical error.
The PR tries to miniminally modify the change in the messages exchange so as to avoid a major redesign at this point.

Closes #7002.

### Important Notes

Unblocks IDE which will need to modify to this new setup.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

~~- [ ] The documentation has been updated, if necessary.~~
~~- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
