### PR TITLE
Add `date_diff`, `date_add` and `date_part` to scalar Enso date-time values.

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
@@ -325,6 +325,50 @@ type Date
             ensure_in_epoch self <| ensure_in_epoch end <|
                 (Time_Utils.days_between self end) + if include_end_date then 1 else 0
 
+    ## Returns a requested date part as integer.
+
+       Produces a warning for a Date that is before epoch start.
+       See `Date_Time.enso_epoch_start`.
+    date_part : Date_Period -> Integer
+    date_part self (period : Date_Period) =
+        case period of
+            Date_Period.Year -> self.year
+            Date_Period.Quarter -> self.quarter
+            Date_Period.Month -> self.month
+            Date_Period.Week -> self.week_of_year locale=Nothing
+            Date_Period.Day -> self.day
+
+    ## Computes a time difference between the two dates.
+
+       It returns an integer expressing how many periods fit between the two
+       dates.
+
+       The difference will be positive if `end` is greater than `self`.
+
+       Produces a warning for a Date that is before epoch start.
+       See `Date_Time.enso_epoch_start`.
+
+       Arguments:
+       - end: A date to compute the difference from.
+       - period: The period to compute the difference in.
+    date_diff : Date -> Date_Period -> Integer
+    date_diff self (end : Date) (period : Date_Period) = ensure_in_epoch self <|
+        java_unit = period.to_java_unit
+        Time_Utils.unit_date_difference java_unit self end
+
+    ## Shifts the date by a specified period.
+
+       Produces a warning for a Date that is before epoch start.
+       See `Date_Time.enso_epoch_start`.
+
+       Arguments:
+       - amount: An integer specifying by how many periods to shift the date.
+       - period: The period by which to shift.
+    date_add : Integer -> Date_Period -> Date
+    date_add self (amount : Integer) (period : Date_Period) = ensure_in_epoch self <|
+        java_unit = period.to_java_unit
+        java_unit.addTo self amount
+
     ## Counts workdays between self (inclusive) and the provided end date
        (exclusive).
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
@@ -353,8 +353,7 @@ type Date
        - period: The period to compute the difference in.
     date_diff : Date -> Date_Period -> Integer
     date_diff self (end : Date) (period : Date_Period) = ensure_in_epoch self <|
-        java_unit = period.to_java_unit
-        Time_Utils.unit_date_difference java_unit self end
+        Time_Utils.unit_date_difference period.to_java_unit self end
 
     ## Shifts the date by a specified period.
 
@@ -366,8 +365,7 @@ type Date
        - period: The period by which to shift.
     date_add : Integer -> Date_Period -> Date
     date_add self (amount : Integer) (period : Date_Period) = ensure_in_epoch self <|
-        java_unit = period.to_java_unit
-        java_unit.addTo self amount
+        Time_Utils.unit_date_add period.to_java_unit self amount
 
     ## Counts workdays between self (inclusive) and the provided end date
        (exclusive).

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
@@ -332,11 +332,11 @@ type Date
     date_part : Date_Period -> Integer
     date_part self (period : Date_Period) =
         case period of
-            Date_Period.Year -> self.year
+            Date_Period.Year    -> self.year
             Date_Period.Quarter -> self.quarter
-            Date_Period.Month -> self.month
-            Date_Period.Week -> self.week_of_year locale=Nothing
-            Date_Period.Day -> self.day
+            Date_Period.Month   -> self.month
+            Date_Period.Week _  -> self.week_of_year locale=Nothing
+            Date_Period.Day     -> self.day
 
     ## Computes a time difference between the two dates.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
@@ -312,6 +312,28 @@ type Date_Time
     second : Integer
     second self = @Builtin_Method "Date_Time.second"
 
+    ## Get the millisecond portion of the time.
+
+       > Example
+         Get the current millisecond.
+
+             from Standard.Base import Date_Time
+
+             example_millisecond = Date_Time.now.millisecond
+    millisecond : Integer
+    millisecond self = @Builtin_Method "Date_Time.millisecond"
+
+    ## Get the microsecond portion of the time.
+
+       > Example
+         Get the current microsecond.
+
+             from Standard.Base import Date_Time
+
+             example_microsecond = Date_Time.now.microsecond
+    microsecond : Integer
+    microsecond self = @Builtin_Method "Date_Time.microsecond"
+
     ## Get the nanosecond portion of the time.
 
        > Example
@@ -494,6 +516,58 @@ type Date_Time
     at_zone : Time_Zone -> Date_Time
     at_zone self zone =
         Time_Utils.with_zone_same_instant self zone
+
+    ## Returns a requested date-time part as integer.
+
+       Produces a warning for a Date_Time that is before epoch start.
+       See `Date_Time.enso_epoch_start`.
+    date_part : Date_Period | Time_Period -> Integer
+    date_part self (period : Date_Period | Time_Period) =
+        case period of
+            Date_Period.Year -> self.year
+            Date_Period.Quarter -> self.quarter
+            Date_Period.Month -> self.month
+            Date_Period.Week -> self.week_of_year locale=Nothing
+            Date_Period.Day -> self.day
+            Time_Period.Day -> self.day
+            Time_Period.Hour -> self.hour
+            Time_Period.Minute -> self.minute
+            Time_Period.Second -> self.second
+            Time_Period.Millisecond -> self.millisecond
+            Time_Period.Microsecond -> self.microsecond
+            Time_Period.Nanosecond -> self.nanosecond
+
+    ## Computes a time difference between the two date-times.
+
+       It returns an integer expressing how many periods fit between the two
+       date-times.
+
+       The difference will be positive if `end` is greater than `self`.
+
+       Produces a warning for a Date_Time that is before epoch start.
+       See `Date_Time.enso_epoch_start`.
+
+       Arguments:
+       - end: A date-time to compute the difference from.
+       - period: The period to compute the difference in.
+    date_diff : Date_Time -> Date_Period | Time_Period -> Integer
+    date_diff self (end : Date_Time) (period : Date_Period | Time_Period) = ensure_in_epoch self <|
+        java_unit = period.to_java_unit
+        Time_Utils.unit_datetime_difference java_unit self end
+
+    ## Shifts the date-time by a specified period.
+
+       Produces a warning for a Date_Time that is before epoch start.
+       See `Date_Time.enso_epoch_start`.
+
+       Arguments:
+       - amount: An integer specifying by how many periods to shift the
+         date-time.
+       - period: The period by which to shift.
+    date_add : Integer -> Date_Period | Time_Period -> Date_Time
+    date_add self (amount : Integer) (period : Date_Period | Time_Period) = ensure_in_epoch self <|
+        java_unit = period.to_java_unit
+        java_unit.addTo self amount
 
     ## ALIAS Add Period, Add Duration
        Add the specified amount of time to this instant to produce a new instant.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
@@ -336,14 +336,20 @@ type Date_Time
 
     ## Get the nanosecond portion of the time.
 
+       Arguments:
+       - include_milliseconds: Specifies if the whole fractional part of the
+         second should be returned as nanoseconds. Defaults to `False`, meaning
+         it will only return the nanosecond part in the range 0-999.
+
        > Example
          Get the current nanosecond.
 
              from Standard.Base import Date_Time
 
              example_nanosecond = Date_Time.now.nanosecond
-    nanosecond : Integer
-    nanosecond self = @Builtin_Method "Date_Time.nanosecond"
+    nanosecond : Boolean -> Integer
+    nanosecond self include_milliseconds=False =
+        self.nanosecond_builtin include_milliseconds
 
     ## Get the timezone for the time.
 
@@ -684,7 +690,7 @@ type Date_Time
        Convert to a display representation of this Date_Time.
     to_display_text : Text
     to_display_text self =
-        time_format = if self.nanosecond == 0 then "HH:mm:ss" else "HH:mm:ss.n"
+        time_format = if self.nanosecond include_milliseconds=True == 0 then "HH:mm:ss" else "HH:mm:ss.n"
         self.format "yyyy-MM-dd "+time_format+" VV"
 
     ## PRIVATE
@@ -698,7 +704,7 @@ type Date_Time
     to_js_object self =
         type_pair = ["type", "Date_Time"]
         cons_pair = ["constructor", "new"]
-        JS_Object.from_pairs [type_pair, cons_pair, ["year", self.year], ["month", self.month], ["day", self.day], ["hour", self.hour], ["minute", self.minute], ["second", self.second], ["nanosecond", self.nanosecond], ["zone", self.zone]]
+        JS_Object.from_pairs [type_pair, cons_pair, ["year", self.year], ["month", self.month], ["day", self.day], ["hour", self.hour], ["minute", self.minute], ["second", self.second], ["nanosecond", self.nanosecond include_milliseconds=True], ["zone", self.zone]]
 
     ## Format this time as text using the specified format specifier.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
@@ -558,8 +558,7 @@ type Date_Time
        - period: The period to compute the difference in.
     date_diff : Date_Time -> Date_Period | Time_Period -> Integer
     date_diff self (end : Date_Time) (period : Date_Period | Time_Period) = ensure_in_epoch self <|
-        java_unit = period.to_java_unit
-        Time_Utils.unit_datetime_difference java_unit self end
+        Time_Utils.unit_datetime_difference period.to_java_unit self end
 
     ## Shifts the date-time by a specified period.
 
@@ -572,8 +571,7 @@ type Date_Time
        - period: The period by which to shift.
     date_add : Integer -> Date_Period | Time_Period -> Date_Time
     date_add self (amount : Integer) (period : Date_Period | Time_Period) = ensure_in_epoch self <|
-        java_unit = period.to_java_unit
-        java_unit.addTo self amount
+        Time_Utils.unit_datetime_add period.to_java_unit self amount
 
     ## ALIAS Add Period, Add Duration
        Add the specified amount of time to this instant to produce a new instant.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
@@ -524,18 +524,18 @@ type Date_Time
     date_part : Date_Period | Time_Period -> Integer
     date_part self (period : Date_Period | Time_Period) =
         case period of
-            Date_Period.Year -> self.year
-            Date_Period.Quarter -> self.quarter
-            Date_Period.Month -> self.month
-            Date_Period.Week -> self.week_of_year locale=Nothing
-            Date_Period.Day -> self.day
-            Time_Period.Day -> self.day
-            Time_Period.Hour -> self.hour
-            Time_Period.Minute -> self.minute
-            Time_Period.Second -> self.second
+            Date_Period.Year        -> self.year
+            Date_Period.Quarter     -> self.quarter
+            Date_Period.Month       -> self.month
+            Date_Period.Week _      -> self.week_of_year locale=Nothing
+            Date_Period.Day         -> self.day
+            Time_Period.Day         -> self.day
+            Time_Period.Hour        -> self.hour
+            Time_Period.Minute      -> self.minute
+            Time_Period.Second      -> self.second
             Time_Period.Millisecond -> self.millisecond
             Time_Period.Microsecond -> self.microsecond
-            Time_Period.Nanosecond -> self.nanosecond
+            Time_Period.Nanosecond  -> self.nanosecond
 
     ## Computes a time difference between the two date-times.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
@@ -12,6 +12,7 @@ import project.Data.Time.Time_Period.Time_Period
 import project.Data.Time.Time_Zone.Time_Zone
 import project.Error.Error
 import project.Errors.Common.Type_Error
+import project.Errors.Illegal_Argument.Illegal_Argument
 import project.Errors.Time_Error.Time_Error
 import project.Meta
 import project.Nothing.Nothing
@@ -280,7 +281,7 @@ type Time_Of_Day
     date_part : Time_Period -> Integer
     date_part self (period : Time_Period) =
         case period of
-            Time_Period.Day         -> self.day
+            Time_Period.Day         -> Error.throw (Illegal_Argument.Error "The Time_Of_Day does not have a day part.")
             Time_Period.Hour        -> self.hour
             Time_Period.Minute      -> self.minute
             Time_Period.Second      -> self.second
@@ -299,9 +300,11 @@ type Time_Of_Day
        - end: A time of day to compute the difference from.
        - period: The period to compute the difference in.
     date_diff : Time_Of_Day -> Time_Period -> Integer
-    date_diff self (end : Time_Of_Day) (period : Time_Period) =
-        java_unit = period.to_java_unit
-        Time_Utils.unit_time_difference java_unit self end
+    date_diff self (end : Time_Of_Day) (period : Time_Period) = case period of
+        Time_Period.Day -> Error.throw (Illegal_Argument.Error "The Time_Of_Day does not have a day part to compute a difference in days.")
+        _ ->
+            java_unit = period.to_java_unit
+            Time_Utils.unit_time_difference java_unit self end
 
     ## Shifts the time of day by a specified period.
 
@@ -309,9 +312,11 @@ type Time_Of_Day
        - amount: An integer specifying by how many periods to shift the time.
        - period: The period by which to shift.
     date_add : Integer -> Time_Period -> Time_Of_Day
-    date_add self (amount : Integer) (period : Time_Period) =
-        java_unit = period.to_java_unit
-        java_unit.addTo self amount
+    date_add self (amount : Integer) (period : Time_Period) = case period of
+        Time_Period.Day -> Error.throw (Illegal_Argument.Error "The Time_Of_Day does not have a day part to add days to.")
+        _ ->
+            java_unit = period.to_java_unit
+            java_unit.addTo self amount
 
     ## ALIAS Add Duration
        Add the specified amount of time to this instant to get a new instant.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
@@ -225,14 +225,20 @@ type Time_Of_Day
 
     ## Get the nanosecond portion of the time of day.
 
+       Arguments:
+       - include_milliseconds: Specifies if the whole fractional part of the
+         second should be returned as nanoseconds. Defaults to `False`, meaning
+         it will only return the nanosecond part in the range 0-999.
+
        > Example
          Get the current nanosecond.
 
              from Standard.Base import Time_Of_Day
 
              example_nanosecond = Time_Of_Day.now.nanosecond
-    nanosecond : Integer
-    nanosecond self = @Builtin_Method "Time_Of_Day.nanosecond"
+    nanosecond : Boolean -> Integer
+    nanosecond self include_milliseconds=False =
+        self.nanosecond_builtin include_milliseconds
 
     ## Returns the first time within the `Time_Period` containing self.
     start_of : Time_Period -> Time_Of_Day
@@ -373,13 +379,13 @@ type Time_Of_Day
     to_js_object self =
         type_pair = ["type", "Time_Of_Day"]
         cons_pair = ["constructor", "new"]
-        JS_Object.from_pairs [type_pair, cons_pair, ["hour", self.hour], ["minute", self.minute], ["second", self.second], ["nanosecond", self.nanosecond]]
+        JS_Object.from_pairs [type_pair, cons_pair, ["hour", self.hour], ["minute", self.minute], ["second", self.second], ["nanosecond", self.nanosecond include_milliseconds=True]]
 
     ## PRIVATE
        Convert to a display representation of this Time_Of_Day.
     to_display_text : Text
     to_display_text self =
-        if self.nanosecond == 0 then self.format "HH:mm:ss" else
+        if self.nanosecond include_milliseconds=True == 0 then self.format "HH:mm:ss" else
             self.format "HH:mm:ss.n"
 
     ## Format this time of day using the provided formatter pattern.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
@@ -274,13 +274,13 @@ type Time_Of_Day
     date_part : Time_Period -> Integer
     date_part self (period : Time_Period) =
         case period of
-            Time_Period.Day -> self.day
-            Time_Period.Hour -> self.hour
-            Time_Period.Minute -> self.minute
-            Time_Period.Second -> self.second
+            Time_Period.Day         -> self.day
+            Time_Period.Hour        -> self.hour
+            Time_Period.Minute      -> self.minute
+            Time_Period.Second      -> self.second
             Time_Period.Millisecond -> self.millisecond
             Time_Period.Microsecond -> self.microsecond
-            Time_Period.Nanosecond -> self.nanosecond
+            Time_Period.Nanosecond  -> self.nanosecond
 
     ## Computes a time difference between the two times of day.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
@@ -201,6 +201,28 @@ type Time_Of_Day
     second : Integer
     second self = @Builtin_Method "Time_Of_Day.second"
 
+    ## Get the millisecond portion of the time of day.
+
+       > Example
+         Get the current millisecond.
+
+             from Standard.Base import Time_Of_Day
+
+             example_millisecond = Time_Of_Day.now.millisecond
+    millisecond : Integer
+    millisecond self = @Builtin_Method "Time_Of_Day.millisecond"
+
+    ## Get the microsecond portion of the time of day.
+
+       > Example
+         Get the current microsecond.
+
+             from Standard.Base import Time_Of_Day
+
+             example_microsecond = Time_Of_Day.now.microsecond
+    microsecond : Integer
+    microsecond self = @Builtin_Method "Time_Of_Day.microsecond"
+
     ## Get the nanosecond portion of the time of day.
 
        > Example
@@ -246,6 +268,44 @@ type Time_Of_Day
     to_date_time : Date -> Time_Zone -> Date_Time
     to_date_time self date (zone=Time_Zone.system) =
         Time_Utils.make_zoned_date_time date self zone
+
+
+    ## Returns a requested time part as integer.
+    date_part : Time_Period -> Integer
+    date_part self (period : Time_Period) =
+        case period of
+            Time_Period.Day -> self.day
+            Time_Period.Hour -> self.hour
+            Time_Period.Minute -> self.minute
+            Time_Period.Second -> self.second
+            Time_Period.Millisecond -> self.millisecond
+            Time_Period.Microsecond -> self.microsecond
+            Time_Period.Nanosecond -> self.nanosecond
+
+    ## Computes a time difference between the two times of day.
+
+       It returns an integer expressing how many periods fit between the two
+       times of day.
+
+       The difference will be positive if `end` is greater than `self`.
+
+       Arguments:
+       - end: A time of day to compute the difference from.
+       - period: The period to compute the difference in.
+    date_diff : Time_Of_Day -> Time_Period -> Integer
+    date_diff self (end : Time_Of_Day) (period : Time_Period) =
+        java_unit = period.to_java_unit
+        Time_Utils.unit_time_difference java_unit self end
+
+    ## Shifts the time of day by a specified period.
+
+       Arguments:
+       - amount: An integer specifying by how many periods to shift the time.
+       - period: The period by which to shift.
+    date_add : Integer -> Time_Period -> Time_Of_Day
+    date_add self (amount : Integer) (period : Time_Period) =
+        java_unit = period.to_java_unit
+        java_unit.addTo self amount
 
     ## ALIAS Add Duration
        Add the specified amount of time to this instant to get a new instant.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
@@ -301,10 +301,10 @@ type Time_Of_Day
        - period: The period to compute the difference in.
     date_diff : Time_Of_Day -> Time_Period -> Integer
     date_diff self (end : Time_Of_Day) (period : Time_Period) = case period of
-        Time_Period.Day -> Error.throw (Illegal_Argument.Error "The Time_Of_Day does not have a day part to compute a difference in days.")
+        Time_Period.Day ->
+            Error.throw (Illegal_Argument.Error "The Time_Of_Day does not have a day part to compute a difference in days.")
         _ ->
-            java_unit = period.to_java_unit
-            Time_Utils.unit_time_difference java_unit self end
+            Time_Utils.unit_time_difference period.to_java_unit self end
 
     ## Shifts the time of day by a specified period.
 
@@ -313,10 +313,10 @@ type Time_Of_Day
        - period: The period by which to shift.
     date_add : Integer -> Time_Period -> Time_Of_Day
     date_add self (amount : Integer) (period : Time_Period) = case period of
-        Time_Period.Day -> Error.throw (Illegal_Argument.Error "The Time_Of_Day does not have a day part to add days to.")
+        Time_Period.Day ->
+            Error.throw (Illegal_Argument.Error "The Time_Of_Day does not have a day part to add days to.")
         _ ->
-            java_unit = period.to_java_unit
-            java_unit.addTo self amount
+            Time_Utils.unit_time_add period.to_java_unit self amount
 
     ## ALIAS Add Duration
        Add the specified amount of time to this instant to get a new instant.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
@@ -1199,7 +1199,7 @@ type Column
 
        Returns a column of `Integer` type.
     @period Date_Time_Helpers.make_period_selector_for_column
-    date_part : Date_Period | Time_Period -> Column ! Invalid_Value_Type
+    date_part : Date_Period | Time_Period -> Column ! Invalid_Value_Type | Illegal_Argument
     date_part self period =
         Date_Time_Helpers.make_date_part_function self period simple_unary_op self.naming_helpers
 
@@ -1226,7 +1226,7 @@ type Column
          differences in time calculations between backends, especially around
          unusual events like DST.
     @period Date_Time_Helpers.make_period_selector_for_column
-    date_diff : (Column | Date | Date_Time | Time_Of_Day) -> Date_Period | Time_Period -> Column
+    date_diff : (Column | Date | Date_Time | Time_Of_Day) -> Date_Period | Time_Period -> Column ! Invalid_Value_Type | Illegal_Argument
     date_diff self end (period : Date_Period | Time_Period) =
         Value_Type.expect_type self .is_date_or_time "date/time" <|
             my_type = self.inferred_precise_value_type
@@ -1253,7 +1253,7 @@ type Column
          differences in time calculations between backends, especially around
          unusual events like DST.
     @period Date_Time_Helpers.make_period_selector_for_column
-    date_add : (Column | Integer) -> Date_Period | Time_Period -> Column
+    date_add : (Column | Integer) -> Date_Period | Time_Period -> Column ! Invalid_Value_Type | Illegal_Argument
     date_add self amount (period : Date_Period | Time_Period) =
         Value_Type.expect_type self .is_date_or_time "date/time" <|
             my_type = self.inferred_precise_value_type

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -1284,7 +1284,7 @@ type Column
 
        Returns a column of `Integer` type.
     @period Date_Time_Helpers.make_period_selector_for_column
-    date_part : Date_Period | Time_Period -> Column ! Invalid_Value_Type
+    date_part : Date_Period | Time_Period -> Column ! Invalid_Value_Type | Illegal_Argument
     date_part self period =
         Date_Time_Helpers.make_date_part_function self period simple_unary_op Naming_Helpers
 
@@ -1311,7 +1311,7 @@ type Column
          differences in time calculations between backends, especially around
          unusual events like DST.
     @period Date_Time_Helpers.make_period_selector_for_column
-    date_diff : (Column | Date | Date_Time | Time_Of_Day) -> Date_Period | Time_Period -> Column
+    date_diff : (Column | Date | Date_Time | Time_Of_Day) -> Date_Period | Time_Period -> Column ! Invalid_Value_Type | Illegal_Argument
     date_diff self end (period : Date_Period | Time_Period) =
         Value_Type.expect_type self .is_date_or_time "date/time" <|
             my_type = self.inferred_precise_value_type
@@ -1346,7 +1346,7 @@ type Column
          differences in time calculations between backends, especially around
          unusual events like DST.
     @period Date_Time_Helpers.make_period_selector_for_column
-    date_add : (Column | Integer) -> Date_Period | Time_Period -> Column
+    date_add : (Column | Integer) -> Date_Period | Time_Period -> Column ! Invalid_Value_Type | Illegal_Argument
     date_add self amount (period : Date_Period | Time_Period) =
         Value_Type.expect_type self .is_date_or_time "date/time" <|
             my_type = self.inferred_precise_value_type

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -1354,6 +1354,10 @@ type Column
                 Date_Time_Helpers.check_period_aligned_with_value_type my_type period <|
                     new_name = Naming_Helpers.function_name "date_add" [self, amount, period.to_display_text]
                     java_unit = period.to_java_unit
+                    ## Here we do not need a Time_Utils helper like in scalar
+                       implementations of `date_add`, because the date coming
+                       from the column will always be already converted into a
+                       Java instance.
                     fn date amount =
                         java_unit.addTo date amount
                     run_binary_op self amount fn new_name

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoDateTime.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoDateTime.java
@@ -108,10 +108,22 @@ public final class EnsoDateTime implements TruffleObject {
     return dateTime.getSecond();
   }
 
+  @Builtin.Method(description = "Gets the millisecond")
+  @CompilerDirectives.TruffleBoundary
+  public long millisecond() {
+    return dateTime.getNano() / 1000_000;
+  }
+
+  @Builtin.Method(description = "Gets the microsecond")
+  @CompilerDirectives.TruffleBoundary
+  public long microsecond() {
+    return (dateTime.getNano() / 1000) % 1000;
+  }
+
   @Builtin.Method(description = "Gets the nanosecond")
   @CompilerDirectives.TruffleBoundary
   public long nanosecond() {
-    return dateTime.getNano();
+    return dateTime.getNano() % 1000;
   }
 
   @Builtin.Method(name = "zone", description = "Gets the zone")

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoDateTime.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoDateTime.java
@@ -120,10 +120,15 @@ public final class EnsoDateTime implements TruffleObject {
     return (dateTime.getNano() / 1000) % 1000;
   }
 
-  @Builtin.Method(description = "Gets the nanosecond")
+  @Builtin.Method(name = "nanosecond_builtin", description = "Gets the nanosecond")
   @CompilerDirectives.TruffleBoundary
-  public long nanosecond() {
-    return dateTime.getNano() % 1000;
+  public long nanosecond(boolean includeMilliseconds) {
+    long nanos = dateTime.getNano();
+    if (includeMilliseconds) {
+      return nanos;
+    } else {
+      return nanos % 1000;
+    }
   }
 
   @Builtin.Method(name = "zone", description = "Gets the zone")

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoTimeOfDay.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoTimeOfDay.java
@@ -66,9 +66,22 @@ public final class EnsoTimeOfDay implements TruffleObject {
     return localTime.getSecond();
   }
 
-  @Builtin.Method(description = "Gets a value nanosecond")
+  @Builtin.Method(description = "Gets the millisecond")
+  @CompilerDirectives.TruffleBoundary
+  public long millisecond() {
+    return localTime.getNano() / 1000_000;
+  }
+
+  @Builtin.Method(description = "Gets the microsecond")
+  @CompilerDirectives.TruffleBoundary
+  public long microsecond() {
+    return (localTime.getNano() / 1000) % 1000;
+  }
+
+  @Builtin.Method(description = "Gets the nanosecond")
+  @CompilerDirectives.TruffleBoundary
   public long nanosecond() {
-    return localTime.getNano();
+    return localTime.getNano() % 1000;
   }
 
   @Builtin.Method(name = "plus_builtin", description = "Adds a duration to this Time_Of_Day")

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoTimeOfDay.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoTimeOfDay.java
@@ -78,10 +78,15 @@ public final class EnsoTimeOfDay implements TruffleObject {
     return (localTime.getNano() / 1000) % 1000;
   }
 
-  @Builtin.Method(description = "Gets the nanosecond")
+  @Builtin.Method(name = "nanosecond_builtin", description = "Gets the nanosecond")
   @CompilerDirectives.TruffleBoundary
-  public long nanosecond() {
-    return localTime.getNano() % 1000;
+  public long nanosecond(boolean includeMilliseconds) {
+    long nanos = localTime.getNano();
+    if (includeMilliseconds) {
+      return nanos;
+    } else {
+      return nanos % 1000;
+    }
   }
 
   @Builtin.Method(name = "plus_builtin", description = "Adds a duration to this Time_Of_Day")

--- a/std-bits/base/src/main/java/org/enso/base/Time_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/Time_Utils.java
@@ -294,4 +294,25 @@ public class Time_Utils {
   public static long unit_datetime_difference(TemporalUnit unit, ZonedDateTime start, ZonedDateTime end) {
     return unit.between(start, end);
   }
+
+  /**
+   * This wrapper function is needed to ensure that EnsoDateTime gets converted to LocalDate correctly.
+   */
+  public static LocalDate unit_date_add(TemporalUnit unit, LocalDate date, long amount) {
+    return date.plus(amount, unit);
+  }
+
+  /**
+   * This wrapper function is needed to ensure that EnsoDateTime gets converted to LocalTime correctly.
+   */
+  public static LocalTime unit_time_add(TemporalUnit unit, LocalTime time, long amount) {
+    return time.plus(amount, unit);
+  }
+
+  /**
+   * This wrapper function is needed to ensure that EnsoDateTime gets converted to ZonedDateTime correctly.
+   */
+  public static ZonedDateTime unit_datetime_add(TemporalUnit unit, ZonedDateTime datetime, long amount) {
+    return datetime.plus(amount, unit);
+  }
 }

--- a/test/Table_Tests/src/Common_Table_Operations/Date_Time_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Date_Time_Spec.enso
@@ -444,7 +444,6 @@ spec setup =
             dt2 = Date_Time.new 2023 03 27 00 30 00 zone=zone
             x.date_diff dt2 Time_Period.Hour . to_vector . should_equal [23]
 
-            # Date_Period.Day and Time_Period.Day are interchangeable.
             ## The results may vary between backends.
                - In-memory we know this is a DST switch moment and so even if
                  there's 23 hours between the instants, it is a day difference.

--- a/test/Tests/src/Data/Time/Date_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Spec.enso
@@ -543,6 +543,8 @@ spec_with name create_new_date parse_date =
 
             Test.expect_panic_with (d1.date_add 1 Time_Period.Hour) Type_Error
             Test.expect_panic_with (d1.date_add 1 Time_Period.Day) Type_Error
+            Test.expect_panic_with (t1.date_add 1.5 Date_Period.Day) Type_Error
+            Test.expect_panic_with (t1.date_add 1.0 Date_Period.Day) Type_Error
 
     Date_Part_Spec.spec name create_new_date
 

--- a/test/Tests/src/Data/Time/Date_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Spec.enso
@@ -538,13 +538,13 @@ spec_with name create_new_date parse_date =
             d1.date_add 3 Date_Period.Year . should_equal (Date.new 2024 01 31)
             d1.date_add -1 Date_Period.Year . should_equal (Date.new 2020 01 31)
 
-            d1.date_add 1 Date_Period.Week . should_equal Date.new 2021 02 07
-            d1.date_add 2 Date_Period.Quarter . should_equal Date.new 2021 07 31
+            d1.date_add 1 Date_Period.Week . should_equal (Date.new 2021 02 07)
+            d1.date_add 2 Date_Period.Quarter . should_equal (Date.new 2021 07 31)
 
             Test.expect_panic_with (d1.date_add 1 Time_Period.Hour) Type_Error
             Test.expect_panic_with (d1.date_add 1 Time_Period.Day) Type_Error
-            Test.expect_panic_with (t1.date_add 1.5 Date_Period.Day) Type_Error
-            Test.expect_panic_with (t1.date_add 1.0 Date_Period.Day) Type_Error
+            Test.expect_panic_with (d1.date_add 1.5 Date_Period.Day) Type_Error
+            Test.expect_panic_with (d1.date_add 1.0 Date_Period.Day) Type_Error
 
     Date_Part_Spec.spec name create_new_date
 

--- a/test/Tests/src/Data/Time/Date_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Spec.enso
@@ -45,7 +45,7 @@ spec_with name create_new_date parse_date =
         Test.specify "should format local date using provided pattern and locale" <|
             d = create_new_date 2020 6 21
             d.format "d. MMMM yyyy" (Locale.new "gb") . should_equal "21. Jun 2020"
-            d.format "d. MMMM yyyy" (Locale.new "fr") . should_equal "21. juin 2020
+            d.format "d. MMMM yyyy" (Locale.new "fr") . should_equal "21. juin 2020"
 
         Test.specify "should format local date using default pattern" <|
             text = create_new_date 2020 12 21 . to_text

--- a/test/Tests/src/Data/Time/Date_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Spec.enso
@@ -489,6 +489,61 @@ spec_with name create_new_date parse_date =
                     (date.add_work_days -n).work_days_until date . should_equal n
                     (date.add_work_days -n holidays).work_days_until date holidays . should_equal n
 
+        Test.specify "should allow extracting a date_part" <|
+            d1 = create_new_date 2023 12 30
+            d1.date_part Date_Period.Year . should_equal 2023
+            d1.date_part Date_Period.Quarter . should_equal 4
+            d1.date_part Date_Period.Month . should_equal 12
+            d1.date_part Date_Period.Week . should_equal 52
+            d1.date_part Date_Period.Day . should_equal 30
+
+            Test.expect_panic_with (d1.date_part Time_Period.Day) Type_Error
+            
+        Test.specify "should allow computing date_diff" <|
+            d1 = create_new_date 2021 11 3
+            d2 = create_new_date 2021 12 5
+
+            d1.date_diff d2 Date_Period.Day . should_equal 32
+            d2.date_diff d1 Date_Period.Day . should_equal -32
+            d1.date_diff (Date.new 2021 11 3) Date_Period.Day . should_equal 0
+
+            d1.date_diff d2 Date_Period.Month . should_equal 1
+            d1.date_diff (Date.new 2021 12 1) Date_Period.Month . should_equal 0
+            d1.date_diff (Date.new 2020 12 1) Date_Period.Month . should_equal -11
+
+            d1.date_diff d2 Date_Period.Quarter . should_equal 0
+            d1.date_diff (Date.new 2021 5 1) Date_Period.Quarter . should_equal -2
+            d1.date_diff (Date.new 2023 7 1) Date_Period.Quarter . should_equal 6
+
+            d1.date_diff d2 Date_Period.Year . should_equal 0
+            d1.date_diff (Date.new 2021 12 1) Date_Period.Year . should_equal 0
+            d1.date_diff (Date.new 2020 10 1) Date_Period.Year . should_equal -1
+
+            # Ensure months of varying length (e.g. February) are still counted right.
+            d3 = create_new_date 2021 01 02
+            d3.date_diff (Date.new 2021 03 02) Date_Period.Day . should_equal 59
+            d3.date_diff (Date.new 2021 03 02) Date_Period.Month . should_equal 2
+            d3.date_diff (Date.new 2021 03 01) Date_Period.Day . should_equal 58
+            d3.date_diff (Date.new 2021 03 01) Date_Period.Month . should_equal 1
+
+            Test.expect_panic_with (d1.date_diff d2 Time_Period.Day) Type_Error
+            Test.expect_panic_with (d1.date_diff d2 Time_Period.Hour) Type_Error
+
+        Test.specify "should allow shifting with date_add" <|
+            d1 = create_new_date 2021 01 31
+            d1.date_add 5 Date_Period.Day . should_equal (Date.new 2021 02 05)
+            d1.date_add -1 Date_Period.Day . should_equal (Date.new 2021 01 30)
+            d1.date_add 1 Date_Period.Month . should_equal (Date.new 2021 02 28)
+            d1.date_add 2 Date_Period.Month . should_equal (Date.new 2021 03 31)
+            d1.date_add 3 Date_Period.Year . should_equal (Date.new 2024 01 31)
+            d1.date_add -1 Date_Period.Year . should_equal (Date.new 2020 01 31)
+
+            d1.date_add 1 Date_Period.Week . should_equal Date.new 2021 02 07
+            d1.date_add 2 Date_Period.Quarter . should_equal Date.new 2021 07 31
+
+            Test.expect_panic_with (d1.date_add 1 Time_Period.Hour) Type_Error
+            Test.expect_panic_with (d1.date_add 1 Time_Period.Day) Type_Error
+
     Date_Part_Spec.spec name create_new_date
 
 

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -78,7 +78,7 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time = create_new_datetime 1970 12 21 (zone = Time_Zone.utc)
             time.to_json.should_equal <|
                 zone_pairs = [["zone", Time_Zone.utc]]
-                time_pairs = [["year", time.year], ["month", time.month], ["day", time.day], ["hour", time.hour], ["minute", time.minute], ["second", time.second], ["nanosecond", time.nanosecond]]
+                time_pairs = [["year", 1970], ["month", 12], ["day", 21], ["hour", 0], ["minute", 0], ["second", 0], ["nanosecond", 0]]
                 JS_Object.from_pairs ([["type", "Date_Time"], ["constructor", "new"]] + time_pairs + zone_pairs) . to_text
 
         Test.specify "should parse default time format" <|
@@ -122,8 +122,17 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . hour . should_equal 0
             time . minute . should_equal 0
             time . second . should_equal 1
-            if nanoseconds_loss_in_precision then time . nanosecond . should_equal 123000000 else
-                time . nanosecond . should_equal 123456789
+            case nanoseconds_loss_in_precision of
+                True ->
+                    time . nanosecond include_milliseconds=True . should_equal 123000000
+                    time . millisecond . should_equal 123
+                    time . microsecond . should_equal 0
+                    time . nanosecond . should_equal 0
+                False ->
+                    time . nanosecond include_milliseconds=True . should_equal 123456789
+                    time . millisecond . should_equal 123
+                    time . microsecond . should_equal 456
+                    time . nanosecond . should_equal 789
             time . zone . zone_id . should_equal "Z"
 
         Test.specify "should parse time with offset-based zone" <|
@@ -134,6 +143,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . hour . should_equal 0
             time . minute . should_equal 0
             time . second . should_equal 1
+            time . millisecond . should_equal 0
+            time . microsecond . should_equal 0
             time . nanosecond . should_equal 0
             time . zone . zone_id . should_equal (Time_Zone.new 1 . zone_id)
 
@@ -145,6 +156,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . hour . should_equal 0
             time . minute . should_equal 0
             time . second . should_equal 1
+            time . millisecond . should_equal 0
+            time . microsecond . should_equal 0
             time . nanosecond . should_equal 0
             time . zone . zone_id . should_equal "Europe/Paris"
             time.to_display_text . should_equal "1970-01-01 00:00:01 Europe/Paris"
@@ -164,6 +177,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . hour . should_equal 4
             time . minute . should_equal 30
             time . second . should_equal 20
+            time . millisecond . should_equal 0
+            time . microsecond . should_equal 0
             time . nanosecond . should_equal 0
             time . zone . zone_id . should_equal "Etc/UTC"
 
@@ -175,6 +190,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . hour . should_equal 4
             time . minute . should_equal 30
             time . second . should_equal 0
+            time . millisecond . should_equal 0
+            time . microsecond . should_equal 0
             time . nanosecond . should_equal 0
 
         Test.specify "should throw error when parsing custom format" <|
@@ -203,6 +220,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . hour . should_equal 1
             time . minute . should_equal 1
             time . second . should_equal 1
+            time . millisecond . should_equal 0
+            time . microsecond . should_equal 0
             time . nanosecond . should_equal 0
             time . zone . zone_id . should_equal tz.zone_id
             time.to_display_text . should_equal "1970-01-01 01:01:01 +01:01:01"
@@ -216,6 +235,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . hour . should_equal 3
             time . minute . should_equal 0
             time . second . should_equal 0
+            time . millisecond . should_equal 0
+            time . microsecond . should_equal 0
             time . nanosecond . should_equal 0
             time . zone . zone_id . should_equal tz.zone_id
             time.to_display_text . should_equal "1970-01-01 03:00:00 Europe/Moscow"
@@ -233,6 +254,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . hour . should_equal 0
             time . minute . should_equal 0
             time . second . should_equal 1
+            time . millisecond . should_equal 0
+            time . microsecond . should_equal 0
             time . nanosecond . should_equal 0
 
         Test.specify "should get time of day from id-based time" <|
@@ -240,6 +263,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . hour . should_equal 0
             time . minute . should_equal 0
             time . second . should_equal 1
+            time . millisecond . should_equal 0
+            time . microsecond . should_equal 0
             time . nanosecond . should_equal 0
 
         Test.specify "should get date from offsed-based time" <|
@@ -262,6 +287,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . hour . should_equal 0
             time . minute . should_equal 0
             time . second . should_equal 0
+            time . millisecond . should_equal 0
+            time . microsecond . should_equal 0
             time . nanosecond . should_equal 1
             time . zone . should_equal Time_Zone.utc
 
@@ -273,6 +300,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . hour . should_equal 0
             time . minute . should_equal 0
             time . second . should_equal 0
+            time . millisecond . should_equal 0
+            time . microsecond . should_equal 0
             time . nanosecond . should_equal 0
             time . zone . zone_id . should_equal Time_Zone.utc.zone_id
 
@@ -284,6 +313,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . hour . should_equal 3
             time . minute . should_equal 0
             time . second . should_equal 0
+            time . millisecond . should_equal 0
+            time . microsecond . should_equal 0
             time . nanosecond . should_equal 0
             time . zone . zone_id . should_equal Time_Zone.utc.zone_id
 
@@ -295,6 +326,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . hour . should_equal 23
             time . minute . should_equal 0
             time . second . should_equal 0
+            time . millisecond . should_equal 0
+            time . microsecond . should_equal 0
             time . nanosecond . should_equal 0
             time . zone . zone_id . should_equal Time_Zone.utc.zone_id
 
@@ -306,6 +339,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . hour . should_equal 0
             time . minute . should_equal 0
             time . second . should_equal 0
+            time . millisecond . should_equal 0
+            time . microsecond . should_equal 0
             time . nanosecond . should_equal 0
             time . zone . zone_id . should_equal Time_Zone.utc.zone_id
 
@@ -317,6 +352,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . hour . should_equal 21
             time . minute . should_equal 0
             time . second . should_equal 0
+            time . millisecond . should_equal 0
+            time . microsecond . should_equal 0
             time . nanosecond . should_equal 0
             time . zone . zone_id . should_equal Time_Zone.utc.zone_id
 
@@ -328,6 +365,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . hour . should_equal 12
             time . minute . should_equal 0
             time . second . should_equal 0
+            time . millisecond . should_equal 0
+            time . microsecond . should_equal 0
             time . nanosecond . should_equal 0
             time . zone . zone_id . should_equal Time_Zone.utc.zone_id
 
@@ -720,7 +759,7 @@ foreign js js_local_datetime_impl year month day hour minute second nanosecond =
 
 js_parse text format="" =
     d = Date_Time.parse text format
-    js_datetime d.year d.month d.day d.hour d.minute d.second d.nanosecond d.zone
+    js_datetime d.year d.month d.day d.hour d.minute d.second (d.nanosecond include_milliseconds=True) d.zone
 
 js_array_datetime year month=1 day=1 hour=0 minute=0 second=0 nanosecond=0 zone=Time_Zone.system =
     arr = Panic.catch Any (js_array_datetimeCreate year month day hour minute second nanosecond) (err -> Error.throw (Time_Error.Error err.payload))

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -622,7 +622,9 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             d4_end.hour . should_equal 2
             d4_end.minute . should_equal 59
             d4_end.second . should_equal 59
-            d4_end.nanosecond . should_equal max_nanos
+            d4_end.millisecond . should_equal 999
+            d4_end.microsecond . should_equal 999
+            d4_end.nanosecond . should_equal 999
             Time_Utils.get_datetime_offset d4_end . should_equal offset_1_h
 
         Test.specify "should allow to shift the date by N working days" <|

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -68,7 +68,7 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
         Test.specify "should format using provided pattern and locale" <|
             d = create_new_datetime 2020 6 21
             d.format "d. MMMM yyyy" (Locale.new "gb") . should_equal "21. Jun 2020"
-            d.format "d. MMMM yyyy" (Locale.new "fr") . should_equal "21. juin 2020
+            d.format "d. MMMM yyyy" (Locale.new "fr") . should_equal "21. juin 2020"
 
         Test.specify "should format using default pattern" <|
             text = create_new_datetime 1970 (zone = Time_Zone.utc) . to_text

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -752,6 +752,59 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
                 d1.date_part Time_Period.Microsecond . should_equal 456
                 d1.date_part Time_Period.Nanosecond . should_equal 789
 
+        Test.specify "should allow computing date_diff" <|
+            t1 = create_new_datetime 2021 11 3 10 15 0
+            t2 = create_new_datetime 2021 12 5 12 30 20
+
+            t1.date_diff t2 Date_Period.Day . should_equal 32
+            t2.date_diff t1 Date_Period.Day . should_equal -32
+            t1.date_diff (Date_Time.new 2021 11 3 10 15 0) Date_Period.Day . should_equal 0
+
+            t1.date_diff t2 Date_Period.Month . should_equal 1
+            t1.date_diff (Date_Time.new 2021 12 1 10 15 0) Date_Period.Month . should_equal 0
+
+            t1.date_diff t2 Date_Period.Year . should_equal 0
+            t1.date_diff (Date_Time.new 2031 12 1 10 15 0) Date_Period.Year . should_equal 10
+
+            t1.date_diff t2 Time_Period.Day . should_equal 32
+
+            t1.date_diff t2 Time_Period.Hour . should_equal 770
+            t1.date_diff (Date_Time.new 2021 11 3 12 15 0) Time_Period.Hour . should_equal 2
+
+            t1.date_diff t2 Time_Period.Minute . should_equal 46215
+            t1.date_diff (Date_Time.new 2021 11 3 10 45 0) Time_Period.Minute . should_equal 30
+
+            t1.date_diff t2 Time_Period.Second . should_equal 2772920
+            t1.date_diff (Date_Time.new 2021 11 3 10 15 30) Time_Period.Second . should_equal 30
+
+            t1.date_diff t2 Time_Period.Millisecond . should_equal 2772920000
+            t1.date_diff (Date_Time.new 2021 11 3 10 15 30 123) Time_Period.Millisecond . should_equal 30123
+
+            if nanoseconds_loss_in_precision.not then
+                t1.date_diff t2 Time_Period.Microsecond . should_equal 2772920000000
+                t1.date_diff (Date_Time.new 2021 11 3 10 15 30 123 456) Time_Period.Microsecond . should_equal 30123456
+                t1.date_diff t2 Time_Period.Nanosecond . should_equal 2772920000000000
+                t1.date_diff (Date_Time.new 2021 11 3 10 15 30 123 456 789) Time_Period.Nanosecond . should_equal 30123456789
+
+        Test.specify "should allow shifting with date_add" <|
+            t1 = Date_Time.new 2021 01 01 12 30 0
+            t1.date_add 5 Date_Period.Day . should_equal (Date_Time.new 2021 01 06 12 30 0)
+            t1.date_add -1 Time_Period.Day . should_equal (Date_Time.new 2020 12 31 12 30 0)
+            t1.date_add 1 Date_Period.Month . should_equal (Date_Time.new 2021 02 01 12 30 0)
+            t1.date_add 10 Date_Period.Year . should_equal (Date_Time.new 2031 01 01 12 30 0)
+
+            t1.date_add 24 Time_Period.Hour . should_equal (Date_Time.new 2021 01 02 12 30 0)
+            t1.date_add -1 Time_Period.Hour . should_equal (Date_Time.new 2021 01 01 11 30 0)
+            t1.date_add 23 Time_Period.Minute . should_equal (Date_Time.new 2021 01 01 12 53 0)
+            t1.date_add -15 Time_Period.Second . should_equal (Date_Time.new 2021 01 01 12 29 45)
+            t1.date_add 1 Time_Period.Millisecond . should_equal (Date_Time.new 2021 01 01 12 30 0 1)
+            if nanoseconds_loss_in_precision.not then
+                t1.date_add 1 Time_Period.Microsecond . should_equal (Date_Time.new 2021 01 01 12 30 0 microsecond=1)
+                t1.date_add 1 Time_Period.Nanosecond . should_equal (Date_Time.new 2021 01 01 12 30 0 nanosecond=1)
+
+            Test.expect_panic_with (t1.date_add 1.5 Date_Period.Day) Type_Error
+            Test.expect_panic_with (t1.date_add 1.0 Date_Period.Day) Type_Error
+
         Test.specify "date_diff and date_add should behave well around DST" <|
             zone = Time_Zone.parse "Europe/Warsaw"
             dt1 = Date_Time.new 2023 03 26 00 30 00 zone=zone
@@ -774,9 +827,9 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             dt3 = Date_Time.new 2023 03 28 01 30 00 zone=zone
             dt4 = Date_Time.new 2023 03 29 00 30 00 zone=zone
 
-            dt3.date_diff dt4 Date_Period.Day . to_vector . should_equal [0]
-            dt3.date_diff dt4 Time_Period.Day . to_vector . should_equal [0]
-            dt3.date_diff dt4 Time_Period.Hour . to_vector . should_equal [23]
+            dt3.date_diff dt4 Date_Period.Day . should_equal 0
+            dt3.date_diff dt4 Time_Period.Day . should_equal 0
+            dt3.date_diff dt4 Time_Period.Hour . should_equal 23
 
     Date_Part_Spec.spec name create_new_datetime
 

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -736,6 +736,48 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             create_new_datetime 1999 10 30 14 40 . add_work_days 0 (duplicated_holiday_november 1999) . should_equal (Date_Time.new 1999 11 3 14 40)
             create_new_datetime 1999 10 30 15 50 . add_work_days 1 (duplicated_holiday_november 1999) . should_equal (Date_Time.new 1999 11 4 15 50)
 
+        Test.specify "should allow extracting a date_part" <|
+            d1 = create_new_datetime 2023 12 30 15 37 58 123456789
+            d1.date_part Date_Period.Year . should_equal 2023
+            d1.date_part Date_Period.Quarter . should_equal 4
+            d1.date_part Date_Period.Month . should_equal 12
+            d1.date_part Date_Period.Week . should_equal 52
+            d1.date_part Date_Period.Day . should_equal 30
+            d1.date_part Time_Period.Day . should_equal 30
+            d1.date_part Time_Period.Hour . should_equal 15
+            d1.date_part Time_Period.Minute . should_equal 37
+            d1.date_part Time_Period.Second . should_equal 58
+            d1.date_part Time_Period.Millisecond . should_equal 123
+            if nanoseconds_loss_in_precision.not then
+                d1.date_part Time_Period.Microsecond . should_equal 456
+                d1.date_part Time_Period.Nanosecond . should_equal 789
+
+        Test.specify "date_diff and date_add should behave well around DST" <|
+            zone = Time_Zone.parse "Europe/Warsaw"
+            dt1 = Date_Time.new 2023 03 26 00 30 00 zone=zone
+
+            # +24h will shift 1 day and 1 hour, because they 26th of March has only 23 hours within it
+            dt1.date_add 24 Time_Period.Hour . should_equal (Date_Time.new 2023 03 27 01 30 00 zone=zone)
+
+            # But 1 day date shift will shift 1 day, keeping the time, even if that particular day is only 23 hours.
+            dt1.date_add 1 Date_Period.Day . should_equal (Date_Time.new 2023 03 27 00 30 00 zone=zone)
+            # Time_Period.Day will shift by 24 hours.
+            dt1.date_add 1 Time_Period.Day . should_equal (Date_Time.new 2023 03 27 01 30 00 zone=zone)
+
+            dt2 = Date_Time.new 2023 03 27 00 30 00 zone=zone
+            dt1.date_diff dt2 Time_Period.Hour . should_equal 23
+
+            dt1.date_diff dt2 Date_Period.Day . should_equal 1
+            # But when counting in hours - 23 hours is not a full 24-hour day.
+            dt1.date_diff dt2 Time_Period.Day . should_equal 0
+
+            dt3 = Date_Time.new 2023 03 28 01 30 00 zone=zone
+            dt4 = Date_Time.new 2023 03 29 00 30 00 zone=zone
+
+            dt3.date_diff dt4 Date_Period.Day . to_vector . should_equal [0]
+            dt3.date_diff dt4 Time_Period.Day . to_vector . should_equal [0]
+            dt3.date_diff dt4 Time_Period.Hour . to_vector . should_equal [23]
+
     Date_Part_Spec.spec name create_new_datetime
 
 js_datetime year month=1 day=1 hour=0 minute=0 second=0 nanosecond=0 zone=Time_Zone.system =

--- a/test/Tests/src/Data/Time/Time_Of_Day_Spec.enso
+++ b/test/Tests/src/Data/Time/Time_Of_Day_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Errors.Common.Incomparable_Values
 import Standard.Base.Errors.Common.Type_Error
+import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Errors.Time_Error.Time_Error
 
 from Standard.Test import Test, Test_Suite
@@ -204,6 +205,66 @@ specWith name create_new_time parse_time nanoseconds_loss_in_precision=False =
             d3.start_of Time_Period.Second . should_equal (Time_Of_Day.new 23 59 59 0)
             d3.end_of Time_Period.Second . should_equal (Time_Of_Day.new 23 59 59 nanosecond=max_nanos)
 
+        Test.specify "should allow extracting a date_part" <|
+            d1 = create_new_time 15 37 58 123456789
+            d1.date_part Time_Period.Hour . should_equal 15
+            d1.date_part Time_Period.Minute . should_equal 37
+            d1.date_part Time_Period.Second . should_equal 58
+            d1.date_part Time_Period.Millisecond . should_equal 123
+            if nanoseconds_loss_in_precision.not then
+                d1.date_part Time_Period.Microsecond . should_equal 456
+                d1.date_part Time_Period.Nanosecond . should_equal 789
+
+            d1.date_part Time_Period.Day . should_fail_with Illegal_Argument
+            Test.expect_panic_with (d1.date_part Date_Period.Day) Type_Error
+
+        Test.specify "should allow computing a date_diff" <|
+            t1 = create_new_time 10 15 0
+            t2 = create_new_time 12 30 20
+
+            # There is no default period:
+            t1.date_diff t2 . should_be_a Function
+            Test.expect_panic_with (t1.date_diff t2 Date_Period.Month) Type_Error
+            t1.date_diff t2 Time_Period.Day . should_fail_with Illegal_Argument
+
+            t1.date_diff t2 Time_Period.Hour . should_equal 2
+            t1.date_diff (Time_Of_Day.new 9 15 0) Time_Period.Hour . should_equal -1
+
+            t1.date_diff t2 Time_Period.Minute . should_equal 135
+            t1.date_diff (Time_Of_Day.new 10 04 0) Time_Period.Minute . should_equal -11
+
+            t1.date_diff t2 Time_Period.Second . should_equal 8120
+            t1.date_diff (Time_Of_Day.new 10 15 12) Time_Period.Second . should_equal 12
+
+            t1.date_diff t2 Time_Period.Millisecond . should_equal 8120*1000
+            t1.date_diff (Time_Of_Day.new 10 15 12 34) Time_Period.Millisecond . should_equal 12034
+
+            if nanoseconds_loss_in_precision.not then
+                t1.date_diff t2 Time_Period.Microsecond . should_equal 8120*1000*1000
+                t1.date_diff (Time_Of_Day.new 10 15 12 34 56) Time_Period.Microsecond . should_equal 12034056
+                t1.date_diff t2 Time_Period.Nanosecond . should_equal 8120*1000*1000*1000
+                t1.date_diff (Time_Of_Day.new 10 15 12 34 56 78) Time_Period.Nanosecond . should_equal 12034056078
+
+        Test.specify "should allow shifting with date_add" <|
+            t1 = create_new_time 23 45 0
+
+            t1.date_add -1 Time_Period.Hour . should_equal (Time_Of_Day.new 22 45 0)
+            t1.date_add 1 Time_Period.Hour . should_equal (Time_Of_Day.new 0 45 0)
+            t1.date_add -1 Time_Period.Minute . should_equal (Time_Of_Day.new 23 44 0)
+            t1.date_add 15 Time_Period.Minute . should_equal (Time_Of_Day.new 0 0 0)
+            t1.date_add -1 Time_Period.Second . should_equal (Time_Of_Day.new 23 44 59)
+            t1.date_add 5 Time_Period.Second . should_equal (Time_Of_Day.new 23 45 05)
+            t1.date_add 1 Time_Period.Millisecond . should_equal (Time_Of_Day.new 23 45 0 1)
+            if nanoseconds_loss_in_precision.not then
+                t1.date_add 123456 Time_Period.Microsecond . should_equal (Time_Of_Day.new 23 45 00 123 456)
+                t1.date_add -2 Time_Period.Nanosecond . should_equal (Time_Of_Day.new 23 44 59 999 999 998)
+
+            # No sense to shift Time_Of_Day by days
+            t1.date_add 1 Time_Period.Day . should_fail_with Illegal_Argument
+            Test.expect_panic_with (t1.date_add 1 Date_Period.Month) Type_Error
+
+            # There is no default period.
+            t1.date_add 10 . should_be_a Function
 
 enso_time hour minute=0 second=0 nanoOfSecond=0 =
     Time_Of_Day.new hour minute second nanosecond=nanoOfSecond

--- a/test/Tests/src/Data/Time/Time_Of_Day_Spec.enso
+++ b/test/Tests/src/Data/Time/Time_Of_Day_Spec.enso
@@ -48,7 +48,7 @@ specWith name create_new_time parse_time nanoseconds_loss_in_precision=False =
         Test.specify "should convert to Json" <|
             time = create_new_time 1 2 3
             time.to_json.should_equal <|
-                time_pairs = [["hour", time.hour], ["minute", time.minute], ["second", time.second], ["nanosecond", time.nanosecond]]
+                time_pairs = [["hour", 1], ["minute", 2], ["second", 3], ["nanosecond", 0]]
                 JS_Object.from_pairs ([["type", "Time_Of_Day"], ["constructor", "new"]] + time_pairs) . to_text
 
         Test.specify "should parse default time format" <|
@@ -87,6 +87,8 @@ specWith name create_new_time parse_time nanoseconds_loss_in_precision=False =
             datetime . hour . should_equal 1
             datetime . minute . should_equal 0
             datetime . second . should_equal 0
+            datetime . millisecond . should_equal 0
+            datetime . microsecond . should_equal 0
             datetime . nanosecond . should_equal 0
             datetime . zone . zone_id . should_equal Time_Zone.utc.zone_id
 

--- a/test/Tests/src/Data/Time/Time_Of_Day_Spec.enso
+++ b/test/Tests/src/Data/Time/Time_Of_Day_Spec.enso
@@ -266,6 +266,9 @@ specWith name create_new_time parse_time nanoseconds_loss_in_precision=False =
             # There is no default period.
             t1.date_add 10 . should_be_a Function
 
+            Test.expect_panic_with (t1.date_add 1.5 Time_Period.Hour) Type_Error
+            Test.expect_panic_with (t1.date_add 1.0 Time_Period.Hour) Type_Error
+
 enso_time hour minute=0 second=0 nanoOfSecond=0 =
     Time_Of_Day.new hour minute second nanosecond=nanoOfSecond
 


### PR DESCRIPTION
### Pull Request Description

Followup of #7221, adding `date_diff`, `date_add` and `date_part` to scalar Enso date-time values.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
