### PR TITLE
Fix error visualization positioning

### DIFF
--- a/app/gui/view/graph-editor/src/component/node.rs
+++ b/app/gui/view/graph-editor/src/component/node.rs
@@ -545,8 +545,14 @@ impl NodeModel {
             .set_x(x_offset_to_node_center + width / 2.0 + CORNER_RADIUS + action_bar_width / 2.0);
         self.action_bar.frp.set_size(Vector2::new(action_bar_width, ACTION_BAR_HEIGHT));
 
-        self.error_visualization.set_xy(VISUALIZATION_OFFSET);
         self.visualization.set_xy(VISUALIZATION_OFFSET);
+        // Error visualization has origin in the center, while regular visualization has it at the
+        // top left corner.
+        let error_vis_offset_y = -ERROR_VISUALIZATION_SIZE.y / 2.0;
+        let error_vis_offset_x = ERROR_VISUALIZATION_SIZE.x / 2.0;
+        let error_vis_offset = Vector2(error_vis_offset_x, error_vis_offset_y);
+        let error_vis_pos = VISUALIZATION_OFFSET + error_vis_offset;
+        self.error_visualization.set_xy(error_vis_pos);
         self.visualization.frp.set_width(width);
 
         size


### PR DESCRIPTION
### Pull Request Description

Fixes #7256 

Sadly no resizing for error vis yet, it is far too complicated and requires a separate task.


https://github.com/enso-org/enso/assets/6566674/77ddbe78-7f27-41d1-9f63-5dd1d717ecd3



### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
