### PR TITLE
Fix broken text vis layout on slow loading

### DIFF
--- a/app/gui/view/graph-editor/src/builtin/visualization/native/text_visualization/grid_view_entry.rs
+++ b/app/gui/view/graph-editor/src/builtin/visualization/native/text_visualization/grid_view_entry.rs
@@ -78,6 +78,10 @@ impl Entry {
         let mut style = "position: absolute; white-space: pre; pointer-events: auto;".to_string();
         write!(style, "left: {left}px; top: {top}px;").ok();
         write!(style, "width: {width}px; height: {height}px;").ok();
+        // This prevents a fallback font from being used. Using any other font than the one
+        // specified will break the layout mechanism because the calculated width of the chunks no
+        // longer matches the rendered width of the chunks.
+        write!(style, "font-display: block;").ok();
         // The default line height in browsers is 1.2, which is great for multi-line text and
         // elements whose height is greater than the line height. In this case, however, where the
         // height and the font size are set to the same value, the default setting of 1.2 pushes


### PR DESCRIPTION
Prevents the text vis from using a fallback font if the main font is not loaded fast enough. Using a fallback font could lead to a broken layout, as we align text chunks based on their width. So if the font changes unexpectedly, this can cause gaps in the layout. 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
