### PR TITLE
Fix opening projects after switching backend

### DIFF
--- a/app/ide-desktop/lib/content/src/index.ts
+++ b/app/ide-desktop/lib/content/src/index.ts
@@ -179,7 +179,7 @@ class Main implements AppRunner {
 
         const newApp = new app.App({
             config,
-            configOptions: contentConfig.OPTIONS,
+            configOptions: contentConfig.OPTIONS.clone(),
             packageInfo: {
                 version: BUILD_INFO.version,
                 engineVersion: BUILD_INFO.engineVersion,

--- a/app/ide-desktop/lib/content/src/index.ts
+++ b/app/ide-desktop/lib/content/src/index.ts
@@ -177,9 +177,11 @@ class Main implements AppRunner {
             inputConfig
         )
 
+        const configOptions = contentConfig.OPTIONS.clone()
+
         const newApp = new app.App({
             config,
-            configOptions: contentConfig.OPTIONS.clone(),
+            configOptions,
             packageInfo: {
                 version: BUILD_INFO.version,
                 engineVersion: BUILD_INFO.engineVersion,
@@ -207,10 +209,10 @@ class Main implements AppRunner {
         if (!this.app.initialized) {
             console.error('Failed to initialize the application.')
         } else {
-            if (!(await checkMinSupportedVersion(contentConfig.OPTIONS))) {
+            if (!(await checkMinSupportedVersion(configOptions))) {
                 displayDeprecatedVersionDialog()
             } else {
-                const email = contentConfig.OPTIONS.groups.authentication.options.email.value
+                const email = configOptions.groups.authentication.options.email.value
                 // The default value is `""`, so a truthiness check is most appropriate here.
                 if (email) {
                     logger.log(`User identified as '${email}'.`)
@@ -234,21 +236,21 @@ class Main implements AppRunner {
         if (isInAuthenticationFlow) {
             history.replaceState(null, '', localStorage.getItem(INITIAL_URL_KEY))
         }
-        const parseOk = contentConfig.OPTIONS.loadAllAndDisplayHelpIfUnsuccessful([app.urlParams()])
+        const configOptions = contentConfig.OPTIONS.clone()
+        const parseOk = configOptions.loadAllAndDisplayHelpIfUnsuccessful([app.urlParams()])
         if (isInAuthenticationFlow) {
             history.replaceState(null, '', authenticationUrl)
         } else {
             localStorage.setItem(INITIAL_URL_KEY, location.href)
         }
         if (parseOk) {
-            const shouldUseAuthentication = contentConfig.OPTIONS.options.authentication.value
+            const shouldUseAuthentication = configOptions.options.authentication.value
             const shouldUseNewDashboard =
-                contentConfig.OPTIONS.groups.featurePreview.options.newDashboard.value
+                configOptions.groups.featurePreview.options.newDashboard.value
             const isOpeningMainEntryPoint =
-                contentConfig.OPTIONS.groups.startup.options.entry.value ===
-                contentConfig.OPTIONS.groups.startup.options.entry.default
-            const initialProjectName =
-                contentConfig.OPTIONS.groups.startup.options.project.value || null
+                configOptions.groups.startup.options.entry.value ===
+                configOptions.groups.startup.options.entry.default
+            const initialProjectName = configOptions.groups.startup.options.project.value || null
             // This MUST be removed as it would otherwise override the `startup.project` passed
             // explicitly in `ide.tsx`.
             if (isOpeningMainEntryPoint && url.searchParams.has('startup.project')) {

--- a/lib/rust/ensogl/pack/js/src/runner/config.ts
+++ b/lib/rust/ensogl/pack/js/src/runner/config.ts
@@ -49,7 +49,7 @@ export interface OptionObject<T> {
     value: T
     valueEval?: string
     description: string
-    defaultDescription?: string
+    defaultDescription?: string | null
     hidden?: boolean
     primary?: boolean
     passToWebApplication?: boolean
@@ -96,6 +96,11 @@ export class Option<T> {
         } else {
             this.type = 'string'
         }
+    }
+
+    /** Return a copy of this option. */
+    clone(): Option<T> {
+        return Object.assign(new Option<T>(this), this)
     }
 
     /** Names of all parent groups and name of this option intercalated with dots. */
@@ -172,6 +177,7 @@ export interface AnyGroup {
     options: OptionsRecord
     groups: GroupsRecord
     setPath(path: string[]): void
+    clone(): this
     merge<Other extends AnyGroup>(other: Other): this & Other
     load(config: StringConfig, stack?: string[]): string[]
     stringify(): StringConfig
@@ -233,6 +239,18 @@ export class Group<Options extends OptionsRecord, Groups extends GroupsRecord> {
         for (const [name, group] of Object.entries(this.groups)) {
             group.setPath(path.concat([name]))
         }
+    }
+
+    /** Return a deep copy of this group definition. */
+    clone(): this {
+        const result: AnyGroup = new Group()
+        for (const [name, group] of Object.entries(this.groups)) {
+            result.groups[name] = group.clone()
+        }
+        for (const [name, option] of Object.entries(this.options)) {
+            result.options[name] = option.clone()
+        }
+        return result as this
     }
 
     /** Merge this group definition with another group definition. Returns a deeply merged group. In


### PR DESCRIPTION
### Pull Request Description
Fix #7424.
This was caused by always using `contentConfig.OPTIONS` as the `configOptions` being passed to `new app.App`, resulting in all options that were ever passed to any IDE instance being accumulated over time. In particular, it means that opening a local project (using the PM endpoint) and then a cloud project (using the LS endpoints) will result in both sets of endpoints existing on `contentConfig.OPTIONS`, resulting in a `MutuallyExclusiveOptions` error.

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
