### PR TITLE
Load a maximum of one IDE entrypoint

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/dashboard.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/dashboard.tsx
@@ -344,6 +344,7 @@ export default function Dashboard(props: DashboardProps) {
                 )}
                 <Editor
                     visible={page === pageSwitcher.Page.editor}
+                    supportsLocalBackend={supportsLocalBackend}
                     projectStartupInfo={projectStartupInfo}
                     appRunner={appRunner}
                 />

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/editor.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/editor.tsx
@@ -28,14 +28,16 @@ const JS_EXTENSION: Record<backendModule.BackendType, string> = {
 /** Props for an {@link Editor}. */
 export interface EditorProps {
     visible: boolean
+    supportsLocalBackend: boolean
     projectStartupInfo: backendModule.ProjectStartupInfo | null
     appRunner: AppRunner
 }
 
 /** The container that launches the IDE. */
 export default function Editor(props: EditorProps) {
-    const { visible, projectStartupInfo, appRunner } = props
+    const { visible, supportsLocalBackend, projectStartupInfo, appRunner } = props
     const toastAndLog = hooks.useToastAndLog()
+    const [initialized, setInitialized] = React.useState(supportsLocalBackend)
 
     React.useEffect(() => {
         const ideElement = document.getElementById(IDE_ELEMENT_ID)
@@ -69,10 +71,8 @@ export default function Editor(props: EditorProps) {
                 const binaryAddress = project.binaryAddress
                 if (jsonAddress == null) {
                     toastAndLog("Could not get the address of the project's JSON endpoint")
-                    return
                 } else if (binaryAddress == null) {
                     toastAndLog("Could not get the address of the project's binary endpoint")
-                    return
                 } else {
                     let assetsRoot: string
                     switch (backendType) {
@@ -119,15 +119,16 @@ export default function Editor(props: EditorProps) {
                             { projectId: project.projectId }
                         )
                     }
-                    if (backendType === backendModule.BackendType.local) {
+                    if (supportsLocalBackend) {
                         await runNewProject()
-                        return
                     } else {
-                        const [style, script] = await Promise.all([
-                            load.loadStyle(`${assetsRoot}style.css`),
-                            load.loadScript(`${assetsRoot}index.js.gz`),
-                        ])
-                        script.remove()
+                        if (!initialized) {
+                            await Promise.all([
+                                load.loadStyle(`${assetsRoot}style.css`),
+                                load.loadScript(`${assetsRoot}index.js.gz`),
+                            ])
+                            setInitialized(true)
+                        }
                         const originalUrl = window.location.href
                         // The URL query contains commandline options when running in the desktop,
                         // which will break the entrypoint for opening a fresh IDE instance.
@@ -135,15 +136,14 @@ export default function Editor(props: EditorProps) {
                         await runNewProject()
                         // Restore original URL so that initialization works correctly on refresh.
                         history.replaceState(null, '', originalUrl)
-                        return () => {
-                            style.remove()
-                        }
                     }
                 }
             })()
             return () => {
                 appRunner.stopApp()
             }
+        } else {
+            return
         }
     }, [
         projectStartupInfo,


### PR DESCRIPTION
### Pull Request Description
Fix for `showLogs` when opening a second cloud project. Alternative to #7568.
This one avoids loading the cloud's `index.js.gz`, unless it is in the cloud - and in the cloud, it only loads the first `index.js.gz`.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
