### PR TITLE
Don't report EOFException on shutdown

### DIFF
--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManager.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManager.scala
@@ -21,10 +21,9 @@ import zio.Console.{printLine, printLineError, readLine}
 import zio.interop.catz.core._
 import zio.{ExitCode, Runtime, Scope, UIO, ZAny, ZIO, ZIOAppArgs, ZIOAppDefault}
 
-import java.io.IOException
+import java.io.{EOFException, IOException}
 import java.nio.file.{FileAlreadyExistsException, Files, Path, Paths}
 import java.util.concurrent.ScheduledThreadPoolExecutor
-
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor}
 
@@ -85,7 +84,12 @@ object ProjectManager extends ZIOAppDefault with LazyLogging {
   private def tryReadLine: ZIO[ZAny, Nothing, String] =
     readLine.catchAll { err =>
       ZIO
-        .succeed { logger.warn("Failed to read line.", err) }
+        .succeed {
+          err match {
+            case _: EOFException =>
+            case _               => logger.warn("Failed to read line.", err)
+          }
+        }
         .as("")
     }
 


### PR DESCRIPTION
### Pull Request Description

It's part of the normal shutdown workflow and confused users are reporting it as a failure.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.