### PR TITLE
Avoid NPEs during regular execution

### DIFF
--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -330,11 +330,15 @@ object ProgramExecutionSupport {
     val expressionId  = value.getExpressionId
     val methodPointer = toMethodCall(value)
     if (
-      !syncState.isExpressionSync(expressionId) ||
-      (
-        methodPointer.isDefined && !syncState.isMethodPointerSync(expressionId)
-      ) ||
-      Types.isPanic(value.getType)
+      value.getValue != null && (
+        !syncState.isExpressionSync(expressionId) ||
+        (
+          methodPointer.isDefined && !syncState.isMethodPointerSync(
+            expressionId
+          )
+        ) ||
+        Types.isPanic(value.getType)
+      )
     ) {
       val payload = value.getValue match {
         case sentinel: PanicSentinel =>

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -330,15 +330,13 @@ object ProgramExecutionSupport {
     val expressionId  = value.getExpressionId
     val methodPointer = toMethodCall(value)
     if (
-      value.getValue != null && (
-        !syncState.isExpressionSync(expressionId) ||
-        (
-          methodPointer.isDefined && !syncState.isMethodPointerSync(
-            expressionId
-          )
-        ) ||
-        Types.isPanic(value.getType)
-      )
+      !syncState.isExpressionSync(expressionId) ||
+      (
+        methodPointer.isDefined && !syncState.isMethodPointerSync(
+          expressionId
+        )
+      ) ||
+      Types.isPanic(value.getType)
     ) {
       val payload = value.getValue match {
         case sentinel: PanicSentinel =>
@@ -367,7 +365,9 @@ object ProgramExecutionSupport {
         case _ =>
           val warnings =
             Option.when(
-              WarningsLibrary.getUncached.hasWarnings(value.getValue)
+              value.getValue != null && WarningsLibrary.getUncached.hasWarnings(
+                value.getValue
+              )
             ) {
               val warnings =
                 WarningsLibrary.getUncached.getWarnings(value.getValue, null)


### PR DESCRIPTION

### Pull Request Description

Seeing plenty of
```
java.lang.NullPointerException: Some(Null receiver values are not supported by libraries.)
  at org.graalvm.truffle/com.oracle.truffle.api.library.LibraryFactory.dispatch(LibraryFactory.java:528)
  at org.graalvm.truffle/com.oracle.truffle.api.library.LibraryFactory.getUncached(LibraryFactory.java:396)
  at org.enso.interpreter.runtime.error.WarningsLibraryGen$UncachedDispatch.hasWarnings(WarningsLibraryGen.java:440)
  at org.enso.interpreter.instrument.job.ProgramExecutionSupport$.sendExpressionUpdate(ProgramExecutionSupport.scala:366)
  at org.enso.interpreter.instrument.job.ProgramExecutionSupport$.$anonfun$executeProgram$1(ProgramExecutionSupport.scala:62)
  at org.enso.interpreter.instrument.job.ProgramExecutionSupport$.$anonfun$executeProgram$10(ProgramExecutionSupport.scala:151)
  at java.base/java.lang.Iterable.forEach(Iterable.java:75)
  at org.enso.interpreter.instrument.job.ProgramExecutionSupport$.executeProgram(ProgramExecutionSupport.scala:139)
  at org.enso.interpreter.instrument.job.ProgramExecutionSupport$.$anonfun$runProgram$3(ProgramExecutionSupport.scala:217)
```
during execution of simple programs.
Added a guard to prevent us from sending expression updates when dealing with nulls.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
