### PR TITLE
Avoid _ after .

### DIFF
--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/IR.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/IR.scala
@@ -7809,6 +7809,11 @@ object IR {
           s"Syntax is not supported yet: $syntaxName"
       }
 
+      case object InvalidUnderscore extends Reason {
+        override def explanation: String =
+          s"Invalid use of _"
+      }
+
       case object InvalidPattern extends Reason {
         override def explanation: String =
           s"Cannot define a pattern outside a pattern context"

--- a/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
@@ -5,6 +5,7 @@ import org.enso.compiler.core.IR$Error$Syntax;
 import org.enso.compiler.core.IR$Error$Syntax$InvalidEscapeSequence$;
 import org.enso.compiler.core.IR$Error$Syntax$InvalidExport;
 import org.enso.compiler.core.IR$Error$Syntax$InvalidImport;
+import org.enso.compiler.core.IR$Error$Syntax$InvalidUnderscore$;
 import org.enso.compiler.core.IR$Error$Syntax$Reason;
 import org.enso.compiler.core.IR$Error$Syntax$UnclosedTextLiteral$;
 import org.enso.compiler.core.IR$Error$Syntax$UnexpectedExpression$;
@@ -14,6 +15,7 @@ import org.enso.syntax.text.Location;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
+
 import scala.collection.immutable.List;
 
 public class ErrorCompilerTest extends CompilerTest {
@@ -25,6 +27,16 @@ public class ErrorCompilerTest extends CompilerTest {
     """);
 
     assertSingleSyntaxError(ir, IR$Error$Syntax$UnclosedTextLiteral$.MODULE$, "Unclosed text literal", 6, 28);
+  }
+
+  @Test
+  public void dotUnderscore() throws Exception {
+    var ir = parse("""
+    run op =
+      op._
+    """);
+
+    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidUnderscore$.MODULE$, "Invalid use of _", 14, 15);
   }
 
   @Test

--- a/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
@@ -40,6 +40,16 @@ public class ErrorCompilerTest extends CompilerTest {
   }
 
   @Test
+  public void dotUnderscore2() throws Exception {
+    var ir = parse("""
+    run op =
+      op._.something
+    """);
+
+    assertSingleSyntaxError(ir, IR$Error$Syntax$InvalidUnderscore$.MODULE$, "Invalid use of _", 14, 15);
+  }
+
+  @Test
   public void unfinishedLiteral2() throws Exception {
     var ir = parse("""
     foo = 'unfinished literal...

--- a/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
@@ -27,6 +27,7 @@ public class ExecCompilerTest {
             RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
             Paths.get("../../distribution/component").toFile().getAbsolutePath()
         )
+        .option(RuntimeOptions.STRICT_ERRORS, "false")
         .logHandler(OutputStream.nullOutputStream())
         .allowAllAccess(true)
         .build();
@@ -114,8 +115,8 @@ public class ExecCompilerTest {
     } catch (PolyglotException e) {
       assertTrue("It is exception", e.getGuestObject().isException());
       assertEquals("Panic", e.getGuestObject().getMetaObject().getMetaSimpleName());
-      if (!e.getMessage().contains("Compiler Internal Error")) {
-        fail("Expecting Compiler Internal Error, but was: " + e.getMessage());
+      if (!e.getMessage().contains("Invalid use of _")) {
+        fail("Expecting Invalid use of _, but was: " + e.getMessage());
       }
     }
   }


### PR DESCRIPTION
### Pull Request Description

Fixes #7582 by generating a syntax error when there is `x._` - e.g. `_` after `.`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
