### PR TITLE
Proper dropdown active area and arrow placement

### DIFF
--- a/app/gui/language/span-tree/src/generate.rs
+++ b/app/gui/language/span-tree/src/generate.rs
@@ -254,11 +254,12 @@ impl<'a> ApplicationBase<'a> {
         ApplicationBase { function_name, ..self }
     }
 
-    fn raw_node_data(&self) -> crate::node::ApplicationData {
+    fn raw_node_data(&self, is_prefix: bool) -> crate::node::ApplicationData {
         crate::node::ApplicationData {
-            suggestion_id:  None,
-            icon_name:      None,
+            suggestion_id: None,
+            icon_name: None,
             self_in_access: self.uses_method_notation,
+            is_prefix,
         }
     }
 }
@@ -312,11 +313,12 @@ impl ResolvedApplication {
         self.chain_arguments.push_front(argument)
     }
 
-    fn node_data(&self) -> crate::node::ApplicationData {
+    fn node_data(&self, is_prefix: bool) -> crate::node::ApplicationData {
         crate::node::ApplicationData {
-            suggestion_id:  self.suggestion_id,
-            icon_name:      self.icon_name.clone(),
+            suggestion_id: self.suggestion_id,
+            icon_name: self.icon_name.clone(),
             self_in_access: self.argument_in_access.is_some(),
+            is_prefix,
         }
     }
 }
@@ -382,8 +384,9 @@ impl SpanTreeGenerator for GeneralizedInfix {
         let kind = kind.into();
         let mut app_base = ApplicationBase::from_infix(self);
         let mut application = app_base.resolve(context);
-        let node_application =
-            application.as_ref().map_or_else(|| app_base.raw_node_data(), |r| r.node_data());
+        let node_application = application
+            .as_ref()
+            .map_or_else(|| app_base.raw_node_data(false), |r| r.node_data(false));
         if app_base.uses_method_notation {
             // This is a standalone method access chain, missing method parameters needs to be
             // handled here. It is guaranteed that no existing prefix arguments are present, as
@@ -559,7 +562,7 @@ fn generate_node_for_prefix_chain(
     let fallback_call_id = app_base.call_id;
     let mut application = app_base.resolve(context);
     let node_application =
-        application.as_ref().map_or_else(|| app_base.raw_node_data(), |r| r.node_data());
+        application.as_ref().map_or_else(|| app_base.raw_node_data(true), |r| r.node_data(true));
 
     // When using method notation, expand the infix access chain manually to maintain correct method
     // application info and avoid generating expected arguments twice. We cannot use the
@@ -801,7 +804,7 @@ fn generate_expected_argument(
     let arg_node = gen.generate_empty_node(InsertionPointType::ExpectedArgument { index, named });
     arg_node.node.set_argument_info(argument_info);
     arg_node.node.set_port_id(port_id);
-    gen.into_node(node::Kind::chained_infix(), None).with_extended_ast_id(extended_ast_id)
+    gen.into_node(node::Kind::ChainedPrefix, None).with_extended_ast_id(extended_ast_id)
 }
 
 /// Build a prefix application-like span tree structure where no prefix argument has been provided
@@ -1250,7 +1253,7 @@ mod test {
             sth_else => panic!("There should be 4 leaves, found: {}", sth_else.len()),
         }
         let expected = TreeBuilder::new(8)
-            .add_child(0, 8, node::Kind::chained_infix(), Crumbs::default())
+            .add_child(0, 8, node::Kind::ChainedPrefix, Crumbs::default())
             .add_child(0, 8, node::Kind::ChainedPrefix, Crumbs::default())
             .add_leaf(0, 3, node::Kind::Operation, PrefixCrumb::Func)
             .add_leaf(4, 4, node::Kind::prefix_argument().removable().indexed(0), PrefixCrumb::Arg)
@@ -1282,7 +1285,7 @@ mod test {
             sth_else => panic!("There should be 5 leaves, found: {}", sth_else.len()),
         }
         let expected = TreeBuilder::new(8)
-            .add_child(0, 8, node::Kind::chained_infix(), Crumbs::default())
+            .add_child(0, 8, node::Kind::ChainedPrefix, Crumbs::default())
             .add_child(0, 8, node::Kind::Operation, Crumbs::default())
             .add_leaf(0, 4, node::Kind::argument(), InfixCrumb::LeftOperand)
             .add_leaf(4, 1, node::Kind::Operation, InfixCrumb::Operator)

--- a/app/gui/language/span-tree/src/node.rs
+++ b/app/gui/language/span-tree/src/node.rs
@@ -56,6 +56,7 @@ pub struct ApplicationData {
     pub suggestion_id:  Option<usize>,
     pub icon_name:      Option<ImString>,
     pub self_in_access: bool,
+    pub is_prefix:      bool,
 }
 
 

--- a/app/gui/view/graph-editor/src/component/node/input/widget.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget.rs
@@ -1688,7 +1688,8 @@ impl<'a> TreeBuilder<'a> {
         let parent_extensions_len = self.extensions.len();
 
         // TODO: We always use `main_nodes` here right now, as widgets are never visible when the
-        // node in edit mode. Once this changes, we will need to use `edited_nodes` conditionally.
+        // node is in edit the mode. Once this changes, we will need to use `edited_nodes`
+        // conditionally.
         let layers = self.layers.main_nodes.layers_for_widgets_at_depth(depth);
 
         let ctx = ConfigContext {

--- a/app/gui/view/graph-editor/src/component/node/input/widget.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget.rs
@@ -396,8 +396,8 @@ macro_rules! define_widget_modules(
     };
 );
 
-/// Definition of implemented widget kinds. The order of the definitions determines the order in
-/// which the widgets are checked for a match with every span-tree node.
+// Definition of implemented widget kinds. The order of the definitions determines the order in
+// which the widgets are checked for a match with every span-tree node.
 define_widget_modules! {
     /// A widget for top-level Enso method calls. Displays an icon.
     Method method,

--- a/app/gui/view/graph-editor/src/component/node/input/widget.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget.rs
@@ -329,7 +329,7 @@ macro_rules! define_widget_modules(
 
             /// Return a bitfield that determines which widget kinds need to be checked for a match
             /// before applying this configuration as override.
-            fn flags_to_query_before_override(&self) -> KindFlags {
+            fn flags_with_priority_before_override(&self) -> KindFlags {
                 // All bits that are set before the current one. Since we know that the `self.flag`
                 // always has only a single bit set, we can just subtract 1 from it.
                 let all_defined_before = KindFlags::from_bits_retain(self.flag().bits() - 1);
@@ -1729,11 +1729,11 @@ impl<'a> TreeBuilder<'a> {
             Some(override_config) => {
                 // Once an override is determined, check if there are other higher-priority widgets
                 // that would like to force their configuration on this node, despite the override.
-                let to_query =
-                    override_config.kind.flags_to_query_before_override() & allowed_configs;
+                let with_priority =
+                    override_config.kind.flags_with_priority_before_override() & allowed_configs;
 
                 let matched_before_override =
-                    Configuration::infer_from_context(&ctx, to_query, Score::OnlyOverride);
+                    Configuration::infer_from_context(&ctx, with_priority, Score::OnlyOverride);
                 if let Some(matched) = matched_before_override {
                     // When an applicable local override ends up not being applied, we need to put
                     // it back into the local overrides map. It may still be used by a child widget

--- a/app/gui/view/graph-editor/src/component/node/input/widget.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget.rs
@@ -76,6 +76,7 @@ pub(super) mod prelude {
     pub use super::ConfigContext;
     pub use super::Configuration;
     pub use super::IdentityBase;
+    pub use super::KindFlags;
     pub use super::NodeInfo;
     pub use super::OverrideKey;
     pub use super::Score;
@@ -165,6 +166,11 @@ pub struct OverrideKey {
 pub trait SpanWidget: display::Object {
     /// Configuration associated with specific widget variant.
     type Config: Debug + Clone + PartialEq;
+    /// Declare whether this widget should be considered for creation despite a config override
+    /// being present. Widgets that declare `true` here should always create a child widget on
+    /// the same span-tree node, so that the override can eventually be applied to it. Only widgets
+    /// declared before the widget selected by override will take priority over it.
+    const QUERY_ON_OVERRIDE: bool = false;
     /// Score how well a widget kind matches current [`ConfigContext`], e.g. checking if the span
     /// node or declaration type match specific patterns. When this method returns
     /// [`Score::Mismatch`], this widget kind will not be used, even if it was requested by an
@@ -269,20 +275,25 @@ macro_rules! define_widget_modules(
         bitflags::bitflags!{
             /// A set of flags that determine the widget kind.
             #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-            pub struct DynKindFlags: u32 {
+            pub struct KindFlags: u32 {
                 $(
                     #[allow(missing_docs, non_upper_case_globals)]
                     const $name = 1 << ${index()};
                 )*
+                /// A combination of flags for all widget kinds that has to be matched first before
+                /// accepting an overridden configuration.
+                const QUERY_ON_OVERRIDE = $(
+                    (<$module::Widget as SpanWidget>::QUERY_ON_OVERRIDE as u32) << ${index()}
+                )|*;
             }
         }
 
-        impl DynKindFlags {
+        impl KindFlags {
             /// Check whether the widget kind matching this flag is able to receive given span node.
             /// When more than one flag is set, [`Score::Mismatch`] will be returned.
             fn match_node(&self, ctx: &ConfigContext) -> Score {
                 match self {
-                    $(&DynKindFlags::$name => $module::Widget::match_node(ctx),)*
+                    $(&KindFlags::$name => $module::Widget::match_node(ctx),)*
                     _ => Score::Mismatch,
                 }
             }
@@ -290,7 +301,7 @@ macro_rules! define_widget_modules(
             /// Create default configuration of the widget kind contained within this flag.
             fn default_config(&self, ctx: &ConfigContext) -> Configuration {
                 match self {
-                    $(&DynKindFlags::$name => $module::Widget::default_config(ctx).into_dyn(),)*
+                    $(&KindFlags::$name => $module::Widget::default_config(ctx).into_dyn(),)*
                     _ => panic!("No widget kind specified.")
                 }
             }
@@ -298,10 +309,19 @@ macro_rules! define_widget_modules(
 
         impl DynConfig {
             /// Return a single flag that determines the used widget kind.
-            fn flag(&self) -> DynKindFlags {
+            fn flag(&self) -> KindFlags {
                 match self {
-                    $(DynConfig::$name(_) => DynKindFlags::$name,)*
+                    $(DynConfig::$name(_) => KindFlags::$name,)*
                 }
+            }
+
+            /// Return a bitfield that determines which widget kinds needs to be checked for a match
+            /// before applying this configuration as override.
+            fn flags_to_query_before_override(&self) -> KindFlags {
+                // All bits that are set before the current one. Since we know that the `self.flag`
+                // always has only a single bit set, we can just subtract 1 from it.
+                let all_defined_before = KindFlags::from_bits_retain(self.flag().bits() - 1);
+                all_defined_before & KindFlags::QUERY_ON_OVERRIDE
             }
         }
 
@@ -367,8 +387,14 @@ macro_rules! define_widget_modules(
 define_widget_modules! {
     /// A widget for top-level Enso method calls. Displays an icon.
     Method method,
+    /// Separating line between top-level argument widgets. Can only be assigned through override,
+    /// which is currently done in hierarchy widget.
+    Separator separator,
     /// A widget for selecting a single value from a list of available options.
     SingleChoice single_choice,
+    /// Displays the argument name next to its value widget. Can only be assigned through override,
+    /// which is currently done in separator widget.
+    ArgumentName argument_name,
     /// A widget for managing a list of values - adding, removing or reordering them.
     ListEditor list_editor,
     /// Empty widget that does not display anything, used for empty insertion points.
@@ -379,13 +405,6 @@ define_widget_modules! {
     Blank blank,
     /// Default widget that only displays text.
     Label label,
-    /// Separating line between top-level argument widgets. Can only be assigned through override,
-    /// which is currently done in hierarchy widget.
-    Separator separator,
-    /// Displays the argument name next to its value widget. Can only be assigned through override,
-    /// which is currently done in separator widget.
-    ArgumentName argument_name,
-
 }
 
 // =====================
@@ -416,22 +435,24 @@ impl Configuration {
     ///
     /// Will never return any configuration kind specified in `disallow` parameter, except for
     /// [`DynConfig::Label`] as an option of last resort.
-    fn infer_from_context(ctx: &ConfigContext, disallowed: DynKindFlags) -> Self {
-        let allowed = !disallowed;
+    fn infer_from_context(
+        ctx: &ConfigContext,
+        allowed: KindFlags,
+        score_better_than: Score,
+    ) -> Option<Self> {
         let mut best_match = None;
         for kind in allowed {
             let score = kind.match_node(ctx);
-            let current_score = best_match.map(|(_, score)| score).unwrap_or(Score::Mismatch);
+            let current_score = best_match.map(|(_, score)| score).unwrap_or(score_better_than);
             if score > current_score {
                 best_match = Some((kind, score));
-                if score == Score::Perfect {
+                if score >= Score::Perfect {
                     break;
                 }
             }
         }
 
-        let matched_kind = best_match.map_or(DynKindFlags::Label, |(kind, _)| kind);
-        matched_kind.default_config(ctx)
+        best_match.map(|(kind, _score)| kind.default_config(ctx))
     }
 
     /// An insertion point that always has a port.
@@ -721,7 +742,7 @@ impl Tree {
             styles,
         );
         self.frp.private.output.on_rebuild_finished.emit(());
-        trace!("Widget tree:\n{:?}", self.pretty_printer());
+        console_log!("Widget tree:\n{:?}", self.pretty_printer());
     }
 
     /// Get the root display object of the widget port for given span tree node. Not all nodes must
@@ -1447,12 +1468,12 @@ impl WidgetIdentity {
 #[derive(Debug, Default)]
 struct PointerUsage {
     /// Next sequence index that will be assigned to a widget created for the same span tree node.
-    next_index:    usize,
+    next_index:       usize,
     /// The pointer index of a widget on this span tree that received a port, if any exist already.
-    assigned_port: Option<(PortId, usize)>,
-    /// The widget configuration kinds that were already used for this span tree node. Those will
-    /// be excluded from config possibilities of the next widget created for this node.
-    used_configs:  DynKindFlags,
+    assigned_port:    Option<(PortId, usize)>,
+    /// The widget kinds that are no longer allowed to be created for this widget pointer. Most
+    /// often used for widgets that were already created on this node.
+    disallowed_kinds: KindFlags,
 }
 
 impl PointerUsage {
@@ -1542,6 +1563,17 @@ impl<'a> TreeBuilder<'a> {
         self.node_settings.custom_child_port_hover_padding = padding;
     }
 
+    /// Mark certain widget kinds as forbidden for particular span-tree node. When the widgets for
+    /// that node are being built, the builder will not evaluate those widget's matching rules.
+    /// This method only has an effect for future widgets created for the same node, and does not
+    /// affect widgets that were already created. Make sure to call it before using
+    /// [`TreeBuilder::create_widget`] on that node.
+    pub fn forbid_widget_kind(&mut self, span_node: &SpanRef<'_>, widget_kinds: KindFlags) {
+        let main_ptr = StableSpanIdentity::from_node(span_node);
+        let ptr_usage = self.pointer_usage.entry(main_ptr).or_default();
+        ptr_usage.disallowed_kinds |= widget_kinds;
+    }
+
     /// Create a new child widget, along with its whole subtree. The widget type will be
     /// automatically inferred, either based on the node kind, or on the configuration provided
     /// from the language server. If possible, an existing widget will be reused under the same
@@ -1612,8 +1644,6 @@ impl<'a> TreeBuilder<'a> {
 
         let disabled = self.node_disabled;
 
-        // TODO: We always use `main_nodes` here right now, as widgets are never visible when the
-        // node in edit mode. Once this changes, we will need to use conditionally use `edit_nodes`.
         let info = NodeInfo {
             identity: widget_id,
             insertion_index,
@@ -1624,17 +1654,27 @@ impl<'a> TreeBuilder<'a> {
             usage_type,
         };
 
-        // Get widget configuration. There are three potential sources for configuration, that are
+        // == Determine widget configuration ==
+
+        // There are three potential sources for configuration, that are
         // used in order, whichever is available and allowed first:
         // 1. The `configuration` argument, which can be set by the parent widget if it wants to
         //    override the configuration for its child.
         // 2. The override associated with a the span tree node, located using `OverrideKey`. This
-        // can be    set by an external source, e.g. based on language server.
+        // can be set by an external source, e.g. based on language server.
         // 3. The default configuration for the widget, which is determined based on the node kind,
         // usage type and whether it has children.
-        let disallowed_configs = ptr_usage.used_configs;
+        //
+        // Note that the override can still be rejected if there is an available higher priority
+        // applicable widget that defines [`SpanWidget::QUERY_ON_OVERRIDE`] as `true` in its
+        // implementation. In that case, it is expected that the forcing widget will declare a child
+        // using the same span-tree node, so that the override can eventually be applied anyway.
+
+        let allowed_configs = !ptr_usage.disallowed_kinds;
         let parent_extensions_len = self.extensions.len();
 
+        // TODO: We always use `main_nodes` here right now, as widgets are never visible when the
+        // node in edit mode. Once this changes, we will need to use conditionally use `edit_nodes`.
         let layers = self.layers.main_nodes.layers_for_widgets_at_depth(depth);
 
         let ctx = ConfigContext {
@@ -1646,41 +1686,68 @@ impl<'a> TreeBuilder<'a> {
         };
 
 
-        let mut select_configuration_override = || {
-            let is_applicable = |ctx: &ConfigContext, cfg: &Configuration| {
-                let flag = cfg.kind.flag();
-                !disallowed_configs.contains(flag)
-                    && !matches!(flag.match_node(ctx), Score::Mismatch)
-            };
-
-            if let Some(config) = configuration.filter(|c| is_applicable(&ctx, c)) {
-                return Some(Cow::Borrowed(config));
-            }
-
-            let kind = &ctx.span_node.kind;
-            let key = OverrideKey {
-                call_id:       kind.call_id()?,
-                argument_name: kind.argument_name()?.into(),
-            };
-            let local_override = ctx.builder.local_overrides.remove(&key);
-            let override_map = &ctx.builder.override_map;
-
-
-            let local = local_override.filter(|c| is_applicable(&ctx, c)).map(Cow::Owned);
-            local.or_else(|| {
-                override_map.get(&key).filter(|c| is_applicable(&ctx, c)).map(Cow::Borrowed)
-            })
+        let config_is_applicable = |ctx: &ConfigContext, cfg: &Configuration| {
+            let flag = cfg.kind.flag();
+            allowed_configs.contains(flag) && flag.match_node(ctx) > Score::Mismatch
         };
 
-        let configuration = match select_configuration_override() {
-            Some(config) => config,
-            None => Cow::Owned(Configuration::infer_from_context(&ctx, disallowed_configs)),
+        let mut local_override_key = None;
+        let arg_override =
+            configuration.filter(|c| config_is_applicable(&ctx, c)).map(Cow::Borrowed);
+        let applicable_override = arg_override.or_else(|| {
+            let key = OverrideKey {
+                call_id:       ctx.span_node.kind.call_id()?,
+                argument_name: ctx.span_node.kind.argument_name()?.into(),
+            };
+            let from_local_map = ctx.builder.local_overrides.remove(&key);
+            if let Some(local_override) = from_local_map.filter(|c| config_is_applicable(&ctx, c)) {
+                local_override_key = Some(key);
+                Some(Cow::Owned(local_override))
+            } else {
+                let external_override =
+                    ctx.builder.override_map.get(&key).filter(|c| config_is_applicable(&ctx, c));
+                external_override.map(Cow::Borrowed)
+            }
+        });
+
+        let configuration = match applicable_override {
+            Some(override_config) => {
+                // Once an override is determined, check if there are other higher-priority widgets
+                // that would like to force their configuration on this node, despite the override.
+                let to_query =
+                    override_config.kind.flags_to_query_before_override() & allowed_configs;
+
+                let matched_before_override =
+                    Configuration::infer_from_context(&ctx, to_query, Score::OnlyOverride);
+                if let Some(matched) = matched_before_override {
+                    // When an applicable local override ends up not being applied, we need to put
+                    // it back into the local overrides map. It may still be used by a child widget
+                    // defined on the same span-tree node.
+                    if let Some(key) = local_override_key {
+                        ctx.builder.local_overrides.insert(key, override_config.into_owned());
+                    }
+                    Cow::Owned(matched)
+                } else {
+                    override_config
+                }
+
+                // If the override config was rejected, put it back into the local overrides map.
+            }
+            None => Cow::Owned(
+                Configuration::infer_from_context(&ctx, allowed_configs, Score::Mismatch)
+                    .unwrap_or_else(|| {
+                        // When no applicable widget was found, fallback to the label.
+                        KindFlags::Label.default_config(&ctx)
+                    }),
+            ),
         };
         let configuration = configuration.as_ref();
 
+        // == Apply selected configuration. ==
+
         let this = &mut *ctx.builder;
         let ptr_usage = this.pointer_usage.entry(main_ptr).or_default();
-        ptr_usage.used_configs |= configuration.kind.flag();
+        ptr_usage.disallowed_kinds |= configuration.kind.flag();
         let can_assign_port = configuration.has_port && !is_extended_ast;
         let widget_has_port =
             ptr_usage.request_port(&widget_id, ctx.span_node.port_id, can_assign_port);
@@ -1690,6 +1757,7 @@ impl<'a> TreeBuilder<'a> {
         let parent_info = mem::replace(&mut this.parent_info, Some(info.clone()));
         let saved_node_settings = mem::take(&mut this.node_settings);
 
+        // === Create the widget ===
 
         // Widget creation/update can recurse into the builder. All borrows must be dropped
         // at this point. The `configure` calls on the widgets are allowed to call back into the
@@ -1716,6 +1784,8 @@ impl<'a> TreeBuilder<'a> {
             TreeNode::Widget(widget)
         };
 
+        // === Maintain hierarchy ===
+
         // Once the node has been configured and all its children have been created, we can update
         // the hierarchy data.
         self.hierarchy[insertion_index].total_descendants =
@@ -1725,6 +1795,8 @@ impl<'a> TreeBuilder<'a> {
         self.parent_info = parent_info;
         self.last_ast_depth = parent_last_ast_depth;
         self.extensions.truncate(parent_extensions_len);
+
+        // === Apply layout ===
 
         let skip_self_margin = self.node_settings.skip_self_margin;
         self.node_settings = saved_node_settings;

--- a/app/gui/view/graph-editor/src/component/node/input/widget/argument_name.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/argument_name.rs
@@ -46,10 +46,13 @@ pub struct Widget {
 impl SpanWidget for Widget {
     type Config = Config;
 
+    const QUERY_ON_OVERRIDE: bool = true;
     fn match_node(ctx: &ConfigContext) -> Score {
         let kind = &ctx.span_node.kind;
-        let matches = ctx.info.subtree_connection.is_none() && kind.is_prefix_argument();
-        Score::allow_override_if(matches)
+        let matches = ctx.info.subtree_connection.is_none()
+            && ctx.info.nesting_level.is_primary()
+            && kind.is_prefix_argument();
+        Score::only_if(matches)
     }
 
     fn default_config(_: &ConfigContext) -> Configuration<Self::Config> {

--- a/app/gui/view/graph-editor/src/component/node/input/widget/argument_name.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/argument_name.rs
@@ -46,7 +46,7 @@ pub struct Widget {
 impl SpanWidget for Widget {
     type Config = Config;
 
-    const QUERY_ON_OVERRIDE: bool = true;
+    const PRIORITY_OVER_OVERRIDE: bool = true;
     fn match_node(ctx: &ConfigContext) -> Score {
         let kind = &ctx.span_node.kind;
         let matches = ctx.info.subtree_connection.is_none()

--- a/app/gui/view/graph-editor/src/component/node/input/widget/hierarchy.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/hierarchy.rs
@@ -51,21 +51,9 @@ impl SpanWidget for Widget {
     }
 
     fn configure(&mut self, _: &Config, ctx: ConfigContext) {
-        let child_level = ctx.info.nesting_level.next_if(ctx.span_node.kind.is_prefix_argument());
-        let is_primary = ctx.info.nesting_level.is_primary();
-
-        // When this is a top-level (primary) hierarchy widget, request children widgets to have
-        // separators. The "separator" widget is a wrapper which will display the default argument
-        // widget next to the separating line. This configuration will only be applied to nodes that
-        // the separator accepts, which is limited to arguments in prefix chains.
-        let separator_config = super::separator::Widget::default_config(&ctx).into_dyn();
-        let child_config = is_primary.then_some(&separator_config);
-
-        self.children_vec.clear();
-        self.children_vec.extend(ctx.span_node.children_iter().map(|node| {
-            ctx.builder.child_widget_of_type(node, child_level, child_config).root_object
-        }));
-
+        let level = ctx.info.nesting_level.next_if(ctx.span_node.kind.is_prefix_argument());
+        let iter = ctx.span_node.children_iter();
+        self.children_vec.extend(iter.map(|n| ctx.builder.child_widget(n, level).root_object));
         self.display_object.replace_children(&self.children_vec);
         self.children_vec.clear();
     }

--- a/app/gui/view/graph-editor/src/component/node/input/widget/separator.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/separator.rs
@@ -43,7 +43,7 @@ pub struct Widget {
 impl SpanWidget for Widget {
     type Config = Config;
 
-    const QUERY_ON_OVERRIDE: bool = true;
+    const PRIORITY_OVER_OVERRIDE: bool = true;
     fn match_node(ctx: &ConfigContext) -> Score {
         let kind = &ctx.span_node.kind;
         let matches = ctx.info.nesting_level.is_primary()
@@ -93,7 +93,7 @@ impl SpanWidget for Widget {
             let _name_node = child_iter.next();
             let _token = child_iter.next();
             let Some(arg_node) = child_iter.next() else { return };
-            // make sure to not create another layer of separator for that nested node.
+            // Make sure to not create another layer of separator for that nested node.
             ctx.builder.forbid_widget_kind(&arg_node, KindFlags::Separator);
             ctx.builder.child_widget(arg_node, level)
         } else {

--- a/app/gui/view/graph-editor/src/component/node/input/widget/separator.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget/separator.rs
@@ -43,13 +43,14 @@ pub struct Widget {
 impl SpanWidget for Widget {
     type Config = Config;
 
+    const QUERY_ON_OVERRIDE: bool = true;
     fn match_node(ctx: &ConfigContext) -> Score {
         let kind = &ctx.span_node.kind;
         let matches = ctx.info.nesting_level.is_primary()
             && (kind.is_expected_argument()
                 || kind.is_prefix_argument()
                 || kind.is_named_argument());
-        Score::allow_override_if(matches)
+        Score::only_if(matches)
     }
 
     fn default_config(_: &ConfigContext) -> Configuration<Self::Config> {
@@ -83,12 +84,6 @@ impl SpanWidget for Widget {
         ctx.builder.manage_child_margins();
         let level = ctx.info.nesting_level;
 
-        // Request separator children widgets to have argument name displayed. This configuration
-        // will only apply to nodes that need it, as the `argument_name` widget will only match
-        // relevant nodes.
-        let argument_name_config = super::argument_name::Widget::default_config(&ctx).into_dyn();
-        let child_config = Some(&argument_name_config);
-
         // NOTE: In order to have proper port behavior for named arguments, the separator widget
         // must handle the named argument nodes, and create a child only for the value part. It is
         // the argument value node that receives the port, and we want that port to be displayed
@@ -98,9 +93,11 @@ impl SpanWidget for Widget {
             let _name_node = child_iter.next();
             let _token = child_iter.next();
             let Some(arg_node) = child_iter.next() else { return };
-            ctx.builder.child_widget_of_type(arg_node, level, child_config)
+            // make sure to not create another layer of separator for that nested node.
+            ctx.builder.forbid_widget_kind(&arg_node, KindFlags::Separator);
+            ctx.builder.child_widget(arg_node, level)
         } else {
-            ctx.builder.child_widget_of_type(ctx.span_node, level, child_config)
+            ctx.builder.child_widget(ctx.span_node, level)
         };
 
         let separator = self.separator.display_object();

--- a/app/gui/view/project-view-top-bar/src/lib.rs
+++ b/app/gui/view/project-view-top-bar/src/lib.rs
@@ -34,6 +34,8 @@ pub mod project_name;
 
 pub use breadcrumbs::LocalCall;
 
+
+
 mod breadcrumbs;
 
 

--- a/app/gui/view/src/notification.rs
+++ b/app/gui/view/src/notification.rs
@@ -10,7 +10,6 @@ use crate::notification::logged::UpdateOptions;
 use ensogl::application::Application;
 
 
-
 // ==============
 // === Export ===
 // ==============

--- a/app/gui/view/src/notification/logged.rs
+++ b/app/gui/view/src/notification/logged.rs
@@ -16,7 +16,6 @@ use crate::notification::js::HandleJsError;
 use uuid::Uuid;
 
 
-
 // ==============
 // === Export ===
 // ==============

--- a/lib/rust/ensogl/app/theme/hardcoded/src/lib.rs
+++ b/lib/rust/ensogl/app/theme/hardcoded/src/lib.rs
@@ -657,7 +657,7 @@ define_themes! { [light:0, dark:1]
             /// Additional space around the triangle shape that will detect mouse hover.
             triangle_offset = Vector2(0.0, -7.0);
             dropdown_offset = Vector2(0.0, -20.0);
-            dropdown_max_size = Vector2(300.0, 500.0);
+            dropdown_max_size = Vector2(800.0, 600.0);
             dropdown_tint = Rgba(0.0,0.0,0.0,0.1);
         }
         list_view {


### PR DESCRIPTION
### Pull Request Description

Fixes #7423

Refactored widget matching algorithm to allow creating wrapper widgets even in cases where the widget config override is present. That allowed the widgets to be reordered, such that the argument name ends up being inside the dropdown widget. That way clicking it opens the dropdown.

Added explicit manual layout for the dropdown arrow position. Now it is positioned on the center of a selected appropriate child widget. For prefix chains, the leftmost part of the prefix application (the method or constructor) is selected.

https://github.com/enso-org/enso/assets/919491/86678b9d-c04e-4545-8d11-2d1e85b9b951


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
