### PR TITLE
Check for PanicSentinel in SequenceLiteralNode

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/SequenceLiteralNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/SequenceLiteralNode.java
@@ -1,11 +1,13 @@
 package org.enso.interpreter.node.callable;
 
-import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.nodes.ExplodeLoop;
-import com.oracle.truffle.api.nodes.NodeInfo;
 import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.data.Array;
 import org.enso.interpreter.runtime.data.Vector;
+import org.enso.interpreter.runtime.error.PanicSentinel;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
+import com.oracle.truffle.api.nodes.NodeInfo;
 
 @NodeInfo(shortName = "[]", description = "Creates a vector from given expressions.")
 public class SequenceLiteralNode extends ExpressionNode {
@@ -37,6 +39,9 @@ public class SequenceLiteralNode extends ExpressionNode {
     Object[] itemValues = new Object[items.length];
     for (int i = 0; i < items.length; i++) {
       itemValues[i] = items[i].executeGeneric(frame);
+      if (itemValues[i] instanceof PanicSentinel sentinel) {
+        throw sentinel;
+      }
     }
     return Vector.fromArray(new Array(itemValues));
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -31,7 +31,7 @@ import org.enso.interpreter.runtime.state.State;
 @ExportLibrary(TypesLibrary.class)
 public final class PanicException extends AbstractTruffleException {
   final Object payload;
-  String cacheMessage;
+  private String cacheMessage;
 
   /**
    * Creates an instance of this class.
@@ -46,12 +46,6 @@ public final class PanicException extends AbstractTruffleException {
       throw new IllegalArgumentException("Only interop values are supported: " + payload);
     }
     this.payload = payload;
-    InteropLibrary library = InteropLibrary.getUncached();
-    try {
-      cacheMessage = library.asString(library.getExceptionMessage(this));
-    } catch (UnsupportedMessageException e) {
-      cacheMessage = TypeToDisplayTextNodeGen.getUncached().execute(payload);
-    }
   }
 
   /**
@@ -65,7 +59,23 @@ public final class PanicException extends AbstractTruffleException {
 
   @Override
   public String getMessage() {
+    if (cacheMessage == null) {
+      return computeMessage();
+    }
     return cacheMessage;
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  private String computeMessage() {
+    String msg;
+    InteropLibrary library = InteropLibrary.getUncached();
+    try {
+      msg = library.asString(library.getExceptionMessage(this));
+    } catch (UnsupportedMessageException e) {
+      msg = TypeToDisplayTextNodeGen.getUncached().execute(payload);
+    }
+    cacheMessage = msg;
+    return msg;
   }
 
   @Override

--- a/engine/runtime/src/test/java/org/enso/interpreter/node/callable/SequenceLiteralNodeTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/node/callable/SequenceLiteralNodeTest.java
@@ -1,0 +1,32 @@
+package org.enso.interpreter.node.callable;
+
+import org.enso.interpreter.node.ExpressionNode;
+import org.enso.interpreter.node.expression.literal.LiteralNode;
+import org.enso.interpreter.runtime.error.PanicException;
+import org.enso.interpreter.runtime.error.PanicSentinel;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+
+public class SequenceLiteralNodeTest {
+  public SequenceLiteralNodeTest() {}
+
+  @Test
+  public void propagatePanicSentinel() {
+    var sentinel = new PanicSentinel(new PanicException(0L, null), null);
+
+    var one = LiteralNode.build(1);
+    var two = LiteralNode.build(2);
+    var three = LiteralNode.build(sentinel);
+    var four = LiteralNode.build(4);
+    var seq = SequenceLiteralNode.build(new ExpressionNode[] {one, two, three, four});
+
+    try {
+      var res = seq.executeGeneric(null);
+      fail("Unexpected result. PanicSentinel should have been thrown: " + res);
+    } catch (PanicSentinel ex) {
+      if (sentinel != ex) {
+        fail("The right exception should have been propagated!");
+      }
+    }
+  }
+}

--- a/engine/runtime/src/test/java/org/enso/interpreter/node/callable/SequenceLiteralNodeTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/node/callable/SequenceLiteralNodeTest.java
@@ -1,10 +1,11 @@
 package org.enso.interpreter.node.callable;
 
+import static org.junit.Assert.fail;
+
 import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.node.expression.literal.LiteralNode;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.error.PanicSentinel;
-import static org.junit.Assert.fail;
 import org.junit.Test;
 
 public class SequenceLiteralNodeTest {


### PR DESCRIPTION
### Pull Request Description

Fixes #7245.

![Vector with a panic](https://github.com/enso-org/enso/assets/26887752/eed01c6c-5492-4cc6-bd4f-63ba761db010)

The above picture shows that the _vector problem_ reported by #7245 is fixed.

### Important Notes

The fix modifies `SequenceLiteralNode` to recognize `PanicSentinel` and `throw` it as common in other places (like invoke function node, etc.).

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
