### PR TITLE
Fix Undo/Redo for visualization toggling

### DIFF
--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -1811,7 +1811,7 @@ impl GraphEditorModel {
                 &visualization.visible, &visualization.visualization_path,
                 move |_init, is_enabled, path| (node_id, is_enabled.and_option(path.clone()))
             );
-            out.enabled_visualization_path <+ enabled_visualization_path;
+            out.enabled_visualization_path <+ enabled_visualization_path.on_change();
 
 
             // === Read-only mode ===


### PR DESCRIPTION
### Pull Request Description
This PR fixes #6589. 

The issue was quite a hassle to debug. Basically, it goes like this:
* user performs undo to reenable visualization;
* undo updates the metadata in the text and send asynchronous invalidation notifications;
* the graph editor presenter gets the invalidation and in turn schedules asynchronous (though this time through frp microtask / debounce) update (`update_view_once`);
* the presenter updates visualization on node: first by toggling its visibility (to true) and then by updating its visualization path (to JSON or whichever visualization was picked);
* this, in turn, caused `enabled_visualization_path` to be emitted twice: once with no visualization (because only the visibility flag was updated, not yet path) and once with the proper visualization (after both flag and path are set);
* both `enabled_visualization_path` updates cause introduce changes to the text code: once removing the visualization and later restoring it (the presenter has no idea why  `enabled_visualization_path` changed);
* these text changes caused bogus undo operations to be generated.

These bogus operations have no checkable relation to the initial undo: after the first debounce in the presenter, all the call stack-stored information is lost. And, what's more troublesome, the views have no notion of undo/redo and its transactions, so there is nothing they can do to prevent the issue, And when the control gets to controllers, it is already too late. (We just see that the view said it wants visualization to be disabled.)

This PR fixes the issue by suppressing the spurious `enabled_visualization_path` events. These are not "real" events, these are just noise coming from the FRP implementation details. However, I am somewhat concerned about the bigger picture here. I suspect that a similar issue might appear elsewhere (or regress). 

Do we have somewhere a rule that says whether "spurious" events are allowed in the views' FRP endpoints? 
* If yes, this will trigger such issues over and over again and a different approach needs to be designed;
* If no, then likely pretty much all the endpoints should have `on_change` semantics, which does not seem to be currently the case.

cc @MichaelMauderer @wdanilo 


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
