### PR TITLE
Add fileModifiedOnDisk notification

### DIFF
--- a/app/gui/controller/engine-protocol/src/language_server/types.rs
+++ b/app/gui/controller/engine-protocol/src/language_server/types.rs
@@ -126,6 +126,11 @@ pub enum Notification {
     #[serde(rename = "text/didChange")]
     TextDidChange(FileEditList),
 
+    /// This is a notification sent from the server to the clients to inform them that a file
+    /// was modified on disk by external editor.
+    #[serde(rename = "text/fileModifiedOnDisk")]
+    TextFileModifiedOnDisk(TextFileModifiedOnDisk),
+
     /// Sent from the server to the client to inform about new information for certain expressions
     /// becoming available. This notification is superseded by executionContext/expressionUpdates.
     #[serde(rename = "executionContext/expressionValuesComputed")]
@@ -364,6 +369,14 @@ pub enum FileEventKind {
 #[derive(Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct TextAutoSave {
+    pub path: Path,
+}
+
+/// The `text/fileModifiedOnDisk` notification parameters.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct TextFileModifiedOnDisk {
     pub path: Path,
 }
 

--- a/app/gui/src/model/project/synchronized.rs
+++ b/app/gui/src/model/project/synchronized.rs
@@ -21,6 +21,7 @@ use engine_protocol::language_server::ContentRoot;
 use engine_protocol::language_server::ExpressionUpdates;
 use engine_protocol::language_server::FileEditList;
 use engine_protocol::language_server::MethodPointer;
+use engine_protocol::language_server::TextFileModifiedOnDisk;
 use engine_protocol::project_manager;
 use engine_protocol::project_manager::MissingComponentAction;
 use engine_protocol::project_manager::ProjectName;
@@ -206,6 +207,20 @@ async fn update_modules_on_file_change(
         if let Some(module) = module_registry.get(&module_path).await? {
             module.apply_text_change_from_ls(file_edit.edits).await?;
         }
+    }
+    Ok(())
+}
+
+
+/// Reload the file from disk when `text/fileModifiedOnDisk` notification received.
+#[profile(Detail)]
+async fn reload_module_on_file_change(
+    modified: TextFileModifiedOnDisk,
+    module_registry: Rc<model::registry::Registry<module::Path, module::Synchronized>>,
+) -> FallibleResult {
+    let module_path = module::Path::from_file_path(modified.path)?;
+    if let Some(module) = module_registry.get(&module_path).await? {
+        module.reopen_externally_changed_file().await?;
     }
     Ok(())
 }
@@ -539,6 +554,16 @@ impl Project {
                             let status = update_modules_on_file_change(changes, module_registry);
                             if let Err(err) = status.await {
                                 error!("Error while applying file changes to modules: {err}");
+                            }
+                        });
+                    }
+                }
+                Event::Notification(Notification::TextFileModifiedOnDisk(modified)) => {
+                    if let Some(module_registry) = weak_module_registry.upgrade() {
+                        executor::global::spawn(async move {
+                            let status = reload_module_on_file_change(modified, module_registry);
+                            if let Err(err) = status.await {
+                                error!("Error while reloading module on file change: {err}");
                             }
                         });
                     }

--- a/docs/language-server/protocol-language-server.md
+++ b/docs/language-server/protocol-language-server.md
@@ -117,6 +117,7 @@ transport formats, please look [here](./protocol-architecture).
   - [`text/applyExpressionValue`](#textapplyexpressionvalue)
   - [`text/didChange`](#textdidchange)
   - [`text/autoSave`](#textautosave)
+  - [`text/fileModifiedOnDisk`](#textfilemodifiedondisk)
 - [Workspace Operations](#workspace-operations)
   - [`workspace/projectInfo`](#workspaceprojectinfo)
 - [Monitoring](#monitoring)
@@ -3135,6 +3136,30 @@ successful auto-save action.
 - **Visibility:** Public
 
 This notification must _only_ be sent for files that the client has open.
+
+#### Parameters
+
+```typescript
+{
+  path: Path;
+}
+```
+
+#### Errors
+
+```typescript
+null;
+```
+
+### `text/fileModifiedOnDisk`
+
+This is a notification sent from the server to the clients to inform them that
+the file was modified on dis by an external editor.
+
+- **Type:** Notification
+- **Direction:** Server -> Client
+- **Connection:** Protocol
+- **Visibility:** Public
 
 #### Parameters
 

--- a/docs/language-server/protocol-language-server.md
+++ b/docs/language-server/protocol-language-server.md
@@ -3154,7 +3154,7 @@ null;
 ### `text/fileModifiedOnDisk`
 
 This is a notification sent from the server to the clients to inform them that
-the file was modified on dis by an external editor.
+the file was modified on disk by an external editor.
 
 - **Type:** Notification
 - **Direction:** Server -> Client

--- a/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/FileManagerProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/FileManagerProtocol.scala
@@ -43,7 +43,7 @@ object FileManagerProtocol {
     *
     * @param result either file system failure or unit representing success
     */
-  case class WriteFileResult(result: Either[FileSystemFailure, Unit])
+  case class WriteFileResult(result: Either[FileSystemFailure, FileAttributes])
 
   /** Requests the Language Server write textual content to an arbitrary file.
     *
@@ -70,6 +70,12 @@ object FileManagerProtocol {
     */
   case class ReadFile(path: Path)
 
+  /** Requests the Language Server read a file with a file attributes.
+    *
+    * @param path a path to a file
+    */
+  case class ReadFileWithAttributes(path: Path)
+
   /** Requests the Language Server to read a binary content of a file.
     *
     * @param path a path to a file
@@ -90,6 +96,14 @@ object FileManagerProtocol {
     */
   case class ReadBinaryFileResult(
     result: Either[FileSystemFailure, BinaryFileContent]
+  )
+
+  /** Returns a result of reading a file with attributes.
+    *
+    * @param result either file system failure or content of a file
+    */
+  case class ReadFileWithAttributesResult(
+    result: Either[FileSystemFailure, (TextualFileContent, FileAttributes)]
   )
 
   /** Requests the Language Server create a file system object.

--- a/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/FileManagerProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/FileManagerProtocol.scala
@@ -1,6 +1,7 @@
 package org.enso.languageserver.filemanager
 
 import java.io.File
+import java.time.OffsetDateTime
 
 object FileManagerProtocol {
 
@@ -43,6 +44,25 @@ object FileManagerProtocol {
     * @param result either file system failure or unit representing success
     */
   case class WriteFileResult(result: Either[FileSystemFailure, Unit])
+
+  /** Requests the Language Server write textual content to an arbitrary file.
+    *
+    * @param path a path to a file
+    * @param content a textual content
+    */
+  case class WriteFileIfNotModified(
+    path: Path,
+    lastModifiedTime: OffsetDateTime,
+    content: String
+  )
+
+  /** Signals file manipulation status.
+    *
+    * @param result either file system failure or unit representing success
+    */
+  case class WriteFileIfNotModifiedResult(
+    result: Either[FileSystemFailure, Option[FileAttributes]]
+  )
 
   /** Requests the Language Server read a file.
     *

--- a/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/FileManagerProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/FileManagerProtocol.scala
@@ -45,9 +45,11 @@ object FileManagerProtocol {
     */
   case class WriteFileResult(result: Either[FileSystemFailure, FileAttributes])
 
-  /** Requests the Language Server write textual content to an arbitrary file.
+  /** Requests the Language Server write textual content to a file if it was not
+    * modified after `lastModifiedTime`.
     *
     * @param path a path to a file
+    * @param lastModifiedTime a last recorded modification time of the file
     * @param content a textual content
     */
   case class WriteFileIfNotModified(

--- a/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/FileSystemApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/FileSystemApi.scala
@@ -255,7 +255,7 @@ object FileSystemApi {
     *
     * @param creationTime creation time
     * @param lastAccessTime last access time
-    * @param lastModifiedtime last modified time
+    * @param lastModifiedTime last modified time
     * @param kind either [[DirectoryEntryTruncated]] or [[FileEntry]] or [[OtherEntry]]
     * @param byteSize size of entry in bytes
     */
@@ -273,7 +273,7 @@ object FileSystemApi {
       *
       * @param creationTime creation time
       * @param lastAccessTime last access time
-      * @param lastModifiedtime last modified time
+      * @param lastModifiedTime last modified time
       * @param kind a type of the file system object
       * @param byteSize size of an entry in bytes
       * @return file attributes
@@ -296,7 +296,7 @@ object FileSystemApi {
     /** Creates [[Attributes]] from file system attributes
       *
       * @param path to the file system object
-      * @param attributes of a file system object
+      * @param basic attributes of a file system object
       * @return file attributes
       */
     def fromBasicAttributes(

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
@@ -304,6 +304,12 @@ class JsonConnectionController(
     case TextProtocol.FileAutoSaved(path) =>
       webActor ! Notification(FileAutoSaved, FileAutoSaved.Params(path))
 
+    case TextProtocol.FileModifiedOnDisk(path) =>
+      webActor ! Notification(
+        FileModifiedOnDisk,
+        FileModifiedOnDisk.Params(path)
+      )
+
     case TextProtocol.FileEvent(path, event) =>
       webActor ! Notification(EventFile, EventFile.Params(path, event))
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonRpc.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonRpc.scala
@@ -106,6 +106,7 @@ object JsonRpc {
     .registerNotification(GrantCapability)
     .registerNotification(TextDidChange)
     .registerNotification(FileAutoSaved)
+    .registerNotification(FileModifiedOnDisk)
     .registerNotification(EventFile)
     .registerNotification(ContentRootAdded)
     .registerNotification(ContentRootRemoved)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/file/WriteBinaryFileHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/file/WriteBinaryFileHandler.scala
@@ -84,7 +84,7 @@ class WriteBinaryFileHandler(
       cancellable.cancel()
       context.stop(self)
 
-    case FileManagerProtocol.WriteFileResult(Right(())) =>
+    case FileManagerProtocol.WriteFileResult(Right(_)) =>
       val packet = SuccessReplyFactory.createPacket(requestId)
       replyTo ! packet
       cancellable.cancel()

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/file/WriteTextualFileHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/file/WriteTextualFileHandler.scala
@@ -61,7 +61,7 @@ class WriteTextualFileHandler(
       cancellable.cancel()
       context.stop(self)
 
-    case FileManagerProtocol.WriteFileResult(Right(())) =>
+    case FileManagerProtocol.WriteFileResult(Right(_)) =>
       replyTo ! ResponseResult(WriteFile, id, Unused)
       cancellable.cancel()
       context.stop(self)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/Buffer.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/Buffer.scala
@@ -6,22 +6,23 @@ import org.enso.text.buffer.Rope
 import org.enso.text.editing.model.Position
 import org.enso.text.editing.model.Range
 
+import java.time.OffsetDateTime
+
 /** A buffer state representation.
   *
-  * @param file the file linked to the buffer.
+  * @param fileWithMetadata the file linked to the buffer.
   * @param contents the contents of the buffer.
   * @param inMemory determines if the buffer is in-memory
   * @param version the current version of the buffer contents.
   */
 case class Buffer(
-  file: File,
+  fileWithMetadata: FileWithMetadata,
   contents: Rope,
   inMemory: Boolean,
   version: ContentVersion
 ) {
 
-  /** Returns a range covering the whole buffer.
-    */
+  /** Returns a range covering the whole buffer. */
   lazy val fullRange: Range = {
     val lines = contents.lines.length
     Range(
@@ -29,6 +30,22 @@ case class Buffer(
       Position(lines - 1, contents.lines.drop(lines - 1).characters.length)
     )
   }
+
+  def withContents(
+    newContents: Rope,
+    inMemory: Boolean = inMemory
+  )(implicit versionCalculator: ContentBasedVersioning): Buffer =
+    copy(
+      contents = newContents,
+      version  = versionCalculator.evalVersion(newContents.toString),
+      inMemory = inMemory
+    )
+
+  def withLastModifiedTime(lastModifiedTime: OffsetDateTime): Buffer =
+    copy(
+      fileWithMetadata =
+        fileWithMetadata.copy(lastModifiedTime = Some(lastModifiedTime))
+    )
 }
 
 object Buffer {
@@ -43,28 +60,13 @@ object Buffer {
     */
   def apply(
     file: File,
-    contents: Rope,
-    inMemory: Boolean
-  )(implicit versionCalculator: ContentBasedVersioning): Buffer =
-    Buffer(
-      file,
-      contents,
-      inMemory,
-      versionCalculator.evalVersion(contents.toString)
-    )
-
-  /** Creates a new buffer with a freshly generated version.
-    *
-    * @param file the file linked to the buffer.
-    * @param contents the contents of this buffer.
-    * @param inMemory determines if the buffer is in-memory
-    * @param versionCalculator a digest calculator for content based versioning.
-    * @return a new buffer instance.
-    */
-  def apply(
-    file: File,
     contents: String,
     inMemory: Boolean
   )(implicit versionCalculator: ContentBasedVersioning): Buffer =
-    Buffer(file, Rope(contents), inMemory)
+    Buffer(
+      FileWithMetadata(file),
+      Rope(contents),
+      inMemory,
+      versionCalculator.evalVersion(contents)
+    )
 }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/Buffer.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/Buffer.scala
@@ -31,6 +31,12 @@ case class Buffer(
     )
   }
 
+  /** Create a buffer with new contents.
+    *
+    * @param newContents the new contents of the buffer
+    * @param inMemory determines if the buffer is in-memory
+    * @return the buffer with new provided contents
+    */
   def withContents(
     newContents: Rope,
     inMemory: Boolean = inMemory
@@ -41,6 +47,11 @@ case class Buffer(
       inMemory = inMemory
     )
 
+  /** Create a buffer with new last modified time.
+    *
+    * @param lastModifiedTime the last modified time of the underlying file
+    * @return the buffer with new last modified time
+    */
   def withLastModifiedTime(lastModifiedTime: OffsetDateTime): Buffer =
     copy(
       fileWithMetadata =

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/FileWithMetadata.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/FileWithMetadata.scala
@@ -1,0 +1,24 @@
+package org.enso.languageserver.text
+
+import java.io.File
+import java.time.OffsetDateTime
+
+/** A file with extra info.
+  *
+  * @param file the underlying file
+  * @param lastModifiedTime the last known modified time on disk
+  */
+case class FileWithMetadata(
+  file: File,
+  lastModifiedTime: Option[OffsetDateTime]
+)
+object FileWithMetadata {
+
+  /** Create a file with metadata.
+    *
+    * @param file the underlying file
+    * @return a new instance of [[FileWithMetadata]]
+    */
+  def apply(file: File): FileWithMetadata =
+    FileWithMetadata(file, None)
+}

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/TextApi.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/TextApi.scala
@@ -107,6 +107,15 @@ object TextApi {
       }
   }
 
+  case object FileModifiedOnDisk extends Method("text/fileModifiedOnDisk") {
+    case class Params(path: Path)
+    implicit
+    val hasParams: HasParams.Aux[this.type, FileModifiedOnDisk.Params] =
+      new HasParams[this.type] {
+        type Params = FileModifiedOnDisk.Params
+      }
+  }
+
   case object SaveFile extends Method("text/save") {
     case class Params(path: Path, currentVersion: Version)
     implicit val hasParams: HasParams.Aux[this.type, SaveFile.Params] =

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/TextProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/TextProtocol.scala
@@ -136,6 +136,13 @@ object TextProtocol {
     */
   case class FileAutoSaved(path: Path)
 
+  /** A notification sent by the Language Server, notifying a client that the
+    * file was modified on disk.
+    *
+    * @param path path to the file
+    */
+  case class FileModifiedOnDisk(path: Path)
+
   /** A notification sent by the Language Server, notifying a client about
     * a file event after reloading the buffer to sync with file system
     *
@@ -155,16 +162,13 @@ object TextProtocol {
     currentVersion: TextApi.Version
   )
 
-  /** Signals the result of saving a file.
-    */
+  /** Signals the result of saving a file. */
   sealed trait SaveFileResult
 
-  /** Signals that saving a file was executed successfully.
-    */
+  /** Signals that saving a file was executed successfully. */
   case object FileSaved extends SaveFileResult
 
-  /** Signals that the client doesn't hold write lock to the buffer.
-    */
+  /** Signals that the client doesn't hold write lock to the buffer. */
   case object SaveDenied extends SaveFileResult
 
   /** Signals that version provided by a client doesn't match to the version
@@ -183,5 +187,8 @@ object TextProtocol {
     * @param fsFailure a filesystem failure
     */
   case class SaveFailed(fsFailure: FileSystemFailure) extends SaveFileResult
+
+  /** Signals that the file is modified on disk. */
+  case object SaveFailedFileModifiedOnDisk extends SaveFileResult
 
 }

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
@@ -2961,6 +2961,11 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
                 }
               }
               """)
+
+      // Change file on disk
+      val fooTxt = testContentRoot.file.toPath.resolve("foo.txt")
+      Files.write(fooTxt, "abcdef".getBytes(StandardCharsets.UTF_8))
+
       client.send(json"""
                 { "jsonrpc": "2.0",
                   "method": "text/applyEdit",
@@ -2999,10 +3004,6 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
                   "result": null
                 }
                 """)
-
-      // Change file on disk
-      val fooTxt = testContentRoot.file.toPath.resolve("foo.txt")
-      Files.write(fooTxt, "abcdef".getBytes(StandardCharsets.UTF_8))
 
       Thread.sleep(8.seconds.toMillis)
       // No explicit file save

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
@@ -2367,7 +2367,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
                 "params": {
                   "path": {
                     "rootId": $testContentRootId,
-                    "segments": [ "foo.txt" ]
+                    "segments": [ "foo1.txt" ]
                   },
                   "contents": "123456789"
                 }
@@ -2386,7 +2386,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
                 "params": {
                   "path": {
                     "rootId": $testContentRootId,
-                    "segments": [ "foo.txt" ]
+                    "segments": [ "foo1.txt" ]
                   }
                 }
               }
@@ -2402,7 +2402,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
                       "path" : {
                         "rootId" : $testContentRootId,
                         "segments" : [
-                          "foo.txt"
+                          "foo1.txt"
                         ]
                       }
                     }
@@ -2421,7 +2421,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
                   "edit": {
                     "path": {
                       "rootId": $testContentRootId,
-                      "segments": [ "foo.txt" ]
+                      "segments": [ "foo1.txt" ]
                     },
                     "oldVersion": "5795c3d628fd638c9835a4c79a55809f265068c88729a1a3fcdf8522",
                     "newVersion": "ebe55342f9c8b86857402797dd723fb4a2174e0b56d6ace0a6929ec3",
@@ -2453,7 +2453,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
               """)
 
       // Change file on disk
-      val fooTxt = testContentRoot.file.toPath.resolve("foo.txt")
+      val fooTxt = testContentRoot.file.toPath.resolve("foo1.txt")
       Files.write(fooTxt, "abcdef".getBytes(StandardCharsets.UTF_8))
 
       client.send(json"""
@@ -2463,7 +2463,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
                 "params": {
                   "path": {
                     "rootId": $testContentRootId,
-                    "segments": [ "foo.txt" ]
+                    "segments": [ "foo1.txt" ]
                   }
                 }
               }
@@ -2482,7 +2482,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
                 "params": {
                   "path": {
                     "rootId": $testContentRootId,
-                    "segments": [ "foo.txt" ]
+                    "segments": [ "foo1.txt" ]
                   },
                   "currentVersion": "ebe55342f9c8b86857402797dd723fb4a2174e0b56d6ace0a6929ec3"
                 }
@@ -2501,7 +2501,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
                 "params": {
                   "path": {
                     "rootId": $testContentRootId,
-                    "segments": [ "foo.txt" ]
+                    "segments": [ "foo1.txt" ]
                   }
                 }
               }

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
@@ -6,6 +6,10 @@ import org.enso.languageserver.event.{BufferClosed, JsonSessionTerminated}
 import org.enso.languageserver.filemanager.Path
 import org.enso.languageserver.session.JsonSession
 import org.enso.testkit.FlakySpec
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
 import scala.concurrent.duration._
 
 class TextOperationsTest extends BaseServerTest with FlakySpec {
@@ -2354,6 +2358,162 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
           """)
     }
 
+    "persist changes when the file was changed to disk" in {
+      val client = getInitialisedWsClient()
+      client.send(json"""
+              { "jsonrpc": "2.0",
+                "method": "file/write",
+                "id": 0,
+                "params": {
+                  "path": {
+                    "rootId": $testContentRootId,
+                    "segments": [ "foo.txt" ]
+                  },
+                  "contents": "123456789"
+                }
+              }
+              """)
+      client.expectJson(json"""
+              { "jsonrpc": "2.0",
+                "id": 0,
+                "result": null
+              }
+              """)
+      client.send(json"""
+              { "jsonrpc": "2.0",
+                "method": "text/openFile",
+                "id": 1,
+                "params": {
+                  "path": {
+                    "rootId": $testContentRootId,
+                    "segments": [ "foo.txt" ]
+                  }
+                }
+              }
+              """)
+      client.expectJson(json"""
+              {
+                "jsonrpc" : "2.0",
+                "id" : 1,
+                "result" : {
+                  "writeCapability" : {
+                    "method" : "text/canEdit",
+                    "registerOptions" : {
+                      "path" : {
+                        "rootId" : $testContentRootId,
+                        "segments" : [
+                          "foo.txt"
+                        ]
+                      }
+                    }
+                  },
+                  "content" : "123456789",
+                  "currentVersion" : "5795c3d628fd638c9835a4c79a55809f265068c88729a1a3fcdf8522"
+                }
+              }
+              """)
+
+      client.send(json"""
+              { "jsonrpc": "2.0",
+                "method": "text/applyEdit",
+                "id": 2,
+                "params": {
+                  "edit": {
+                    "path": {
+                      "rootId": $testContentRootId,
+                      "segments": [ "foo.txt" ]
+                    },
+                    "oldVersion": "5795c3d628fd638c9835a4c79a55809f265068c88729a1a3fcdf8522",
+                    "newVersion": "ebe55342f9c8b86857402797dd723fb4a2174e0b56d6ace0a6929ec3",
+                    "edits": [
+                      {
+                        "range": {
+                          "start": { "line": 0, "character": 0 },
+                          "end": { "line": 0, "character": 0 }
+                        },
+                        "text": "bar"
+                      },
+                      {
+                        "range": {
+                          "start": { "line": 0, "character": 12 },
+                          "end": { "line": 0, "character": 12 }
+                        },
+                        "text": "foo"
+                      }
+                    ]
+                  }
+                }
+              }
+              """)
+      client.expectJson(json"""
+              { "jsonrpc": "2.0",
+                "id": 2,
+                "result": null
+              }
+              """)
+
+      // Change file on disk
+      val fooTxt = testContentRoot.file.toPath.resolve("foo.txt")
+      Files.write(fooTxt, "abcdef".getBytes(StandardCharsets.UTF_8))
+
+      client.send(json"""
+              { "jsonrpc": "2.0",
+                "method": "file/read",
+                "id": 3,
+                "params": {
+                  "path": {
+                    "rootId": $testContentRootId,
+                    "segments": [ "foo.txt" ]
+                  }
+                }
+              }
+              """)
+      client.expectJson(json"""
+              { "jsonrpc": "2.0",
+                "id": 3,
+                "result": { "contents": "abcdef" }
+              }
+              """)
+
+      client.send(json"""
+              { "jsonrpc": "2.0",
+                "method": "text/save",
+                "id": 3,
+                "params": {
+                  "path": {
+                    "rootId": $testContentRootId,
+                    "segments": [ "foo.txt" ]
+                  },
+                  "currentVersion": "ebe55342f9c8b86857402797dd723fb4a2174e0b56d6ace0a6929ec3"
+                }
+              }
+              """)
+      client.expectJson(json"""
+              { "jsonrpc": "2.0",
+                "id": 3,
+                "result": null
+              }
+              """)
+      client.send(json"""
+              { "jsonrpc": "2.0",
+                "method": "file/read",
+                "id": 4,
+                "params": {
+                  "path": {
+                    "rootId": $testContentRootId,
+                    "segments": [ "foo.txt" ]
+                  }
+                }
+              }
+              """)
+      client.expectJson(json"""
+              { "jsonrpc": "2.0",
+                "id": 4,
+                "result": { "contents": "bar123456789foo" }
+              }
+              """)
+    }
+
   }
 
   "auto-save" must {
@@ -2743,6 +2903,138 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
           }
           """)
 
+    }
+
+    "not persist changes when the file is changed on disk" in {
+      this.timingsConfig.withAutoSave(2.seconds)
+
+      val client = getInitialisedWsClient()
+      client.send(json"""
+              { "jsonrpc": "2.0",
+                "method": "file/write",
+                "id": 0,
+                "params": {
+                  "path": {
+                    "rootId": $testContentRootId,
+                    "segments": [ "foo.txt" ]
+                  },
+                  "contents": "123456789"
+                }
+              }
+              """)
+      client.expectJson(json"""
+              { "jsonrpc": "2.0",
+                "id": 0,
+                "result": null
+              }
+              """)
+      client.send(json"""
+              { "jsonrpc": "2.0",
+                "method": "text/openFile",
+                "id": 1,
+                "params": {
+                  "path": {
+                    "rootId": $testContentRootId,
+                    "segments": [ "foo.txt" ]
+                  }
+                }
+              }
+              """)
+      client.expectJson(json"""
+              {
+                "jsonrpc" : "2.0",
+                "id" : 1,
+                "result" : {
+                  "writeCapability" : {
+                    "method" : "text/canEdit",
+                    "registerOptions" : {
+                      "path" : {
+                        "rootId" : $testContentRootId,
+                        "segments" : [
+                          "foo.txt"
+                        ]
+                      }
+                    }
+                  },
+                  "content" : "123456789",
+                  "currentVersion" : "5795c3d628fd638c9835a4c79a55809f265068c88729a1a3fcdf8522"
+                }
+              }
+              """)
+      client.send(json"""
+                { "jsonrpc": "2.0",
+                  "method": "text/applyEdit",
+                  "id": 2,
+                  "params": {
+                    "edit": {
+                      "path": {
+                        "rootId": $testContentRootId,
+                        "segments": [ "foo.txt" ]
+                      },
+                      "oldVersion": "5795c3d628fd638c9835a4c79a55809f265068c88729a1a3fcdf8522",
+                      "newVersion": "ebe55342f9c8b86857402797dd723fb4a2174e0b56d6ace0a6929ec3",
+                      "edits": [
+                        {
+                          "range": {
+                            "start": { "line": 0, "character": 0 },
+                            "end": { "line": 0, "character": 0 }
+                          },
+                          "text": "bar"
+                        },
+                        {
+                          "range": {
+                            "start": { "line": 0, "character": 12 },
+                            "end": { "line": 0, "character": 12 }
+                          },
+                          "text": "foo"
+                        }
+                      ]
+                    }
+                  }
+                }
+                """)
+      client.expectJson(json"""
+                { "jsonrpc": "2.0",
+                  "id": 2,
+                  "result": null
+                }
+                """)
+
+      // Change file on disk
+      val fooTxt = testContentRoot.file.toPath.resolve("foo.txt")
+      Files.write(fooTxt, "abcdef".getBytes(StandardCharsets.UTF_8))
+
+      Thread.sleep(8.seconds.toMillis)
+      // No explicit file save
+      client.expectJson(json"""
+              { "jsonrpc": "2.0",
+                "method":"text/fileModifiedOnDisk",
+                "params": {
+                  "path": {
+                    "rootId": $testContentRootId,
+                    "segments": [ "foo.txt" ]
+                  }
+                }
+              }
+              """)
+      client.send(json"""
+              { "jsonrpc": "2.0",
+                "method": "file/read",
+                "id": 3,
+                "params": {
+                  "path": {
+                    "rootId": $testContentRootId,
+                    "segments": [ "foo.txt" ]
+                  }
+                }
+              }
+              """)
+      client.expectJson(json"""
+              { "jsonrpc": "2.0",
+                "id": 3,
+                "result": { "contents": "abcdef" }
+              }
+              """)
     }
 
   }

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
@@ -2963,6 +2963,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
               """)
 
       // Change file on disk
+      Thread.sleep(1.seconds.toMillis)
       val fooTxt = testContentRoot.file.toPath.resolve("foo.txt")
       Files.write(fooTxt, "abcdef".getBytes(StandardCharsets.UTF_8))
 

--- a/lib/scala/text-buffer/src/main/scala/org/enso/text/ContentVersion.scala
+++ b/lib/scala/text-buffer/src/main/scala/org/enso/text/ContentVersion.scala
@@ -3,12 +3,7 @@ package org.enso.text
 import org.bouncycastle.util.encoders.Hex
 
 /** Version of the text contents. */
-case class ContentVersion(toHexString: String) {
-
-  /** Calculate digest. */
-  def toDigest: Array[Byte] =
-    Hex.decode(toHexString)
-}
+case class ContentVersion(toHexString: String)
 
 object ContentVersion {
 


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->
part of #7178 

Changelog:
- add: `text/fileModifiedOnDisk` notification
- update: during the auto-save, check if the file is modified on disk and send the notification. I.e. auto-save does not overwrite the file if it was changed on disk (but the save command does)
- update: IDE handles the file-modified-on-disk notification and reloads the module from disk

### Important Notes

Currently, the auto-save (and the check that the file is modified on disk) is triggered only after the file was edited. The proper check (using the file-watcher service) will be added in the next PR

https://github.com/enso-org/enso/assets/357683/ff91f3e6-2f7a-4c01-a745-98cb140e1964



<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
