### PR TITLE
Fix node name visibility

### DIFF
--- a/app/gui/view/graph-editor/src/component/node.rs
+++ b/app/gui/view/graph-editor/src/component/node.rs
@@ -711,7 +711,6 @@ impl Node {
             // === View Mode ===
 
             model.input.set_view_mode <+ input.set_view_mode;
-            model.output.set_view_mode <+ input.set_view_mode;
             model.input.set_edit_ready_mode <+ input.set_edit_ready_mode;
             model.profiling_label.set_view_mode <+ input.set_view_mode;
             model.vcs_indicator.set_visibility  <+ input.set_view_mode.map(|&mode| {


### PR DESCRIPTION
Fixes #7259

Node label (and output port in general) used to depend on view-mode logic, which is currently not fully functional. Since we have removed profiling mode from the application, It's best to remove some remaining parts of it to avoid them from interfering.

Labels now work as they used to, being shown on hover or when ctrl is held down.

![image](https://github.com/enso-org/enso/assets/919491/5e6996a4-6d84-4d36-a624-03a53f7e6e8a)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
