### PR TITLE
Fix Dockerfile - do not download R component

### DIFF
--- a/tools/ci/docker/Dockerfile
+++ b/tools/ci/docker/Dockerfile
@@ -30,7 +30,7 @@ ENV ENSO_RUNTIME_DIRECTORY=/opt/enso/work
 ENV ENSO_LOG_DIRECTORY=/opt/enso/logs
 ENV ENSO_HOME=/volumes/workspace/home
 
-RUN gu install js python r
+RUN gu install js python
 RUN chown -hR ensodev:ensodev /opt/enso
 RUN chmod -R u=rX,g=rX /opt/enso
 RUN chmod a+x /opt/enso/bin/*


### PR DESCRIPTION
### Pull Request Description

The latest nightly release action is failing in https://github.com/enso-org/enso/actions/runs/5640089073/job/15281429023#step:10:542 when building the Docker image. It is because `gu` no longer provides `R` component. This PR just removes the component and therefore fixes the nightly release actions.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [X] Unit tests have been written where possible.
  - [X] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
