### PR TITLE
Add missing cognito oauth scope

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/config.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/config.ts
@@ -84,7 +84,11 @@ export type RegisterOpenAuthenticationUrlCallbackFn = () => void
 /** AWS region in which our Cognito pool is located. */
 export const AWS_REGION = AwsRegion('eu-west-1')
 /** Complete list of OAuth scopes used by the app. */
-export const OAUTH_SCOPES = [OAuthScope('email'), OAuthScope('openid'), OAuthScope('aws.cognito.signin.user.admin')]
+export const OAUTH_SCOPES = [
+    OAuthScope('email'),
+    OAuthScope('openid'),
+    OAuthScope('aws.cognito.signin.user.admin'),
+]
 /** OAuth response type used in the OAuth flows. */
 export const OAUTH_RESPONSE_TYPE = OAuthResponseType('code')
 

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/config.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/config.ts
@@ -84,7 +84,7 @@ export type RegisterOpenAuthenticationUrlCallbackFn = () => void
 /** AWS region in which our Cognito pool is located. */
 export const AWS_REGION = AwsRegion('eu-west-1')
 /** Complete list of OAuth scopes used by the app. */
-export const OAUTH_SCOPES = [OAuthScope('email'), OAuthScope('openid')]
+export const OAUTH_SCOPES = [OAuthScope('email'), OAuthScope('openid'), OAuthScope('aws.cognito.signin.user.admin')]
 /** OAuth response type used in the OAuth flows. */
 export const OAUTH_RESPONSE_TYPE = OAuthResponseType('code')
 


### PR DESCRIPTION
### Pull Request Description

For some reason, the hosted UI for both email and password and SSO, as well as the `Auth.federatedSignIn({provider: 'Google'})` call require the `aws.cognito.signin.user.admin` scope to be enabled to fetch and update user attributed. However, a call to `Auth.signIn(email, password)` does not. This is not well documented in AWS Cognito.

### Important Notes

`aws.cognito.signin.user.admin` gives you access to all Cognito User Pool APIs. Which federatedSignIn with google provider uses to get `currentUserInfo()` where we store optional `organizationId`. It does not provide any admin level access to other cognito or AWS parts.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
