### PR TITLE
Fix column naming edge cases - invalid and duplicated columns, case-insensitive name aliasing for case-insensitive backends

### DIFF
--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -221,12 +221,23 @@ type Connection
                     True -> result
                     False ->
                         Error.throw (Table_Not_Found.Error query sql_error treated_as_query=True extra_message="")
-        SQL_Query.Raw_SQL raw_sql -> handle_sql_errors <|
+        SQL_Query.Raw_SQL raw_sql -> handle_sql_errors <| alias.if_not_error <|
             self.jdbc_connection.ensure_query_has_no_holes raw_sql . if_not_error <|
                 columns = self.fetch_columns raw_sql Statement_Setter.null
                 name = if alias == "" then (UUID.randomUUID.to_text) else alias
                 ctx = Context.for_query raw_sql name
-                Database_Table_Module.make_table self name columns ctx
+                ## Any problems are treated as errors - e.g. if the query
+                   contains clashing column names, it may very likely lead to
+                   data corruption. Our renaming mechanism is used to fix issues
+                   with existing tables with problematic names, but that
+                   mechanism will only provide a false-sense of security in case
+                   of a query, whereas a query like `SELECT 1 AS "A", 2 AS "A"`
+                   will actually result in both columns `A` and `A 1` containing
+                   the value 1; and value 2 being lost. That is why such queries
+                   must fail.
+                r = Database_Table_Module.make_table self name columns ctx on_problems=Problem_Behavior.Report_Error
+                r.catch Any error->
+                    Error.throw (Illegal_Argument.Error "The provided custom SQL query is invalid and may suffer data corruption when being processed, especially if it contains aliased column names, it may not be interpreted correctly. Please ensure the names are unique. The original error was: "+error.to_display_text cause=error)
         SQL_Query.Table_Name name ->
             case self.table_naming_helper.is_table_name_valid name of
                 True -> make_table_for_name self name alias
@@ -440,6 +451,12 @@ make_table_for_name connection name alias internal_temporary_keep_alive_referenc
         statement = connection.dialect.generate_sql (Query.Select Nothing ctx)
         statement_setter = connection.dialect.get_statement_setter
         columns = connection.fetch_columns statement statement_setter
-        Database_Table_Module.make_table connection name columns ctx
+        ## In case of accessing an existing table, we assume that column names
+           are distinguishable by the backend, so any issues that are caught
+           only affect Enso columns, and just renaming Enso columns is enough to
+           fix that - so we are good with just attaching the problems as a
+           warning. We do not want to fail, as we do want to allow the user to
+           access any table already present in the database.
+        Database_Table_Module.make_table connection name columns ctx on_problems=Problem_Behavior.Report_Warning
     result.catch SQL_Error sql_error->
         Error.throw (Table_Not_Found.Error name sql_error treated_as_query=False extra_message="")

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -780,11 +780,11 @@ type Table
 
         renamed.if_not_error <|
             index = self.internal_columns.index_of (c -> c.name == renamed.name)
-            to_add = case set_mode of
+            check_add = case set_mode of
                 Set_Mode.Add_Or_Update -> True
                 Set_Mode.Add -> if index.is_nothing then True else Error.throw (Existing_Column.Error renamed.name)
                 Set_Mode.Update -> if index.is_nothing then Error.throw (Missing_Column.Error renamed.name) else True
-            if to_add then
+            check_add.if_not_error <|
                 new_col = renamed.as_internal
                 new_cols = if index.is_nothing then self.internal_columns + [new_col] else
                     Vector.new self.column_count i-> if i == index then new_col else self.internal_columns.at i

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -780,7 +780,7 @@ type Table
            Nothing -> resolved
            _ : Text -> resolved.rename new_name
 
-        renamed.if_not_error <|
+        renamed.if_not_error <| self.column_naming_helper.check_ambiguity self.column_names new_name <|
             index = self.internal_columns.index_of (c -> c.name == renamed.name)
             check_add = case set_mode of
                 Set_Mode.Add_Or_Update -> True

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -768,7 +768,9 @@ type Table
     set self column new_name=Nothing set_mode=Set_Mode.Add_Or_Update on_problems=Report_Warning =
         resolved = case column of
             _ : Text -> self.evaluate_expression column on_problems
-            _ : Column -> column
+            _ : Column ->
+                if Helpers.check_integrity self column then column else
+                    Error.throw (Integrity_Error.Error "Column "+column.name)
             _ : Vector -> Error.throw (Unsupported_Database_Operation.Error "Cannot use `Vector` for `set` in the database.")
             _ : Array -> Error.throw (Unsupported_Database_Operation.Error "Cannot use `Array` for `set` in the database.")
             _ : Range -> Error.throw (Unsupported_Database_Operation.Error "Cannot use `Range` for `set` in the database.")

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -2202,8 +2202,9 @@ type Table
    - columns: List of columns to fetch. Each column is represented by a pair of
      column name and its expected SQL Type.
    - ctx: The context to use for the table.
-make_table : Connection -> Text -> Vector -> Context -> Table
-make_table connection table_name columns ctx =
+   - on_problems: The behavior to use when problems are encountered.
+make_table : Connection -> Text -> Vector -> Context -> Problem_Behavior -> Table
+make_table connection table_name columns ctx on_problems =
     if columns.is_empty then Error.throw (Illegal_State.Error "Unexpectedly attempting to create a Database Table with no columns. This is a bug in the Database library.") else
         problem_builder = Problem_Builder.new
         column_names_validator = connection.base_connection.column_naming_helper.create_unique_name_strategy
@@ -2217,7 +2218,7 @@ make_table connection table_name columns ctx =
             Internal_Column.Value enso_name (SQL_Type_Reference.from_constant sql_type) expression
         problem_builder.report_unique_name_strategy column_names_validator
         # We do not want to stop the table from being fetched, so we report the issues as warnings.
-        problem_builder.attach_problems_before Problem_Behavior.Report_Warning <|
+        problem_builder.attach_problems_before on_problems <|
             Table.Value table_name connection cols ctx
 
 ## PRIVATE

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -402,7 +402,7 @@ type Table
            `Missing_Input_Columns` is raised as an error, unless
            `error_on_missing_columns` is set to `False`, in which case the
            problem is reported according to the `on_problems` setting.
-         - If any of the new names are invalid, an `Invalid_Output_Column_Names`
+         - If any of the new names are invalid, an `Invalid_Column_Names`
            error is raised.
          - Other problems are reported according to the `on_problems` setting:
              - If a column is matched by two selectors resulting in a different
@@ -442,7 +442,7 @@ type Table
 
               table.rename_columns (Map.from_vector [["name=(.*)".to_regex, "key:$1"]])
     @column_map Widget_Helpers.make_rename_name_vector_selector
-    rename_columns : Map (Text | Integer | Regex) Text | Vector Text | Vector Vector -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Ambiguous_Column_Rename | Too_Many_Column_Names_Provided | Invalid_Output_Column_Names | Duplicate_Output_Column_Names
+    rename_columns : Map (Text | Integer | Regex) Text | Vector Text | Vector Vector -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Ambiguous_Column_Rename | Too_Many_Column_Names_Provided | Invalid_Column_Names | Duplicate_Output_Column_Names
     rename_columns self (column_map:(Map | Vector)=["Column"]) (case_sensitivity:Case_Sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=True) (on_problems:Problem_Behavior=Report_Warning) =
         new_names = Table_Helpers.rename_columns self.column_naming_helper self.internal_columns column_map case_sensitivity error_on_missing_columns on_problems
         Warning.with_suspended new_names names->
@@ -457,7 +457,7 @@ type Table
 
          The following problems can occur:
          - If any of the new names are invalid, an
-           `Invalid_Output_Column_Names`.
+           `Invalid_Column_Names`.
          - If any of the new names clash either with existing names or each
            other, a Duplicate_Output_Column_Names.
 
@@ -1470,7 +1470,7 @@ type Table
          - The following additional problems may be reported according to the
            `on_problems` settings:
            - If there are invalid column names in the output table,
-             a `Invalid_Output_Column_Names`.
+             a `Invalid_Column_Names`.
            - If there are duplicate column names in the output table,
              a `Duplicate_Output_Column_Names`.
            - If grouping on or computing the `Mode` on a floating point number,
@@ -1485,7 +1485,7 @@ type Table
 
               table.aggregate [Aggregate_Column.Group_By "Key", Aggregate_Column.Count]
     @columns Widget_Helpers.make_aggregate_column_vector_selector
-    aggregate : Vector Aggregate_Column -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Invalid_Aggregate_Column | Invalid_Output_Column_Names | Duplicate_Output_Column_Names | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings
+    aggregate : Vector Aggregate_Column -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Invalid_Aggregate_Column | Invalid_Column_Names | Duplicate_Output_Column_Names | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings
     aggregate self columns (error_on_missing_columns=False) (on_problems=Report_Warning) =
         validated = Aggregate_Column_Helper.prepare_aggregate_columns self.column_naming_helper columns self error_on_missing_columns=error_on_missing_columns
         key_columns = validated.key_columns
@@ -1613,7 +1613,7 @@ type Table
            match any columns in the input table nor is it a valid expression, an
            `Invalid_Aggregate_Column` dataflow error is raised.
          - If a column name generated from the input data is invalid,
-           `Invalid_Output_Column_Names` error is raised.
+           `Invalid_Column_Names` error is raised.
          - If an aggregation fails, an `Invalid_Aggregation` dataflow error is
            raised.
          - Additionally, the following problems may be reported according to the
@@ -1642,7 +1642,7 @@ type Table
     @group_by Widget_Helpers.make_column_name_vector_selector
     @name_column Widget_Helpers.make_column_name_selector
     @values (Widget_Helpers.make_aggregate_column_selector include_group_by=False)
-    cross_tab : Vector (Integer | Text | Regex | Aggregate_Column) | Text | Integer | Regex -> (Text | Integer) -> Aggregate_Column | Vector Aggregate_Column -> Problem_Behavior -> Table ! Missing_Input_Columns | Invalid_Aggregate_Column | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings | Invalid_Output_Column_Names
+    cross_tab : Vector (Integer | Text | Regex | Aggregate_Column) | Text | Integer | Regex -> (Text | Integer) -> Aggregate_Column | Vector Aggregate_Column -> Problem_Behavior -> Table ! Missing_Input_Columns | Invalid_Aggregate_Column | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings | Invalid_Column_Names
     cross_tab self group_by name_column values=Aggregate_Column.Count (on_problems=Report_Warning) =
         ## Avoid unused arguments warning. We cannot rename arguments to `_`,
            because we need to keep the API consistent with the in-memory table.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Table.enso
@@ -2205,11 +2205,20 @@ type Table
 make_table : Connection -> Text -> Vector -> Context -> Table
 make_table connection table_name columns ctx =
     if columns.is_empty then Error.throw (Illegal_State.Error "Unexpectedly attempting to create a Database Table with no columns. This is a bug in the Database library.") else
+        problem_builder = Problem_Builder.new
+        column_names_validator = connection.base_connection.column_naming_helper.create_unique_name_strategy
         cols = columns.map p->
-            name = p.first
+            raw_name = p.first
             sql_type = p.second
-            Internal_Column.Value name (SQL_Type_Reference.from_constant sql_type) (SQL_Expression.Column table_name name)
-        Table.Value table_name connection cols ctx
+            # We ensure that the name used in the Enso table is a valid name for Enso column and is unique, possibly changing the input name slightly.
+            enso_name = column_names_validator.make_unique raw_name
+            # The expression keeps the original 'raw' name coming from the database.
+            expression = SQL_Expression.Column table_name raw_name
+            Internal_Column.Value enso_name (SQL_Type_Reference.from_constant sql_type) expression
+        problem_builder.report_unique_name_strategy column_names_validator
+        # We do not want to stop the table from being fetched, so we report the issues as warnings.
+        problem_builder.attach_problems_before Problem_Behavior.Report_Warning <|
+            Table.Value table_name connection cols ctx
 
 ## PRIVATE
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Common/Encoding_Limited_Naming_Properties.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Common/Encoding_Limited_Naming_Properties.enso
@@ -10,7 +10,7 @@ from Standard.Table.Errors import Name_Too_Long
    size of a string encoded in a particular encoding, in bytes.
 type Encoding_Limited_Naming_Properties
     ## PRIVATE
-    Instance (encoding : Encoding) (limit : Integer)
+    Instance (encoding : Encoding) (limit : Integer) (is_case_sensitive : Boolean = True)
 
     ## PRIVATE
     encoded_size : Text -> Integer

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Entity_Naming_Properties.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Entity_Naming_Properties.enso
@@ -33,10 +33,13 @@ new jdbc_connection =
         if column_limit == 0 then
             Panic.throw (Illegal_State.Error "Unexpected: The database server does not report the maximum column name length.")
 
-        table_properties = Encoding_Limited_Naming_Properties.Instance encoding table_limit
-        column_properties = Encoding_Limited_Naming_Properties.Instance encoding column_limit
+        ## Postgres column/table names may be lowercased if unquoted, but when
+           quoted we have full case sensitivity and can distinguish columns
+           `A` from `a` as different.
+           Our generator is supposed to always quote identifiers.
+        table_properties = Encoding_Limited_Naming_Properties.Instance encoding table_limit is_case_sensitive=True
+        column_properties = Encoding_Limited_Naming_Properties.Instance encoding column_limit is_case_sensitive=True
         Entity_Naming_Properties.Value for_table_names=table_properties for_column_names=column_properties
-
 
 ## PRIVATE
 get_pragma_value : JDBC_Connection -> Text -> Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Entity_Naming_Properties.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Entity_Naming_Properties.enso
@@ -7,6 +7,5 @@ import project.Internal.Connection.Entity_Naming_Properties.Entity_Naming_Proper
 ## PRIVATE
 new : Entity_Naming_Properties
 new =
-    # TODO for #7412 we will customize this to indicate the case insensitivity
-    default = Unlimited_Naming_Properties.Instance
+    default = Unlimited_Naming_Properties.Instance is_case_sensitive=False
     Entity_Naming_Properties.Value for_table_names=default for_column_names=default

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload_Table.enso
@@ -6,6 +6,7 @@ import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Runtime.Context
 
 import Standard.Table.Data.Table.Table as In_Memory_Table
+import Standard.Table.Internal.Problem_Builder.Problem_Builder
 from Standard.Table import Aggregate_Column, Join_Kind, Value_Type
 from Standard.Table.Errors import all
 
@@ -60,8 +61,7 @@ create_table_implementation connection table_name structure primary_key temporar
 internal_create_table_structure connection table_name structure primary_key temporary on_problems =
     aligned_structure = align_structure structure
     resolved_primary_key = resolve_primary_key aligned_structure primary_key
-    column_names = aligned_structure.map .name
-    connection.base_connection.column_naming_helper.validate_many_column_names column_names <|
+    validate_structure connection.base_connection.column_naming_helper aligned_structure <|
         create_table_statement = prepare_create_table_statement connection table_name aligned_structure resolved_primary_key temporary on_problems
         check_transaction_ddl_support connection
         update_result = create_table_statement.if_not_error <|
@@ -232,6 +232,24 @@ align_structure table_or_columns = case table_or_columns of
 structure_from_existing_table table =
     table.columns.map column->
         Column_Description.Value column.name column.value_type
+
+## PRIVATE
+   Verifies that the provided structure is valid, and runs the provided action
+   or raises an error.
+
+   In particular it checks if there are no clashing column names.
+validate_structure column_naming_helper structure ~action =
+    column_names = structure.map .name
+    # We first check if the names are valid, to throw a more specific error.
+    column_naming_helper.validate_many_column_names column_names <|
+        problem_builder = Problem_Builder.new
+        ## Then we run the deduplication logic. We discard the results, because
+           if anything is wrong we will fail anyway.
+        unique = column_naming_helper.create_unique_name_strategy
+        column_names.each unique.make_unique
+        problem_builder.report_unique_name_strategy unique
+        problem_builder.attach_problems_before Problem_Behavior.Report_Error <|
+            action
 
 ## PRIVATE
    Returns the name of the first column in the provided table structure.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -24,7 +24,7 @@ import project.Internal.Parse_Values_Helper
 import project.Internal.Widget_Helpers
 from project.Data.Table import print_table
 from project.Data.Type.Value_Type import Auto, Value_Type
-from project.Errors import Conversion_Failure, Floating_Point_Equality, Inexact_Type_Coercion, Invalid_Value_Type, No_Index_Set_Error, Invalid_Output_Column_Names
+from project.Errors import Conversion_Failure, Floating_Point_Equality, Inexact_Type_Coercion, Invalid_Value_Type, No_Index_Set_Error, Invalid_Column_Names
 from project.Internal.Column_Format import all
 from project.Internal.Java_Exports import make_date_builder_adapter, make_double_builder, make_long_builder, make_string_builder
 
@@ -54,14 +54,14 @@ type Column
         ## TODO [RW] in #6111 use a more specific storage type, and if it is a
            type that does not allow date/time values, use `fromItemsNoDateConversion` instead.
         expected_storage_type = Nothing
-        Invalid_Output_Column_Names.handle_java_exception <| Polyglot_Helpers.handle_polyglot_dataflow_errors <|
+        Invalid_Column_Names.handle_java_exception <| Polyglot_Helpers.handle_polyglot_dataflow_errors <|
             Column.Value (Java_Column.fromItems name items expected_storage_type)
 
     ## PRIVATE
        Creates a new column given a name and an internal Java storage.
     from_storage : Text -> Java_Storage -> Column
     from_storage name storage =
-        Invalid_Output_Column_Names.handle_java_exception <|
+        Invalid_Column_Names.handle_java_exception <|
             Column.Value (Java_Column.new name storage)
 
     ## PRIVATE
@@ -74,7 +74,7 @@ type Column
        - repeats: The number of times to repeat the vector.
     from_vector_repeated : Text -> Vector -> Integer -> Column
     from_vector_repeated name items repeats =
-        Invalid_Output_Column_Names.handle_java_exception <| Illegal_Argument.handle_java_exception <|
+        Invalid_Column_Names.handle_java_exception <| Illegal_Argument.handle_java_exception <|
             Column.Value (Java_Column.fromRepeatedItems name items repeats)
 
     ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1324,16 +1324,17 @@ type Table
         renamed = case new_name of
            Nothing -> resolved
            _ : Text -> resolved.rename new_name
-        check_add_mode = case set_mode of
-            Set_Mode.Add_Or_Update -> True
-            Set_Mode.Add -> if self.java_table.getColumnByName renamed.name . is_nothing then True else
-                Error.throw (Existing_Column.Error renamed.name)
-            Set_Mode.Update -> if self.java_table.getColumnByName renamed.name . is_nothing . not then True else
-                Error.throw (Missing_Column.Error renamed.name)
+        renamed.if_not_error <| self.column_naming_helper.check_ambiguity self.column_names new_name <|
+            check_add_mode = case set_mode of
+                Set_Mode.Add_Or_Update -> True
+                Set_Mode.Add -> if self.java_table.getColumnByName renamed.name . is_nothing then True else
+                    Error.throw (Existing_Column.Error renamed.name)
+                Set_Mode.Update -> if self.java_table.getColumnByName renamed.name . is_nothing . not then True else
+                    Error.throw (Missing_Column.Error renamed.name)
 
-        check_add_mode.if_not_error <|
-            if resolved.length != self.row_count then Error.throw (Row_Count_Mismatch.Error self.row_count resolved.length) else
-                Table.Value (self.java_table.addOrReplaceColumn renamed.java_column)
+            check_add_mode.if_not_error <|
+                if resolved.length != self.row_count then Error.throw (Row_Count_Mismatch.Error self.row_count resolved.length) else
+                    Table.Value (self.java_table.addOrReplaceColumn renamed.java_column)
 
     ## Given an expression, create a derived column where each value is the
        result of evaluating the expression for the row.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -523,7 +523,7 @@ type Table
            `Missing_Input_Columns` is raised as an error, unless
            `error_on_missing_columns` is set to `False`, in which case the
            problem is reported according to the `on_problems` setting.
-         - If any of the new names are invalid, an `Invalid_Output_Column_Names`
+         - If any of the new names are invalid, an `Invalid_Column_Names`
            error is raised.
          - Other problems are reported according to the `on_problems` setting:
              - If a column is matched by two selectors resulting in a different
@@ -563,7 +563,7 @@ type Table
 
               table.rename_columns (Map.from_vector [["name=(.*)".to_regex, "key:$1"]])
     @column_map Widget_Helpers.make_rename_name_vector_selector
-    rename_columns : Map (Text | Integer | Regex) Text | Vector Text | Vector Vector -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Ambiguous_Column_Rename | Too_Many_Column_Names_Provided | Invalid_Output_Column_Names | Duplicate_Output_Column_Names
+    rename_columns : Map (Text | Integer | Regex) Text | Vector Text | Vector Vector -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Ambiguous_Column_Rename | Too_Many_Column_Names_Provided | Invalid_Column_Names | Duplicate_Output_Column_Names
     rename_columns self (column_map:(Map | Vector)=["Column"]) (case_sensitivity:Case_Sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=True) (on_problems:Problem_Behavior=Report_Warning) =
         new_names = Table_Helpers.rename_columns self.column_naming_helper self.columns column_map case_sensitivity error_on_missing_columns on_problems
         Warning.with_suspended new_names names->
@@ -578,7 +578,7 @@ type Table
 
          The following problems can occur:
          - If any of the new names are invalid, an
-           `Invalid_Output_Column_Names`.
+           `Invalid_Column_Names`.
          - If any of the new names clash either with existing names or each
            other, a Duplicate_Output_Column_Names.
 
@@ -638,7 +638,7 @@ type Table
          - Additionally, the following problems may be reported according to the
            `on_problems` setting:
            - If there are invalid column names in the output table,
-             a `Invalid_Output_Column_Names`.
+             a `Invalid_Column_Names`.
            - If there are duplicate column names in the output table,
              a `Duplicate_Output_Column_Names`.
            - If grouping on or computing the `Mode` on a floating point number,
@@ -653,7 +653,7 @@ type Table
 
               table.aggregate [Aggregate_Column.Group_By "Key", Aggregate_Column.Count]
     @columns Widget_Helpers.make_aggregate_column_vector_selector
-    aggregate : Vector Aggregate_Column -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Invalid_Aggregate_Column | Invalid_Output_Column_Names | Duplicate_Output_Column_Names | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings
+    aggregate : Vector Aggregate_Column -> Boolean -> Problem_Behavior -> Table ! No_Output_Columns | Invalid_Aggregate_Column | Invalid_Column_Names | Duplicate_Output_Column_Names | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings
     aggregate self columns (error_on_missing_columns=False) (on_problems=Report_Warning) =
         validated = Aggregate_Column_Helper.prepare_aggregate_columns self.column_naming_helper columns self error_on_missing_columns=error_on_missing_columns
 
@@ -1889,7 +1889,7 @@ type Table
            match any columns in the input table nor is it a valid expression, an
            `Invalid_Aggregate_Column` dataflow error is raised.
          - If a column name generated from the input data is invalid,
-           `Invalid_Output_Column_Names` error is raised.
+           `Invalid_Column_Names` error is raised.
          - If an aggregation fails, an `Invalid_Aggregation` dataflow error is
            raised.
          - Additionally, the following problems may be reported according to the
@@ -1918,7 +1918,7 @@ type Table
     @group_by Widget_Helpers.make_column_name_vector_selector
     @name_column Widget_Helpers.make_column_name_selector
     @values (Widget_Helpers.make_aggregate_column_selector include_group_by=False)
-    cross_tab : Vector (Integer | Text | Regex | Aggregate_Column) | Text | Integer | Regex -> (Text | Integer) -> Aggregate_Column | Vector Aggregate_Column -> Problem_Behavior -> Table ! Missing_Input_Columns | Invalid_Aggregate_Column | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings | Invalid_Output_Column_Names
+    cross_tab : Vector (Integer | Text | Regex | Aggregate_Column) | Text | Integer | Regex -> (Text | Integer) -> Aggregate_Column | Vector Aggregate_Column -> Problem_Behavior -> Table ! Missing_Input_Columns | Invalid_Aggregate_Column | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings | Invalid_Column_Names
     cross_tab self group_by name_column values=Aggregate_Column.Count (on_problems=Report_Warning) =
         columns_helper = self.columns_helper
         problem_builder = Problem_Builder.new error_on_missing_columns=True
@@ -1976,7 +1976,7 @@ type Table
                         inner_panic = caught_panic.payload
                         Error.throw (Column_Count_Exceeded.Error inner_panic.getMaximumColumnCount inner_panic.getColumnCount)
                     Panic.catch TooManyColumnsException handler=too_many_columns <|
-                        Invalid_Output_Column_Names.handle_java_exception <|
+                        Invalid_Column_Names.handle_java_exception <|
                             index.makeCrossTabTable java_key_columns matched_name.first.java_column data_columns aggregate_names
 
             on_problems.attach_problems_after (Table.Value result) <|

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1321,18 +1321,18 @@ type Table
             _ : Date_Range -> Column.from_vector (new_name.if_nothing "Date Range") column.to_vector
             _ -> Error.throw (Illegal_Argument.Error "Unsupported type for `Table.set`.")
 
-        if resolved.length != self.row_count then Error.throw (Row_Count_Mismatch.Error self.row_count resolved.length) else
-            renamed = case new_name of
-               Nothing -> resolved
-               _ : Text -> resolved.rename new_name
-            check_add_mode = case set_mode of
-                Set_Mode.Add_Or_Update -> True
-                Set_Mode.Add -> if self.java_table.getColumnByName renamed.name . is_nothing then True else
-                    Error.throw (Existing_Column.Error renamed.name)
-                Set_Mode.Update -> if self.java_table.getColumnByName renamed.name . is_nothing . not then True else
-                    Error.throw (Missing_Column.Error renamed.name)
+        renamed = case new_name of
+           Nothing -> resolved
+           _ : Text -> resolved.rename new_name
+        check_add_mode = case set_mode of
+            Set_Mode.Add_Or_Update -> True
+            Set_Mode.Add -> if self.java_table.getColumnByName renamed.name . is_nothing then True else
+                Error.throw (Existing_Column.Error renamed.name)
+            Set_Mode.Update -> if self.java_table.getColumnByName renamed.name . is_nothing . not then True else
+                Error.throw (Missing_Column.Error renamed.name)
 
-            check_add_mode.if_not_error <|
+        check_add_mode.if_not_error <|
+            if resolved.length != self.row_count then Error.throw (Row_Count_Mismatch.Error self.row_count resolved.length) else
                 Table.Value (self.java_table.addOrReplaceColumn renamed.java_column)
 
     ## Given an expression, create a derived column where each value is the

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
@@ -648,3 +648,14 @@ type Truncated_Column_Names
     to_display_text : Text
     to_display_text self =
         "The column names " + self.original_names.to_display_text + " were truncated to fit the maximum length supported by the backend (" + self.max_length.to_text + ")."
+
+type Clashing_Column_Name
+    ## PRIVATE
+       Indicates that a provided column name is clashing with another column name.
+    Error (provided_name : Text) (clashing_name : Text)
+
+    ## PRIVATE
+       Pretty print the clashing column name error.
+    to_display_text : Text
+    to_display_text self =
+        "The column name [" + self.provided_name.to_display_text + "] is clashing with the column name [" + self.clashing_name.to_display_text + "] - they cannot be distinguished because the backend is not case sensitive, so only one of these can exist within a single table. If you wanted to replace the column, use the exact (case sensitive) name of the column to replace."

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
@@ -651,7 +651,8 @@ type Truncated_Column_Names
 
 type Clashing_Column_Name
     ## PRIVATE
-       Indicates that a provided column name is clashing with another column name.
+       Indicates that a provided column name is clashing with another column
+       name in the `Table.set` operation.
     Error (provided_name : Text) (clashing_name : Text)
 
     ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
@@ -51,7 +51,7 @@ type Too_Many_Column_Names_Provided
         "Too many column names provided. " + (self.column_names.at 0).to_text + " are unused."
 
 ## One or more column names were invalid during a rename operation.
-type Invalid_Output_Column_Names
+type Invalid_Column_Names
     Error (column_names : Vector Text) (extra_message : Text | Nothing = Nothing)
 
     ## PRIVATE
@@ -71,7 +71,7 @@ type Invalid_Output_Column_Names
     handle_java_exception ~action =
         Panic.catch InvalidColumnNameException action caught_panic->
             exception = caught_panic.payload
-            error = Invalid_Output_Column_Names.Error [exception.name] exception.extraMessage
+            error = Invalid_Column_Names.Error [exception.name] exception.extraMessage
             Error.throw error
 
 ## One or more column names clashed during a rename operation.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
@@ -50,7 +50,7 @@ type Too_Many_Column_Names_Provided
     to_display_text self =
         "Too many column names provided. " + (self.column_names.at 0).to_text + " are unused."
 
-## One or more column names were invalid during a rename operation.
+## One or more column names were invalid.
 type Invalid_Column_Names
     Error (column_names : Vector Text) (extra_message : Text | Nothing = Nothing)
 
@@ -63,8 +63,8 @@ type Invalid_Column_Names
             Nothing -> ""
             message -> " "+message
         case self.column_names.length == 1 of
-            True -> "The name " + (self.column_names.at 0).to_display_text.pretty + " is invalid."+suffix
-            False -> "The names "+self.column_names.short_display_text+" are invalid."+suffix
+            True -> "The name " + (self.column_names.at 0).to_display_text.pretty + " is invalid and may be replaced in the resulting table."+suffix
+            False -> "The names "+self.column_names.short_display_text+" are invalid and may be replaced in the resulting table."+suffix
 
     ## PRIVATE
        Handles the Java counterpart `InvalidColumnNameException` and converts it into a dataflow error.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Aggregate_Column_Helper.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Aggregate_Column_Helper.enso
@@ -10,7 +10,7 @@ import project.Internal.Problem_Builder.Problem_Builder
 import project.Internal.Table_Helpers
 import project.Internal.Unique_Name_Strategy.Unique_Name_Strategy
 from project.Data.Aggregate_Column.Aggregate_Column import all
-from project.Errors import Duplicate_Output_Column_Names, Invalid_Aggregation, Invalid_Output_Column_Names, No_Output_Columns
+from project.Errors import Duplicate_Output_Column_Names, Invalid_Aggregation, Invalid_Column_Names, No_Output_Columns
 
 polyglot java import org.enso.table.aggregations.Aggregator
 polyglot java import org.enso.table.aggregations.Concatenate as ConcatenateAggregator

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Column_Naming_Helper.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Column_Naming_Helper.enso
@@ -3,7 +3,7 @@ import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 import project.Internal.Naming_Properties.Unlimited_Naming_Properties
 import project.Internal.Unique_Name_Strategy.Unique_Name_Strategy
-from project.Errors import Invalid_Column_Names
+from project.Errors import Invalid_Column_Names, Clashing_Column_Name
 from project.Internal.Table_Helpers import is_column
 
 polyglot java import org.enso.base.Text_Utils
@@ -52,6 +52,28 @@ type Column_Naming_Helper
         case self.naming_properties.size_limit of
             Nothing  -> cleaned
             max_size -> self.naming_properties.truncate cleaned max_size
+
+    ## PRIVATE
+       Checks if the new name is unambiguously different from the existing ones.
+       In particular, it is used for case-insensitive backends to ensure that
+       there are no two columns that while not equal, are equal ignoring case -
+       which could introduce problems.
+    check_ambiguity : Vector Text -> Text -> Any -> Any ! Clashing_Column_Name
+    check_ambiguity self existing_names new_name ~continuation =
+        case self.naming_properties.is_case_sensitive of
+            # Nothing to check for case-sensitive backends.
+            True -> continuation
+            False ->
+                case_insensitive_match = existing_names.find name-> name.equals_ignore_case new_name
+                case case_insensitive_match of
+                    # No matches at all, so we can continue.
+                    Nothing -> continuation
+                    # We've got a match.
+                    existing_name ->
+                        is_exact = existing_name == new_name
+                        if is_exact then continuation else
+                            # If the match was not exact, we have ambiguity.
+                            Error.throw (Clashing_Column_Name.Error new_name existing_name)
 
     ## PRIVATE
        Generates a column name for a binary operation.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Column_Naming_Helper.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Column_Naming_Helper.enso
@@ -3,7 +3,7 @@ import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 import project.Internal.Naming_Properties.Unlimited_Naming_Properties
 import project.Internal.Unique_Name_Strategy.Unique_Name_Strategy
-from project.Errors import Invalid_Output_Column_Names
+from project.Errors import Invalid_Column_Names
 from project.Internal.Table_Helpers import is_column
 
 polyglot java import org.enso.base.Text_Utils
@@ -29,7 +29,7 @@ type Column_Naming_Helper
     ## PRIVATE
        Checks if the name is valid and runs the action, otherwise raises an error.
     ensure_name_is_valid self name ~action =
-        checked = Invalid_Output_Column_Names.handle_java_exception <|
+        checked = Invalid_Column_Names.handle_java_exception <|
             Java_Column.ensureNameIsValid name
         checked.if_not_error <| case self.naming_properties.size_limit of
             Nothing -> action

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Column_Naming_Helper.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Column_Naming_Helper.enso
@@ -64,7 +64,7 @@ type Column_Naming_Helper
             # Nothing to check for case-sensitive backends.
             True -> continuation
             False ->
-                case_insensitive_match = existing_names.find name-> name.equals_ignore_case new_name
+                case_insensitive_match = existing_names.find if_missing=Nothing name-> name.equals_ignore_case new_name
                 case case_insensitive_match of
                     # No matches at all, so we can continue.
                     Nothing -> continuation

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Excel_Reader.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Excel_Reader.enso
@@ -6,7 +6,7 @@ import Standard.Base.System.File.Input_Stream
 import project.Data.Table.Table
 import project.Excel.Excel_Range.Excel_Range
 import project.Excel.Excel_Section.Excel_Section
-from project.Errors import Duplicate_Output_Column_Names, Empty_Sheet_Error, Invalid_Location, Invalid_Output_Column_Names
+from project.Errors import Duplicate_Output_Column_Names, Empty_Sheet_Error, Invalid_Location, Invalid_Column_Names
 
 polyglot java import org.apache.poi.poifs.filesystem.NotOLE2FileException
 polyglot java import org.apache.poi.UnsupportedFileFormatException
@@ -21,7 +21,7 @@ prepare_reader_table : Problem_Behavior -> Any -> Table
 prepare_reader_table on_problems result_with_problems =
     map_problem java_problem =
         if Java.is_instance java_problem DuplicateNames then Duplicate_Output_Column_Names.Error (Vector.from_polyglot_array java_problem.duplicatedNames) else
-              if Java.is_instance java_problem InvalidNames then Invalid_Output_Column_Names.Error (Vector.from_polyglot_array java_problem.invalidNames) else
+              if Java.is_instance java_problem InvalidNames then Invalid_Column_Names.Error (Vector.from_polyglot_array java_problem.invalidNames) else
                 java_problem
     parsing_problems = Vector.from_polyglot_array (result_with_problems.problems) . map map_problem
     on_problems.attach_problems_after (Table.Value result_with_problems.value) parsing_problems

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Java_Problems.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Java_Problems.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base.Errors.Common.Arithmetic_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
-from project.Errors import Additional_Invalid_Rows, Additional_Warnings, Duplicate_Output_Column_Names, Floating_Point_Equality, Invalid_Aggregation, Invalid_Output_Column_Names, Invalid_Row, Unquoted_Characters_In_Output, Unquoted_Delimiter
+from project.Errors import Additional_Invalid_Rows, Additional_Warnings, Duplicate_Output_Column_Names, Floating_Point_Equality, Invalid_Aggregation, Invalid_Column_Names, Invalid_Row, Unquoted_Characters_In_Output, Unquoted_Delimiter
 
 polyglot java import org.enso.table.data.table.problems.ArithmeticError
 polyglot java import org.enso.table.data.table.problems.FloatingPointGrouping
@@ -36,7 +36,7 @@ translate_problem p = case p of
     _ : DuplicateNames ->
         Duplicate_Output_Column_Names.Error (Vector.from_polyglot_array p.duplicatedNames)
     _ : InvalidNames ->
-        Invalid_Output_Column_Names.Error (Vector.from_polyglot_array p.invalidNames)
+        Invalid_Column_Names.Error (Vector.from_polyglot_array p.invalidNames)
     _ : InvalidFormat ->
         Panic.throw (Illegal_Argument.Error "InvalidFormat should be translated using the Parse_Values_Helper.translate_parsing_problem instead. This is a bug in the Table library.")
     _ ->

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Naming_Properties.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Naming_Properties.enso
@@ -34,6 +34,13 @@ type Naming_Properties
         Unimplemented.throw "This is an interface only."
 
     ## PRIVATE
+       Specifies if names are case sensitive.
+       If not, names that are equal case insensitively, need to be deduplicated.
+    is_case_sensitive : Boolean
+    is_case_sensitive =
+        Unimplemented.throw "This is an interface only."
+
+    ## PRIVATE
        Raises a `Name_Too_Long` error for the given name.
        The implementation may customize the extra message appended to the error
        explaining the limitations.
@@ -45,20 +52,23 @@ type Naming_Properties
 ## PRIVATE
    A default singleton implementation of a `Naming_Properties` which imposes no
    length limit.
+
+   Its case sensitivity may be customized. By default it is case sensitive, as
+   that is the behaviour for the in-memory backend.
 type Unlimited_Naming_Properties
-    Instance
+    Instance (is_case_sensitive : Boolean = True)
 
     ## PRIVATE
     encoded_size : Text -> Integer
     encoded_size self name =
         _ = name
-        Panic.throw (Illegal_State.Error "`In_Memory_Naming_Helper.encoded_size` but `size_limit` is `Nothing`. This is a bug in the Table library.")
+        Panic.throw (Illegal_State.Error "`Unlimited_Naming_Properties.encoded_size` but `size_limit` is `Nothing`. This is a bug in the Table library.")
 
     ## PRIVATE
     truncate : Text -> Integer -> Text
     truncate self name size =
         _ = [name, size]
-        Panic.throw (Illegal_State.Error "`In_Memory_Naming_Helper.truncate` but `size_limit` is `Nothing`. This is a bug in the Table library.")
+        Panic.throw (Illegal_State.Error "`Unlimited_Naming_Properties.truncate` but `size_limit` is `Nothing`. This is a bug in the Table library.")
 
     ## PRIVATE
     size_limit : Integer | Nothing
@@ -68,7 +78,7 @@ type Unlimited_Naming_Properties
     raise_name_too_long_error : Text -> Text -> Nothing ! Name_Too_Long
     raise_name_too_long_error self entity_kind name =
         _ = [entity_kind, name]
-        Panic.throw (Illegal_State.Error "`In_Memory_Naming_Helper.raise_name_too_long_error` but `size_limit` is `Nothing`. This is a bug in the Table library.")
+        Panic.throw (Illegal_State.Error "`Unlimited_Naming_Properties.raise_name_too_long_error` but `size_limit` is `Nothing`. This is a bug in the Table library.")
 
 ## PRIVATE
    A helper method that recovers panics thrown by `Naming_Properties`.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Problem_Builder.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Problem_Builder.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base.Runtime.Ref.Ref
 
 import project.Internal.Vector_Builder.Vector_Builder
-from project.Errors import Duplicate_Output_Column_Names, Invalid_Aggregate_Column, Invalid_Output_Column_Names, Missing_Input_Columns, Truncated_Column_Names
+from project.Errors import Duplicate_Output_Column_Names, Invalid_Aggregate_Column, Invalid_Column_Names, Missing_Input_Columns, Truncated_Column_Names
 
 ## PRIVATE
 type Problem_Builder
@@ -20,7 +20,7 @@ type Problem_Builder
     ## PRIVATE
     report_unique_name_strategy self unique_name_strategy =
         if unique_name_strategy.invalid_names.not_empty then
-            self.report_other_warning (Invalid_Output_Column_Names.Error unique_name_strategy.invalid_names)
+            self.report_other_warning (Invalid_Column_Names.Error unique_name_strategy.invalid_names)
         if unique_name_strategy.renames.not_empty then
             self.report_other_warning (Duplicate_Output_Column_Names.Error unique_name_strategy.renames)
         truncated_map = unique_name_strategy.truncated_names

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Unique_Name_Strategy.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Unique_Name_Strategy.enso
@@ -90,7 +90,6 @@ type Unique_Name_Strategy
     renames : Vector
     renames self = Vector.from_polyglot_array self.deduplicator.getDuplicatedNames
 
-
     ## PRIVATE
        ADVANCED
        Vector of any invalid names.

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Problems.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Problems.enso
@@ -115,11 +115,9 @@ expect_only_warning expected_warning result =
         (x == expected_warning) || (x.is_a expected_warning)
     found = warnings.find if_missing=Nothing is_expected
     if found.is_nothing then
-        loc = Meta.get_source_location 3
         Test.fail "Expected the result to contain a warning: "+expected_warning.to_text+", but it did not. The warnings were "+warnings.short_display_text+' (at '+loc+').'
     invalid = warnings.filter x-> is_expected x . not
     if invalid.not_empty then
-        loc = Meta.get_source_location 3
         Test.fail "Expected the result to contain only the warning: "+found.to_text+", but it also contained: "+invalid.to_text+' (at '+loc+').'
     found
 

--- a/std-bits/base/src/main/java/org/enso/base/text/CaseInsensitiveUnicodeNormalizedTextEquivalence.java
+++ b/std-bits/base/src/main/java/org/enso/base/text/CaseInsensitiveUnicodeNormalizedTextEquivalence.java
@@ -1,0 +1,35 @@
+package org.enso.base.text;
+
+import org.enso.base.Text_Utils;
+import org.graalvm.collections.Equivalence;
+
+import java.util.Locale;
+
+public class CaseInsensitiveUnicodeNormalizedTextEquivalence extends Equivalence {
+  private final Locale locale;
+
+  public CaseInsensitiveUnicodeNormalizedTextEquivalence(Locale locale) {
+    this.locale = locale;
+  }
+
+  @Override
+  public boolean equals(Object a, Object b) {
+    if (a instanceof String sa) {
+      if (b instanceof String sb) {
+        return Text_Utils.equals_ignore_case(sa, sb, locale);
+      }
+    }
+
+    throw new IllegalStateException("UnicodeNormalizedTextEquivalence can only compare Strings.");
+  }
+
+  @Override
+  public int hashCode(Object o) {
+    if (o instanceof String s) {
+      String keyed = Text_Utils.case_insensitive_key(s, locale);
+      return Text_Utils.unicodeNormalizedHashCode(keyed);
+    }
+
+    throw new IllegalStateException("CaseInsensitiveUnicodeNormalizedTextEquivalence can only hash Strings.");
+  }
+}

--- a/std-bits/base/src/main/java/org/enso/base/text/CaseInsensitiveUnicodeNormalizedTextEquivalence.java
+++ b/std-bits/base/src/main/java/org/enso/base/text/CaseInsensitiveUnicodeNormalizedTextEquivalence.java
@@ -5,6 +5,10 @@ import org.graalvm.collections.Equivalence;
 
 import java.util.Locale;
 
+/**
+ * An {@link Equivalence} for Text that ensures the same behaviour as Enso case-insensitive equality
+ * (`equals_ignore_case`) on the Text type.
+ */
 public class CaseInsensitiveUnicodeNormalizedTextEquivalence extends Equivalence {
   private final Locale locale;
 

--- a/std-bits/base/src/main/java/org/enso/base/text/UnicodeNormalizedTextEquivalence.java
+++ b/std-bits/base/src/main/java/org/enso/base/text/UnicodeNormalizedTextEquivalence.java
@@ -3,6 +3,9 @@ package org.enso.base.text;
 import org.enso.base.Text_Utils;
 import org.graalvm.collections.Equivalence;
 
+/**
+ * An {@link Equivalence} for Text that ensures the same behaviour as Enso equality (`==`) on the Text type.
+ */
 public class UnicodeNormalizedTextEquivalence extends Equivalence {
   @Override
   public boolean equals(Object a, Object b) {

--- a/std-bits/table/src/main/java/org/enso/table/util/NameDeduplicator.java
+++ b/std-bits/table/src/main/java/org/enso/table/util/NameDeduplicator.java
@@ -3,7 +3,10 @@ package org.enso.table.util;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
+
+import org.enso.base.text.CaseInsensitiveUnicodeNormalizedTextEquivalence;
 import org.enso.base.text.UnicodeNormalizedTextEquivalence;
 import org.enso.table.data.table.Column;
 import org.enso.table.problems.Problem;
@@ -11,14 +14,13 @@ import org.enso.table.util.problems.DuplicateNames;
 import org.enso.table.util.problems.InvalidNames;
 import org.graalvm.collections.EconomicMap;
 import org.graalvm.collections.EconomicSet;
+import org.graalvm.collections.Equivalence;
 import org.graalvm.collections.Pair;
 
 public class NameDeduplicator {
-  private final EconomicSet<String> usedNames =
-      EconomicSet.create(UnicodeNormalizedTextEquivalence.INSTANCE);
+  private final EconomicSet<String> usedNames;
   private final List<String> invalidNames = new ArrayList<>();
-  private final EconomicMap<String, String> truncatedNames =
-      EconomicMap.create(UnicodeNormalizedTextEquivalence.INSTANCE);
+  private final EconomicMap<String, String> truncatedNames;
   private final List<String> duplicatedNames = new ArrayList<>();
 
   private final String invalidNameReplacement;
@@ -46,6 +48,11 @@ public class NameDeduplicator {
       throw new IllegalStateException(
           "`DefaultNamingProperties.encoded_size` called but no limit is set.");
     }
+
+    @Override
+    public boolean is_case_sensitive() {
+      return true;
+    }
   }
 
   public NameDeduplicator(NamingProperties namingProperties) {
@@ -68,6 +75,15 @@ public class NameDeduplicator {
     }
 
     this.invalidNameReplacement = invalidNameReplacement;
+
+    Equivalence nameEquivalence;
+    if (namingProperties.is_case_sensitive()) {
+      nameEquivalence = UnicodeNormalizedTextEquivalence.INSTANCE;
+    } else {
+      nameEquivalence = new CaseInsensitiveUnicodeNormalizedTextEquivalence(Locale.ROOT);
+    }
+    usedNames = EconomicSet.create(nameEquivalence);
+    truncatedNames = EconomicMap.create(nameEquivalence);
   }
 
   public String makeValidAndTruncate(String input) {

--- a/std-bits/table/src/main/java/org/enso/table/util/NameDeduplicator.java
+++ b/std-bits/table/src/main/java/org/enso/table/util/NameDeduplicator.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
-
 import org.enso.base.text.CaseInsensitiveUnicodeNormalizedTextEquivalence;
 import org.enso.base.text.UnicodeNormalizedTextEquivalence;
 import org.enso.table.data.table.Column;

--- a/std-bits/table/src/main/java/org/enso/table/util/NamingProperties.java
+++ b/std-bits/table/src/main/java/org/enso/table/util/NamingProperties.java
@@ -26,4 +26,11 @@ public interface NamingProperties {
    * <p>If there is no size limit, this function may panic.
    */
   String truncate(String name, long max_encoded_size);
+
+  /**
+   * Specifies if names are case-sensitive.
+   * <p>
+   * If not, names that are equal case insensitively, need to be deduplicated.
+   */
+  boolean is_case_sensitive();
 }

--- a/std-bits/table/src/main/java/org/enso/table/util/NamingProperties.java
+++ b/std-bits/table/src/main/java/org/enso/table/util/NamingProperties.java
@@ -29,8 +29,8 @@ public interface NamingProperties {
 
   /**
    * Specifies if names are case-sensitive.
-   * <p>
-   * If not, names that are equal case insensitively, need to be deduplicated.
+   *
+   * <p>If not, names that are equal case insensitively, need to be deduplicated.
    */
   boolean is_case_sensitive();
 }

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Name_Edge_Cases_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Name_Edge_Cases_Spec.enso
@@ -31,6 +31,8 @@ spec setup =
                         t2.at "X" . to_vector . should_equal [1]
                         t2.at "x" . to_vector . should_equal [101]
 
+                    ## These tests are mostly inspired by issues described in:
+                       https://github.com/enso-org/enso/issues/7412
                     Test.with_clue "The distinction must be preserved after complex operations: " <|
                         t3 = t2.join t2 on="X"
                         t3.at "X" . to_vector . should_equal [1]
@@ -44,10 +46,10 @@ spec setup =
 
                         t5 = t4.reorder_columns "x"
                         t6 = t5.join t5 on="X"
-                        t6.at "X" . to_vector . should_equal [1, 1]
-                        t6.at "x" . to_vector . should_equal [101, 101]
-                        t6.at "Right X" . to_vector . should_equal [1, 1]
-                        t6.at "Right x" . to_vector . should_equal [101, 101]
+                        t6.at "X" . to_vector . should_equal [1, 1, 1, 1]
+                        t6.at "x" . to_vector . should_equal [101, 101, 101, 101]
+                        t6.at "Right X" . to_vector . should_equal [1, 1, 1, 1]
+                        t6.at "Right x" . to_vector . should_equal [101, 101, 101, 101]
 
         Test.specify "case insensitive name collisions - aggregate" <|
             t1 = table_builder [["X", [2, 1, 3, 2]]]
@@ -96,7 +98,6 @@ spec setup =
 
         Test.specify "case insensitive name collisions - cross_tab" <|
             t0 = table_builder [["X", ["a", "A", "b"]], ["Y", [4, 5, 6]]]
-
             t1 = t0.cross_tab group_by=[] name_column="X" values=[Aggregate_Column.First "Y"] . sort_columns
             case setup.is_database of
                 # TODO remove this check once implemented
@@ -114,6 +115,7 @@ spec setup =
                             t1.should_fail_with Clashing_Column_Name
 
         Test.specify "case insensitive name collisions - transpose" <|
+            t0 = table_builder [["X", [1, 2, 3]], ["Y", [4, 5, 6]]]
             t1 = t0.transpose attribute_column_name="a" value_column_name="A"
             case setup.is_database of
                 # TODO remove this check once implemented
@@ -121,11 +123,11 @@ spec setup =
                 False ->
                     case is_case_sensitive of
                         True ->
-                            t1.column_names . should_equal ["A", "a"]
+                            t1.column_names . should_equal ["a", "A"]
                             Problems.assume_no_problems t1
                         False ->
                             # TODO specify a more generic error once this is implemented
-                            t1.column_names . should_equal ["A", "a 1"]
+                            t1.column_names . should_equal ["a", "A 1"]
                             Problems.expect_only_warning Duplicate_Output_Column_Names t1
 
         Test.specify "unicode-normalized-equality vs selecting columns" <|

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Name_Edge_Cases_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Name_Edge_Cases_Spec.enso
@@ -1,0 +1,129 @@
+from Standard.Base import all
+
+# We hide the table constructor as instead we are supposed to use `table_builder` which is backend-agnostic.
+from Standard.Table import all hiding Table
+from Standard.Table.Errors import Clashing_Column_Name, Duplicate_Output_Column_Names
+
+from Standard.Database.Errors import Unsupported_Database_Operation
+
+from Standard.Test import Test, Problems
+import Standard.Test.Extensions
+
+from project.Common_Table_Operations.Util import run_default_backend
+from project.Common_Table_Operations.Core_Spec import weird_names
+
+main = run_default_backend spec
+
+spec setup =
+    table_builder = setup.table_builder
+    materialize = setup.materialize
+    is_case_sensitive = setup.test_selection.supports_case_sensitive_columns
+    Test.group setup.prefix+"Column Naming edge cases" <|
+        Test.specify "case insensitive name collisions - set" <|
+            t1 = table_builder [["X", [1]]]
+            Problems.assume_no_problems (t1.at "X" . rename "x")
+            t2 = t1.set "[X] + 100" "x"
+            case is_case_sensitive of
+                False ->
+                    t2.should_fail_with Clashing_Column_Name
+                True ->
+                    Test.with_clue "The columns should be correctly distinguished." <|
+                        t2.at "X" . to_vector . should_equal [1]
+                        t2.at "x" . to_vector . should_equal [101]
+
+                    Test.with_clue "The distinction must be preserved after complex operations: " <|
+                        t3 = t2.join t2 on="X"
+                        t3.at "X" . to_vector . should_equal [1]
+                        t3.at "x" . to_vector . should_equal [101]
+                        t3.at "Right X" . to_vector . should_equal [1]
+                        t3.at "Right x" . to_vector . should_equal [101]
+
+                        t4 = t2.union t2
+                        t4.at "X" . to_vector . should_equal [1, 1]
+                        t4.at "x" . to_vector . should_equal [101, 101]
+
+                        t5 = t4.reorder_columns "x"
+                        t6 = t5.join t5 on="X"
+                        t6.at "X" . to_vector . should_equal [1, 1]
+                        t6.at "x" . to_vector . should_equal [101, 101]
+                        t6.at "Right X" . to_vector . should_equal [1, 1]
+                        t6.at "Right x" . to_vector . should_equal [101, 101]
+
+        Test.specify "case insensitive name collisions - aggregate" <|
+            t1 = table_builder [["X", [2, 1, 3, 2]]]
+            t2 = t1.aggregate [Aggregate_Column.Maximum "X" "A", Aggregate_Column.Minimum "X" "a"]
+
+            case is_case_sensitive of
+                True ->
+                    t2.column_names . should_equal ["A", "a"]
+                    Problems.assume_no_problems t2
+                False ->
+                    t2.column_names . should_equal ["A", "a 1"]
+                    Problems.expect_only_warning Duplicate_Output_Column_Names t2
+
+            # Ensure that further processing does not break anything either.
+            t3 = t2.join t2 on="A"
+            case is_case_sensitive of
+                True ->  t3.column_names . should_equal ["A", "a", "Right A", "Right a"]
+                False -> t3.column_names . should_equal ["A", "a 1", "Right A", "Right a 1"]
+            t3.at 0 . to_vector . should_equal [3]
+            t3.at 1 . to_vector . should_equal [1]
+
+        Test.specify "case insensitive name collisions - joins" <|
+            # TODO like above
+            Nothing
+
+        Test.specify "case insensitive name collisions - cross_tab" <|
+            t0 = table_builder [["X", ["a", "A", "b"]], ["Y", [4, 5, 6]]]
+
+            t1 = t0.cross_tab group_by=[] name_column="X" values=[Aggregate_Column.First "Y"] . sort_columns
+            case setup.is_database of
+                # TODO remove this check once implemented
+                True -> t1.should_fail_with Unsupported_Database_Operation
+                False ->
+                    case is_case_sensitive of
+                        True ->
+                            t1.column_names . should_equal ["A", "a", "b"]
+                            Problems.assume_no_problems t1
+                            t1.at "A" . to_vector . should_equal [5]
+                            t1.at "a" . to_vector . should_equal [4]
+                            t1.at "b" . to_vector . should_equal [6]
+                        False ->
+                            # TODO specify a more generic error once this is implemented
+                            t1.should_fail_with Any
+
+        Test.specify "case insensitive name collisions - transpose" <|
+            t1 = t0.transpose attribute_column_name="a" value_column_name="A"
+            case setup.is_database of
+                # TODO remove this check once implemented
+                True -> t1.should_fail_with Unsupported_Database_Operation
+                False ->
+                    case is_case_sensitive of
+                        True ->
+                            t1.column_names . should_equal ["A", "a"]
+                            Problems.assume_no_problems t1
+                        False ->
+                            # TODO specify a more generic error once this is implemented
+                            t1.column_names . should_equal ["A", "a 1"]
+                            Problems.expect_only_warning Duplicate_Output_Column_Names t1
+
+        Test.specify "unicode-normalized-equality vs selecting columns" <|
+            ## In Enso column 'ś' and 's\u0301' are the same entity.
+               But in Databases, quite not necessarily.
+            t1 = table_builder [['ś', [1, 2]], ['X', ['a', 'b']]]
+            t2 = table_builder [['s\u0301', [2, 1]], ['Y', ['x', 'y']]]
+
+            # The two representations of the same string just address the same column:
+            t1.at 'ś' . to_vector . should_equal [1, 2]
+            t1.at 's\u0301' . to_vector . should_equal [1, 2]
+
+            t2.at 's\u0301' . to_vector . should_equal [2, 1]
+            t2.at 'ś' . to_vector . should_equal [2, 1]
+
+            t3 = t1.join t2 on='ś'
+            t3.column_names . should_equal ['ś', 'X', 'Right ś', 'Y']
+            m3 = materialize t3 . order_by 'ś'
+            m3.at 'ś' . to_vector . should_equal [1, 2]
+            m3.at 'X' . to_vector . should_equal ['a', 'b']
+            m3.at 'Right ś' . to_vector . should_equal [1, 2]
+            m3.at 'Y' . to_vector . should_equal ['y', 'x']

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Name_Edge_Cases_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Name_Edge_Cases_Spec.enso
@@ -82,7 +82,8 @@ spec setup =
                     Problems.assume_no_problems t3
                 False ->
                     t3.column_names . should_equal ["X", "a", "Right A"]
-                    Problems.expect_only_warning Duplicate_Output_Column_Names t3
+                    # No warning here as well, as 'just' adding the prefix is not considered enough to issue a `Duplicate_Output_Column_Names` in join.
+                    Problems.assume_no_problems t3
 
             t4 = t1.cross_join t2
             case is_case_sensitive of
@@ -91,7 +92,8 @@ spec setup =
                     Problems.assume_no_problems t4
                 False ->
                     t4.column_names . should_equal ["X", "a", "Right X", "Right A"]
-                    Problems.expect_only_warning Duplicate_Output_Column_Names t4
+                    # As above with join, no warning.
+                    Problems.assume_no_problems t4
 
             t5 = t1.join t2 on="X" join_kind=Join_Kind.Left_Exclusive
             t5.column_names . should_equal ["X", "a"]

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Name_Edge_Cases_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Name_Edge_Cases_Spec.enso
@@ -51,6 +51,26 @@ spec setup =
                         t6.at "Right X" . to_vector . should_equal [1, 1, 1, 1]
                         t6.at "Right x" . to_vector . should_equal [101, 101, 101, 101]
 
+        Test.specify "case insensitive name collisions - rename" <|
+            t1 = table_builder [["X", [1]], ["Y", [2]]]
+            t2 = t1.rename_columns [["X", "A"], ["Y", "a"]]
+            case is_case_sensitive of
+                True ->
+                    t2.column_names . should_equal ["A", "a"]
+                    Problems.assume_no_problems t2
+                False ->
+                    t2.column_names . should_equal ["A", "a 1"]
+                    Problems.expect_only_warning Duplicate_Output_Column_Names t2
+
+            t3 = t1.rename_columns [["Y", "x"]]
+            case is_case_sensitive of
+                True ->
+                    t3.column_names . should_equal ["X", "x"]
+                    Problems.assume_no_problems t3
+                False ->
+                    t3.column_names . should_equal ["X 1", "x"]
+                    Problems.expect_only_warning Duplicate_Output_Column_Names t3
+
         Test.specify "case insensitive name collisions - aggregate" <|
             t1 = table_builder [["X", [2, 1, 3, 2]]]
             t2 = t1.aggregate [Aggregate_Column.Maximum "X" "A", Aggregate_Column.Minimum "X" "a"]

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Name_Edge_Cases_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Name_Edge_Cases_Spec.enso
@@ -70,8 +70,29 @@ spec setup =
             t3.at 1 . to_vector . should_equal [1]
 
         Test.specify "case insensitive name collisions - joins" <|
-            # TODO like above
-            Nothing
+            t1 = table_builder [["X", [1, 2]], ["a", [3, 4]]]
+            t2 = table_builder [["X", [2, 1]], ["A", [5, 6]]]
+
+            t3 = t1.join t2 on="X" join_kind=Join_Kind.Inner
+            case is_case_sensitive of
+                True ->
+                    t3.column_names . should_equal ["X", "a", "A"]
+                    Problems.assume_no_problems t3
+                False ->
+                    t3.column_names . should_equal ["X", "a", "Right A"]
+                    Problems.expect_only_warning Duplicate_Output_Column_Names t3
+
+            t4 = t1.cross_join t2
+            case is_case_sensitive of
+                True ->
+                    t4.column_names . should_equal ["X", "a", "Right X", "A"]
+                    Problems.assume_no_problems t4
+                False ->
+                    t4.column_names . should_equal ["X", "a", "Right X", "Right A"]
+                    Problems.expect_only_warning Duplicate_Output_Column_Names t4
+
+            t5 = t1.join t2 on="X" join_kind=Join_Kind.Left_Exclusive
+            t5.column_names . should_equal ["X", "a"]
 
         Test.specify "case insensitive name collisions - cross_tab" <|
             t0 = table_builder [["X", ["a", "A", "b"]], ["Y", [4, 5, 6]]]
@@ -89,8 +110,8 @@ spec setup =
                             t1.at "a" . to_vector . should_equal [4]
                             t1.at "b" . to_vector . should_equal [6]
                         False ->
-                            # TODO specify a more generic error once this is implemented
-                            t1.should_fail_with Any
+                            # TODO possibly ensure a more detailed error message is included here so that the user knows the column names come from cross_tab
+                            t1.should_fail_with Clashing_Column_Name
 
         Test.specify "case insensitive name collisions - transpose" <|
             t1 = t0.transpose attribute_column_name="a" value_column_name="A"

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -1432,10 +1432,10 @@ spec setup =
             t = table_builder [["a", [1, 2, 3]]]
             c = t.at "a"
 
-            c.rename Nothing . should_fail_with Invalid_Output_Column_Names
-            c.rename '' . should_fail_with Invalid_Output_Column_Names
-            c.rename 'a\0b' . should_fail_with Invalid_Output_Column_Names
-            c.rename '\0' . should_fail_with Invalid_Output_Column_Names
+            c.rename Nothing . should_fail_with Invalid_Column_Names
+            c.rename '' . should_fail_with Invalid_Column_Names
+            c.rename 'a\0b' . should_fail_with Invalid_Column_Names
+            c.rename '\0' . should_fail_with Invalid_Column_Names
 
     Test.group prefix+"Column.const" <|
         Test.specify "Should allow the creation of constant columns" <|

--- a/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
@@ -107,8 +107,8 @@ spec setup =
             t3.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123", "bar2", "bar3"]
 
         Test.specify "should not allow illegal column names" <|
-            table.set (table.get "bar") new_name="" . should_fail_with Invalid_Output_Column_Names
-            table.set (table.get "bar") new_name='a\0b' . should_fail_with Invalid_Output_Column_Names
+            table.set (table.get "bar") new_name="" . should_fail_with Invalid_Column_Names
+            table.set (table.get "bar") new_name='a\0b' . should_fail_with Invalid_Column_Names
 
         Test.specify "should allow replacing a column" <|
             foo = table.get "bar" . rename "foo"

--- a/test/Table_Tests/src/Common_Table_Operations/Cross_Tab_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Cross_Tab_Spec.enso
@@ -227,23 +227,23 @@ spec setup =
         Test.specify "should fail gracefully if an effective column name would contain invalid characters" <|
             table = table_builder [["Key", ['x', 'x', 'y\0', '\0', 'y\0', 'z', 'z', 'z', 'z']], ["Value", [1, 2, 3, 4, 5, 6, 7, 8, 9]]]
             r1 = table.cross_tab [] "Key"
-            r1.should_fail_with Invalid_Output_Column_Names
+            r1.should_fail_with Invalid_Column_Names
             r1.catch.to_display_text . should_contain "cannot contain the NUL character"
 
             r2 = table2.cross_tab [] "Key" values=[Average "Value" new_name='x\0']
             r2.print
-            r2.should_fail_with Invalid_Output_Column_Names
+            r2.should_fail_with Invalid_Column_Names
             r2.catch.to_display_text . should_contain "cannot contain the NUL character"
 
         Test.specify "should fail gracefully if an effective column name would be empty or null" <|
             table = table_builder [["Key", [" ", "x", "x", "x", "", "", "", "y", "y"]], ["Value", [1, 2, 3, 4, 5, 6, 7, 8, 9]]]
             r1 = table.cross_tab [] "Key"
-            r1.should_fail_with Invalid_Output_Column_Names
+            r1.should_fail_with Invalid_Column_Names
             r1.catch.to_display_text . should_contain "cannot be empty"
 
             table2 = table_builder [["Key", [" ", "x", "x", "x", Nothing, Nothing, Nothing, "y", "y"]], ["Value", [1, 2, 3, 4, 5, 6, 7, 8, 9]]]
             r2 = table2.cross_tab [] "Key"
-            r2 . should_fail_with Invalid_Output_Column_Names
+            r2 . should_fail_with Invalid_Column_Names
             r2.catch.to_display_text . should_contain "cannot be Nothing"
 
         Test.specify "should fail gracefully if producing too many columns in a table" <|

--- a/test/Table_Tests/src/Common_Table_Operations/Main.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Main.enso
@@ -4,6 +4,7 @@ import Standard.Database.Internal.Replace_Params.Replace_Params
 
 import project.Common_Table_Operations.Add_Row_Number_Spec
 import project.Common_Table_Operations.Aggregate_Spec
+import project.Common_Table_Operations.Column_Name_Edge_Cases_Spec
 import project.Common_Table_Operations.Column_Operations_Spec
 import project.Common_Table_Operations.Core_Spec
 import project.Common_Table_Operations.Cross_Tab_Spec
@@ -109,6 +110,7 @@ type Test_Selection
 spec setup =
     Core_Spec.spec setup
     Select_Columns_Spec.spec setup
+    Column_Name_Edge_Cases_Spec.spec setup
     Column_Operations_Spec.spec setup
     Date_Time_Spec.spec setup
     Conversion_Spec.spec setup

--- a/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
@@ -442,19 +442,19 @@ spec setup =
             map = Map.from_vector [[1, ""]]
             [Problem_Behavior.Ignore, Problem_Behavior.Report_Warning, Problem_Behavior.Report_Error].each pb->
                 r = table.rename_columns map on_problems=pb
-                r.should_fail_with Invalid_Output_Column_Names
+                r.should_fail_with Invalid_Column_Names
 
         Test.specify "should correctly handle problems: invalid names Nothing" <|
             map = ["alpha", Nothing]
             [Problem_Behavior.Ignore, Problem_Behavior.Report_Warning, Problem_Behavior.Report_Error].each pb->
                 r = table.rename_columns map on_problems=pb
-                r.should_fail_with Invalid_Output_Column_Names
+                r.should_fail_with Invalid_Column_Names
 
         Test.specify "should correctly handle problems: invalid names null character" <|
             map = ["alpha", 'a\0b']
             [Problem_Behavior.Ignore, Problem_Behavior.Report_Warning, Problem_Behavior.Report_Error].each pb->
                 r = table.rename_columns map on_problems=pb
-                r.should_fail_with Invalid_Output_Column_Names
+                r.should_fail_with Invalid_Column_Names
 
         Test.specify "should correctly handle problems: duplicate names" <|
             map = ["Test", "Test", "Test", "Test"]

--- a/test/Table_Tests/src/Database/Common/Common_Spec.enso
+++ b/test/Table_Tests/src/Database/Common/Common_Spec.enso
@@ -48,6 +48,9 @@ run_tests prefix connection upload =
             original = Table.new [["a", Vector.new n ix->ix], ["b", Vector.new n ix-> ix *  3.1415926], ["c", Vector.new n ix-> ix.to_text]]
             table = upload "Big" original
             table.read.row_count . should_equal n
+        Test.specify "should not allow to set a column coming from another table" <|
+            t2 = upload "T2" (Table.new [["d", [100, 200]]])
+            t1.set (t2.at "d") . should_fail_with Integrity_Error
 
     Test.group prefix+"Table.query" <|
         name = t1.name

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -5,6 +5,7 @@ import Standard.Base.Runtime.Ref.Ref
 import Standard.Table.Data.Type.Value_Type.Bits
 from Standard.Table import Table, Value_Type
 from Standard.Table.Data.Aggregate_Column.Aggregate_Column import all hiding First, Last
+from Standard.Table.Errors import Invalid_Output_Column_Names, Duplicate_Output_Column_Names
 
 import Standard.Database.Data.Column.Column
 import Standard.Database.Data.SQL_Type.SQL_Type
@@ -216,6 +217,23 @@ postgres_specific_spec connection db_name setup =
             effective_name = table.column_names . at 0
             effective_name . should_not_equal long_name
             long_name.should_contain effective_name
+
+        Test.specify "is capable of handling weird tables" <|
+            connection.execute_update 'CREATE TEMPORARY TABLE "empty-column-name" ("" VARCHAR)' . should_fail_with SQL_Error
+
+            Problems.assume_no_problems <|
+                connection.execute_update 'CREATE TEMPORARY TABLE "clashing-unicode-names" ("ś" VARCHAR, "s\u0301" INTEGER)'
+            Problems.assume_no_problems <|
+                connection.execute_update 'INSERT INTO "clashing-unicode-names" VALUES (1, 2)'
+            t2 = connection.query (SQL_Query.Table_Name "clashing-unicode-names")
+            Problems.expect_only_warning Duplicate_Output_Column_Names t2
+            t2.column_names . should_equal ["ś", "ś 1"]
+            m2 = t2.read
+            m2.at "ś"   . to_vector . should_equal [1]
+            m2.at "ś 1" . to_vector . should_equal [2]
+
+            t3 = connection.query 'SELECT 1 AS "A", 2 AS "A"'
+            t3.should_fail_with Illegal_State
 
     table_builder = setup.table_builder
     materialize = setup.materialize

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -224,12 +224,12 @@ postgres_specific_spec connection db_name setup =
             Problems.assume_no_problems <|
                 connection.execute_update 'CREATE TEMPORARY TABLE "clashing-unicode-names" ("ś" VARCHAR, "s\u0301" INTEGER)'
             Problems.assume_no_problems <|
-                connection.execute_update 'INSERT INTO "clashing-unicode-names" VALUES (1, 2)'
+                connection.execute_update 'INSERT INTO "clashing-unicode-names" VALUES (\'A\', 2)'
             t2 = connection.query (SQL_Query.Table_Name "clashing-unicode-names")
             Problems.expect_only_warning Duplicate_Output_Column_Names t2
             t2.column_names . should_equal ["ś", "ś 1"]
             m2 = t2.read
-            m2.at "ś"   . to_vector . should_equal [1]
+            m2.at "ś"   . to_vector . should_equal ["A"]
             m2.at "ś 1" . to_vector . should_equal [2]
 
             t3 = connection.query 'SELECT 1 AS "A", 2 AS "A"'

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Runtime.Ref.Ref
 
@@ -232,8 +233,12 @@ postgres_specific_spec connection db_name setup =
             m2.at "ś"   . to_vector . should_equal ["A"]
             m2.at "ś 1" . to_vector . should_equal [2]
 
-            t3 = connection.query 'SELECT 1 AS "A", 2 AS "A"'
-            t3.should_fail_with Illegal_State
+            r3 = connection.query 'SELECT 1 AS "A", 2 AS "A"'
+            r3.should_fail_with Illegal_Argument
+            r3.catch.cause . should_be_a Duplicate_Output_Column_Names
+
+            r4 = connection.query 'SELECT 1 AS ""'
+            r4.should_fail_with SQL_Error
 
     table_builder = setup.table_builder
     materialize = setup.materialize

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -5,7 +5,7 @@ import Standard.Base.Runtime.Ref.Ref
 import Standard.Table.Data.Type.Value_Type.Bits
 from Standard.Table import Table, Value_Type
 from Standard.Table.Data.Aggregate_Column.Aggregate_Column import all hiding First, Last
-from Standard.Table.Errors import Invalid_Output_Column_Names, Duplicate_Output_Column_Names
+from Standard.Table.Errors import Invalid_Column_Names, Duplicate_Output_Column_Names
 
 import Standard.Database.Data.Column.Column
 import Standard.Database.Data.SQL_Type.SQL_Type

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -106,12 +106,12 @@ sqlite_specific_spec prefix connection setup =
             Problems.assume_no_problems <|
                 connection.execute_update 'CREATE TEMPORARY TABLE "clashing-unicode-names" ("ś" VARCHAR, "s\u0301" INTEGER)'
             Problems.assume_no_problems <|
-                connection.execute_update 'INSERT INTO "clashing-unicode-names" VALUES (1, 2)'
+                connection.execute_update 'INSERT INTO "clashing-unicode-names" VALUES (\'A\', 2)'
             t2 = connection.query (SQL_Query.Table_Name "clashing-unicode-names")
             Problems.expect_only_warning Duplicate_Output_Column_Names t2
             t2.column_names . should_equal ["ś", "ś 1"]
             m2 = t2.read
-            m2.at "ś"   . to_vector . should_equal [1]
+            m2.at "ś"   . to_vector . should_equal ["A"]
             m2.at "ś 1" . to_vector . should_equal [2]
 
             t3 = connection.query 'SELECT 1 AS "A", 2 AS "A"'

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -1,16 +1,18 @@
 from Standard.Base import all
 import Standard.Base.Runtime.Ref.Ref
 import Standard.Base.Errors.File_Error.File_Error
+import Standard.Base.Errors.Illegal_State.Illegal_State
 
 import Standard.Table.Data.Type.Value_Type.Bits
 from Standard.Table import Table, Value_Type
+from Standard.Table.Errors import Invalid_Output_Column_Names, Duplicate_Output_Column_Names
 
 import Standard.Database.Data.Column.Column
 import Standard.Database.Internal.Replace_Params.Replace_Params
 from Standard.Database import all
 from Standard.Database.Errors import SQL_Error, Unsupported_Database_Operation
 
-from Standard.Test import Test, Test_Suite
+from Standard.Test import Test, Test_Suite, Problems
 import Standard.Test.Extensions
 
 import project.Database.Common.Common_Spec
@@ -91,6 +93,30 @@ sqlite_specific_spec prefix connection setup =
             action = connection.read (SQL_Query.Raw_SQL "SELECT A FROM undefined_table")
             action . should_fail_with SQL_Error
             action.catch.to_text . should_equal "There was an SQL error: [SQLITE_ERROR] SQL error or missing database (no such table: undefined_table). [Query was: SELECT A FROM undefined_table]"
+
+        Test.specify "is capable of handling weird tables" <|
+            Problems.assume_no_problems <|
+                connection.execute_update 'CREATE TEMPORARY TABLE "empty-column-name" ("" VARCHAR)'
+            t1 = connection.query (SQL_Query.Table_Name "empty-column-name")
+            Problems.expect_only_warning Invalid_Output_Column_Names t1
+            t1.column_names . should_equal "Column 1"
+            m1 = t1.read
+            m1.at "Column 1" . to_vector . should_equal []
+
+            Problems.assume_no_problems <|
+                connection.execute_update 'CREATE TEMPORARY TABLE "clashing-unicode-names" ("ś" VARCHAR, "s\u0301" INTEGER)'
+            Problems.assume_no_problems <|
+                connection.execute_update 'INSERT INTO "clashing-unicode-names" VALUES (1, 2)'
+            t2 = connection.query (SQL_Query.Table_Name "clashing-unicode-names")
+            Problems.expect_only_warning Duplicate_Output_Column_Names t2
+            t2.column_names . should_equal ["ś", "ś 1"]
+            m2 = t2.read
+            m2.at "ś"   . to_vector . should_equal [1]
+            m2.at "ś 1" . to_vector . should_equal [2]
+
+            t3 = connection.query 'SELECT 1 AS "A", 2 AS "A"'
+            # We specifically fail the query, because it is bound to give invalid results (the columns will not be distinguishable by the backend, so after any of Enso transformations, both columns will have value 1).
+            t3.should_fail_with Illegal_State
 
     tinfo = Name_Generator.random_name "Tinfo"
     connection.execute_update 'CREATE TABLE "'+tinfo+'" ("strs" VARCHAR, "ints" INTEGER, "bools" BOOLEAN, "reals" REAL)'

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Runtime.Ref.Ref
 import Standard.Base.Errors.File_Error.File_Error
-import Standard.Base.Errors.Illegal_State.Illegal_State
+import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 import Standard.Table.Data.Type.Value_Type.Bits
 from Standard.Table import Table, Value_Type
@@ -114,9 +114,13 @@ sqlite_specific_spec prefix connection setup =
             m2.at "ś"   . to_vector . should_equal ["A"]
             m2.at "ś 1" . to_vector . should_equal [2]
 
-            t3 = connection.query 'SELECT 1 AS "A", 2 AS "A"'
-            # We specifically fail the query, because it is bound to give invalid results (the columns will not be distinguishable by the backend, so after any of Enso transformations, both columns will have value 1).
-            t3.should_fail_with Illegal_State
+            r3 = connection.query 'SELECT 1 AS "A", 2 AS "A"'
+            r3.should_fail_with Illegal_Argument
+            r3.catch.cause . should_be_a Duplicate_Output_Column_Names
+
+            r4 = connection.query 'SELECT 1 AS ""'
+            r4.should_fail_with Illegal_Argument
+            r4.catch.cause . should_be_a Invalid_Column_Names
 
     tinfo = Name_Generator.random_name "Tinfo"
     connection.execute_update 'CREATE TABLE "'+tinfo+'" ("strs" VARCHAR, "ints" INTEGER, "bools" BOOLEAN, "reals" REAL)'

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -99,7 +99,7 @@ sqlite_specific_spec prefix connection setup =
                 connection.execute_update 'CREATE TEMPORARY TABLE "empty-column-name" ("" VARCHAR)'
             t1 = connection.query (SQL_Query.Table_Name "empty-column-name")
             Problems.expect_only_warning Invalid_Column_Names t1
-            t1.column_names . should_equal "Column 1"
+            t1.column_names . should_equal ["Column 1"]
             m1 = t1.read
             m1.at "Column 1" . to_vector . should_equal []
 

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -5,7 +5,7 @@ import Standard.Base.Errors.Illegal_State.Illegal_State
 
 import Standard.Table.Data.Type.Value_Type.Bits
 from Standard.Table import Table, Value_Type
-from Standard.Table.Errors import Invalid_Output_Column_Names, Duplicate_Output_Column_Names
+from Standard.Table.Errors import Invalid_Column_Names, Duplicate_Output_Column_Names
 
 import Standard.Database.Data.Column.Column
 import Standard.Database.Internal.Replace_Params.Replace_Params
@@ -98,7 +98,7 @@ sqlite_specific_spec prefix connection setup =
             Problems.assume_no_problems <|
                 connection.execute_update 'CREATE TEMPORARY TABLE "empty-column-name" ("" VARCHAR)'
             t1 = connection.query (SQL_Query.Table_Name "empty-column-name")
-            Problems.expect_only_warning Invalid_Output_Column_Names t1
+            Problems.expect_only_warning Invalid_Column_Names t1
             t1.column_names . should_equal "Column 1"
             m1 = t1.read
             m1.at "Column 1" . to_vector . should_equal []

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -108,25 +108,35 @@ spec make_new_connection prefix persistent_connector=True =
 
         Test.specify "should not allow to create a table with duplicated column names" <|
             run_with_and_without_output <|
-                r1 = connection.create_table (Name_Generator.random_name "creating-invalid-table") structure=[Column_Description.Value "X" Value_Type.Integer, Column_Description.Value "X" Value_Type.Char] temporary=True
+                table_name = Name_Generator.random_name "creating-invalid-table"
+                r1 = connection.create_table table_name structure=[Column_Description.Value "X" Value_Type.Integer, Column_Description.Value "X" Value_Type.Char] temporary=True
                 r1.should_fail_with Duplicate_Output_Column_Names
+
+                # Ensure that the table was not created.
+                connection.tables . at "Name" . to_vector . should_not_contain table_name
 
         Test.specify "should not allow to create a table with invalid column names" <|
             Test.expect_panic_with (Column_Description.Value Nothing Value_Type.Char) Type_Error
 
             run_with_and_without_output <|
-                r1 = connection.create_table (Name_Generator.random_name "creating-invalid-table") structure=[Column_Description.Value "" Value_Type.Integer] temporary=True
+                table_name = Name_Generator.random_name "creating-invalid-table"
+                r1 = connection.create_table table_name structure=[Column_Description.Value "" Value_Type.Integer] temporary=True
                 r1.should_fail_with Invalid_Output_Column_Names
+                # Ensure that the table was not created.
+                connection.tables . at "Name" . to_vector . should_not_contain table_name
 
-                r2 = connection.create_table (Name_Generator.random_name "creating-invalid-table") structure=[Column_Description.Value 'a\0b' Value_Type.Integer] temporary=True
+                r2 = connection.create_table table_name structure=[Column_Description.Value 'a\0b' Value_Type.Integer] temporary=True
                 r2.should_fail_with Invalid_Output_Column_Names
+                connection.tables . at "Name" . to_vector . should_not_contain table_name
 
         Test.specify "should not allow to create a table with duplicated column names, if the difference is just in Unicode normalization form" <|
             run_with_and_without_output <|
                 a = 'ś'
                 b = 's\u0301'
-                r1 = connection.create_table (Name_Generator.random_name "creating-invalid-table") structure=[Column_Description.Value a Value_Type.Integer, Column_Description.Value b Value_Type.Char] temporary=True
+                table_name = Name_Generator.random_name "creating-invalid-table"
+                r1 = connection.create_table table_name structure=[Column_Description.Value a Value_Type.Integer, Column_Description.Value b Value_Type.Char] temporary=True
                 r1.should_fail_with Duplicate_Output_Column_Names
+                connection.tables . at "Name" . to_vector . should_not_contain table_name
 
         Test.specify "should include the created table in the tables directory" <|
             name = Name_Generator.random_name "persistent_table 1"

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Errors.Common.Forbidden_Operation
 import Standard.Base.Errors.Common.Dry_Run_Operation
+import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Runtime.Context
@@ -102,7 +103,29 @@ spec make_new_connection prefix persistent_connector=True =
 
         Test.specify "should fail if empty structure is provided" <|
             run_with_and_without_output <|
-                r1 = connection.create_table (Name_Generator.random_name "creating-table") structure=[] temporary=True
+                r1 = connection.create_table (Name_Generator.random_name "creating-invalid-table") structure=[] temporary=True
+                r1.should_fail_with Illegal_Argument
+
+        Test.specify "should not allow to create a table with duplicated column names" <|
+            run_with_and_without_output <|
+                r1 = connection.create_table (Name_Generator.random_name "creating-invalid-table") structure=[Column_Description.Value "X" Value_Type.Integer, Column_Description.Value "X" Value_Type.Char] temporary=True
+                r1.should_fail_with Illegal_Argument
+
+        Test.specify "should not allow to create a table with invalid column names" <|
+            Panic.expect_panic_with (Column_Description.Value Nothing Value_Type.Char) Type_Error
+
+            run_with_and_without_output <|
+                r1 = connection.create_table (Name_Generator.random_name "creating-invalid-table") structure=[Column_Description.Value "" Value_Type.Integer] temporary=True
+                r1.should_fail_with Invalid_Output_Column_Names
+
+                r2 = connection.create_table (Name_Generator.random_name "creating-invalid-table") structure=[Column_Description.Value 'a\0b' Value_Type.Integer] temporary=True
+                r2.should_fail_with Invalid_Output_Column_Names
+
+        Test.specify "should not allow to create a table with duplicated column names, if the difference is just in Unicode normalization form" <|
+            run_with_and_without_output <|
+                a = 'ś'
+                b = 's\u0301'
+                r1 = connection.create_table (Name_Generator.random_name "creating-invalid-table") structure=[Column_Description.Value a Value_Type.Integer, Column_Description.Value b Value_Type.Char] temporary=True
                 r1.should_fail_with Illegal_Argument
 
         Test.specify "should include the created table in the tables directory" <|

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -109,10 +109,10 @@ spec make_new_connection prefix persistent_connector=True =
         Test.specify "should not allow to create a table with duplicated column names" <|
             run_with_and_without_output <|
                 r1 = connection.create_table (Name_Generator.random_name "creating-invalid-table") structure=[Column_Description.Value "X" Value_Type.Integer, Column_Description.Value "X" Value_Type.Char] temporary=True
-                r1.should_fail_with Illegal_Argument
+                r1.should_fail_with Duplicate_Output_Column_Names
 
         Test.specify "should not allow to create a table with invalid column names" <|
-            Panic.expect_panic_with (Column_Description.Value Nothing Value_Type.Char) Type_Error
+            Test.expect_panic_with (Column_Description.Value Nothing Value_Type.Char) Type_Error
 
             run_with_and_without_output <|
                 r1 = connection.create_table (Name_Generator.random_name "creating-invalid-table") structure=[Column_Description.Value "" Value_Type.Integer] temporary=True
@@ -126,7 +126,7 @@ spec make_new_connection prefix persistent_connector=True =
                 a = 'ś'
                 b = 's\u0301'
                 r1 = connection.create_table (Name_Generator.random_name "creating-invalid-table") structure=[Column_Description.Value a Value_Type.Integer, Column_Description.Value b Value_Type.Char] temporary=True
-                r1.should_fail_with Illegal_Argument
+                r1.should_fail_with Duplicate_Output_Column_Names
 
         Test.specify "should include the created table in the tables directory" <|
             name = Name_Generator.random_name "persistent_table 1"

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -121,12 +121,12 @@ spec make_new_connection prefix persistent_connector=True =
             run_with_and_without_output <|
                 table_name = Name_Generator.random_name "creating-invalid-table"
                 r1 = connection.create_table table_name structure=[Column_Description.Value "" Value_Type.Integer] temporary=True
-                r1.should_fail_with Invalid_Output_Column_Names
+                r1.should_fail_with Invalid_Column_Names
                 # Ensure that the table was not created.
                 connection.tables . at "Name" . to_vector . should_not_contain table_name
 
                 r2 = connection.create_table table_name structure=[Column_Description.Value 'a\0b' Value_Type.Integer] temporary=True
-                r2.should_fail_with Invalid_Output_Column_Names
+                r2.should_fail_with Invalid_Column_Names
                 connection.tables . at "Name" . to_vector . should_not_contain table_name
 
         Test.specify "should not allow to create a table with duplicated column names, if the difference is just in Unicode normalization form" <|

--- a/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
+++ b/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
@@ -39,7 +39,7 @@ spec =
                 table.at "c" . to_vector . should_equal ["3"]
                 table.at "Column 2" . to_vector . should_equal ["4"]
                 table.at "d" . to_vector . should_equal ["5"]
-            problems = [Invalid_Output_Column_Names.Error [Nothing, Nothing]]
+            problems = [Invalid_Column_Names.Error [Nothing, Nothing]]
             Problems.test_problem_handling action problems tester
 
         Test.specify "should infer headers based on the first two rows" <|

--- a/test/Table_Tests/src/IO/Excel_Spec.enso
+++ b/test/Table_Tests/src/IO/Excel_Spec.enso
@@ -4,7 +4,7 @@ import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 from Standard.Table import Table, Match_Columns, Excel, Excel_Range, Data_Formatter, Sheet_Names, Range_Names, Worksheet, Cell_Range, Delimited, Excel_Workbook
 
-from Standard.Table.Errors import Invalid_Output_Column_Names, Duplicate_Output_Column_Names, Invalid_Location, Range_Exceeded, Existing_Data, Column_Count_Mismatch, Column_Name_Mismatch, Empty_Sheet_Error
+from Standard.Table.Errors import Invalid_Column_Names, Duplicate_Output_Column_Names, Invalid_Location, Range_Exceeded, Existing_Data, Column_Count_Mismatch, Column_Name_Mismatch, Empty_Sheet_Error
 
 from Standard.Test import Test, Test_Suite, Problems
 import Standard.Test.Extensions

--- a/test/Table_Tests/src/In_Memory/Column_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Column_Spec.enso
@@ -9,7 +9,7 @@ import Standard.Examples
 import Standard.Test.Extensions
 
 from Standard.Table import Column, Value_Type
-from Standard.Table.Errors import Invalid_Value_Type, Invalid_Output_Column_Names
+from Standard.Table.Errors import Invalid_Value_Type, Invalid_Column_Names
 from Standard.Test import Test, Test_Suite, Problems
 
 main = Test_Suite.run_main spec
@@ -87,16 +87,16 @@ spec =
 
         Test.specify "should not allow invalid column names" <|
             c1 = Column.from_vector "" [1, 2, 3]
-            c1.should_fail_with Invalid_Output_Column_Names
+            c1.should_fail_with Invalid_Column_Names
 
             c2 = Column.from_vector Nothing [1, 2, 3]
-            c2.should_fail_with Invalid_Output_Column_Names
+            c2.should_fail_with Invalid_Column_Names
 
             c3 = Column.from_vector '\0' [1, 2, 3]
-            c3.should_fail_with Invalid_Output_Column_Names
+            c3.should_fail_with Invalid_Column_Names
 
             c4 = Column.from_vector 'foo\0bar' [1, 2, 3]
-            c4.should_fail_with Invalid_Output_Column_Names
+            c4.should_fail_with Invalid_Column_Names
 
         Test.specify "will coerce integers to decimals by default, to get a numeric column" <|
             c1 = Column.from_vector "X" [1, 2.0]

--- a/test/Table_Tests/src/In_Memory/Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Spec.enso
@@ -7,7 +7,7 @@ import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 from Standard.Table import Table, Column, Sort_Column, Aggregate_Column
 from Standard.Table.Data.Aggregate_Column.Aggregate_Column import all hiding First, Last
 import Standard.Table.Data.Type.Value_Type.Value_Type
-from Standard.Table.Errors import Invalid_Output_Column_Names, Duplicate_Output_Column_Names, No_Input_Columns_Selected, Missing_Input_Columns, No_Such_Column, Floating_Point_Equality, Invalid_Value_Type, Row_Count_Mismatch
+from Standard.Table.Errors import Invalid_Column_Names, Duplicate_Output_Column_Names, No_Input_Columns_Selected, Missing_Input_Columns, No_Such_Column, Floating_Point_Equality, Invalid_Value_Type, Row_Count_Mismatch
 
 import Standard.Visualization
 
@@ -96,7 +96,7 @@ spec =
             Table.from_rows [] [] . should_fail_with Illegal_Argument
             Table.from_rows [] [[]] . should_fail_with Illegal_Argument
 
-            Table.new [["X", [1,2,3]], ["", [4,5,6]]] . should_fail_with Invalid_Output_Column_Names
+            Table.new [["X", [1,2,3]], ["", [4,5,6]]] . should_fail_with Invalid_Column_Names
 
         Test.specify "should be internally guarded against creating a table without columns" <|
             Test.expect_panic_with (Java_Table.new []) IllegalArgumentException
@@ -601,7 +601,7 @@ spec =
             table = Table.new [c_0, c_1, c_2, c_3, c_4]
             action = table.use_first_row_as_names on_problems=_
             tester = expect_column_names ["Column 1", "1980-01-01", "1", "5.3", "True"]
-            problems = [Invalid_Output_Column_Names.Error [""]]
+            problems = [Invalid_Column_Names.Error [""]]
             Problems.test_problem_handling action problems tester
 
         Test.specify "should correctly handle problems: invalid names Nothing" <|
@@ -613,7 +613,7 @@ spec =
             table = Table.new [c_0, c_1, c_2, c_3, c_4]
             action = table.use_first_row_as_names on_problems=_
             tester = expect_column_names ["A", "1980-01-01", "Column 1", "5.3", "True"]
-            problems = [Invalid_Output_Column_Names.Error [Nothing]]
+            problems = [Invalid_Column_Names.Error [Nothing]]
             Problems.test_problem_handling action problems tester
 
         Test.specify "should correctly handle problems: multiple invalid names" <|
@@ -625,7 +625,7 @@ spec =
             table = Table.new [c_0, c_1, c_2, c_3, c_4]
             action = table.use_first_row_as_names on_problems=_
             tester = expect_column_names ["Column 1", "1980-01-01", "Column 2", "5.3", "True"]
-            problems = [Invalid_Output_Column_Names.Error ["", Nothing]]
+            problems = [Invalid_Column_Names.Error ["", Nothing]]
             Problems.test_problem_handling action problems tester
 
         Test.specify "should correctly handle problems: duplicate names" <|


### PR DESCRIPTION
### Pull Request Description

- Fixes #7412 
- Also adds tests and fixes some more edge cases:
	- Ensures correct handling of existing Database tables whose column names may be invalid from Enso perspective, or clashing from Enso perspective (e.g. for most DBs `ś` and `s\u0301` are different names, but for Enso they are basically the same so this would cause issues - thus Enso now renames such columns when accessed (still using the correct column reference in the generated SQL under the hood).

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
