### PR TITLE
No need to depend on EnsoContext when working with PackageRepository

### DIFF
--- a/engine/runtime/src/main/java/org/enso/compiler/PackageRepositoryUtils.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/PackageRepositoryUtils.java
@@ -1,0 +1,45 @@
+package org.enso.compiler;
+
+import com.oracle.truffle.api.TruffleFile;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+import org.enso.interpreter.util.ScalaConversions;
+import org.enso.pkg.Package;
+import org.enso.pkg.QualifiedName;
+
+public final class PackageRepositoryUtils {
+  private PackageRepositoryUtils() {}
+
+  /**
+   * Fetches the module name associated with a given file, using the environment packages
+   * information.
+   *
+   * @param packageRepository repository to work on
+   * @param file the path to decode.
+   * @return a qualified name of the module corresponding to the file, if exists.
+   */
+  public static Optional<QualifiedName> getModuleNameForFile(
+      PackageRepository packageRepository, TruffleFile file) {
+    return ScalaConversions.asJava(packageRepository.getLoadedPackages()).stream()
+        .filter(pkg -> file.startsWith(pkg.sourceDir()))
+        .map(pkg -> pkg.moduleNameForFile(file))
+        .findFirst();
+  }
+
+  /**
+   * Finds the package the provided module belongs to.
+   *
+   * @param packageRepository repository to work on
+   * @param file the module to find the package of
+   * @return {@code module}'s package, if exists
+   */
+  public static Optional<Package<TruffleFile>> getPackageOf(
+      PackageRepository packageRepository, TruffleFile file) {
+    if (file == null) {
+      return Optional.empty();
+    }
+    return StreamSupport.stream(packageRepository.getLoadedPackagesJava().spliterator(), true)
+        .filter(pkg -> file.getAbsoluteFile().startsWith(pkg.root().getAbsoluteFile()))
+        .findFirst();
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -22,9 +22,9 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.StreamSupport;
 import org.enso.compiler.Compiler;
 import org.enso.compiler.PackageRepository;
+import org.enso.compiler.PackageRepositoryUtils;
 import org.enso.compiler.data.CompilerConfig;
 import org.enso.distribution.DistributionManager;
 import org.enso.distribution.locking.LockManager;
@@ -38,7 +38,6 @@ import org.enso.interpreter.runtime.scope.TopLevelScope;
 import org.enso.interpreter.runtime.state.ExecutionEnvironment;
 import org.enso.interpreter.runtime.state.State;
 import org.enso.interpreter.runtime.util.TruffleFileSystem;
-import org.enso.interpreter.util.ScalaConversions;
 import org.enso.librarymanager.ProjectLoadingFailure;
 import org.enso.pkg.Package;
 import org.enso.pkg.PackageManager;
@@ -289,10 +288,7 @@ public class EnsoContext {
    * @return a qualified name of the module corresponding to the file, if exists.
    */
   public Optional<QualifiedName> getModuleNameForFile(TruffleFile file) {
-    return ScalaConversions.asJava(packageRepository.getLoadedPackages()).stream()
-        .filter(pkg -> file.startsWith(pkg.sourceDir()))
-        .map(pkg -> pkg.moduleNameForFile(file))
-        .findFirst();
+    return PackageRepositoryUtils.getModuleNameForFile(packageRepository, file);
   }
 
   /**
@@ -384,12 +380,7 @@ public class EnsoContext {
    * @return {@code module}'s package, if exists
    */
   public Optional<Package<TruffleFile>> getPackageOf(TruffleFile file) {
-    if (file == null) {
-      return Optional.empty();
-    }
-    return StreamSupport.stream(packageRepository.getLoadedPackagesJava().spliterator(), true)
-        .filter(pkg -> file.getAbsoluteFile().startsWith(pkg.root().getAbsoluteFile()))
-        .findFirst();
+    return PackageRepositoryUtils.getPackageOf(packageRepository, file);
   }
 
   /**

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -436,7 +436,9 @@ class Compiler(
 
   private def isModuleInRootPackage(module: Module): Boolean = {
     if (!module.isInteractive) {
-      val pkg = PackageRepositoryUtils.getPackageOf(context.getPackageRepository, module.getSourceFile).toScala
+      val pkg = PackageRepositoryUtils
+        .getPackageOf(context.getPackageRepository, module.getSourceFile)
+        .toScala
       pkg.contains(context.getPackageRepository.getMainProjectPackage.get)
     } else false
   }

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -436,7 +436,7 @@ class Compiler(
 
   private def isModuleInRootPackage(module: Module): Boolean = {
     if (!module.isInteractive) {
-      val pkg = context.getPackageOf(module.getSourceFile).toScala
+      val pkg = PackageRepositoryUtils.getPackageOf(context.getPackageRepository, module.getSourceFile).toScala
       pkg.contains(context.getPackageRepository.getMainProjectPackage.get)
     } else false
   }


### PR DESCRIPTION
### Pull Request Description

On a quest to avoid dependencies on `EnsoContext` from `Compiler`. Step one. The ultimate goal is to move `Compiler` and all its `IRPasses` into a dedicated `runtime/compiler` module that could be used from #7054.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      Scala and [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests continue to pass
