### PR TITLE
Fix dev version check

### DIFF
--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/protocol/ProjectManagementApi.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/protocol/ProjectManagementApi.scala
@@ -261,11 +261,13 @@ object ProjectManagementApi {
 
   case class BrokenComponentError(msg: String) extends Error(4021, msg)
 
-  case class ProjectManagerUpgradeRequired(minimumRequiredVersion: SemVer)
-      extends Error(
+  case class ProjectManagerUpgradeRequired(
+    currentVersion: SemVer,
+    minimumRequiredVersion: SemVer
+  ) extends Error(
         4022,
         s"Project manager $minimumRequiredVersion is required to install the " +
-        s"requested engine. Please upgrade."
+        s"requested engine. Current version is $currentVersion. Please upgrade."
       ) {
 
     /** Additional payload that can be used to get the version string of the

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectServiceFailureMapper.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectServiceFailureMapper.scala
@@ -27,8 +27,8 @@ object ProjectServiceFailureMapper {
     case CannotRemoveOpenProject    => CannotRemoveOpenProjectError
     case ProjectOperationTimeout    => ServiceError
     case LanguageServerFailure(msg) => LanguageServerError(msg)
-    case ProjectManagerUpgradeRequiredFailure(version) =>
-      ProjectManagerUpgradeRequired(version)
+    case ProjectManagerUpgradeRequiredFailure(current, required) =>
+      ProjectManagerUpgradeRequired(current, required)
     case MissingComponentFailure(msg)      => MissingComponentError(msg)
     case BrokenComponentFailure(msg)       => BrokenComponentError(msg)
     case ComponentInstallationFailure(msg) => ComponentInstallationError(msg)

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectServiceFailure.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectServiceFailure.scala
@@ -84,6 +84,7 @@ object ProjectServiceFailure {
     * than what is currently running.
     */
   case class ProjectManagerUpgradeRequiredFailure(
+    currentVersion: SemVer,
     minimumRequiredVersion: SemVer
   ) extends ProjectServiceFailure
 

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/versionmanagement/RuntimeVersionManagerErrorRecoverySyntax.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/versionmanagement/RuntimeVersionManagerErrorRecoverySyntax.scala
@@ -29,6 +29,7 @@ object RuntimeVersionManagerErrorRecoverySyntax {
             MissingComponentFailure(message)
           case upgradeRequired: UpgradeRequiredError =>
             ProjectManagerUpgradeRequiredFailure(
+              upgradeRequired.currentVersion,
               upgradeRequired.expectedVersion
             )
           case UninstallationError(message) =>

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectCreateDefaultToLatestSpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectCreateDefaultToLatestSpec.scala
@@ -32,7 +32,7 @@ class ProjectCreateDefaultToLatestSpec
         */
       val message =
         "Project manager 9999.0.0 is required to install the requested " +
-        "engine. Please upgrade."
+        "engine. Current version is 0.1.0. Please upgrade."
       client.expectJson(json"""
           {
             "jsonrpc":"2.0",

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/CurrentVersion.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/CurrentVersion.scala
@@ -25,7 +25,7 @@ object CurrentVersion {
 
   /** Check if the current version is the development one. */
   def isDevVersion: Boolean =
-    currentVersion == defaultDevEnsoVersion
+    currentVersion.preRelease == defaultDevEnsoVersion.preRelease
 
   /** Override launcher version with the provided one.
     *

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/ComponentsException.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/ComponentsException.scala
@@ -59,13 +59,15 @@ case class ComponentMissingError(message: String, cause: Throwable = null)
 /** Indicates that a requested engine version requires a newer launcher/project
   * manager version.
   *
+  * @param currentVersion the current engine version
   * @param expectedVersion the minimum version that is required to run the engine
   */
 case class UpgradeRequiredError(
+  currentVersion: SemVer,
   expectedVersion: SemVer
 ) extends ComponentsException(
       s"Minimum version required to use this engine is " +
-      s"$expectedVersion."
+      s"$expectedVersion. Current version is $currentVersion."
     )
 
 /** Indicates uninstallation failure. */

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/RuntimeVersionManager.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/components/RuntimeVersionManager.scala
@@ -464,7 +464,10 @@ class RuntimeVersionManager(
       engineRelease.manifest
     )
     if (!isCompatible) {
-      throw UpgradeRequiredError(engineRelease.manifest.minimumRequiredVersion)
+      throw UpgradeRequiredError(
+        CurrentVersion.version,
+        engineRelease.manifest.minimumRequiredVersion
+      )
     }
     if (engineRelease.isBroken) {
       val continue = userInterface.shouldInstallBrokenEngine(version)
@@ -726,7 +729,12 @@ class RuntimeVersionManager(
   ): Try[Manifest] = {
     Manifest.load(path / Manifest.DEFAULT_MANIFEST_NAME).flatMap { manifest =>
       if (!isEngineVersionCompatibleWithThisInstaller(manifest)) {
-        Failure(UpgradeRequiredError(manifest.minimumRequiredVersion))
+        Failure(
+          UpgradeRequiredError(
+            CurrentVersion.version,
+            manifest.minimumRequiredVersion
+          )
+        )
       } else Success(manifest)
     }
   }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

When building the dev IDE version with `./run ide build`, it creates the engine distribution with version `2023.2.1-dev`. This causes the version check to fail preventing opening the projects.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
