### PR TITLE
Improve error message on `Filter_Condition` missing arguments in `Table.filter`

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Filter_Condition.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Filter_Condition.enso
@@ -276,20 +276,20 @@ unify_condition_or_predicate : Filter_Condition | (Any -> Boolean) -> (Any -> Bo
 unify_condition_or_predicate (condition_or_predicate : Filter_Condition | Function) =
     case condition_or_predicate of
         condition : Filter_Condition -> condition.to_predicate
-        predicate -> handle_constructor_missing_arguments predicate
+        predicate -> handle_constructor_missing_arguments predicate predicate
 
 ## PRIVATE
 unify_condition_predicate_or_element condition =
     case condition of
         condition : Filter_Condition -> condition.to_predicate
-        predicate : Function -> handle_constructor_missing_arguments predicate
+        predicate : Function -> handle_constructor_missing_arguments predicate predicate
         element -> (== element)
 
 ## PRIVATE
    Checks if the given `function` is actually a `Filter_Condition` constructor
    that is just missing arguments. If so, it will report a more friendly error.
-   Otherwise it will just return the `function` as is.
-handle_constructor_missing_arguments function =
+   Otherwise it will run the `continuation`.
+handle_constructor_missing_arguments function ~continuation =
     is_filter_condition_constructor = case Meta.meta function of
         constructor : Meta.Constructor ->
             constructor.declaring_type == Meta.meta Filter_Condition
@@ -302,6 +302,6 @@ handle_constructor_missing_arguments function =
             text = function.to_text
             text.starts_with "Filter_Condition." && text.contains "[Filter_Condition.enso:"
         _ -> False
-    if is_filter_condition_constructor.not then function else
+    if is_filter_condition_constructor.not then continuation else
         message = "Got a Filter_Condition constructor without all required arguments provided. Please provide the missing arguments."
         Error.throw (Illegal_Argument.Error message)

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -452,7 +452,7 @@ type Table
              people.filter "age" (age -> (age%10 == 0))
     @column Widget_Helpers.make_column_name_selector
     filter : (Column | Text | Integer) -> (Filter_Condition|(Any->Boolean)) -> Problem_Behavior -> Table ! No_Such_Column | Index_Out_Of_Bounds | Invalid_Value_Type
-    filter self column filter=(Filter_Condition.Equal True) on_problems=Report_Warning = case column of
+    filter self column (filter : Filter_Condition | Function = Filter_Condition.Equal True) on_problems=Report_Warning = case column of
        _ : Column ->
            mask filter_column = case Helpers.check_integrity self filter_column of
                False ->

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Data.Array_Proxy.Array_Proxy
+import Standard.Base.Data.Filter_Condition as Filter_Condition_Module
 import Standard.Base.Errors.Common.Incomparable_Values
 import Standard.Base.Errors.Common.Index_Out_Of_Bounds
 import Standard.Base.Errors.Common.Type_Error
@@ -463,7 +464,11 @@ type Table
                    self.updated_context new_ctx
            case filter of
                _ : Filter_Condition -> mask (make_filter_column column filter on_problems)
-               _ : Function -> Error.throw (Unsupported_Database_Operation.Error "Filtering with a custom predicate is not supported in the database.")
+               ## We check the `filter` predicate before reporting unsupported
+                  operation, because it may just be a Filter_Condition with
+                  missing arguments and then another error is more appropriate.
+               _ : Function -> Filter_Condition_Module.handle_constructor_missing_arguments filter <|
+                   Error.throw (Unsupported_Database_Operation.Error "Filtering with a custom predicate is not supported in the database.")
        _ ->
            table_at = self.at column
            self.filter table_at filter on_problems

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Data.Array_Proxy.Array_Proxy
+import Standard.Base.Data.Filter_Condition as Filter_Condition_Module
 import Standard.Base.Data.Index_Sub_Range as Index_Sub_Range_Module
 import Standard.Base.Errors.Common.Incomparable_Values
 import Standard.Base.Errors.Common.Index_Out_Of_Bounds
@@ -1080,7 +1081,8 @@ type Table
             mask filter_column = Table.Value (self.java_table.mask filter_column.java_column)
             case filter of
                 _ : Filter_Condition -> mask (make_filter_column column filter on_problems)
-                _ : Function -> mask (column.map filter)
+                _ : Function -> Filter_Condition_Module.handle_constructor_missing_arguments filter <|
+                    mask (column.map filter)
         _ ->
             table_at = self.at column
             self.filter table_at filter on_problems

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1075,7 +1075,7 @@ type Table
              people.filter "age" (age -> (age%10 == 0))
     @column Widget_Helpers.make_column_name_selector
     filter : (Column | Text | Integer) -> (Filter_Condition|(Any->Boolean)) -> Problem_Behavior -> Table ! No_Such_Column | Index_Out_Of_Bounds | Invalid_Value_Type
-    filter self column filter=(Filter_Condition.Equal True) on_problems=Report_Warning = case column of
+    filter self column (filter : Filter_Condition | Function = Filter_Condition.Equal True) on_problems=Report_Warning = case column of
         _ : Column ->
             mask filter_column = Table.Value (self.java_table.mask filter_column.java_column)
             case filter of

--- a/test/Table_Tests/src/Common_Table_Operations/Filter_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Filter_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Errors.Common.Arithmetic_Error
 import Standard.Base.Errors.Common.Index_Out_Of_Bounds
+import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Errors.Illegal_State.Illegal_State
 
@@ -282,6 +283,17 @@ spec setup =
             t = table_builder [["X", [10, 20, 13, 4, 5]]]
             t.filter 4 . should_fail_with Index_Out_Of_Bounds
             t.filter 4 . catch . should_equal (Index_Out_Of_Bounds.Error 4 1)
+
+        Test.specify "should handle illegal arguments" <|
+            t = table_builder [["X", [10, 20, 13, 4, 5]]]
+            Test.expect_panic_with (t.filter "X" "NOT A CONDITION") Type_Error
+
+        Test.specify "should nicely handle Filter_Condition with unapplied arguments" <|
+            t = table_builder [["X", [10, 20, 13, 4, 5]]]
+            t.filter "X" (Filter_Condition.Equal) . should_fail_with Illegal_Argument
+            t.filter "X" (Filter_Condition.Starts_With) . should_fail_with Illegal_Argument
+            t.filter "X" (Filter_Condition.Between) . should_fail_with Illegal_Argument
+            t.filter "X" (Filter_Condition.Between 1) . should_fail_with Illegal_Argument
 
         Test.specify "should report issues: floating point equality" <|
             t = table_builder [["ix", [1, 2, 3, 4, 5]], ["X", [10.0, 2.0001, 2.0, 4.5, 2.0]]]


### PR DESCRIPTION
### Pull Request Description

In #7148 I improved the error message when a `Filter_Condition` constructor without arguments is provided to `Vector.filter` and its friends. This PR applies the same check to the `Table.filter`.

This is useful, because when we select a Filter_Condition from a widget, initially it does not have all its arguments applied. This used to lead to confusing errors being reported to the user, now, a much clearer error is shown:

![image](https://github.com/enso-org/enso/assets/1436948/19140a7b-d6fc-4292-81d3-dc6d61135cb9)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
