### PR TITLE
Provide human-readable error log during installation

### DIFF
--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/GraalVMComponentUpdater.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/GraalVMComponentUpdater.scala
@@ -33,7 +33,7 @@ class GraalVMComponentUpdater(runtime: GraalRuntime)
 
     logger.trace("{} {}", gu, Properties(gu))
     logger.debug(
-      "Executing: JAVA_HOME={} GRRAALVM_HOME={} {} {}",
+      "Executing: JAVA_HOME={} GRAALVM_HOME={} {} {}",
       runtime.javaHome,
       runtime.javaHome,
       gu,

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/RuntimeVersionManager.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/RuntimeVersionManager.scala
@@ -623,7 +623,7 @@ class RuntimeVersionManager(
           val msg = translateError(error)
           logger.warn(
             "Failed to install required components on the existing [{}]. " +
-            "Some language features may be unavailable. {}.",
+            "Some language features may be unavailable. {}",
             runtime,
             msg
           )
@@ -642,7 +642,7 @@ class RuntimeVersionManager(
       case OS.MacOS => msg
       case OS.Windows =>
         if (msg.contains("-1073741515")) {
-          "Required Microsoft Visual C++ installation is missing"
+          "Required Microsoft Visual C++ installation is missing."
         } else {
           msg
         }

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/RuntimeVersionManager.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/RuntimeVersionManager.scala
@@ -620,14 +620,33 @@ class RuntimeVersionManager(
       _ <- runtime.ensureValid()
       _ <- installRequiredRuntimeComponents(runtime).recover {
         case NonFatal(error) =>
+          val msg = translateError(error)
           logger.warn(
             "Failed to install required components on the existing [{}]. " +
-            "Some language features may be unavailable. {}",
+            "Some language features may be unavailable. {}.",
             runtime,
-            error.getMessage
+            msg
           )
       }
     } yield runtime
+  }
+
+  /** Provide human-readable error messages for OS-specific failures
+    * @param cause exception thrown when executing the process
+    * @return human-readable error message
+    */
+  private def translateError(cause: Throwable): String = {
+    val msg = cause.getMessage
+    OS.operatingSystem match {
+      case OS.Linux => msg
+      case OS.MacOS => msg
+      case OS.Windows =>
+        if (msg.contains("-1073741515")) {
+          "Required Microsoft Visual C++ installation is missing"
+        } else {
+          msg
+        }
+    }
   }
 
   /** Gets the runtime version from its name.


### PR DESCRIPTION
### Pull Request Description

Windows insists on reporting cryptic error codes that are then hard to debug.
When identified, we can provide more cases.

As identified for #7150.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
