### PR TITLE
Fix broken text vis layout 

### DIFF
--- a/app/gui/view/graph-editor/src/builtin/visualization/native/text_visualization.rs
+++ b/app/gui/view/graph-editor/src/builtin/visualization/native/text_visualization.rs
@@ -238,7 +238,7 @@ impl<T: TextProvider + 'static> TextGrid<T> {
         init.emit(());
     }
 
-    fn init_style(&self, init: &frp::Source, on_data_update: &frp::Stream ) {
+    fn init_style(&self, init: &frp::Source, on_data_update: &frp::Stream) {
         let init = init.clone_ref();
         let on_data_update = on_data_update.clone_ref();
 

--- a/app/gui/view/graph-editor/src/builtin/visualization/native/text_visualization.rs
+++ b/app/gui/view/graph-editor/src/builtin/visualization/native/text_visualization.rs
@@ -215,8 +215,6 @@ impl<T: TextProvider + 'static> TextGrid<T> {
         let frp = visualization::instance::Frp::new(&network);
         let model = Rc::new(Model::new(app));
         let fonts_loaded_notifier = FontLoadedNotifier::new(&network);
-
-
         Self { model, frp, network, fonts_loaded_notifier }
     }
 
@@ -235,13 +233,14 @@ impl<T: TextProvider + 'static> TextGrid<T> {
         self.init_text_grid_api(&init, &on_data_update);
 
         self.init_scrolling(&init, text_provider, &on_data_update);
-        self.init_style(&init);
+        self.init_style(&init, &on_data_update);
 
         init.emit(());
     }
 
-    fn init_style(&self, init: &frp::Source) {
+    fn init_style(&self, init: &frp::Source, on_data_update: &frp::Stream ) {
         let init = init.clone_ref();
+        let on_data_update = on_data_update.clone_ref();
 
         let scene = &self.model.app.display.default_scene;
         let style_watch = StyleWatchFrp::new(&scene.style_sheet);
@@ -267,9 +266,16 @@ impl<T: TextProvider + 'static> TextGrid<T> {
                     grid_view_entry::Params { parent }
                 })
             );
-
-            item_width_update <- all(init, fonts_loaded, font_name, font_size);
-            item_width <- item_width_update.map(f!([]((_, _, font_name, font_size)) {
+            // In order for the layout to be correct, we need to ensure that we know the correct
+            // width of a rendered chunk. That means we have to update our measurement, when the
+            // font family or size change, but also when we update the text. While it seems that
+            // the font properties alone should be enough to ensure the chunk width does not
+            // change, that is incorrect. The text might be rendered differently because of
+            // external changes (e.g., which fonts are loaded). Tracking these is difficult
+            // and thus we need to just measure before we set new text.
+            item_width_update <- all5(&init, &on_data_update, &fonts_loaded, &font_name,
+                &font_size);
+            item_width <- item_width_update.map(f!([]((_, _, _, font_name, font_size)) {
                 let font_size = *font_size;
                 let char_width = measure_character_width(font_name, font_size);
                 CHARS_PER_CHUNK as f32 * char_width
@@ -290,7 +296,6 @@ impl<T: TextProvider + 'static> TextGrid<T> {
 
         frp::extend! { network
             text_grid.request_model_for_visible_entries <+ any(on_data_update,init);
-
 
             requested_entry <- text_grid.model_for_entry_needed.map2(&text_grid.grid_size,
                  f!([model]((row, col), _grid_size) {

--- a/app/gui/view/graph-editor/src/builtin/visualization/native/text_visualization/grid_view_entry.rs
+++ b/app/gui/view/graph-editor/src/builtin/visualization/native/text_visualization/grid_view_entry.rs
@@ -78,10 +78,6 @@ impl Entry {
         let mut style = "position: absolute; white-space: pre; pointer-events: auto;".to_string();
         write!(style, "left: {left}px; top: {top}px;").ok();
         write!(style, "width: {width}px; height: {height}px;").ok();
-        // This prevents a fallback font from being used. Using any other font than the one
-        // specified will break the layout mechanism because the calculated width of the chunks no
-        // longer matches the rendered width of the chunks.
-        write!(style, "font-display: block;").ok();
         // The default line height in browsers is 1.2, which is great for multi-line text and
         // elements whose height is greater than the line height. In this case, however, where the
         // height and the font size are set to the same value, the default setting of 1.2 pushes


### PR DESCRIPTION
Updated the text visualization mechanism in `text_visualization.rs` to address layout drift issues. Text layout now updates when the font family, font size, or text content changes. This is important as the text might render differently due to external factors like loaded fonts.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
