### PR TITLE
Update the Enso grammar in the VS Code extension

### DIFF
--- a/tools/enso4igv/src/main/resources/org/enso/tools/enso4igv/enso.tmLanguage.json
+++ b/tools/enso4igv/src/main/resources/org/enso/tools/enso4igv/enso.tmLanguage.json
@@ -21,7 +21,7 @@
 		"keywords": {
 			"patterns": [{
 					"name": "keyword.other",
-					"match": "\\b(here|self|type)\\b"
+					"match": "\\b(self|type)\\b"
 				}, {
 					"name": "keyword.control",
 					"match": "\\b(case|of|if|then|else)\\b"

--- a/tools/enso4igv/src/main/resources/org/enso/tools/enso4igv/enso.tmLanguage.json
+++ b/tools/enso4igv/src/main/resources/org/enso/tools/enso4igv/enso.tmLanguage.json
@@ -88,12 +88,22 @@
 				{
 					"contentName": "string.quoted.triple.begin",
 					"begin": "^(\\s*)(\"\"\"|''')",
-					"end": "^(?!\\1\\s+)(?!\\s*$)"
+					"end": "^(?!\\1\\s+)(?!\\s*$)",
+					"beginCaptures": {
+						"2": {
+							"name": "string.quoted.triple.begin"
+						}
+					}
 				},
 				{
 					"contentName": "string.quoted.triple.middle",
 					"begin": "^(\\s*)[^\\s].*(\"\"\"|''')",
-					"end": "^(?!\\1\\s+)(?!\\s*$)"
+					"end": "^(?!\\1\\s+)(?!\\s*$)",
+					"beginCaptures": {
+						"2": {
+							"name": "string.quoted.triple.begin"
+						}
+					}
 				},
 				{
 					"name": "string.quoted.single",

--- a/tools/enso4igv/src/main/resources/org/enso/tools/enso4igv/enso.tmLanguage.json
+++ b/tools/enso4igv/src/main/resources/org/enso/tools/enso4igv/enso.tmLanguage.json
@@ -21,7 +21,7 @@
 		"keywords": {
 			"patterns": [{
 					"name": "keyword.other",
-					"match": "\\b(here|this|type)\\b"
+					"match": "\\b(here|self|type)\\b"
 				}, {
 					"name": "keyword.control",
 					"match": "\\b(case|of|if|then|else)\\b"


### PR DESCRIPTION
### Pull Request Description

Following up on #7539 which introduced great improvements to the Enso grammar, I add some more to try to make it even better.

- Changing to highlight `self` instead of `this` (as the keyword was renamed a long time ago).
- Trying to include the string quotes to be highlighted as part of the string - a bit more controversial but IMO it looks more consistent with simple literals.

Before:
![image](https://github.com/enso-org/enso/assets/1436948/7d455c22-042a-4b43-a603-d661190aa7a4)

After:
![image](https://github.com/enso-org/enso/assets/1436948/5bfab6c0-ad67-4302-b5d3-0ef2fce232a9)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
