### PR TITLE
Special support for Python Date/Time/Zone interop

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Zone.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Zone.enso
@@ -2,6 +2,7 @@ import project.Any.Any
 import project.Data.Json.JS_Object
 import project.Data.Numbers.Integer
 import project.Data.Text.Text
+import project.Data.Time.Date_Time.Date_Time
 import project.Error.Error
 import project.Errors.Time_Error.Time_Error
 import project.Panic.Panic
@@ -154,6 +155,13 @@ type Time_Zone
              example_zone_id = Time_Zone.system.zone_id
     zone_id : Text
     zone_id self = @Builtin_Method "Time_Zone.zone_id"
+
+    ## Get the offset in seconds at given date time.
+       Arguments:
+       - at: The date to compute offset at.
+
+    offset : Date_Time -> Integer
+    offset self at = @Builtin_Method "Time_Zone.offset"
 
     ## PRIVATE
        Convert to a JavaScript Object representing this Time_Zone.

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/ForeignEvalNode.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/ForeignEvalNode.java
@@ -6,10 +6,8 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.exception.AbstractTruffleException;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.interop.ArityException;
+import com.oracle.truffle.api.interop.InteropException;
 import com.oracle.truffle.api.interop.InteropLibrary;
-import com.oracle.truffle.api.interop.UnsupportedMessageException;
-import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.Source;
 import java.util.Arrays;
@@ -55,8 +53,8 @@ public class ForeignEvalNode extends RootNode {
     if (foreign != null) {
       try {
         return foreign.execute(frame.getArguments());
-      } catch (UnsupportedMessageException | ArityException | UnsupportedTypeException ex) {
-        throw raise(RuntimeException.class, ex);
+      } catch (InteropException ex) {
+        throw new ForeignParsingException(ex.getMessage(), this);
       }
     } else {
       CompilerDirectives.transferToInterpreter();
@@ -186,10 +184,5 @@ public class ForeignEvalNode extends RootNode {
     } finally {
       inner.leave(this, p);
     }
-  }
-
-  @SuppressWarnings("unchecked")
-  private static <E extends Exception> E raise(Class<E> clazz, Exception ex) throws E {
-    throw (E) ex;
   }
 }

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/ForeignFunctionCallNode.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/ForeignFunctionCallNode.java
@@ -1,8 +1,6 @@
 package org.enso.interpreter.epb.node;
 
-import com.oracle.truffle.api.interop.ArityException;
-import com.oracle.truffle.api.interop.UnsupportedMessageException;
-import com.oracle.truffle.api.interop.UnsupportedTypeException;
+import com.oracle.truffle.api.interop.InteropException;
 import com.oracle.truffle.api.nodes.Node;
 
 /** An interface for nodes responsible for calling into foreign languages. */
@@ -12,7 +10,7 @@ public abstract class ForeignFunctionCallNode extends Node {
    *
    * @param arguments the arguments to pass to the foreign function
    * @return the result of executing the foreign function
+   * @throws InteropException when execution fails during foreign call
    */
-  public abstract Object execute(Object[] arguments)
-      throws UnsupportedTypeException, ArityException, UnsupportedMessageException;
+  public abstract Object execute(Object[] arguments) throws InteropException;
 }

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/ForeignFunctionCallNode.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/ForeignFunctionCallNode.java
@@ -1,5 +1,8 @@
 package org.enso.interpreter.epb.node;
 
+import com.oracle.truffle.api.interop.ArityException;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
+import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.nodes.Node;
 
 /** An interface for nodes responsible for calling into foreign languages. */
@@ -10,5 +13,6 @@ public abstract class ForeignFunctionCallNode extends Node {
    * @param arguments the arguments to pass to the foreign function
    * @return the result of executing the foreign function
    */
-  public abstract Object execute(Object[] arguments);
+  public abstract Object execute(Object[] arguments)
+      throws UnsupportedTypeException, ArityException, UnsupportedMessageException;
 }

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/JsForeignNode.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/JsForeignNode.java
@@ -2,7 +2,8 @@ package org.enso.interpreter.epb.node;
 
 import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.interop.*;
+import com.oracle.truffle.api.interop.InteropException;
+import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.library.CachedLibrary;
 
 /** A node responsible for performing foreign JS calls. */
@@ -30,19 +31,13 @@ public abstract class JsForeignNode extends ForeignFunctionCallNode {
 
   @Specialization
   Object doExecute(
-      Object[] arguments, @CachedLibrary("foreignFunction") InteropLibrary interopLibrary) {
+      Object[] arguments, @CachedLibrary("foreignFunction") InteropLibrary interopLibrary)
+      throws InteropException {
     int newLength = getArity() - 1;
     Object[] positionalArgs = new Object[newLength];
     System.arraycopy(arguments, 1, positionalArgs, 0, newLength);
-    try {
-      return coercePrimitiveNode.execute(
-          interopLibrary.invokeMember(
-              getForeignFunction(), "apply", arguments[0], new ReadOnlyArray(positionalArgs)));
-    } catch (UnsupportedMessageException
-        | UnknownIdentifierException
-        | ArityException
-        | UnsupportedTypeException e) {
-      throw new IllegalStateException("Invalid JS function resulted from parsing.");
-    }
+    return coercePrimitiveNode.execute(
+        interopLibrary.invokeMember(
+            getForeignFunction(), "apply", arguments[0], new ReadOnlyArray(positionalArgs)));
   }
 }

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/PyForeignNode.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/PyForeignNode.java
@@ -18,10 +18,6 @@ import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.source.Source;
 
-/**
- *
- * @author devel
- */
 @NodeField(name = "foreignFunction", type = Object.class)
 public abstract class PyForeignNode extends ForeignFunctionCallNode {
   @Child

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/PyForeignNode.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/PyForeignNode.java
@@ -1,5 +1,10 @@
 package org.enso.interpreter.epb.node;
 
+import java.time.LocalDate;
+
+import org.enso.interpreter.epb.EpbContext;
+
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.ArityException;
@@ -7,6 +12,7 @@ import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.library.CachedLibrary;
+import com.oracle.truffle.api.source.Source;
 
 @NodeField(name = "foreignFunction", type = Object.class)
 public abstract class PyForeignNode extends ForeignFunctionCallNode {
@@ -15,10 +21,40 @@ public abstract class PyForeignNode extends ForeignFunctionCallNode {
 
   abstract Object getForeignFunction();
 
+  @CompilerDirectives.TruffleBoundary
+  private Object wrapPythonDate(LocalDate date) {
+
+    var ctx = EpbContext.get(this);
+    var src = Source.newBuilder("python", """
+    from datetime import date
+
+    def conv(y, m, d):
+        return date(y, m, d)
+
+    conv
+    """, "convert.py").build();
+
+    var conv = ctx.getEnv().parsePublic(src).call();
+
+    try {
+      return InteropLibrary.getUncached().execute(conv, date.getYear(), date.getMonthValue(), date.getDayOfMonth());
+    } catch (UnsupportedTypeException | ArityException | UnsupportedMessageException ex) {
+      throw new IllegalStateException(ex);
+    }
+  }
+
   @Specialization
   public Object doExecute(
-      Object[] arguments, @CachedLibrary("foreignFunction") InteropLibrary interopLibrary) {
+      Object[] arguments,
+      @CachedLibrary("foreignFunction") InteropLibrary interopLibrary,
+      @CachedLibrary(limit="3") InteropLibrary iop
+  ) {
     try {
+      for (int i = 0; i < arguments.length; i++) {
+        if (iop.isDate(arguments[i])) {
+          arguments[i] = wrapPythonDate(iop.asDate(arguments[i]));
+        }
+      }
       return coercePrimitiveNode.execute(interopLibrary.execute(getForeignFunction(), arguments));
     } catch (UnsupportedMessageException | UnsupportedTypeException | ArityException e) {
       throw new IllegalStateException("Python parser returned a malformed object", e);

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/PyForeignNode.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/PyForeignNode.java
@@ -89,7 +89,7 @@ public abstract class PyForeignNode extends ForeignFunctionCallNode {
     Instant when;
     if (time != null) {
       if (date != null) {
-        when = date.atTime(time).atZone(zone).toInstant();
+        when = instantAtDateTimeZone(date, time, zone);
       } else {
         when = Instant.now();
       }
@@ -101,6 +101,11 @@ public abstract class PyForeignNode extends ForeignFunctionCallNode {
       }
     }
     return nodePythonZone.execute(fnPythonZone, zone.getRules().getOffset(when).getTotalSeconds());
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  private static Instant instantAtDateTimeZone(LocalDate date, LocalTime time, ZoneId zone) {
+    return date.atTime(time).atZone(zone).toInstant();
   }
 
   private Object combinePythonDateTimeZone(Object date, Object time, Object zone)

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/PyForeignNode.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/PyForeignNode.java
@@ -19,79 +19,72 @@ import com.oracle.truffle.api.source.Source;
 
 @NodeField(name = "foreignFunction", type = Object.class)
 public abstract class PyForeignNode extends ForeignFunctionCallNode {
-
-  private @Child CoercePrimitiveNode coercePrimitiveNode = CoercePrimitiveNode.build();
+  @Child
+  private CoercePrimitiveNode coercePrimitiveNode = CoercePrimitiveNode.build();
+  @CompilerDirectives.CompilationFinal
+  private Object fnPythonDate;
+  @Child
+  private InteropLibrary nodePythonDate;
+  @CompilerDirectives.CompilationFinal
+  private Object fnPythonTime;
+  @Child
+  private InteropLibrary nodePythonTime;
+  @CompilerDirectives.CompilationFinal
+  private Object fnPythonZone;
+  @Child
+  private InteropLibrary nodePythonZone;
+  @CompilerDirectives.CompilationFinal
+  private Object fnPythonCombine;
+  @Child
+  private InteropLibrary nodePythonCombine;
 
   abstract Object getForeignFunction();
 
-  @CompilerDirectives.TruffleBoundary
-  private Object wrapPythonDate(LocalDate date) {
+  private Object wrapPythonDate(LocalDate date) throws UnsupportedTypeException, ArityException, UnsupportedMessageException {
+    if (nodePythonDate == null) {
+      CompilerDirectives.transferToInterpreterAndInvalidate();
+      var ctx = EpbContext.get(this);
+      var src = Source.newBuilder("python", """
+      from datetime import date
+      date
+      """, "convert_date.py").build();
 
-    var ctx = EpbContext.get(this);
-    var src = Source.newBuilder("python", """
-    from datetime import date
-    date
-    """, "convert_date.py").build();
-
-    var conv = ctx.getEnv().parsePublic(src).call();
-
-    try {
-      return InteropLibrary.getUncached().execute(conv, date.getYear(), date.getMonthValue(), date.getDayOfMonth());
-    } catch (UnsupportedTypeException | ArityException | UnsupportedMessageException ex) {
-      throw new IllegalStateException(ex);
+      fnPythonDate = ctx.getEnv().parsePublic(src).call();
+      nodePythonDate = insert(InteropLibrary.getFactory().create(fnPythonDate));
     }
+    return nodePythonDate.execute(fnPythonDate, date.getYear(), date.getMonthValue(), date.getDayOfMonth());
   }
 
-  @CompilerDirectives.TruffleBoundary
-  private Object wrapPythonTime(LocalTime time) {
-    var ctx = EpbContext.get(this);
-    var src = Source.newBuilder("python", """
-    from datetime import time
-    time
-    """, "convert_time.py").build();
-
-    var conv = ctx.getEnv().parsePublic(src).call();
-
-    try {
-      return InteropLibrary.getUncached().execute(conv, time.getHour(), time.getMinute(), time.getSecond(), time.getNano() / 1000);
-    } catch (UnsupportedTypeException | ArityException | UnsupportedMessageException ex) {
-      throw new IllegalStateException(ex);
+  private Object wrapPythonTime(LocalTime time) throws UnsupportedTypeException, ArityException, UnsupportedMessageException {
+    if (nodePythonTime == null) {
+      CompilerDirectives.transferToInterpreterAndInvalidate();
+      var ctx = EpbContext.get(this);
+      var src = Source.newBuilder("python", """
+      from datetime import time
+      time
+      """, "convert_time.py").build();
+      fnPythonTime = ctx.getEnv().parsePublic(src).call();
+      nodePythonTime = insert(InteropLibrary.getFactory().create(fnPythonTime));
     }
+    return nodePythonTime.execute(fnPythonTime, time.getHour(), time.getMinute(), time.getSecond(), time.getNano() / 1000);
   }
 
-  @CompilerDirectives.TruffleBoundary
-  private Object combinePythonDateTimeZone(Object date, Object time, Object zone) {
-    var ctx = EpbContext.get(this);
-    var src = Source.newBuilder("python", """
-    from datetime import datetime
-    datetime.combine
-    """, "convert_combine.py").build();
+  private Object wrapPythonZone(ZoneId zone, LocalTime time, LocalDate date)
+  throws UnsupportedTypeException, ArityException, UnsupportedMessageException {
+    if (nodePythonZone == null) {
+      CompilerDirectives.transferToInterpreterAndInvalidate();
+      var ctx = EpbContext.get(this);
+      var src = Source.newBuilder("python", """
+      from datetime import timezone, timedelta
+      def conv(sec):
+          d = timedelta(seconds=sec)
+          return timezone(d)
+      conv
+      """, "convert_time_zone.py").build();
 
-    var conv = ctx.getEnv().parsePublic(src).call();
-
-    try {
-      if (zone != null) {
-        return InteropLibrary.getUncached().execute(conv, date, time, zone);
-      } else {
-        return InteropLibrary.getUncached().execute(conv, date, time);
-      }
-    } catch (UnsupportedTypeException | ArityException | UnsupportedMessageException ex) {
-      throw new IllegalStateException(ex);
+      fnPythonZone = ctx.getEnv().parsePublic(src).call();
+      nodePythonZone = insert(InteropLibrary.getFactory().create(fnPythonZone));
     }
-  }
-
-  @CompilerDirectives.TruffleBoundary
-  private Object wrapPythonZone(ZoneId zone, LocalTime time, LocalDate date) {
-    var ctx = EpbContext.get(this);
-    var src = Source.newBuilder("python", """
-    from datetime import timezone, timedelta
-    def conv(sec):
-        d = timedelta(seconds=sec)
-        return timezone(d)
-    conv
-    """, "convert_time_zone.py").build();
-
-    var conv = ctx.getEnv().parsePublic(src).call();
 
     Instant when;
     if (time != null) {
@@ -107,10 +100,27 @@ public abstract class PyForeignNode extends ForeignFunctionCallNode {
         when = Instant.now();
       }
     }
-    try {
-      return InteropLibrary.getUncached().execute(conv, zone.getRules().getOffset(when).getTotalSeconds());
-    } catch (UnsupportedTypeException | ArityException | UnsupportedMessageException ex) {
-      throw new IllegalStateException(ex);
+    return nodePythonZone.execute(fnPythonZone, zone.getRules().getOffset(when).getTotalSeconds());
+  }
+
+  private Object combinePythonDateTimeZone(Object date, Object time, Object zone)
+  throws UnsupportedTypeException, ArityException, UnsupportedMessageException {
+    if (nodePythonCombine == null) {
+      CompilerDirectives.transferToInterpreterAndInvalidate();
+      var ctx = EpbContext.get(this);
+      var src = Source.newBuilder("python", """
+      from datetime import datetime
+      datetime.combine
+      """, "convert_combine.py").build();
+
+      fnPythonCombine = ctx.getEnv().parsePublic(src).call();
+      nodePythonCombine = insert(InteropLibrary.getFactory().create(fnPythonCombine));
+    }
+
+    if (zone != null) {
+      return nodePythonCombine.execute(fnPythonCombine, date, time, zone);
+    } else {
+      return nodePythonCombine.execute(fnPythonCombine, date, time);
     }
   }
 
@@ -119,27 +129,23 @@ public abstract class PyForeignNode extends ForeignFunctionCallNode {
       Object[] arguments,
       @CachedLibrary("foreignFunction") InteropLibrary interopLibrary,
       @CachedLibrary(limit="3") InteropLibrary iop
-  ) {
-    try {
-      for (int i = 0; i < arguments.length; i++) {
-        var javaTime = iop.isTime(arguments[i]) ? iop.asTime(arguments[i]) : null;
-        var time = javaTime != null ? wrapPythonTime(javaTime) : null;
-        var javaDate = iop.isDate(arguments[i]) ? iop.asDate(arguments[i]) : null;
-        var date = javaDate != null ? wrapPythonDate(javaDate) : null;
-        var zone = iop.isTimeZone(arguments[i]) ? wrapPythonZone(iop.asTimeZone(arguments[i]), javaTime, javaDate) : null;
-        if (date != null && time != null) {
-          arguments[i] = combinePythonDateTimeZone(date, time, zone);
-        } else if (date != null) {
-          arguments[i] = date;
-        } else if (time != null) {
-          arguments[i] = time;
-        } else if (zone != null) {
-          arguments[i] = zone;
-        }
+  ) throws UnsupportedTypeException, ArityException, UnsupportedMessageException {
+    for (int i = 0; i < arguments.length; i++) {
+      var javaTime = iop.isTime(arguments[i]) ? iop.asTime(arguments[i]) : null;
+      var time = javaTime != null ? wrapPythonTime(javaTime) : null;
+      var javaDate = iop.isDate(arguments[i]) ? iop.asDate(arguments[i]) : null;
+      var date = javaDate != null ? wrapPythonDate(javaDate) : null;
+      var zone = iop.isTimeZone(arguments[i]) ? wrapPythonZone(iop.asTimeZone(arguments[i]), javaTime, javaDate) : null;
+      if (date != null && time != null) {
+        arguments[i] = combinePythonDateTimeZone(date, time, zone);
+      } else if (date != null) {
+        arguments[i] = date;
+      } else if (time != null) {
+        arguments[i] = time;
+      } else if (zone != null) {
+        arguments[i] = zone;
       }
-      return coercePrimitiveNode.execute(interopLibrary.execute(getForeignFunction(), arguments));
-    } catch (UnsupportedMessageException | UnsupportedTypeException | ArityException e) {
-      throw new IllegalStateException("Python parser returned a malformed object", e);
     }
+    return coercePrimitiveNode.execute(interopLibrary.execute(getForeignFunction(), arguments));
   }
 }

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/PyForeignNode.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/PyForeignNode.java
@@ -11,12 +11,17 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.ArityException;
+import com.oracle.truffle.api.interop.InteropException;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.source.Source;
 
+/**
+ *
+ * @author devel
+ */
 @NodeField(name = "foreignFunction", type = Object.class)
 public abstract class PyForeignNode extends ForeignFunctionCallNode {
   @Child
@@ -134,7 +139,7 @@ public abstract class PyForeignNode extends ForeignFunctionCallNode {
       Object[] arguments,
       @CachedLibrary("foreignFunction") InteropLibrary interopLibrary,
       @CachedLibrary(limit="3") InteropLibrary iop
-  ) throws UnsupportedTypeException, ArityException, UnsupportedMessageException {
+  ) throws InteropException {
     for (int i = 0; i < arguments.length; i++) {
       var javaTime = iop.isTime(arguments[i]) ? iop.asTime(arguments[i]) : null;
       var time = javaTime != null ? wrapPythonTime(javaTime) : null;

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/PyForeignNode.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/PyForeignNode.java
@@ -1,6 +1,7 @@
 package org.enso.interpreter.epb.node;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 
 import org.enso.interpreter.epb.EpbContext;
 
@@ -27,17 +28,47 @@ public abstract class PyForeignNode extends ForeignFunctionCallNode {
     var ctx = EpbContext.get(this);
     var src = Source.newBuilder("python", """
     from datetime import date
-
-    def conv(y, m, d):
-        return date(y, m, d)
-
-    conv
-    """, "convert.py").build();
+    date
+    """, "convert_date.py").build();
 
     var conv = ctx.getEnv().parsePublic(src).call();
 
     try {
       return InteropLibrary.getUncached().execute(conv, date.getYear(), date.getMonthValue(), date.getDayOfMonth());
+    } catch (UnsupportedTypeException | ArityException | UnsupportedMessageException ex) {
+      throw new IllegalStateException(ex);
+    }
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  private Object wrapPythonTime(LocalTime time) {
+    var ctx = EpbContext.get(this);
+    var src = Source.newBuilder("python", """
+    from datetime import time
+    time
+    """, "convert_time.py").build();
+
+    var conv = ctx.getEnv().parsePublic(src).call();
+
+    try {
+      return InteropLibrary.getUncached().execute(conv, time.getHour(), time.getMinute(), time.getSecond(), time.getNano() / 1000);
+    } catch (UnsupportedTypeException | ArityException | UnsupportedMessageException ex) {
+      throw new IllegalStateException(ex);
+    }
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  private Object combinePythonDateTime(Object date, Object time) {
+    var ctx = EpbContext.get(this);
+    var src = Source.newBuilder("python", """
+    from datetime import datetime
+    datetime.combine
+    """, "convert_combine.py").build();
+
+    var conv = ctx.getEnv().parsePublic(src).call();
+
+    try {
+      return InteropLibrary.getUncached().execute(conv, date, time);
     } catch (UnsupportedTypeException | ArityException | UnsupportedMessageException ex) {
       throw new IllegalStateException(ex);
     }
@@ -51,8 +82,14 @@ public abstract class PyForeignNode extends ForeignFunctionCallNode {
   ) {
     try {
       for (int i = 0; i < arguments.length; i++) {
-        if (iop.isDate(arguments[i])) {
-          arguments[i] = wrapPythonDate(iop.asDate(arguments[i]));
+        var time = iop.isTime(arguments[i]) ? wrapPythonTime(iop.asTime(arguments[i])) : null;
+        var date = iop.isDate(arguments[i]) ? wrapPythonDate(iop.asDate(arguments[i])) : null;
+        if (date != null && time != null) {
+          arguments[i] = combinePythonDateTime(date, time);
+        } else if (date != null) {
+          arguments[i] = date;
+        } else if (time != null) {
+          arguments[i] = time;
         }
       }
       return coercePrimitiveNode.execute(interopLibrary.execute(getForeignFunction(), arguments));

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/PyForeignNode.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/PyForeignNode.java
@@ -1,7 +1,9 @@
 package org.enso.interpreter.epb.node;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneId;
 
 import org.enso.interpreter.epb.EpbContext;
 
@@ -58,7 +60,7 @@ public abstract class PyForeignNode extends ForeignFunctionCallNode {
   }
 
   @CompilerDirectives.TruffleBoundary
-  private Object combinePythonDateTime(Object date, Object time) {
+  private Object combinePythonDateTimeZone(Object date, Object time, Object zone) {
     var ctx = EpbContext.get(this);
     var src = Source.newBuilder("python", """
     from datetime import datetime
@@ -68,7 +70,45 @@ public abstract class PyForeignNode extends ForeignFunctionCallNode {
     var conv = ctx.getEnv().parsePublic(src).call();
 
     try {
-      return InteropLibrary.getUncached().execute(conv, date, time);
+      if (zone != null) {
+        return InteropLibrary.getUncached().execute(conv, date, time, zone);
+      } else {
+        return InteropLibrary.getUncached().execute(conv, date, time);
+      }
+    } catch (UnsupportedTypeException | ArityException | UnsupportedMessageException ex) {
+      throw new IllegalStateException(ex);
+    }
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  private Object wrapPythonZone(ZoneId zone, LocalTime time, LocalDate date) {
+    var ctx = EpbContext.get(this);
+    var src = Source.newBuilder("python", """
+    from datetime import timezone, timedelta
+    def conv(sec):
+        d = timedelta(seconds=sec)
+        return timezone(d)
+    conv
+    """, "convert_time_zone.py").build();
+
+    var conv = ctx.getEnv().parsePublic(src).call();
+
+    Instant when;
+    if (time != null) {
+      if (date != null) {
+        when = date.atTime(time).atZone(zone).toInstant();
+      } else {
+        when = Instant.now();
+      }
+    } else {
+      if (date != null) {
+        when = date.atStartOfDay(zone).toInstant();
+      } else {
+        when = Instant.now();
+      }
+    }
+    try {
+      return InteropLibrary.getUncached().execute(conv, zone.getRules().getOffset(when).getTotalSeconds());
     } catch (UnsupportedTypeException | ArityException | UnsupportedMessageException ex) {
       throw new IllegalStateException(ex);
     }
@@ -82,14 +122,19 @@ public abstract class PyForeignNode extends ForeignFunctionCallNode {
   ) {
     try {
       for (int i = 0; i < arguments.length; i++) {
-        var time = iop.isTime(arguments[i]) ? wrapPythonTime(iop.asTime(arguments[i])) : null;
-        var date = iop.isDate(arguments[i]) ? wrapPythonDate(iop.asDate(arguments[i])) : null;
+        var javaTime = iop.isTime(arguments[i]) ? iop.asTime(arguments[i]) : null;
+        var time = javaTime != null ? wrapPythonTime(javaTime) : null;
+        var javaDate = iop.isDate(arguments[i]) ? iop.asDate(arguments[i]) : null;
+        var date = javaDate != null ? wrapPythonDate(javaDate) : null;
+        var zone = iop.isTimeZone(arguments[i]) ? wrapPythonZone(iop.asTimeZone(arguments[i]), javaTime, javaDate) : null;
         if (date != null && time != null) {
-          arguments[i] = combinePythonDateTime(date, time);
+          arguments[i] = combinePythonDateTimeZone(date, time, zone);
         } else if (date != null) {
           arguments[i] = date;
         } else if (time != null) {
           arguments[i] = time;
+        } else if (zone != null) {
+          arguments[i] = zone;
         }
       }
       return coercePrimitiveNode.execute(interopLibrary.execute(getForeignFunction(), arguments));

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/PyForeignNode.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/PyForeignNode.java
@@ -95,7 +95,7 @@ public abstract class PyForeignNode extends ForeignFunctionCallNode {
       }
     } else {
       if (date != null) {
-        when = date.atStartOfDay(zone).toInstant();
+        when = instantAtStartOfDay(date, zone);
       } else {
         when = Instant.now();
       }
@@ -106,6 +106,11 @@ public abstract class PyForeignNode extends ForeignFunctionCallNode {
   @CompilerDirectives.TruffleBoundary
   private static Instant instantAtDateTimeZone(LocalDate date, LocalTime time, ZoneId zone) {
     return date.atTime(time).atZone(zone).toInstant();
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  private Instant instantAtStartOfDay(LocalDate date, ZoneId zone) {
+    return date.atStartOfDay(zone).toInstant();
   }
 
   private Object combinePythonDateTimeZone(Object date, Object time, Object zone)

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/RForeignNode.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/node/RForeignNode.java
@@ -2,10 +2,8 @@ package org.enso.interpreter.epb.node;
 
 import com.oracle.truffle.api.dsl.NodeField;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.interop.ArityException;
+import com.oracle.truffle.api.interop.InteropException;
 import com.oracle.truffle.api.interop.InteropLibrary;
-import com.oracle.truffle.api.interop.UnsupportedMessageException;
-import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.library.CachedLibrary;
 
 @NodeField(name = "foreignFunction", type = Object.class)
@@ -17,11 +15,8 @@ public abstract class RForeignNode extends ForeignFunctionCallNode {
 
   @Specialization
   public Object doExecute(
-      Object[] arguments, @CachedLibrary("foreignFunction") InteropLibrary interopLibrary) {
-    try {
-      return coercePrimitiveNode.execute(interopLibrary.execute(getForeignFunction(), arguments));
-    } catch (UnsupportedMessageException | UnsupportedTypeException | ArityException e) {
-      throw new IllegalStateException("R parser returned a malformed object", e);
-    }
+      Object[] arguments, @CachedLibrary("foreignFunction") InteropLibrary interopLibrary)
+      throws InteropException {
+    return coercePrimitiveNode.execute(interopLibrary.execute(getForeignFunction(), arguments));
   }
 }

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/runtime/ForeignParsingException.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/runtime/ForeignParsingException.java
@@ -24,10 +24,19 @@ public class ForeignParsingException extends AbstractTruffleException {
    * @param location Location node passed to {@link AbstractTruffleException}.
    */
   public ForeignParsingException(String truffleLangId, Set<String> installedLangs, Node location) {
-    super(createMessage(truffleLangId, installedLangs), location);
-    this.message = createMessage(truffleLangId, installedLangs);
+    this(createMessage(truffleLangId, installedLangs), location);
   }
 
+  /**
+   * @param msg message of the exception
+   * @param location Location node passed to {@link AbstractTruffleException}.
+   */
+  public ForeignParsingException(String msg, Node location) {
+    super(msg, location);
+    this.message = msg;
+  }
+
+  @TruffleBoundary
   private static String createMessage(String truffleLangId, Set<String> installedLangs) {
     return String.format(
         "Cannot parse foreign %s method. Only available languages are %s",

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -20,7 +20,10 @@ spec =
     spec_with "Date_Time" enso_datetime Date_Time.parse
     spec_with "JavascriptDate" js_datetime js_parse nanoseconds_loss_in_precision=True
     if Polyglot.is_language_installed "python" then
-        spec_with "PythonDate" python_datetime python_parse nanoseconds_loss_in_precision=True
+        ignore_z_check a b =
+            if a == 'Z' || b == 'Z' then True else
+                a.should_equal b
+        spec_with "PythonDate" python_datetime python_parse nanoseconds_loss_in_precision=True loose_zone_equal=ignore_z_check
     spec_with "JavaZonedDateTime" java_datetime java_parse
     spec_with "JavascriptDataInArray" js_array_datetime js_parse nanoseconds_loss_in_precision=True
 

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -44,7 +44,7 @@ spec =
             (Date_Time.new 2022 12 12).should_not_equal (Date_Time.new 1996)
 
 default_zone_equal z1 z2 =
-    z1 . should_equal z2
+    z1 . should_equal frames_to_skip=1 z2
     False
 
 spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=False loose_zone_equal=default_zone_equal =
@@ -860,13 +860,8 @@ js_set_zone local_datetime zone =
     datetime_with_tz + diff
 
 python_datetime year month=1 day=1 hour=0 minute=0 second=0 nanosecond=0 zone=Nothing =
-    delta = if zone.is_nothing then -1 else
-        rules = Polyglot.invoke (ZoneId.of (zone.zone_id)) "getRules" []
-        zone_offset = Polyglot.invoke rules "getOffset" [ LocalDateTime.now ]
-        Polyglot.invoke zone_offset "getTotalSeconds" []
-    name = if zone.is_nothing then "Z" else
-        zone.zone_id
-    Panic.catch Any (python_datetime_impl year month day hour minute second nanosecond delta name) (err -> Error.throw (Time_Error.Error err.payload))
+    z = if zone.is_nothing then -1 else zone
+    python_datetime_impl year month day hour minute second nanosecond z
 
 python_parse text format="" =
     d = Date_Time.parse text format
@@ -892,26 +887,14 @@ foreign js js_array_datetimeCreate year month day hour minute second nanosecond 
     }
     return [ new Date(year, month - 1, day, hour, minute, second, nanosecond / 1000000) ];
 
-foreign python python_datetime_impl year month day hour minute second nanosecond zone zone_name = """
+foreign python python_datetime_impl year month day hour minute second nanosecond zone = """
     import datetime
 
-    class Zone(datetime.tzinfo):
-        def __init__(self, zone, name):
-            self.zone = zone
-            self.name = name
-
-        def utcoffset(self, dt):
-            return datetime.timedelta(seconds=zone)
-
-        def tzname(self, dt):
-            return self.name
-
     microseconds = int(nanosecond / 1000000) * 1000
-
     if zone == -1:
         return datetime.datetime(year, month, day, hour, minute, second, microseconds)
     else:
-        return datetime.datetime(year, month, day, hour, minute, second, microseconds, Zone(zone, zone_name))
+        return datetime.datetime(year, month, day, hour, minute, second, microseconds, zone)
 
 enso_datetime year month=1 day=1 hour=0 minute=0 second=0 nanosecond=0 zone=Time_Zone.system =
     Date_Time.new year month day hour minute second nanosecond=nanosecond zone=zone

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -15,6 +15,7 @@ polyglot java import java.time.ZoneId
 polyglot java import java.time.ZoneOffset
 polyglot java import java.time.format.DateTimeFormatter
 polyglot java import java.lang.Exception as JException
+polyglot java import java.util.Objects
 
 spec =
     spec_with "Date_Time" enso_datetime Date_Time.parse
@@ -453,6 +454,11 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time_1 = parse_datetime "2021-01-01T00:30:12.7102[UTC]"
             time_2 = parse_datetime "2021-01-01T04:00:10.0+04:00"
             (time_1 == time_2) . should_be_false
+            if time_1==time_1 . not then
+                msg = "Equality isn't reflexive for " + (Objects.toString time_1) + " info:"
+                info_1 = " time_1.zone: " + (Objects.toString time_1.zone) + " type: " + (Meta.type_of time_1).to_text
+                info_2 = " Time_Zone.system: " + Time_Zone.system.to_text
+                Test.fail msg+info_1+info_2
             time_1==time_1 . should_be_true
             time_1!=time_2 . should_be_true
             time_1>time_2 . should_be_true

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -593,7 +593,8 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
         offset_2_h = ZoneOffset.ofTotalSeconds 2*3600
         tz = Time_Zone.parse "Europe/Warsaw"
         dst_pending = if name.contains "Javascript" then "Javascript implementation does not support time zones correctly, so the tests for conversion around DST switches would fail and thus are disabled. We may revisit once JS gets better time support, see project Temporal: https://tc39.es/proposal-temporal/docs/ and our issue tracking our integration: https://github.com/enso-org/enso/issues/5384" else
-            if loose_zone_equal "" "" then "Loose Zone conversions are on, skipping the test"
+            if name.contains "Python" then "Python doesn't support time zones correctly" else
+                Nothing
 
         Test.specify "should find start/end of a Date_Period or Time_Period containing the current datetime correctly near the spring DST switch" pending=dst_pending <|
             d1 = create_new_datetime 2022 3 27 1 34 15 0 tz

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -20,8 +20,7 @@ spec =
     spec_with "Date_Time" enso_datetime Date_Time.parse
     spec_with "JavascriptDate" js_datetime js_parse nanoseconds_loss_in_precision=True
     if Polyglot.is_language_installed "python" then
-        skip_check _ _ = True
-        spec_with "PythonDate" python_datetime python_parse nanoseconds_loss_in_precision=True loose_zone_equal=skip_check
+        spec_with "PythonDate" python_datetime python_parse nanoseconds_loss_in_precision=True
     spec_with "JavaZonedDateTime" java_datetime java_parse
     spec_with "JavascriptDataInArray" js_array_datetime js_parse nanoseconds_loss_in_precision=True
 

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -158,7 +158,7 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . millisecond . should_equal 0
             time . microsecond . should_equal 0
             time . nanosecond . should_equal 0
-            loose_zone_equal time.zone.zone_id (Time_Zone.new 1 . zone_id)
+            time.zone.zone_id . take (Last 6) . should_equal "+01:00"
 
         Test.specify "should parse time with id-based zone" <|
             time = parse_datetime "1970-01-01T00:00:01+01:00[Europe/Paris]"
@@ -171,8 +171,9 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . millisecond . should_equal 0
             time . microsecond . should_equal 0
             time . nanosecond . should_equal 0
-            loose_zone_equal time.zone.zone_id  "Europe/Paris"
-            loose_zone_equal time.to_display_text "1970-01-01 00:00:01 Europe/Paris"
+            if name.contains "Python" then time.zone.zone_id . should_equal "UTC+02:00" else
+                time.zone.zone_id . should_equal "Europe/Paris"
+                time.to_display_text . should_equal "1970-01-01 00:00:01 Europe/Paris"
 
         Test.specify "should throw error when parsing invalid time" <|
             case parse_datetime "2008-1-1" . catch of

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -861,7 +861,8 @@ js_set_zone local_datetime zone =
 
 python_datetime year month=1 day=1 hour=0 minute=0 second=0 nanosecond=0 zone=Nothing =
     z = if zone.is_nothing then -1 else zone
-    python_datetime_impl year month day hour minute second nanosecond z
+    Panic.catch Any (python_datetime_impl year month day hour minute second nanosecond z) err->
+        Error.throw (Time_Error.Error err.payload)
 
 python_parse text format="" =
     d = Date_Time.parse text format
@@ -889,6 +890,9 @@ foreign js js_array_datetimeCreate year month day hour minute second nanosecond 
 
 foreign python python_datetime_impl year month day hour minute second nanosecond zone = """
     import datetime
+
+    if month > 12 or month < 1:
+        raise Exception("Invalid value for MonthOfYear (valid values 1 - 12): {}".format(month))
 
     microseconds = int(nanosecond / 1000000) * 1000
     if zone == -1:

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -22,7 +22,7 @@ spec =
     if Polyglot.is_language_installed "python" then
         ignore_z_check a b =
             if a == 'Z' || b == 'Z' then True else
-                a.should_equal b
+                a.should_equal frames_to_skip=2 b
         spec_with "PythonDate" python_datetime python_parse nanoseconds_loss_in_precision=True loose_zone_equal=ignore_z_check
     spec_with "JavaZonedDateTime" java_datetime java_parse
     spec_with "JavascriptDataInArray" js_array_datetime js_parse nanoseconds_loss_in_precision=True
@@ -767,7 +767,7 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
                 d1.date_part Time_Period.Microsecond . should_equal 456
                 d1.date_part Time_Period.Nanosecond . should_equal 789
 
-        pending_date_diff_test = if loose_zone_equal "" "" then "Loose Zone conversions are on, skipping the test"
+        pending_date_diff_test = if name.contains "Python" then "Loose Zone conversions are on, skipping the test"
 
         Test.specify "should allow computing date_diff" pending=pending_date_diff_test <|
             t1 = create_new_datetime 2021 11 3 10 15 0

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -114,7 +114,7 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . minute . should_equal 0
             time . second . should_equal 1
             time . nanosecond . should_equal 0
-            loose_zone_equal time.zone Time_Zone.system
+            time.zone . should_equal Time_Zone.system
 
         Test.specify "should parse time Z" <|
             time = parse_datetime "1582-10-15T00:00:01Z"
@@ -193,7 +193,7 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . millisecond . should_equal 0
             time . microsecond . should_equal 0
             time . nanosecond . should_equal 0
-            loose_zone_equal (time.zone.zone_id . take (Last 3) . to_case Case.Upper)  "UTC"
+            (time.zone.zone_id . take (Last 3) . to_case Case.Upper) . should_equal "UTC"
 
         Test.specify "should parse custom format of local time" <|
             time = parse_datetime "06 of May 2020 at 04:30AM" "dd 'of' MMMM yyyy 'at' hh:mma"
@@ -604,7 +604,7 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             d1 = create_new_datetime 2022 3 27 1 34 15 0 tz
             d2 = create_new_datetime 2022 3 27 3 34 15 0 tz
             d1_plus = d1 + (Duration.new hours=1)
-            loose_zone_equal d1_plus d2
+            d1_plus . should_equal d2
 
             check_dates_spring date =
                 date.start_of Date_Period.Day . should_equal (Date_Time.new 2022 3 27 zone=tz)
@@ -704,13 +704,13 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
 
         Test.specify "should handle shifting dates around spring DST edge cases" pending=dst_pending <|
             # 2022-10-30 and 2022-03-27 are DST switch days, Sundays.
-            loose_zone_equal (create_new_datetime 2022 10 30 2 30 55 1234 . add_work_days 0) (create_new_datetime 2022 10 31 2 30 55 1234)
-            loose_zone_equal (create_new_datetime 2022 10 30 1 30 . add_work_days 1) (Date_Time.new 2022 11 1 1 30)
-            loose_zone_equal (create_new_datetime 2022 10 30 3 30 . add_work_days 1) (Date_Time.new 2022 11 1 3 30)
+            (create_new_datetime 2022 10 30 2 30 55 1234 . add_work_days 0) . should_equal (create_new_datetime 2022 10 31 2 30 55 1234)
+            (create_new_datetime 2022 10 30 1 30 . add_work_days 1) . should_equal (Date_Time.new 2022 11 1 1 30)
+            (create_new_datetime 2022 10 30 3 30 . add_work_days 1) . should_equal (Date_Time.new 2022 11 1 3 30)
 
             tz = Time_Zone.parse "Europe/Warsaw"
-            loose_zone_equal (create_new_datetime 2022 3 27 1 30 zone=tz . add_work_days 0) (Date_Time.new 2022 3 28 1 30 zone=tz)
-            loose_zone_equal (create_new_datetime 2022 3 27 3 30 zone=tz . add_work_days 1) (Date_Time.new 2022 3 29 3 30 zone=tz)
+            (create_new_datetime 2022 3 27 1 30 zone=tz . add_work_days 0) . should_equal (Date_Time.new 2022 3 28 1 30 zone=tz)
+            (create_new_datetime 2022 3 27 3 30 zone=tz . add_work_days 1) . should_equal (Date_Time.new 2022 3 29 3 30 zone=tz)
 
         Test.specify "should handle shifting dates around autumn DST edge cases" pending=dst_overlap_message <|
             d3 = create_new_datetime 2022 10 30 2 30 15 0 tz

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -866,7 +866,8 @@ python_datetime year month=1 day=1 hour=0 minute=0 second=0 nanosecond=0 zone=No
 
 python_parse text format="" =
     d = Date_Time.parse text format
-    python_datetime d.year d.month d.day d.hour d.minute d.second (d.nanosecond include_milliseconds=True) d.zone
+    z = if d.zone == Time_Zone.system then Nothing else d.zone
+    python_datetime d.year d.month d.day d.hour d.minute d.second (d.nanosecond include_milliseconds=True) z
 
 foreign js js_local_datetime_impl year month day hour minute second nanosecond = """
     if (month > 12 || month < 1) {

--- a/test/Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Tests/src/Data/Time/Date_Time_Spec.enso
@@ -115,7 +115,7 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . minute . should_equal 0
             time . second . should_equal 1
             time . nanosecond . should_equal 0
-            time.zone . should_equal Time_Zone.system
+            (time.zone.offset time) . should_equal (Time_Zone.system.offset time)
 
         Test.specify "should parse time Z" <|
             time = parse_datetime "1582-10-15T00:00:01Z"
@@ -172,8 +172,10 @@ spec_with name create_new_datetime parse_datetime nanoseconds_loss_in_precision=
             time . millisecond . should_equal 0
             time . microsecond . should_equal 0
             time . nanosecond . should_equal 0
-            if name.contains "Python" then time.zone.zone_id . should_equal "UTC+02:00" else
-                time.zone.zone_id . should_equal "Europe/Paris"
+            zone = time.zone
+            zone.offset time . should_equal 3600
+            if name.contains "Python" then time.zone.zone_id . should_equal "UTC+01:00" else
+                zone.zone_id . should_equal "Europe/Paris"
                 time.to_display_text . should_equal "1970-01-01 00:00:01 Europe/Paris"
 
         Test.specify "should throw error when parsing invalid time" <|
@@ -877,8 +879,7 @@ python_datetime year month=1 day=1 hour=0 minute=0 second=0 nanosecond=0 zone=No
 
 python_parse text format="" =
     d = Date_Time.parse text format
-    z = if d.zone == Time_Zone.system then Nothing else d.zone
-    python_datetime d.year d.month d.day d.hour d.minute d.second (d.nanosecond include_milliseconds=True) z
+    python_datetime d.year d.month d.day d.hour d.minute d.second (d.nanosecond include_milliseconds=True) d.zone
 
 foreign js js_local_datetime_impl year month day hour minute second nanosecond = """
     if (month > 12 || month < 1) {


### PR DESCRIPTION
### Pull Request Description

Fixes #7418 by adding specialized date/time/zone conversions in `EpbLanguage` before calling into Python.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] Avoid asGuestValue at [EnsoTzInfo conversion](https://github.com/enso-org/enso/pull/7617/files#diff-0fa850ff76924c1a9f3fba80858292d72a2b9efbda35f9a31970e0b3fc5fe6f6R110) - **done** in beaceed
