### PR TITLE
Reload externally changed file on a keypress

### DIFF
--- a/app/gui/src/controller/graph/executed.rs
+++ b/app/gui/src/controller/graph/executed.rs
@@ -375,6 +375,19 @@ impl Handle {
         if self.project.read_only() {
             Err(ReadOnly.into())
         } else {
+            self.execution_ctx.restart().await?;
+            Ok(())
+        }
+    }
+
+    /// Reload the main file and restart the program execution.
+    ///
+    /// ### Errors
+    /// - Fails if the project is in read-only mode.
+    pub async fn reload_and_restart(&self) -> FallibleResult {
+        if self.project.read_only() {
+            Err(ReadOnly.into())
+        } else {
             let model = self.project.main_module_model().await?;
             model.reopen_externally_changed_file().await?;
             self.execution_ctx.restart().await?;

--- a/app/gui/src/controller/graph/executed.rs
+++ b/app/gui/src/controller/graph/executed.rs
@@ -375,6 +375,8 @@ impl Handle {
         if self.project.read_only() {
             Err(ReadOnly.into())
         } else {
+            let model = self.project.main_module_model().await?;
+            model.reopen_file_in_language_server().await?;
             self.execution_ctx.restart().await?;
             Ok(())
         }

--- a/app/gui/src/controller/graph/executed.rs
+++ b/app/gui/src/controller/graph/executed.rs
@@ -376,7 +376,7 @@ impl Handle {
             Err(ReadOnly.into())
         } else {
             let model = self.project.main_module_model().await?;
-            model.reopen_file_in_language_server().await?;
+            model.reopen_externally_changed_file().await?;
             self.execution_ctx.restart().await?;
             Ok(())
         }

--- a/app/gui/src/model/module.rs
+++ b/app/gui/src/model/module.rs
@@ -673,6 +673,9 @@ pub trait API: Debug + model::undo_redo::Aware {
 
     /// Reopen file in language server.
     fn reopen_file_in_language_server(&self) -> BoxFuture<FallibleResult>;
+
+    /// Reopen externally changed file.
+    fn reopen_externally_changed_file(&self) -> BoxFuture<FallibleResult>;
 }
 
 /// Trait for methods that cannot be defined in `API` because it is a trait object.

--- a/app/gui/src/model/module/plain.rs
+++ b/app/gui/src/model/module/plain.rs
@@ -311,6 +311,11 @@ impl model::module::API for Module {
         info!("Ignoring request for reopening file in the Language Server, because it's not connected");
         future::ready_boxed(Ok(()))
     }
+
+    fn reopen_externally_changed_file(&self) -> BoxFuture<FallibleResult> {
+        info!("Ignoring request for reopening externally changed file in the Language Server, because it's not connected");
+        future::ready_boxed(Ok(()))
+    }
 }
 
 impl model::undo_redo::Aware for Module {

--- a/app/gui/src/presenter/project.rs
+++ b/app/gui/src/presenter/project.rs
@@ -248,6 +248,15 @@ impl Model {
         })
     }
 
+    fn execution_context_reload_and_restart(&self) {
+        let controller = self.graph_controller.clone_ref();
+        executor::global::spawn(async move {
+            if let Err(err) = controller.reload_and_restart().await {
+                error!("Error reloading and restarting execution context: {err}");
+            }
+        })
+    }
+
     /// Prepare a list of projects to display in the Open Project dialog.
     fn project_list_opened(&self, project_list_ready: frp::Source<()>) {
         let controller = self.ide_controller.clone_ref();
@@ -374,6 +383,7 @@ impl Project {
             eval_ view.execution_context_interrupt(model.execution_context_interrupt());
 
             eval_ view.execution_context_restart(model.execution_context_restart());
+            eval_ view.execution_context_reload_and_restart(model.execution_context_reload_and_restart());
 
             view.set_read_only <+ view.toggle_read_only.map(f_!(model.toggle_read_only()));
             eval graph_view.execution_environment((env) model.execution_environment_changed(*env));

--- a/app/gui/view/src/project.rs
+++ b/app/gui/view/src/project.rs
@@ -107,6 +107,8 @@ ensogl::define_endpoints! {
         execution_context_interrupt(),
         /// Restart the program execution.
         execution_context_restart(),
+        /// Reload the main module and restart the program execution.
+        execution_context_reload_and_restart(),
         toggle_read_only(),
         set_read_only(bool),
     }
@@ -759,6 +761,9 @@ impl application::View for View {
             (Press, "debug_mode", DEBUG_MODE_SHORTCUT, "disable_debug_mode"),
             (Press, "", "cmd alt t", "execution_context_interrupt"),
             (Press, "", "cmd alt r", "execution_context_restart"),
+            // TODO(#7178): Remove this temporary shortcut when the modified-on-disk notification
+            // is ready.
+            (Press, "", "cmd alt y", "execution_context_reload_and_restart"),
             // TODO(#6179): Remove this temporary shortcut when Play button is ready.
             (Press, "", "ctrl shift b", "toggle_read_only"),
         ]


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

part of #7178

Changelog:
- add: `cmd+alt+y` keybinding that re-opens the file, applies new content, and re-executes the program

This is the first part of the task to support the external edits. The next step will be to reload the module contents by the notification from the language server.

### Important Notes


https://github.com/enso-org/enso/assets/357683/79917e22-b846-4bd9-b03a-33a48d5f75b9



<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
