### PR TITLE
Type checks inconsistent when dealing with a -> b function types

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -660,6 +660,8 @@ class IrToTruffle(
     def extractAscribedType(t: IR.Expression): List[Type] = t match {
       case u: IR.Type.Set.Union     => u.operands.flatMap(extractAscribedType)
       case p: IR.Application.Prefix => extractAscribedType(p.function)
+      case _: IR.Type.Function =>
+        List(context.getTopScope().getBuiltins().function())
       case t => {
         t.getMetadata(TypeNames) match {
           case Some(

--- a/test/Tests/src/Main.enso
+++ b/test/Tests/src/Main.enso
@@ -64,6 +64,7 @@ import project.Network.Http.Request_Spec as Http_Request_Spec
 import project.Network.Http_Spec
 import project.Network.URI_Spec
 
+import project.Runtime.Ascribed_Parameters_Spec
 import project.Runtime.Lazy_Spec
 import project.Runtime.Lazy_Generator_Spec
 import project.Runtime.Managed_Resource_Spec
@@ -129,6 +130,7 @@ main = Test_Suite.run_main <|
     Range_Spec.spec
     Ref_Spec.spec
     Regex_Spec.spec
+    Ascribed_Parameters_Spec.spec
     Lazy_Spec.spec
     Runtime_Spec.spec
     Self_Type_Spec.spec

--- a/test/Tests/src/Runtime/Ascribed_Parameters_Spec.enso
+++ b/test/Tests/src/Runtime/Ascribed_Parameters_Spec.enso
@@ -6,19 +6,19 @@ import Standard.Test.Extensions
 import Standard.Base.Errors.Common.Type_Error
 
 spec = Test.group "Function Ascribed Parameters" <|
-    t1 (f : Function) =
-        f "x"
+    t1 (f1 : Function) =
+        f1 "x"
 
-    t2 (f : (Text -> Any)) =
-        f "x"
+    t2 (f2 : (Text -> Any)) =
+        f2 "x"
 
-    t3 (f : (Integer | Function)) = case f of
+    t3 (f3 : (Integer | Function)) = case f3 of
         n : Integer -> n*7
-        _ -> f "x"
+        _ -> f3 "x"
 
-    t4 (f : (Integer | (Text -> Any))) = case f of
+    t4 (f4 : (Integer | (Text -> Any))) = case f4 of
         n : Integer -> n*7
-        _ -> f "x"
+        _ -> f4 "x"
 
     surround x = "|" + x + "|"
 
@@ -37,10 +37,10 @@ spec = Test.group "Function Ascribed Parameters" <|
         (t4 surround) . should_equal "|x|"
 
     Test.specify "t1 with 42 type check" <|
-        (t1 6) . should_equal "|x|"
+        with_type_error (t1 6) . should_fail_with Type_Error
 
     Test.specify "t2 with 42 type check" <|
-        (t2 6) . should_equal "|x|"
+        with_type_error (t2 6) . should_fail_with Type_Error
 
     Test.specify "t3 with 42 type check" <|
         (t3 6) . should_equal 42

--- a/test/Tests/src/Runtime/Ascribed_Parameters_Spec.enso
+++ b/test/Tests/src/Runtime/Ascribed_Parameters_Spec.enso
@@ -1,0 +1,64 @@
+from Standard.Base import all
+
+from Standard.Test import Test, Test_Suite
+import Standard.Test.Extensions
+
+import Standard.Base.Errors.Common.Type_Error
+
+spec = Test.group "Function Ascribed Parameters" <|
+    t1 (f : Function) =
+        f "x"
+
+    t2 (f : (Text -> Any)) =
+        f "x"
+
+    t3 (f : (Integer | Function)) = case f of
+        n : Integer -> n*7
+        _ -> f "x"
+
+    t4 (f : (Integer | (Text -> Any))) = case f of
+        n : Integer -> n*7
+        _ -> f "x"
+
+    surround x = "|" + x + "|"
+
+    with_type_error ~action = Panic.catch Type_Error action panic->panic.convert_to_dataflow_error
+
+    Test.specify "t1 with surround type check" <|
+        (t1 surround) . should_equal "|x|"
+
+    Test.specify "t2 with surround type check" <|
+        (t2 surround) . should_equal "|x|"
+
+    Test.specify "t3 with surround type check" <|
+        (t3 surround) . should_equal "|x|"
+
+    Test.specify "t4 with surround type check" <|
+        (t4 surround) . should_equal "|x|"
+
+    Test.specify "t1 with 42 type check" <|
+        (t1 6) . should_equal "|x|"
+
+    Test.specify "t2 with 42 type check" <|
+        (t2 6) . should_equal "|x|"
+
+    Test.specify "t3 with 42 type check" <|
+        (t3 6) . should_equal 42
+
+    Test.specify "t4 with 42 type check" <|
+        (t4 6) . should_equal 42
+
+    Test.specify "t1 with text type check" <|
+        with_type_error (t1 "hi") . should_fail_with Type_Error
+
+    Test.specify "t2 with text type check" <|
+        with_type_error (t2 "hi") . should_fail_with Type_Error
+
+    Test.specify "t3 with text type check" <|
+        with_type_error (t3 "hi") . should_fail_with Type_Error
+
+    Test.specify "t4 with text type check" <|
+        with_type_error (t4 "hi") . should_fail_with Type_Error
+
+
+main = Test_Suite.run_main spec


### PR DESCRIPTION
### Pull Request Description

Test to check faulty behavior described in #7289 and a fix.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
