### PR TITLE
Use only Type instances as keys for State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -917,6 +917,7 @@
 - [Using official BigInteger support][7420]
 - [Allow users to give a project other than Upper_Snake_Case name][7397]
 - [Support renaming variable or function][7515]
+- [Only use types as State keys][7585]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -1048,6 +1049,7 @@
 [7420]: https://github.com/enso-org/enso/pull/7420
 [7397]: https://github.com/enso-org/enso/pull/7397
 [7515]: https://github.com/enso-org/enso/pull/7515
+[7585]: https://github.com/enso-org/enso/pull/7585
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/State.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Runtime/State.enso
@@ -12,7 +12,7 @@ from project.Errors.Common import Uninitialized_State
 
    Arguments:
    - key: The key to associate your local_state with in the environment.
-     It is recommended that types be used as keys.
+     Use types as keys.
    - local_state: The value to associate with key.
    - computation: The computation to execute in the local state
      environment.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/SQL.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/SQL.enso
@@ -158,23 +158,23 @@ optimize_fragments : Vector SQL_Fragment -> Vector SQL_Fragment
 optimize_fragments fragments =
     builder = Vector.new_builder
     go elem =
-        last_part = State.get SQL_Fragment.Code_Part
+        last_part = State.get SQL_Fragment
         case elem of
             SQL_Fragment.Code_Part code ->
                 new_part = case last_part of
                     Nothing -> SQL_Fragment.Code_Part code
                     SQL_Fragment.Code_Part other -> SQL_Fragment.Code_Part other+code
-                State.put SQL_Fragment.Code_Part new_part
+                State.put SQL_Fragment new_part
             SQL_Fragment.Interpolation _ ->
                 case last_part of
                     Nothing -> Nothing
                     SQL_Fragment.Code_Part _ ->
                         builder.append last_part
-                        State.put SQL_Fragment.Code_Part Nothing
+                        State.put SQL_Fragment Nothing
                 builder.append elem
-    State.run SQL_Fragment.Code_Part Nothing <|
+    State.run SQL_Fragment Nothing <|
         fragments.each go
-        last_part = State.get SQL_Fragment.Code_Part
+        last_part = State.get SQL_Fragment
         case last_part of
             Nothing -> Nothing
             SQL_Fragment.Code_Part _ -> builder.append last_part

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/state/GetStateNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/state/GetStateNode.java
@@ -1,10 +1,5 @@
 package org.enso.interpreter.node.expression.builtin.state;
 
-import org.enso.interpreter.dsl.BuiltinMethod;
-import org.enso.interpreter.runtime.EnsoContext;
-import org.enso.interpreter.runtime.error.PanicException;
-import org.enso.interpreter.runtime.state.State;
-
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.ReportPolymorphism;
@@ -12,6 +7,10 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.object.DynamicObjectLibrary;
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.EnsoContext;
+import org.enso.interpreter.runtime.error.PanicException;
+import org.enso.interpreter.runtime.state.State;
 
 @BuiltinMethod(
     type = "State",

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/state/GetStateNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/state/GetStateNode.java
@@ -1,5 +1,10 @@
 package org.enso.interpreter.node.expression.builtin.state;
 
+import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.EnsoContext;
+import org.enso.interpreter.runtime.error.PanicException;
+import org.enso.interpreter.runtime.state.State;
+
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.ReportPolymorphism;
@@ -7,10 +12,6 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.object.DynamicObjectLibrary;
-import org.enso.interpreter.dsl.BuiltinMethod;
-import org.enso.interpreter.runtime.EnsoContext;
-import org.enso.interpreter.runtime.error.PanicException;
-import org.enso.interpreter.runtime.state.State;
 
 @BuiltinMethod(
     type = "State",

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/state/RunStateNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/state/RunStateNode.java
@@ -2,6 +2,7 @@ package org.enso.interpreter.node.expression.builtin.state;
 
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached.Shared;
+import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -12,6 +13,9 @@ import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.dsl.Suspend;
 import org.enso.interpreter.node.BaseNode;
 import org.enso.interpreter.node.callable.thunk.ThunkExecutorNode;
+import org.enso.interpreter.runtime.EnsoContext;
+import org.enso.interpreter.runtime.data.Type;
+import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.state.State;
 
 @BuiltinMethod(
@@ -35,7 +39,7 @@ public abstract class RunStateNode extends Node {
   Object doExisting(
       VirtualFrame frame,
       State state,
-      Object key,
+      Type key,
       Object local,
       Object computation,
       @Bind("state.getContainer()") State.Container data,
@@ -54,7 +58,7 @@ public abstract class RunStateNode extends Node {
   Object doFresh(
       VirtualFrame frame,
       State state,
-      Object key,
+      Type key,
       Object local,
       Object computation,
       @Bind("state.getContainer()") State.Container data,
@@ -66,5 +70,12 @@ public abstract class RunStateNode extends Node {
     } finally {
       objects.removeKey(data, key);
     }
+  }
+
+  @Fallback
+  Object doNonType(State state, Object key, Object local, Object computation) {
+    var b = EnsoContext.get(this).getBuiltins();
+    var payload = b.error().makeUnsupportedArgumentsError(new Object[] {key}, "Use type as a key.");
+    throw new PanicException(payload, this);
   }
 }

--- a/test/Tests/src/Main.enso
+++ b/test/Tests/src/Main.enso
@@ -69,6 +69,7 @@ import project.Runtime.Lazy_Spec
 import project.Runtime.Lazy_Generator_Spec
 import project.Runtime.Managed_Resource_Spec
 import project.Runtime.Ref_Spec
+import project.Runtime.State_Spec
 import project.Runtime.Stack_Traces_Spec
 
 import project.System.Environment_Spec
@@ -135,6 +136,7 @@ main = Test_Suite.run_main <|
     Runtime_Spec.spec
     Self_Type_Spec.spec
     Span_Spec.spec
+    State_Spec.spec
     Encoding_Spec.spec
     Text_Sub_Range_Spec.spec
     Managed_Resource_Spec.spec

--- a/test/Tests/src/Runtime/State_Spec.enso
+++ b/test/Tests/src/Runtime/State_Spec.enso
@@ -1,0 +1,25 @@
+from Standard.Base import all
+
+import Standard.Base.Runtime.State
+import Standard.Base.Errors.Common.Unsupported_Argument_Types
+
+from Standard.Test import Test, Test_Suite
+import Standard.Test.Extensions
+
+spec = Test.group "State" <|
+    Test.specify "Type as a key" <|
+        s = State.run Test 42 <|
+            State.get Test
+        s . should_equal 42
+
+    Test.specify "string as a key" <|
+        s n = State.run "my_state" n <|
+            State.get "my_state"
+
+        p = Panic.catch Unsupported_Argument_Types (s 42) err->
+            err.payload
+
+        Meta.type_of p . should_equal Unsupported_Argument_Types
+
+
+main = Test_Suite.run_main spec


### PR DESCRIPTION
### Pull Request Description

Fixes #7572 by requiring keys to be Type instances.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
