### PR TITLE
Fix CB scoring for new label format.

### DIFF
--- a/app/gui/src/controller/searcher/search.rs
+++ b/app/gui/src/controller/searcher/search.rs
@@ -144,8 +144,10 @@ impl score::ScoreBuilder for ScoreBuilder {
     fn match_delimiter(&mut self, _pattern: char, value: char) {
         self.word_chars_matched_since_last_delimiter = false;
         if value == '.' {
-            // Penalty for every matched `.`.
-            self.penalty += SUBMATCH_INCLUDES_NAMESPACE_PENALTY;
+            if self.word_chars_matched {
+                // Penalty for every matched `.` after the first matched character.
+                self.penalty += SUBMATCH_INCLUDES_NAMESPACE_PENALTY;
+            }
             self.word_chars_skipped_since_last_dot = false;
             self.word_chars_matched_since_last_dot = false;
         }
@@ -267,6 +269,8 @@ mod test_score {
             ("abx", TargetInfo { is_alias: false }),
             // Prefix match, first-word: Name (Lower % of word used)
             ("abxx", TargetInfo { is_alias: false }),
+            // Prefix match, first-word: Name (Type not used in match)
+            ("x.abxyz", TargetInfo { is_alias: false }),
             // Prefix match, first-word: Type (Exact match)
             ("ab.x", TargetInfo { is_alias: false }),
             // Prefix match, first-word: Type


### PR DESCRIPTION
### Pull Request Description

- Tweak the definition of "first-word match" so that, now that all components except aliases contain `.`, the delimiter doesn't result in penalizing non-alias matches.
- Fix matching of aliases containing spaces, and add test.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
