### PR TITLE
Copy-pasting nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,10 @@
   <kbd>enter</kbd>][7527]
 - [Connections to lamdas are displayed correctly][7550]. It is possible to drag
   a connection to any expression inside the lambda body.
+- [Copying and pasting a single node][7618]. Using the common
+  <kbd>cmd</kbd>+<kbd>C</kbd> and <kbd>cmd</kbd>+<kbd>V</kbd> shortcuts, it is
+  now possible to copy a single selected node and paste its code to the graph or
+  another program.
 
 [5910]: https://github.com/enso-org/enso/pull/5910
 [6279]: https://github.com/enso-org/enso/pull/6279
@@ -245,6 +249,7 @@
 [7311]: https://github.com/enso-org/enso/pull/7311
 [7527]: https://github.com/enso-org/enso/pull/7527
 [7550]: https://github.com/enso-org/enso/pull/7550
+[7618]: https://github.com/enso-org/enso/pull/7618
 
 #### EnsoGL (rendering engine)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4716,9 +4716,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libm"

--- a/app/gui/controller/double-representation/src/node.rs
+++ b/app/gui/controller/double-representation/src/node.rs
@@ -458,7 +458,7 @@ impl NodeAst {
 
     /// AST of the node's expression. Typically no external user wants to access it directly. Use
     /// [`Self::expression`] instead.
-    fn whole_expression(&self) -> &Ast {
+    pub fn whole_expression(&self) -> &Ast {
         match self {
             NodeAst::Binding { infix, .. } => &infix.rarg,
             NodeAst::Expression { ast, .. } => ast,

--- a/app/gui/docs/product/shortcuts.md
+++ b/app/gui/docs/product/shortcuts.md
@@ -54,7 +54,7 @@ broken and require further investigation.
 | <kbd>cmd</kbd>+<kbd>shift</kbd>+<kbd>k</kbd>                                    | Switch the execution environment to Design.                                                                                                                                                                                                          |
 | <kbd>cmd</kbd>+<kbd>shift</kbd>+<kbd>l</kbd>                                    | Switch the execution environment to Live.                                                                                                                                                                                                            |
 | <kbd>cmd</kbd>+<kbd>c</kbd>                                                     | Copy the selected nodes to the clipboard.                                                                                                                                                                                                            |
-| <kbd>cmd</kbd>+<kbd>v</kbd>                                                     | Paste a node from clipboard at mouse cursor position.                                                                                                                                                                                                |
+| <kbd>cmd</kbd>+<kbd>v</kbd>                                                     | Paste a node from the clipboard at the mouse cursor position.                                                                                                                                                                                        |
 
 #### Navigation
 

--- a/app/gui/docs/product/shortcuts.md
+++ b/app/gui/docs/product/shortcuts.md
@@ -53,8 +53,8 @@ broken and require further investigation.
 | <kbd>cmd</kbd>+<kbd>alt</kbd>+<kbd>r</kbd>                                      | Re-execute the program                                                                                                                                                                                                                               |
 | <kbd>cmd</kbd>+<kbd>shift</kbd>+<kbd>k</kbd>                                    | Switch the execution environment to Design.                                                                                                                                                                                                          |
 | <kbd>cmd</kbd>+<kbd>shift</kbd>+<kbd>l</kbd>                                    | Switch the execution environment to Live.                                                                                                                                                                                                            |
-| <kbd>cmd</kbd>+<kbd>c</kbd> | Copy the selected nodes to the clipboard. |
-| <kbd>cmd</kbd>+<kbd>v</kbd> | Paste a node from clipboard at mouse cursor position. |
+| <kbd>cmd</kbd>+<kbd>c</kbd>                                                     | Copy the selected nodes to the clipboard.                                                                                                                                                                                                            |
+| <kbd>cmd</kbd>+<kbd>v</kbd>                                                     | Paste a node from clipboard at mouse cursor position.                                                                                                                                                                                                |
 
 #### Navigation
 

--- a/app/gui/docs/product/shortcuts.md
+++ b/app/gui/docs/product/shortcuts.md
@@ -53,6 +53,8 @@ broken and require further investigation.
 | <kbd>cmd</kbd>+<kbd>alt</kbd>+<kbd>r</kbd>                                      | Re-execute the program                                                                                                                                                                                                                               |
 | <kbd>cmd</kbd>+<kbd>shift</kbd>+<kbd>k</kbd>                                    | Switch the execution environment to Design.                                                                                                                                                                                                          |
 | <kbd>cmd</kbd>+<kbd>shift</kbd>+<kbd>l</kbd>                                    | Switch the execution environment to Live.                                                                                                                                                                                                            |
+| <kbd>cmd</kbd>+<kbd>c</kbd> | Copy the selected nodes to the clipboard. |
+| <kbd>cmd</kbd>+<kbd>v</kbd> | Paste a node from clipboard at mouse cursor position. |
 
 #### Navigation
 

--- a/app/gui/src/controller/graph.rs
+++ b/app/gui/src/controller/graph.rs
@@ -960,6 +960,7 @@ impl Handle {
     pub fn paste_node(&self, cursor_pos: Vector2) -> FallibleResult {
         let this = self.clone_ref();
         clipboard::read(move |content| {
+            let _transaction = this.module.get_or_open_transaction("Paste node");
             if let Ok(content) = serde_json::from_str(&content) {
                 match content {
                     ClipboardContent::Node(node) => {

--- a/app/gui/src/controller/graph.rs
+++ b/app/gui/src/controller/graph.rs
@@ -421,6 +421,7 @@ impl EndpointInfo {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 struct CopiedNode {
     expression: String,
+    metadata:   Option<NodeMetadata>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -947,8 +948,9 @@ impl Handle {
         let graph = GraphInfo::from_definition(self.definition()?.item);
         let node = graph.locate_node(id)?;
         let expression = node.whole_expression().repr();
+        let metadata = self.module.node_metadata(id).ok();
         console_log!("Copying node {expression}");
-        let content = ClipboardContent::Node(CopiedNode { expression });
+        let content = ClipboardContent::Node(CopiedNode { expression, metadata });
         let text_repr = serde_json::to_string(&content)?;
         clipboard::write(text_repr);
         Ok(())
@@ -962,13 +964,14 @@ impl Handle {
                 match content {
                     ClipboardContent::Node(node) => {
                         let expression = node.expression;
+                        let metadata = node.metadata;
                         console_log!("Pasting node: {expression}");
                         let info = NewNodeInfo {
-                            expression:        expression.into(),
-                            doc_comment:       None,
-                            metadata:          None,
-                            id:                None,
-                            location_hint:     double_representation::graph::LocationHint::End,
+                            expression,
+                            doc_comment: None,
+                            metadata,
+                            id: None,
+                            location_hint: double_representation::graph::LocationHint::End,
                             introduce_pattern: true,
                         };
                         this.add_node(info);

--- a/app/gui/src/controller/graph.rs
+++ b/app/gui/src/controller/graph.rs
@@ -952,16 +952,17 @@ impl Handle {
         console_log!("Copying node {expression}");
         let content = ClipboardContent::Node(CopiedNode { expression, metadata });
         let text_repr = serde_json::to_string(&content)?;
-        clipboard::write(text_repr);
+        clipboard::write(text_repr.as_bytes(), "web application/enso".to_string());
         Ok(())
     }
 
     /// TODO: add docs
     pub fn paste_node(&self, cursor_pos: Vector2) -> FallibleResult {
         let this = self.clone_ref();
-        clipboard::read(move |content| {
+        clipboard::read("web application/enso".to_string(), move |content| {
             let _transaction = this.module.get_or_open_transaction("Paste node");
-            if let Ok(content) = serde_json::from_str(&content) {
+            let string = String::from_utf8(content).unwrap();
+            if let Ok(content) = serde_json::from_str(&string) {
                 match content {
                     ClipboardContent::Node(node) => {
                         let expression = node.expression;

--- a/app/gui/src/controller/graph.rs
+++ b/app/gui/src/controller/graph.rs
@@ -957,7 +957,7 @@ impl Handle {
     }
 
     /// TODO: add docs
-    pub fn paste_node(&self) -> FallibleResult {
+    pub fn paste_node(&self, cursor_pos: Vector2) -> FallibleResult {
         let this = self.clone_ref();
         clipboard::read(move |content| {
             if let Ok(content) = serde_json::from_str(&content) {
@@ -974,7 +974,9 @@ impl Handle {
                             location_hint: double_representation::graph::LocationHint::End,
                             introduce_pattern: true,
                         };
-                        this.add_node(info);
+                        if let Ok(ast_id) = this.add_node(info) {
+                            this.set_node_position(ast_id, cursor_pos);
+                        }
                     }
                 }
             } else {

--- a/app/gui/src/controller/graph.rs
+++ b/app/gui/src/controller/graph.rs
@@ -945,9 +945,8 @@ impl Handle {
 
     /// Paste a node from clipboard at cursor position. See `clipboard` module documentation for
     /// details.
-    pub fn paste_node(&self, cursor_pos: Vector2) -> FallibleResult {
-        clipboard::paste_node(self, cursor_pos)?;
-        Ok(())
+    pub fn paste_node(&self, cursor_pos: Vector2, on_error: fn(String)) {
+        clipboard::paste_node(self, cursor_pos, on_error);
     }
 
     /// Sets the given's node expression.

--- a/app/gui/src/controller/graph.rs
+++ b/app/gui/src/controller/graph.rs
@@ -26,6 +26,7 @@ use double_representation::node::NodeAst;
 use double_representation::node::NodeInfo;
 use double_representation::node::NodeLocation;
 use engine_protocol::language_server;
+use ensogl::system::web::clipboard;
 use parser::Parser;
 use span_tree::action::Action;
 use span_tree::action::Actions;
@@ -926,6 +927,15 @@ impl Handle {
 
         // It's fine if there were no metadata.
         let _ = self.module.remove_node_metadata(id);
+        Ok(())
+    }
+
+    pub fn copy_node(&self, id: ast::Id) -> FallibleResult {
+        let graph = GraphInfo::from_definition(self.definition()?.item);
+        let node = graph.locate_node(id)?;
+        let code = node.whole_expression().repr();
+        console_log!("Copying node {code}");
+        clipboard::write_text(code);
         Ok(())
     }
 

--- a/app/gui/src/controller/graph/clipboard.rs
+++ b/app/gui/src/controller/graph/clipboard.rs
@@ -1,0 +1,142 @@
+//! Copy-pasting nodes using clipboard.
+//!
+//! # Clipboard Content Format
+//!
+//! We use a JSON-encoded [`ClipboardContent`] structure, marked with our custom [`MIME_TYPE`].
+//! This way we have a separate clipboard format for our application, and can extend it in the
+//! future.
+//! To make it easier to use the clipboard in other applications, we also support plain text
+//! pasting, but only if the [`PLAIN_TEXT_PASTING_ENABLED`] is `true`. Allowing pasting plain text
+//! can bring unnecessary security risks, like immediate execution of the malicious code pasted from
+//! an untrusted source.
+//!
+//! To copy the node as plain text, the user can enter editing node, select the node expression,
+//! and copy it to the clipboard using `text::Area` functionality.
+
+use crate::prelude::*;
+
+use crate::controller::graph::Handle;
+use crate::controller::graph::NewNodeInfo;
+use crate::model::module::NodeMetadata;
+
+use ensogl::system::web::clipboard;
+use serde::Deserialize;
+use serde::Serialize;
+
+
+
+/// We use `web` prefix to be able to use a custom MIME-type. Typically browsers support a
+/// restricted set of MIME-types in clipboard.
+/// See [Clipboard pickling](https://github.com/w3c/editing/blob/gh-pages/docs/clipboard-pickling/explainer.md).
+///
+/// `application/enso` is not an officially registered MIME-type (yet), but it is not needed for
+/// our purposes.
+const MIME_TYPE: &str = "web application/enso";
+/// Whether to allow pasting nodes from plain text.
+const PLAIN_TEXT_PASTING_ENABLED: bool = true;
+
+/// Clipboard payload.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+enum ClipboardContent {
+    /// A single node that was copied from the application.
+    Node(CopiedNode),
+}
+
+/// A single node that was copied from the application.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct CopiedNode {
+    /// A whole node's expression (without a pattern).
+    expression: String,
+    /// Node's metadata.
+    metadata:   Option<NodeMetadata>,
+}
+
+/// Copy the node to the clipboard.
+pub fn copy_node(expression: String, metadata: Option<NodeMetadata>) -> FallibleResult {
+    let content = ClipboardContent::Node(CopiedNode { expression, metadata });
+    let text_repr = serde_json::to_string(&content)?;
+    clipboard::write(text_repr.as_bytes(), MIME_TYPE.to_string());
+    Ok(())
+}
+
+
+/// Paste the node from the clipboard.
+pub fn paste_node(graph: &Handle, cursor_pos: Vector2) -> FallibleResult {
+    clipboard::read(
+        MIME_TYPE.to_string(),
+        paste_node_from_custom_format(graph, cursor_pos),
+        plain_text_fallback(graph, cursor_pos),
+    );
+    Ok(())
+}
+
+/// A standard callback for pasting node using our custom format.
+fn paste_node_from_custom_format(
+    graph: &Handle,
+    cursor_pos: Vector2,
+) -> impl Fn(Vec<u8>) + 'static {
+    let graph = graph.clone_ref();
+    move |content| {
+        let _transaction = graph.module.get_or_open_transaction("Paste node");
+        let string = String::from_utf8(content).unwrap();
+        if let Ok(content) = serde_json::from_str(&string) {
+            match content {
+                ClipboardContent::Node(node) => {
+                    let expression = node.expression;
+                    let metadata = node.metadata;
+                    if let Err(err) = graph.new_node_at_position(cursor_pos, expression, metadata) {
+                        error!("Failed to paste node. {err}");
+                    }
+                }
+            }
+        } else {
+            error!(
+                "`application/enso` MIME-type is used, but clipboard content has incorrect format."
+            );
+        }
+    }
+}
+
+/// An alternative callback for pasting node from plain text. It is used when [`MIME_TYPE`] is not
+/// available in the clipboard, and only if [`PLAIN_TEXT_PASTING_ENABLED`]. Otherwise, it is a
+/// noop.
+fn plain_text_fallback(graph: &Handle, cursor_pos: Vector2) -> impl Fn(String) + 'static {
+    let graph = graph.clone_ref();
+    move |text| {
+        if PLAIN_TEXT_PASTING_ENABLED {
+            let _transaction = graph.module.get_or_open_transaction("Paste node");
+            let expression = text;
+            if let Err(err) = graph.new_node_at_position(cursor_pos, expression, None) {
+                error!("Failed to paste node. {err}");
+            }
+        }
+    }
+}
+
+
+
+// ===============
+// === Helpers ===
+// ===============
+
+impl Handle {
+    /// Create a new node at the provided position.
+    fn new_node_at_position(
+        &self,
+        position: Vector2,
+        expression: String,
+        metadata: Option<NodeMetadata>,
+    ) -> FallibleResult {
+        let info = NewNodeInfo {
+            expression,
+            doc_comment: None,
+            metadata,
+            id: None,
+            location_hint: double_representation::graph::LocationHint::End,
+            introduce_pattern: true,
+        };
+        let ast_id = self.add_node(info)?;
+        self.set_node_position(ast_id, position)?;
+        Ok(())
+    }
+}

--- a/app/gui/src/controller/graph/clipboard.rs
+++ b/app/gui/src/controller/graph/clipboard.rs
@@ -53,9 +53,10 @@ struct CopiedNode {
 
 /// Copy the node to the clipboard.
 pub fn copy_node(expression: String, metadata: Option<NodeMetadata>) -> FallibleResult {
+    let text_data = Some(expression.clone());
     let content = ClipboardContent::Node(CopiedNode { expression, metadata });
     let text_repr = serde_json::to_string(&content)?;
-    clipboard::write(text_repr.as_bytes(), MIME_TYPE.to_string());
+    clipboard::write(text_repr.as_bytes(), MIME_TYPE.to_string(), text_data);
     Ok(())
 }
 

--- a/app/gui/src/controller/ide.rs
+++ b/app/gui/src/controller/ide.rs
@@ -58,7 +58,7 @@ impl StatusNotificationPublisher {
     pub fn publish_event(&self, label: impl Into<String>) {
         let label = label.into();
         let notification = StatusNotification::Event { label };
-        executor::global::spawn(self.publisher.publish(notification));
+        self.publisher.notify(notification);
     }
 
     /// Publish a notification about new process (see [`StatusNotification::ProcessStarted`]).
@@ -69,7 +69,7 @@ impl StatusNotificationPublisher {
         let label = label.into();
         let handle = Uuid::new_v4();
         let notification = StatusNotification::BackgroundTaskStarted { label, handle };
-        executor::global::spawn(self.publisher.publish(notification));
+        self.publisher.notify(notification);
         handle
     }
 
@@ -78,7 +78,7 @@ impl StatusNotificationPublisher {
     #[profile(Debug)]
     pub fn published_background_task_finished(&self, handle: BackgroundTaskHandle) {
         let notification = StatusNotification::BackgroundTaskFinished { handle };
-        executor::global::spawn(self.publisher.publish(notification));
+        self.publisher.notify(notification);
     }
 
     /// The asynchronous stream of published notifications.

--- a/app/gui/src/presenter/graph.rs
+++ b/app/gui/src/presenter/graph.rs
@@ -444,8 +444,8 @@ impl Model {
         }
     }
 
-    fn paste_node(&self) {
-        if let Err(err) = self.controller.graph().paste_node() {
+    fn paste_node(&self, cursor_pos: Vector2) {
+        if let Err(err) = self.controller.graph().paste_node(cursor_pos) {
             error!("Error when pasting the node: {err}");
         }
     }
@@ -785,7 +785,7 @@ impl Graph {
 
             // === Dropping Files ===
 
-            eval_ view.request_paste_node(model.paste_node());
+            eval view.request_paste_node((pos) model.paste_node(*pos));
             file_upload_requested <- view.file_dropped.gate(&project_view.drop_files_enabled);
             eval file_upload_requested (((file,position)) model.file_dropped(file.clone_ref(),*position));
         }

--- a/app/gui/src/presenter/graph.rs
+++ b/app/gui/src/presenter/graph.rs
@@ -445,19 +445,9 @@ impl Model {
     }
 
     fn paste_node(&self) {
-        let graph = self.controller.graph();
-        let expression = ensogl::system::web::clipboard::read_text(move |expression| {
-            console_log!("Pasting node: {expression}");
-            let info = NewNodeInfo {
-                expression:        expression.into(),
-                doc_comment:       None,
-                metadata:          None,
-                id:                None,
-                location_hint:     double_representation::graph::LocationHint::End,
-                introduce_pattern: true,
-            };
-            graph.add_node(info);
-        });
+        if let Err(err) = self.controller.graph().paste_node() {
+            error!("Error when pasting the node: {err}");
+        }
     }
 
     /// Look through all graph's nodes in AST and set position where it is missing.

--- a/app/gui/src/presenter/graph.rs
+++ b/app/gui/src/presenter/graph.rs
@@ -1,6 +1,7 @@
 //! The module with the [`Graph`] presenter. See [`crate::presenter`] documentation to know more
 //! about presenters in general.
 
+use crate::controller::graph::NewNodeInfo;
 use crate::prelude::*;
 use enso_web::traits::*;
 
@@ -443,6 +444,22 @@ impl Model {
         }
     }
 
+    fn paste_node(&self) {
+        let graph = self.controller.graph();
+        let expression = ensogl::system::web::clipboard::read_text(move |expression| {
+            console_log!("Pasting node: {expression}");
+            let info = NewNodeInfo {
+                expression:        expression.into(),
+                doc_comment:       None,
+                metadata:          None,
+                id:                None,
+                location_hint:     double_representation::graph::LocationHint::End,
+                introduce_pattern: true,
+            };
+            graph.add_node(info);
+        });
+    }
+
     /// Look through all graph's nodes in AST and set position where it is missing.
     #[profile(Debug)]
     fn initialize_nodes_positions(&self, default_gap_between_nodes: f32) {
@@ -778,6 +795,7 @@ impl Graph {
 
             // === Dropping Files ===
 
+            eval_ view.request_paste_node(model.paste_node());
             file_upload_requested <- view.file_dropped.gate(&project_view.drop_files_enabled);
             eval file_upload_requested (((file,position)) model.file_dropped(file.clone_ref(),*position));
         }

--- a/app/gui/src/presenter/graph.rs
+++ b/app/gui/src/presenter/graph.rs
@@ -291,6 +291,16 @@ impl Model {
         Some((node_id, config))
     }
 
+    fn node_copied(&self, id: ViewNodeId) {
+        self.log_action(
+            || {
+                let ast_id = self.state.update_from_view().copy_node(id)?;
+                Some(self.controller.graph().copy_node(ast_id))
+            },
+            "copy node",
+        )
+    }
+
     /// Node was removed in view.
     fn node_removed(&self, id: ViewNodeId) {
         self.log_action(
@@ -751,6 +761,7 @@ impl Graph {
 
             // === Changes from the View ===
 
+            eval view.node_copied((node_id) model.node_copied(*node_id));
             eval view.node_position_set_batched(((node_id, position)) model.node_position_changed(*node_id, *position));
             eval view.node_removed((node_id) model.node_removed(*node_id));
             eval view.nodes_collapsed(((nodes, _)) model.nodes_collapsed(nodes));

--- a/app/gui/src/presenter/graph.rs
+++ b/app/gui/src/presenter/graph.rs
@@ -1,7 +1,6 @@
 //! The module with the [`Graph`] presenter. See [`crate::presenter`] documentation to know more
 //! about presenters in general.
 
-use crate::controller::graph::NewNodeInfo;
 use crate::prelude::*;
 use enso_web::traits::*;
 
@@ -295,7 +294,7 @@ impl Model {
     fn node_copied(&self, id: ViewNodeId) {
         self.log_action(
             || {
-                let ast_id = self.state.update_from_view().copy_node(id)?;
+                let ast_id = self.state.ast_node_id_of_view(id)?;
                 Some(self.controller.graph().copy_node(ast_id))
             },
             "copy node",
@@ -446,7 +445,7 @@ impl Model {
 
     fn paste_node(&self, cursor_pos: Vector2) {
         if let Err(err) = self.controller.graph().paste_node(cursor_pos) {
-            error!("Error when pasting the node: {err}");
+            error!("Error when pasting node: {err}");
         }
     }
 
@@ -783,7 +782,7 @@ impl Graph {
             eval_ view.reopen_file_in_language_server (model.reopen_file_in_ls());
 
 
-            // === Dropping Files ===
+            // === Dropping Files and Pasting Node ===
 
             eval view.request_paste_node((pos) model.paste_node(*pos));
             file_upload_requested <- view.file_dropped.gate(&project_view.drop_files_enabled);

--- a/app/gui/src/presenter/graph.rs
+++ b/app/gui/src/presenter/graph.rs
@@ -19,6 +19,7 @@ use ide_view::graph_editor::component::node as node_view;
 use ide_view::graph_editor::component::visualization as visualization_view;
 use span_tree::generate::Context as _;
 use view::graph_editor::CallWidgetsConfig;
+use view::notification::logged as notification;
 
 
 // ==============
@@ -444,9 +445,11 @@ impl Model {
     }
 
     fn paste_node(&self, cursor_pos: Vector2) {
-        if let Err(err) = self.controller.graph().paste_node(cursor_pos) {
-            error!("Error when pasting node: {err}");
+        fn on_error(msg: String) {
+            error!("Error when pasting node. {}", msg);
+            notification::error(msg, &None);
         }
+        self.controller.graph().paste_node(cursor_pos, on_error);
     }
 
     /// Look through all graph's nodes in AST and set position where it is missing.

--- a/app/gui/src/presenter/graph/state.rs
+++ b/app/gui/src/presenter/graph/state.rs
@@ -607,10 +607,6 @@ impl<'a> ViewChange<'a> {
         }
     }
 
-    pub fn copy_node(&self, id: ViewNodeId) -> Option<AstNodeId> {
-        self.nodes.borrow().ast_node_by_view_id.get(&id).cloned()
-    }
-
     /// Remove the node, and returns its AST ID.
     pub fn remove_node(&self, id: ViewNodeId) -> Option<AstNodeId> {
         self.nodes.borrow_mut().remove_node(id)

--- a/app/gui/src/presenter/graph/state.rs
+++ b/app/gui/src/presenter/graph/state.rs
@@ -607,6 +607,10 @@ impl<'a> ViewChange<'a> {
         }
     }
 
+    pub fn copy_node(&self, id: ViewNodeId) -> Option<AstNodeId> {
+        self.nodes.borrow().ast_node_by_view_id.get(&id).cloned()
+    }
+
     /// Remove the node, and returns its AST ID.
     pub fn remove_node(&self, id: ViewNodeId) -> Option<AstNodeId> {
         self.nodes.borrow_mut().remove_node(id)

--- a/app/gui/view/graph-editor/src/component/node/input/widget.rs
+++ b/app/gui/view/graph-editor/src/component/node/input/widget.rs
@@ -50,8 +50,6 @@
 //! [`SpanWidget::PRIORITY_OVER_OVERRIDE`] as `true` in their implementation. In that case, the
 //! override will be applied again on their children that use the same span-tree node.
 
-
-
 use crate::prelude::*;
 
 use crate::component::node::input::area::NODE_HEIGHT;

--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -3018,7 +3018,7 @@ fn init_remaining_graph_editor_frp(
 
     frp::extend! { network
         out.node_copied <+ inputs.copy_selected_node.map(f_!(model.nodes.last_selected())).unwrap();
-        out.request_paste_node <+ cursor.position.sample(&inputs.paste_node).map(|v| v.xy());
+        out.request_paste_node <+ cursor.scene_position.sample(&inputs.paste_node).map(|v| v.xy());
     }
 
 

--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -723,7 +723,7 @@ ensogl::define_endpoints_2! {
 
         // === Copy-Paste ===
         node_copied(NodeId),
-        request_node_pasted(),
+        request_paste_node(),
 
         file_dropped     (ensogl_drop_manager::File,Vector2<f32>),
 
@@ -3028,7 +3028,7 @@ fn init_remaining_graph_editor_frp(
 
     frp::extend! { network
         out.node_copied <+ inputs.copy_selected_node.map(f_!(model.nodes.last_selected())).unwrap();
-        eval_ inputs.paste_node(model.paste_node());
+        out.request_paste_node <+ inputs.paste_node;
     }
 
 

--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -723,7 +723,7 @@ ensogl::define_endpoints_2! {
 
         // === Copy-Paste ===
         node_copied(NodeId),
-        request_paste_node(),
+        request_paste_node(Vector2),
 
         file_dropped     (ensogl_drop_manager::File,Vector2<f32>),
 
@@ -1910,18 +1910,6 @@ impl GraphEditorModel {
     }
 }
 
-// === Copy-paste ===
-impl GraphEditorModel {
-    pub fn copy_selected_node(&self) {
-        let selected_node = self.nodes.last_selected();
-        console_log!("Copy selected node");
-    }
-
-    pub fn paste_node(&self) {
-        console_log!("Paste node");
-    }
-}
-
 
 // === Remove ===
 
@@ -3028,7 +3016,7 @@ fn init_remaining_graph_editor_frp(
 
     frp::extend! { network
         out.node_copied <+ inputs.copy_selected_node.map(f_!(model.nodes.last_selected())).unwrap();
-        out.request_paste_node <+ inputs.paste_node;
+        out.request_paste_node <+ cursor.position.sample(&inputs.paste_node).map(|v| v.xy());
     }
 
 

--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -539,7 +539,6 @@ ensogl::define_endpoints_2! {
         // === Copy-Paste ===
         copy_selected_node(),
         paste_node(),
-        paste_node_with_code(ImString),
 
 
         /// Remove all selected nodes from the graph.

--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -536,7 +536,10 @@ ensogl::define_endpoints_2! {
         /// opposed to e.g. when loading a graph from a file).
         start_node_creation_from_port(),
 
-
+        // === Copy-Paste ===
+        copy_selected_node(),
+        paste_node(),
+        paste_node_with_code(ImString),
 
 
         /// Remove all selected nodes from the graph.
@@ -717,6 +720,10 @@ ensogl::define_endpoints_2! {
 
         node_being_edited (Option<NodeId>),
         node_editing (bool),
+
+        // === Copy-Paste ===
+        node_copied(NodeId),
+        request_node_pasted(),
 
         file_dropped     (ensogl_drop_manager::File,Vector2<f32>),
 
@@ -1903,6 +1910,18 @@ impl GraphEditorModel {
     }
 }
 
+// === Copy-paste ===
+impl GraphEditorModel {
+    pub fn copy_selected_node(&self) {
+        let selected_node = self.nodes.last_selected();
+        console_log!("Copy selected node");
+    }
+
+    pub fn paste_node(&self) {
+        console_log!("Paste node");
+    }
+}
+
 
 // === Remove ===
 
@@ -3002,6 +3021,14 @@ fn init_remaining_graph_editor_frp(
         eval inputs.set_node_context_switch(((id, context_switch))
             model.set_node_context_switch(*id, context_switch)
         );
+    }
+
+
+    // === Copy-Paste ===
+
+    frp::extend! { network
+        out.node_copied <+ inputs.copy_selected_node.map(f_!(model.nodes.last_selected())).unwrap();
+        eval_ inputs.paste_node(model.paste_node());
     }
 
 

--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -721,8 +721,11 @@ ensogl::define_endpoints_2! {
         node_being_edited (Option<NodeId>),
         node_editing (bool),
 
+
         // === Copy-Paste ===
+
         node_copied(NodeId),
+        // Paste node at position.
         request_paste_node(Vector2),
 
         file_dropped     (ensogl_drop_manager::File,Vector2<f32>),

--- a/app/gui/view/graph-editor/src/lib.rs
+++ b/app/gui/view/graph-editor/src/lib.rs
@@ -3018,7 +3018,10 @@ fn init_remaining_graph_editor_frp(
 
     frp::extend! { network
         out.node_copied <+ inputs.copy_selected_node.map(f_!(model.nodes.last_selected())).unwrap();
-        out.request_paste_node <+ cursor.scene_position.sample(&inputs.paste_node).map(|v| v.xy());
+        cursor_pos_at_paste <- cursor.scene_position.sample(&inputs.paste_node).map(|v| v.xy());
+        out.request_paste_node <+ cursor_pos_at_paste.map(
+            f!([model](pos) new_node_position::at_mouse_aligned_to_close_nodes(&model, *pos))
+        );
     }
 
 

--- a/app/gui/view/graph-editor/src/shortcuts.rs
+++ b/app/gui/view/graph-editor/src/shortcuts.rs
@@ -79,6 +79,9 @@ pub const SHORTCUTS: &[(ensogl::application::shortcut::ActionType, &str, &str, &
     (Release, "!read_only", "cmd", "edit_mode_off"),
     (Press, "!read_only", "cmd left-mouse-button", "edit_mode_on"),
     (Release, "!read_only", "cmd left-mouse-button", "edit_mode_off"),
+    // === Copy-paste ===
+    (Press, "", "cmd c", "copy_selected_node"),
+    (Press, "!read_only", "cmd v", "paste_node"),
     // === Debug ===
     (Press, "debug_mode", "ctrl d", "debug_set_test_visualization_data_for_selected_node"),
     (Press, "debug_mode", "ctrl n", "add_node_at_cursor"),

--- a/app/gui/view/graph-editor/src/shortcuts.rs
+++ b/app/gui/view/graph-editor/src/shortcuts.rs
@@ -80,7 +80,7 @@ pub const SHORTCUTS: &[(ensogl::application::shortcut::ActionType, &str, &str, &
     (Press, "!read_only", "cmd left-mouse-button", "edit_mode_on"),
     (Release, "!read_only", "cmd left-mouse-button", "edit_mode_off"),
     // === Copy-paste ===
-    (Press, "", "cmd c", "copy_selected_node"),
+    (Press, "!node_editing", "cmd c", "copy_selected_node"),
     (Press, "!read_only", "cmd v", "paste_node"),
     // === Debug ===
     (Press, "debug_mode", "ctrl d", "debug_set_test_visualization_data_for_selected_node"),

--- a/lib/rust/web/js/clipboard.js
+++ b/lib/rust/web/js/clipboard.js
@@ -119,7 +119,7 @@ export function readText(callback) {
     }
 }
 
-/// Read a custom payload of `expectedMimeType` from the clipboard, passing it to `whenExpecte` callback.
+/// Read a custom payload of `expectedMimeType` from the clipboard, passing it to `whenExpected` callback.
 /// If there is no value of `expectedMimeType` in the payload, use `plainTextFallback` callback instead.
 ///
 /// Unlike `readText`, there are no special fallbacks in case of errors or the clipboard being unavailable.

--- a/lib/rust/web/js/clipboard.js
+++ b/lib/rust/web/js/clipboard.js
@@ -72,13 +72,13 @@ export function writeText(text) {
     }
 }
 
-export function write(data) {
+export function write(data, mime_type) {
   if (!navigator.clipboard) {
     console.error('Clipboard API not available.')
   } else {
-    const blob = new Blob([data], { type: 'web application/enso' })
+    const blob = new Blob([data], { type: mime_type })
     navigator.clipboard.write(
-      [new ClipboardItem({ ['web application/enso']: blob })]
+      [new ClipboardItem({ [blob.type]: blob })]
     ).then(
         () => {},
         err => {
@@ -117,15 +117,17 @@ export function readText(callback) {
     }
 }
 
-export function read(callback) {
+export function read(expected_mime_type, callback) {
   if (!navigator.clipboard) {
     console.error('Clipboard API not available.')
   } else {
     navigator.clipboard.read().then(
         function (data) { 
-            data[0].getType('web application/enso')
+            data[0].getType(expected_mime_type)
               .then(
-                  (blob) => blob.text().then((data) => callback(data)), 
+                  (blob) => {
+                      blob.arrayBuffer().then(buffer => callback(new Uint8Array(buffer)))
+                  },
                   (err) => console.error("Could not get data from clipboard.", err)
               )
         },

--- a/lib/rust/web/js/clipboard.js
+++ b/lib/rust/web/js/clipboard.js
@@ -72,20 +72,22 @@ export function writeText(text) {
     }
 }
 
+/// Write custom `data` payload to the clipboard. Data will be saved as a `Blob` with `mimeType`.
+///
+/// Unlike `writeText`, there are no special fallbacks in case of errors or the clipboard being unavailable.
+/// If writing did not succeeed, the function will simply log an error to the console.
 export function writeCustom(mimeType, data) {
-  if (!navigator.clipboard) {
-    console.error('Clipboard API not available.')
-  } else {
-    const blob = new Blob([data], { type: mimeType })
-    navigator.clipboard.write(
-      [new ClipboardItem({ [blob.type]: blob })]
-    ).then(
-        () => {},
-        err => {
-            console.error('Could not write to clipboard.', err)
-        }
-    )
-  }
+    if (!navigator.clipboard) {
+        console.error('Clipboard API not available.')
+    } else {
+        const blob = new Blob([data], { type: mimeType })
+        navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]).then(
+            () => {},
+            err => {
+                console.error('Could not write to clipboard.', err)
+            }
+        )
+    }
 }
 
 /// Firefox only supports reading the clipboard in browser extensions, so it will
@@ -117,32 +119,41 @@ export function readText(callback) {
     }
 }
 
-async function readCustomImpl(expectedMimeType, whenExpected, plainTextFallback) {
-  try {
-    const data = await navigator.clipboard.read()
-    const item = data[0]
-    if (item.types.includes(expectedMimeType)) {
-      const blob = await item.getType(expectedMimeType)
-      const buffer = await blob.arrayBuffer()
-      whenExpected(new Uint8Array(buffer))
-    } else if (item.types.includes("text/plain")) {
-      const blob = await item.getType("text/plain")
-      const text = await blob.text()
-      plainTextFallback(text)
+/// Read a custom payload of `expectedMimeType` from the clipboard, passing it to `whenExpecte` callback.
+/// If there is no value of `expectedMimeType` in the payload, use `plainTextFallback` callback instead.
+///
+/// Unlike `readText`, there are no special fallbacks in case of errors or the clipboard being unavailable.
+/// If reading did not succeeed, the function will simply log an error to the console.
+export function readCustom(expectedMimeType, whenExpected, plainTextFallback) {
+    if (!navigator.clipboard) {
+        console.error('Clipboard API not available.')
     } else {
-      console.error("Unexpected clipboard payload MIME-type: ", item.types)
+        readCustomImpl(expectedMimeType, whenExpected, plainTextFallback)
     }
-  } catch (error) {
-    console.error("Error while reading clipboard: ", error)
-  }
 }
 
-export function readCustom(expectedMimeType, whenExpected, plainTextFallback) {
-  if (!navigator.clipboard) {
-    console.error('Clipboard API not available.')
-  } else {
-    readCustomImpl(expectedMimeType, whenExpected, plainTextFallback)
-  }
+/// Helper function for `readCustom`, see its documentation.
+async function readCustomImpl(expectedMimeType, whenExpected, plainTextFallback) {
+    try {
+        const data = await navigator.clipboard.read()
+        if (data.length === 0) {
+            return
+        }
+        const item = data[0]
+        if (item.types.includes(expectedMimeType)) {
+            const blob = await item.getType(expectedMimeType)
+            const buffer = await blob.arrayBuffer()
+            whenExpected(new Uint8Array(buffer))
+        } else if (item.types.includes('text/plain')) {
+            const blob = await item.getType('text/plain')
+            const text = await blob.text()
+            plainTextFallback(text)
+        } else {
+            console.error('Unexpected clipboard payload MIME-type.', item.types)
+        }
+    } catch (error) {
+        console.error('Error while reading clipboard.', error)
+    }
 }
 
 // ======================

--- a/lib/rust/web/js/clipboard.js
+++ b/lib/rust/web/js/clipboard.js
@@ -73,15 +73,20 @@ export function writeText(text) {
 }
 
 /// Write custom `data` payload to the clipboard. Data will be saved as a `Blob` with `mimeType`.
+/// If `textData` is not empty, an additional clipboard item will be written with the `text/plain` type.
 ///
 /// Unlike `writeText`, there are no special fallbacks in case of errors or the clipboard being unavailable.
 /// If writing did not succeeed, the function will simply log an error to the console.
-export function writeCustom(mimeType, data) {
+export function writeCustom(mimeType, data, textData) {
     if (!navigator.clipboard) {
         console.error('Clipboard API not available.')
     } else {
         const blob = new Blob([data], { type: mimeType })
-        navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]).then(
+        const payload = { [blob.type]: blob }
+        if (typeof textData === 'string' && textData !== '') {
+            payload['text/plain'] = new Blob([textData], { type: 'text/plain' })
+        }
+        navigator.clipboard.write([new ClipboardItem(payload)]).then(
             () => {},
             err => {
                 console.error('Could not write to clipboard.', err)
@@ -136,20 +141,22 @@ export function readCustom(expectedMimeType, whenExpected, plainTextFallback) {
 async function readCustomImpl(expectedMimeType, whenExpected, plainTextFallback) {
     try {
         const data = await navigator.clipboard.read()
-        if (data.length === 0) {
-            return
+        for (const item of data) {
+            if (item.types.includes(expectedMimeType)) {
+                const blob = await item.getType(expectedMimeType)
+                const buffer = await blob.arrayBuffer()
+                whenExpected(new Uint8Array(buffer))
+                return
+            }
         }
-        const item = data[0]
-        if (item.types.includes(expectedMimeType)) {
-            const blob = await item.getType(expectedMimeType)
-            const buffer = await blob.arrayBuffer()
-            whenExpected(new Uint8Array(buffer))
-        } else if (item.types.includes('text/plain')) {
-            const blob = await item.getType('text/plain')
-            const text = await blob.text()
-            plainTextFallback(text)
-        } else {
-            console.error('Unexpected clipboard payload MIME-type.', item.types)
+        // We use a separate loop to make sure `expectedMimeType` has a priority, no matter the order of items.
+        for (const item of data) {
+            if (item.types.includes('text/plain')) {
+                const blob = await item.getType('text/plain')
+                const text = await blob.text()
+                plainTextFallback(text)
+                return
+            }
         }
     } catch (error) {
         console.error('Error while reading clipboard.', error)

--- a/lib/rust/web/js/clipboard.js
+++ b/lib/rust/web/js/clipboard.js
@@ -72,11 +72,11 @@ export function writeText(text) {
     }
 }
 
-export function write(data, mime_type) {
+export function writeCustom(mimeType, data) {
   if (!navigator.clipboard) {
     console.error('Clipboard API not available.')
   } else {
-    const blob = new Blob([data], { type: mime_type })
+    const blob = new Blob([data], { type: mimeType })
     navigator.clipboard.write(
       [new ClipboardItem({ [blob.type]: blob })]
     ).then(
@@ -117,24 +117,31 @@ export function readText(callback) {
     }
 }
 
-export function read(expected_mime_type, callback) {
+async function readCustomImpl(expectedMimeType, whenExpected, plainTextFallback) {
+  try {
+    const data = await navigator.clipboard.read()
+    const item = data[0]
+    if (item.types.includes(expectedMimeType)) {
+      const blob = await item.getType(expectedMimeType)
+      const buffer = await blob.arrayBuffer()
+      whenExpected(new Uint8Array(buffer))
+    } else if (item.types.includes("text/plain")) {
+      const blob = await item.getType("text/plain")
+      const text = await blob.text()
+      plainTextFallback(text)
+    } else {
+      console.error("Unexpected clipboard payload MIME-type: ", item.types)
+    }
+  } catch (error) {
+    console.error("Error while reading clipboard: ", error)
+  }
+}
+
+export function readCustom(expectedMimeType, whenExpected, plainTextFallback) {
   if (!navigator.clipboard) {
     console.error('Clipboard API not available.')
   } else {
-    navigator.clipboard.read().then(
-        function (data) { 
-            data[0].getType(expected_mime_type)
-              .then(
-                  (blob) => {
-                      blob.arrayBuffer().then(buffer => callback(new Uint8Array(buffer)))
-                  },
-                  (err) => console.error("Could not get data from clipboard.", err)
-              )
-        },
-        (err) => {
-            console.error('Could not read from clipboard.', err)
-        }
-    )
+    readCustomImpl(expectedMimeType, whenExpected, plainTextFallback)
   }
 }
 

--- a/lib/rust/web/js/clipboard.js
+++ b/lib/rust/web/js/clipboard.js
@@ -72,33 +72,68 @@ export function writeText(text) {
     }
 }
 
+export function write(data) {
+  if (!navigator.clipboard) {
+    console.error('Clipboard API not available.')
+  } else {
+    const blob = new Blob([data], { type: 'web application/enso' })
+    navigator.clipboard.write(
+      [new ClipboardItem({ ['web application/enso']: blob })]
+    ).then(
+        () => {},
+        err => {
+            console.error('Could not write to clipboard.', err)
+        }
+    )
+  }
+}
+
 /// Firefox only supports reading the clipboard in browser extensions, so it will
 /// only work with `cmd + v` shortcut. To learn more, see the
 /// [MSDN compatibility note](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/readText).
-let lastPaste = ''
+let lastTextPaste = ''
 function init_firefox_fallback() {
     // Checking whether the window is defined. It could not be defined if the program is run in
     // node, for example to extract the shaders.
     if (typeof window !== 'undefined') {
         window.addEventListener('paste', event => {
-            lastPaste = (event.clipboardData || window.clipboardData).getData('text')
+            lastTextPaste = (event.clipboardData || window.clipboardData).getData('text')
         })
     }
 }
 
 export function readText(callback) {
     if (!navigator.clipboard) {
-        callback(lastPaste)
+        callback(lastTextPaste)
     } else {
         navigator.clipboard.readText().then(
             function (text) {
                 callback(text)
             },
             function (err) {
-                callback(lastPaste)
+                callback(lastTextPaste)
             }
         )
     }
+}
+
+export function read(callback) {
+  if (!navigator.clipboard) {
+    console.error('Clipboard API not available.')
+  } else {
+    navigator.clipboard.read().then(
+        function (data) { 
+            data[0].getType('web application/enso')
+              .then(
+                  (blob) => blob.text().then((data) => callback(data)), 
+                  (err) => console.error("Could not get data from clipboard.", err)
+              )
+        },
+        (err) => {
+            console.error('Could not read from clipboard.', err)
+        }
+    )
+  }
 }
 
 // ======================

--- a/lib/rust/web/src/clipboard.rs
+++ b/lib/rust/web/src/clipboard.rs
@@ -1,4 +1,21 @@
 //! Clipboard management utilities.
+//!
+//! Please note:
+//! - Every function here uses the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API)
+//!   under the hood.
+//! - Every function is asynchronous. The delay for receiving or sending data may be caused for
+//!   example by waiting for permission from the user.
+//! - Every function will probably display a permission prompt to the user for the first time it is
+//!   used.
+//! - The website has to be served over HTTPS for these functions to work correctly.
+//! - These functions needs to be called from within user-initiated event callbacks, like mouse or
+//!   key press. Otherwise it may not work.
+//! - Web browsers do not support MIME-types other than `text/plain`, `text/html`, and `image/png`
+//!   in general. However, using
+//!   [Clipboard pickling](https://github.com/w3c/editing/blob/gh-pages/docs/clipboard-pickling/explainer.md),
+//!   we can practically use any MIME-type.
+//!
+//! To learn more, see this [StackOverflow question](https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript).
 
 use crate::prelude::*;
 
@@ -12,8 +29,11 @@ use wasm_bindgen::prelude::Closure;
 // === Types ===
 // =============
 
+/// MIME-type of the data.
 pub type MimeType = String;
+/// The data to be written to the clipboard.
 pub type BinaryData<'a> = &'a [u8];
+
 type ReadTextClosure = Closure<dyn Fn(String)>;
 type ReadClosure = Closure<dyn Fn(Vec<u8>)>;
 
@@ -42,30 +62,32 @@ extern "C" {
     );
 }
 
+/// Write the provided data to the clipboard, using the provided MIME-type.
+///
+/// See the module documentation for mode details.
+///
+/// - Unlike `write_text`, there is no special fallback mechanism in case of failures or unavailable
+///   clipboard. The function will simply report an error to the console.
 pub fn write(data: BinaryData<'_>, mime_type: MimeType) {
     let data = Uint8Array::from(data);
     writeCustom(mime_type, data);
 }
 
+/// Read the arbitrary binary data from the console. It is expected to have `expected_mime_type`.
+/// If the value of such type is not present in the clipboard content, the `plain/text` MIME-type
+/// is requested and the result is passed to the `plain_text_fallback` callback.
+///
+/// See the module documentation for more details.
+///
+/// - Unlike `read_text`, there is no special fallback mechanism in case of failures or unavailable
+///   clipboard. The function will simply report an error to the console.
 pub fn read(
     expected_mime_type: MimeType,
     when_expected: impl Fn(Vec<u8>) + 'static,
     plain_text_fallback: impl Fn(String) + 'static,
 ) {
-    let when_expected_handler: Rc<RefCell<Option<ReadClosure>>> = default();
-    let handler_clone = when_expected_handler.clone_ref();
-    let when_expected: ReadClosure = Closure::new(move |result| {
-        *handler_clone.borrow_mut() = None;
-        when_expected(result);
-    });
-    *when_expected_handler.borrow_mut() = Some(when_expected);
-    let fallback_handler: Rc<RefCell<Option<ReadTextClosure>>> = default();
-    let handler_clone = fallback_handler.clone_ref();
-    let plain_text_fallback: ReadTextClosure = Closure::new(move |result| {
-        *handler_clone.borrow_mut() = None;
-        plain_text_fallback(result);
-    });
-    *fallback_handler.borrow_mut() = Some(plain_text_fallback);
+    let when_expected_handler = create_handler_binary(when_expected);
+    let fallback_handler = create_handler_string(plain_text_fallback);
     readCustom(
         expected_mime_type,
         when_expected_handler.borrow().as_ref().unwrap(),
@@ -73,45 +95,42 @@ pub fn read(
     );
 }
 
-/// Write the provided text to the clipboard. Please note that:
-/// - It uses the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API)
-///   under the hood.
-/// - This is an asynchronous function. The results will not appear in the clipboard immediately.
-///   The delay may be caused for example by waiting for permission from the user.
-/// - This will probably display a permission prompt to the user for the first time it is used.
-/// - The website has to be served over HTTPS for this function to work correctly.
-/// - This function needs to be called from within user-initiated event callbacks, like mouse or key
-///   press. Otherwise it will not work.
+/// Write the provided text to the clipboard.
 ///
-/// Moreover, in case something fails, this function implements a fallback mechanism which tries
+/// See the module documentation for more details.
+///
+/// In case something fails, this function implements a fallback mechanism which tries
 /// to create a hidden text field, fill it with the text and use the obsolete
 /// [Document.execCommand](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand)
 /// function.
-///
-/// To learn more, see this [StackOverflow question](https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript).
 pub fn write_text(text: impl Into<String>) {
     let text = text.into();
     writeText(text)
 }
 
-/// Read the text from the clipboard. Please note that:
-/// - It uses the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API)
-///   under the hood.
-/// - This is an asynchronous function. The callback with the text will be called when the text will
-///   be ready. The delay may be caused for example by waiting for permissions from the user.
-/// - This will probably display a permission prompt to the user for the first time it is used.
-/// - The website has to be served over HTTPS for this function to work correctly.
-/// - This function needs to be called from within user-initiated event callbacks, like mouse or key
-///   press. Otherwise it will not work.
+/// Read the text from the clipboard.
 ///
-/// Moreover, this function works in a very strange way in Firefox.
+/// See the module documentation for more details.
+///
+/// This function works in a very strange way in Firefox.
 /// [Firefox only supports reading the clipboard in browser extensions](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/readText).
 /// In such case this function fallbacks to the `paste` event. Whenever it is triggered, it
 /// remembers its value and passes it to the callback. This means, that in Firefox this function
 /// will work correctly only when called as a direct action to the `cmd + v` shortcut.
-///
-/// To learn more, see this [StackOverflow question](https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript).
 pub fn read_text(callback: impl Fn(String) + 'static) {
+    let handler = create_handler_string(callback);
+    readText(handler.borrow().as_ref().unwrap());
+}
+
+
+
+// ===============
+// === Helpers ===
+// ===============
+
+fn create_handler_string(
+    callback: impl Fn(String) + 'static,
+) -> Rc<RefCell<Option<Closure<dyn Fn(String)>>>> {
     let handler: Rc<RefCell<Option<ReadTextClosure>>> = default();
     let handler_clone = handler.clone_ref();
     let closure: ReadTextClosure = Closure::new(move |result| {
@@ -119,5 +138,18 @@ pub fn read_text(callback: impl Fn(String) + 'static) {
         callback(result);
     });
     *handler.borrow_mut() = Some(closure);
-    readText(handler.borrow().as_ref().unwrap());
+    handler
+}
+
+fn create_handler_binary(
+    callback: impl Fn(Vec<u8>) + 'static,
+) -> Rc<RefCell<Option<Closure<dyn Fn(Vec<u8>)>>>> {
+    let handler: Rc<RefCell<Option<ReadClosure>>> = default();
+    let handler_clone = handler.clone_ref();
+    let closure: ReadClosure = Closure::new(move |result| {
+        *handler_clone.borrow_mut() = None;
+        callback(result);
+    });
+    *handler.borrow_mut() = Some(closure);
+    handler
 }

--- a/lib/rust/web/src/clipboard.rs
+++ b/lib/rust/web/src/clipboard.rs
@@ -10,10 +10,10 @@
 //! - The website has to be served over HTTPS for these functions to work correctly.
 //! - These functions needs to be called from within user-initiated event callbacks, like mouse or
 //!   key press. Otherwise it may not work.
-//! - Web browsers do not support MIME-types other than `text/plain`, `text/html`, and `image/png`
+//! - Web browsers do not support MIME types other than `text/plain`, `text/html`, and `image/png`
 //!   in general. However, using
 //!   [Clipboard pickling](https://github.com/w3c/editing/blob/gh-pages/docs/clipboard-pickling/explainer.md),
-//!   we can practically use any MIME-type.
+//!   we can practically use any MIME type.
 //!
 //! To learn more, see this [StackOverflow question](https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript).
 
@@ -29,7 +29,7 @@ use wasm_bindgen::prelude::Closure;
 // === Types ===
 // =============
 
-/// MIME-type of the data.
+/// MIME type of the data.
 pub type MimeType = String;
 /// The data to be written to the clipboard.
 pub type BinaryData<'a> = &'a [u8];
@@ -52,7 +52,7 @@ extern "C" {
     fn readText(closure: &ReadTextClosure);
 
     #[allow(unsafe_code)]
-    fn writeCustom(mime_type: String, data: Uint8Array);
+    fn writeCustom(mime_type: String, data: Uint8Array, text_data: String);
 
     #[allow(unsafe_code)]
     fn readCustom(
@@ -62,19 +62,20 @@ extern "C" {
     );
 }
 
-/// Write the provided data to the clipboard, using the provided MIME-type.
+/// Write the provided data to the clipboard, using the provided MIME type.
+/// If `text_data` is present, it will be added to the clipboard with a `text/plain` MIME type.
 ///
 /// See the module documentation for mode details.
 ///
 /// - Unlike `write_text`, there is no special fallback mechanism in case of failures or unavailable
 ///   clipboard. The function will simply report an error to the console.
-pub fn write(data: BinaryData<'_>, mime_type: MimeType) {
+pub fn write(data: BinaryData<'_>, mime_type: MimeType, text_data: Option<String>) {
     let data = Uint8Array::from(data);
-    writeCustom(mime_type, data);
+    writeCustom(mime_type, data, text_data.unwrap_or_default());
 }
 
 /// Read the arbitrary binary data from the console. It is expected to have `expected_mime_type`.
-/// If the value of such type is not present in the clipboard content, the `plain/text` MIME-type
+/// If the value of such type is not present in the clipboard content, the `plain/text` MIME type
 /// is requested and the result is passed to the `plain_text_fallback` callback.
 ///
 /// See the module documentation for more details.

--- a/lib/rust/web/src/clipboard.rs
+++ b/lib/rust/web/src/clipboard.rs
@@ -26,6 +26,29 @@ extern "C" {
 
     #[allow(unsafe_code)]
     fn readText(closure: &ReadTextClosure);
+
+    #[allow(unsafe_code)]
+    #[wasm_bindgen(js_name = "write")]
+    fn write_js(data: String);
+
+    #[allow(unsafe_code)]
+    #[wasm_bindgen(js_name = "read")]
+    fn read_js(closure: &ReadTextClosure);
+}
+
+pub fn write(data: String) {
+    write_js(data);
+}
+
+pub fn read(callback: impl Fn(String) + 'static) {
+    let handler: Rc<RefCell<Option<ReadTextClosure>>> = default();
+    let handler_clone = handler.clone_ref();
+    let closure: Closure<dyn Fn(String)> = Closure::new(move |result| {
+        *handler_clone.borrow_mut() = None;
+        callback(result);
+    });
+    *handler.borrow_mut() = Some(closure);
+    read_js(handler.borrow().as_ref().unwrap());
 }
 
 /// Write the provided text to the clipboard. Please note that:


### PR DESCRIPTION
### Pull Request Description

Closes #6261 

- Adds support for copy-pasting nodes with `cmd + C` and `cmd + V` shortcuts.
- Only a single, currently selected node will be copied. Adding support for multiple node copies seems easy, though (but was out of the scope of the task).
- We use a custom data format for clipboard content. Node's metadata is also copied, so opened visualizations are preserved. However, the visualization's size is not preserved, as we do not store this info in metadata.
- For custom format to work, we use a pretty new feature called [Clipboard pickling](https://github.com/w3c/editing/blob/gh-pages/docs/clipboard-pickling/explainer.md), but it is available in Electron and in most browsers already.
- Pasting plain text from other applications (or from Enso, if the code is copied in edit mode) is supported and is currently enabled. There are some security concerns related to this, though. I will create a separate issue/discussion for that.
- Undo/redo works as you expect.
- New node is pasted at the cursor position.


https://github.com/enso-org/enso/assets/6566674/7a04d941-19f7-4a39-9bce-0e554af50ba3



### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
