### PR TITLE
Show spinner on templates when creating project

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/authentication/src/components/svg.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/components/svg.tsx
@@ -8,40 +8,6 @@
 // === SVGs with custom formatting ===
 // ===================================
 
-/** Props for a {@link Spinner}. */
-export interface SpinnerProps {
-    size: number
-    className: string
-}
-
-/** A spinning arc that animates using the `dasharray-<percentage>` custom Tailwind classes. */
-export function Spinner(props: SpinnerProps) {
-    const { size, className } = props
-    return (
-        <svg
-            width={size}
-            height={size}
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-        >
-            <rect
-                x={1.5}
-                y={1.5}
-                width={21}
-                height={21}
-                rx={10.5}
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeWidth={3}
-                className={
-                    'animate-spin-ease origin-center transition-stroke-dasharray ' + className
-                }
-            />
-        </svg>
-    )
-}
-
 /** Props for a {@link StopIcon}. */
 export interface StopIconProps {
     className?: string

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/dashboard.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/dashboard.tsx
@@ -22,6 +22,7 @@ import * as localBackend from '../localBackend'
 import * as newtype from '../../newtype'
 import * as projectManager from '../projectManager'
 import * as remoteBackendModule from '../remoteBackend'
+import * as spinner from './spinner'
 import * as uploadMultipleFiles from '../../uploadMultipleFiles'
 
 import * as authProvider from '../../authentication/providers/auth'
@@ -300,6 +301,9 @@ function Dashboard(props: DashboardProps) {
     )
     const [nameOfProjectToImmediatelyOpen, setNameOfProjectToImmediatelyOpen] =
         react.useState(initialProjectName)
+    const [onSpinnerStateChange, setOnSpinnerStateChange] = react.useState<
+        ((state: spinner.SpinnerState | null) => void) | null
+    >(null)
     const [projectEvent, setProjectEvent] = react.useState<projectActionButton.ProjectEvent | null>(
         null
     )
@@ -539,6 +543,7 @@ function Dashboard(props: DashboardProps) {
                         setProjectEvent({
                             type: projectActionButton.ProjectEventType.open,
                             projectId: projectAsset.id,
+                            onSpinnerStateChange: null,
                         })
                     } else if (
                         event.ctrlKey &&
@@ -606,6 +611,7 @@ function Dashboard(props: DashboardProps) {
                         setProjectEvent({
                             type: projectActionButton.ProjectEventType.open,
                             projectId: projectAsset.id,
+                            onSpinnerStateChange: null,
                         })
                     }}
                     onClose={() => {
@@ -904,9 +910,11 @@ function Dashboard(props: DashboardProps) {
                 setProjectEvent({
                     type: projectActionButton.ProjectEventType.open,
                     projectId: projectToLoad.id,
+                    onSpinnerStateChange,
                 })
             }
             setNameOfProjectToImmediatelyOpen(null)
+            setOnSpinnerStateChange(null)
         }
         onDirectoryNextLoaded?.(assets)
         setOnDirectoryNextLoaded(null)
@@ -991,7 +999,10 @@ function Dashboard(props: DashboardProps) {
         return `${prefix}${highestProjectIndex + 1}`
     }
 
-    const handleCreateProject = async (templateId?: string | null) => {
+    const handleCreateProject = async (
+        templateId?: string | null,
+        newOnSpinnerStateChange?: (state: spinner.SpinnerState) => void
+    ) => {
         const projectName = getNewProjectName(templateId)
         const body: backendModule.CreateProjectRequestBody = {
             projectName,
@@ -1020,10 +1031,11 @@ function Dashboard(props: DashboardProps) {
             error: (promiseError: Error) =>
                 `Error creating '${projectName}'${templateText}: ${promiseError.message}`,
         })
-        // `newProject.projectId` cannot be used directly in a `ProjectEvet` as the project
+        // `newProject.projectId` cannot be used directly in a `ProjectEvent` as the project
         // does not yet exist in the project list. Opening the project would work, but the project
         // would display as closed as it would be created after the event is sent.
         setNameOfProjectToImmediatelyOpen(projectName)
+        setOnSpinnerStateChange(() => newOnSpinnerStateChange ?? null)
         doRefresh()
     }
 
@@ -1274,6 +1286,7 @@ function Dashboard(props: DashboardProps) {
                                             setProjectEvent({
                                                 type: projectActionButton.ProjectEventType.open,
                                                 projectId: projectAsset.id,
+                                                onSpinnerStateChange: null,
                                             })
                                         }
                                         const doOpenAsFolder = () => {

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectActionButton.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectActionButton.tsx
@@ -192,6 +192,9 @@ function ProjectActionButton(props: ProjectActionButtonProps) {
                 }
                 case ProjectEventType.cancelOpeningAll: {
                     setShouldOpenWhenReady(false)
+                    onSpinnerStateChange?.(null)
+                    setOnSpinnerStateChange(null)
+                    break
                 }
             }
         }

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectActionButton.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectActionButton.tsx
@@ -11,6 +11,8 @@ import * as localBackend from '../localBackend'
 import * as modalProvider from '../../providers/modal'
 import * as svg from '../../components/svg'
 
+import * as spinner from './spinner'
+
 // =============
 // === Types ===
 // =============
@@ -35,11 +37,11 @@ interface ProjectBaseEvent<Type extends ProjectEventType> {
 
 /** Requests the specified project to be opened. */
 export interface ProjectOpenEvent extends ProjectBaseEvent<ProjectEventType.open> {
-    // FIXME: provide projectId instead
     /** This must be a name because it may be specified by name on the command line.
      * Note that this will not work properly with the cloud backend if there are multiple projects
      * with the same name. */
     projectId: backendModule.ProjectId
+    onSpinnerStateChange: ((state: spinner.SpinnerState) => void) | null
 }
 
 /** Requests the specified project to be opened. */
@@ -48,13 +50,6 @@ export interface ProjectCancelOpeningAllEvent
 
 /** Every possible type of project event. */
 export type ProjectEvent = ProjectCancelOpeningAllEvent | ProjectOpenEvent
-
-/** The state of the spinner. It should go from initial, to loading, to done. */
-enum SpinnerState {
-    initial = 'initial',
-    loading = 'loading',
-    done = 'done',
-}
 
 // =================
 // === Constants ===
@@ -70,20 +65,24 @@ const LOADING_MESSAGE =
 const CHECK_STATUS_INTERVAL_MS = 5000
 /** The interval between requests checking whether the VM is ready. */
 const CHECK_RESOURCES_INTERVAL_MS = 1000
-/** The corresponding {@link SpinnerState} for each {@link backendModule.ProjectState}. */
-const SPINNER_STATE: Record<backendModule.ProjectState, SpinnerState> = {
-    [backendModule.ProjectState.closed]: SpinnerState.initial,
-    [backendModule.ProjectState.created]: SpinnerState.initial,
-    [backendModule.ProjectState.new]: SpinnerState.initial,
-    [backendModule.ProjectState.openInProgress]: SpinnerState.loading,
-    [backendModule.ProjectState.opened]: SpinnerState.done,
+/** The corresponding {@link SpinnerState} for each {@link backendModule.ProjectState},
+ * when using the remote backend. */
+const REMOTE_SPINNER_STATE: Record<backendModule.ProjectState, spinner.SpinnerState> = {
+    [backendModule.ProjectState.closed]: spinner.SpinnerState.initial,
+    [backendModule.ProjectState.created]: spinner.SpinnerState.initial,
+    [backendModule.ProjectState.new]: spinner.SpinnerState.initial,
+    [backendModule.ProjectState.openInProgress]: spinner.SpinnerState.loadingSlow,
+    [backendModule.ProjectState.opened]: spinner.SpinnerState.done,
 }
-
-const SPINNER_CSS_CLASSES: Record<SpinnerState, string> = {
-    [SpinnerState.initial]: 'dasharray-5 ease-linear',
-    [SpinnerState.loading]: 'dasharray-75 duration-90000 ease-linear',
-    [SpinnerState.done]: 'dasharray-100 duration-1000 ease-in',
-} as const
+/** The corresponding {@link SpinnerState} for each {@link backendModule.ProjectState},
+ * when using the local backend. */
+const LOCAL_SPINNER_STATE: Record<backendModule.ProjectState, spinner.SpinnerState> = {
+    [backendModule.ProjectState.closed]: spinner.SpinnerState.initial,
+    [backendModule.ProjectState.created]: spinner.SpinnerState.initial,
+    [backendModule.ProjectState.new]: spinner.SpinnerState.initial,
+    [backendModule.ProjectState.openInProgress]: spinner.SpinnerState.loadingMedium,
+    [backendModule.ProjectState.opened]: spinner.SpinnerState.done,
+}
 
 // =================
 // === Component ===
@@ -132,7 +131,10 @@ function ProjectActionButton(props: ProjectActionButtonProps) {
     })
     const [isCheckingStatus, setIsCheckingStatus] = react.useState(false)
     const [isCheckingResources, setIsCheckingResources] = react.useState(false)
-    const [spinnerState, setSpinnerState] = react.useState(SPINNER_STATE[state])
+    const [spinnerState, setSpinnerState] = react.useState(REMOTE_SPINNER_STATE[state])
+    const [onSpinnerStateChange, setOnSpinnerStateChange] = react.useState<
+        ((state: spinner.SpinnerState | null) => void) | null
+    >(null)
     const [shouldOpenWhenReady, setShouldOpenWhenReady] = react.useState(false)
     const [toastId, setToastId] = react.useState<string | null>(null)
 
@@ -149,9 +151,18 @@ function ProjectActionButton(props: ProjectActionButtonProps) {
     react.useEffect(() => {
         // Ensure that the previous spinner state is visible for at least one frame.
         requestAnimationFrame(() => {
-            setSpinnerState(SPINNER_STATE[state])
+            const newSpinnerState =
+                backend.type === backendModule.BackendType.remote
+                    ? REMOTE_SPINNER_STATE[state]
+                    : LOCAL_SPINNER_STATE[state]
+            setSpinnerState(newSpinnerState)
+            onSpinnerStateChange?.(newSpinnerState)
         })
-    }, [state])
+    }, [state, onSpinnerStateChange])
+
+    react.useEffect(() => {
+        onSpinnerStateChange?.(spinner.SpinnerState.initial)
+    }, [onSpinnerStateChange])
 
     react.useEffect(() => {
         if (toastId != null && state !== backendModule.ProjectState.openInProgress) {
@@ -174,6 +185,7 @@ function ProjectActionButton(props: ProjectActionButtonProps) {
                         setShouldOpenWhenReady(false)
                     } else {
                         setShouldOpenWhenReady(true)
+                        setOnSpinnerStateChange(() => event.onSpinnerStateChange)
                         void openProject()
                     }
                     break
@@ -291,6 +303,8 @@ function ProjectActionButton(props: ProjectActionButtonProps) {
         onClose()
         setShouldOpenWhenReady(false)
         setState(backendModule.ProjectState.closed)
+        onSpinnerStateChange?.(null)
+        setOnSpinnerStateChange(null)
         appRunner?.stopApp()
         setIsCheckingStatus(false)
         setIsCheckingResources(false)
@@ -362,7 +376,7 @@ function ProjectActionButton(props: ProjectActionButtonProps) {
                         await closeProject()
                     }}
                 >
-                    <svg.StopIcon className={SPINNER_CSS_CLASSES[spinnerState]} />
+                    <svg.StopIcon className={spinner.SPINNER_CSS_CLASSES[spinnerState]} />
                 </button>
             )
         case backendModule.ProjectState.opened:
@@ -375,7 +389,7 @@ function ProjectActionButton(props: ProjectActionButtonProps) {
                             await closeProject()
                         }}
                     >
-                        <svg.StopIcon className={SPINNER_CSS_CLASSES[spinnerState]} />
+                        <svg.StopIcon className={spinner.SPINNER_CSS_CLASSES[spinnerState]} />
                     </button>
                     <button
                         onClick={clickEvent => {

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectActionButton.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectActionButton.tsx
@@ -156,7 +156,9 @@ function ProjectActionButton(props: ProjectActionButtonProps) {
                     ? REMOTE_SPINNER_STATE[state]
                     : LOCAL_SPINNER_STATE[state]
             setSpinnerState(newSpinnerState)
-            onSpinnerStateChange?.(newSpinnerState)
+            onSpinnerStateChange?.(
+                state === backendModule.ProjectState.closed ? null : newSpinnerState
+            )
         })
     }, [state, onSpinnerStateChange, backend.type])
 
@@ -217,6 +219,9 @@ function ProjectActionButton(props: ProjectActionButtonProps) {
                 case ProjectEventType.open: {
                     if (event.projectId !== project.id) {
                         setShouldOpenWhenReady(false)
+                        if (onSpinnerStateChange === event.onSpinnerStateChange) {
+                            setOnSpinnerStateChange(null)
+                        }
                     } else {
                         setShouldOpenWhenReady(true)
                         setOnSpinnerStateChange(() => event.onSpinnerStateChange)
@@ -232,7 +237,9 @@ function ProjectActionButton(props: ProjectActionButtonProps) {
                 }
             }
         }
-    }, [event, openProject, project.id, onSpinnerStateChange])
+        // This effect MUST run if and only if `event` changes.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [event])
 
     React.useEffect(() => {
         if (shouldOpenWhenReady && state === backendModule.ProjectState.opened) {

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/rows.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/rows.tsx
@@ -1,7 +1,7 @@
 /** @file Table that projects an object into each column. */
 import * as react from 'react'
 
-import * as svg from '../../components/svg'
+import Spinner, * as spinner from './spinner'
 
 // =================
 // === Constants ===
@@ -9,10 +9,6 @@ import * as svg from '../../components/svg'
 
 /** The size of the loading spinner. */
 const LOADING_SPINNER_SIZE = 36
-/** The classes for the initial state of the spinner. */
-const SPINNER_INITIAL_CLASSES = 'grow dasharray-5 ease-linear'
-/** The classes for the final state of the spinner. */
-const SPINNER_LOADING_CLASSES = 'grow dasharray-75 duration-1000 ease-linear'
 
 // =============
 // === Types ===
@@ -43,7 +39,7 @@ export interface RowsProps<T> {
 /** Table that projects an object into each column. */
 function Rows<T>(props: RowsProps<T>) {
     const { columns, items, isLoading, getKey, placeholder, onClick, onContextMenu } = props
-    const [spinnerClasses, setSpinnerClasses] = react.useState(SPINNER_INITIAL_CLASSES)
+    const [spinnerState, setSpinnerState] = react.useState(spinner.SpinnerState.initial)
 
     const headerRow = (
         <tr>
@@ -62,10 +58,10 @@ function Rows<T>(props: RowsProps<T>) {
         if (isLoading) {
             // Ensure the spinner stays in the "initial" state for at least one frame.
             requestAnimationFrame(() => {
-                setSpinnerClasses(SPINNER_LOADING_CLASSES)
+                setSpinnerState(spinner.SpinnerState.loadingFast)
             })
         } else {
-            setSpinnerClasses(SPINNER_INITIAL_CLASSES)
+            setSpinnerState(spinner.SpinnerState.initial)
         }
     }, [isLoading])
 
@@ -73,7 +69,7 @@ function Rows<T>(props: RowsProps<T>) {
         <tr className="h-10">
             <td colSpan={columns.length}>
                 <div className="grid justify-around w-full">
-                    <svg.Spinner size={LOADING_SPINNER_SIZE} className={spinnerClasses} />
+                    <Spinner size={LOADING_SPINNER_SIZE} state={spinnerState} />
                 </div>
             </td>
         </tr>

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/spinner.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/spinner.tsx
@@ -1,0 +1,60 @@
+/** @file A spinning arc that animates using the `dasharray-<percentage>` custom Tailwind
+ * classes. */
+
+// ===============
+// === Spinner ===
+// ===============
+
+/** The state of the spinner. It should go from initial, to loading, to done. */
+export enum SpinnerState {
+    initial = 'initial',
+    loadingSlow = 'loading-slow',
+    loadingMedium = 'loading-medium',
+    loadingFast = 'loading-fast',
+    done = 'done',
+}
+
+export const SPINNER_CSS_CLASSES: Record<SpinnerState, string> = {
+    [SpinnerState.initial]: 'dasharray-5 ease-linear',
+    [SpinnerState.loadingSlow]: 'dasharray-75 duration-90000 ease-linear',
+    [SpinnerState.loadingMedium]: 'dasharray-75 duration-5000 ease-linear',
+    [SpinnerState.loadingFast]: 'dasharray-75 duration-1000 ease-linear',
+    [SpinnerState.done]: 'dasharray-100 duration-1000 ease-in',
+} as const
+
+/** Props for a {@link Spinner}. */
+export interface SpinnerProps {
+    size: number
+    state: SpinnerState
+}
+
+/** A spinning arc that animates using the `dasharray-<percentage>` custom Tailwind classes. */
+function Spinner(props: SpinnerProps) {
+    const { size, state } = props
+    return (
+        <svg
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <rect
+                x={1.5}
+                y={1.5}
+                width={21}
+                height={21}
+                rx={10.5}
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeWidth={3}
+                className={
+                    'animate-spin-ease origin-center transition-stroke-dasharray ' +
+                    SPINNER_CSS_CLASSES[state]
+                }
+            />
+        </svg>
+    )
+}
+
+export default Spinner

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/templates.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/templates.tsx
@@ -6,6 +6,8 @@ import RotatingArrowIcon from 'enso-assets/rotating_arrow.svg'
 
 import * as common from 'enso-common'
 
+import Spinner, * as spinner from './spinner'
+
 // =================
 // === Constants ===
 // =================
@@ -18,6 +20,10 @@ const MAX_WIDTH_NEEDING_SCROLL = 1031
 /** The height of the bottom padding - 8px for the grid gap, and another 8px for the height
  * of the padding div. */
 const PADDING_HEIGHT = 16
+/** The size (both width and height) of the spinner, in pixels. */
+const SPINNER_SIZE = 64
+/** The duration of the "spinner done" animation. */
+const SPINNER_DONE_DURATION_MS = 1000
 
 // =============
 // === Types ===
@@ -83,63 +89,133 @@ export const TEMPLATES: [Template, ...Template[]] = [
     },
 ]
 
-// =======================
-// === TemplatesRender ===
-// =======================
+// ==========================
+// === EmptyProjectButton ===
+// ==========================
 
-/** Props for a {@link TemplatesRender}. */
-export interface TemplatesRenderProps {
-    // Later this data may be requested and therefore needs to be passed dynamically.
-    templates: Template[]
-    onTemplateClick: (name: string | null) => void
+/** Props for an {@link EmptyProjectButton}. */
+interface InternalEmptyProjectButtonProps {
+    onTemplateClick: (
+        name: null,
+        onSpinnerStateChange: (spinnerState: spinner.SpinnerState | null) => void
+    ) => void
 }
 
-/** Render all templates, and a button to create an empty project. */
-function TemplatesRender(props: TemplatesRenderProps) {
-    const { templates, onTemplateClick } = props
+/** A button that, when clicked, creates and opens a new blank project. */
+function EmptyProjectButton(props: InternalEmptyProjectButtonProps) {
+    const { onTemplateClick } = props
+    const [spinnerState, setSpinnerState] = react.useState<spinner.SpinnerState | null>(null)
 
-    /** The action button for creating an empty project. */
-    const CreateEmptyTemplate = (
+    return (
         <button
             onClick={() => {
-                onTemplateClick(null)
+                onTemplateClick(null, newSpinnerState => {
+                    setSpinnerState(newSpinnerState)
+                    if (newSpinnerState === spinner.SpinnerState.done) {
+                        setTimeout(() => {
+                            setSpinnerState(null)
+                        }, SPINNER_DONE_DURATION_MS)
+                    }
+                })
             }}
-            className="h-40 cursor-pointer"
+            className="cursor-pointer relative text-primary h-40"
         >
-            <div className="flex h-full w-full border-dashed-custom rounded-2xl text-primary">
+            <div className="flex h-full w-full border-dashed-custom rounded-2xl">
                 <div className="flex flex-col text-center items-center m-auto">
-                    <img src={PlusCircledIcon} />
+                    {spinnerState != null ? (
+                        <div className="p-2">
+                            <Spinner size={SPINNER_SIZE} state={spinnerState} />
+                        </div>
+                    ) : (
+                        <img src={PlusCircledIcon} />
+                    )}
                     <p className="font-semibold text-sm">New empty project</p>
                 </div>
             </div>
         </button>
     )
+}
+
+// ======================
+// === TemplateButton ===
+// ======================
+
+/** Props for a {@link TemplateButton}. */
+interface InternalTemplateButtonProps {
+    template: Template
+    onTemplateClick: (
+        name: string | null,
+        onSpinnerStateChange: (state: spinner.SpinnerState | null) => void
+    ) => void
+}
+
+/** A button that, when clicked, creates and opens a new project based on a template. */
+function TemplateButton(props: InternalTemplateButtonProps) {
+    const { template, onTemplateClick } = props
+    const [spinnerState, setSpinnerState] = react.useState<spinner.SpinnerState | null>(null)
+
+    return (
+        <button
+            key={template.title}
+            className="h-40 cursor-pointer"
+            onClick={() => {
+                onTemplateClick(template.id, newSpinnerState => {
+                    setSpinnerState(newSpinnerState)
+                    if (newSpinnerState === spinner.SpinnerState.done) {
+                        setTimeout(() => {
+                            setSpinnerState(null)
+                        }, SPINNER_DONE_DURATION_MS)
+                    }
+                })
+            }}
+        >
+            <div
+                style={{
+                    background: template.background,
+                }}
+                className="relative flex flex-col justify-end h-full w-full rounded-2xl overflow-hidden text-white text-left"
+            >
+                <div className="bg-black bg-opacity-30 px-4 py-2">
+                    <h2 className="text-sm font-bold">{template.title}</h2>
+                    <div className="text-xs h-16 text-ellipsis py-2">{template.description}</div>
+                </div>
+                {spinnerState && (
+                    <div className="absolute grid w-full h-full place-items-center">
+                        <Spinner size={SPINNER_SIZE} state={spinnerState} />
+                    </div>
+                )}
+            </div>
+        </button>
+    )
+}
+
+// =======================
+// === TemplatesRender ===
+// =======================
+
+/** Props for a {@link TemplatesRender}. */
+interface InternalTemplatesRenderProps {
+    // Later this data may be requested and therefore needs to be passed dynamically.
+    templates: Template[]
+    onTemplateClick: (
+        name: string | null,
+        onSpinnerStateChange: (spinnerState: spinner.SpinnerState | null) => void
+    ) => void
+}
+
+/** Render all templates, and a button to create an empty project. */
+function TemplatesRender(props: InternalTemplatesRenderProps) {
+    const { templates, onTemplateClick } = props
 
     return (
         <>
-            {CreateEmptyTemplate}
+            <EmptyProjectButton onTemplateClick={onTemplateClick} />
             {templates.map(template => (
-                <button
-                    key={template.title}
-                    className="h-40 cursor-pointer"
-                    onClick={() => {
-                        onTemplateClick(template.id)
-                    }}
-                >
-                    <div
-                        style={{
-                            background: template.background,
-                        }}
-                        className="flex flex-col justify-end h-full w-full rounded-2xl overflow-hidden text-white text-left"
-                    >
-                        <div className="bg-black bg-opacity-30 px-4 py-2">
-                            <h2 className="text-sm font-bold">{template.title}</h2>
-                            <div className="text-xs h-16 text-ellipsis py-2">
-                                {template.description}
-                            </div>
-                        </div>
-                    </div>
-                </button>
+                <TemplateButton
+                    key={template.id}
+                    template={template}
+                    onTemplateClick={onTemplateClick}
+                />
             ))}
         </>
     )
@@ -151,7 +227,10 @@ function TemplatesRender(props: TemplatesRenderProps) {
 
 /** Props for a {@link Templates}. */
 export interface TemplatesProps {
-    onTemplateClick: (name?: string | null) => void
+    onTemplateClick: (
+        name: string | null,
+        onSpinnerStateChange: (state: spinner.SpinnerState | null) => void
+    ) => void
 }
 
 /** A container for a {@link TemplatesRender} which passes it a list of templates. */

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/templates.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/templates.tsx
@@ -109,6 +109,7 @@ function EmptyProjectButton(props: InternalEmptyProjectButtonProps) {
     return (
         <button
             onClick={() => {
+                setSpinnerState(spinner.SpinnerState.initial)
                 onTemplateClick(null, newSpinnerState => {
                     setSpinnerState(newSpinnerState)
                     if (newSpinnerState === spinner.SpinnerState.done) {
@@ -159,6 +160,7 @@ function TemplateButton(props: InternalTemplateButtonProps) {
             key={template.title}
             className="h-40 cursor-pointer"
             onClick={() => {
+                setSpinnerState(spinner.SpinnerState.initial)
                 onTemplateClick(template.id, newSpinnerState => {
                     setSpinnerState(newSpinnerState)
                     if (newSpinnerState === spinner.SpinnerState.done) {

--- a/app/ide-desktop/lib/dashboard/tailwind.config.ts
+++ b/app/ide-desktop/lib/dashboard/tailwind.config.ts
@@ -72,6 +72,7 @@ inset 0 -36px 51px -51px #00000014`,
             'stroke-dasharray': 'stroke-dasharray',
         },
         transitionDuration: {
+            '5000': '5000ms',
             '90000': '90000ms',
         },
         gridTemplateColumns: {


### PR DESCRIPTION
### Pull Request Description
Closes [cloud-v2/#531](https://github.com/enso-org/cloud-v2/issues/531).
Adds spinner to every template button (including the empty project button) indicating that a new project of that type is currently being created.

### Important Notes
The design is a placeholder and MUST be changed later.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
