### PR TITLE
Bench builder API

### DIFF
--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Bench.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Bench.enso
@@ -1,7 +1,68 @@
 from Standard.Base import all
 import Standard.Base.Runtime.Ref.Ref
 
+
+type Bench_Options
+    ## PRIVATE
+    Impl iter_size num_iters
+
+    size : Integer -> Bench_Options
+    size self v = Bench_Options.Impl v self.num_iters
+
+    iter : Integer -> Bench_Options
+    iter self v = Bench_Options.Impl self.iter_size v
+
+    to_text self = "[iter_size=" + self.iter_size.to_text + ", num_iters=" + self.num_iters.to_text + "]"
+
+type Bench_Builder
+    ## PRIVATE
+    Impl builder
+
+    group : Text -> Bench_Options -> (Group_Builder -> Any) -> Any
+    group self (name:Text) (configuration:Bench_Options) fn =
+        b = Vector.new_builder
+        fn (Group_Builder.Impl b)
+        self.builder.append <| Bench.Group name configuration b.to_vector
+
+type Group_Builder
+    ## PRIVATE
+    Impl builder
+
+    specify : Text -> Any -> Bench
+    specify self (name:Text) ~benchmark =
+        self.builder.append <| Bench.Spec name (_ -> benchmark)
+
+
 type Bench
+    All (groups : Vector Bench)
+    Group (name:Text) (configuration:Bench_Options) (specs : Vector Bench)
+    Spec (name:Text) (code : Any -> Any)
+
+    build : (Bench_Builder -> Any) -> Bench
+    build fn =
+        b = Vector.new_builder
+        fn (Bench_Builder.Impl b)
+        Bench.All b.to_vector
+
+    options : Bench_Options
+    options = Bench_Options.Impl -1 -1
+
+    fold : Any -> (Any -> Bench -> Bench -> Any) -> Any
+    fold self value fn = case self of
+        Bench.All groups -> groups.fold value (v-> g-> g.fold v fn)
+        Bench.Group _ _ specs -> specs.fold value (v-> s-> fn v self s)
+        Bench.Spec _ _ -> fn value self self
+
+    run_main self =
+        count = self.fold 0 v-> _-> _-> v+1
+        IO.println <| "Found " + count.to_text + " cases to execute"
+
+        self.fold Nothing _-> g-> s->
+            c = g.configuration
+            IO.println <| "Benchmarking  " + s.name + " configuration: " + c.to_text
+            Bench.measure (s.code 0) s.name c.iter_size c.num_iters
+            IO.println <| "Benchmarking of " + s.name + " finished"
+
     ## Measure the amount of time it takes to execute a given computation.
 
        Arguments:

--- a/test/Benchmarks/src/Vector/Operations.enso
+++ b/test/Benchmarks/src/Vector/Operations.enso
@@ -21,29 +21,29 @@ collect_benches group_builder =
     random_vec_2 = Utils.make_random_vec 100000
     random_gen = Java_Random.new 123456
 
-    bench_measure ~act name _ _ = group_builder.specify name act
+    bench_measure ~act name = group_builder.specify name act
 
-    bench_measure (Base.Vector.new vector_size i->i) "New Vector" iter_size num_iterations
-    bench_measure (Base.Vector.new vector_size _->42) "New Constant" iter_size num_iterations
-    bench_measure (Base.Vector.new vector_size _->random_gen.nextLong) "New Random" iter_size num_iterations
-    bench_measure (Base.Vector.fill vector_size 42) "Fill Constant" iter_size num_iterations
-    bench_measure (Base.Vector.fill vector_size random_gen.nextLong) "Fill Random (constant)" iter_size num_iterations
-    bench_measure (random_vec + [1]) "Append Single" iter_size num_iterations
-    bench_measure (random_vec + random_vec_2) "Append Large" iter_size num_iterations
-    bench_measure (random_vec.reduce (+)) "Sum" iter_size num_iterations
-    bench_measure ((random_vec.drop (First 20)).reduce (+)) "Drop First 20 and Sum" iter_size num_iterations
-    bench_measure ((random_vec.drop (Last 20)).reduce (+)) "Drop Last 20 and Sum" iter_size num_iterations
-    bench_measure (random_vec.filter (x -> x % 3 == 1)) "Filter" iter_size num_iterations
-    bench_measure (random_vec.filter_with_index (i-> x-> (i+x) % 3 == 1)) "Filter With Index" iter_size num_iterations
+    bench_measure (Base.Vector.new vector_size i->i) "New Vector"
+    bench_measure (Base.Vector.new vector_size _->42) "New Constant"
+    bench_measure (Base.Vector.new vector_size _->random_gen.nextLong) "New Random"
+    bench_measure (Base.Vector.fill vector_size 42) "Fill Constant"
+    bench_measure (Base.Vector.fill vector_size random_gen.nextLong) "Fill Random (constant)"
+    bench_measure (random_vec + [1]) "Append Single"
+    bench_measure (random_vec + random_vec_2) "Append Large"
+    bench_measure (random_vec.reduce (+)) "Sum"
+    bench_measure ((random_vec.drop (First 20)).reduce (+)) "Drop First 20 and Sum"
+    bench_measure ((random_vec.drop (Last 20)).reduce (+)) "Drop Last 20 and Sum"
+    bench_measure (random_vec.filter (x -> x % 3 == 1)) "Filter"
+    bench_measure (random_vec.filter_with_index (i-> x-> (i+x) % 3 == 1)) "Filter With Index"
 
-    bench_measure (random_vec . map (x -> x +  random_gen.nextLong) . filter (x -> x % 3 == 1)) "Map & Filter" iter_size num_iterations
-    bench_measure (random_vec.partition (x -> x % 3 == 1)) "Partition" iter_size num_iterations
-    bench_measure (random_vec.partition_with_index (i-> x-> (i+x) % 3 == 1)) "Partition With Index" iter_size num_iterations
+    bench_measure (random_vec . map (x -> x +  random_gen.nextLong) . filter (x -> x % 3 == 1)) "Map & Filter"
+    bench_measure (random_vec.partition (x -> x % 3 == 1)) "Partition"
+    bench_measure (random_vec.partition_with_index (i-> x-> (i+x) % 3 == 1)) "Partition With Index"
 
     stateful_fun x =
        s = State.get Number
        State.put s+x
-    bench_measure (State.run Number 0 <| random_vec.each stateful_fun) "Each" iter_size num_iterations
+    bench_measure (State.run Number 0 <| random_vec.each stateful_fun) "Each"
 
 bench =
     options = Bench.options . size iter_size . iter num_iterations

--- a/test/Benchmarks/src/Vector/Operations.enso
+++ b/test/Benchmarks/src/Vector/Operations.enso
@@ -16,31 +16,42 @@ num_iterations = 10
 
 # The Benchmarks ==============================================================
 
-bench =
+collect_benches group_builder =
     random_vec = Utils.make_random_vec vector_size
     random_vec_2 = Utils.make_random_vec 100000
     random_gen = Java_Random.new 123456
 
-    Bench.measure (Base.Vector.new vector_size i->i) "New Vector" iter_size num_iterations
-    Bench.measure (Base.Vector.new vector_size _->42) "New Constant" iter_size num_iterations
-    Bench.measure (Base.Vector.new vector_size _->random_gen.nextLong) "New Random" iter_size num_iterations
-    Bench.measure (Base.Vector.fill vector_size 42) "Fill Constant" iter_size num_iterations
-    Bench.measure (Base.Vector.fill vector_size random_gen.nextLong) "Fill Random (constant)" iter_size num_iterations
-    Bench.measure (random_vec + [1]) "Append Single" iter_size num_iterations
-    Bench.measure (random_vec + random_vec_2) "Append Large" iter_size num_iterations
-    Bench.measure (random_vec.reduce (+)) "Sum" iter_size num_iterations
-    Bench.measure ((random_vec.drop (First 20)).reduce (+)) "Drop First 20 and Sum" iter_size num_iterations
-    Bench.measure ((random_vec.drop (Last 20)).reduce (+)) "Drop Last 20 and Sum" iter_size num_iterations
-    Bench.measure (random_vec.filter (x -> x % 3 == 1)) "Filter" iter_size num_iterations
-    Bench.measure (random_vec.filter_with_index (i-> x-> (i+x) % 3 == 1)) "Filter With Index" iter_size num_iterations
+    bench_measure ~act name _ _ = group_builder.specify name act
 
-    Bench.measure (random_vec . map (x -> x +  random_gen.nextLong) . filter (x -> x % 3 == 1)) "Map & Filter" iter_size num_iterations
-    Bench.measure (random_vec.partition (x -> x % 3 == 1)) "Partition" iter_size num_iterations
-    Bench.measure (random_vec.partition_with_index (i-> x-> (i+x) % 3 == 1)) "Partition With Index" iter_size num_iterations
+    bench_measure (Base.Vector.new vector_size i->i) "New Vector" iter_size num_iterations
+    bench_measure (Base.Vector.new vector_size _->42) "New Constant" iter_size num_iterations
+    bench_measure (Base.Vector.new vector_size _->random_gen.nextLong) "New Random" iter_size num_iterations
+    bench_measure (Base.Vector.fill vector_size 42) "Fill Constant" iter_size num_iterations
+    bench_measure (Base.Vector.fill vector_size random_gen.nextLong) "Fill Random (constant)" iter_size num_iterations
+    bench_measure (random_vec + [1]) "Append Single" iter_size num_iterations
+    bench_measure (random_vec + random_vec_2) "Append Large" iter_size num_iterations
+    bench_measure (random_vec.reduce (+)) "Sum" iter_size num_iterations
+    bench_measure ((random_vec.drop (First 20)).reduce (+)) "Drop First 20 and Sum" iter_size num_iterations
+    bench_measure ((random_vec.drop (Last 20)).reduce (+)) "Drop Last 20 and Sum" iter_size num_iterations
+    bench_measure (random_vec.filter (x -> x % 3 == 1)) "Filter" iter_size num_iterations
+    bench_measure (random_vec.filter_with_index (i-> x-> (i+x) % 3 == 1)) "Filter With Index" iter_size num_iterations
+
+    bench_measure (random_vec . map (x -> x +  random_gen.nextLong) . filter (x -> x % 3 == 1)) "Map & Filter" iter_size num_iterations
+    bench_measure (random_vec.partition (x -> x % 3 == 1)) "Partition" iter_size num_iterations
+    bench_measure (random_vec.partition_with_index (i-> x-> (i+x) % 3 == 1)) "Partition With Index" iter_size num_iterations
 
     stateful_fun x =
        s = State.get Number
        State.put s+x
-    Bench.measure (State.run Number 0 <| random_vec.each stateful_fun) "Each" iter_size num_iterations
+    bench_measure (State.run Number 0 <| random_vec.each stateful_fun) "Each" iter_size num_iterations
+
+bench =
+    options = Bench.options . size iter_size . iter num_iterations
+
+    all = Bench.build builder->
+        builder.group "Vector Operations" options group_builder->
+            collect_benches group_builder
+
+    all . run_main
 
 main = bench


### PR DESCRIPTION
### Pull Request Description

Designing new `Bench` API to _collect benchmarks_ first and only execute them then. This is a minimal change to allow  implementation of #7323  - e.g. ability to invoke a _single benchmark_ via JMH harness.

### Important Notes

This is just the basic API skeleton. It can be enhanced, if the basic properties (allowing integration with JMH) are kept. It is not intent of this PR to make the API 100% perfect and usable. Neither it is goal of this PR to update existing benchmarks to use it (74ac8d7 changes only one of them to demonstrate _it all works_ somehow). It is however expected that once this PR is integrated, the newly written benchmarks (like the ones from #7270) are going to use (or even enhance) the new API.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the style guides. 
- All code has been tested:
  - [x] `Vector/Operations.enso` continue to run
