### PR TITLE
 Cache dataflow errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -852,6 +852,7 @@
 - [Add method call info for infix operators][7090]
 - [`executionComplete` response is sent on successful execution only][7143]
 - [Send info about function values][7168]
+- [Cache dataflow errors][7193]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -976,6 +977,7 @@
 [7090]: https://github.com/enso-org/enso/pull/7090
 [7143]: https://github.com/enso-org/enso/pull/7143
 [7168]: https://github.com/enso-org/enso/pull/7168
+[7193]: https://github.com/enso-org/enso/pull/7193
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/engine/runtime-instrument-id-execution/src/main/java/org/enso/interpreter/instrument/IdExecutionInstrument.java
+++ b/engine/runtime-instrument-id-execution/src/main/java/org/enso/interpreter/instrument/IdExecutionInstrument.java
@@ -25,6 +25,7 @@ import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.control.TailCallException;
 import org.enso.interpreter.runtime.data.Type;
+import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.error.PanicSentinel;
 import org.enso.interpreter.runtime.state.State;
@@ -250,7 +251,7 @@ public class IdExecutionInstrument extends TruffleInstrument implements IdExecut
     }
 
     private void onExpressionReturn(Object result, Node node, EventContext context) throws ThreadDeath {
-      boolean isPanic = result instanceof AbstractTruffleException;
+      boolean isPanic = result instanceof AbstractTruffleException && !(result instanceof DataflowError);
       UUID nodeId = ((ExpressionNode) node).getId();
 
       String resultType = typeOf(result);

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
@@ -128,7 +128,7 @@ class RuntimeErrorsTest
         |    x = undefined
         |    y = foo x 42
         |    foo y 1
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -225,7 +225,7 @@ class RuntimeErrorsTest
         |    x = undefined
         |    y = foo x 42
         |    foo y 1
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -315,7 +315,7 @@ class RuntimeErrorsTest
       """foo a b = a + b + x
         |
         |main = foo 1 2
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -391,7 +391,7 @@ class RuntimeErrorsTest
         |foo a b = a + b + x
         |
         |main = foo 1 2
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -476,7 +476,7 @@ class RuntimeErrorsTest
         |    x = Error.throw MyError
         |    y = foo x 42
         |    foo y 1
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -553,7 +553,7 @@ class RuntimeErrorsTest
         |    x = undefined
         |    y = 42
         |    IO.println y
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -639,7 +639,7 @@ class RuntimeErrorsTest
         |    x = Error.throw MyError
         |    y = 42
         |    IO.println y
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -723,7 +723,7 @@ class RuntimeErrorsTest
         |    x = Error.throw MyError
         |    y = x - 1
         |    IO.println y
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -898,7 +898,7 @@ class RuntimeErrorsTest
         |    x = Error.throw MyError1
         |    y = x - 1
         |    IO.println y
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1001,7 +1001,7 @@ class RuntimeErrorsTest
         |    x = foo
         |    y = x - 1
         |    IO.println y
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1093,7 +1093,7 @@ class RuntimeErrorsTest
         |    x = Panic.throw MyError
         |    y = x - 1
         |    IO.println y
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1207,7 +1207,7 @@ class RuntimeErrorsTest
         |    x = 1 + foo
         |    y = x - 1
         |    IO.println y
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1329,7 +1329,7 @@ class RuntimeErrorsTest
         |    x = Panic.throw MyError1
         |    y = x - 1
         |    IO.println y
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1477,7 +1477,7 @@ class RuntimeErrorsTest
         |    x = foo
         |    y = x + 1
         |    IO.println y
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1594,7 +1594,7 @@ class RuntimeErrorsTest
         |main =
         |    x = foo
         |    x
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1665,7 +1665,7 @@ class RuntimeErrorsTest
         |    x = foo
         |    y = x + 1
         |    IO.println y
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1770,7 +1770,7 @@ class RuntimeErrorsTest
       """main =
         |    x = IO.println "MyError"
         |    x
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1882,7 +1882,7 @@ class RuntimeErrorsTest
         |main =
         |    x = IO.println "MyError"
         |    x
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1995,7 +1995,7 @@ class RuntimeErrorsTest
         |main =
         |    x = Error.throw (Illegal_Argument.Error "The operation failed due to some reason.")
         |    x
-        |""".stripMargin.linesIterator.mkString("\n")
+        |""".stripMargin
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
@@ -128,7 +128,7 @@ class RuntimeErrorsTest
         |    x = undefined
         |    y = foo x 42
         |    foo y 1
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -225,7 +225,7 @@ class RuntimeErrorsTest
         |    x = undefined
         |    y = foo x 42
         |    foo y 1
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -315,7 +315,7 @@ class RuntimeErrorsTest
       """foo a b = a + b + x
         |
         |main = foo 1 2
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -391,7 +391,7 @@ class RuntimeErrorsTest
         |foo a b = a + b + x
         |
         |main = foo 1 2
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -476,7 +476,7 @@ class RuntimeErrorsTest
         |    x = Error.throw MyError
         |    y = foo x 42
         |    foo y 1
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -553,7 +553,7 @@ class RuntimeErrorsTest
         |    x = undefined
         |    y = 42
         |    IO.println y
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -639,7 +639,7 @@ class RuntimeErrorsTest
         |    x = Error.throw MyError
         |    y = 42
         |    IO.println y
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -723,7 +723,7 @@ class RuntimeErrorsTest
         |    x = Error.throw MyError
         |    y = x - 1
         |    IO.println y
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -898,7 +898,7 @@ class RuntimeErrorsTest
         |    x = Error.throw MyError1
         |    y = x - 1
         |    IO.println y
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1001,7 +1001,7 @@ class RuntimeErrorsTest
         |    x = foo
         |    y = x - 1
         |    IO.println y
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1093,7 +1093,7 @@ class RuntimeErrorsTest
         |    x = Panic.throw MyError
         |    y = x - 1
         |    IO.println y
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1207,7 +1207,7 @@ class RuntimeErrorsTest
         |    x = 1 + foo
         |    y = x - 1
         |    IO.println y
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1329,7 +1329,7 @@ class RuntimeErrorsTest
         |    x = Panic.throw MyError1
         |    y = x - 1
         |    IO.println y
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1477,7 +1477,7 @@ class RuntimeErrorsTest
         |    x = foo
         |    y = x + 1
         |    IO.println y
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1594,7 +1594,7 @@ class RuntimeErrorsTest
         |main =
         |    x = foo
         |    x
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1665,7 +1665,7 @@ class RuntimeErrorsTest
         |    x = foo
         |    y = x + 1
         |    IO.println y
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1770,7 +1770,7 @@ class RuntimeErrorsTest
       """main =
         |    x = IO.println "MyError"
         |    x
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1882,7 +1882,7 @@ class RuntimeErrorsTest
         |main =
         |    x = IO.println "MyError"
         |    x
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 
@@ -1995,7 +1995,7 @@ class RuntimeErrorsTest
         |main =
         |    x = Error.throw (Illegal_Argument.Error "The operation failed due to some reason.")
         |    x
-        |""".stripMargin
+        |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
 

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
@@ -1983,9 +1983,9 @@ class RuntimeErrorsTest
     val moduleName = "Enso_Test.Test.Main"
     val newline    = "\n" // was: System.lineSeparator()
 
-    val metadata  = new Metadata
-    val xId       = metadata.addItem(111, 79)
-    val mainResId = metadata.addItem(195, 1)
+    val metadata   = new Metadata
+    val xId        = metadata.addItem(111, 79)
+    val mainResId  = metadata.addItem(195, 1)
     val mainRes1Id = metadata.addItem(209, 1)
 
     val code =

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
@@ -799,7 +799,14 @@ class RuntimeErrorsTest
       3,
       updatesOnlyFor = Set(xId, yId)
     ) should contain theSameElementsAs Seq(
-      TestMessages.update(contextId, xId, ConstantsGen.INTEGER),
+      TestMessages.update(contextId, xId, ConstantsGen.INTEGER,
+        methodCall = Some(Api.MethodCall(
+          Api.MethodPointer(
+            "Standard.Base.Error",
+            "Standard.Base.Error.Error",
+            "throw"
+          )
+        ))),
       TestMessages.update(contextId, yId, ConstantsGen.INTEGER),
       context.executionComplete(contextId)
     )

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
@@ -799,14 +799,20 @@ class RuntimeErrorsTest
       3,
       updatesOnlyFor = Set(xId, yId)
     ) should contain theSameElementsAs Seq(
-      TestMessages.update(contextId, xId, ConstantsGen.INTEGER,
-        methodCall = Some(Api.MethodCall(
-          Api.MethodPointer(
-            "Standard.Base.Error",
-            "Standard.Base.Error.Error",
-            "throw"
+      TestMessages.update(
+        contextId,
+        xId,
+        ConstantsGen.INTEGER,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.Error",
+              "Standard.Base.Error.Error",
+              "throw"
+            )
           )
-        ))),
+        )
+      ),
       TestMessages.update(contextId, yId, ConstantsGen.INTEGER),
       context.executionComplete(contextId)
     )
@@ -1969,6 +1975,108 @@ class RuntimeErrorsTest
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("MyError")
+  }
+
+  it should "cache dataflow errors" in {
+    val contextId  = UUID.randomUUID()
+    val requestId  = UUID.randomUUID()
+    val moduleName = "Enso_Test.Test.Main"
+    val newline    = "\n" // was: System.lineSeparator()
+
+    val metadata  = new Metadata
+    val xId       = metadata.addItem(111, 79)
+    val mainResId = metadata.addItem(195, 1)
+    val mainRes1Id = metadata.addItem(209, 1)
+
+    val code =
+      """import Standard.Base.Error.Error
+        |import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
+        |
+        |main =
+        |    x = Error.throw (Illegal_Argument.Error "The operation failed due to some reason.")
+        |    x
+        |""".stripMargin.linesIterator.mkString("\n")
+    val contents = metadata.appendToCode(code)
+    val mainFile = context.writeMain(contents)
+
+    // create context
+    context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
+    context.receive shouldEqual Some(
+      Api.Response(requestId, Api.CreateContextResponse(contextId))
+    )
+
+    // Open the new file
+    context.send(
+      Api.Request(Api.OpenFileNotification(mainFile, contents))
+    )
+    context.receiveNone shouldEqual None
+
+    // push main
+    context.send(
+      Api.Request(
+        requestId,
+        Api.PushContextRequest(
+          contextId,
+          Api.StackItem.ExplicitCall(
+            Api.MethodPointer(moduleName, "Enso_Test.Test.Main", "main"),
+            None,
+            Vector()
+          )
+        )
+      )
+    )
+    context.receiveNIgnorePendingExpressionUpdates(
+      5
+    ) should contain theSameElementsAs Seq(
+      Api.Response(Api.BackgroundJobsStartedNotification()),
+      Api.Response(requestId, Api.PushContextResponse(contextId)),
+      TestMessages.error(
+        contextId,
+        xId,
+        methodCall = Api.MethodCall(
+          Api.MethodPointer(
+            "Standard.Base.Error",
+            "Standard.Base.Error.Error",
+            "throw"
+          )
+        ),
+        Api.ExpressionUpdate.Payload.DataflowError(Seq(xId))
+      ),
+      TestMessages.error(
+        contextId,
+        mainResId,
+        Api.ExpressionUpdate.Payload.DataflowError(Seq(xId))
+      ),
+      context.executionComplete(contextId)
+    )
+    context.consumeOut shouldEqual Seq()
+
+    // Modify the file
+    context.send(
+      Api.Request(
+        Api.EditFileNotification(
+          mainFile,
+          Seq(
+            TextEdit(
+              model.Range(model.Position(5, 4), model.Position(5, 5)),
+              s"y = x - 1${newline}    y"
+            )
+          ),
+          execute = true
+        )
+      )
+    )
+    context.receiveNIgnorePendingExpressionUpdates(
+      2
+    ) should contain theSameElementsAs Seq(
+      TestMessages.error(
+        contextId,
+        mainRes1Id,
+        Api.ExpressionUpdate.Payload.DataflowError(Seq(xId))
+      ),
+      context.executionComplete(contextId)
+    )
+    context.consumeOut shouldEqual Seq()
   }
 
 }

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Illegal_Argument.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Illegal_Argument.enso
@@ -1,0 +1,7 @@
+import project.Nothing.Nothing
+import project.Data.Text.Text
+
+type Illegal_Argument
+    Error message cause=Nothing
+
+    to_display_text self = "Illegal Argument: "+self.message


### PR DESCRIPTION
### Pull Request Description

The logic in instrumentation specifically prohibited caching of panics (added in https://github.com/enso-org/enso/pull/1611).
Except it seems that the restriction was too aggressive because dataflow errors could be cached.
This indirectly fixes the problem with dataflow error in the context of a (temporary) change in execution context, which should keep around the old value.

Closes #7140.

After the fix:
[fix_7140.webm](https://github.com/enso-org/enso/assets/292128/b8d522db-985a-4e57-bbf1-a075d14d39a2)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

~~- [ ] The documentation has been updated, if necessary.~~
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
