### PR TITLE
Single column in component browser

### DIFF
--- a/app/gui/view/component-browser/component-list-panel/grid/src/entry.rs
+++ b/app/gui/view/component-browser/component-list-panel/grid/src/entry.rs
@@ -96,11 +96,15 @@ pub mod background {
 // === Kind ===
 
 /// The kind of entry:
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Kind {
     /// A standard entry with icon and caption.
-    #[default]
-    Entry,
+    Entry {
+        /// Entries in the first line will not add an (overlap)[ENTRIES_OVERLAP_PX].
+        ///
+        /// This flag is false if there is header present.
+        first_line: bool,
+    },
     /// A group header; there is no icon, the text id stronger and there is a gap above header
     /// being a group separator.
     Header,
@@ -110,6 +114,12 @@ pub enum Kind {
         /// Entries in the first line will not add an (overlap)[ENTRIES_OVERLAP_PX].
         first_line: bool,
     },
+}
+
+impl Default for Kind {
+    fn default() -> Self {
+        Self::Entry { first_line: false }
+    }
 }
 
 
@@ -255,7 +265,8 @@ impl Data {
             _ => 0.0,
         };
         let overlap = match kind {
-            Kind::Entry | Kind::LocalScopeEntry { first_line: false } => ENTRIES_OVERLAP_PX,
+            Kind::Entry { first_line } | Kind::LocalScopeEntry { first_line } if !first_line =>
+                ENTRIES_OVERLAP_PX,
             _ => 0.0,
         };
         let gap_over_header = match kind {

--- a/app/gui/view/component-browser/component-list-panel/grid/src/layout.rs
+++ b/app/gui/view/component-browser/component-list-panel/grid/src/layout.rs
@@ -15,16 +15,6 @@ use std::collections::hash_map::Entry;
 
 
 
-// =================
-// === Constants ===
-// =================
-
-/// Height of the header of the component group. This value is added to the group's number of
-/// entries to get the total height.
-pub const HEADER_HEIGHT_IN_ROWS: usize = 1;
-
-
-
 // =============
 // === Group ===
 // =============
@@ -35,30 +25,33 @@ pub const HEADER_HEIGHT_IN_ROWS: usize = 1;
 /// The information of group in the layout.
 #[derive(Copy, Clone, Debug)]
 pub struct LaidGroup<'a> {
-    /// The row where header is placed.
-    pub header_row: Row,
+    /// The first row of the group. It may be a header.
+    pub first_row:         Row,
+    /// First row with group's content. It may differ from the `first_row` if group contains
+    /// a header.
+    pub first_content_row: Row,
     /// The column where the group is placed.
-    pub column:     Col,
+    pub column:            Col,
     /// The reference to the group information in [`Layout`] structure.
-    pub group:      &'a Group,
+    pub group:             &'a Group,
 }
 
 impl<'a> LaidGroup<'a> {
-    fn from_map_entry(column: Col, entry: (&Row, &'a Group)) -> Self {
-        let (&header_row, group) = entry;
-        Self { header_row, column, group }
+    fn from_map_entry(column: Col, entry: (&Row, &'a Group), header_height: Row) -> Self {
+        let (&first_row, group) = entry;
+        Self { first_row, first_content_row: first_row + header_height, column, group }
     }
 
     /// The range of rows where the group spans, _including_ the header.
     pub fn rows(&self) -> Range<Row> {
-        self.header_row..(self.header_row + self.group.height + HEADER_HEIGHT_IN_ROWS)
+        self.first_row..(self.first_content_row + self.group.height)
     }
 
     /// The id of element at given row, or `None` if row is outside the group.
     pub fn element_at_row(&self, row: Row) -> Option<ElementId> {
         let rows = self.rows();
         let element = rows.contains(&row).then(|| {
-            if row < self.header_row + HEADER_HEIGHT_IN_ROWS {
+            if row < self.first_content_row {
                 ElementInGroup::Header
             } else {
                 // We may unwrap here, as we check above if rows.contains(&row) - if range contains
@@ -67,6 +60,10 @@ impl<'a> LaidGroup<'a> {
             }
         });
         element.map(|element| ElementId { group: self.group.id, element })
+    }
+
+    pub fn has_header(&self) -> bool {
+        self.first_row < self.first_content_row
     }
 }
 
@@ -105,7 +102,7 @@ impl Column {
 /// information about their heights. It provides information about where given group is laid out
 /// in Grid View, and what group element is at given location (row and column).
 #[derive(Clone, Debug, Default)]
-pub struct Layout {
+pub struct Layout<const HEADER_HEIGHT: Row = 0> {
     columns:                 Vec<Column>,
     positions:               HashMap<GroupId, (Range<Row>, Col)>,
     local_scope_first_row:   Row,
@@ -113,7 +110,7 @@ pub struct Layout {
     row_count:               Row,
 }
 
-impl Layout {
+impl<const HEADER_HEIGHT: Row> Layout<HEADER_HEIGHT> {
     /// Create layout without standard (not the "Local Scope") groups.
     ///
     /// The layout will be completely empty if `local_scope_entry_count` will be 0.
@@ -138,9 +135,8 @@ impl Layout {
             g.drain_filter(|g| g.height == 0);
             g
         });
-        let col_heights: [usize; COLUMN_COUNT] = filtered_groups
-            .each_ref()
-            .map(|v| v.iter().map(|g| g.height + HEADER_HEIGHT_IN_ROWS).sum());
+        let col_heights: [usize; COLUMN_COUNT] =
+            filtered_groups.each_ref().map(|v| v.iter().map(|g| g.height + HEADER_HEIGHT).sum());
         let groups_rows = col_heights.into_iter().max().unwrap_or_default();
         let all_rows = local_scope_rows + groups_rows;
         let mut this = Self::new(all_rows, COLUMN_COUNT, local_scope_entry_count);
@@ -174,7 +170,7 @@ impl Layout {
     pub fn group_at_location(&self, row: Row, column: Col) -> Option<LaidGroup> {
         let groups_in_col = &self.columns.get(column)?.groups;
         let group_before_entry = groups_in_col.range(..=row).last()?;
-        let group_before = LaidGroup::from_map_entry(column, group_before_entry);
+        let group_before = LaidGroup::from_map_entry(column, group_before_entry, HEADER_HEIGHT);
         group_before.rows().contains(&row).as_some(group_before)
     }
 
@@ -182,9 +178,10 @@ impl Layout {
     pub fn group_above_location(&self, row: Row, column: Col) -> Option<LaidGroup> {
         let groups_in_col = &self.columns.get(column)?.groups;
         let mut groups_before = groups_in_col.range(..row).rev();
-        let first_before = LaidGroup::from_map_entry(column, groups_before.next()?);
+        let first_before = LaidGroup::from_map_entry(column, groups_before.next()?, HEADER_HEIGHT);
         if first_before.rows().contains(&row) {
-            let second_before = LaidGroup::from_map_entry(column, groups_before.next()?);
+            let second_before =
+                LaidGroup::from_map_entry(column, groups_before.next()?, HEADER_HEIGHT);
             Some(second_before)
         } else {
             Some(first_before)
@@ -196,7 +193,7 @@ impl Layout {
     pub fn group_below_location(&self, row: Row, column: Col) -> Option<LaidGroup> {
         let groups_in_col = &self.columns.get(column)?.groups;
         let group_after = groups_in_col.range((row + 1)..).next()?;
-        Some(LaidGroup::from_map_entry(column, group_after))
+        Some(LaidGroup::from_map_entry(column, group_after, HEADER_HEIGHT))
     }
 
     /// Get the information what element is at given location.
@@ -215,23 +212,28 @@ impl Layout {
 
     /// Return the location of element in Grid View.
     pub fn location_of_element(&self, element: ElementId) -> Option<(Row, Col)> {
-        if element.group.section == SectionId::LocalScope {
-            match element.element {
-                ElementInGroup::Header => None,
-                ElementInGroup::Entry(index) => {
-                    let row = self.local_scope_first_row + index / self.columns.len();
-                    let col = index % self.columns.len();
-                    Some((row, col))
+        self.positions
+            .get(&element.group)
+            .cloned()
+            .and_then(|(rows, col)| {
+                let header_pos = rows.start;
+                match element.element {
+                    ElementInGroup::Header => Some((header_pos, col)),
+                    ElementInGroup::Entry(index) => Some((rows.last()? - index, col)),
                 }
-            }
-        } else {
-            let (rows, col) = self.positions.get(&element.group)?.clone();
-            let header_pos = rows.start;
-            match element.element {
-                ElementInGroup::Header => Some((header_pos, col)),
-                ElementInGroup::Entry(index) => Some((rows.last()? - index, col)),
-            }
-        }
+            })
+            .or_else(|| {
+                (element.group.section == SectionId::LocalScope).and_option_from(|| {
+                    match element.element {
+                        ElementInGroup::Header => None,
+                        ElementInGroup::Entry(index) => {
+                            let row = self.local_scope_first_row + index / self.columns.len();
+                            let col = index % self.columns.len();
+                            Some((row, col))
+                        }
+                    }
+                })
+            })
     }
 
     /// Return the location of given group. Returns [`None`] if there's no such group in the layout
@@ -242,11 +244,12 @@ impl Layout {
 
     /// Return the minimum row range containing all entries from given section in a column.
     pub fn section_rows_at_column(&self, section: SectionId, column: Col) -> Option<Range<Row>> {
-        if section == SectionId::LocalScope {
-            Some(self.local_scope_rows())
-        } else {
-            self.columns.get(column)?.section_range.get(&section).cloned()
-        }
+        self.columns
+            .get(column)?
+            .section_range
+            .get(&section)
+            .cloned()
+            .or_else(|| (section == SectionId::LocalScope).as_some_from(|| self.local_scope_rows()))
     }
 
     /// Return the range of rows taken by Local Scope group.
@@ -258,7 +261,7 @@ impl Layout {
     pub fn push_group(&mut self, column: Col, group: Group) -> Row {
         let group_column = &mut self.columns[column];
         let prev_header_row = group_column.top_row;
-        let next_header_row = group_column.top_row - group.height - HEADER_HEIGHT_IN_ROWS;
+        let next_header_row = group_column.top_row - group.height - HEADER_HEIGHT;
         let group_rows = next_header_row..prev_header_row;
         group_column.groups.insert(next_header_row, group);
         group_column.top_row = next_header_row;
@@ -315,7 +318,7 @@ mod tests {
         let groups = group_data.map(mk_group).collect_vec();
         let groups_in_columns =
             [vec![groups[1], groups[4]], vec![groups[0], groups[3]], vec![groups[2], groups[5]]];
-        let layout = Layout::create_from_arranged_groups(groups_in_columns, 8);
+        let layout = Layout::<1>::create_from_arranged_groups(groups_in_columns, 8);
 
         let header_of = |group_idx| ElementId {
             group:   group_ids[group_idx],
@@ -375,7 +378,7 @@ mod tests {
 
     #[test]
     fn checking_element_at_location_empty_column_and_empty_local_scope() {
-        let mut layout = Layout::new(3, 3, 0);
+        let mut layout = Layout::<1>::new(3, 3, 0);
         let group = Group {
             id:               GroupId { section: SectionId::Popular, index: 0 },
             height:           2,
@@ -401,7 +404,7 @@ mod tests {
 
     #[test]
     fn section_ranges_in_layout() {
-        let mut layout = Layout::new(9, 3, 0);
+        let mut layout = Layout::<1>::new(9, 3, 0);
         let popular_group_ids = (0..6).map(|index| GroupId { section: SectionId::Popular, index });
         let submodule_group_ids =
             (6..8).map(|index| GroupId { section: SectionId::Namespace(0), index });

--- a/app/gui/view/component-browser/component-list-panel/grid/src/layout.rs
+++ b/app/gui/view/component-browser/component-list-panel/grid/src/layout.rs
@@ -62,6 +62,7 @@ impl<'a> LaidGroup<'a> {
         element.map(|element| ElementId { group: self.group.id, element })
     }
 
+    /// Check if there are rows assigned to group's header.
     pub fn has_header(&self) -> bool {
         self.first_row < self.first_content_row
     }
@@ -451,7 +452,7 @@ mod tests {
         // 6 |     |     |     |
         // - +-----+-----+-----+
         // ```
-        let mut layout = Layout::new(7, 3, 0);
+        let mut layout = Layout::<1>::new(7, 3, 0);
         let group_ids = (0..7).map(|index| GroupId { section: SectionId::Popular, index });
         let group_sizes = [1, 2].into_iter().cycle();
         let group_columns = [CENTER, LEFT, RIGHT].into_iter().cycle();

--- a/app/gui/view/component-browser/component-list-panel/grid/src/layouting.rs
+++ b/app/gui/view/component-browser/component-list-panel/grid/src/layouting.rs
@@ -1,3 +1,4 @@
+//TODO[ao] update docs.
 //! An algorithm for arranging component groups in the Favorites section in an order that optimizes
 //! the keyboard access to them.
 //!
@@ -7,7 +8,6 @@ use ensogl_core::prelude::*;
 
 use crate::content::Group;
 use crate::layout::Layout;
-use crate::layout::HEADER_HEIGHT_IN_ROWS;
 
 use ensogl_grid_view::Col;
 
@@ -23,6 +23,9 @@ const COLUMNS: usize = 3;
 const LEFT: usize = 0;
 const CENTER: usize = 1;
 const RIGHT: usize = 2;
+/// Height of the header of the component group. This value is added to the group's number of
+/// entries to get the total height.
+const HEADER_HEIGHT_IN_ROWS: usize = 1;
 
 
 

--- a/app/gui/view/component-browser/component-list-panel/grid/src/layouting.rs
+++ b/app/gui/view/component-browser/component-list-panel/grid/src/layouting.rs
@@ -1,8 +1,9 @@
-//TODO[ao] update docs.
 //! An algorithm for arranging component groups in the Favorites section in an order that optimizes
 //! the keyboard access to them.
 //!
 //! See [`Layouter`] struct documentation to learn more.
+
+//TODO[ao] update docs.
 
 use ensogl_core::prelude::*;
 

--- a/app/gui/view/component-browser/component-list-panel/grid/src/lib.rs
+++ b/app/gui/view/component-browser/component-list-panel/grid/src/lib.rs
@@ -250,6 +250,7 @@ pub struct Model {
     grid:                   Grid,
     grid_layer:             Layer,
     selection_layer:        Layer,
+    scroll_bars_layer:      Layer,
     layout:                 Rc<RefCell<Layout>>,
     enterable_elements:     Rc<RefCell<HashSet<ElementId>>>,
     colors:                 Rc<RefCell<HashMap<GroupId, entry::MainColor>>>,
@@ -274,9 +275,11 @@ impl component::Model for Model {
         let base_layer = &app.display.default_scene.layers.node_searcher;
         let grid_layer = base_layer.create_sublayer("grid_layer");
         let selection_layer = base_layer.create_sublayer("selection_layer");
+        let scroll_bars_layer = base_layer.create_sublayer("scrollbars_layer");
         display_object.add_child(&grid);
         grid_layer.add(&grid);
         grid.selection_highlight_frp().setup_masked_layer(selection_layer.downgrade());
+        grid.set_scrollbars_layer(&scroll_bars_layer);
         Self {
             display_object,
             grid,
@@ -285,6 +288,7 @@ impl component::Model for Model {
             colors,
             grid_layer,
             selection_layer,
+            scroll_bars_layer,
             requested_section_info,
         }
     }

--- a/app/gui/view/component-browser/component-list-panel/grid/src/lib.rs
+++ b/app/gui/view/component-browser/component-list-panel/grid/src/lib.rs
@@ -299,16 +299,19 @@ impl Model {
         let row_count = content.groups.iter().map(|group| group.height).sum::<usize>()
             + content.local_scope_entry_count;
         let mut layout = Layout::<0>::new(row_count, 1, 0);
-        for group in &content.groups {
+        for group in content.groups.iter().filter(|g| g.height > 0) {
             layout.push_group(0, *group);
         }
-        layout.push_group(0, content::Group {
-            id:               GroupId::local_scope_group(),
-            height:           content.local_scope_entry_count,
-            original_height:  content.local_scope_entry_count,
-            color:            None,
-            best_match_score: 0.0,
-        });
+        if content.local_scope_entry_count > 0 {
+            layout.push_group(0, content::Group {
+                id:               GroupId::local_scope_group(),
+                height:           content.local_scope_entry_count,
+                original_height:  content.local_scope_entry_count,
+                color:            None,
+                best_match_score: 0.0,
+            });
+        }
+        console_log!("{layout:?}");
 
         let rows_and_cols = (layout.row_count(), layout.column_count());
         *self.layout.borrow_mut() = layout;

--- a/app/gui/view/component-browser/component-list-panel/grid/src/lib.rs
+++ b/app/gui/view/component-browser/component-list-panel/grid/src/lib.rs
@@ -63,11 +63,11 @@ pub mod entry;
 pub mod layout;
 pub mod layouting;
 
-use crate::prelude::web_sys::console::group;
 pub use content::ElementId;
 pub use content::GroupEntryId;
 pub use content::GroupId;
 pub use content::SectionId;
+
 
 
 /// A module containing common imports.

--- a/app/gui/view/component-browser/component-list-panel/src/navigator.rs
+++ b/app/gui/view/component-browser/component-list-panel/src/navigator.rs
@@ -293,6 +293,7 @@ impl Navigator {
         colors.init.emit(());
         tooltip_hide_timer.reset();
         top_buttons.reset_entries(TOP_BUTTONS_COUNT, 1);
+        set_namespace_section_count.emit(0);
 
         Self {
             display_object,

--- a/lib/rust/ensogl/app/theme/hardcoded/src/lib.rs
+++ b/lib/rust/ensogl/app/theme/hardcoded/src/lib.rs
@@ -198,7 +198,7 @@ define_themes! { [light:0, dark:1]
                 corner_radius = 14.0, 14.0;
             }
             component_list_panel {
-                background_color = Rgb::from_base_255(234.0, 234.0, 234.0), Rgb::from_base_255(234.0, 234.0, 234.0);
+                background_color = Rgb::from_base_255(236.0, 240.0, 242.0),Rgb::from_base_255(236.0, 240.0, 242.0);
                 corners_radius = 16.0, 16.0;
                 grid {
                     width = 196.0, 196.0;

--- a/lib/rust/ensogl/app/theme/hardcoded/src/lib.rs
+++ b/lib/rust/ensogl/app/theme/hardcoded/src/lib.rs
@@ -283,7 +283,7 @@ define_themes! { [light:0, dark:1]
                         // Pink
                         group_3 = Rgb::from_base_255(193.0, 71.0, 171.0), Rgb::from_base_255(193.0, 71.0, 171.0);
                         // Blue
-                        group_4 = Rgb::from_base_255(42.0, 103.0, 223.0), Rgb::from_base_255(42.0, 103.0, 223.0)    ;
+                        group_4 = Rgb::from_base_255(42.0, 103.0, 223.0), Rgb::from_base_255(42.0, 103.0, 223.0);
                         // Orange
                         group_5 = Rgb::from_base_255(181.0, 97.0, 35.0), Rgb::from_base_255(181.0, 97.0, 35.0);
                         local_scope_group = Rgba::new(0.0, 0.42, 0.64, 1.0),Rgba::new(0.0, 0.42, 0.64, 1.0);

--- a/lib/rust/ensogl/app/theme/hardcoded/src/lib.rs
+++ b/lib/rust/ensogl/app/theme/hardcoded/src/lib.rs
@@ -198,8 +198,7 @@ define_themes! { [light:0, dark:1]
                 corner_radius = 14.0, 14.0;
             }
             component_list_panel {
-                // background_color = Rgb::from_base_255(236.0, 240.0, 242.0),Rgb::from_base_255(236.0, 240.0, 242.0);
-                background_color = Rgb::from_base_255(241.0, 238.0, 237.0), Rgb::from_base_255(241.0, 238.0, 237.0);
+                background_color = Rgb::from_base_255(234.0, 234.0, 234.0), Rgb::from_base_255(234.0, 234.0, 234.0);
                 corners_radius = 16.0, 16.0;
                 grid {
                     width = 196.0, 196.0;

--- a/lib/rust/ensogl/app/theme/hardcoded/src/lib.rs
+++ b/lib/rust/ensogl/app/theme/hardcoded/src/lib.rs
@@ -198,14 +198,15 @@ define_themes! { [light:0, dark:1]
                 corner_radius = 14.0, 14.0;
             }
             component_list_panel {
-                background_color = Rgb::from_base_255(236.0, 240.0, 242.0),Rgb::from_base_255(236.0, 240.0, 242.0);
+                // background_color = Rgb::from_base_255(236.0, 240.0, 242.0),Rgb::from_base_255(236.0, 240.0, 242.0);
+                background_color = Rgb::from_base_255(241.0, 238.0, 237.0), Rgb::from_base_255(241.0, 238.0, 237.0);
                 corners_radius = 16.0, 16.0;
                 grid {
-                    width = 413.0, 413.0;
+                    width = 196.0, 196.0;
                     height = 414.0, 414.0;
                     padding = 4.0, 4.0;
                     column_gap = 3.0, 3.0;
-                    entry_height = 30.0, 30.0;
+                    entry_height = 32.0, 32.0;
 
                     // The `color` values support color types (like `color::Rgba`)
                     // and floating-point numbers. This is possible due to a custom stylesheet
@@ -214,16 +215,16 @@ define_themes! { [light:0, dark:1]
                     // Floating-point numbers mean the alpha multiplier for the "main" color of the
                     // component group.
                     entry {
-                        background.intensity = 0.08, 0.08;
+                        background.intensity = 0.0, 0.0;
                         dimmed = Rgb::from_base_255(160.0, 163.0, 165.0), Rgb::from_base_255(160.0, 163.0, 165.0);
-                        padding = 16.0, 16.0;
+                        padding = 8.0, 8.0;
                         text {
                             font = DEFAULT_FONT, DEFAULT_FONT;
                             y_offset = 8.0, 8.0;
                             y_offset_header = 5.0, 5.0;
                             x_offset_header = 0.0, 0.0;
                             size = 11.5, 11.5;
-                            color = 1.0, 1.0;
+                            color = Rgba(0.0, 0.0, 0.0, 0.6), Rgba(0.0, 0.0, 0.0, 0.6);
                             highlight_bold = 0.01, 0.01;
                         }
                         icon {
@@ -253,7 +254,7 @@ define_themes! { [light:0, dark:1]
                             }
                         }
                         highlight {
-                            corners_radius = 12.0, 12.0;
+                            corners_radius = 16.0, 16.0;
                             hover.color = 0.4, 0.4;
                             selection {
                                 background.intensity = 0.75, 0.75;
@@ -273,16 +274,16 @@ define_themes! { [light:0, dark:1]
                     }
 
                     group_colors {
-                        // Yellow
-                        group_0 = Rgb::from_base_255(134.0, 135.0, 43.0), Rgb::from_base_255(134.0, 135.0, 43.0);
                         // Green
-                        group_1 = Rgb::from_base_255(63.0, 139.0, 41.0), Rgb::from_base_255(63.0, 139.0, 41.0);
-                        // Light Blue
-                        group_2 = Rgb::from_base_255(54.0, 122.0, 185.0), Rgb::from_base_255(54.0, 122.0, 185.0);
+                        group_0 = Rgb::from_base_255(77.0, 154.0, 41.0), Rgb::from_base_255(77.0, 154.0, 41.0);
+                        // Yellow
+                        group_1 = Rgb::from_base_255(178.0, 121.0, 35.0), Rgb::from_base_255(178.0, 121.0, 35.0);
+                        // Purple
+                        group_2 = Rgb::from_base_255(151.0, 53.0, 185.0), Rgb::from_base_255(151.0, 53.0, 185.0);
                         // Pink
                         group_3 = Rgb::from_base_255(193.0, 71.0, 171.0), Rgb::from_base_255(193.0, 71.0, 171.0);
                         // Blue
-                        group_4 = Rgb::from_base_255(43.0, 117.0, 239.0), Rgb::from_base_255(43.0, 117.0, 239.0);
+                        group_4 = Rgb::from_base_255(42.0, 103.0, 223.0), Rgb::from_base_255(42.0, 103.0, 223.0)    ;
                         // Orange
                         group_5 = Rgb::from_base_255(181.0, 97.0, 35.0), Rgb::from_base_255(181.0, 97.0, 35.0);
                         local_scope_group = Rgba::new(0.0, 0.42, 0.64, 1.0),Rgba::new(0.0, 0.42, 0.64, 1.0);

--- a/lib/rust/ensogl/component/grid-view/src/scrollable.rs
+++ b/lib/rust/ensogl/component/grid-view/src/scrollable.rs
@@ -225,6 +225,10 @@ impl<InnerGridView> GridViewTemplate<InnerGridView> {
         self.area.deref()
     }
 
+    /// Set layer where the scrollbars will be displayed.
+    ///
+    /// It just calls [`set_scrollbars_layer`](ScrollArea::set_scrollbars_layer) of the underlying
+    /// area.
     pub fn set_scrollbars_layer(&self, layer: &Layer) {
         self.area.set_scrollbars_layer(layer)
     }

--- a/lib/rust/ensogl/component/grid-view/src/scrollable.rs
+++ b/lib/rust/ensogl/component/grid-view/src/scrollable.rs
@@ -225,6 +225,10 @@ impl<InnerGridView> GridViewTemplate<InnerGridView> {
         self.area.deref()
     }
 
+    pub fn set_scrollbars_layer(&self, layer: &Layer) {
+        self.area.set_scrollbars_layer(layer)
+    }
+
     /// Access the parts of the FRP API of a scrollable Grid View that are not available through
     /// either the [`InnerGridView`] FRP or the [`scroll_frp`] API.
     pub fn extra_scroll_frp(&self) -> &Frp {


### PR DESCRIPTION
### Pull Request Description

This PR contains minimal changes to have a visual part of #7198. It updates the view of _component list only_ to the newest design. The CB panel was shrunk in process, and breadcrumbs are a bit obscured, but they will be moved around in the next few PRs.

![image](https://github.com/enso-org/enso/assets/3919101/a562e365-d512-4320-ae19-10701edaa9ac)


### Important Notes

* This does not touch proper entry ordering yet.
* The component browser background is not (yet) updated; as some colors have alphas in the design, this may affect them.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
