### PR TITLE
Preview keeps showing when cursor is over it, preventing flickering

### DIFF
--- a/app/gui/view/graph-editor/src/component/visualization/container.rs
+++ b/app/gui/view/graph-editor/src/component/visualization/container.rs
@@ -463,7 +463,6 @@ impl ContainerModel {
             dom.set_style_or_warn("height", "0");
             bg_dom.set_style_or_warn("width", format!("{}px", size[0]));
             bg_dom.set_style_or_warn("height", format!("{}px", size[1]));
-            self.action_bar.frp.set_size.emit(Vector2::zero());
         } else {
             self.view.overlay.radius.set(CORNER_RADIUS);
             self.view.background.radius.set(CORNER_RADIUS);
@@ -474,11 +473,13 @@ impl ContainerModel {
             dom.set_style_or_warn("height", format!("{}px", size[1]));
             bg_dom.set_style_or_warn("width", "0");
             bg_dom.set_style_or_warn("height", "0");
-
-            let action_bar_size = Vector2::new(size.x, ACTION_BAR_HEIGHT);
-            self.action_bar.frp.set_size.emit(action_bar_size);
         }
-
+        let action_bar_size = if matches!(view_state, ViewState::Enabled) {
+            Vector2::new(size.x, ACTION_BAR_HEIGHT)
+        } else {
+            Vector2::zero()
+        };
+        self.action_bar.frp.set_size.emit(action_bar_size);
         self.action_bar.set_y((size.y - ACTION_BAR_HEIGHT) / 2.0);
 
         if let Some(viz) = &*self.visualization.borrow() {


### PR DESCRIPTION
### Pull Request Description

Fixes #6379 

https://github.com/enso-org/enso/assets/3919101/be509314-a5f7-41c8-be0f-a7c46deca477

Before, the quick visualization preview (ctrl/cmd + output port hover) was flickering, because shown visualization made output port no longer hovered. To fix that, the preview is hidden only when both the output port _and_ the preview stop being hovered.

Also discovered that the visualization chooser is not visible or looks ugly when visualization with HTML elements is shown over the nodes, so I made it not being visible on previews.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
