### PR TITLE
Fix validation regexes

### DIFF
--- a/app/ide-desktop/lib/dashboard/package.json
+++ b/app/ide-desktop/lib/dashboard/package.json
@@ -8,7 +8,8 @@
     "lint": "npx --yes eslint src",
     "build": "tsx bundle.ts",
     "watch": "tsx watch.ts",
-    "start": "tsx start.ts"
+    "start": "tsx start.ts",
+    "test": "tsx test.ts"
   },
   "dependencies": {
     "@heroicons/react": "^2.0.15",
@@ -25,6 +26,7 @@
     "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
     "@typescript-eslint/eslint-plugin": "^5.49.0",
     "@typescript-eslint/parser": "^5.49.0",
+    "chalk": "^5.3.0",
     "enso-authentication": "^1.0.0",
     "enso-chat": "git://github.com/enso-org/enso-bot",
     "enso-content": "^1.0.0",

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/components/resetPassword.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/components/resetPassword.tsx
@@ -11,6 +11,7 @@ import LockIcon from 'enso-assets/lock.svg'
 
 import * as app from '../../components/app'
 import * as auth from '../providers/auth'
+import * as string from '../../string'
 import * as validation from '../../dashboard/validation'
 
 import Input from './input'
@@ -150,6 +151,8 @@ export default function ResetPassword() {
                                     type="password"
                                     name="new_password_confirm"
                                     placeholder="Confirm New Password"
+                                    pattern={string.regexEscape(newPassword)}
+                                    error={validation.CONFIRM_PASSWORD_ERROR}
                                     value={newPasswordConfirm}
                                     setValue={setNewPasswordConfirm}
                                 />

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/components/resetPassword.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/components/resetPassword.tsx
@@ -82,6 +82,7 @@ export default function ResetPassword() {
                                     <SvgMask src={AtIcon} />
                                 </SvgIcon>
                                 <Input
+                                    required
                                     id="email"
                                     type="email"
                                     name="email"
@@ -103,6 +104,7 @@ export default function ResetPassword() {
                                     <SvgMask src={LockIcon} />
                                 </SvgIcon>
                                 <Input
+                                    required
                                     id="code"
                                     type="text"
                                     name="code"
@@ -124,6 +126,8 @@ export default function ResetPassword() {
                                     <SvgMask src={LockIcon} />
                                 </SvgIcon>
                                 <Input
+                                    required
+                                    validate
                                     id="new_password"
                                     type="password"
                                     name="new_password"
@@ -147,6 +151,8 @@ export default function ResetPassword() {
                                     <SvgMask src={LockIcon} />
                                 </SvgIcon>
                                 <Input
+                                    required
+                                    validate
                                     id="new_password_confirm"
                                     type="password"
                                     name="new_password_confirm"

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/components/resetPassword.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/components/resetPassword.tsx
@@ -133,7 +133,7 @@ export default function ResetPassword() {
                                     name="new_password"
                                     placeholder="New Password"
                                     pattern={validation.PASSWORD_PATTERN}
-                                    title={validation.PASSWORD_ERROR}
+                                    error={validation.PASSWORD_ERROR}
                                     value={newPassword}
                                     setValue={setNewPassword}
                                 />

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/changePasswordModal.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/changePasswordModal.tsx
@@ -70,8 +70,8 @@ export default function ChangePasswordModal() {
                                     type="password"
                                     name="old_password"
                                     placeholder="Old Password"
-                                    pattern={validation.PREVIOUS_PASSWORD_PATTERN}
-                                    error={validation.PREVIOUS_PASSWORD_ERROR}
+                                    pattern={validation.PASSWORD_PATTERN}
+                                    error={validation.PASSWORD_ERROR}
                                     value={oldPassword}
                                     setValue={setOldPassword}
                                     className="text-sm sm:text-base placeholder-gray-500 pl-10 pr-4 rounded-lg border border-gray-400 w-full py-2 focus:outline-none focus:border-blue-400"

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/validation.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/validation.ts
@@ -2,20 +2,11 @@
 
 /** Regex pattern for valid AWS Cognito passwords. */
 export const PASSWORD_PATTERN =
-    '(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])(?=.*[ ^$*.\\[\\]\\{\\}\\(\\)?"!@#%&\\/,><\':;\\|_~`=+\\-])' +
-    '[0-9A-Za-z ^$*.\\[\\]\\{\\}\\(\\)?"!@#%&\\/,><\':;\\|_~`=+\\-]{6,256}'
+    '(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])(?=.*[ ^$*.\\[\\]\\{\\}\\(\\)?"!@#%&\\/,><\':;\\|_~`=+\\-]).{6,256}'
 /** Human readable explanation of password requirements. */
 export const PASSWORD_ERROR =
     'Your password must include numbers, letters (both lowercase and uppercase) and symbols, ' +
     'and must be between 6 and 256 characters long.'
-
-/** Regex pattern used by the backend for validating the previous password,
- * when changing password. */
-export const PREVIOUS_PASSWORD_PATTERN = '^[\\S]+.*[\\S]+$'
-/** Human readable explanation of password requirements. */
-export const PREVIOUS_PASSWORD_ERROR =
-    'Your password must neither start nor end with whitespace, and must contain ' +
-    'at least two characters.'
 
 export const CONFIRM_PASSWORD_ERROR = 'Passwords must match.'
 

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/validation.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/validation.ts
@@ -1,6 +1,17 @@
 /** @file Validation patterns for text inputs. */
 
-/** Regex pattern for valid AWS Cognito passwords. */
+/** Regex pattern for valid AWS Cognito passwords. 
+ * A fully correct regex is here: https://stackoverflow.com/a/58767981/3323231.
+ * Official documentation is here: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html.
+ * However, non-ASCII passwords are allowed, contrary to the official documentation. Further
+ * investigation may be needed.
+ *
+ * Each of the four lookaheads in the regex below check for, respectively:
+ * - a digit
+ * - a Basic Latin uppercase character
+ * - a Basic Latin lowercase character, and
+ * - an ASCII symbol.
+ */
 export const PASSWORD_PATTERN =
     '(?=.*[0-9])(?=.*[A-Z])(?=.*[a-z])(?=.*[ ^$*.\\[\\]\\{\\}\\(\\)?"!@#%&\\/,><\':;\\|_~`=+\\-]).{6,256}'
 /** Human readable explanation of password requirements. */

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/validation.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/validation.ts
@@ -1,6 +1,6 @@
 /** @file Validation patterns for text inputs. */
 
-/** Regex pattern for valid AWS Cognito passwords. 
+/** Regex pattern for valid AWS Cognito passwords.
  * A fully correct regex is here: https://stackoverflow.com/a/58767981/3323231.
  * Official documentation is here: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-policies.html.
  * However, non-ASCII passwords are allowed, contrary to the official documentation. Further

--- a/app/ide-desktop/lib/dashboard/test.ts
+++ b/app/ide-desktop/lib/dashboard/test.ts
@@ -1,0 +1,101 @@
+/** @file Basic tests for this */
+import chalk from 'chalk'
+
+import * as validation from './src/authentication/src/dashboard/validation'
+
+// =================
+// === Constants ===
+// =================
+
+/** The text displayed on success. */
+const SUCCESS_TEXT = chalk.green('✔') + ' '
+/** The text displayed on failure. */
+const FAILURE_TEXT = chalk.red('✗') + ' '
+
+// ==================
+// === TestRunner ===
+// ==================
+
+/** A simple test runner. */
+class TestRunner {
+    succeeded = 0
+    failed = 0
+    total = 0
+
+    /** Prints a success or error message depending on whether the `condition` is true. */
+    expect(condition: boolean, message: string) {
+        this.total += 1
+        if (condition) {
+            this.succeeded += 1
+        } else {
+            this.failed += 1
+        }
+        const prefix = condition ? SUCCESS_TEXT : FAILURE_TEXT
+        console.log(`${prefix} ${message}`)
+    }
+
+    /** Prints a summary of test results. */
+    summarize() {
+        console.log(
+            `\n${chalk.green(this.succeeded)}/${this.total} tests succeeded, ${chalk.red(
+                this.failed
+            )}/${this.total} tests failed` +
+                (this.failed === 0 ? '\n' + chalk.green('All tests passed') : '')
+        )
+    }
+}
+
+// =============
+// === Tests ===
+// =============
+
+/** Runs all tests. */
+function runAllTests() {
+    const test = new TestRunner()
+    const pattern = new RegExp(`^(?:${validation.PASSWORD_PATTERN})$`)
+    const emptyPassword = ''
+    test.expect(
+        !pattern.test(emptyPassword),
+        `${chalk.yellow(`'${emptyPassword}'`)} fails validation`
+    )
+    const shortPassword = 'Aa0!'
+    test.expect(!pattern.test(shortPassword), `${chalk.yellow(`'${shortPassword}'`)} is too short`)
+    const passwordMissingDigit = 'Aa!Aa!Aa!'
+    test.expect(
+        !pattern.test(passwordMissingDigit),
+        `${chalk.yellow(`'${passwordMissingDigit}'`)} is missing a digit`
+    )
+    const passwordMissingLowercase = 'A0!A0!A0!'
+    test.expect(
+        !pattern.test(passwordMissingLowercase),
+        `${chalk.yellow(`'${passwordMissingLowercase}'`)} is missing a lowercase letter`
+    )
+    const passwordMissingUppercase = 'a0!a0!a0!'
+    test.expect(
+        !pattern.test(passwordMissingUppercase),
+        `${chalk.yellow(`'${passwordMissingUppercase}'`)} is missing an uppercase letter`
+    )
+    const passwordMissingSymbol = 'Aa0Aa0Aa0'
+    test.expect(
+        !pattern.test(passwordMissingSymbol),
+        `${chalk.yellow(`'${passwordMissingSymbol}'`)} is missing a symbol`
+    )
+    const validPassword = 'Aa0!Aa0!'
+    test.expect(
+        pattern.test(validPassword),
+        `${chalk.yellow(`'${validPassword}'`)} passes validation`
+    )
+    const basicPassword = 'Password0!'
+    test.expect(
+        pattern.test(basicPassword),
+        `${chalk.yellow(`'${basicPassword}'`)} passes validation`
+    )
+    const issue7498Password = 'ÑéFÛÅÐåÒ.ú¿¼\u00b4N@aö¶U¹jÙÇ3'
+    test.expect(
+        pattern.test(issue7498Password),
+        `${chalk.yellow(`'${issue7498Password}'`)} passes validation`
+    )
+    test.summarize()
+}
+
+runAllTests()

--- a/app/ide-desktop/package-lock.json
+++ b/app/ide-desktop/package-lock.json
@@ -443,6 +443,7 @@
         "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
         "@typescript-eslint/eslint-plugin": "^5.49.0",
         "@typescript-eslint/parser": "^5.49.0",
+        "chalk": "^5.3.0",
         "enso-authentication": "^1.0.0",
         "enso-chat": "git://github.com/enso-org/enso-bot",
         "enso-content": "^1.0.0",
@@ -462,6 +463,18 @@
     "lib/dashboard/node_modules/@types/node": {
       "version": "16.18.14",
       "license": "MIT"
+    },
+    "lib/dashboard/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
     },
     "lib/dashboard/node_modules/debug": {
       "version": "4.3.4",
@@ -21530,6 +21543,7 @@
         "@types/react-dom": "^18.0.10",
         "@typescript-eslint/eslint-plugin": "^5.49.0",
         "@typescript-eslint/parser": "^5.49.0",
+        "chalk": "^5.3.0",
         "enso-authentication": "^1.0.0",
         "enso-chat": "git://github.com/enso-org/enso-bot",
         "enso-content": "^1.0.0",
@@ -21548,6 +21562,12 @@
       "dependencies": {
         "@types/node": {
           "version": "16.18.14"
+        },
+        "chalk": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+          "dev": true
         },
         "debug": {
           "version": "4.3.4",

--- a/app/ide-desktop/package.json
+++ b/app/ide-desktop/package.json
@@ -39,6 +39,7 @@
     "watch": "npm run watch --workspace enso-content",
     "watch-dashboard": "npm run watch --workspace enso-dashboard",
     "build-dashboard": "npm run build --workspace enso-dashboard",
+    "test": "npm run test --workspace enso-dashboard",
     "typecheck": "npx tsc -p lib/types/tsconfig.json && npm run typecheck --workspace enso && npm run typecheck --workspace enso-content && npm run typecheck --workspace enso-dashboard && npm run typecheck --workspace enso-authentication"
   },
   "dependencies": {


### PR DESCRIPTION
### Pull Request Description
- Closes #7498
  - Validation regex previously disallowed non-ASCII characters, now fixed
- Changes every password input to use the correct regex. For old/new passwords, it uses the regular input. For password confirmations, it uses the new password, converted to a regex. This makes it so that the password confirmation input's validation only succeeds when it exactly matches the new password.

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
