### PR TITLE
Turn abnormal CompilerError into regular Panic

### DIFF
--- a/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
@@ -2,6 +2,7 @@ package org.enso.compiler;
 
 import java.io.OutputStream;
 import java.nio.file.Paths;
+
 import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.PolyglotException;
@@ -99,6 +100,24 @@ public class ExecCompilerTest {
     assertTrue("We get an error value back", error.isException());
     assertTrue("The error value also represents null", error.isNull());
     assertEquals("(Error: Uninitialized value)", error.toString());
+  }
+  @Test
+  public void dotUnderscore() throws Exception {
+    var module = ctx.eval("enso", """
+    run op =
+      op._
+    """);
+    var run = module.invokeMember("eval_expression", "run");
+    try {
+      var error = run.execute("false_hope");
+      fail("Should never return, but: " + error);
+    } catch (PolyglotException e) {
+      assertTrue("It is exception", e.getGuestObject().isException());
+      assertEquals("Panic", e.getGuestObject().getMetaObject().getMetaSimpleName());
+      if (!e.getMessage().contains("Compiler Internal Error")) {
+        fail("Expecting Compiler Internal Error, but was: " + e.getMessage());
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
### Pull Request Description

Fixes #7582 by turning `ComplerError` (during construction of Truffle nodes in `IrToTruffle`) into `PanicException`. That way the abnormal situation turns into a regular panic. Such a panic can be caught or let to be propagated - just like any other panic during execution.

### Important Notes

This is a _safety net_ fix. Investigation of targeted, better fix may continue.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
