### PR TITLE
A dataflow error with warnings reports the former

### DIFF
--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -22,7 +22,8 @@ import org.enso.interpreter.runtime.control.ThreadInterruptedException
 import org.enso.interpreter.runtime.error.{
   DataflowError,
   PanicSentinel,
-  WarningsLibrary
+  WarningsLibrary,
+  WithWarnings
 }
 import org.enso.interpreter.service.error._
 import org.enso.polyglot.LanguageInfo
@@ -352,6 +353,13 @@ object ProgramExecutionSupport {
               VisualizationResult.findExceptionMessage(panic),
               ErrorResolver.getStackTrace(panic).flatMap(_.expressionId)
             )
+        case warnings: WithWarnings
+            if warnings.getValue.isInstanceOf[DataflowError] =>
+          Api.ExpressionUpdate.Payload.DataflowError(
+            ErrorResolver
+              .getStackTrace(warnings.getValue.asInstanceOf[DataflowError])
+              .flatMap(_.expressionId)
+          )
         case _ =>
           val warnings =
             Option.when(

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
@@ -242,6 +242,6 @@ public final class WithWarnings implements TruffleObject {
 
   @Override
   public String toString() {
-    return "WithWarnings{" + value + " + " + warnings.size() + " warnings" + (limitReached ? " (warnings limit reached)}" : "}");
+    return "WithWarnings{" + value + " has " + warnings.size() + " warnings" + (limitReached ? " (warnings limit reached)}" : "}");
   }
 }

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -1,3 +1,4 @@
 @Builtin_Type
 type Vector a
     from_array array = @Builtin_Method "Vector.from_array"
+    at self index = @Builtin_Method "Vector.at"


### PR DESCRIPTION
### Pull Request Description

A dataflow error resulting from calling a value with warnings now reports only the error rather than the warning.

Closes #7141.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
