### PR TITLE
Text blocks in Enso grammar for TextMate based editor

### DIFF
--- a/tools/enso4igv/pom.xml
+++ b/tools/enso4igv/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>enso4igv</artifactId>
     <packaging>nbm</packaging>
     <name>Enso Language Support for NetBeans &amp; Ideal Graph Visualizer</name>
-    <version>1.12-NAPSHOT</version>
+    <version>1.13-NAPSHOT</version>
     <build>
         <plugins>
             <plugin>

--- a/tools/enso4igv/src/main/resources/org/enso/tools/enso4igv/enso.tmLanguage.json
+++ b/tools/enso4igv/src/main/resources/org/enso/tools/enso4igv/enso.tmLanguage.json
@@ -86,6 +86,16 @@
 					}]
 				},
 				{
+					"name": "string.quoted.tripple.begin",
+                                        "begin": "^(\\s*)\"\"\"",
+                                        "end": "^(?!\\1\\s+)(?!\\s*$)"
+				},
+				{
+					"name": "string.quoted.tripple.middle",
+                                        "begin": "^(\\s*)[^\\s].*\"\"\"",
+                                        "end": "^(?!\\1\\s+)(?!\\s*$)"
+				},
+				{
 					"name": "string.quoted.single",
 					"begin": "\\'",
 					"end": "\\'",

--- a/tools/enso4igv/src/main/resources/org/enso/tools/enso4igv/enso.tmLanguage.json
+++ b/tools/enso4igv/src/main/resources/org/enso/tools/enso4igv/enso.tmLanguage.json
@@ -86,14 +86,14 @@
 					}]
 				},
 				{
-					"name": "string.quoted.triple.begin",
-                                        "begin": "^(\\s*)\"\"\"",
-                                        "end": "^(?!\\1\\s+)(?!\\s*$)"
+					"contentName": "string.quoted.triple.begin",
+					"begin": "^(\\s*)\"\"\"",
+					"end": "^(?!\\1\\s+)(?!\\s*$)"
 				},
 				{
-					"name": "string.quoted.triple.middle",
-                                        "begin": "^(\\s*)[^\\s].*\"\"\"",
-                                        "end": "^(?!\\1\\s+)(?!\\s*$)"
+					"contentName": "string.quoted.triple.middle",
+					"begin": "^(\\s*)[^\\s].*\"\"\"",
+					"end": "^(?!\\1\\s+)(?!\\s*$)"
 				},
 				{
 					"name": "string.quoted.single",
@@ -146,7 +146,7 @@
 				"name": "comment.block.documentation",
 				"begin": "^(\\s*)##",
 				"end": "^(?!\\1\\s+)(?!\\s*$)"
-			}, 
+			},
 			{
 				"name":"comment.line.number-sign",
 				"begin": "#",

--- a/tools/enso4igv/src/main/resources/org/enso/tools/enso4igv/enso.tmLanguage.json
+++ b/tools/enso4igv/src/main/resources/org/enso/tools/enso4igv/enso.tmLanguage.json
@@ -86,12 +86,12 @@
 					}]
 				},
 				{
-					"name": "string.quoted.tripple.begin",
+					"name": "string.quoted.triple.begin",
                                         "begin": "^(\\s*)\"\"\"",
                                         "end": "^(?!\\1\\s+)(?!\\s*$)"
 				},
 				{
-					"name": "string.quoted.tripple.middle",
+					"name": "string.quoted.triple.middle",
                                         "begin": "^(\\s*)[^\\s].*\"\"\"",
                                         "end": "^(?!\\1\\s+)(?!\\s*$)"
 				},

--- a/tools/enso4igv/src/main/resources/org/enso/tools/enso4igv/enso.tmLanguage.json
+++ b/tools/enso4igv/src/main/resources/org/enso/tools/enso4igv/enso.tmLanguage.json
@@ -87,12 +87,12 @@
 				},
 				{
 					"contentName": "string.quoted.triple.begin",
-					"begin": "^(\\s*)\"\"\"",
+					"begin": "^(\\s*)(\"\"\"|''')",
 					"end": "^(?!\\1\\s+)(?!\\s*$)"
 				},
 				{
 					"contentName": "string.quoted.triple.middle",
-					"begin": "^(\\s*)[^\\s].*\"\"\"",
+					"begin": "^(\\s*)[^\\s].*(\"\"\"|''')",
 					"end": "^(?!\\1\\s+)(?!\\s*$)"
 				},
 				{


### PR DESCRIPTION
### Pull Request Description

New rules to recognize `"""` and `'''` at the end of line and color everything that's inside nested block of text as string. It properly _stops the string literal when nested block ends_.

### Important Notes

The  [text mate grammar rules](https://macromates.com/manual/en/language_grammars)  properly _end_ the text block when the block ends. For example in:
```ruby
main =
    x = """
        a text
    y
```
`a text` is properly recognized as string.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

![Text Block properly ends](https://github.com/enso-org/enso/assets/26887752/cbb7b88e-f953-4004-b063-28aa4d32560a)

- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the style guides.
- All code has been tested:
  - [x] I tried to write a test for the grammar, but failed. Giving up for now.
