### PR TITLE
Add size-limited strings and varying bit-width integer Value_Types to in-memory backend and check for ArithmeticOverflow in LongStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -553,6 +553,8 @@
 - [Retire `Column_Selector` and allow regex based selection of columns.][7295]
 - [`Text.parse_to_table` can take a `Regex`.][7297]
 - [Expose `Text.normalize`.][7425]
+- [Implemented new value types (various sizes of `Integer` type, fixed-length
+  and length-limited `Char` type) for the in-memory `Table` backend.][7557]
 
 [debug-shortcuts]:
   https://github.com/enso-org/enso/blob/develop/app/gui/docs/product/shortcuts.md#debug
@@ -786,6 +788,7 @@
 [7295]: https://github.com/enso-org/enso/pull/7295
 [7297]: https://github.com/enso-org/enso/pull/7297
 [7425]: https://github.com/enso-org/enso/pull/7425
+[7557]: https://github.com/enso-org/enso/pull/7557
 
 #### Enso Compiler
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
@@ -369,6 +369,15 @@ type Column
        Returns a column containing the result of adding `other` to each element
        of `self`.  If `other` is a column, the operation is performed pairwise
        between corresponding elements of `self` and `other`.
+
+       ? Arithmetic Overflow
+
+         For integer columns, the operation may yield results that will not fit
+         into the range supported by the column. In such case, the in-memory
+         backend will replace such results with `Nothing` and report a
+         `Arithmetic_Overflow` warning. The behaviour in Database backends is
+         not specified and will depend on the particular database - it may
+         cause a hard error, the value may be truncated or wrap-around etc.
     + : Column | Any -> Column
     + self other =
         op = case Value_Type_Helpers.resolve_addition_kind self other of
@@ -388,6 +397,15 @@ type Column
        Returns a column containing the result of subtracting `other` from each
        element of `self`.  If `other` is a column, the operation is performed
        pairwise between corresponding elements of `self` and `other`.
+
+       ? Arithmetic Overflow
+
+         For integer columns, the operation may yield results that will not fit
+         into the range supported by the column. In such case, the in-memory
+         backend will replace such results with `Nothing` and report a
+         `Arithmetic_Overflow` warning. The behaviour in Database backends is
+         not specified and will depend on the particular database - it may
+         cause a hard error, the value may be truncated or wrap-around etc.
     - : Column | Any -> Column
     - self other =
         case Value_Type_Helpers.resolve_subtraction_kind self other of
@@ -405,6 +423,15 @@ type Column
        Returns a column containing the result of multiplying `other` by each
        element of `self`.  If `other` is a column, the operation is performed
        pairwise between corresponding elements of `self` and `other`.
+
+       ? Arithmetic Overflow
+
+         For integer columns, the operation may yield results that will not fit
+         into the range supported by the column. In such case, the in-memory
+         backend will replace such results with `Nothing` and report a
+         `Arithmetic_Overflow` warning. The behaviour in Database backends is
+         not specified and will depend on the particular database - it may
+         cause a hard error, the value may be truncated or wrap-around etc.
     * : Column | Any -> Column
     * self other =
         Value_Type_Helpers.check_binary_numeric_op self other <|
@@ -425,6 +452,15 @@ type Column
 
          - If division by zero occurs, an `Arithmetic_Error` warning is attached
            to the result.
+
+       ? Arithmetic Overflow
+
+         For integer columns, the operation may yield results that will not fit
+         into the range supported by the column. In such case, the in-memory
+         backend will replace such results with `Nothing` and report a
+         `Arithmetic_Overflow` warning. The behaviour in Database backends is
+         not specified and will depend on the particular database - it may
+         cause a hard error, the value may be truncated or wrap-around etc.
 
        > Example
          Divide the elements of one column by the elements of another.
@@ -492,6 +528,15 @@ type Column
 
        Returns a column containing the result of raising each element of `self`
        by `other`.
+
+       ? Arithmetic Overflow
+
+         For integer columns, the operation may yield results that will not fit
+         into the range supported by the column. In such case, the in-memory
+         backend will replace such results with `Nothing` and report a
+         `Arithmetic_Overflow` warning. The behaviour in Database backends is
+         not specified and will depend on the particular database - it may
+         cause a hard error, the value may be truncated or wrap-around etc.
 
        > Example
          Squares the elements of one column.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Column_Fetcher.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Column_Fetcher.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 import Standard.Table.Data.Column.Column as Materialized_Column
+import Standard.Table.Data.Type.Value_Type.Bits
 import Standard.Table.Data.Type.Value_Type.Value_Type
 import Standard.Table.Internal.Java_Exports
 
@@ -69,13 +70,13 @@ double_fetcher =
     Column_Fetcher.Value fetch_value make_builder
 
 ## PRIVATE
-long_fetcher : Column_Fetcher
-long_fetcher =
+long_fetcher : Bits -> Column_Fetcher
+long_fetcher bits =
     fetch_value rs i =
         l = rs.getLong i
         if rs.wasNull then Nothing else l
     make_builder initial_size =
-        java_builder = Java_Exports.make_long_builder initial_size
+        java_builder = Java_Exports.make_long_builder initial_size bits=bits
         append v =
             if v.is_nothing then java_builder.appendNulls 1 else
                 java_builder.appendLong v
@@ -137,10 +138,10 @@ date_time_fetcher =
 default_fetcher_for_value_type : Value_Type -> Column_Fetcher
 default_fetcher_for_value_type value_type =
     case value_type of
-        ## TODO [RW] once we support varying bit-width in storages, we should specify it
-           Revisit in #5159.
-        Value_Type.Integer _ -> long_fetcher
+        Value_Type.Integer bits -> long_fetcher bits
         Value_Type.Float _ -> double_fetcher
+        ## TODO [RW] once we support fixed length in storages, we should specify it
+           Revisit in #5159.
         Value_Type.Char _ _ -> text_fetcher
         Value_Type.Boolean -> boolean_fetcher
         Value_Type.Time -> time_fetcher

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Column_Fetcher.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Column_Fetcher.enso
@@ -84,13 +84,13 @@ long_fetcher bits =
     Column_Fetcher.Value fetch_value make_builder
 
 ## PRIVATE
-text_fetcher : Column_Fetcher
-text_fetcher =
+text_fetcher : Value_Type -> Column_Fetcher
+text_fetcher value_type =
     fetch_value rs i =
         t = rs.getString i
         if rs.wasNull then Nothing else t
     make_builder initial_size =
-        java_builder = Java_Exports.make_string_builder initial_size
+        java_builder = Java_Exports.make_string_builder initial_size value_type=value_type
         make_builder_from_java_object_builder java_builder
     Column_Fetcher.Value fetch_value make_builder
 
@@ -140,9 +140,7 @@ default_fetcher_for_value_type value_type =
     case value_type of
         Value_Type.Integer bits -> long_fetcher bits
         Value_Type.Float _ -> double_fetcher
-        ## TODO [RW] once we support fixed length in storages, we should specify it
-           Revisit in #5159.
-        Value_Type.Char _ _ -> text_fetcher
+        Value_Type.Char _ _ -> text_fetcher value_type
         Value_Type.Boolean -> boolean_fetcher
         Value_Type.Time -> time_fetcher
         # We currently don't distinguish timestamps without a timezone on the Enso value side.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -30,7 +30,6 @@ from project.Internal.Column_Format import all
 from project.Internal.Java_Exports import make_date_builder_adapter, make_double_builder, make_long_builder, make_string_builder
 
 polyglot java import org.enso.base.Time_Utils
-polyglot java import org.enso.table.data.column.builder.StringBuilder
 polyglot java import org.enso.table.data.column.operation.map.MapOperationProblemBuilder
 polyglot java import org.enso.table.data.column.storage.Storage as Java_Storage
 polyglot java import org.enso.table.data.table.Column as Java_Column
@@ -1274,7 +1273,7 @@ type Column
                 length = self.length
                 storage = self.java_column.getStorage
 
-                builder = StringBuilder.new length
+                builder = make_string_builder length
                 0.up_to length . each i->
                     replaced = do_replace i (storage.getItem i)
                     builder.append replaced

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -388,6 +388,15 @@ type Column
        Returns a column with results of adding `other` from each element of
        `self`.
 
+       ? Arithmetic Overflow
+
+         For integer columns, the operation may yield results that will not fit
+         into the range supported by the column. In such case, the in-memory
+         backend will replace such results with `Nothing` and report a
+         `Arithmetic_Overflow` warning. The behaviour in Database backends is
+         not specified and will depend on the particular database - it may
+         cause a hard error, the value may be truncated or wrap-around etc.
+
        > Example
          Add two columns to each other.
 
@@ -417,6 +426,15 @@ type Column
 
        Returns a column with results of subtracting `other` from each element of
        `self`.
+
+       ? Arithmetic Overflow
+
+         For integer columns, the operation may yield results that will not fit
+         into the range supported by the column. In such case, the in-memory
+         backend will replace such results with `Nothing` and report a
+         `Arithmetic_Overflow` warning. The behaviour in Database backends is
+         not specified and will depend on the particular database - it may
+         cause a hard error, the value may be truncated or wrap-around etc.
 
        > Example
          Subtract one column from another.
@@ -461,6 +479,15 @@ type Column
        Returns a column containing the result of multiplying each element of
        `self` by `other`.
 
+       ? Arithmetic Overflow
+
+         For integer columns, the operation may yield results that will not fit
+         into the range supported by the column. In such case, the in-memory
+         backend will replace such results with `Nothing` and report a
+         `Arithmetic_Overflow` warning. The behaviour in Database backends is
+         not specified and will depend on the particular database - it may
+         cause a hard error, the value may be truncated or wrap-around etc.
+
        > Example
          Multiply the elements of two columns together.
 
@@ -494,6 +521,15 @@ type Column
 
          - If division by zero occurs, an `Arithmetic_Error` warning is attached
            to the result.
+
+       ? Arithmetic Overflow
+
+         For integer columns, the operation may yield results that will not fit
+         into the range supported by the column. In such case, the in-memory
+         backend will replace such results with `Nothing` and report a
+         `Arithmetic_Overflow` warning. The behaviour in Database backends is
+         not specified and will depend on the particular database - it may
+         cause a hard error, the value may be truncated or wrap-around etc.
 
        > Example
          Divide the elements of one column by the elements of another.
@@ -559,6 +595,15 @@ type Column
 
        Returns a column containing the result of raising each element of `self`
        by `other`.
+
+       ? Arithmetic Overflow
+
+         For integer columns, the operation may yield results that will not fit
+         into the range supported by the column. In such case, the in-memory
+         backend will replace such results with `Nothing` and report a
+         `Arithmetic_Overflow` warning. The behaviour in Database backends is
+         not specified and will depend on the particular database - it may
+         cause a hard error, the value may be truncated or wrap-around etc.
 
        > Example
          Squares the elements of one column.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Data_Formatter.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Data_Formatter.enso
@@ -173,9 +173,10 @@ type Data_Formatter
             WhitespaceStrippingParser.new base_parser
 
     ## PRIVATE
-    make_integer_parser self auto_mode=False =
+    make_integer_parser self auto_mode=False target_type=Value_Type.Integer =
         separator = if self.thousand_separator.is_empty then Nothing else self.thousand_separator
-        NumberParser.createIntegerParser auto_mode.not (auto_mode.not || self.allow_leading_zeros) self.trim_values separator
+        storage_type = ???
+        NumberParser.createIntegerParser storage_type auto_mode.not (auto_mode.not || self.allow_leading_zeros) self.trim_values separator
 
     ## PRIVATE
     make_decimal_parser self auto_mode=False =
@@ -221,8 +222,8 @@ type Data_Formatter
 
     ## PRIVATE
     make_value_type_parser self value_type = case value_type of
-        # TODO once we implement #5159 we will need to add checks for bounds here and support 16/32-bit ints
-        Value_Type.Integer Bits.Bits_64 -> self.make_integer_parser
+        Value_Type.Integer _ ->
+            self.make_integer_parser target_type=value_type
         # TODO once we implement #6109 we can support 32-bit floats
         Value_Type.Float Bits.Bits_64   -> self.make_decimal_parser
         Value_Type.Boolean              -> self.make_boolean_parser

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Data_Formatter.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Data_Formatter.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
+import project.Data.Type.Storage
 import project.Internal.Java_Problems
 import project.Internal.Parse_Values_Helper
 from project.Data.Type.Value_Type import Auto, Bits, Value_Type
@@ -175,7 +176,7 @@ type Data_Formatter
     ## PRIVATE
     make_integer_parser self auto_mode=False target_type=Value_Type.Integer =
         separator = if self.thousand_separator.is_empty then Nothing else self.thousand_separator
-        storage_type = ???
+        storage_type = Storage.from_value_type_strict target_type
         NumberParser.createIntegerParser storage_type auto_mode.not (auto_mode.not || self.allow_leading_zeros) self.trim_values separator
 
     ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Type/Storage.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Type/Storage.enso
@@ -41,7 +41,6 @@ to_value_type storage_type = case storage_type of
 
 ## PRIVATE
 closest_storage_type value_type = case value_type of
-    # TODO we will want builders and storages with bounds checking, but for now we approximate
     Value_Type.Byte -> IntegerType.INT_8
     Value_Type.Integer bits ->
         java_bits = Java_Bits.fromInteger bits.to_integer

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Type/Storage.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Type/Storage.enso
@@ -42,6 +42,7 @@ to_value_type storage_type = case storage_type of
 closest_storage_type value_type = case value_type of
     # TODO we will want builders and storages with bounds checking, but for now we approximate
     Value_Type.Byte -> IntegerType.INT_64
+    # TODO FIXME!!!
     Value_Type.Integer _ -> IntegerType.INT_64
     Value_Type.Float _ -> FloatType.FLOAT_64
     Value_Type.Boolean -> BooleanType.INSTANCE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Type/Storage.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Type/Storage.enso
@@ -9,6 +9,7 @@ from Standard.Table.Errors import Inexact_Type_Coercion
 
 polyglot java import org.enso.table.data.column.builder.Builder
 polyglot java import org.enso.table.data.column.storage.type.AnyObjectType
+polyglot java import org.enso.table.data.column.storage.type.Bits as Java_Bits
 polyglot java import org.enso.table.data.column.storage.type.BooleanType
 polyglot java import org.enso.table.data.column.storage.type.DateTimeType
 polyglot java import org.enso.table.data.column.storage.type.DateType
@@ -24,9 +25,9 @@ to_value_type : StorageType -> Value_Type
 to_value_type storage_type = case storage_type of
     i : IntegerType -> case i.bits.toInteger of
         8 -> Value_Type.Byte
-        b -> Value_Type.Integer (Bits.from_bits b)
+        b -> Value_Type.Integer (Bits.from_integer b)
     f : FloatType ->
-        bits = Bits.from_bits f.bits.toInteger
+        bits = Bits.from_integer f.bits.toInteger
         Value_Type.Float bits
     _ : BooleanType -> Value_Type.Boolean
     s : TextType ->
@@ -41,12 +42,18 @@ to_value_type storage_type = case storage_type of
 ## PRIVATE
 closest_storage_type value_type = case value_type of
     # TODO we will want builders and storages with bounds checking, but for now we approximate
-    Value_Type.Byte -> IntegerType.INT_64
-    # TODO FIXME!!!
-    Value_Type.Integer _ -> IntegerType.INT_64
+    Value_Type.Byte -> IntegerType.INT_8
+    Value_Type.Integer bits ->
+        java_bits = Java_Bits.fromInteger bits.to_integer
+        IntegerType.create java_bits
     Value_Type.Float _ -> FloatType.FLOAT_64
     Value_Type.Boolean -> BooleanType.INSTANCE
-    Value_Type.Char _ _ -> TextType.VARIABLE_LENGTH
+    Value_Type.Char Nothing True -> TextType.VARIABLE_LENGTH
+    Value_Type.Char Nothing False ->
+        Error.throw (Illegal_Argument.Error "Value_Type.Char with fixed length must have a non-nothing size")
+    Value_Type.Char max_length variable_length ->
+        fixed_length = variable_length.not
+        TextType.new max_length fixed_length
     Value_Type.Date -> DateType.INSTANCE
     # We currently will not support storing dates without timezones in in-memory mode.
     Value_Type.Date_Time _ -> DateTimeType.INSTANCE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Type/Value_Type.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Type/Value_Type.enso
@@ -16,15 +16,15 @@ type Bits
     Bits_64
 
     ## PRIVATE
-    to_bits : Integer
-    to_bits self = case self of
+    to_integer : Integer
+    to_integer self = case self of
         Bits.Bits_16 -> 16
         Bits.Bits_32 -> 32
         Bits.Bits_64 -> 64
 
     ## PRIVATE
-    from_bits : Integer -> Bits
-    from_bits bits = case bits of
+    from_integer : Integer -> Bits
+    from_integer bits = case bits of
         16 -> Bits.Bits_16
         32 -> Bits.Bits_32
         64 -> Bits.Bits_64
@@ -33,17 +33,17 @@ type Bits
     ## PRIVATE
        Provides the text representation of the bit-size.
     to_text : Text
-    to_text self = self.to_bits.to_text + " bits"
+    to_text self = self.to_integer.to_text + " bits"
 
 ## PRIVATE
 type Bits_Comparator
     ## PRIVATE
     compare : Bits -> Bits -> Ordering
-    compare x y = Comparable.from x.to_bits . compare x.to_bits y.to_bits
+    compare x y = Comparable.from x.to_integer . compare x.to_integer y.to_integer
 
     ## PRIVATE
     hash : Bits -> Integer
-    hash x = Comparable.from x.to_bits . hash x.to_bits
+    hash x = Comparable.from x.to_integer . hash x.to_integer
 
 Comparable.from (_:Bits) = Bits_Comparator
 
@@ -96,8 +96,9 @@ type Value_Type
 
        Arguments:
        - size: the maximum number of characters that can be stored in the
-         column.
+         column. It can be nothing to indicate no limit.
        - variable_length: whether the size is a maximum or a fixed length.
+         A fixed length string must have a non-nothing size.
     Char size:(Integer|Nothing)=Nothing variable_length:Boolean=True
 
     ## Date
@@ -389,9 +390,9 @@ type Value_Type
         constructor_name = Meta.meta self . constructor . name
         additional_fields = case self of
             Value_Type.Integer size ->
-                [["bits", size.to_bits]]
+                [["bits", size.to_integer]]
             Value_Type.Float size ->
-                [["bits", size.to_bits]]
+                [["bits", size.to_integer]]
             Value_Type.Decimal precision scale ->
                 [["precision", precision], ["scale", scale]]
             Value_Type.Char size variable_length ->

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
@@ -562,6 +562,9 @@ type Conversion_Failure
        the target text type.
     Text_Too_Long (target_type : Value_Type) (related_column : Text) (affected_rows_count : Nothing|Integer) (example_values : Vector Text)
 
+    ## Indicates that some values are out of the range of the target type.
+    Out_Of_Bounds (target_type : Value_Type) (related_column : Text) (affected_rows_count : Nothing|Integer) (example_values : Vector Integer)
+
     ## PRIVATE
 
        Create a human-readable version of the error.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
@@ -612,6 +612,27 @@ type Loss_Of_Integer_Precision
     to_text self =
         "(Loss_Of_Integer_Precision.Warning (affected_rows_count = " + self.affected_rows_count.to_text + ") (example_value = " + self.example_value.to_text + ") (example_value_converted = " + self.example_value_converted.to_text + "))"
 
+type Arithmetic_Overflow
+    ## PRIVATE
+       Indicates that the result of an arithmetic operation is too large to fit the target type.
+    Warning (target_type : Value_Type) (affected_rows_count : Nothing|Integer) (example_operands : Nothing | Vector Any)
+
+    ## PRIVATE
+       Create a human-readable version of the error.
+    to_display_text : Text
+    to_display_text self =
+        rows_info = case self.affected_rows_count of
+            Nothing -> "Some rows"
+            count   -> count.to_text+" rows"
+        op_info = case self.example_operands of
+            Nothing -> ""
+            operands -> "(e.g. operation " + (operands.map .to_display_text . join " ") + ")"
+        rows_info + op_info + " encountered integer overflow, the results do not fit the type "+self.target_type.to_display_text+"."
+
+    ## PRIVATE
+    to_text : Text
+    to_text self =
+        "(Arithmetic_Overflow.Warning (target_type = " + self.target_type.to_text + ") (affected_rows_count = " + self.affected_rows_count.to_text + ") (example_operands = " + self.example_operands.to_display_text + "))"
 
 type Invalid_Value_For_Type
     ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
@@ -626,8 +626,9 @@ type Arithmetic_Overflow
             count   -> count.to_text+" rows"
         op_info = case self.example_operands of
             Nothing -> ""
-            operands -> "(e.g. operation " + (operands.map .to_display_text . join " ") + ")"
-        rows_info + op_info + " encountered integer overflow, the results do not fit the type "+self.target_type.to_display_text+"."
+            operands ->
+                " (e.g. operation " + (operands.map .to_display_text . join " ") + ")"
+        rows_info + op_info + " encountered integer overflow - the results do not fit the type "+self.target_type.to_display_text+". These values have ben replaced with `Nothing`."
 
     ## PRIVATE
     to_text : Text

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
@@ -556,14 +556,14 @@ type Conversion_Failure
 
        This may occur for example when a number does not fit the range of the
        target type.
-    Error (target_type : Value_Type) (related_column : Text) (affected_rows_count : Nothing|Integer) (example_values : Vector Any)
+    Error (target_type : Value_Type) (related_column : Text|Nothing) (affected_rows_count : Nothing|Integer) (example_values : Vector Any)
 
     ## Indicates that for some values, their text representation is too long for
        the target text type.
-    Text_Too_Long (target_type : Value_Type) (related_column : Text) (affected_rows_count : Nothing|Integer) (example_values : Vector Text)
+    Text_Too_Long (target_type : Value_Type) (related_column : Text|Nothing) (affected_rows_count : Nothing|Integer) (example_values : Vector Text)
 
     ## Indicates that some values are out of the range of the target type.
-    Out_Of_Bounds (target_type : Value_Type) (related_column : Text) (affected_rows_count : Nothing|Integer) (example_values : Vector Integer)
+    Out_Of_Range (target_type : Value_Type) (related_column : Text|Nothing) (affected_rows_count : Nothing|Integer) (example_values : Vector Integer)
 
     ## PRIVATE
 
@@ -582,12 +582,17 @@ type Conversion_Failure
                         cases = if remaining_count == 1 then "case" else "cases"
                         " and "+remaining_count.to_text+" other "+cases
                     "["+examples+additional+"]"
+        column_suffix = case self.related_column of
+            Nothing -> ""
+            column_name -> " when converting the column ["+column_name+"]"
 
         case self of
             Conversion_Failure.Error _ _ _ _ ->
-                rows_info + " could not be converted into the target type "+self.target_type.to_display_text+" when converting the column ["+self.related_column+"]."
+                rows_info + " could not be converted into the target type "+self.target_type.to_display_text+column_suffix+"."
+            Conversion_Failure.Out_Of_Range _ _ _ _ ->
+                rows_info + " are out of the range of the target type "+self.target_type.to_display_text+column_suffix+"."
             Conversion_Failure.Text_Too_Long _ _ _ _ ->
-                rows_info + " have a text representation that does not fit the target type "+self.target_type.to_display_text+" when converting the column ["+self.related_column+"]."
+                rows_info + " have a text representation that does not fit the target type "+self.target_type.to_display_text+column_suffix+"."
 
 type Loss_Of_Integer_Precision
     ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Cast_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Cast_Helpers.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
+import project.Data.Type.Storage
 import project.Data.Type.Value_Type.Value_Type
 import project.Internal.Java_Problems
 import project.Internal.Parse_Values_Helper
@@ -38,31 +39,16 @@ is_a_valid_parse_target target_type =
 ## PRIVATE
 type Cast_Problem_Builder
     ## PRIVATE
-    Value column_name target_type to_java
+    Value to_java
 
     ## PRIVATE
        Returns a vector of all reported problems.
     get_problems : Vector
     get_problems self =
-        builder = Vector.new_builder
-        java_instance = self.to_java
-
-        lossy_conversion_rows = java_instance.getFailedConversionsCount
-        if lossy_conversion_rows > 0 then
-            example_values = Vector.from_polyglot_array java_instance.getFailedConversionExamples
-            builder.append (Conversion_Failure.Error self.target_type self.column_name lossy_conversion_rows example_values)
-
-        text_too_long_rows = java_instance.getTextTooLongCount
-        if text_too_long_rows > 0 then
-            example_values = Vector.from_polyglot_array java_instance.getTextTooLongExamples
-            builder.append (Conversion_Failure.Text_Too_Long self.target_type self.column_name text_too_long_rows example_values)
-
-        aggregated = Java_Problems.parse_aggregated_problems java_instance.getAggregatedProblems
-        builder.append_vector_range aggregated
-
-        builder.to_vector
+        Java_Problems.parse_aggregated_problems self.to_java.getAggregatedProblems
 
 ## PRIVATE
 new_java_problem_builder : Text -> Value_Type -> Cast_Problem_Builder
 new_java_problem_builder column_name target_type =
-    Cast_Problem_Builder.Value column_name target_type CastProblemBuilder.new
+    storage_type = Storage.from_value_type_strict target_type
+    Cast_Problem_Builder.Value (CastProblemBuilder.new column_name storage_type)

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Java_Exports.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Java_Exports.enso
@@ -1,5 +1,9 @@
 from Standard.Base import all
 
+import project.Data.Type.Storage
+import project.Data.Type.Value_Type.Bits
+import project.Data.Type.Value_Type.Value_Type
+
 polyglot java import org.enso.table.data.column.builder.BoolBuilder
 polyglot java import org.enso.table.data.column.builder.DateBuilder
 polyglot java import org.enso.table.data.column.builder.DateTimeBuilder
@@ -7,7 +11,7 @@ polyglot java import org.enso.table.data.column.builder.InferredBuilder
 polyglot java import org.enso.table.data.column.builder.NumericBuilder
 polyglot java import org.enso.table.data.column.builder.StringBuilder
 polyglot java import org.enso.table.data.column.builder.TimeOfDayBuilder
-polyglot java import org.enso.table.data.column.storage.Storage
+polyglot java import org.enso.table.data.column.storage.Storage as Java_Storage
 
 ## PRIVATE
 make_bool_builder : BoolBuilder
@@ -19,7 +23,9 @@ make_double_builder initial_size = NumericBuilder.createDoubleBuilder initial_si
 
 ## PRIVATE
 make_long_builder : Integer -> NumericBuilder
-make_long_builder initial_size = NumericBuilder.createLongBuilder initial_size
+make_long_builder initial_size bits=Bits.Bits_64 =
+    integer_type = Storage.from_value_type_strict (Value_Type.Integer bits)
+    NumericBuilder.createLongBuilder initial_size integer_type
 
 ## PRIVATE
 make_string_builder : Integer -> StringBuilder
@@ -53,7 +59,7 @@ type DateBuilderAdapter
         self.date_builder.appendDate date
 
     ## PRIVATE
-    seal : Storage
+    seal : Java_Storage
     seal self = self.date_builder.seal
 
 ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Java_Exports.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Java_Exports.enso
@@ -28,8 +28,10 @@ make_long_builder initial_size bits=Bits.Bits_64 =
     NumericBuilder.createLongBuilder initial_size integer_type
 
 ## PRIVATE
-make_string_builder : Integer -> StringBuilder
-make_string_builder initial_size = StringBuilder.new initial_size
+make_string_builder : Integer -> Value_Type -> StringBuilder
+make_string_builder initial_size value_type=Value_Type.Char =
+    storage_type = Storage.from_value_type_strict value_type
+    StringBuilder.new initial_size storage_type
 
 ## PRIVATE
 make_time_of_day_builder : Integer -> TimeOfDayBuilder

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Java_Problems.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Java_Problems.enso
@@ -2,9 +2,12 @@ from Standard.Base import all
 import Standard.Base.Errors.Common.Arithmetic_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
-from project.Errors import Additional_Invalid_Rows, Additional_Warnings, Duplicate_Output_Column_Names, Floating_Point_Equality, Invalid_Aggregation, Invalid_Column_Names, Invalid_Row, Loss_Of_Integer_Precision, Unquoted_Characters_In_Output, Unquoted_Delimiter
+import project.Data.Type.Storage
+from project.Errors import Additional_Invalid_Rows, Additional_Warnings, Duplicate_Output_Column_Names, Floating_Point_Equality, Invalid_Aggregation, Invalid_Column_Names, Invalid_Row, Unquoted_Characters_In_Output, Unquoted_Delimiter, Loss_Of_Integer_Precision, Conversion_Failure
 
 polyglot java import org.enso.table.data.column.builder.LossOfIntegerPrecision
+polyglot java import org.enso.table.data.column.operation.cast.ConversionFailure
+polyglot java import org.enso.table.data.column.operation.cast.ConversionFailureType
 polyglot java import org.enso.table.data.table.problems.ArithmeticError
 polyglot java import org.enso.table.data.table.problems.FloatingPointGrouping
 polyglot java import org.enso.table.data.table.problems.IllegalArgumentError
@@ -33,6 +36,15 @@ translate_problem p = case p of
         Floating_Point_Equality.Error p.getLocationName
     _ : LossOfIntegerPrecision ->
         Loss_Of_Integer_Precision.Warning p.getAffectedRowsCount p.getExampleValue p.getExampleValueConverted
+    _ : ConversionFailure ->
+        examples = Vector.from_polyglot_array p.examples
+        target_type = Storage.to_value_type p.targetType
+        related_column = p.relatedColumn
+        affected_rows_count = p.affectedRowCount
+        constructor = if p.errorType == ConversionFailureType.NUMBER_OUT_OF_RANGE then Conversion_Failure.Out_Of_Range else
+            if p.errorType == ConversionFailureType.TEXT_TOO_LONG then Conversion_Failure.Text_Too_Long else
+                Conversion_Failure.Error
+        constructor target_type related_column affected_rows_count examples
     _ : UnquotedCharactersInOutput ->
         Unquoted_Characters_In_Output.Warning p.getLocationName (Vector.from_polyglot_array p.getRows)
     _ : UnquotedDelimiter ->

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Java_Problems.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Java_Problems.enso
@@ -3,12 +3,13 @@ import Standard.Base.Errors.Common.Arithmetic_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 import project.Data.Type.Storage
-from project.Errors import Additional_Invalid_Rows, Additional_Warnings, Duplicate_Output_Column_Names, Floating_Point_Equality, Invalid_Aggregation, Invalid_Column_Names, Invalid_Row, Unquoted_Characters_In_Output, Unquoted_Delimiter, Loss_Of_Integer_Precision, Conversion_Failure
+from project.Errors import Additional_Invalid_Rows, Additional_Warnings, Duplicate_Output_Column_Names, Floating_Point_Equality, Invalid_Aggregation, Invalid_Column_Names, Invalid_Row, Unquoted_Characters_In_Output, Unquoted_Delimiter, Loss_Of_Integer_Precision, Conversion_Failure, Arithmetic_Overflow
 
 polyglot java import org.enso.table.data.column.builder.LossOfIntegerPrecision
 polyglot java import org.enso.table.data.column.operation.cast.ConversionFailure
 polyglot java import org.enso.table.data.column.operation.cast.ConversionFailureType
 polyglot java import org.enso.table.data.table.problems.ArithmeticError
+polyglot java import org.enso.table.data.table.problems.ArithmeticOverflow
 polyglot java import org.enso.table.data.table.problems.FloatingPointGrouping
 polyglot java import org.enso.table.data.table.problems.IllegalArgumentError
 polyglot java import org.enso.table.data.table.problems.InvalidAggregation
@@ -36,6 +37,12 @@ translate_problem p = case p of
         Floating_Point_Equality.Error p.getLocationName
     _ : LossOfIntegerPrecision ->
         Loss_Of_Integer_Precision.Warning p.getAffectedRowsCount p.getExampleValue p.getExampleValueConverted
+    _ : ArithmeticOverflow ->
+        target_type = Storage.to_value_type p.targetType
+        example_operands = case p.exampleOperands of
+            Nothing -> Nothing
+            array -> Vector.from_polyglot_array array
+        Arithmetic_Overflow.Warning target_type p.affectedRowCount example_operands
     _ : ConversionFailure ->
         examples = Vector.from_polyglot_array p.examples
         target_type = Storage.to_value_type p.targetType

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
@@ -23,16 +23,11 @@ public abstract class Builder {
       case DateType x -> new DateBuilder(size);
       case DateTimeType x -> new DateTimeBuilder(size);
       case TimeOfDayType x -> new TimeOfDayBuilder(size);
-      case FloatType floatType ->
-        switch (floatType.bits()) {
-          case BITS_64 -> NumericBuilder.createDoubleBuilder(size);
-          default -> throw new IllegalArgumentException("Only 64-bit floats are currently supported.");
-        };
-      case IntegerType integerType ->
-          switch (integerType.bits()) {
-            case BITS_64 -> NumericBuilder.createLongBuilder(size);
-            default -> throw new IllegalArgumentException("TODO: Builders other than 64-bit int are not yet supported.");
-          };
+      case FloatType floatType -> switch (floatType.bits()) {
+        case BITS_64 -> NumericBuilder.createDoubleBuilder(size);
+        default -> throw new IllegalArgumentException("Only 64-bit floats are currently supported.");
+      };
+      case IntegerType integerType -> NumericBuilder.createLongBuilder(size, integerType);
       case TextType textType -> {
         if (textType.fixedLength()) {
           throw new IllegalArgumentException("Fixed-length text builders are not yet supported yet.");

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/Builder.java
@@ -6,9 +6,6 @@ import org.enso.table.data.column.storage.type.BooleanType;
 import org.enso.table.data.column.storage.type.FloatType;
 import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.problems.AggregatedProblems;
-import org.enso.table.problems.Problem;
-
-import java.util.List;
 
 /** A builder for creating columns dynamically. */
 public abstract class Builder {
@@ -28,16 +25,7 @@ public abstract class Builder {
         default -> throw new IllegalArgumentException("Only 64-bit floats are currently supported.");
       };
       case IntegerType integerType -> NumericBuilder.createLongBuilder(size, integerType);
-      case TextType textType -> {
-        if (textType.fixedLength()) {
-          throw new IllegalArgumentException("Fixed-length text builders are not yet supported yet.");
-        }
-        if (textType.maxLength() >= 0) {
-          throw new IllegalArgumentException("Text builders with a maximum length are not yet supported yet.");
-        }
-
-        yield new StringBuilder(size);
-      }
+      case TextType textType -> new StringBuilder(size, textType);
       case null -> new InferredBuilder(size);
     };
     assert builder.getType().equals(type);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
@@ -114,7 +114,7 @@ public class DoubleBuilder extends NumericBuilder {
                 + storage
                 + ". This is a bug in the Table library.");
       }
-    } else if (Objects.equals(storage.getType(), IntegerType.INT_64)) {
+    } else if (storage.getType() instanceof IntegerType) {
       if (storage instanceof LongStorage longStorage) {
         int n = longStorage.size();
         BitSets.copy(longStorage.getIsMissing(), isMissing, currentSize, n);
@@ -125,7 +125,7 @@ public class DoubleBuilder extends NumericBuilder {
         }
       } else {
         throw new IllegalStateException(
-            "Unexpected storage implementation for type LONG: "
+            "Unexpected storage implementation for type INTEGER: "
                 + storage
                 + ". This is a bug in the Table library.");
       }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/DoubleBuilder.java
@@ -3,9 +3,9 @@ package org.enso.table.data.column.builder;
 import org.enso.base.polyglot.NumericConverter;
 import org.enso.table.data.column.operation.cast.ToFloatStorageConverter;
 import org.enso.table.data.column.storage.BoolStorage;
-import org.enso.table.data.column.storage.numeric.DoubleStorage;
-import org.enso.table.data.column.storage.numeric.LongStorage;
 import org.enso.table.data.column.storage.Storage;
+import org.enso.table.data.column.storage.numeric.AbstractLongStorage;
+import org.enso.table.data.column.storage.numeric.DoubleStorage;
 import org.enso.table.data.column.storage.type.BooleanType;
 import org.enso.table.data.column.storage.type.FloatType;
 import org.enso.table.data.column.storage.type.IntegerType;
@@ -115,7 +115,7 @@ public class DoubleBuilder extends NumericBuilder {
                 + ". This is a bug in the Table library.");
       }
     } else if (storage.getType() instanceof IntegerType) {
-      if (storage instanceof LongStorage longStorage) {
+      if (storage instanceof AbstractLongStorage longStorage) {
         int n = longStorage.size();
         BitSets.copy(longStorage.getIsMissing(), isMissing, currentSize, n);
         for (int i = 0; i < n; i++) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredBuilder.java
@@ -97,7 +97,8 @@ public class InferredBuilder extends Builder {
     if (o instanceof Boolean) {
       currentBuilder = new BoolBuilder();
     } else if (NumericConverter.isCoercibleToLong(o)) {
-      currentBuilder = NumericBuilder.createLongBuilder(initialCapacity);
+      // In inferred builder, we always default to 64-bits.
+      currentBuilder = NumericBuilder.createLongBuilder(initialCapacity, IntegerType.INT_64);
     } else if (NumericConverter.isCoercibleToDouble(o)) {
       currentBuilder = NumericBuilder.createDoubleBuilder(initialCapacity);
     } else if (o instanceof LocalDate) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredBuilder.java
@@ -108,7 +108,7 @@ public class InferredBuilder extends Builder {
     } else if (o instanceof ZonedDateTime) {
       currentBuilder = new DateTimeBuilder(initialCapacity);
     } else if (o instanceof String) {
-      currentBuilder = new StringBuilder(initialCapacity);
+      currentBuilder = new StringBuilder(initialCapacity, TextType.VARIABLE_LENGTH);
     } else {
       currentBuilder = new MixedBuilder(initialCapacity);
     }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilder.java
@@ -78,7 +78,7 @@ public class LongBuilder extends NumericBuilder {
       System.arraycopy(longStorage.getRawData(), 0, data, currentSize, n);
       BitSets.copy(longStorage.getIsMissing(), isMissing, currentSize, n);
       currentSize += n;
-    } else if (storage.getType() instanceof IntegerType) {
+    } else if (storage.getType() instanceof IntegerType otherType && type.fits(otherType)) {
       if (storage instanceof AbstractLongStorage longStorage) {
         int n = longStorage.size();
         ensureFreeSpaceFor(n);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilderChecked.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilderChecked.java
@@ -1,16 +1,16 @@
 package org.enso.table.data.column.builder;
 
+import java.util.BitSet;
 import org.enso.base.polyglot.NumericConverter;
 import org.enso.table.data.column.operation.cast.CastProblemBuilder;
 import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.problems.AggregatedProblems;
 
-import java.util.BitSet;
-
 /** A LongBuilder that ensures values it is given fit the target type. */
 public class LongBuilderChecked extends LongBuilder {
   private final IntegerType type;
   private final CastProblemBuilder castProblemBuilder;
+
   protected LongBuilderChecked(BitSet isMissing, long[] data, int currentSize, IntegerType type) {
     super(isMissing, data, currentSize);
     this.type = type;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilderChecked.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilderChecked.java
@@ -1,0 +1,52 @@
+package org.enso.table.data.column.builder;
+
+import org.enso.base.polyglot.NumericConverter;
+import org.enso.table.data.column.operation.cast.CastProblemBuilder;
+import org.enso.table.data.column.storage.type.IntegerType;
+import org.enso.table.problems.AggregatedProblems;
+
+import java.util.BitSet;
+
+/** A LongBuilder that ensures values it is given fit the target type. */
+public class LongBuilderChecked extends LongBuilder {
+  private final IntegerType type;
+  private final CastProblemBuilder castProblemBuilder;
+  protected LongBuilderChecked(BitSet isMissing, long[] data, int currentSize, IntegerType type) {
+    super(isMissing, data, currentSize);
+    this.type = type;
+
+    // Currently we have no correlation with column name, and it may not be necessary for now.
+    String relatedColumnName = null;
+    this.castProblemBuilder = new CastProblemBuilder(relatedColumnName, type);
+  }
+
+  @Override
+  public void appendNoGrow(Object o) {
+    if (o == null) {
+      isMissing.set(currentSize++);
+    } else {
+      long x = NumericConverter.coerceToLong(o);
+      appendLongNoGrow(x);
+    }
+  }
+
+  @Override
+  public IntegerType getType() {
+    return type;
+  }
+
+  @Override
+  public void appendLongNoGrow(long x) {
+    if (type.fits(x)) {
+      data[currentSize++] = x;
+    } else {
+      isMissing.set(currentSize++);
+      castProblemBuilder.reportNumberOutOfRange(x);
+    }
+  }
+
+  @Override
+  public AggregatedProblems getProblems() {
+    return castProblemBuilder.getAggregatedProblems();
+  }
+}

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilderUnchecked.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilderUnchecked.java
@@ -1,13 +1,12 @@
 package org.enso.table.data.column.builder;
 
+import java.util.BitSet;
 import org.enso.base.polyglot.NumericConverter;
 import org.enso.table.data.column.storage.type.IntegerType;
 
-import java.util.BitSet;
-
 /**
- * A LongBuilder that does not need to check value ranges, because it stores 64-bit integers and no larger integers will
- * come to appendLong anyway.
+ * A LongBuilder that does not need to check value ranges, because it stores 64-bit integers and no
+ * larger integers will come to appendLong anyway.
  */
 public class LongBuilderUnchecked extends LongBuilder {
   protected LongBuilderUnchecked(BitSet isMissing, long[] data, int currentSize) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilderUnchecked.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/LongBuilderUnchecked.java
@@ -1,0 +1,36 @@
+package org.enso.table.data.column.builder;
+
+import org.enso.base.polyglot.NumericConverter;
+import org.enso.table.data.column.storage.type.IntegerType;
+
+import java.util.BitSet;
+
+/**
+ * A LongBuilder that does not need to check value ranges, because it stores 64-bit integers and no larger integers will
+ * come to appendLong anyway.
+ */
+public class LongBuilderUnchecked extends LongBuilder {
+  protected LongBuilderUnchecked(BitSet isMissing, long[] data, int currentSize) {
+    super(isMissing, data, currentSize);
+  }
+
+  @Override
+  public void appendNoGrow(Object o) {
+    if (o == null) {
+      isMissing.set(currentSize++);
+    } else {
+      long x = NumericConverter.coerceToLong(o);
+      data[currentSize++] = x;
+    }
+  }
+
+  @Override
+  public void appendLongNoGrow(long data) {
+    appendRawNoGrow(data);
+  }
+
+  @Override
+  public IntegerType getType() {
+    return IntegerType.INT_64;
+  }
+}

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/NumericBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/NumericBuilder.java
@@ -18,11 +18,11 @@ public abstract class NumericBuilder extends TypedBuilder {
   }
 
   public static DoubleBuilder createDoubleBuilder(int size) {
-    return new DoubleBuilder(new BitSet(size), new long[size], 0);
+    return new DoubleBuilder(new BitSet(), new long[size], 0);
   }
 
   public static LongBuilder createLongBuilder(int size, IntegerType type) {
-    return new LongBuilder(new BitSet(size), new long[size], 0, type);
+    return LongBuilder.make(size, type);
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/NumericBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/NumericBuilder.java
@@ -1,5 +1,7 @@
 package org.enso.table.data.column.builder;
 
+import org.enso.table.data.column.storage.type.IntegerType;
+
 import java.util.Arrays;
 import java.util.BitSet;
 
@@ -19,8 +21,8 @@ public abstract class NumericBuilder extends TypedBuilder {
     return new DoubleBuilder(new BitSet(size), new long[size], 0);
   }
 
-  public static LongBuilder createLongBuilder(int size) {
-    return new LongBuilder(new BitSet(size), new long[size], 0);
+  public static LongBuilder createLongBuilder(int size, IntegerType type) {
+    return new LongBuilder(new BitSet(size), new long[size], 0, type);
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/NumericBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/NumericBuilder.java
@@ -1,9 +1,8 @@
 package org.enso.table.data.column.builder;
 
-import org.enso.table.data.column.storage.type.IntegerType;
-
 import java.util.Arrays;
 import java.util.BitSet;
+import org.enso.table.data.column.storage.type.IntegerType;
 
 /** A common base for numeric builders. */
 public abstract class NumericBuilder extends TypedBuilder {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/StringBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/StringBuilder.java
@@ -1,5 +1,6 @@
 package org.enso.table.data.column.builder;
 
+import org.enso.table.data.column.storage.SpecializedStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.StringStorage;
 import org.enso.table.data.column.storage.type.StorageType;
@@ -41,6 +42,24 @@ public class StringBuilder extends TypedBuilderImpl<String> {
     } else {
       return false;
     }
+  }
+
+  @Override
+  public void appendBulkStorage(Storage<?> storage) {
+    if (storage.getType() instanceof TextType gotType) {
+      if (type.fitsExactly(gotType)) {
+        if (storage instanceof SpecializedStorage<?>) {
+          // This cast is safe, because storage.getType() == this.getType() == TextType iff storage.T == String
+          @SuppressWarnings("unchecked")
+          SpecializedStorage<String> specializedStorage = (SpecializedStorage<String>) storage;
+          System.arraycopy(specializedStorage.getData(), 0, data, currentSize, storage.size());
+          currentSize += storage.size();
+          return;
+        }
+      }
+    }
+
+    super.appendBulkStorage(storage);
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/StringBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/StringBuilder.java
@@ -7,32 +7,44 @@ import org.enso.table.data.column.storage.type.TextType;
 
 /** A builder for string columns. */
 public class StringBuilder extends TypedBuilderImpl<String> {
+  private final TextType type;
   @Override
   protected String[] newArray(int size) {
     return new String[size];
   }
 
-  public StringBuilder(int size) {
+  public StringBuilder(int size, TextType type) {
     super(size);
+    this.type = type;
   }
 
   @Override
   public StorageType getType() {
-    return TextType.VARIABLE_LENGTH;
+    return type;
   }
 
   @Override
   public void appendNoGrow(Object o) {
-    data[currentSize++] = (String) o;
+    String str = (String) o;
+    if (!type.fits(str)) {
+      // TODO
+      throw new IllegalArgumentException("String does not fit the type");
+    }
+
+    data[currentSize++] = str;
   }
 
   @Override
   public boolean accepts(Object o) {
-    return o instanceof String;
+    if (o instanceof String s) {
+      return type.fits(s);
+    } else {
+      return false;
+    }
   }
 
   @Override
   protected Storage<String> doSeal() {
-    return new StringStorage(data, currentSize);
+    return new StringStorage(data, currentSize, type);
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/StringBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/StringBuilder.java
@@ -28,8 +28,8 @@ public class StringBuilder extends TypedBuilderImpl<String> {
   public void appendNoGrow(Object o) {
     String str = (String) o;
     if (!type.fits(str)) {
-      // TODO
-      throw new IllegalArgumentException("String does not fit the type");
+      str = type.adapt(str);
+
     }
 
     data[currentSize++] = str;
@@ -61,6 +61,8 @@ public class StringBuilder extends TypedBuilderImpl<String> {
 
     super.appendBulkStorage(storage);
   }
+
+
 
   @Override
   protected Storage<String> doSeal() {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/CastProblemBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/CastProblemBuilder.java
@@ -1,17 +1,27 @@
 package org.enso.table.data.column.operation.cast;
 
 import java.util.ArrayList;
-import java.util.List;
+
+import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.problems.AggregatedProblems;
 
 public class CastProblemBuilder {
+  private final String columnName;
+  private final StorageType targetType;
   private int failedConversionsCount = 0;
+  private int numberOutOfRangeCount = 0;
   private int textTooLongCount = 0;
 
   private static final int MAX_EXAMPLES_COUNT = 3;
   private final ArrayList<Object> failedConversionExamples = new ArrayList<>(MAX_EXAMPLES_COUNT);
+  private final ArrayList<Object> numberOutOfRangeExamples = new ArrayList<>(MAX_EXAMPLES_COUNT);
   private final ArrayList<String> textTooLongExamples = new ArrayList<>(MAX_EXAMPLES_COUNT);
   private AggregatedProblems otherProblems = new AggregatedProblems();
+
+  public CastProblemBuilder(String columnName, StorageType targetType) {
+    this.columnName = columnName;
+    this.targetType = targetType;
+  }
 
   public void reportConversionFailure(Object sourceValue) {
     failedConversionsCount++;
@@ -29,27 +39,55 @@ public class CastProblemBuilder {
     }
   }
 
-  public int getFailedConversionsCount() {
-    return failedConversionsCount;
-  }
+  public void reportNumberOutOfRange(Number number) {
+    numberOutOfRangeCount++;
 
-  public List<Object> getFailedConversionExamples() {
-    return failedConversionExamples;
-  }
-
-  public int getTextTooLongCount() {
-    return textTooLongCount;
-  }
-
-  public List<String> getTextTooLongExamples() {
-    return textTooLongExamples;
+    if (numberOutOfRangeExamples.size() < MAX_EXAMPLES_COUNT) {
+      numberOutOfRangeExamples.add(number);
+    }
   }
 
   public void aggregateOtherProblems(AggregatedProblems problems) {
     otherProblems = AggregatedProblems.merge(otherProblems, problems);
   }
 
+  private AggregatedProblems summarizeMyProblems() {
+    AggregatedProblems problems = new AggregatedProblems();
+
+    if (failedConversionsCount > 0) {
+      problems.add(
+          new ConversionFailure(
+              ConversionFailureType.FAILED_CONVERSION,
+              targetType,
+              columnName,
+              failedConversionsCount,
+              failedConversionExamples));
+    }
+
+    if (numberOutOfRangeCount > 0) {
+      problems.add(
+          new ConversionFailure(
+              ConversionFailureType.NUMBER_OUT_OF_RANGE,
+              targetType,
+              columnName,
+              numberOutOfRangeCount,
+              numberOutOfRangeExamples));
+    }
+
+    if (textTooLongCount > 0) {
+      problems.add(
+          new ConversionFailure(
+              ConversionFailureType.TEXT_TOO_LONG,
+              targetType,
+              columnName,
+              textTooLongCount,
+              textTooLongExamples));
+    }
+
+    return problems;
+  }
+
   public AggregatedProblems getAggregatedProblems() {
-    return otherProblems;
+    return AggregatedProblems.merge(summarizeMyProblems(), otherProblems);
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/CastProblemBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/CastProblemBuilder.java
@@ -1,7 +1,6 @@
 package org.enso.table.data.column.operation.cast;
 
 import java.util.ArrayList;
-
 import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.problems.AggregatedProblems;
 

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ConversionFailure.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ConversionFailure.java
@@ -1,0 +1,15 @@
+package org.enso.table.data.column.operation.cast;
+
+import org.enso.table.data.column.storage.type.StorageType;
+import org.enso.table.problems.Problem;
+
+import java.util.List;
+
+public record ConversionFailure(
+    ConversionFailureType errorType,
+    StorageType targetType,
+    String relatedColumn,
+    long affectedRowCount,
+    List<?> examples
+) implements Problem {
+}

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ConversionFailureType.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ConversionFailureType.java
@@ -1,0 +1,7 @@
+package org.enso.table.data.column.operation.cast;
+
+public enum ConversionFailureType {
+  FAILED_CONVERSION,
+  NUMBER_OUT_OF_RANGE,
+  TEXT_TOO_LONG
+}

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToFloatStorageConverter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToFloatStorageConverter.java
@@ -4,8 +4,8 @@ import org.enso.base.polyglot.NumericConverter;
 import org.enso.table.data.column.builder.DoubleBuilder;
 import org.enso.table.data.column.builder.NumericBuilder;
 import org.enso.table.data.column.storage.BoolStorage;
+import org.enso.table.data.column.storage.numeric.AbstractLongStorage;
 import org.enso.table.data.column.storage.numeric.DoubleStorage;
-import org.enso.table.data.column.storage.numeric.LongStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.type.AnyObjectType;
 import org.enso.table.data.column.storage.type.Bits;
@@ -22,8 +22,8 @@ public class ToFloatStorageConverter implements StorageConverter<Double> {
   public Storage<Double> cast(Storage<?> storage, CastProblemBuilder problemBuilder) {
     if (storage instanceof DoubleStorage doubleStorage) {
       return doubleStorage;
-    } else if (storage instanceof LongStorage longStorage) {
-      return convertDoubleStorage(longStorage, problemBuilder);
+    } else if (storage instanceof AbstractLongStorage longStorage) {
+      return convertLongStorage(longStorage, problemBuilder);
     } else if (storage instanceof BoolStorage boolStorage) {
       return convertBoolStorage(boolStorage, problemBuilder);
     } else if (storage.getType() instanceof AnyObjectType) {
@@ -43,7 +43,8 @@ public class ToFloatStorageConverter implements StorageConverter<Double> {
       } else if (o instanceof Boolean b) {
         builder.appendDouble(booleanAsDouble(b));
       } else if (NumericConverter.isCoercibleToLong(o)) {
-        builder.appendLong(NumericConverter.coerceToLong(o));
+        long x = NumericConverter.coerceToLong(o);
+        builder.appendLong(x);
       } else if (NumericConverter.isDecimalLike(o)) {
         double x = NumericConverter.coerceToDouble(o);
         builder.appendDouble(x);
@@ -59,7 +60,7 @@ public class ToFloatStorageConverter implements StorageConverter<Double> {
     return builder.seal();
   }
 
-  private Storage<Double> convertDoubleStorage(LongStorage longStorage, CastProblemBuilder problemBuilder) {
+  private Storage<Double> convertLongStorage(AbstractLongStorage longStorage, CastProblemBuilder problemBuilder) {
     int n = longStorage.size();
     DoubleBuilder builder = NumericBuilder.createDoubleBuilder(n);
     for (int i = 0; i < n; i++) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToIntegerStorageConverter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToIntegerStorageConverter.java
@@ -21,7 +21,12 @@ public class ToIntegerStorageConverter implements StorageConverter<Long> {
 
   public Storage<Long> cast(Storage<?> storage, CastProblemBuilder problemBuilder) {
     if (storage instanceof LongStorage longStorage) {
-      return longStorage;
+      if (storage.getType().equals(targetType)) {
+        return longStorage;
+      } else {
+        // TODO [RW] FIXME this is just a hack that is totally invalid, just doing it to check a test in Union
+        return new LongStorage(longStorage.getRawData(), longStorage.size(), longStorage.getIsMissing(), targetType);
+      }
     } else if (storage instanceof DoubleStorage doubleStorage) {
       return convertDoubleStorage(doubleStorage, problemBuilder);
     } else if (storage instanceof BoolStorage boolStorage) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToTextStorageConverter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToTextStorageConverter.java
@@ -3,12 +3,14 @@ package org.enso.table.data.column.operation.cast;
 import org.enso.base.Text_Utils;
 import org.enso.polyglot.common_utils.Core_Date_Utils;
 import org.enso.table.data.column.builder.StringBuilder;
-import org.enso.table.data.column.storage.*;
+import org.enso.table.data.column.storage.BoolStorage;
+import org.enso.table.data.column.storage.Storage;
+import org.enso.table.data.column.storage.StringStorage;
 import org.enso.table.data.column.storage.datetime.DateStorage;
 import org.enso.table.data.column.storage.datetime.DateTimeStorage;
 import org.enso.table.data.column.storage.datetime.TimeOfDayStorage;
+import org.enso.table.data.column.storage.numeric.AbstractLongStorage;
 import org.enso.table.data.column.storage.numeric.DoubleStorage;
-import org.enso.table.data.column.storage.numeric.LongStorage;
 import org.enso.table.data.column.storage.type.AnyObjectType;
 import org.enso.table.data.column.storage.type.TextType;
 import org.graalvm.polyglot.Context;
@@ -43,7 +45,7 @@ public class ToTextStorageConverter implements StorageConverter<String> {
         return adaptStringStorage(stringStorage, problemBuilder);
       }
     }
-    if (storage instanceof LongStorage longStorage) {
+    if (storage instanceof AbstractLongStorage longStorage) {
       return castLongStorage(longStorage, problemBuilder);
     } else if (storage instanceof DoubleStorage doubleStorage) {
       return castDoubleStorage(doubleStorage, problemBuilder);
@@ -104,7 +106,7 @@ public class ToTextStorageConverter implements StorageConverter<String> {
     return b ? "True" : "False";
   }
 
-  private Storage<String> castLongStorage(LongStorage longStorage, CastProblemBuilder problemBuilder) {
+  private Storage<String> castLongStorage(AbstractLongStorage longStorage, CastProblemBuilder problemBuilder) {
     Context context = Context.getCurrent();
     StringBuilder builder = new StringBuilder(longStorage.size(), targetType);
     for (int i = 0; i < longStorage.size(); i++) {
@@ -181,6 +183,8 @@ public class ToTextStorageConverter implements StorageConverter<String> {
     String adapted = adaptWithoutWarning(value);
 
     // If the value was truncated, report the data loss.
+    // (We can use the codepoint lengths here because truncation on grapheme length will still change the codepoint
+    // length too, and this check is simply faster.)
     if (adapted.length() < value.length()) {
       problemBuilder.reportTextTooLong(value);
     }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToTextStorageConverter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToTextStorageConverter.java
@@ -22,18 +22,9 @@ import java.time.format.DateTimeFormatter;
 import java.util.function.Function;
 
 public class ToTextStorageConverter implements StorageConverter<String> {
-  private final int minLength;
-  private final int maxLength;
   private final TextType targetType;
 
   public ToTextStorageConverter(TextType textType) {
-    maxLength = Math.toIntExact(textType.maxLength());
-    if (textType.fixedLength()) {
-      minLength = maxLength;
-    } else {
-      minLength = -1;
-    }
-
     targetType = textType;
   }
 
@@ -193,19 +184,7 @@ public class ToTextStorageConverter implements StorageConverter<String> {
   }
 
   private String adaptWithoutWarning(String value) {
-    if (maxLength == -1) {
-      return value;
-    }
-
-    int textLength = (int) Text_Utils.grapheme_length(value);
-
-    if (textLength > maxLength) {
-      return Text_Utils.take_prefix(value, maxLength);
-    } else if (textLength < minLength) {
-      return value + " ".repeat(minLength - textLength);
-    } else {
-      return value;
-    }
+    return targetType.adapt(value);
   }
 
   private Storage<String> adaptStringStorage(StringStorage stringStorage, CastProblemBuilder problemBuilder) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToTextStorageConverter.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/cast/ToTextStorageConverter.java
@@ -64,7 +64,7 @@ public class ToTextStorageConverter implements StorageConverter<String> {
 
   public Storage<String> castFromMixed(Storage<?> mixedStorage, CastProblemBuilder problemBuilder) {
     Context context = Context.getCurrent();
-    StringBuilder builder = new StringBuilder(mixedStorage.size());
+    StringBuilder builder = new StringBuilder(mixedStorage.size(), targetType);
     for (int i = 0; i < mixedStorage.size(); i++) {
       Object o = mixedStorage.getItemBoxed(i);
       switch (o) {
@@ -106,7 +106,7 @@ public class ToTextStorageConverter implements StorageConverter<String> {
 
   private Storage<String> castLongStorage(LongStorage longStorage, CastProblemBuilder problemBuilder) {
     Context context = Context.getCurrent();
-    StringBuilder builder = new StringBuilder(longStorage.size());
+    StringBuilder builder = new StringBuilder(longStorage.size(), targetType);
     for (int i = 0; i < longStorage.size(); i++) {
       if (longStorage.isNa(i)) {
         builder.appendNulls(1);
@@ -124,7 +124,7 @@ public class ToTextStorageConverter implements StorageConverter<String> {
 
   private Storage<String> castBoolStorage(BoolStorage boolStorage, CastProblemBuilder problemBuilder) {
     Context context = Context.getCurrent();
-    StringBuilder builder = new StringBuilder(boolStorage.size());
+    StringBuilder builder = new StringBuilder(boolStorage.size(), targetType);
     for (int i = 0; i < boolStorage.size(); i++) {
       if (boolStorage.isNa(i)) {
         builder.appendNulls(1);
@@ -142,7 +142,7 @@ public class ToTextStorageConverter implements StorageConverter<String> {
 
   private Storage<String> castDoubleStorage(DoubleStorage doubleStorage, CastProblemBuilder problemBuilder) {
     Context context = Context.getCurrent();
-    StringBuilder builder = new StringBuilder(doubleStorage.size());
+    StringBuilder builder = new StringBuilder(doubleStorage.size(), targetType);
     for (int i = 0; i < doubleStorage.size(); i++) {
       if (doubleStorage.isNa(i)) {
         builder.appendNulls(1);
@@ -160,7 +160,7 @@ public class ToTextStorageConverter implements StorageConverter<String> {
 
   private <T> Storage<String> castDateTimeStorage(Storage<T> storage, Function<T, String> converter, CastProblemBuilder problemBuilder) {
     Context context = Context.getCurrent();
-    StringBuilder builder = new StringBuilder(storage.size());
+    StringBuilder builder = new StringBuilder(storage.size(), targetType);
     for (int i = 0; i < storage.size(); i++) {
       if (storage.isNa(i)) {
         builder.appendNulls(1);
@@ -206,7 +206,7 @@ public class ToTextStorageConverter implements StorageConverter<String> {
 
   private Storage<String> adaptStringStorage(StringStorage stringStorage, CastProblemBuilder problemBuilder) {
     Context context = Context.getCurrent();
-    StringBuilder builder = new StringBuilder(stringStorage.size());
+    StringBuilder builder = new StringBuilder(stringStorage.size(), targetType);
     for (int i = 0; i < stringStorage.size(); i++) {
       if (stringStorage.isNa(i)) {
         builder.appendNulls(1);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/MapOperationProblemBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/MapOperationProblemBuilder.java
@@ -22,8 +22,7 @@ public class MapOperationProblemBuilder {
     AggregatedProblems additionalProblems = new AggregatedProblems();
     if (overflowCount > 0) {
       additionalProblems.add(
-          new ArithmeticOverflow(overflowTargetType, overflowCount, overflowExample)
-      );
+          new ArithmeticOverflow(overflowTargetType, overflowCount, overflowExample));
     }
     return AggregatedProblems.merge(problems, additionalProblems);
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/MapOperationProblemBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/MapOperationProblemBuilder.java
@@ -7,6 +7,12 @@ import org.enso.table.data.table.problems.FloatingPointGrouping;
 import org.enso.table.data.table.problems.IllegalArgumentError;
 import org.enso.table.problems.AggregatedProblems;
 
+/**
+ * This class is used to aggregate problems occurring during map operations performed on a storage.
+ * <p>
+ * A single instance of this builder should not be re-used for different map operations. It may only be used with a
+ * single operation.
+ */
 public class MapOperationProblemBuilder {
   private final String location;
   private final AggregatedProblems problems = new AggregatedProblems(10);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/MapOperationProblemBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/MapOperationProblemBuilder.java
@@ -1,20 +1,31 @@
 package org.enso.table.data.column.operation.map;
 
+import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.data.table.problems.ArithmeticError;
+import org.enso.table.data.table.problems.ArithmeticOverflow;
 import org.enso.table.data.table.problems.FloatingPointGrouping;
 import org.enso.table.data.table.problems.IllegalArgumentError;
 import org.enso.table.problems.AggregatedProblems;
 
 public class MapOperationProblemBuilder {
   private final String location;
-  private final AggregatedProblems problems = new AggregatedProblems(3);
+  private final AggregatedProblems problems = new AggregatedProblems(10);
+  private long overflowCount = 0;
+  private Object[] overflowExample = null;
+  private StorageType overflowTargetType = null;
 
   public MapOperationProblemBuilder(String location) {
     this.location = location;
   }
 
   public AggregatedProblems getProblems() {
-    return problems;
+    AggregatedProblems additionalProblems = new AggregatedProblems();
+    if (overflowCount > 0) {
+      additionalProblems.add(
+          new ArithmeticOverflow(overflowTargetType, overflowCount, overflowExample)
+      );
+    }
+    return AggregatedProblems.merge(problems, additionalProblems);
   }
 
   public void reportFloatingPointEquality(int row) {
@@ -27,6 +38,14 @@ public class MapOperationProblemBuilder {
 
   public void reportIllegalArgumentError(String message, Integer row) {
     problems.add(new IllegalArgumentError(location, message, row));
+  }
+
+  public void reportOverflow(StorageType targetType, long x, String op, long y) {
+    overflowCount++;
+    if (overflowTargetType == null) {
+      overflowTargetType = targetType;
+      overflowExample = new Object[] {x, op, y};
+    }
   }
 
   public void reportDivisionByZero(Integer row) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/MapOperationProblemBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/MapOperationProblemBuilder.java
@@ -9,9 +9,9 @@ import org.enso.table.problems.AggregatedProblems;
 
 /**
  * This class is used to aggregate problems occurring during map operations performed on a storage.
- * <p>
- * A single instance of this builder should not be re-used for different map operations. It may only be used with a
- * single operation.
+ *
+ * <p>A single instance of this builder should not be re-used for different map operations. It may
+ * only be used with a single operation.
  */
 public class MapOperationProblemBuilder {
   private final String location;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/DoubleLongMapOpWithSpecialNumericHandling.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/DoubleLongMapOpWithSpecialNumericHandling.java
@@ -5,6 +5,7 @@ import org.enso.table.data.column.operation.map.MapOperationProblemBuilder;
 import org.enso.table.data.column.operation.map.UnaryMapOperation;
 import org.enso.table.data.column.storage.numeric.DoubleStorage;
 import org.enso.table.data.column.storage.numeric.LongStorage;
+import org.enso.table.data.column.storage.type.IntegerType;
 import org.graalvm.polyglot.Context;
 
 public abstract class DoubleLongMapOpWithSpecialNumericHandling
@@ -38,6 +39,6 @@ public abstract class DoubleLongMapOpWithSpecialNumericHandling
 
       context.safepoint();
     }
-    return new LongStorage(out, storage.size(), isMissing);
+    return new LongStorage(out, storage.size(), isMissing, IntegerType.INT_64);
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/DoubleNumericOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/DoubleNumericOp.java
@@ -2,9 +2,9 @@ package org.enso.table.data.column.operation.map.numeric;
 
 import org.enso.table.data.column.operation.map.BinaryMapOperation;
 import org.enso.table.data.column.operation.map.MapOperationProblemBuilder;
-import org.enso.table.data.column.storage.numeric.DoubleStorage;
-import org.enso.table.data.column.storage.numeric.LongStorage;
 import org.enso.table.data.column.storage.Storage;
+import org.enso.table.data.column.storage.numeric.AbstractLongStorage;
+import org.enso.table.data.column.storage.numeric.DoubleStorage;
 import org.enso.table.error.UnexpectedTypeException;
 import org.graalvm.polyglot.Context;
 
@@ -49,7 +49,7 @@ public abstract class DoubleNumericOp extends BinaryMapOperation<Double, DoubleS
   @Override
   public Storage<Double> runZip(DoubleStorage storage, Storage<?> arg, MapOperationProblemBuilder problemBuilder) {
     Context context = Context.getCurrent();
-    if (arg instanceof LongStorage v) {
+    if (arg instanceof AbstractLongStorage v) {
       long[] out = new long[storage.size()];
       BitSet newMissing = new BitSet();
       for (int i = 0; i < storage.size(); i++) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/DoubleRoundOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/DoubleRoundOp.java
@@ -8,6 +8,7 @@ import org.enso.table.data.column.operation.map.MapOperationProblemBuilder;
 import org.enso.table.data.column.storage.numeric.DoubleStorage;
 import org.enso.table.data.column.storage.numeric.LongStorage;
 import org.enso.table.data.column.storage.Storage;
+import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.error.UnexpectedTypeException;
 import org.graalvm.polyglot.Context;
 
@@ -54,7 +55,7 @@ public class DoubleRoundOp extends TernaryMapOperation<Double, DoubleStorage> {
 
                 context.safepoint();
             }
-            return new LongStorage(out, storage.size(), isMissing);
+            return new LongStorage(out, storage.size(), isMissing, IntegerType.INT_64);
         } else {
             // Return double storage.
             DoubleBuilder doubleBuilder = NumericBuilder.createDoubleBuilder(storage.size());

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/LongBooleanOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/LongBooleanOp.java
@@ -6,7 +6,6 @@ import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.numeric.AbstractLongStorage;
 import org.enso.table.data.column.storage.numeric.DoubleStorage;
-import org.enso.table.data.column.storage.numeric.LongStorage;
 import org.enso.table.error.UnexpectedTypeException;
 import org.graalvm.polyglot.Context;
 
@@ -90,7 +89,7 @@ public abstract class LongBooleanOp extends BinaryMapOperation<Long, AbstractLon
         context.safepoint();
       }
       return new BoolStorage(newVals, newMissing, storage.size(), false);
-    } else if (arg instanceof LongStorage v) {
+    } else if (arg instanceof AbstractLongStorage v) {
       BitSet newVals = new BitSet();
       BitSet newMissing = new BitSet();
       for (int i = 0; i < storage.size(); i++) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/LongNumericOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/LongNumericOp.java
@@ -7,6 +7,7 @@ import org.enso.table.data.column.storage.numeric.AbstractLongStorage;
 import org.enso.table.data.column.storage.numeric.DoubleStorage;
 import org.enso.table.data.column.storage.numeric.LongStorage;
 import org.enso.table.data.column.storage.numeric.NumericStorage;
+import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.error.UnexpectedTypeException;
 import org.enso.table.util.BitSets;
 import org.graalvm.polyglot.Context;
@@ -39,7 +40,8 @@ public abstract class LongNumericOp extends BinaryMapOperation<Long, AbstractLon
       if (alwaysCastToDouble) {
         return DoubleStorage.makeEmpty(storage.size());
       } else {
-        return LongStorage.makeEmpty(storage.size());
+        // TODO inherit type
+        return LongStorage.makeEmpty(storage.size(), IntegerType.INT_64);
       }
     } else if (!alwaysCastToDouble && arg instanceof Long x) {
       BitSet newMissing = BitSets.makeDuplicate(storage.getIsMissing());
@@ -56,7 +58,9 @@ public abstract class LongNumericOp extends BinaryMapOperation<Long, AbstractLon
 
         context.safepoint();
       }
-      return new LongStorage(newVals, newVals.length, newMissing);
+
+      // TODO use a combined type
+      return new LongStorage(newVals, newVals.length, newMissing, IntegerType.INT_64);
     } else if (arg instanceof Double || arg instanceof Long) {
       double x = (arg instanceof Double) ? (Double) arg : (Long) arg;
       long[] newVals = new long[storage.size()];
@@ -96,7 +100,8 @@ public abstract class LongNumericOp extends BinaryMapOperation<Long, AbstractLon
 
         context.safepoint();
       }
-      return alwaysCastToDouble ? new DoubleStorage(out, storage.size(), newMissing) : new LongStorage(out, storage.size(), newMissing);
+      // TODO inherit type or not?
+      return alwaysCastToDouble ? new DoubleStorage(out, storage.size(), newMissing) : new LongStorage(out, storage.size(), newMissing, IntegerType.INT_64);
     } else if (arg instanceof DoubleStorage v) {
       long[] out = new long[storage.size()];
       BitSet newMissing = new BitSet();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/LongNumericOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/LongNumericOp.java
@@ -20,6 +20,9 @@ import java.util.BitSet;
 public abstract class LongNumericOp extends BinaryMapOperation<Long, AbstractLongStorage> {
   private final boolean alwaysCastToDouble;
 
+  // Regardless of input type, our operations return 64-bit integers.
+  private static final IntegerType INTEGER_RESULT_TYPE = IntegerType.INT_64;
+
   public LongNumericOp(String name, boolean alwaysCastToDouble) {
     super(name);
     this.alwaysCastToDouble = alwaysCastToDouble;
@@ -40,8 +43,7 @@ public abstract class LongNumericOp extends BinaryMapOperation<Long, AbstractLon
       if (alwaysCastToDouble) {
         return DoubleStorage.makeEmpty(storage.size());
       } else {
-        // Regardless of input type, our operations return 64-bit integers.
-        return LongStorage.makeEmpty(storage.size(), IntegerType.INT_64);
+        return LongStorage.makeEmpty(storage.size(), INTEGER_RESULT_TYPE);
       }
     } else if (!alwaysCastToDouble && arg instanceof Long x) {
       BitSet newMissing = BitSets.makeDuplicate(storage.getIsMissing());
@@ -59,7 +61,7 @@ public abstract class LongNumericOp extends BinaryMapOperation<Long, AbstractLon
         context.safepoint();
       }
 
-      return new LongStorage(newVals, newVals.length, newMissing, IntegerType.INT_64);
+      return new LongStorage(newVals, newVals.length, newMissing, INTEGER_RESULT_TYPE);
     } else if (arg instanceof Double || arg instanceof Long) {
       double x = (arg instanceof Double) ? (Double) arg : (Long) arg;
       long[] newVals = new long[storage.size()];
@@ -99,8 +101,8 @@ public abstract class LongNumericOp extends BinaryMapOperation<Long, AbstractLon
 
         context.safepoint();
       }
-      // TODO inherit type or not?
-      return alwaysCastToDouble ? new DoubleStorage(out, storage.size(), newMissing) : new LongStorage(out, storage.size(), newMissing, IntegerType.INT_64);
+
+      return alwaysCastToDouble ? new DoubleStorage(out, storage.size(), newMissing) : new LongStorage(out, storage.size(), newMissing, INTEGER_RESULT_TYPE);
     } else if (arg instanceof DoubleStorage v) {
       long[] out = new long[storage.size()];
       BitSet newMissing = new BitSet();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/LongNumericOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/LongNumericOp.java
@@ -40,7 +40,7 @@ public abstract class LongNumericOp extends BinaryMapOperation<Long, AbstractLon
       if (alwaysCastToDouble) {
         return DoubleStorage.makeEmpty(storage.size());
       } else {
-        // TODO inherit type
+        // Regardless of input type, our operations return 64-bit integers.
         return LongStorage.makeEmpty(storage.size(), IntegerType.INT_64);
       }
     } else if (!alwaysCastToDouble && arg instanceof Long x) {
@@ -59,7 +59,6 @@ public abstract class LongNumericOp extends BinaryMapOperation<Long, AbstractLon
         context.safepoint();
       }
 
-      // TODO use a combined type
       return new LongStorage(newVals, newVals.length, newMissing, IntegerType.INT_64);
     } else if (arg instanceof Double || arg instanceof Long) {
       double x = (arg instanceof Double) ? (Double) arg : (Long) arg;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/LongRoundOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/LongRoundOp.java
@@ -6,6 +6,7 @@ import org.enso.table.data.column.operation.map.MapOperationProblemBuilder;
 import org.enso.table.data.column.storage.numeric.AbstractLongStorage;
 import org.enso.table.data.column.storage.numeric.LongStorage;
 import org.enso.table.data.column.storage.Storage;
+import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.error.UnexpectedTypeException;
 import org.graalvm.polyglot.Context;
 
@@ -68,6 +69,6 @@ public class LongRoundOp extends TernaryMapOperation<Long, AbstractLongStorage> 
             context.safepoint();
         }
 
-        return new LongStorage(out, storage.size(), isMissing);
+        return new LongStorage(out, storage.size(), isMissing, IntegerType.INT_64);
     }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/UnaryDoubleToLongOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/UnaryDoubleToLongOp.java
@@ -5,6 +5,7 @@ import org.enso.table.data.column.operation.map.MapOperationProblemBuilder;
 import org.enso.table.data.column.operation.map.UnaryMapOperation;
 import org.enso.table.data.column.storage.numeric.DoubleStorage;
 import org.enso.table.data.column.storage.numeric.LongStorage;
+import org.enso.table.data.column.storage.type.IntegerType;
 import org.graalvm.polyglot.Context;
 
 /** An operation that takes a single double argumebnt and returns a long. */
@@ -32,6 +33,6 @@ public abstract class UnaryDoubleToLongOp extends UnaryMapOperation<Double, Doub
       context.safepoint();
     }
 
-    return new LongStorage(newVals, newVals.length, newMissing);
+    return new LongStorage(newVals, newVals.length, newMissing, IntegerType.INT_64);
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/UnaryIntegerOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/UnaryIntegerOp.java
@@ -11,6 +11,8 @@ import org.graalvm.polyglot.Context;
 /** An operation that takes a single argument of some type and returns an integer. */
 public abstract class UnaryIntegerOp<T, I extends Storage<T>> extends UnaryMapOperation<T, I> {
 
+  private static final IntegerType RESULT_TYPE = IntegerType.INT_64;
+
   public UnaryIntegerOp(String name) {
     super(name);
   }
@@ -32,7 +34,6 @@ public abstract class UnaryIntegerOp<T, I extends Storage<T>> extends UnaryMapOp
       context.safepoint();
     }
 
-    // TODO probably inherit type?
-    return new LongStorage(newVals, newVals.length, newMissing, IntegerType.INT_64);
+    return new LongStorage(newVals, newVals.length, newMissing, RESULT_TYPE);
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/UnaryIntegerOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/UnaryIntegerOp.java
@@ -5,6 +5,7 @@ import org.enso.table.data.column.operation.map.MapOperationProblemBuilder;
 import org.enso.table.data.column.operation.map.UnaryMapOperation;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.numeric.LongStorage;
+import org.enso.table.data.column.storage.type.IntegerType;
 import org.graalvm.polyglot.Context;
 
 /** An operation that takes a single argument of some type and returns an integer. */
@@ -31,6 +32,7 @@ public abstract class UnaryIntegerOp<T, I extends Storage<T>> extends UnaryMapOp
       context.safepoint();
     }
 
-    return new LongStorage(newVals, newVals.length, newMissing);
+    // TODO probably inherit type?
+    return new LongStorage(newVals, newVals.length, newMissing, IntegerType.INT_64);
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/UnaryLongToLongOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/UnaryLongToLongOp.java
@@ -5,6 +5,7 @@ import org.enso.table.data.column.operation.map.MapOperationProblemBuilder;
 import org.enso.table.data.column.operation.map.UnaryMapOperation;
 import org.enso.table.data.column.storage.numeric.AbstractLongStorage;
 import org.enso.table.data.column.storage.numeric.LongStorage;
+import org.enso.table.data.column.storage.type.IntegerType;
 import org.graalvm.polyglot.Context;
 
 /** An operation that takes a single double argument and returns a long. */
@@ -32,6 +33,7 @@ public abstract class UnaryLongToLongOp extends UnaryMapOperation<Long, Abstract
       context.safepoint();
     }
 
-    return new LongStorage(newVals, newVals.length, newMissing);
+    // TODO is inheriting type ok? it may not be enough!
+    return new LongStorage(newVals, newVals.length, newMissing, storage.getType());
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/UnaryLongToLongOp.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/operation/map/numeric/UnaryLongToLongOp.java
@@ -5,7 +5,6 @@ import org.enso.table.data.column.operation.map.MapOperationProblemBuilder;
 import org.enso.table.data.column.operation.map.UnaryMapOperation;
 import org.enso.table.data.column.storage.numeric.AbstractLongStorage;
 import org.enso.table.data.column.storage.numeric.LongStorage;
-import org.enso.table.data.column.storage.type.IntegerType;
 import org.graalvm.polyglot.Context;
 
 /** An operation that takes a single double argument and returns a long. */

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/Storage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/Storage.java
@@ -13,6 +13,7 @@ import org.enso.table.data.column.operation.cast.CastProblemBuilder;
 import org.enso.table.data.column.operation.cast.StorageConverter;
 import org.enso.table.data.column.operation.map.MapOperationProblemBuilder;
 import org.enso.table.data.column.storage.numeric.LongStorage;
+import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.data.mask.OrderMask;
 import org.enso.table.data.mask.SliceRange;
@@ -496,7 +497,7 @@ public abstract class Storage<T> {
       occurenceCount.put(value, count + 1);
       context.safepoint();
     }
-    return new LongStorage(data);
+    return new LongStorage(data, IntegerType.INT_64);
   }
 
   public final Storage<?> cast(StorageType targetType, CastProblemBuilder castProblemBuilder) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/StringStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/StringStorage.java
@@ -21,17 +21,20 @@ import java.util.BitSet;
 /** A column storing strings. */
 public final class StringStorage extends SpecializedStorage<String> {
 
+  private final TextType type;
   /**
    * @param data the underlying data
    * @param size the number of items stored
+   * @param type the type of the column
    */
-  public StringStorage(String[] data, int size) {
+  public StringStorage(String[] data, int size, TextType type) {
     super(data, size, buildOps());
+    this.type = type;
   }
 
   @Override
   protected SpecializedStorage<String> newInstance(String[] data, int size) {
-    return new StringStorage(data, size);
+    return new StringStorage(data, size, type);
   }
 
   @Override
@@ -40,7 +43,7 @@ public final class StringStorage extends SpecializedStorage<String> {
   }
 
   @Override
-  public StorageType getType() {
+  public TextType getType() {
     // TODO [RW] constant length strings support
     return TextType.VARIABLE_LENGTH;
   }
@@ -48,7 +51,7 @@ public final class StringStorage extends SpecializedStorage<String> {
   @Override
   public Storage<?> fillMissing(Value arg) {
     if (arg.isString()) {
-      return fillMissingHelper(arg, new StringBuilder(size()));
+      return fillMissingHelper(arg, new StringBuilder(size(), type));
     } else {
       return super.fillMissing(arg);
     }
@@ -56,7 +59,7 @@ public final class StringStorage extends SpecializedStorage<String> {
 
   @Override
   public Builder createDefaultBuilderOfSameType(int capacity) {
-    return new StringBuilder(capacity);
+    return new StringBuilder(capacity, type);
   }
 
   private static MapOperationStorage<String, SpecializedStorage<String>> buildOps() {
@@ -149,6 +152,11 @@ public final class StringStorage extends SpecializedStorage<String> {
           @Override
           protected String doString(String a, String b) {
             return a + b;
+          }
+
+          @Override
+          protected TextType computeResultType(TextType a, TextType b) {
+            return TextType.concatTypes(a, b);
           }
         });
     return t;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/StringStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/StringStorage.java
@@ -44,14 +44,14 @@ public final class StringStorage extends SpecializedStorage<String> {
 
   @Override
   public TextType getType() {
-    // TODO [RW] constant length strings support
-    return TextType.VARIABLE_LENGTH;
+    return type;
   }
 
   @Override
   public Storage<?> fillMissing(Value arg) {
     if (arg.isString()) {
-      return fillMissingHelper(arg, new StringBuilder(size(), type));
+      TextType newType = TextType.maxType(type, TextType.preciseTypeForValue(arg.asString()));
+      return fillMissingHelper(arg, new StringBuilder(size(), newType));
     } else {
       return super.fillMissing(arg);
     }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
@@ -15,7 +15,6 @@ import org.enso.table.data.column.operation.map.numeric.UnaryLongToLongOp;
 import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.type.IntegerType;
-import org.enso.table.data.column.storage.type.StorageType;
 import org.graalvm.polyglot.Context;
 
 public abstract class AbstractLongStorage extends NumericStorage<Long> {
@@ -343,8 +342,8 @@ public abstract class AbstractLongStorage extends NumericStorage<Long> {
 
   /**
    * Return an instance of storage containing the same data but with a wider type.
-   * <p>
-   * Ideally it should avoid copying the data, if it's possible.
+   *
+   * <p>Ideally it should avoid copying the data, if it's possible.
    */
   public abstract AbstractLongStorage widen(IntegerType widerType);
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
@@ -84,7 +84,12 @@ public abstract class AbstractLongStorage extends NumericStorage<Long> {
               @Override
               public Long doLong(
                   long in, long arg, int ix, MapOperationProblemBuilder problemBuilder) {
-                return in + arg;
+                try {
+                  return Math.addExact(in, arg);
+                } catch (ArithmeticException e) {
+                  problemBuilder.reportOverflow(IntegerType.INT_64, in, "+", arg);
+                  return null;
+                }
               }
             })
         .add(
@@ -98,7 +103,12 @@ public abstract class AbstractLongStorage extends NumericStorage<Long> {
               @Override
               public Long doLong(
                   long in, long arg, int ix, MapOperationProblemBuilder problemBuilder) {
-                return in - arg;
+                try {
+                  return Math.subtractExact(in, arg);
+                } catch (ArithmeticException e) {
+                  problemBuilder.reportOverflow(IntegerType.INT_64, in, "-", arg);
+                  return null;
+                }
               }
             })
         .add(
@@ -112,7 +122,12 @@ public abstract class AbstractLongStorage extends NumericStorage<Long> {
               @Override
               public Long doLong(
                   long in, long arg, int ix, MapOperationProblemBuilder problemBuilder) {
-                return in * arg;
+                try {
+                  return Math.multiplyExact(in, arg);
+                } catch (ArithmeticException e) {
+                  problemBuilder.reportOverflow(IntegerType.INT_64, in, "*", arg);
+                  return null;
+                }
               }
             })
         .add(

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
@@ -14,6 +14,8 @@ import org.enso.table.data.column.operation.map.numeric.LongRoundOp;
 import org.enso.table.data.column.operation.map.numeric.UnaryLongToLongOp;
 import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.Storage;
+import org.enso.table.data.column.storage.type.IntegerType;
+import org.enso.table.data.column.storage.type.StorageType;
 import org.graalvm.polyglot.Context;
 
 public abstract class AbstractLongStorage extends NumericStorage<Long> {
@@ -63,8 +65,11 @@ public abstract class AbstractLongStorage extends NumericStorage<Long> {
 
   @Override
   public Builder createDefaultBuilderOfSameType(int capacity) {
-    return NumericBuilder.createLongBuilder(capacity);
+    return NumericBuilder.createLongBuilder(capacity, getType());
   }
+
+  @Override
+  public abstract IntegerType getType();
 
   private static MapOperationStorage<Long, AbstractLongStorage> buildOps() {
     MapOperationStorage<Long, AbstractLongStorage> ops = new MapOperationStorage<>();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
@@ -259,7 +259,7 @@ public abstract class AbstractLongStorage extends NumericStorage<Long> {
                   MapOperationProblemBuilder problemBuilder) {
                 if (arg instanceof DoubleStorage) {
                   problemBuilder.reportFloatingPointEquality(-1);
-                } else if (!(arg instanceof LongStorage)) {
+                } else if (!(arg instanceof AbstractLongStorage)) {
                   boolean hasFloats = false;
                   Context context = Context.getCurrent();
                   for (int i = 0; i < storage.size(); i++) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/AbstractLongStorage.java
@@ -325,4 +325,11 @@ public abstract class AbstractLongStorage extends NumericStorage<Long> {
         .add(new LongIsInOp());
     return ops;
   }
+
+  /**
+   * Return an instance of storage containing the same data but with a wider type.
+   * <p>
+   * Ideally it should avoid copying the data, if it's possible.
+   */
+  public abstract AbstractLongStorage widen(IntegerType widerType);
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/ComputedLongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/ComputedLongStorage.java
@@ -4,7 +4,6 @@ import java.util.BitSet;
 import java.util.List;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.type.IntegerType;
-import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.data.index.Index;
 import org.enso.table.data.mask.OrderMask;
 import org.enso.table.data.mask.SliceRange;
@@ -151,7 +150,8 @@ public abstract class ComputedLongStorage extends AbstractLongStorage {
 
   @Override
   public AbstractLongStorage widen(IntegerType widerType) {
-    // Currently the implementation only reports 64-bit type so there is no widening to do - we can just return self.
+    // Currently the implementation only reports 64-bit type so there is no widening to do - we can
+    // just return self.
     assert getType().equals(IntegerType.INT_64);
     return this;
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/ComputedLongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/ComputedLongStorage.java
@@ -148,4 +148,11 @@ public abstract class ComputedLongStorage extends AbstractLongStorage {
   }
 
   private static final BitSet EMPTY = new BitSet();
+
+  @Override
+  public AbstractLongStorage widen(IntegerType widerType) {
+    // Currently the implementation only reports 64-bit type so there is no widening to do - we can just return self.
+    assert getType().equals(IntegerType.INT_64);
+    return this;
+  }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/ComputedLongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/ComputedLongStorage.java
@@ -35,7 +35,7 @@ public abstract class ComputedLongStorage extends AbstractLongStorage {
   }
 
   @Override
-  public StorageType getType() {
+  public IntegerType getType() {
     return IntegerType.INT_64;
   }
 
@@ -76,7 +76,7 @@ public abstract class ComputedLongStorage extends AbstractLongStorage {
 
       context.safepoint();
     }
-    return new LongStorage(newData, cardinality, newMissing);
+    return new LongStorage(newData, cardinality, newMissing, getType());
   }
 
   @Override
@@ -94,7 +94,7 @@ public abstract class ComputedLongStorage extends AbstractLongStorage {
 
       context.safepoint();
     }
-    return new LongStorage(newData, positions.length, newMissing);
+    return new LongStorage(newData, positions.length, newMissing, getType());
   }
 
   @Override
@@ -111,7 +111,7 @@ public abstract class ComputedLongStorage extends AbstractLongStorage {
 
       context.safepoint();
     }
-    return new LongStorage(newData, total, newMissing);
+    return new LongStorage(newData, total, newMissing, getType());
   }
 
   @Override
@@ -124,7 +124,7 @@ public abstract class ComputedLongStorage extends AbstractLongStorage {
       context.safepoint();
     }
     BitSet newMask = new BitSet();
-    return new LongStorage(newData, newSize, newMask);
+    return new LongStorage(newData, newSize, newMask, getType());
   }
 
   @Override
@@ -144,7 +144,7 @@ public abstract class ComputedLongStorage extends AbstractLongStorage {
       offset += length;
     }
 
-    return new LongStorage(newData, newSize, newMissing);
+    return new LongStorage(newData, newSize, newMissing, getType());
   }
 
   private static final BitSet EMPTY = new BitSet();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/LongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/LongStorage.java
@@ -6,7 +6,6 @@ import org.enso.base.polyglot.NumericConverter;
 import org.enso.table.data.column.builder.NumericBuilder;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.type.IntegerType;
-import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.data.index.Index;
 import org.enso.table.data.mask.OrderMask;
 import org.enso.table.data.mask.SliceRange;
@@ -27,7 +26,8 @@ public final class LongStorage extends AbstractLongStorage {
   /**
    * @param data the underlying data
    * @param size the number of items stored
-   * @param isMissing a bit set denoting at index {@code i} whether or not the value at index {@code i} is missing.
+   * @param isMissing a bit set denoting at index {@code i} whether or not the value at index {@code
+   *     i} is missing.
    * @param type the type specifying the bit-width of integers that are allowed in this storage
    */
   public LongStorage(long[] data, int size, BitSet isMissing, IntegerType type) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/LongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/LongStorage.java
@@ -241,4 +241,11 @@ public final class LongStorage extends AbstractLongStorage {
 
     return new LongStorage(newData, newSize, newMissing, type);
   }
+
+  /** Widening to a bigger type can be done without copying the data. */
+  @Override
+  public LongStorage widen(IntegerType widerType) {
+    assert widerType.fits(type);
+    return new LongStorage(data, size, isMissing, widerType);
+  }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/LongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/LongStorage.java
@@ -22,30 +22,33 @@ public final class LongStorage extends AbstractLongStorage {
   private final BitSet isMissing;
   private final int size;
 
+  private final IntegerType type;
+
   /**
    * @param data the underlying data
    * @param size the number of items stored
-   * @param isMissing a bit set denoting at index {@code i} whether or not the value at index {@code
-   *     i} is missing.
+   * @param isMissing a bit set denoting at index {@code i} whether or not the value at index {@code i} is missing.
+   * @param type the type specifying the bit-width of integers that are allowed in this storage
    */
-  public LongStorage(long[] data, int size, BitSet isMissing) {
+  public LongStorage(long[] data, int size, BitSet isMissing, IntegerType type) {
     this.data = data;
     this.isMissing = isMissing;
     this.size = size;
+    this.type = type;
   }
 
   public static LongStorage fromArray(long[] data) {
-    return new LongStorage(data, data.length, new BitSet());
+    return new LongStorage(data, data.length, new BitSet(), IntegerType.INT_64);
   }
 
-  public static LongStorage makeEmpty(int size) {
+  public static LongStorage makeEmpty(int size, IntegerType type) {
     BitSet isMissing = new BitSet(size);
     isMissing.set(0, size);
-    return new LongStorage(new long[0], size, isMissing);
+    return new LongStorage(new long[0], size, isMissing, type);
   }
 
-  public LongStorage(long[] data) {
-    this(data, data.length, new BitSet());
+  public LongStorage(long[] data, IntegerType type) {
+    this(data, data.length, new BitSet(), type);
   }
 
   /** @inheritDoc */
@@ -75,9 +78,8 @@ public final class LongStorage extends AbstractLongStorage {
 
   /** @inheritDoc */
   @Override
-  public StorageType getType() {
-    // TODO add possibility to set integer bit limit (#5159)
-    return IntegerType.INT_64;
+  public IntegerType getType() {
+    return type;
   }
 
   /** @inheritDoc */
@@ -87,6 +89,12 @@ public final class LongStorage extends AbstractLongStorage {
   }
 
   private Storage<?> fillMissingDouble(double arg) {
+    if (!type.fits(arg)) {
+      // TODO possibly a more precise exception?
+      throw new IllegalArgumentException(
+          "Cannot fill missing values with a value that does not fit the column type.");
+    }
+
     final var builder = NumericBuilder.createDoubleBuilder(size());
     long rawArg = Double.doubleToRawLongBits(arg);
     Context context = Context.getCurrent();
@@ -104,7 +112,13 @@ public final class LongStorage extends AbstractLongStorage {
   }
 
   private Storage<?> fillMissingLong(long arg) {
-    final var builder = NumericBuilder.createLongBuilder(size());
+    if (!type.fits(arg)) {
+      // TODO possibly a more precise exception?
+      throw new IllegalArgumentException(
+          "Cannot fill missing values with a value that does not fit the column type.");
+    }
+
+    final var builder = NumericBuilder.createLongBuilder(size(), type);
     Context context = Context.getCurrent();
     for (int i = 0; i < size(); i++) {
       if (isMissing.get(i)) {
@@ -148,7 +162,7 @@ public final class LongStorage extends AbstractLongStorage {
 
       context.safepoint();
     }
-    return new LongStorage(newData, cardinality, newMissing);
+    return new LongStorage(newData, cardinality, newMissing, type);
   }
 
   @Override
@@ -166,7 +180,7 @@ public final class LongStorage extends AbstractLongStorage {
 
       context.safepoint();
     }
-    return new LongStorage(newData, positions.length, newMissing);
+    return new LongStorage(newData, positions.length, newMissing, type);
   }
 
   @Override
@@ -187,7 +201,7 @@ public final class LongStorage extends AbstractLongStorage {
 
       context.safepoint();
     }
-    return new LongStorage(newData, total, newMissing);
+    return new LongStorage(newData, total, newMissing, type);
   }
 
   @Override
@@ -205,7 +219,7 @@ public final class LongStorage extends AbstractLongStorage {
     long[] newData = new long[newSize];
     System.arraycopy(data, offset, newData, 0, newSize);
     BitSet newMask = isMissing.get(offset, offset + limit);
-    return new LongStorage(newData, newSize, newMask);
+    return new LongStorage(newData, newSize, newMask, type);
   }
 
   @Override
@@ -225,6 +239,6 @@ public final class LongStorage extends AbstractLongStorage {
       offset += length;
     }
 
-    return new LongStorage(newData, newSize, newMissing);
+    return new LongStorage(newData, newSize, newMissing, type);
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/LongStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/numeric/LongStorage.java
@@ -89,12 +89,6 @@ public final class LongStorage extends AbstractLongStorage {
   }
 
   private Storage<?> fillMissingDouble(double arg) {
-    if (!type.fits(arg)) {
-      // TODO possibly a more precise exception?
-      throw new IllegalArgumentException(
-          "Cannot fill missing values with a value that does not fit the column type.");
-    }
-
     final var builder = NumericBuilder.createDoubleBuilder(size());
     long rawArg = Double.doubleToRawLongBits(arg);
     Context context = Context.getCurrent();
@@ -112,13 +106,7 @@ public final class LongStorage extends AbstractLongStorage {
   }
 
   private Storage<?> fillMissingLong(long arg) {
-    if (!type.fits(arg)) {
-      // TODO possibly a more precise exception?
-      throw new IllegalArgumentException(
-          "Cannot fill missing values with a value that does not fit the column type.");
-    }
-
-    final var builder = NumericBuilder.createLongBuilder(size(), type);
+    final var builder = NumericBuilder.createLongBuilder(size(), IntegerType.INT_64);
     Context context = Context.getCurrent();
     for (int i = 0; i < size(); i++) {
       if (isMissing.get(i)) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/type/Bits.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/type/Bits.java
@@ -19,4 +19,14 @@ public enum Bits {
   public int toInteger() {
     return this.size;
   }
+
+  public static Bits fromInteger(int size) {
+    return switch (size) {
+      case 8 -> BITS_8;
+      case 16 -> BITS_16;
+      case 32 -> BITS_32;
+      case 64 -> BITS_64;
+      default -> throw new IllegalArgumentException("Invalid bit-size: " + size);
+    };
+  }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/type/IntegerType.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/type/IntegerType.java
@@ -20,4 +20,15 @@ public record IntegerType(Bits bits) implements StorageType {
       case BITS_64 -> Long.MIN_VALUE;
     };
   }
+
+  public boolean fits(long value) {
+    if (this.bits == Bits.BITS_64) return true;
+    return value >= getMinValue() && value <= getMaxValue();
+  }
+
+  public boolean fits(double value) {
+    double min = getMinValue();
+    double max = getMaxValue();
+    return value >= min && value <= max;
+  }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/type/IntegerType.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/type/IntegerType.java
@@ -2,6 +2,18 @@ package org.enso.table.data.column.storage.type;
 
 public record IntegerType(Bits bits) implements StorageType {
   public static final IntegerType INT_64 = new IntegerType(Bits.BITS_64);
+  public static final IntegerType INT_32 = new IntegerType(Bits.BITS_32);
+  public static final IntegerType INT_16 = new IntegerType(Bits.BITS_16);
+  public static final IntegerType INT_8 = new IntegerType(Bits.BITS_8);
+
+  public static IntegerType create(Bits bits) {
+    return switch (bits) {
+      case BITS_8 -> INT_8;
+      case BITS_16 -> INT_16;
+      case BITS_32 -> INT_32;
+      case BITS_64 -> INT_64;
+    };
+  }
 
   public long getMaxValue() {
     return switch (bits) {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/type/IntegerType.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/type/IntegerType.java
@@ -43,4 +43,11 @@ public record IntegerType(Bits bits) implements StorageType {
     double max = getMaxValue();
     return value >= min && value <= max;
   }
+
+  /**
+   * Checks if this type can hold values of otherType - i.e. if otherType has the same or smaller number of bits.
+   */
+  public boolean fits(IntegerType otherType) {
+    return bits.toInteger() >= otherType.bits.toInteger();
+  }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/type/TextType.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/type/TextType.java
@@ -1,5 +1,56 @@
 package org.enso.table.data.column.storage.type;
 
+import org.enso.base.Text_Utils;
+
 public record TextType(long maxLength, boolean fixedLength) implements StorageType {
   public static final TextType VARIABLE_LENGTH = new TextType(-1, false);
+
+  public static TextType fixedLength(long length) {
+    return new TextType(length, true);
+  }
+
+  public static TextType variableLengthWithLimit(long maxLength) {
+    assert maxLength >= 0;
+    return new TextType(maxLength, false);
+  }
+
+  public boolean fits(String string) {
+    if (maxLength == -1) {
+      return true;
+    }
+
+    long length = Text_Utils.grapheme_length(string);
+    if (fixedLength) {
+      return length == maxLength;
+    } else {
+      return length <= maxLength;
+    }
+  }
+
+  public static TextType preciseTypeForValue(String value) {
+    return fixedLength(Text_Utils.grapheme_length(value));
+  }
+
+  public static TextType maxType(TextType type1, TextType type2) {
+    if (type1.maxLength < 0 || type2.maxLength < 0) {
+      return VARIABLE_LENGTH;
+    }
+
+    boolean bothFixed = type1.fixedLength && type2.fixedLength;
+    if (bothFixed && type1.maxLength == type2.maxLength) {
+      return fixedLength(type1.maxLength);
+    } else {
+      return variableLengthWithLimit(Math.max(type1.maxLength, type2.maxLength));
+    }
+  }
+
+  public static TextType concatTypes(TextType type1, TextType type2) {
+    if (type1.maxLength < 0 || type2.maxLength < 0) {
+      return VARIABLE_LENGTH;
+    }
+
+    boolean bothFixed = type1.fixedLength && type2.fixedLength;
+    long lengthSum = type1.maxLength + type2.maxLength;
+    return new TextType(lengthSum, bothFixed);
+  }
 }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/type/TextType.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/type/TextType.java
@@ -27,6 +27,24 @@ public record TextType(long maxLength, boolean fixedLength) implements StorageTy
     }
   }
 
+  /**
+   * Checks if values of otherType can be transferred to this type without any conversions.
+   * <p>
+   * For example, values of type TextType(3, false) will fit TextType(3, true), but they need to be padded to fit the
+   * target type. So this function will return false for such a case.
+   */
+  public boolean fitsExactly(TextType otherType) {
+    if (fixedLength) {
+      if (otherType.fixedLength) {
+        return maxLength == otherType.maxLength;
+      } else {
+        return false;
+      }
+    } else {
+      return maxLength == -1 || (otherType.maxLength != -1 && maxLength >= otherType.maxLength);
+    }
+  }
+
   public static TextType preciseTypeForValue(String value) {
     return fixedLength(Text_Utils.grapheme_length(value));
   }

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/type/TextType.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/type/TextType.java
@@ -27,6 +27,23 @@ public record TextType(long maxLength, boolean fixedLength) implements StorageTy
     }
   }
 
+  /** Truncate or pad the string to make sure that it fits. */
+  public String adapt(String string) {
+    if (maxLength == -1) {
+      return string;
+    }
+
+    long textLength = Text_Utils.grapheme_length(string);
+
+    if (textLength > maxLength) {
+      return Text_Utils.take_prefix(string, maxLength);
+    } else if (fixedLength && textLength < maxLength) {
+      return string + " ".repeat(Math.toIntExact(maxLength - textLength));
+    } else {
+      return string;
+    }
+  }
+
   /**
    * Checks if values of otherType can be transferred to this type without any conversions.
    * <p>

--- a/std-bits/table/src/main/java/org/enso/table/data/table/Table.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/Table.java
@@ -8,6 +8,7 @@ import org.enso.table.data.column.builder.InferredBuilder;
 import org.enso.table.data.column.builder.StringBuilder;
 import org.enso.table.data.column.storage.BoolStorage;
 import org.enso.table.data.column.storage.Storage;
+import org.enso.table.data.column.storage.type.TextType;
 import org.enso.table.data.index.DefaultIndex;
 import org.enso.table.data.index.Index;
 import org.enso.table.data.index.CrossTabIndex;
@@ -437,7 +438,7 @@ public class Table {
       System.arraycopy(id_columns, 0, newColumns, 0, id_columns.length);
 
       int size = id_columns.length == 0 ? 0 : id_columns[0].getSize();
-      Builder builder = new StringBuilder(size);
+      Builder builder = new StringBuilder(size, TextType.VARIABLE_LENGTH);
       builder.appendNulls(size);
       Storage<?> newStorage = builder.seal();
       newColumns[id_columns.length] = new Column(name_field, newStorage);
@@ -452,7 +453,7 @@ public class Table {
     // Create Storage
     Builder[] storage = new Builder[id_columns.length + 2];
     IntStream.range(0, id_columns.length).forEach(i -> storage[i] = Builder.getForType(id_columns[i].getStorage().getType(), new_count));
-    storage[id_columns.length] = new StringBuilder(new_count);
+    storage[id_columns.length] = new StringBuilder(new_count, TextType.VARIABLE_LENGTH);
     storage[id_columns.length + 1] = new InferredBuilder(new_count);
 
     // Load Data

--- a/std-bits/table/src/main/java/org/enso/table/data/table/problems/ArithmeticOverflow.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/problems/ArithmeticOverflow.java
@@ -1,0 +1,12 @@
+package org.enso.table.data.table.problems;
+
+import org.enso.table.data.column.storage.type.StorageType;
+import org.enso.table.problems.Problem;
+
+/** Indicates that an arithmetic operation did not fit in the target type. */
+public record ArithmeticOverflow(
+    StorageType targetType,
+    long affectedRowCount,
+    Object[] exampleOperands
+) implements Problem {
+}

--- a/std-bits/table/src/main/java/org/enso/table/parsing/IdentityParser.java
+++ b/std-bits/table/src/main/java/org/enso/table/parsing/IdentityParser.java
@@ -2,6 +2,7 @@ package org.enso.table.parsing;
 
 import org.enso.table.data.column.builder.StringBuilder;
 import org.enso.table.data.column.storage.Storage;
+import org.enso.table.data.column.storage.type.TextType;
 import org.enso.table.parsing.problems.ProblemAggregator;
 import org.enso.table.problems.AggregatedProblems;
 import org.enso.table.problems.WithAggregatedProblems;
@@ -16,7 +17,7 @@ public class IdentityParser extends IncrementalDatatypeParser {
 
   @Override
   public StringBuilder makeBuilderWithCapacity(int capacity) {
-    return new StringBuilder(capacity);
+    return new StringBuilder(capacity, TextType.VARIABLE_LENGTH);
   }
 
   @Override

--- a/std-bits/table/src/main/java/org/enso/table/read/DelimitedReader.java
+++ b/std-bits/table/src/main/java/org/enso/table/read/DelimitedReader.java
@@ -5,6 +5,7 @@ import com.univocity.parsers.csv.CsvParser;
 import com.univocity.parsers.csv.CsvParserSettings;
 import org.enso.table.data.column.builder.StringBuilder;
 import org.enso.table.data.column.storage.Storage;
+import org.enso.table.data.column.storage.type.TextType;
 import org.enso.table.data.table.Column;
 import org.enso.table.data.table.Table;
 import org.enso.table.error.EmptyFileException;
@@ -521,7 +522,7 @@ public class DelimitedReader {
   private void initBuilders(int count) {
     builders = new StringBuilder[count];
     for (int i = 0; i < count; i++) {
-      builders[i] = new StringBuilder(INITIAL_ROW_CAPACITY);
+      builders[i] = new StringBuilder(INITIAL_ROW_CAPACITY, TextType.VARIABLE_LENGTH);
     }
   }
 

--- a/std-bits/table/src/main/java/org/enso/table/read/QuoteStrippingParser.java
+++ b/std-bits/table/src/main/java/org/enso/table/read/QuoteStrippingParser.java
@@ -2,6 +2,7 @@ package org.enso.table.read;
 
 import org.enso.table.data.column.builder.Builder;
 import org.enso.table.data.column.builder.StringBuilder;
+import org.enso.table.data.column.storage.type.TextType;
 import org.enso.table.parsing.IncrementalDatatypeParser;
 import org.enso.table.parsing.problems.ProblemAggregator;
 
@@ -35,6 +36,6 @@ public class QuoteStrippingParser extends IncrementalDatatypeParser {
 
   @Override
   protected Builder makeBuilderWithCapacity(int capacity) {
-    return new StringBuilder(capacity);
+    return new StringBuilder(capacity, TextType.VARIABLE_LENGTH);
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/write/ExcelWriter.java
+++ b/std-bits/table/src/main/java/org/enso/table/write/ExcelWriter.java
@@ -10,12 +10,16 @@ import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.enso.table.data.column.storage.BoolStorage;
+import org.enso.table.data.column.storage.numeric.AbstractLongStorage;
 import org.enso.table.data.column.storage.numeric.DoubleStorage;
-import org.enso.table.data.column.storage.numeric.LongStorage;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.table.Column;
 import org.enso.table.data.table.Table;
-import org.enso.table.error.*;
+import org.enso.table.error.ColumnCountMismatchException;
+import org.enso.table.error.ColumnNameMismatchException;
+import org.enso.table.error.ExistingDataException;
+import org.enso.table.error.InvalidLocationException;
+import org.enso.table.error.RangeExceededException;
 import org.enso.table.excel.ExcelHeaders;
 import org.enso.table.excel.ExcelRange;
 import org.enso.table.excel.ExcelRow;
@@ -311,7 +315,7 @@ public class ExcelWriter {
       cell.setBlank();
     } else if (storage instanceof DoubleStorage doubleStorage) {
       cell.setCellValue(doubleStorage.getItem(j));
-    } else if (storage instanceof LongStorage longStorage) {
+    } else if (storage instanceof AbstractLongStorage longStorage) {
       cell.setCellValue(longStorage.getItem(j));
     } else if (storage instanceof BoolStorage boolStorage) {
       cell.setCellValue(boolStorage.getItem(j));

--- a/test/Benchmarks/src/Main.enso
+++ b/test/Benchmarks/src/Main.enso
@@ -6,6 +6,7 @@ import project.Vector.Operations
 import project.Vector.Sort
 import project.Statistics.Count_Min_Max
 import project.Table.Aggregate
+import project.Table.Arithmetic
 import project.Table.Cross_Tab
 import project.Table.Sorting
 import project.Text.Build
@@ -39,6 +40,7 @@ all_benchmarks =
 
     # Table
     builder.append Aggregate.collect_benches
+    builder.append Arithmetic.collect_benches
     builder.append Cross_Tab.collect_benches
     builder.append Sorting.collect_benches
 
@@ -82,4 +84,3 @@ list_names =
     IO.println <| "Benchmarks: (count = " + all_names.length.to_text + ")"
     all_names.each name->
         IO.println <| "  " + name
-

--- a/test/Benchmarks/src/Table/Arithmetic.enso
+++ b/test/Benchmarks/src/Table/Arithmetic.enso
@@ -1,0 +1,52 @@
+from Standard.Base import all
+
+from Standard.Table import Table, Value_Type
+
+from Standard.Test import Bench, Faker
+
+polyglot java import java.lang.Long as Java_Long
+
+options = Bench.options . set_warmup (Bench.phase_conf 1 2) . set_measure (Bench.phase_conf 1 2)
+
+
+create_table : Table
+create_table num_rows =
+    x = Vector.new num_rows i->
+        i+1
+    y = Vector.new num_rows i->
+        if i % 10 < 2 then Java_Long.MAX_VALUE else i+1
+    u = Vector.new num_rows i->
+        10 + (i % 100)
+
+    t = Table.new [["X", x], ["Y", y], ["U", u]]
+
+    assert condition =
+        if condition.not then Panic.throw "Assertion failed"
+
+    assert ((t.at "X" . value_type) == Value_Type.Integer)
+    assert ((t.at "Y" . value_type) == Value_Type.Integer)
+    assert ((t.at "U" . value_type) == Value_Type.Integer)
+    t
+
+
+type Data
+    Value ~table
+
+    create num_rows = Data.Value (create_table num_rows)
+
+
+collect_benches = Bench.build builder->
+    num_rows = 1000000
+    data = Data.create num_rows
+
+    builder.group ("Column_Arithmetic_" + num_rows.to_text) options group_builder->
+        group_builder.specify "Plus_Fitting" <|
+            (data.table.at "X") + (data.table.at "U")
+        group_builder.specify "Plus_Overflowing" <|
+            (data.table.at "Y") + (data.table.at "U")
+        group_builder.specify "Multiply_Fitting" <|
+            (data.table.at "X") * (data.table.at "U")
+        group_builder.specify "Multiply_Overflowing" <|
+            (data.table.at "Y") * (data.table.at "U")
+
+main = collect_benches . run_main

--- a/test/Benchmarks/src/Table/Arithmetic.enso
+++ b/test/Benchmarks/src/Table/Arithmetic.enso
@@ -6,7 +6,7 @@ from Standard.Test import Bench, Faker
 
 polyglot java import java.lang.Long as Java_Long
 
-options = Bench.options . set_warmup (Bench.phase_conf 1 2) . set_measure (Bench.phase_conf 1 2)
+options = Bench.options . set_warmup (Bench.phase_conf 3 5) . set_measure (Bench.phase_conf 3 5)
 
 
 create_table : Table

--- a/test/Exploratory_Benchmarks/polyglot-sources/exploratory-benchmark-java-helpers/src/main/java/org/enso/exploratory_benchmark_helpers/MapHelpers.java
+++ b/test/Exploratory_Benchmarks/polyglot-sources/exploratory-benchmark-java-helpers/src/main/java/org/enso/exploratory_benchmark_helpers/MapHelpers.java
@@ -12,6 +12,7 @@ import org.enso.table.data.column.storage.datetime.DateStorage;
 import org.enso.table.data.column.storage.numeric.LongStorage;
 import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.data.column.storage.type.StorageType;
+import org.enso.table.data.column.storage.type.TextType;
 
 public class MapHelpers {
   public static StringStorage stringConcatBimap(StringStorage storage1, StringStorage storage2) {
@@ -28,7 +29,7 @@ public class MapHelpers {
         result[i] = null;
       }
     }
-    return new StringStorage(result, n);
+    return new StringStorage(result, n, TextType.VARIABLE_LENGTH);
   }
 
   public static LongStorage longAddBimap(LongStorage storage1, LongStorage storage2) {

--- a/test/Exploratory_Benchmarks/polyglot-sources/exploratory-benchmark-java-helpers/src/main/java/org/enso/exploratory_benchmark_helpers/MapHelpers.java
+++ b/test/Exploratory_Benchmarks/polyglot-sources/exploratory-benchmark-java-helpers/src/main/java/org/enso/exploratory_benchmark_helpers/MapHelpers.java
@@ -10,6 +10,7 @@ import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.StringStorage;
 import org.enso.table.data.column.storage.datetime.DateStorage;
 import org.enso.table.data.column.storage.numeric.LongStorage;
+import org.enso.table.data.column.storage.type.IntegerType;
 import org.enso.table.data.column.storage.type.StorageType;
 
 public class MapHelpers {
@@ -45,7 +46,7 @@ public class MapHelpers {
         missing.set(i);
       }
     }
-    return new LongStorage(result, n, missing);
+    return new LongStorage(result, n, missing, IntegerType.INT_64);
   }
 
   public static BoolStorage textEndsWith(StringStorage storage, String suffix) {
@@ -75,7 +76,7 @@ public class MapHelpers {
         missing.set(i);
       }
     }
-    return new LongStorage(result, n, missing);
+    return new LongStorage(result, n, missing, IntegerType.INT_64);
   }
 
   public static LongStorage getYear(DateStorage storage) {
@@ -89,7 +90,7 @@ public class MapHelpers {
         missing.set(i);
       }
     }
-    return new LongStorage(result, n, missing);
+    return new LongStorage(result, n, missing, IntegerType.INT_64);
   }
 
   public static Storage<?> mapCallback(

--- a/test/Table_Tests/src/Common_Table_Operations/Conversion_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Conversion_Spec.enso
@@ -140,6 +140,7 @@ spec setup =
 
                     w2 = Problems.expect_warning Conversion_Failure c2
                     w2.affected_rows_count . should_equal 1
+                    w2.to_display_text . should_contain "out of the range of the target type"
 
                     r3 = t2.at "X" . cast (Value_Type.Integer Bits.Bits_16) on_problems=Problem_Behavior.Report_Error
                     r3.should_fail_with Conversion_Failure
@@ -168,6 +169,7 @@ spec setup =
                     c1.to_vector . should_equal [1, 2, Nothing, Nothing, 0]
                     w1 = Problems.expect_warning Conversion_Failure c1
                     w1.affected_rows_count . should_equal 2
+                    w1.to_display_text . should_contain "out of the range of the target type"
 
                     c2 = t2.at "X" . cast (Value_Type.Integer Bits.Bits_16)
                     c2.value_type . should_equal (Value_Type.Integer Bits.Bits_16)
@@ -384,6 +386,21 @@ spec setup =
                 c1.to_vector . should_equal ([1, 2] + (nulls 8) + [1, Nothing, Nothing])
                 w1 = Problems.expect_warning Conversion_Failure c1
                 w1.affected_rows_count . should_equal 9
+
+                # Also check that integer range is checked in Mixed conversions.
+                t3 = table_builder [["numbermix", ["a", 34, 300, 10^12]]]
+                c1_2 = t3.at "numbermix" . cast (Value_Type.Integer Bits.Bits_16)
+                c1_2.value_type . should_equal (Value_Type.Integer Bits.Bits_16)
+                c1_2.to_vector . should_equal [Nothing, 34, 300, Nothing]
+                # We should have 2 separate warnings: for values of wrong type and for integers that just did not fit the range.
+                w1_2 = Problems.get_attached_warnings c1_2
+                w1_2.each w-> w.affected_rows_count . should_equal 1
+                w1_2.find (w-> w.to_display_text . contains "out of the range") . should_not_equal Nothing
+                w1_2.find (w-> w.to_display_text . contains "could not be converted") . should_not_equal Nothing
+                w1_2.length . should_equal 2
+                c1_3 = t3.at "numbermix" . cast Value_Type.Byte
+                c1_3.value_type . should_equal Value_Type.Byte
+                c1_3.to_vector . should_equal [Nothing, 34, Nothing, Nothing]
 
                 c2 = t2.cast "super-mix" Value_Type.Float . at "super-mix"
                 c2.value_type . should_equal Value_Type.Float

--- a/test/Table_Tests/src/Common_Table_Operations/Conversion_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Conversion_Spec.enso
@@ -27,6 +27,7 @@ spec setup =
     table_builder = setup.table_builder
     materialize = setup.materialize
     supports_dates = setup.test_selection.date_time
+    supports_conversion_failure_reporting = setup.is_database.not
     Test.group prefix+"Table/Column.cast - to text" <|
         Test.specify "should allow to cast columns of various basic types to text" <|
             t = table_builder [["X", [1, 2, 3000]], ["Y", [True, False, True]], ["Z", [1.5, 0.125, -2.5]], ["W", ["a", "DEF", "a slightly longer text"]]]
@@ -76,6 +77,15 @@ spec setup =
                 # No Conversion_Failure warning here, because we started with text, so it was expected we will trim it if needed.
                 Problems.assume_no_problems c
 
+            Test.specify "should allow to cast a text column to variable-length with a max size" <|
+                t = table_builder [["X", ["a", "DEF", "a slightly longer text"]]]
+                c = t.at "X" . cast (Value_Type.Char size=3 variable_length=True)
+                c.value_type . should_equal (Value_Type.Char size=3 variable_length=True)
+                c.to_vector . should_equal ["a", "DEF", "a s"]
+
+                # No Conversion_Failure warning here, because we started with text, so it was expected we will trim it if needed.
+                Problems.assume_no_problems c
+
             Test.specify "should allow casting a non-text column to fixed-length text" <|
                 t = table_builder [["X", [1, 22, 333]]]
                 c = t.at "X" . cast (Value_Type.Char size=3 variable_length=False)
@@ -83,14 +93,21 @@ spec setup =
                 c.to_vector . should_equal ["1  ", "22 ", "333"]
                 Problems.assume_no_problems c
 
-            Test.specify "should warn when losing data if the fixed-length text length is too short to fit the data" pending=(if setup.is_database then "Conversion_Failure is not supported in Database yet.") <|
+            Test.specify "should warn when losing data if the fixed-length text length is too short to fit the data" pending=(if supports_conversion_failure_reporting.not then "Conversion_Failure is not supported in Database yet.") <|
                 t = table_builder [["X", [15, 1000000, 123456, 1000, 1000]]]
-                c = t.at "X" . cast (Value_Type.Char size=3 variable_length=False)
-                c.value_type . should_equal (Value_Type.Char size=3 variable_length=False)
-                c.to_vector . should_equal ["15 ", "100", "123"]
-                warning = Problems.expect_warning Conversion_Failure c
-                warning.affected_rows_count . should_equal 4
-                warning.to_display_text . should_contain "['1000000', '123456', '1000' and 1 other case] have a text representation that does not fit the target type"
+                c1 = t.at "X" . cast (Value_Type.Char size=3 variable_length=False)
+                c1.value_type . should_equal (Value_Type.Char size=3 variable_length=False)
+                c1.to_vector . should_equal ["15 ", "100", "123", "100", "100"]
+                w1 = Problems.expect_warning Conversion_Failure c1
+                w1.affected_rows_count . should_equal 4
+                w1.to_display_text . should_contain "['1000000', '123456', '1000' and 1 other case] have a text representation that does not fit the target type"
+
+                c2 = t.at "X" . cast (Value_Type.Char size=3 variable_length=True)
+                c2.value_type . should_equal (Value_Type.Char size=3 variable_length=True)
+                # No padding in variable length, but also truncated.
+                c2.to_vector . should_equal ["15", "100", "123", "100", "100"]
+                w2 = Problems.expect_warning Conversion_Failure c2
+                w2.affected_rows_count . should_equal 4
 
     Test.group prefix+"Table/Column.cast - numeric" <|
         Test.specify "should allow to cast a boolean column to integer" <|
@@ -107,30 +124,58 @@ spec setup =
             c.value_type.is_floating_point . should_be_true
             c.to_vector . should_equal [1.0, 2.0, 3.0]
 
-        Test.specify "should allow to cast an integer column to a smaller bit-width and larger bit-width" pending="TODO: #5159" <|
-            t = table_builder [["X", [1, 2, 3]]]
-            c = t.at "X" . cast (Value_Type.Integer Bits.Bits_16)
-            c.value_type . should_equal (Value_Type.Integer Bits.Bits_16)
-            c.to_vector . should_equal [1, 2, 3]
+        if setup.test_selection.different_size_integer_types then
+            Test.specify "should allow to cast an integer column to a smaller bit-width and larger bit-width" <|
+                t = table_builder [["X", [1, 2, 3]]]
+                c = t.at "X" . cast (Value_Type.Integer Bits.Bits_16)
+                c.value_type . should_equal (Value_Type.Integer Bits.Bits_16)
+                c.to_vector . should_equal [1, 2, 3]
+                Problems.assume_no_problems c
 
-            t2 = table_builder [["X", [1, 2, 12000000]]]
-            c2 = t2.at "X" . cast (Value_Type.Integer Bits.Bits_16)
-            c2.value_type . should_equal (Value_Type.Integer Bits.Bits_16)
-            c2.to_vector . should_equal [1, 2, Nothing]
-            # This can likely only be checked on in-memory.
-            Problems.expect_warning Conversion_Failure c2
+                t2 = table_builder [["X", [1, 2, 12000000]]]
+                c2 = t2.at "X" . cast (Value_Type.Integer Bits.Bits_16)
+                if supports_conversion_failure_reporting then
+                    c2.value_type . should_equal (Value_Type.Integer Bits.Bits_16)
+                    c2.to_vector . should_equal [1, 2, Nothing]
 
-            r3 = t2.at "X" . cast (Value_Type.Integer Bits.Bits_16) on_problems=Problem_Behavior.Report_Error
-            r3.should_fail_with Conversion_Failure
+                    w2 = Problems.expect_warning Conversion_Failure c2
+                    w2.affected_rows_count . should_equal 1
 
-            # Now converting the 16-bit column `c` into 32 bits.
-            c3 = c.cast (Value_Type.Integer Bits.Bits_32)
-            c3.value_type . should_equal (Value_Type.Integer Bits.Bits_32)
-            c3.to_vector . should_equal [1, 2, 3]
+                    r3 = t2.at "X" . cast (Value_Type.Integer Bits.Bits_16) on_problems=Problem_Behavior.Report_Error
+                    r3.should_fail_with Conversion_Failure
 
-            c4 = c.cast Value_Type.Byte
-            c4.value_type . should_equal Value_Type.Byte
-            c4.to_vector . should_equal [1, 2, 3]
+                # Now converting the 16-bit column `c` into 32 bits.
+                c3 = c.cast (Value_Type.Integer Bits.Bits_32)
+                c3.value_type . should_equal (Value_Type.Integer Bits.Bits_32)
+                c3.to_vector . should_equal [1, 2, 3]
+
+        if setup.test_selection.supports_8bit_integer then
+            Test.specify "should allow to cast an integer column to a byte and back" <|
+                t = table_builder [["X", [1, 2, 3]]]
+                c1 = t.at "X" . cast Value_Type.Byte
+                c1.value_type . should_equal Value_Type.Byte
+                c1.to_vector . should_equal [1, 2, 3]
+
+                # And converting byte back to 64 bits.
+                c2 = c1.cast (Value_Type.Integer Bits.Bits_64)
+                c2.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
+                c2.to_vector . should_equal [1, 2, 3]
+
+                if supports_conversion_failure_reporting then
+                    t2 = table_builder [["X", [1, 2, 257, -300, 0]]]
+                    c1 = t2.at "X" . cast Value_Type.Byte
+                    c1.value_type . should_equal Value_Type.Byte
+                    c1.to_vector . should_equal [1, 2, Nothing, Nothing, 0]
+                    w1 = Problems.expect_warning Conversion_Failure c1
+                    w1.affected_rows_count . should_equal 2
+
+                    c2 = t2.at "X" . cast (Value_Type.Integer Bits.Bits_16)
+                    c2.value_type . should_equal (Value_Type.Integer Bits.Bits_16)
+                    c2.to_vector . should_equal [1, 2, 257, -300, 0]
+
+                    c3 = c1.cast (Value_Type.Integer Bits.Bits_32)
+                    c3.value_type . should_equal (Value_Type.Integer Bits.Bits_32)
+                    c3.to_vector . should_equal [1, 2, Nothing, Nothing, 0]
 
         Test.specify "should allow to cast a floating point column to integer" <|
             t = table_builder [["X", [1.0001, 2.25, 4.0]]]
@@ -281,13 +326,18 @@ spec setup =
             t2.at "Z" . to_vector . should_equal ["7", "8", "9"]
             t2.at "A" . to_vector . should_equal [True, False, True]
 
-        if setup.test_selection.fixed_length_text_columns then
-            Test.specify "should preserve the overridden types when materialized" pending="TODO: #5159 needed" <|
-                t = table_builder [["X", [1, 2, 100]], ["Y", ["a", "abcdef", "abc"]]]
-                t2 = t . cast "X" (Value_Type.Integer Bits.Bits_16) . cast "Y" (Value_Type.Char size=3 variable_length=False)
-
+        if setup.test_selection.different_size_integer_types then
+            Test.specify "should preserve the overridden types when materialized (Integer)" <|
+                t = table_builder [["X", [1, 2, 100]]]
+                t2 = t . cast "X" (Value_Type.Integer Bits.Bits_16)
                 t3 = materialize t2
-                t3.at "X" . value_type . should_equal (t2.at "X" . value_type)
+                t3.at "X" . value_type . should_equal (Value_Type.Integer Bits.Bits_16)
+
+        if setup.test_selection.fixed_length_text_columns then
+            Test.specify "should preserve the overridden types when materialized (Char)" <|
+                t = table_builder [["Y", ["a", "abcdef", "abc"]]]
+                t2 = t . cast "Y" (Value_Type.Char size=3 variable_length=False)
+                t3 = materialize t2
                 t3.at "Y" . value_type . should_equal (Value_Type.Char size=3 variable_length=False)
                 t3.at "Y" . to_vector . should_equal ["a  ", "abc", "abc"]
 
@@ -350,7 +400,7 @@ spec setup =
                 if setup.test_selection.fixed_length_text_columns then
                     c3_2 = t2.cast "super-mix" (Value_Type.Char size=2) . at "super-mix"
                     c3_2.value_type . should_equal (Value_Type.Char size=2)
-                    c3.to_vector . should_equal ["1.", "2.", "3", "-4", "2.", "X", "20", "20", "12", "{{", "Tr", Nothing, "Tr"]
+                    c3_2.to_vector . should_equal ["1.", "2.", "3", "-4", "2.", "X", "20", "20", "12", "{{", "Tr", Nothing, "Tr"]
                     w3_2 = Problems.expect_warning Conversion_Failure c3_2
                     w3_2.affected_rows_count . should_equal 10
 

--- a/test/Table_Tests/src/Common_Table_Operations/Integration_Tests.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Integration_Tests.enso
@@ -134,6 +134,22 @@ spec setup =
                 r5.at "A" . to_vector . should_contain_the_same_elements_as ["b", "a"]
                 r5.at "B" . to_vector . should_equal [5, 5]
 
+            Test.specify "add_row_number and union" <|
+                t1 = table_builder [["X", ["a", "b", "c"]]]
+                t2 = table_builder [["X", ["ddd", "eee", "fff"]]]
+
+                t12 = (t1.add_row_number order_by="X") . union (t2.add_row_number order_by="X")
+                r12 = t12 |> materialize
+                r12.at "X" . to_vector . should_equal ["a", "b", "c", "ddd", "eee", "fff"]
+                r12.at "Row" . to_vector . should_equal [1, 2, 3, 1, 2, 3]
+
+                t3 = table_builder [["X", ["a", "b", "c"]], ["Row", [1.5, 2.5, 3.5]]]
+
+                t123 = ((t1.add_row_number order_by="X").union [(t2.add_row_number order_by="X"), t3])
+                r123 = t123 |> materialize
+                r123.at "X" . to_vector . should_equal ["a", "b", "c", "ddd", "eee", "fff", "a", "b", "c"]
+                r123.at "Row" . to_vector . should_equal [1, 2, 3, 1, 2, 3, 1.5, 2.5, 3.5]
+
         if setup.test_selection.fixed_length_text_columns then
             Test.specify "types of unioned fixed-length columns should be correctly inferred after passing through other operations that infer types from Database, like aggregate Shortest" <|
                 t1 = table_builder [["X", ["a", "b", "c"]], ["Y", [1, 0, 2]]] . cast "X" (Value_Type.Char 1 False)

--- a/test/Table_Tests/src/Common_Table_Operations/Integration_Tests.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Integration_Tests.enso
@@ -134,18 +134,29 @@ spec setup =
                 r5.at "A" . to_vector . should_contain_the_same_elements_as ["b", "a"]
                 r5.at "B" . to_vector . should_equal [5, 5]
 
-            Test.specify "add_row_number and union" <|
-                t1 = table_builder [["X", ["a", "b", "c"]]]
+            if setup.is_database.not then Test.specify "add_row_number and other operations" <|
+                t1 = table_builder [["X", ["a", "b", "c"]], ["Y", [1, 2, 3]], ["Z", [0.25, 0.5, 0.75]]]
                 t2 = table_builder [["X", ["ddd", "eee", "fff"]]]
 
-                t12 = (t1.add_row_number order_by="X") . union (t2.add_row_number order_by="X")
+                t11 = t1.add_row_number
+                (t11.at "Row" + 2) . to_vector . should_equal [3, 4, 5]
+                (t11.at "Row" + 0.5) . to_vector . should_equal [1.5, 2.5, 3.5]
+                ((t11.at "Y") + (t11.at "Row")) . to_vector . should_equal [2, 4, 6]
+                ((t11.at "Z") + (t11.at "Row")) . to_vector . should_equal [1.25, 2.5, 3.75]
+
+                xls = (enso_project.data / 'transient' / 'add_row_number.xls')
+                Problems.assume_no_problems <| t11.write xls
+                t11_loaded = xls.read
+                t11_loaded.at "Row" . to_vector . should_equal [1, 2, 3]
+
+                t12 = (t1.add_row_number) . union (t2.add_row_number from=100)
                 r12 = t12 |> materialize
                 r12.at "X" . to_vector . should_equal ["a", "b", "c", "ddd", "eee", "fff"]
-                r12.at "Row" . to_vector . should_equal [1, 2, 3, 1, 2, 3]
+                r12.at "Row" . to_vector . should_equal [1, 2, 3, 101, 102, 103]
 
                 t3 = table_builder [["X", ["a", "b", "c"]], ["Row", [1.5, 2.5, 3.5]]]
 
-                t123 = ((t1.add_row_number order_by="X").union [(t2.add_row_number order_by="X"), t3])
+                t123 = ((t1.add_row_number).union [(t2.add_row_number), t3])
                 r123 = t123 |> materialize
                 r123.at "X" . to_vector . should_equal ["a", "b", "c", "ddd", "eee", "fff", "a", "b", "c"]
                 r123.at "Row" . to_vector . should_equal [1, 2, 3, 1, 2, 3, 1.5, 2.5, 3.5]

--- a/test/Table_Tests/src/Common_Table_Operations/Integration_Tests.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Integration_Tests.enso
@@ -134,6 +134,8 @@ spec setup =
                 r5.at "A" . to_vector . should_contain_the_same_elements_as ["b", "a"]
                 r5.at "B" . to_vector . should_equal [5, 5]
 
+            ## This mostly checks that various operations handle all kinds of Integer storage implementations
+               (add_row_number may use a different storage than regular columns)
             if setup.is_database.not then Test.specify "add_row_number and other operations" <|
                 t1 = table_builder [["X", ["a", "b", "c"]], ["Y", [1, 2, 3]], ["Z", [0.25, 0.5, 0.75]]]
                 t2 = table_builder [["X", ["ddd", "eee", "fff"]]]
@@ -146,13 +148,14 @@ spec setup =
 
                 xls = (enso_project.data / 'transient' / 'add_row_number.xls')
                 Problems.assume_no_problems <| t11.write xls
-                t11_loaded = xls.read
+                workbook = xls.read
+                t11_loaded = workbook.read workbook.sheet_names.first
                 t11_loaded.at "Row" . to_vector . should_equal [1, 2, 3]
 
                 t12 = (t1.add_row_number) . union (t2.add_row_number from=100)
                 r12 = t12 |> materialize
                 r12.at "X" . to_vector . should_equal ["a", "b", "c", "ddd", "eee", "fff"]
-                r12.at "Row" . to_vector . should_equal [1, 2, 3, 101, 102, 103]
+                r12.at "Row" . to_vector . should_equal [1, 2, 3, 100, 101, 102]
 
                 t3 = table_builder [["X", ["a", "b", "c"]], ["Row", [1.5, 2.5, 3.5]]]
 

--- a/test/Table_Tests/src/Common_Table_Operations/Join/Union_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Join/Union_Spec.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 
+import Standard.Table.Data.Type.Value_Type.Bits
 from Standard.Table import all
 from Standard.Table.Errors import all
 
@@ -338,3 +339,24 @@ spec setup =
             t4 = table_builder [["A", [1.5]]]
             e5 = t1.union t4 allow_type_widening=False on_problems=Problem_Behavior.Ignore
             e5.should_fail_with No_Output_Columns
+
+        t1 = table_builder [["X", [0, 1, 2]], ["Y", ['aa', 'bb', 'cc']]] . cast "X" (Value_Type.Integer Bits.Bits_16) . cast "Y" (Value_Type.Char size=2 variable_length=False)
+        t2 = table_builder [["X", [3, 4, 5]], ["Y", ['x', 'y', 'z']]] . cast "X" (Value_Type.Integer Bits.Bits_32) . cast "Y" (Value_Type.Char size=1 variable_length=False)
+        supports_complex_types = (t1.is_error || t2.is_error || Problems.get_attached_warnings t1 . not_empty).not
+        if supports_complex_types then
+            Test.specify "should find a common type (2)" <|
+                t12 = t1.union t2
+                Problems.assume_no_problems t12
+                t12.at "X" . value_type . should_equal (Value_Type.Integer Bits.Bits_32)
+                t12.at "Y" . value_type . should_equal (Value_Type.Char size=2 variable_length=True)
+
+                t12.at "X" . to_vector . should_equal [0, 1, 2, 3, 4, 5]
+                t12.at "Y" . to_vector . should_equal ['aa', 'bb', 'cc', 'x', 'y', 'z']
+
+            Test.specify "should fail to find a common type if widening is not allowed (2)" <|
+                # TODO No_Output_Columns should have Column_Type_Mismatch as its cause for better readability
+                t1.union t2 allow_type_widening=False . should_fail_with No_Output_Columns
+
+                # And this should report Column_Type_Mismatch as the more important error too.
+                #t1.union t2 allow_type_widening=False on_problems=Problem_Behavior.Report_Error . should_fail_with Column_Type_Mismatch
+                t1.union t2 allow_type_widening=False on_problems=Problem_Behavior.Report_Error . should_fail_with No_Output_Columns

--- a/test/Table_Tests/src/Common_Table_Operations/Join/Union_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Join/Union_Spec.enso
@@ -354,7 +354,7 @@ spec setup =
                 t12.at "Y" . to_vector . should_equal ['aa', 'bb', 'cc', 'x', 'y', 'z']
 
             Test.specify "should fail to find a common type if widening is not allowed (2)" <|
-                # TODO No_Output_Columns should have Column_Type_Mismatch as its cause for better readability
+                # ToDo No_Output_Columns should have Column_Type_Mismatch as its cause for better readability (#7635)
                 t1.union t2 allow_type_widening=False . should_fail_with No_Output_Columns
 
                 # And this should report Column_Type_Mismatch as the more important error too.

--- a/test/Table_Tests/src/Common_Table_Operations/Main.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Main.enso
@@ -95,6 +95,10 @@ type Test_Selection
        - date_time: Specifies if the backend supports date/time operations.
        - fixed_length_text_columns: Specifies if the backend supports fixed
          length text columns.
+       - different_size_integer_types: Specifies if the backend supports
+         integer types of various sizes, like 16-bit or 32-bit integers.
+       - supports_8bit_integer: Specifies if the backend supports 8-bit
+         integers.
        - supports_decimal_type: Specifies if the backend supports the `Decimal`
          high-precision type.
        - supports_time_duration: Specifies if the backend supports a
@@ -105,7 +109,7 @@ type Test_Selection
          columns.
        - supported_replace_params: Specifies the possible values of
          Replace_Params that a backend supports.
-    Config supports_case_sensitive_columns=True order_by=True natural_ordering=False case_insensitive_ordering=True order_by_unicode_normalization_by_default=False case_insensitive_ascii_only=False take_drop=True allows_mixed_type_comparisons=True supports_unicode_normalization=False is_nan_and_nothing_distinct=True distinct_returns_first_row_from_group_if_ordered=True date_time=True fixed_length_text_columns=False supports_decimal_type=False supports_time_duration=False supports_nanoseconds_in_time=False supports_mixed_columns=False supported_replace_params=Nothing
+    Config supports_case_sensitive_columns=True order_by=True natural_ordering=False case_insensitive_ordering=True order_by_unicode_normalization_by_default=False case_insensitive_ascii_only=False take_drop=True allows_mixed_type_comparisons=True supports_unicode_normalization=False is_nan_and_nothing_distinct=True distinct_returns_first_row_from_group_if_ordered=True date_time=True fixed_length_text_columns=False different_size_integer_types=True supports_8bit_integer=False supports_decimal_type=False supports_time_duration=False supports_nanoseconds_in_time=False supports_mixed_columns=False supported_replace_params=Nothing
 
 spec setup =
     Core_Spec.spec setup

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -158,6 +158,22 @@ postgres_specific_spec connection db_name setup =
             t.at "bools" . value_type . is_boolean . should_be_true
             t.at "doubles" . value_type . is_floating_point . should_be_true
 
+        Test.specify "should preserve Postgres types when table is materialized, where possible" <|
+            name = Name_Generator.random_name "types-test"
+            Problems.assume_no_problems <|
+                connection.execute_update 'CREATE TEMPORARY TABLE "'+name+'" ("int4" int4, "int2" int2, "txt-limited" varchar(10), "txt-fixed" char(3))'
+            t1 = connection.query (SQL_Query.Table_Name name)
+            t1.at "int4" . value_type . should_equal (Value_Type.Integer Bits.Bits_32)
+            t1.at "int2" . value_type . should_equal (Value_Type.Integer Bits.Bits_16)
+            t1.at "txt-limited" . value_type . should_equal (Value_Type.Char size=10 variable_length=True)
+            t1.at "txt-fixed" . value_type . should_equal (Value_Type.Char size=3 variable_length=False)
+
+            in_memory = t1.read
+            in_memory.at "int4" . value_type . should_equal (Value_Type.Integer Bits.Bits_32)
+            in_memory.at "int2" . value_type . should_equal (Value_Type.Integer Bits.Bits_16)
+            in_memory.at "txt-limited" . value_type . should_equal (Value_Type.Char size=10 variable_length=True)
+            in_memory.at "txt-fixed" . value_type . should_equal (Value_Type.Char size=3 variable_length=False)
+
     Test.group "[PostgreSQL] Dialect-specific codegen" <|
         Test.specify "should generate queries for the Distinct operation" <|
             t = connection.query (SQL_Query.Table_Name tinfo)

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -235,7 +235,7 @@ sqlite_spec connection prefix =
 
     Common_Spec.spec prefix connection
 
-    common_selection = Common_Table_Operations.Main.Test_Selection.Config supports_case_sensitive_columns=False order_by=True natural_ordering=False case_insensitive_ordering=True case_insensitive_ascii_only=True take_drop=False is_nan_and_nothing_distinct=False date_time=False supported_replace_params=supported_replace_params
+    common_selection = Common_Table_Operations.Main.Test_Selection.Config supports_case_sensitive_columns=False order_by=True natural_ordering=False case_insensitive_ordering=True case_insensitive_ascii_only=True take_drop=False is_nan_and_nothing_distinct=False date_time=False supported_replace_params=supported_replace_params different_size_integer_types=False
 
     ## For now `advanced_stats`, `first_last`, `text_shortest_longest` and
        `multi_distinct` remain disabled, because SQLite does not provide the

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -850,22 +850,9 @@ spec make_new_connection prefix persistent_connector=True =
             has_warning_or_error.not
         if non_trivial_types_supported then
             src = source_table_builder [["X", [1, 2, 3]], ["Y", ["a", "xyz", "abcdefghijkl"]], ["Z", ["a", "pqrst", "abcdefghijkl"]]]
-            ## TODO [RW] figure out what semantics we want here; I think the current one may be OK but it is going to
-               be slightly painful, so IMO an auto-conversion could be useful. We could make it so that we do
-               auto-conversion (cast), but in a more strict mode such that if anything does not fit
-               (even just string padding required) we fail hard and tell the user to fix this.
             Test.specify "fails if the target type is more restrictive than source" <|
                 result = src.update_database_table dest update_action=Update_Action.Insert key_columns=[]
                 result.should_fail_with Column_Type_Mismatch
-            but_maybe="I'm not sure if we want this automatic restriction. If anything, we should probably report situations like abcdefghijkl being truncated."
-            Test.specify "should warn if the target type is more restrictive than source and truncation may occur" pending=but_maybe <|
-                result = src.update_database_table dest update_action=Update_Action.Insert key_columns=[]
-                IO.println (Problems.get_attached_warnings result)
-
-                result.column_names . should_equal ["X", "Y", "Z"]
-                result.at "X" . to_vector . should_contain_the_same_elements_as [1, 2, 3]
-                result.at "Y" . to_vector . should_contain_the_same_elements_as ["a", "xyz", "abc"]
-                result.at "Z" . to_vector . should_contain_the_same_elements_as ["a     ", "pqrst", "abcde"]
 
         Test.specify "should not leave behind any garbage temporary tables if the upload fails" <|
             dest_name = Name_Generator.random_name "dest-table"

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -8,6 +8,7 @@ import Standard.Base.Runtime.Context
 import Standard.Base.Runtime.Managed_Resource.Managed_Resource
 import Standard.Base.Runtime.Ref.Ref
 
+import Standard.Table.Data.Type.Value_Type.Bits
 from Standard.Table import all
 from Standard.Table.Errors import all
 
@@ -836,6 +837,35 @@ spec make_new_connection prefix persistent_connector=True =
                 err.column_name.should_equal "X"
                 err.expected_type.is_text . should_be_true
                 err.got_type.is_numeric . should_be_true
+
+        dest_name = Name_Generator.random_name "dest-table-test-types"
+        structure =
+            x = Column_Description.Value "X" (Value_Type.Integer Bits.Bits_16)
+            y = Column_Description.Value "Y" (Value_Type.Char size=4 variable_length=True)
+            z = Column_Description.Value "Z" (Value_Type.Char size=5 variable_length=False)
+            [x, y, z]
+        dest = connection.create_table dest_name structure temporary=True primary_key=[]
+        non_trivial_types_supported =
+            has_warning_or_error = dest.is_error || (Problems.get_attached_warnings dest . not_empty)
+            has_warning_or_error.not
+        if non_trivial_types_supported then
+            src = source_table_builder [["X", [1, 2, 3]], ["Y", ["a", "xyz", "abcdefghijkl"]], ["Z", ["a", "pqrst", "abcdefghijkl"]]]
+            ## TODO [RW] figure out what semantics we want here; I think the current one may be OK but it is going to
+               be slightly painful, so IMO an auto-conversion could be useful. We could make it so that we do
+               auto-conversion (cast), but in a more strict mode such that if anything does not fit
+               (even just string padding required) we fail hard and tell the user to fix this.
+            Test.specify "fails if the target type is more restrictive than source" <|
+                result = src.update_database_table dest update_action=Update_Action.Insert key_columns=[]
+                result.should_fail_with Column_Type_Mismatch
+            but_maybe="I'm not sure if we want this automatic restriction. If anything, we should probably report situations like abcdefghijkl being truncated."
+            Test.specify "should warn if the target type is more restrictive than source and truncation may occur" pending=but_maybe <|
+                result = src.update_database_table dest update_action=Update_Action.Insert key_columns=[]
+                IO.println (Problems.get_attached_warnings result)
+
+                result.column_names . should_equal ["X", "Y", "Z"]
+                result.at "X" . to_vector . should_contain_the_same_elements_as [1, 2, 3]
+                result.at "Y" . to_vector . should_contain_the_same_elements_as ["a", "xyz", "abc"]
+                result.at "Z" . to_vector . should_contain_the_same_elements_as ["a     ", "pqrst", "abcde"]
 
         Test.specify "should not leave behind any garbage temporary tables if the upload fails" <|
             dest_name = Name_Generator.random_name "dest-table"

--- a/test/Table_Tests/src/In_Memory/Column_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Column_Spec.enso
@@ -6,7 +6,6 @@ import Standard.Base.Errors.Common.Arithmetic_Error
 import Standard.Base.Errors.Common.Index_Out_Of_Bounds
 import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
-import Standard.Examples
 import Standard.Test.Extensions
 
 from Standard.Table import Column, Value_Type

--- a/test/Table_Tests/src/In_Memory/Common_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Common_Spec.enso
@@ -7,7 +7,7 @@ from Standard.Test import Test_Suite
 import project.Common_Table_Operations
 
 run_common_spec spec =
-    selection = Common_Table_Operations.Main.Test_Selection.Config supports_case_sensitive_columns=True order_by=True natural_ordering=True case_insensitive_ordering=True order_by_unicode_normalization_by_default=True supports_unicode_normalization=True supports_time_duration=True supports_nanoseconds_in_time=True supports_mixed_columns=True
+    selection = Common_Table_Operations.Main.Test_Selection.Config supports_case_sensitive_columns=True order_by=True natural_ordering=True case_insensitive_ordering=True order_by_unicode_normalization_by_default=True supports_unicode_normalization=True supports_time_duration=True supports_nanoseconds_in_time=True supports_mixed_columns=True fixed_length_text_columns=True supports_8bit_integer=True
     aggregate_selection = Common_Table_Operations.Aggregate_Spec.Test_Selection.Config
 
     table = (enso_project.data / "data.csv") . read

--- a/test/Table_Tests/src/In_Memory/Integer_Overflow_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Integer_Overflow_Spec.enso
@@ -109,10 +109,11 @@ spec =
             c3.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
             Problems.assume_no_problems c3
 
-            # But operations that have no risk of overflow (currently only modulus) will not widen the type unnecessarily
+            ## There is no risk of overflow in modulus, but for consistency we always return int-64.
+               We may adapt this in the future.
             c4 = y%2
             c4.to_vector . should_equal [0, -1, 0, 0]
-            c4.value_type . should_equal value_type
+            c4.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
             Problems.assume_no_problems c4
 
         test_no_overflow Value_Type.Byte Java_Byte.MAX_VALUE Java_Byte.MIN_VALUE
@@ -145,10 +146,9 @@ spec =
             c4.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
             Problems.assume_no_problems c4
 
-            # But operations that have no risk of overflow (currently only modulus) will widen the type to the bigger of the two operands.
             c5 = x%y
             c5.to_vector . should_equal [0]
-            c5.value_type . should_equal (Value_Type.Integer Bits.Bits_16)
+            c5.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
             Problems.assume_no_problems c5
 
-            (x%2).value_type . should_equal (Value_Type.Byte)
+            (x%2).value_type . should_equal (Value_Type.Integer Bits.Bits_64)

--- a/test/Table_Tests/src/In_Memory/Integer_Overflow_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Integer_Overflow_Spec.enso
@@ -116,6 +116,16 @@ spec =
             c4.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
             Problems.assume_no_problems c4
 
+            c5 = x+u
+            c5.to_vector . should_equal [1, 2, max_value+1, 1]
+            c5.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
+            Problems.assume_no_problems c5
+
+            c6 = y-u
+            c6.to_vector . should_equal [-1, -2, min_value-1, -1]
+            c6.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
+            Problems.assume_no_problems c6
+
         test_no_overflow Value_Type.Byte Java_Byte.MAX_VALUE Java_Byte.MIN_VALUE
         test_no_overflow (Value_Type.Integer Bits.Bits_16) Java_Short.MAX_VALUE Java_Short.MIN_VALUE
         test_no_overflow (Value_Type.Integer Bits.Bits_32) Java_Integer.MAX_VALUE Java_Integer.MIN_VALUE

--- a/test/Table_Tests/src/In_Memory/Integer_Overflow_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Integer_Overflow_Spec.enso
@@ -1,0 +1,17 @@
+from Standard.Base import all
+
+from Standard.Table import all
+from Standard.Table.Errors import Conversion_Failure
+
+from Standard.Test import Test, Test_Suite, Problems
+import Standard.Test.Extensions
+
+from project.Util import all
+
+main = Test_Suite.run_main spec
+
+spec =
+    table_builder = Table.new
+    Test.group "[In-Memory] Column operation Integer Overflow handling" <|
+        Test.specify "TODO" <|
+            1

--- a/test/Table_Tests/src/In_Memory/Integer_Overflow_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Integer_Overflow_Spec.enso
@@ -18,7 +18,10 @@ main = Test_Suite.run_main spec
 
 spec =
     Test.group "[In-Memory] Column operation Integer Overflow handling" <|
-        test_overflow name value_type max_value min_value = Test.specify name <|
+        Test.specify "64-bit integer column overflow" <|
+            min_value = Java_Long.MIN_VALUE
+            max_value = Java_Long.MAX_VALUE
+            value_type = Value_Type.Integer Bits.Bits_64
             t = Table.new [["X", [0, 1, max_value, 0]], ["Y", [0, -1, min_value, 0]], ["U", [1, 1, 1, 1]]]
             x = t.at "X" . cast value_type
             y = t.at "Y" . cast value_type
@@ -85,10 +88,36 @@ spec =
             c10.value_type . should_equal value_type
             Problems.expect_only_warning Arithmetic_Overflow c10
 
-        test_overflow "Byte" Value_Type.Byte Java_Byte.MAX_VALUE Java_Byte.MIN_VALUE
-        test_overflow "Integer 16-bit" (Value_Type.Integer Bits.Bits_16) Java_Short.MAX_VALUE Java_Short.MIN_VALUE
-        test_overflow "Integer 32-bit" (Value_Type.Integer Bits.Bits_32) Java_Integer.MAX_VALUE Java_Integer.MIN_VALUE
-        test_overflow "Integer 64-bit" (Value_Type.Integer Bits.Bits_64) Java_Long.MAX_VALUE Java_Long.MIN_VALUE
+        test_no_overflow value_type min_value max_value = Test.specify "operations on "+value_type.to_display_text+" will not overflow, because the result type is always 64-bit integer column" <|
+            t = Table.new [["X", [0, 1, max_value, 0]], ["Y", [0, -1, min_value, 0]], ["U", [1, 1, 1, 1]]]
+            x = t.at "X" . cast value_type
+            y = t.at "Y" . cast value_type
+            u = t.at "U" . cast value_type
+
+            c1 = x+1
+            c1.to_vector . should_equal [1, 2, max_value+1, 1]
+            c1.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
+            Problems.assume_no_problems c1
+
+            c2 = y-1
+            c2.to_vector . should_equal [-1, -2, min_value-1, -1]
+            c2.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
+            Problems.assume_no_problems c2
+
+            c3 = x*y
+            c3.to_vector . should_equal [0, -1, min_value*max_value, 0]
+            c3.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
+            Problems.assume_no_problems c3
+
+            # But operations that have no risk of overflow (currently only modulus) will not widen the type unnecessarily
+            c4 = y%2
+            c4.to_vector . should_equal [0, -1, 0, 0]
+            c4.value_type . should_equal value_type
+            Problems.assume_no_problems c4
+
+        test_no_overflow Value_Type.Byte Java_Byte.MAX_VALUE Java_Byte.MIN_VALUE
+        test_no_overflow (Value_Type.Integer Bits.Bits_16) Java_Short.MAX_VALUE Java_Short.MIN_VALUE
+        test_no_overflow (Value_Type.Integer Bits.Bits_32) Java_Integer.MAX_VALUE Java_Integer.MIN_VALUE
 
         Test.specify "mixed operations" <|
             t = Table.new [["X", [Java_Short.MAX_VALUE]], ["Y", [1]]]
@@ -100,25 +129,26 @@ spec =
 
             c2 = x+y
             c2.to_vector . should_equal [Nothing]
-            # The resulting value type is the larger of the two.
-            c2.value_type . should_equal Value_Type.Bits_16
-            Problems.expect_only_warning Arithmetic_Overflow c2
-
-            c3 = x + (y.cast Value_Type.Integer Bits.Bits_64)
-            c3.to_vector . should_equal [Java_Short.MAX_VALUE + 1]
-            c3.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
-            Problems.assume_no_problems c3
+            # The resulting value type is always 64-bit integer.
+            c2.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
 
             # The scalar also gets its value type, and it can make the result wider.
             big_scalar = Java_Integer.MAX_VALUE + 1
-            c4 = y + big_scalar
-            c4.to_vector . should_equal [big_scalar + 1]
+            c3 = y + big_scalar
+            c3.to_vector . should_equal [big_scalar + 1]
+            c3.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
+            Problems.assume_no_problems c3
+
+            medium_scalar = Java_Short.MAX_VALUE + 1
+            c4 = y + medium_scalar
+            c4.to_vector . should_equal [medium_scalar + 1]
             c4.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
             Problems.assume_no_problems c4
 
-            medium_scalar = Java_Short.MAX_VALUE + 1
-            c5 = y + medium_scalar
-            c5.to_vector . should_equal [medium_scalar + 1]
-            # The size grows to the size of the scalar which is no bigger than necessary.
-            c5.value_type . should_equal (Value_Type.Integer Bits.Bits_32)
+            # But operations that have no risk of overflow (currently only modulus) will widen the type to the bigger of the two operands.
+            c5 = x%y
+            c5.to_vector . should_equal [0]
+            c5.value_type . should_equal (Value_Type.Integer Bits.Bits_16)
             Problems.assume_no_problems c5
+
+            (x%2).value_type . should_equal (Value_Type.Byte)

--- a/test/Table_Tests/src/In_Memory/Integer_Overflow_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Integer_Overflow_Spec.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 
 import Standard.Table.Data.Type.Value_Type.Bits
 from Standard.Table import all
-from Standard.Table.Errors import Arithmetic_Overflow
+from Standard.Table.Errors import Arithmetic_Overflow, Conversion_Failure
 
 from Standard.Test import Test, Test_Suite, Problems
 import Standard.Test.Extensions
@@ -88,7 +88,7 @@ spec =
             c10.value_type . should_equal value_type
             Problems.expect_only_warning Arithmetic_Overflow c10
 
-        test_no_overflow value_type min_value max_value = Test.specify "operations on "+value_type.to_display_text+" will not overflow, because the result type is always 64-bit integer column" <|
+        test_no_overflow value_type max_value min_value = Test.specify "operations on "+value_type.to_display_text+" will not overflow, because the result type is always 64-bit integer column" <|
             t = Table.new [["X", [0, 1, max_value, 0]], ["Y", [0, -1, min_value, 0]], ["U", [1, 1, 1, 1]]]
             x = t.at "X" . cast value_type
             y = t.at "Y" . cast value_type
@@ -98,16 +98,21 @@ spec =
             c1.to_vector . should_equal [1, 2, max_value+1, 1]
             c1.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
             Problems.assume_no_problems c1
+            c1_casted = c1.cast value_type
+            c1_casted.to_vector . should_equal [1, 2, Nothing, 1]
+            Problems.expect_only_warning Conversion_Failure c1_casted
 
             c2 = y-1
             c2.to_vector . should_equal [-1, -2, min_value-1, -1]
             c2.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
             Problems.assume_no_problems c2
+            c2.cast value_type . to_vector . should_equal [-1, -2, Nothing, -1]
 
             c3 = x*y
             c3.to_vector . should_equal [0, -1, min_value*max_value, 0]
             c3.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
             Problems.assume_no_problems c3
+            c3.cast value_type . to_vector . should_equal [0, -1, Nothing, 0]
 
             ## There is no risk of overflow in modulus, but for consistency we always return int-64.
                We may adapt this in the future.
@@ -115,16 +120,19 @@ spec =
             c4.to_vector . should_equal [0, -1, 0, 0]
             c4.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
             Problems.assume_no_problems c4
+            c4.cast value_type . to_vector . should_equal [0, -1, 0, 0]
 
             c5 = x+u
             c5.to_vector . should_equal [1, 2, max_value+1, 1]
             c5.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
             Problems.assume_no_problems c5
+            c5.cast value_type . to_vector . should_equal [1, 2, Nothing, 1]
 
             c6 = y-u
             c6.to_vector . should_equal [-1, -2, min_value-1, -1]
             c6.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
             Problems.assume_no_problems c6
+            c6.cast value_type . to_vector . should_equal [-1, -2, Nothing, -1]
 
         test_no_overflow Value_Type.Byte Java_Byte.MAX_VALUE Java_Byte.MIN_VALUE
         test_no_overflow (Value_Type.Integer Bits.Bits_16) Java_Short.MAX_VALUE Java_Short.MIN_VALUE
@@ -138,9 +146,9 @@ spec =
             c1 = x-y
             Problems.assume_no_problems c1
 
-            c2 = x+y
-            c2.to_vector . should_equal [Nothing]
             # The resulting value type is always 64-bit integer.
+            c2 = x+y
+            c2.to_vector . should_equal [32768]
             c2.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
 
             # The scalar also gets its value type, and it can make the result wider.

--- a/test/Table_Tests/src/In_Memory/Integer_Overflow_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Integer_Overflow_Spec.enso
@@ -1,17 +1,124 @@
 from Standard.Base import all
 
+import Standard.Table.Data.Type.Value_Type.Bits
 from Standard.Table import all
-from Standard.Table.Errors import Conversion_Failure
+from Standard.Table.Errors import Arithmetic_Overflow
 
 from Standard.Test import Test, Test_Suite, Problems
 import Standard.Test.Extensions
 
 from project.Util import all
 
+polyglot java import java.lang.Byte as Java_Byte
+polyglot java import java.lang.Short as Java_Short
+polyglot java import java.lang.Integer as Java_Integer
+polyglot java import java.lang.Long as Java_Long
+
 main = Test_Suite.run_main spec
 
 spec =
-    table_builder = Table.new
     Test.group "[In-Memory] Column operation Integer Overflow handling" <|
-        Test.specify "TODO" <|
-            1
+        test_overflow name value_type max_value min_value = Test.specify name <|
+            t = Table.new [["X", [0, 1, max_value, 0]], ["Y", [0, -1, min_value, 0]], ["U", [1, 1, 1, 1]]]
+            x = t.at "X" . cast value_type
+            y = t.at "Y" . cast value_type
+            u = t.at "U" . cast value_type
+
+            # No overflow
+            c1 = x - 1
+            c1.to_vector . should_equal [-1, 0, max_value-1, -1]
+            c1.value_type . should_equal value_type
+            Problems.assume_no_problems c1
+
+            # Overflow
+            c2 = x + 1
+            c2.to_vector . should_equal [1, 2, Nothing, 1]
+            c2.value_type . should_equal value_type
+            w2 = Problems.expect_only_warning Arithmetic_Overflow c2
+            w2.affected_rows_count . should_equal 1
+            w2.to_display_text . should_contain "1 rows (e.g. operation "+max_value.to_text+" + 1) encountered integer overflow"
+
+            # Power operator actually makes a floating point result, so it is not affected by overflow.
+            c3 = x^x
+            c3.value_type . should_equal Value_Type.Float
+            Problems.assume_no_problems c3
+
+            # Overflow the other way round
+            c4 = y - 1
+            c4.to_vector . should_equal [-1, -2, Nothing, -1]
+            c4.value_type . should_equal value_type
+            w4 = Problems.expect_only_warning Arithmetic_Overflow c4
+            w4.affected_rows_count . should_equal 1
+            w4.to_display_text . should_contain "1 rows (e.g. operation "+min_value.to_text+" - 1) encountered integer overflow"
+
+            c5 = x * 2
+            c5.to_vector . should_equal [0, 2, Nothing, 0]
+            c5.value_type . should_equal value_type
+            Problems.expect_only_warning Arithmetic_Overflow c5
+
+            ## The division operator can overflow in one situation - MIN_VALUE / -1;
+               that is because the min value has larger magnitude than the max value - e.g. -128 vs 127.
+               But it does not happen because our `/` operator converts to Float!
+            c6 = y / (-1)
+            c6.to_vector . should_equal [0, 1, -min_value, 0]
+            c6.value_type . should_equal Value_Type.Float
+            Problems.assume_no_problems c6
+
+            # Now some more tests on column-column operations.
+            c7 = x + u
+            c7.to_vector . should_equal [1, 2, Nothing, 1]
+            c7.value_type . should_equal value_type
+            Problems.expect_only_warning Arithmetic_Overflow c7
+
+            c8 = x - u
+            c8.to_vector . should_equal [-1, 0, max_value-1, -1]
+            c8.value_type . should_equal value_type
+            Problems.assume_no_problems c8
+
+            c9 = y - u
+            c9.to_vector . should_equal [-1, -2, Nothing, -1]
+            c9.value_type . should_equal value_type
+            Problems.expect_only_warning Arithmetic_Overflow c9
+
+            c10 = y * (u+u)
+            c10.to_vector . should_equal [0, -2, Nothing, 0]
+            c10.value_type . should_equal value_type
+            Problems.expect_only_warning Arithmetic_Overflow c10
+
+        test_overflow "Byte" Value_Type.Byte Java_Byte.MAX_VALUE Java_Byte.MIN_VALUE
+        test_overflow "Integer 16-bit" (Value_Type.Integer Bits.Bits_16) Java_Short.MAX_VALUE Java_Short.MIN_VALUE
+        test_overflow "Integer 32-bit" (Value_Type.Integer Bits.Bits_32) Java_Integer.MAX_VALUE Java_Integer.MIN_VALUE
+        test_overflow "Integer 64-bit" (Value_Type.Integer Bits.Bits_64) Java_Long.MAX_VALUE Java_Long.MIN_VALUE
+
+        Test.specify "mixed operations" <|
+            t = Table.new [["X", [Java_Short.MAX_VALUE]], ["Y", [1]]]
+            x = t.at "X" . cast (Value_Type.Integer Bits.Bits_16)
+            y = t.at "Y" . cast Value_Type.Byte
+
+            c1 = x-y
+            Problems.assume_no_problems c1
+
+            c2 = x+y
+            c2.to_vector . should_equal [Nothing]
+            # The resulting value type is the larger of the two.
+            c2.value_type . should_equal Value_Type.Bits_16
+            Problems.expect_only_warning Arithmetic_Overflow c2
+
+            c3 = x + (y.cast Value_Type.Integer Bits.Bits_64)
+            c3.to_vector . should_equal [Java_Short.MAX_VALUE + 1]
+            c3.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
+            Problems.assume_no_problems c3
+
+            # The scalar also gets its value type, and it can make the result wider.
+            big_scalar = Java_Integer.MAX_VALUE + 1
+            c4 = y + big_scalar
+            c4.to_vector . should_equal [big_scalar + 1]
+            c4.value_type . should_equal (Value_Type.Integer Bits.Bits_64)
+            Problems.assume_no_problems c4
+
+            medium_scalar = Java_Short.MAX_VALUE + 1
+            c5 = y + medium_scalar
+            c5.to_vector . should_equal [medium_scalar + 1]
+            # The size grows to the size of the scalar which is no bigger than necessary.
+            c5.value_type . should_equal (Value_Type.Integer Bits.Bits_32)
+            Problems.assume_no_problems c5

--- a/test/Table_Tests/src/In_Memory/Main.enso
+++ b/test/Table_Tests/src/In_Memory/Main.enso
@@ -7,6 +7,7 @@ import project.In_Memory.Builders_Spec
 import project.In_Memory.Column_Spec
 import project.In_Memory.Column_Format_Spec
 import project.In_Memory.Common_Spec
+import project.In_Memory.Integer_Overflow_Spec
 import project.In_Memory.Join_Performance_Spec
 import project.In_Memory.Lossy_Conversions_Spec
 import project.In_Memory.Parse_To_Table_Spec
@@ -21,6 +22,7 @@ spec =
     Column_Spec.spec
     Column_Format_Spec.spec
     Common_Spec.spec
+    Integer_Overflow_Spec.spec
     Lossy_Conversions_Spec.spec
     Table_Date_Spec.spec
     Table_Date_Time_Spec.spec


### PR DESCRIPTION
### Pull Request Description

- Closes #5159 
- Now data downloaded from the database can keep the type much closer to the original type (like string length limits or smaller integer types).
- Cast also exposes these types.
- The integers are still all stored as 64-bit Java `long`s, we just check their bounds. Changing underlying storage for memory efficiency may come in the future: #6109 
- Fixes #7565
- Fixes #7529 by checking for arithmetic overflow in in-memory integer arithmetic operations that could overflow. Adds a documentation note saying that the behaviour for Database backends is unspecified and depends on particular database.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
