### PR TITLE
Round on a column was always adding a warning

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Any.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Any.enso
@@ -21,17 +21,6 @@ from project.Function import const
    be used in that position.
 @Builtin_Type
 type Any
-
-    ## PRIVATE
-
-       Executes the provided handler on a dataflow error, or executes as
-       identity on a non-error value.
-
-       Arguments:
-       - handler: The function to call on this if it is an error value.
-    catch_primitive : (Error -> Any) -> Any
-    catch_primitive self handler = @Builtin_Method "Any.catch_primitive"
-
     ## Generic conversion of an arbitrary Enso value to a corresponding textual
        representation.
 
@@ -299,6 +288,16 @@ type Any
             case error_value.is_a error_type of
                 True -> handler error_value
                 False -> self
+
+    ## PRIVATE
+
+       Executes the provided handler on a dataflow error, or executes as
+       identity on a non-error value.
+
+       Arguments:
+       - handler: The function to call on this if it is an error value.
+    catch_primitive : (Error -> Any) -> Any
+    catch_primitive self handler = @Builtin_Method "Any.catch_primitive"
 
     ## Transforms an error.
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
@@ -851,7 +851,7 @@ type Column
     ## Returns a column of booleans, with `True` items at the positions where
        this column contains a NaN. This is only applicable to double columns.
     is_nan : Column
-    is_nan self = Value_Type.expect_floating_point self <|
+    is_nan self = Value_Type.expect_numeric self <|
         new_name = self.naming_helpers.function_name "is_nan" [self]
         self.make_unary_op "IS_NAN" new_name
 
@@ -859,7 +859,7 @@ type Column
        this column contains a +Inf/-Inf. This is only applicable to double
        columns.
     is_infinite : Column
-    is_infinite self = Value_Type.expect_floating_point self <|
+    is_infinite self = Value_Type.expect_numeric self <|
         new_name = self.naming_helpers.function_name "is_infinite" [self]
         self.make_unary_op "IS_INF" new_name
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
@@ -855,8 +855,7 @@ type Column
         new_name = self.naming_helpers.function_name "is_nan" [self]
         self.make_unary_op "IS_NAN" new_name
 
-    ## UNSTABLE
-       Returns a column of booleans, with `True` items at the positions where
+    ## Returns a column of booleans, with `True` items at the positions where
        this column contains a +Inf/-Inf. This is only applicable to double
        columns.
     is_infinite : Column

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
@@ -454,7 +454,7 @@ make_order_descriptor internal_column sort_direction text_ordering =
 
 ## PRIVATE
 is_nan = Base_Generator.lift_unary_op "IS_NAN" arg->
-    (arg ++ " = double precision 'NaN'").paren
+    (arg ++ " in (double precision 'NaN')").paren
 
 ## PRIVATE
 is_inf = Base_Generator.lift_unary_op "IS_INF" arg->

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -911,6 +911,7 @@ type Column
         new_name = Naming_Helpers.function_name "is_nan" [self]
         fallback x = case x of
             _ : Decimal -> x.is_nan
+            Nothing     -> on_missing
             _           -> False
         run_vectorized_unary_op self "is_nan" fallback expected_result_type=Value_Type.Boolean new_name on_missing=on_missing
 
@@ -922,6 +923,7 @@ type Column
         new_name = Naming_Helpers.function_name "is_infinite" [self]
         fallback x = case x of
             _ : Decimal -> x.is_infinite
+            Nothing     -> Nothing
             _           -> False
         run_vectorized_unary_op self "is_infinite" fallback expected_result_type=Value_Type.Boolean new_name on_missing=Nothing
 
@@ -968,9 +970,9 @@ type Column
         result = case self.value_type of
             Value_Type.Char _ _ -> self.is_empty
             Value_Type.Float _ ->
-                if treat_nans_as_blank then self.is_nothing || (self.internal_is_nan on_missing=False) else self.is_nothing
+                if treat_nans_as_blank then self.is_nothing.iif True (self.internal_is_nan on_missing=False) else self.is_nothing
             Value_Type.Mixed ->
-                self.internal_is_empty || (if treat_nans_as_blank then self.is_nothing || (self.internal_is_nan on_missing=False) else self.is_nothing)
+                self.internal_is_empty || (if treat_nans_as_blank then self.is_nothing.iif True (self.internal_is_nan on_missing=False) else self.is_nothing)
             _ -> self.is_nothing
         result.rename new_name
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -902,9 +902,8 @@ type Column
     ## Returns a column of booleans, with `True` items at the positions where
        this column contains a NaN. This is only applicable to double columns.
     is_nan : Column
-    is_nan self =
-        Value_Type.expect_floating_point self <|
-            self.internal_is_nan on_missing=Nothing
+    is_nan self = Value_Type.expect_numeric self <|
+        self.internal_is_nan on_missing=Nothing
 
     ## PRIVATE
     internal_is_nan : Any -> Column
@@ -919,13 +918,12 @@ type Column
        this column contains a +Inf/-Inf. This is only applicable to double
        columns.
     is_infinite : Column
-    is_infinite self =
-        Value_Type.expect_floating_point self <|
-            new_name = Naming_Helpers.function_name "is_infinite" [self]
-            fallback x = case x of
-                _ : Decimal -> x.is_infinite
-                _           -> False
-            run_vectorized_unary_op self "is_infinite" fallback expected_result_type=Value_Type.Boolean new_name on_missing=Nothing
+    is_infinite self = Value_Type.expect_numeric self <|
+        new_name = Naming_Helpers.function_name "is_infinite" [self]
+        fallback x = case x of
+            _ : Decimal -> x.is_infinite
+            _           -> False
+        run_vectorized_unary_op self "is_infinite" fallback expected_result_type=Value_Type.Boolean new_name on_missing=Nothing
 
     ## PRIVATE
        Returns a column of booleans, with `True` items at the positions where

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -732,32 +732,32 @@ type Column
             if self.value_type.is_integer && decimal_places >= 0 then self.rename new_name else
                 should_cast_to_integer = decimal_places <= 0 || self.value_type.is_integer
                 target_value_type = if should_cast_to_integer then Value_Type.Integer else self.value_type
-                result = self.check_round_input target_value_type <|
+                result = self.check_round_input col->
                     scale = 10 ^ decimal_places
-                    scaled = self * scale
+                    scaled = col * scale
                     round_base = scaled.floor
                     round_midpoint = (round_base + 0.5) / scale
-                    even_is_up = (self >= 0).iif ((scaled.truncate % 2) != 0) ((scaled.truncate % 2) == 0)
-                    half_goes_up = if use_bankers then even_is_up else self >= 0
-                    do_round_up = half_goes_up.iif (self >= round_midpoint) (self > round_midpoint)
+                    even_is_up = (col >= 0).iif ((scaled.truncate % 2) != 0) ((scaled.truncate % 2) == 0)
+                    half_goes_up = if use_bankers then even_is_up else col >= 0
+                    do_round_up = half_goes_up.iif (col >= round_midpoint) (col > round_midpoint)
                     result_float = do_round_up.iif ((round_base + 1.0) / scale) (round_base / scale)
                     cast_if_needed result_float target_value_type
                 result.rename new_name
 
     ## PRIVATE
        Restrict allowed range of input to rounding methods.
-    check_round_input : Column -> Value_Type -> Any ! Illegal_Argument
-    check_round_input self target_value_type column =
+    check_round_input : (Column -> Column) -> Any ! Illegal_Argument
+    check_round_input self action =
         min = Rounding_Helpers.round_min_long
         max = Rounding_Helpers.round_max_long
-        within_range = self >= self.const min && self <= self.const max
-        warning = Illegal_Argument.Error <| "Error: `round` can only accept values between " + min.to_text + " and " + max.to_text + " (inclusive)"
-        nothing_with_problem = Warning.attach warning Nothing
-        ## TODO: This should be cast to NULL when that type is available,
-           see https://github.com/enso-org/enso/issues/6281.
-        nothings = self.const nothing_with_problem . cast target_value_type
-        result = within_range.iif column nothings
-        result.rename column.name
+        within_range = if self.value_type.is_floating_point.not then self.between min max else
+            self.is_nan || self.is_infinite || self.between min max
+
+        any_issues = within_range.to_vector . any (== False)
+        if any_issues.not then action self else
+            warning = Illegal_Argument.Error <| "Error: `round` can only accept values between " + min.to_text + " and " + max.to_text + " (inclusive)"
+            result = action (within_range.iif self Nothing)
+            Warning.attach warning result
 
     ## ALIAS int
 
@@ -914,6 +914,18 @@ type Column
             _ : Decimal -> x.is_nan
             _           -> False
         run_vectorized_unary_op self "is_nan" fallback expected_result_type=Value_Type.Boolean new_name on_missing=on_missing
+
+    ## Returns a column of booleans, with `True` items at the positions where
+       this column contains a +Inf/-Inf. This is only applicable to double
+       columns.
+    is_infinite : Column
+    is_infinite self =
+        Value_Type.expect_floating_point self <|
+            new_name = Naming_Helpers.function_name "is_infinite" [self]
+            fallback x = case x of
+                _ : Decimal -> x.is_infinite
+                _           -> False
+            run_vectorized_unary_op self "is_infinite" fallback expected_result_type=Value_Type.Boolean new_name on_missing=Nothing
 
     ## PRIVATE
        Returns a column of booleans, with `True` items at the positions where

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/Storage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/Storage.java
@@ -75,6 +75,7 @@ public abstract class Storage<T> {
     public static final String OR = "||";
     public static final String IS_NOTHING = "is_nothing";
     public static final String IS_NAN = "is_nan";
+    public static final String IS_INFINITE = "is_infinite";
     public static final String IS_EMPTY = "is_empty";
     public static final String STARTS_WITH = "starts_with";
     public static final String ENDS_WITH = "ends_with";

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
@@ -283,7 +283,7 @@ public abstract class AbstractLongStorage extends NumericStorage<Long> {
             new UnaryMapOperation<>(Storage.Maps.IS_NAN) {
               @Override
               public BoolStorage run(AbstractLongStorage storage) {
-                BitSet isNaN = new BitSet(storage.size());
+                BitSet isNaN = new BitSet();
                 return new BoolStorage(storage.getIsMissing(), isNaN, storage.size(), false);
               }
             })
@@ -291,8 +291,8 @@ public abstract class AbstractLongStorage extends NumericStorage<Long> {
             new UnaryMapOperation<>(Storage.Maps.IS_INFINITE) {
               @Override
               public BoolStorage run(AbstractLongStorage storage) {
-                BitSet isNaN = new BitSet(storage.size());
-                return new BoolStorage(storage.getIsMissing(), isNaN, storage.size(), false);
+                BitSet isInfinte = new BitSet();
+                return new BoolStorage(storage.getIsMissing(), isInfinte, storage.size(), false);
               }
             })
         .add(new LongIsInOp());

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
@@ -279,6 +279,22 @@ public abstract class AbstractLongStorage extends NumericStorage<Long> {
                 return new BoolStorage(storage.getIsMissing(), new BitSet(), storage.size(), false);
               }
             })
+        .add(
+            new UnaryMapOperation<>(Storage.Maps.IS_NAN) {
+              @Override
+              public BoolStorage run(AbstractLongStorage storage) {
+                BitSet isNaN = new BitSet(storage.size());
+                return new BoolStorage(storage.getIsMissing(), isNaN, storage.size(), false);
+              }
+            })
+        .add(
+            new UnaryMapOperation<>(Storage.Maps.IS_INFINITE) {
+              @Override
+              public BoolStorage run(AbstractLongStorage storage) {
+                BitSet isNaN = new BitSet(storage.size());
+                return new BoolStorage(storage.getIsMissing(), isNaN, storage.size(), false);
+              }
+            })
         .add(new LongIsInOp());
     return ops;
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
@@ -291,8 +291,8 @@ public abstract class AbstractLongStorage extends NumericStorage<Long> {
             new UnaryMapOperation<>(Storage.Maps.IS_INFINITE) {
               @Override
               public BoolStorage run(AbstractLongStorage storage) {
-                BitSet isInfinte = new BitSet();
-                return new BoolStorage(storage.getIsMissing(), isInfinte, storage.size(), false);
+                BitSet isInfinite = new BitSet();
+                return new BoolStorage(storage.getIsMissing(), isInfinite, storage.size(), false);
               }
             })
         .add(new LongIsInOp());

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
@@ -284,7 +284,7 @@ public abstract class AbstractLongStorage extends NumericStorage<Long> {
               @Override
               public BoolStorage run(AbstractLongStorage storage) {
                 BitSet isNaN = new BitSet();
-                return new BoolStorage(storage.getIsMissing(), isNaN, storage.size(), false);
+                return new BoolStorage(isNaN, storage.getIsMissing(), storage.size(), false);
               }
             })
         .add(
@@ -292,7 +292,7 @@ public abstract class AbstractLongStorage extends NumericStorage<Long> {
               @Override
               public BoolStorage run(AbstractLongStorage storage) {
                 BitSet isInfinite = new BitSet();
-                return new BoolStorage(storage.getIsMissing(), isInfinite, storage.size(), false);
+                return new BoolStorage(isInfinite, storage.getIsMissing(), storage.size(), false);
               }
             })
         .add(new LongIsInOp());

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/DoubleStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/DoubleStorage.java
@@ -358,7 +358,7 @@ public final class DoubleStorage extends NumericStorage<Double> {
 
                   context.safepoint();
                 }
-                return new BoolStorage(nans, new BitSet(), storage.size, false);
+                return new BoolStorage(nans, storage.isMissing, storage.size, false);
               }
             })
         .add(
@@ -374,7 +374,7 @@ public final class DoubleStorage extends NumericStorage<Double> {
 
                   context.safepoint();
                 }
-                return new BoolStorage(infintes, new BitSet(), storage.size, false);
+                return new BoolStorage(infintes, storage.isMissing, storage.size, false);
               }
             })
         .add(new DoubleIsInOp());

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/DoubleStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/DoubleStorage.java
@@ -361,6 +361,22 @@ public final class DoubleStorage extends NumericStorage<Double> {
                 return new BoolStorage(nans, new BitSet(), storage.size, false);
               }
             })
+        .add(
+            new UnaryMapOperation<>(Maps.IS_INFINITE) {
+              @Override
+              public BoolStorage run(DoubleStorage storage) {
+                BitSet infintes = new BitSet();
+                Context context = Context.getCurrent();
+                for (int i = 0; i < storage.size; i++) {
+                  if (!storage.isNa(i) && Double.isInfinite(storage.getItem(i))) {
+                    infintes.set(i);
+                  }
+
+                  context.safepoint();
+                }
+                return new BoolStorage(infintes, new BitSet(), storage.size, false);
+              }
+            })
         .add(new DoubleIsInOp());
     return ops;
   }

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -430,17 +430,19 @@ spec setup =
                     t.at "Z" . is_nan . to_vector . should_fail_with Invalid_Value_Type
 
                 Test.specify "should support is_infinite" <|
-                    t.at "X" . is_nan . to_vector . should_equal [False, False, True, True, False, Nothing]
-                    t.at "Y" . is_nan . to_vector . should_equal [False, False, False, False, False, Nothing]
-                    t.at "Z" . is_nan . to_vector . should_fail_with Invalid_Value_Type
+                    t.at "X" . is_infinite . to_vector . should_equal [False, False, True, True, False, Nothing]
+                    t.at "Y" . is_infinite . to_vector . should_equal [False, False, False, False, False, Nothing]
+                    t.at "Z" . is_infinite . to_vector . should_fail_with Invalid_Value_Type
             False ->
                 Test.specify "should report that is_nan is not supported" <|
                     t = table_builder [["X", [1.5]]]
                     t.at "X" . is_nan . should_fail_with Unsupported_Database_Operation
 
-                Test.specify "should report that is_infinite is not supported" <|
-                    t = table_builder [["X", [1.5]]]
-                    t.at "X" . is_infinite . should_fail_with Unsupported_Database_Operation
+                Test.specify "should support is_infinite" <|
+                    t = table_builder [["X", [1.5, 3.0, Number.positive_infinity, Number.negative_infinity, Nothing]], ["Y", [1, 2, 3, 4, Nothing]], ["Z", ["1", "2", "3", "4", Nothing]]]
+                    t.at "X" . is_infinite . to_vector . should_equal [False, False, True, True, Nothing]
+                    t.at "Y" . is_infinite . to_vector . should_equal [False, False, False, False, Nothing]
+                    t.at "Z" . is_infinite . to_vector . should_fail_with Invalid_Value_Type
 
         Test.specify "should support is_blank" <|
             t = table_builder [["X", [1.5, 2, Number.nan, Nothing]], ["Y", [1, Nothing, 3, 4]]]

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -421,14 +421,26 @@ spec setup =
             (y ^ 42).should_fail_with Invalid_Value_Type
 
         case setup.test_selection.is_nan_and_nothing_distinct of
-            True -> Test.specify "should support is_nan" <|
-                t = table_builder [["X", [1.5, 2, Number.nan]], ["Y", [1, 2, 3]], ["Z", ["1", "2", "3"]]]
-                t.at "X" . is_nan . to_vector . should_equal [False, False, True]
-                t.at "Y" . is_nan . to_vector . should_equal [False, False, False]
-                t.at "Z" . is_nan . to_vector . should_fail_with Invalid_Value_Type
-            False -> Test.specify "should report that is_nan is not supported" <|
-                t = table_builder [["X", [1.5]]]
-                t.at "X" . is_nan . should_fail_with Unsupported_Database_Operation
+            True ->
+                t = table_builder [["X", [1.5, 3.0, Number.positive_infinity, Number.negative_infinity, Number.nan, Nothing]], ["Y", [1, 2, 3, 4, 5, Nothing]], ["Z", ["1", "2", "3", "4", "5", Nothing]]]
+
+                Test.specify "should support is_nan" <|
+                    t.at "X" . is_nan . to_vector . should_equal [False, False, False, False, True, Nothing]
+                    t.at "Y" . is_nan . to_vector . should_equal [False, False, False, False, False, Nothing]
+                    t.at "Z" . is_nan . to_vector . should_fail_with Invalid_Value_Type
+
+                Test.specify "should support is_infinite" <|
+                    t.at "X" . is_nan . to_vector . should_equal [False, False, True, True, False, Nothing]
+                    t.at "Y" . is_nan . to_vector . should_equal [False, False, False, False, False, Nothing
+                    t.at "Z" . is_nan . to_vector . should_fail_with Invalid_Value_Type
+            False ->
+                Test.specify "should report that is_nan is not supported" <|
+                    t = table_builder [["X", [1.5]]]
+                    t.at "X" . is_nan . should_fail_with Unsupported_Database_Operation
+
+                Test.specify "should report that is_infinite is not supported" <|
+                    t = table_builder [["X", [1.5]]]
+                    t.at "X" . is_infinite . should_fail_with Unsupported_Database_Operation
 
         Test.specify "should support is_blank" <|
             t = table_builder [["X", [1.5, 2, Number.nan, Nothing]], ["Y", [1, Nothing, 3, 4]]]

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -431,7 +431,7 @@ spec setup =
 
                 Test.specify "should support is_infinite" <|
                     t.at "X" . is_nan . to_vector . should_equal [False, False, True, True, False, Nothing]
-                    t.at "Y" . is_nan . to_vector . should_equal [False, False, False, False, False, Nothing
+                    t.at "Y" . is_nan . to_vector . should_equal [False, False, False, False, False, Nothing]
                     t.at "Z" . is_nan . to_vector . should_fail_with Invalid_Value_Type
             False ->
                 Test.specify "should report that is_nan is not supported" <|

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -422,9 +422,10 @@ spec setup =
 
         case setup.test_selection.is_nan_and_nothing_distinct of
             True -> Test.specify "should support is_nan" <|
-                t = table_builder [["X", [1.5, 2, Number.nan]], ["Y", [1, 2, 3]]]
+                t = table_builder [["X", [1.5, 2, Number.nan]], ["Y", [1, 2, 3]], ["Z", ["1", "2", "3"]]]
                 t.at "X" . is_nan . to_vector . should_equal [False, False, True]
-                t.at "Y" . is_nan . should_fail_with Invalid_Value_Type
+                t.at "Y" . is_nan . to_vector . should_equal [False, False, False]
+                t.at "Z" . is_nan . to_vector . should_fail_with Invalid_Value_Type
             False -> Test.specify "should report that is_nan is not supported" <|
                 t = table_builder [["X", [1.5]]]
                 t.at "X" . is_nan . should_fail_with Unsupported_Database_Operation

--- a/test/Table_Tests/src/Common_Table_Operations/Main.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Main.enso
@@ -79,7 +79,7 @@ type Test_Selection
          such comparisons, when mixed type storage is allowed or by coercing to
          the target type; others will fail with a type error.
        - supports_unicode_normalization: Specifies if the backend compares
-         strings taking Unicode Normalization into accout, i.e. whether
+         strings taking Unicode Normalization into account, i.e. whether
          's\u0301' is considered equal to 'ś'.
        - is_nan_and_nothing_distinct: Specifies if the backend is able to
          distinguish between a decimal NaN value and a missing value (Enso's

--- a/test/Table_Tests/src/In_Memory/Column_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Column_Spec.enso
@@ -118,7 +118,7 @@ spec =
             Column.from_vector "foo" [12, 24, 25, 29] . round -1 . value_type . should_equal Value_Type.Integer
 
         Test.specify "rounding should not attach a warning by default" <|
-            Column.from_vector "foo" [12, 24, 25, 29] . round 1 . has_warnings . should_be_false
+            Problems.assume_no_problems <| Column.from_vector "foo" [12, 24, 25, 29] . round 1
 
         Test.specify "should report out-of-range values as warnings" <|
             col = Column.from_vector "foo" [12, 23, 99999999999999999]

--- a/test/Table_Tests/src/In_Memory/Column_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Column_Spec.enso
@@ -117,6 +117,9 @@ spec =
             Column.from_vector "foo" [12, 24, 25, 29] . round 0 . value_type . should_equal Value_Type.Integer
             Column.from_vector "foo" [12, 24, 25, 29] . round -1 . value_type . should_equal Value_Type.Integer
 
+        Test.specify "rounding should not attach a warning by default" <|
+            Column.from_vector "foo" [12, 24, 25, 29] . round 1 . has_warnings . should_be_false
+
         Test.specify "should report out-of-range values as warnings" <|
             col = Column.from_vector "foo" [12, 23, 99999999999999999]
             expected = Column.from_vector "round([foo])" [10, 20, Nothing]


### PR DESCRIPTION
### Pull Request Description

- Only warn if outside allowed range.
- Added `is_infinite` to In-Memory column.
- Allow integer value type for `is_nan` and `is_infinite`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
