### PR TITLE
Add double-arrow cursor for visualization resizing

### DIFF
--- a/app/gui/view/graph-editor/src/component/visualization/container.rs
+++ b/app/gui/view/graph-editor/src/component/visualization/container.rs
@@ -208,7 +208,7 @@ impl View {
             r.set_color(INVISIBLE_HOVER_COLOR).set_border_color(INVISIBLE_HOVER_COLOR);
         });
         display_object.add_child(&selection);
-        selection.add_child(&hover_area);
+        display_object.add_child(&hover_area);
         hover_area.add_child(&resize_grip);
         let div = web::document.create_div_or_panic();
         let background_dom = DomSymbol::new(&div);
@@ -511,6 +511,7 @@ impl ContainerModel {
             bg_dom.set_style_or_warn("width", "0");
             bg_dom.set_style_or_warn("height", "0");
             self.drag_root.set_xy(Vector2(size.x / 2.0, -size.y / 2.0));
+            self.view.hover_area.set_xy(-size / 2.0);
         }
         let action_bar_size = if matches!(view_state, ViewState::Enabled { has_error: false }) {
             Vector2::new(size.x, ACTION_BAR_HEIGHT)
@@ -519,6 +520,7 @@ impl ContainerModel {
         };
         self.action_bar.frp.set_size.emit(action_bar_size);
         self.action_bar.set_y((size.y - ACTION_BAR_HEIGHT) / 2.0);
+
 
         if view_state.is_visible() && let Some(viz) = &*self.visualization.borrow() {
             viz.frp.set_size.emit(size);

--- a/app/gui/view/graph-editor/src/component/visualization/container.rs
+++ b/app/gui/view/graph-editor/src/component/visualization/container.rs
@@ -36,6 +36,7 @@ use ensogl::display::scene::Shape;
 use ensogl::display::shape::StyleWatchFrp;
 use ensogl::display::DomScene;
 use ensogl::display::DomSymbol;
+use ensogl::gui::cursor;
 use ensogl::system::web;
 use ensogl::Animation;
 use ensogl_component::shadow;
@@ -612,6 +613,7 @@ impl Container {
         let width_anim = Animation::new(network);
         let style = StyleWatchFrp::new(&app.display.default_scene.style_sheet);
         let selection_style = SelectionStyle::from_theme(network, &style);
+        let cursor = &app.cursor.frp;
 
         frp::extend! { network
             init <- source_();
@@ -647,6 +649,27 @@ impl Container {
             _eval <- background_color.all_with(&init, f!((color, _) model.view.set_background_color(*color)));
             grip_offset <- all_with3(&init, &grip_offset_x, &grip_offset_y, |_, x, y| Vector2(*x, *y));
             eval grip_offset((offset) model.view.set_resize_grip_offset(*offset));
+
+
+            // == Grip Hover Cursor Style ==
+
+            let on_hover = model.view.resize_grip.on_event::<mouse::Move>();
+            on_hover_pos <- on_hover.map(|event| event.client_centered());
+            cursor.set_style_override <+ on_hover_pos.map(f!([model](pos) {
+                let relative_position = model.screen_to_object_space(*pos);
+                let lower_right_corner = model.size.get();
+                // Check whether we are right of the diagonal line going from the top left to the
+                // bottom right corner.
+                let is_left = ((lower_right_corner.x * -relative_position.y) - (lower_right_corner.y * relative_position.x)) < 0.0;
+                if is_left {
+                    Some(cursor::Style::double_arrow(0.0))
+                } else {
+                    Some(cursor::Style::double_arrow(std::f32::consts::PI/2.0))
+                }
+            }));
+
+            let on_hover_end = model.view.resize_grip.on_event::<mouse::Leave>();
+            cursor.set_style_override <+ on_hover_end.constant(None);
 
 
             // === Drag-resize ===


### PR DESCRIPTION
### Pull Request Description

This commit introduces a new cursor shape, a double arrow, to be displayed during the hover over the resize grip in the graph editor's visualization component. The rotation of the double arrow depends on whether the cursor is to the left or right of the dividing line from the top left to bottom-right corner of the grip. This gives a more intuitive visual cue to users about the direction of resizing.

![Peek 2023-08-23 13-57](https://github.com/enso-org/enso/assets/1428930/d0f19205-85f3-4046-b3ef-7540030c9ab5)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
