### PR TITLE
Add timeout retries for project-related operations

### DIFF
--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/Package.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/Package.scala
@@ -463,10 +463,12 @@ class PackageManager[F](implicit val fileSystem: FileSystem[F]) {
   private def copyResource(from: URI, to: F): Unit = {
     val fromStream = getClass.getResourceAsStream(from.toString)
     val toStream   = to.newOutputStream
-    try PackageManager.copyStream(fromStream, toStream)
-    finally {
-      fromStream.close()
-      toStream.close()
+    if (fromStream != null && toStream != null) {
+      try PackageManager.copyStream(fromStream, toStream)
+      finally {
+        fromStream.close()
+        toStream.close()
+      }
     }
   }
 }

--- a/lib/scala/project-manager/src/main/resources/application.conf
+++ b/lib/scala/project-manager/src/main/resources/application.conf
@@ -66,6 +66,7 @@ project-manager {
     boot-timeout = 40 seconds
     shutdown-timeout = 20 seconds
     socket-close-timeout = 15 seconds
+    retries = 5
   }
 
   tutorials {

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/configuration.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/configuration.scala
@@ -63,13 +63,18 @@ object configuration {
     *
     * @param ioTimeout a timeout for IO operations
     * @param requestTimeout a timeout for JSON RPC request timeout
+    * @param bootTimeout a timeout for booting process
+    * @param shutdownTimeout a timeout for shutdown request
+    * @param socketCloseTimeout a timeout for closing the socket
+    * @param retries a number of retries attempted when timeout is reached
     */
   case class TimeoutConfig(
     ioTimeout: FiniteDuration,
     requestTimeout: FiniteDuration,
     bootTimeout: FiniteDuration,
     shutdownTimeout: FiniteDuration,
-    socketCloseTimeout: FiniteDuration
+    socketCloseTimeout: FiniteDuration,
+    retries: Int
   )
 
   /** A configuration object for networking.

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/protocol/ClientController.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/protocol/ClientController.scala
@@ -73,7 +73,6 @@ class ClientController[F[+_, +_]: Exec: CovariantFlatMap: ErrorChannel](
         ),
       ProjectList -> ProjectListHandler
         .props[F](
-          clientId,
           projectService,
           timeoutConfig.requestTimeout,
           RequestHandler.defaultNumOfTimeoutRetries

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/protocol/ClientController.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/protocol/ClientController.scala
@@ -53,7 +53,8 @@ class ClientController[F[+_, +_]: Exec: CovariantFlatMap: ErrorChannel](
         .props[F](
           globalConfigService,
           projectService,
-          timeoutConfig.requestTimeout
+          timeoutConfig.requestTimeout,
+          RequestHandler.defaultNumOfTimeoutRetries
         ),
       ProjectDelete -> ProjectDeleteHandler
         .props[F](projectService, timeoutConfig.requestTimeout),
@@ -61,7 +62,8 @@ class ClientController[F[+_, +_]: Exec: CovariantFlatMap: ErrorChannel](
         .props[F](
           clientId,
           projectService,
-          timeoutConfig.bootTimeout
+          timeoutConfig.bootTimeout,
+          RequestHandler.defaultNumOfTimeoutRetries
         ),
       ProjectClose -> ProjectCloseHandler
         .props[F](
@@ -70,7 +72,12 @@ class ClientController[F[+_, +_]: Exec: CovariantFlatMap: ErrorChannel](
           timeoutConfig.shutdownTimeout.plus(1.second)
         ),
       ProjectList -> ProjectListHandler
-        .props[F](clientId, projectService, timeoutConfig.requestTimeout),
+        .props[F](
+          clientId,
+          projectService,
+          timeoutConfig.requestTimeout,
+          RequestHandler.defaultNumOfTimeoutRetries
+        ),
       ProjectRename -> ProjectRenameHandler
         .props[F](projectService, timeoutConfig.requestTimeout),
       EngineListInstalled -> EngineListInstalledHandler.props(

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/protocol/ClientController.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/protocol/ClientController.scala
@@ -54,7 +54,7 @@ class ClientController[F[+_, +_]: Exec: CovariantFlatMap: ErrorChannel](
           globalConfigService,
           projectService,
           timeoutConfig.requestTimeout,
-          RequestHandler.defaultNumOfTimeoutRetries
+          timeoutConfig.retries
         ),
       ProjectDelete -> ProjectDeleteHandler
         .props[F](projectService, timeoutConfig.requestTimeout),
@@ -63,7 +63,7 @@ class ClientController[F[+_, +_]: Exec: CovariantFlatMap: ErrorChannel](
           clientId,
           projectService,
           timeoutConfig.bootTimeout,
-          RequestHandler.defaultNumOfTimeoutRetries
+          timeoutConfig.retries
         ),
       ProjectClose -> ProjectCloseHandler
         .props[F](
@@ -75,7 +75,7 @@ class ClientController[F[+_, +_]: Exec: CovariantFlatMap: ErrorChannel](
         .props[F](
           projectService,
           timeoutConfig.requestTimeout,
-          RequestHandler.defaultNumOfTimeoutRetries
+          timeoutConfig.retries
         ),
       ProjectRename -> ProjectRenameHandler
         .props[F](projectService, timeoutConfig.requestTimeout),

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectCreateHandler.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectCreateHandler.scala
@@ -22,11 +22,13 @@ import scala.concurrent.duration.FiniteDuration
   * @param configurationService the configuration service
   * @param projectService a project service
   * @param requestTimeout a request timeout
+  * @param timeoutRetries a number of timeouts to wait until a failure is reported
   */
 class ProjectCreateHandler[F[+_, +_]: Exec: CovariantFlatMap: ErrorChannel](
   configurationService: GlobalConfigServiceApi[F],
   projectService: ProjectServiceApi[F],
-  requestTimeout: FiniteDuration
+  requestTimeout: FiniteDuration,
+  timeoutRetries: Int
 ) extends RequestHandler[
       F,
       ProjectServiceFailure,
@@ -35,7 +37,8 @@ class ProjectCreateHandler[F[+_, +_]: Exec: CovariantFlatMap: ErrorChannel](
       ProjectCreate.Result
     ](
       ProjectCreate,
-      Some(requestTimeout)
+      Some(requestTimeout),
+      timeoutRetries
     ) {
 
   override def handleRequest
@@ -76,18 +79,21 @@ object ProjectCreateHandler {
     * @param configurationService
     * @param projectService a project service
     * @param requestTimeout a request timeout
+    * @param timeoutRetries a number of timeouts to wait until a failure is reported
     * @return a configuration object
     */
   def props[F[+_, +_]: Exec: CovariantFlatMap: ErrorChannel](
     configurationService: GlobalConfigServiceApi[F],
     projectService: ProjectServiceApi[F],
-    requestTimeout: FiniteDuration
+    requestTimeout: FiniteDuration,
+    timeoutRetries: Int
   ): Props =
     Props(
       new ProjectCreateHandler(
         configurationService,
         projectService,
-        requestTimeout
+        requestTimeout,
+        timeoutRetries
       )
     )
 

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectListHandler.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectListHandler.scala
@@ -1,23 +1,17 @@
 package org.enso.projectmanager.requesthandler
 
-import java.util.UUID
-
-import akka.actor.{Actor, ActorRef, Cancellable, Props, Status}
-import akka.pattern.pipe
-import com.typesafe.scalalogging.LazyLogging
-import org.enso.jsonrpc.Errors.ServiceError
-import org.enso.jsonrpc.{Id, Request, ResponseError, ResponseResult}
+import akka.actor.Props
+import org.enso.projectmanager.control.core.CovariantFlatMap
+import org.enso.projectmanager.control.core.syntax._
 import org.enso.projectmanager.control.effect.Exec
 import org.enso.projectmanager.data.ProjectMetadata
 import org.enso.projectmanager.protocol.ProjectManagementApi.ProjectList
-import org.enso.projectmanager.requesthandler.ProjectServiceFailureMapper.mapFailure
+import org.enso.projectmanager.requesthandler.ProjectServiceFailureMapper.failureMapper
 import org.enso.projectmanager.service.{
   ProjectServiceApi,
   ProjectServiceFailure
 }
-import org.enso.projectmanager.util.UnhandledLogging
 
-import scala.annotation.unused
 import scala.concurrent.duration.FiniteDuration
 
 /** A request handler for `project/list` commands.
@@ -27,77 +21,28 @@ import scala.concurrent.duration.FiniteDuration
   * @param requestTimeout a request timeout
   * @param timeoutRetries a number of timeouts to wait until a failure is reported
   */
-class ProjectListHandler[F[+_, +_]: Exec](
-  @unused clientId: UUID,
-  service: ProjectServiceApi[F],
+class ProjectListHandler[F[+_, +_]: Exec: CovariantFlatMap](
+  projectService: ProjectServiceApi[F],
   requestTimeout: FiniteDuration,
   timeoutRetries: Int
-) extends Actor
-    with LazyLogging
-    with UnhandledLogging {
+) extends RequestHandler[
+      F,
+      ProjectServiceFailure,
+      ProjectList.type,
+      ProjectList.Params,
+      ProjectList.Result
+    ](
+      ProjectList,
+      Some(requestTimeout),
+      timeoutRetries
+    ) {
 
-  override def receive: Receive = requestStage
-
-  import context.dispatcher
-
-  private def requestStage: Receive = {
-    case Request(ProjectList, id, params: ProjectList.Params) =>
-      Exec[F]
-        .exec { service.listProjects(params.numberOfProjects) }
-        .pipeTo(self)
-      val cancellable =
-        context.system.scheduler
-          .scheduleOnce(requestTimeout, self, RequestTimeout)
-      context.become(responseStage(id, sender(), cancellable, timeoutRetries))
-  }
-
-  private def responseStage(
-    id: Id,
-    replyTo: ActorRef,
-    cancellable: Cancellable,
-    retry: Int
-  ): Receive = {
-    case Status.Failure(ex) =>
-      logger.error("Failure during ProjectList operation.", ex)
-      replyTo ! ResponseError(Some(id), ServiceError)
-      cancellable.cancel()
-      context.stop(self)
-
-    case RequestTimeout =>
-      if (retry == 0) {
-        logger.error("Request {} with {} timed out.", ProjectList, id)
-        replyTo ! ResponseError(Some(id), ServiceError)
-        context.stop(self)
-      } else {
-        val cancellable =
-          context.system.scheduler
-            .scheduleOnce(requestTimeout, self, RequestTimeout)
-        val retriesLeft = retry - 1
-        logger.warn(
-          "Pending ProjectList response. Timeout retries left: {}.",
-          retriesLeft
-        )
-        responseStage(id, replyTo, cancellable, retriesLeft - 1)
-      }
-
-    case Left(failure: ProjectServiceFailure) =>
-      logger.error("Request {} failed due to {}.", id, failure)
-      replyTo ! ResponseError(Some(id), mapFailure(failure))
-      cancellable.cancel()
-      context.stop(self)
-
-    case Right(list: List[_]) =>
-      val metadata = list.collect { case meta: ProjectMetadata =>
-        meta
-      }
-
-      replyTo ! ResponseResult(
-        ProjectList,
-        id,
-        ProjectList.Result(metadata)
-      )
-      cancellable.cancel()
-      context.stop(self)
+  override def handleRequest = { params =>
+    for {
+      projects <- projectService.listProjects(params.numberOfProjects)
+    } yield ProjectList.Result(projects.collect { case meta: ProjectMetadata =>
+      meta
+    })
   }
 
 }
@@ -112,14 +57,13 @@ object ProjectListHandler {
     * @param timeoutRetries a number of timeouts to wait until a failure is reported
     * @return a configuration object
     */
-  def props[F[+_, +_]: Exec](
-    clientId: UUID,
+  def props[F[+_, +_]: Exec: CovariantFlatMap](
     service: ProjectServiceApi[F],
     requestTimeout: FiniteDuration,
     timeoutRetries: Int
   ): Props =
     Props(
-      new ProjectListHandler(clientId, service, requestTimeout, timeoutRetries)
+      new ProjectListHandler(service, requestTimeout, timeoutRetries)
     )
 
 }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectOpenHandler.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectOpenHandler.scala
@@ -21,11 +21,13 @@ import scala.concurrent.duration.FiniteDuration
   * @param clientId the requester id
   * @param projectService a project service
   * @param requestTimeout a request timeout
+  * @param timeoutRetries a number of timeouts to wait until a failure is reported
   */
 class ProjectOpenHandler[F[+_, +_]: Exec: CovariantFlatMap](
   clientId: UUID,
   projectService: ProjectServiceApi[F],
-  requestTimeout: FiniteDuration
+  requestTimeout: FiniteDuration,
+  timeoutRetries: Int
 ) extends RequestHandler[
       F,
       ProjectServiceFailure,
@@ -37,7 +39,8 @@ class ProjectOpenHandler[F[+_, +_]: Exec: CovariantFlatMap](
       // TODO [RW] maybe we can get rid of this timeout since boot timeout is
       //  handled by the LanguageServerProcess; still the ? message of
       //  LanguageServerGateway will result in timeouts (#1315)
-      Some(requestTimeout)
+      Some(requestTimeout),
+      timeoutRetries
     ) {
 
   override def handleRequest = { params =>
@@ -69,18 +72,21 @@ object ProjectOpenHandler {
     * @param clientId the requester id
     * @param projectService a project service
     * @param requestTimeout a request timeout
+    * @param timeoutRetries a number of timeouts to wait until a failure is reported
     * @return a configuration object
     */
   def props[F[+_, +_]: Exec: CovariantFlatMap](
     clientId: UUID,
     projectService: ProjectServiceApi[F],
-    requestTimeout: FiniteDuration
+    requestTimeout: FiniteDuration,
+    timeoutRetries: Int
   ): Props =
     Props(
       new ProjectOpenHandler(
         clientId,
         projectService,
-        requestTimeout
+        requestTimeout,
+        timeoutRetries
       )
     )
 

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/RequestHandler.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/RequestHandler.scala
@@ -23,7 +23,10 @@ import scala.concurrent.duration.FiniteDuration
   * @param requestTimeout timeout for the request; if set, the request will be
   *                       marked as failed after the specified time; the request
   *                       logic is however NOT cancelled as this is not possible
-  *                       to do in a general way
+  *                       to do in a general way.
+  *                       If number of retry attempts is bigger than 0,
+  *                       action will timeout and handler will stop only when the number
+  *                       of retries reaches 0.
   */
 abstract class RequestHandler[
   F[+_, +_]: Exec,
@@ -33,7 +36,8 @@ abstract class RequestHandler[
   +Result
 ](
   method: M,
-  requestTimeout: Option[FiniteDuration]
+  requestTimeout: Option[FiniteDuration],
+  numberOfTimeoutRetries: Int
 )(implicit
   @unused evParams: HasParams.Aux[M, Params],
   @unused evResult: HasResult.Aux[M, Result]
@@ -44,6 +48,16 @@ abstract class RequestHandler[
   override def receive: Receive = requestStage
 
   import context.dispatcher
+
+  def this(
+    method: M,
+    requestTimeout: Option[FiniteDuration]
+  )(implicit
+    @unused evParams: HasParams.Aux[M, Params],
+    @unused evResult: HasResult.Aux[M, Result]
+  ) = {
+    this(method, requestTimeout, 0)
+  }
 
   /** Waits for the request, tries to pass it into the [[handleRequest]]
     * function, sets up the timeout and routing of the result.
@@ -56,13 +70,16 @@ abstract class RequestHandler[
         .map(_.map(ResponseResult(method, request.id, _)))
         .pipeTo(self)
       val timeoutCancellable = {
-        requestTimeout.map { timeout =>
-          context.system.scheduler.scheduleOnce(
-            timeout,
-            self,
-            RequestTimeout
+        requestTimeout.map(timeout =>
+          (
+            context.system.scheduler.scheduleOnce(
+              timeout,
+              self,
+              RequestTimeout
+            ),
+            numberOfTimeoutRetries
           )
-        }
+        )
       }
       context.become(responseStage(request.id, sender(), timeoutCancellable))
   }
@@ -80,29 +97,51 @@ abstract class RequestHandler[
   private def responseStage(
     id: Id,
     replyTo: ActorRef,
-    timeoutCancellable: Option[Cancellable]
+    timeoutCancellable: Option[(Cancellable, Int)]
   ): Receive = {
     case Status.Failure(ex) =>
       logger.error(s"Failure during $method operation.", ex)
       replyTo ! ResponseError(Some(id), ServiceError)
-      timeoutCancellable.foreach(_.cancel())
+      timeoutCancellable.foreach(_._1.cancel())
       context.stop(self)
 
     case RequestTimeout =>
-      logger.error("Request {} with {} timed out.", method, id)
-      replyTo ! ResponseError(Some(id), ServiceError)
-      context.stop(self)
+      val retry = timeoutCancellable.map(_._2).getOrElse(0)
+      if (retry == 0) {
+        logger.error("Request {} with {} timed out.", method, id)
+        replyTo ! ResponseError(Some(id), ServiceError)
+        context.stop(self)
+      } else {
+        val retriesLeft = retry - 1
+        val cancellable =
+          requestTimeout.map(timeout =>
+            (
+              context.system.scheduler.scheduleOnce(
+                timeout,
+                self,
+                RequestTimeout
+              ),
+              retriesLeft
+            )
+          )
+
+        logger.warn(
+          s"Pending $method response. Timeout retries left: {}.",
+          retriesLeft
+        )
+        responseStage(id, replyTo, cancellable)
+      }
 
     case Left(failure: FailureType) =>
       logger.error("Request {} with {} failed due to {}.", method, id, failure)
       val error = implicitly[FailureMapper[FailureType]].mapFailure(failure)
       replyTo ! ResponseError(Some(id), error)
-      timeoutCancellable.foreach(_.cancel())
+      timeoutCancellable.foreach(_._1.cancel())
       context.stop(self)
 
     case Right(response) =>
       replyTo ! response
-      timeoutCancellable.foreach(_.cancel())
+      timeoutCancellable.foreach(_._1.cancel())
       context.stop(self)
 
     case notification: ProgressNotification =>
@@ -123,9 +162,9 @@ abstract class RequestHandler[
   private def abandonTimeout(
     id: Id,
     replyTo: ActorRef,
-    timeoutCancellable: Option[Cancellable]
+    timeoutCancellable: Option[(Cancellable, Int)]
   ): Unit = {
-    timeoutCancellable.foreach { cancellable =>
+    timeoutCancellable.foreach { case (cancellable, _) =>
       cancellable.cancel()
       Logger[this.type].trace(
         "The operation {} ({}) reported starting a long-running task, " +
@@ -136,4 +175,8 @@ abstract class RequestHandler[
     }
     context.become(responseStage(id, replyTo, None))
   }
+}
+
+object RequestHandler {
+  val defaultNumOfTimeoutRetries: Int = 3
 }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/RequestHandler.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/RequestHandler.scala
@@ -176,7 +176,3 @@ abstract class RequestHandler[
     context.become(responseStage(id, replyTo, None))
   }
 }
-
-object RequestHandler {
-  val defaultNumOfTimeoutRetries: Int = 3
-}


### PR DESCRIPTION
### Pull Request Description

It is relatively easy to reach timeouts on weak systems for startup
operations on project manager. Once a timeout is reached, startup will
not proceed any further.

This PR is a bit of an experiment. It adds adds timeout retries to give a bit of a leeway to
under-powered machines and to log some progress on the way, so that we
know that certain actions are still in progress.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
