### PR TITLE
HashMapNode supports atoms with custom comparators

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsAtomNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsAtomNode.java
@@ -46,7 +46,7 @@ public abstract class EqualsAtomNode extends Node {
       },
       limit = "10")
   @ExplodeLoop
-  boolean equalsAtoms(
+  boolean equalsAtomsWithDefaultComparator(
       Atom self,
       Atom other,
       @Cached("self.getConstructor()") AtomConstructor selfCtorCached,
@@ -81,7 +81,7 @@ public abstract class EqualsAtomNode extends Node {
         "cachedComparator != null",
       },
       limit = "10")
-  boolean equalsAtoms(
+  boolean equalsAtomsWithCustomComparator(
       Atom self,
       Atom other,
       @Cached("self.getConstructor()") AtomConstructor selfCtorCached,
@@ -101,10 +101,24 @@ public abstract class EqualsAtomNode extends Node {
   }
 
   @CompilerDirectives.TruffleBoundary
-  @Specialization(replaces = "equalsAtoms")
+  @Specialization(replaces = {"equalsAtomsWithDefaultComparator", "equalsAtomsWithCustomComparator"})
   boolean equalsAtomsUncached(Atom self, Atom other) {
     if (self.getConstructor() != other.getConstructor()) {
       return false;
+    }
+    Type customComparator = CustomComparatorNode.getUncached().execute(self);
+    if (customComparator != null) {
+      Function compareFunc = findCompareMethod(customComparator);
+      var invokeFuncNode = invokeCompareNode(compareFunc);
+      return equalsAtomsWithCustomComparator(
+          self,
+          other,
+          self.getConstructor(),
+          CustomComparatorNode.getUncached(),
+          customComparator,
+          compareFunc,
+          invokeFuncNode
+      );
     }
     Object[] selfFields = StructsLibrary.getUncached().getFields(self);
     Object[] otherFields = StructsLibrary.getUncached().getFields(other);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsAtomNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsAtomNode.java
@@ -101,7 +101,8 @@ public abstract class EqualsAtomNode extends Node {
   }
 
   @CompilerDirectives.TruffleBoundary
-  @Specialization(replaces = {"equalsAtomsWithDefaultComparator", "equalsAtomsWithCustomComparator"})
+  @Specialization(
+      replaces = {"equalsAtomsWithDefaultComparator", "equalsAtomsWithCustomComparator"})
   boolean equalsAtomsUncached(Atom self, Atom other) {
     if (self.getConstructor() != other.getConstructor()) {
       return false;
@@ -117,8 +118,7 @@ public abstract class EqualsAtomNode extends Node {
           CustomComparatorNode.getUncached(),
           customComparator,
           compareFunc,
-          invokeFuncNode
-      );
+          invokeFuncNode);
     }
     Object[] selfFields = StructsLibrary.getUncached().getFields(self);
     Object[] otherFields = StructsLibrary.getUncached().getFields(other);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsNode.java
@@ -227,9 +227,9 @@ public abstract class EqualsNode extends Node {
   boolean equalsAtoms(
       Atom self,
       Atom other,
-      @Cached EqualsAtomNode equalsNode,
+      @Cached EqualsAtomNode equalsAtomNode,
       @Cached IsSameObjectNode isSameObjectNode) {
-    return isSameObjectNode.execute(self, other) || equalsNode.execute(self, other);
+    return isSameObjectNode.execute(self, other) || equalsAtomNode.execute(self, other);
   }
 
   @Specialization(guards = "isNotPrimitive(self, other, interop, warnings)")

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMap.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMap.java
@@ -165,8 +165,8 @@ public final class EnsoHashMap implements TruffleObject {
 
   @ExportMessage
   @TruffleBoundary
-  Object toDisplayString(boolean allowSideEffects,
-      @CachedLibrary(limit = "5") InteropLibrary interop) {
+  Object toDisplayString(
+      boolean allowSideEffects, @CachedLibrary(limit = "5") InteropLibrary interop) {
     var sb = new StringBuilder();
     sb.append("{");
     boolean empty = true;
@@ -207,7 +207,6 @@ public final class EnsoHashMap implements TruffleObject {
     }
     return keyStr + "=" + valStr;
   }
-
 
   private boolean isEntryInThisMap(StorageEntry entry) {
     return entry != null && entry.index() < snapshotSize;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMap.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMap.java
@@ -110,7 +110,7 @@ public final class EnsoHashMap implements TruffleObject {
   }
 
   @ExportMessage
-  public int getHashSize() {
+  int getHashSize() {
     return snapshotSize;
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMap.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMap.java
@@ -110,7 +110,7 @@ public final class EnsoHashMap implements TruffleObject {
   }
 
   @ExportMessage
-  int getHashSize() {
+  public int getHashSize() {
     return snapshotSize;
   }
 
@@ -165,14 +165,15 @@ public final class EnsoHashMap implements TruffleObject {
 
   @ExportMessage
   @TruffleBoundary
-  Object toDisplayString(boolean allowSideEffects) {
+  Object toDisplayString(boolean allowSideEffects,
+      @CachedLibrary(limit = "5") InteropLibrary interop) {
     var sb = new StringBuilder();
     sb.append("{");
     boolean empty = true;
     for (StorageEntry entry : mapBuilder.getStorage().getValues()) {
       if (isEntryInThisMap(entry)) {
         empty = false;
-        sb.append(entry.key()).append("=").append(entry.value()).append(", ");
+        sb.append(entryToString(entry, interop)).append(", ");
       }
     }
     if (!empty) {
@@ -185,8 +186,28 @@ public final class EnsoHashMap implements TruffleObject {
 
   @Override
   public String toString() {
-    return (String) toDisplayString(true);
+    // We are not using uncached InteropLibrary in this method, as it may substantially
+    // slow down Java debugger.
+    return (String) toDisplayString(true, null);
   }
+
+  private static String entryToString(StorageEntry entry, InteropLibrary interop) {
+    String keyStr;
+    String valStr;
+    if (interop != null) {
+      try {
+        keyStr = interop.asString(interop.toDisplayString(entry.key()));
+        valStr = interop.asString(interop.toDisplayString(entry.value()));
+      } catch (UnsupportedMessageException e) {
+        throw new IllegalStateException("Unreachable", e);
+      }
+    } else {
+      keyStr = entry.key().toString();
+      valStr = entry.value().toString();
+    }
+    return keyStr + "=" + valStr;
+  }
+
 
   private boolean isEntryInThisMap(StorageEntry entry) {
     return entry != null && entry.index() < snapshotSize;

--- a/test/Tests/src/Data/Map_Spec.enso
+++ b/test/Tests/src/Data/Map_Spec.enso
@@ -18,6 +18,20 @@ type My_Nan_Comparator
 
 Comparable.from (_:My_Nan) = My_Nan_Comparator
 
+type My_Key
+    Value hash_code:Integer value:Text idx:Integer
+
+type My_Key_Comparator
+    # Comparison ignores idx field
+    compare x y =
+        if x.hash_code != y.hash_code then Nothing else
+            if x.value == y.value then Ordering.Equal else Nothing
+
+    hash x = x.hash_code
+
+Comparable.from (_:My_Key) = My_Key_Comparator
+
+
 foreign js js_str str = """
     return new String(str)
 
@@ -192,6 +206,20 @@ spec =
             m3 = m2.insert k 30
             m3.size . should_equal 2
             m3.get k . should_equal 30
+
+        Test.specify "should support atom with custom comparators with complicated hash method" <|
+            keys = 0.up_to 500 . map ix->
+                value = ["A", "B", "C", "D", "E"].at (ix % 5)
+                hash_code = Comparable.from value . hash value
+                My_Key.Value hash_code value ix
+            distinct_keys = keys.fold Map.empty acc_map->
+                item->
+                    acc_map.insert item True
+            distinct_keys.size . should_equal 5
+            distinct_key_values = keys.map (_.value) . fold Map.empty acc_map->
+                item->
+                    acc_map.insert item True
+            distinct_key_values.size . should_equal 5
 
         Test.specify "should handle keys with standard equality semantics" <|
             map = Map.singleton 2 "Hello"


### PR DESCRIPTION
Closes #7161.

### Pull Request Description

Add proper handling for atoms with custom comparators into the hashing machinery.

### Important Notes


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [X] Unit tests have been written where possible.
  - [X] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
