### PR TITLE
Fix GraalVM distribution download on MacOS

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -8,11 +8,9 @@ on:
 
 env:
   # Please ensure that this is in sync with graalVersion in build.sbt
-  graalVersion: 22.3.1
-  # Please ensure that this is in sync with javaVersion in build.sbt
-  javaVersion: 11
+  javaVersion: 17.0.7
   # Please ensure that this is in sync with project/build.properties
-  sbtVersion: 1.5.2
+  sbtVersion: 1.9.0
 
 jobs:
   test_formatting:
@@ -25,11 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup GraalVM Environment
-        uses: ayltai/setup-graalvm@v1
+        uses: graalvm/setup-graalvm@v1
         with:
-          graalvm-version: ${{ env.graalVersion }}
           java-version: ${{ env.javaVersion }}
-          native-image: true
+          distribution: graalvm-community
       - name: Set Up SBT
         shell: bash
         run: |

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           java-version: ${{ env.javaVersion }}
           distribution: graalvm-community
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set Up SBT
         shell: bash
         run: |

--- a/build.sbt
+++ b/build.sbt
@@ -1340,6 +1340,9 @@ lazy val runtime = (project in file("engine/runtime"))
     Test / envVars ++= distributionEnvironmentOverrides ++ Map(
       "ENSO_TEST_DISABLE_IR_CACHE" -> "false"
     ),
+    Global / onLoad := GraalVersionCheck.addVersionCheck(
+      graalVersion
+    )((Global / onLoad).value),
     bootstrap := CopyTruffleJAR.bootstrapJARs.value
   )
   .settings(

--- a/build/build/src/paths.rs
+++ b/build/build/src/paths.rs
@@ -56,7 +56,7 @@ pub fn new_repo_root(repo_root: impl Into<PathBuf>, triple: &TargetTriple) -> ge
 
 pub fn pretty_print_arch(arch: Arch) -> &'static str {
     match arch {
-        Arch::X86_64 => "amd64",
+        Arch::X86_64 => "x64",
         Arch::AArch64 => "aarch64",
         _ => panic!("Unrecognized architecture {arch}"),
     }

--- a/build/ci_utils/src/cache/goodie/graalvm.rs
+++ b/build/ci_utils/src/cache/goodie/graalvm.rs
@@ -106,7 +106,7 @@ impl GraalVM {
         let os_name = match *os {
             OS::Linux => "linux",
             OS::Windows => "windows",
-            OS::MacOS => "darwin",
+            OS::MacOS => "macos",
             other_os => unimplemented!("System `{}` is not supported!", other_os),
         };
         let arch_name = match *arch {

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/releases/graalvm/GraalCEReleaseProvider.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/releases/graalvm/GraalCEReleaseProvider.scala
@@ -69,7 +69,7 @@ object GraalCEReleaseProvider {
   def packageFileNameForCurrentOS(version: GraalVMVersion): String = {
     val os = OS.operatingSystem match {
       case OS.Linux   => "linux"
-      case OS.MacOS   => "darwin"
+      case OS.MacOS   => if (version.graalMajorVersion < 23) "darwin" else "macos"
       case OS.Windows => "windows"
     }
     val extension = OS.operatingSystem match {

--- a/project/DistributionPackage.scala
+++ b/project/DistributionPackage.scala
@@ -422,7 +422,6 @@ object DistributionPackage {
   sealed trait OS {
     def name:                String
     def hasSupportForSulong: Boolean
-    def graalName: String                    = name
     def executableName(base: String): String = base
     def archiveExt: String                   = ".tar.gz"
     def isUNIX: Boolean                      = true
@@ -435,7 +434,6 @@ object DistributionPackage {
     case object MacOS extends OS {
       override val name: String                 = "macos"
       override val hasSupportForSulong: Boolean = true
-      override def graalName: String            = "darwin"
     }
     case object Windows extends OS {
       override val name: String                         = "windows"
@@ -461,7 +459,7 @@ object DistributionPackage {
   }
   object Architecture {
     case object X64 extends Architecture {
-      override def name: String = "amd64"
+      override def name: String = "x64"
     }
 
     val archs = Seq(X64)
@@ -566,9 +564,9 @@ object DistributionPackage {
         )
         val graalUrl =
           s"https://github.com/graalvm/graalvm-ce-builds/releases/download/" +
-          s"vm-$graalVersion/" +
-          s"graalvm-ce-java$graalJavaVersion-${os.graalName}-" +
-          s"${architecture.name}-$graalVersion${os.archiveExt}"
+          s"jdk-$graalJavaVersion/" +
+          s"graalvm-community-jdk-${graalJavaVersion}_${os.name}-" +
+          s"${architecture.name}_bin${os.archiveExt}"
         val exitCode = (url(graalUrl) #> archive).!
         if (exitCode != 0) {
           throw new RuntimeException(s"Graal download from $graalUrl failed.")
@@ -614,7 +612,7 @@ object DistributionPackage {
         extract(archive, packageDir)
 
         log.info("Installing components")
-        gu(log, os, extractedGraalDir, "install", "python", "R")
+        gu(log, os, extractedGraalDir, "install", "python")
 
         log.info(s"Re-creating $archive")
         IO.delete(archive)

--- a/project/GraalVersionCheck.scala
+++ b/project/GraalVersionCheck.scala
@@ -1,0 +1,80 @@
+import java.io.IOException
+import sbt.*
+import sbt.internal.util.ManagedLogger
+
+import scala.sys.process.*
+import nl.gn0s1s.bump.SemVer
+
+object GraalVersionCheck {
+
+  /** Compares the version of JVM running sbt with the GraalVM versions defined
+    * in project configuration and reports errors if the versions do not match.
+    *
+    * @param expectedGraalVersionRaw the GraalVM version that should be used for
+    *                             building this project
+    * @param log a logger used to report errors if the versions are mismatched
+    */
+  def graalVersionOk(
+    expectedGraalVersionRaw: String,
+    log: ManagedLogger
+  ): Boolean = {
+    val expectedGraalVersion = SemVer(expectedGraalVersionRaw)
+    require(expectedGraalVersion.isDefined, "Invalid version string")
+
+    val versionProperty = "java.vendor.version"
+    val rawGraalVersion = System.getProperty(versionProperty)
+
+    def graalVersion: Option[SemVer] = {
+      val versionRegex = """GraalVM (CE|EE) ([\d.]+.*)""".r
+      rawGraalVersion match {
+        case versionRegex(_, version) =>
+          SemVer(version)
+        case _ => None
+      }
+    }
+
+    if (rawGraalVersion == null) {
+      log.error(
+        s"Property $versionProperty is not defined. " +
+        s"Make sure your current JVM is set to " +
+        s"GraalVM $expectedGraalVersionRaw."
+      )
+      false
+    } else {
+      graalVersion match {
+        case Some(version)
+            if expectedGraalVersion.get.withoutBuildMetadata == version.withoutBuildMetadata =>
+          true
+        case _ =>
+          log.error(
+            s"GraalVM version mismatch - you are running $rawGraalVersion " +
+            s"but GraalVM $expectedGraalVersionRaw is expected."
+          )
+          false
+      }
+    }
+  }
+
+  /** Augments a state transition to do a Rust and GraalVM version check.
+    *
+    * @param graalVersion the GraalVM version that should be used for
+    *                     building this project
+    * @param oldTransition the state transition to be augmented
+    * @return an augmented state transition that does all the state changes of
+    *         oldTransition but also runs the version checks
+    */
+  def addVersionCheck(
+    graalVersion: String
+  )(
+    oldTransition: State => State
+  ): State => State =
+    (state: State) => {
+      val newState = oldTransition(state)
+      val logger   = newState.log
+      if (!graalVersionOk(graalVersion, logger)) {
+        logger.error("GraalVM version check failed.")
+        System.exit(1)
+      }
+      newState
+    }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,3 +8,4 @@ addSbtPlugin("com.simplytyped"   % "sbt-antlr4"         % "0.8.3")
 
 libraryDependencies += "io.circe"  %% "circe-yaml" % "0.14.2"
 libraryDependencies += "commons-io" % "commons-io" % "2.12.0"
+libraryDependencies += "nl.gn0s1s" %% "bump"       % "0.1.3"


### PR DESCRIPTION
### Pull Request Description

Follow-up of recent GraalVM update #7176 that fixes downloading of GraalVM for Mac - instead of "darwin", the releases are now named "macos"

### Important Notes

Also re-enables the JDK/GraalVM version check as onLoad hook to the `sbt` process. We used to have that check a long time ago. Provides errors like this one if the `sbt` is run with a different JVM version:
```
[error] GraalVM version mismatch - you are running Oracle GraalVM 20.0.1+9.1 but GraalVM 17.0.7 is expected.
[error] GraalVM version check failed.
```


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [X] Unit tests have been written where possible.
  - [X] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
