### PR TITLE
Refactor project normalized name

### DIFF
--- a/app/gui/controller/engine-protocol/src/project_manager.rs
+++ b/app/gui/controller/engine-protocol/src/project_manager.rs
@@ -137,32 +137,32 @@ impl From<ProjectName> for ImString {
 
 /// Project module.
 #[derive(Clone, Debug, Deserialize, Display, Eq, From, Hash, PartialEq, Serialize)]
-pub struct ProjectModule(String);
+pub struct ProjectNormalizedName(String);
 
-impl ProjectModule {
-    /// Create new ProjectModule without any validation.
+impl ProjectNormalizedName {
+    /// Create new ProjectNormalizedName without any validation.
     ///
-    /// The caller is responsible for making sure that provided string is a valid project module
+    /// The caller is responsible for making sure that provided string is a valid project normalized
     /// name (e.g. not empty and starts with a capital letter).
     pub fn new_unchecked(name: impl Str) -> Self {
         Self(name.into())
     }
 }
 
-impl AsRef<str> for ProjectModule {
+impl AsRef<str> for ProjectNormalizedName {
     fn as_ref(&self) -> &str {
         &self.0
     }
 }
 
-impl From<ProjectModule> for String {
-    fn from(name: ProjectModule) -> Self {
+impl From<ProjectNormalizedName> for String {
+    fn from(name: ProjectNormalizedName) -> Self {
         name.0
     }
 }
 
-impl From<ProjectModule> for ImString {
-    fn from(name: ProjectModule) -> Self {
+impl From<ProjectNormalizedName> for ImString {
+    fn from(name: ProjectNormalizedName) -> Self {
         name.0.into()
     }
 }
@@ -227,8 +227,8 @@ pub mod response {
         pub language_server_binary_address: IpWithSocket,
         /// The name of the project as it is opened.
         pub project_name:                   ProjectName,
-        /// The module name of the project.
-        pub project_module:                 ProjectModule,
+        /// The normalized name of the project.
+        pub project_normalized_name:        ProjectNormalizedName,
         /// The namespace of the project.
         pub project_namespace:              String,
     }
@@ -278,7 +278,7 @@ mod mock_client_tests {
             language_server_json_address:   language_server_address.clone(),
             language_server_binary_address: language_server_address,
             project_name:                   ProjectName::new_unchecked("Test"),
-            project_module:                 ProjectModule::new_unchecked("Test"),
+            project_normalized_name:        ProjectNormalizedName::new_unchecked("Test"),
             project_namespace:              "local".to_owned(),
         };
         let open_result = Ok(expected_open_result.clone());
@@ -447,14 +447,14 @@ mod remote_client_tests {
         let language_server_binary_address =
             IpWithSocket { host: "localhost".to_string(), port: 27016 };
         let project_name = ProjectName::new_unchecked("Test");
-        let project_module = ProjectModule::new_unchecked("Test");
+        let project_normalized_name = ProjectNormalizedName::new_unchecked("Test");
         let project_namespace = "test_ns".to_owned();
         let open_result = response::OpenProject {
             engine_version,
             language_server_json_address,
             language_server_binary_address,
             project_name,
-            project_module,
+            project_normalized_name,
             project_namespace,
         };
         let open_result_json = json!({
@@ -467,9 +467,9 @@ mod remote_client_tests {
                 "host" : "localhost",
                 "port" : 27016
             },
-            "projectName"      : "Test",
-            "projectModule"    : "Test",
-            "projectNamespace" : "test_ns",
+            "projectName"           : "Test",
+            "projectNormalizedName" : "Test",
+            "projectNamespace"      : "test_ns",
         });
         let project_name = ProjectName::new_unchecked("HelloWorld");
         let project_template = Some(String::from("template"));

--- a/app/gui/src/model/project/synchronized.rs
+++ b/app/gui/src/model/project/synchronized.rs
@@ -422,13 +422,13 @@ impl Project {
         let action = MissingComponentAction::Install;
         let opened = project_manager.open_project(&id, &action).await?;
         let namespace = opened.project_namespace;
-        let module = opened.project_module;
+        let normalized_name = opened.project_normalized_name;
         let project_manager = Some(project_manager);
         let json_endpoint = opened.language_server_json_address.to_string();
         let binary_endpoint = opened.language_server_binary_address.to_string();
         let properties = Properties {
             id,
-            name: project::QualifiedName::new(namespace, module),
+            name: project::QualifiedName::new(namespace, normalized_name),
             engine_version: semver::Version::parse(&opened.engine_version)?,
         };
         Self::new_connected(project_manager, json_endpoint, binary_endpoint, properties).await

--- a/docs/language-server/protocol-project-manager.md
+++ b/docs/language-server/protocol-project-manager.md
@@ -225,8 +225,8 @@ the action.
   // The name of the project as it is opened.
   projectName: String;
 
-  // The module name of the project.
-  projectModule: String;
+  // The normalized name of the project.
+  projectNormalizedName: String;
 
   // The namespace of the project.
   projectNamespace: String;

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/data/RunningLanguageServerInfo.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/data/RunningLanguageServerInfo.scala
@@ -7,13 +7,13 @@ import nl.gn0s1s.bump.SemVer
   * @param engineVersion the version of the started language server
   * @param sockets the sockets listened by the language server
   * @param projectName the name of the project
-  * @param projectModule the module of the project
+  * @param projectNormalizedName the normalized name of the project
   * @param projectNamespace the namespace of the project
   */
 case class RunningLanguageServerInfo(
   engineVersion: SemVer,
   sockets: LanguageServerSockets,
   projectName: String,
-  projectModule: String,
+  projectNormalizedName: String,
   projectNamespace: String
 )

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/protocol/ProjectManagementApi.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/protocol/ProjectManagementApi.scala
@@ -84,7 +84,7 @@ object ProjectManagementApi {
       languageServerJsonAddress: Socket,
       languageServerBinaryAddress: Socket,
       projectName: String,
-      projectModule: String,
+      projectNormalizedName: String,
       projectNamespace: String
     )
 

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectOpenHandler.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectOpenHandler.scala
@@ -59,7 +59,7 @@ class ProjectOpenHandler[F[+_, +_]: Exec: CovariantFlatMap](
       languageServerJsonAddress   = server.sockets.jsonSocket,
       languageServerBinaryAddress = server.sockets.binarySocket,
       projectName                 = server.projectName,
-      projectModule               = server.projectModule,
+      projectNormalizedName       = server.projectNormalizedName,
       projectNamespace            = server.projectNamespace
     )
   }

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/ProjectManagementOps.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/ProjectManagementOps.scala
@@ -79,17 +79,17 @@ trait ProjectManagementOps { this: BaseServerSpec =>
   def openProjectData(implicit client: WsTestClient): ProjectOpen.Result = {
     val Right(openReply) = parse(client.expectMessage(20.seconds.dilated))
     val openResult = for {
-      result        <- openReply.hcursor.downExpectedField("result")
-      engineVer     <- result.downField("engineVersion").as[SemVer]
-      jsonAddr      <- result.downExpectedField("languageServerJsonAddress")
-      jsonHost      <- jsonAddr.downField("host").as[String]
-      jsonPort      <- jsonAddr.downField("port").as[Int]
-      binAddr       <- result.downExpectedField("languageServerBinaryAddress")
-      binHost       <- binAddr.downField("host").as[String]
-      binPort       <- binAddr.downField("port").as[Int]
-      projectName   <- result.downField("projectName").as[String]
-      projectModule <- result.downField("projectModule").as[String]
-      namespace     <- result.downField("projectNamespace").as[String]
+      result         <- openReply.hcursor.downExpectedField("result")
+      engineVer      <- result.downField("engineVersion").as[SemVer]
+      jsonAddr       <- result.downExpectedField("languageServerJsonAddress")
+      jsonHost       <- jsonAddr.downField("host").as[String]
+      jsonPort       <- jsonAddr.downField("port").as[Int]
+      binAddr        <- result.downExpectedField("languageServerBinaryAddress")
+      binHost        <- binAddr.downField("host").as[String]
+      binPort        <- binAddr.downField("port").as[Int]
+      projectName    <- result.downField("projectName").as[String]
+      normalizedName <- result.downField("projectNormalizedName").as[String]
+      namespace      <- result.downField("projectNamespace").as[String]
     } yield {
       val jsonSock = Socket(jsonHost, jsonPort)
       val binSock  = Socket(binHost, binPort)
@@ -98,7 +98,7 @@ trait ProjectManagementOps { this: BaseServerSpec =>
         jsonSock,
         binSock,
         projectName,
-        projectModule,
+        normalizedName,
         namespace
       )
     }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Followup to #7397. When started this refactoring I only changed the config types and forgot to change the API.

Changelog:
- refactor: rename `projectModule` to `projectNormalizedName` in the API

### Important Notes


https://github.com/enso-org/enso/assets/357683/a840dc90-15f8-4b6d-bbfb-571c53cd2f7d



<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
