### PR TITLE
Set background throttling to false by default

### DIFF
--- a/app/ide-desktop/lib/client/src/config.ts
+++ b/app/ide-desktop/lib/client/src/config.ts
@@ -154,7 +154,7 @@ export const CONFIG = contentConfig.OPTIONS.merge(
                 options: {
                     backgroundThrottling: new contentConfig.Option({
                         passToWebApplication: true,
-                        value: true,
+                        value: false,
                         description: 'Throttle animations when run in background.',
                     }),
 


### PR DESCRIPTION
### Pull Request Description


This PR [fixes](https://github.com/enso-org/enso/issues/7216) and sets the background throttling electron setting to `false` by default (see electron [documentation](https://www.electronjs.org/docs/latest/api/browser-window) for more details).

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
