### PR TITLE
Add `Provisioned` project state

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/backend.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/backend.ts
@@ -98,6 +98,7 @@ export enum ProjectState {
     created = 'Created',
     new = 'New',
     openInProgress = 'OpenInProgress',
+    provisioned = 'Provisioned',
     opened = 'Opened',
     closed = 'Closed',
     /** A frontend-specific state, representing a project that should be displayed as

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectIcon.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectIcon.tsx
@@ -31,6 +31,7 @@ const REMOTE_SPINNER_STATE: Record<backendModule.ProjectState, spinner.SpinnerSt
     [backendModule.ProjectState.new]: spinner.SpinnerState.initial,
     [backendModule.ProjectState.placeholder]: spinner.SpinnerState.loadingSlow,
     [backendModule.ProjectState.openInProgress]: spinner.SpinnerState.loadingSlow,
+    [backendModule.ProjectState.provisioned]: spinner.SpinnerState.loadingSlow,
     [backendModule.ProjectState.opened]: spinner.SpinnerState.done,
 }
 /** The corresponding {@link SpinnerState} for each {@link backendModule.ProjectState},
@@ -42,6 +43,7 @@ const LOCAL_SPINNER_STATE: Record<backendModule.ProjectState, spinner.SpinnerSta
     [backendModule.ProjectState.new]: spinner.SpinnerState.initial,
     [backendModule.ProjectState.placeholder]: spinner.SpinnerState.loadingMedium,
     [backendModule.ProjectState.openInProgress]: spinner.SpinnerState.loadingMedium,
+    [backendModule.ProjectState.provisioned]: spinner.SpinnerState.loadingMedium,
     [backendModule.ProjectState.opened]: spinner.SpinnerState.done,
 }
 
@@ -296,6 +298,7 @@ export default function ProjectIcon(props: ProjectIconProps) {
                 </button>
             )
         case backendModule.ProjectState.openInProgress:
+        case backendModule.ProjectState.provisioned:
         case backendModule.ProjectState.placeholder:
             return (
                 <button

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectIcon.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectIcon.tsx
@@ -118,6 +118,7 @@ export default function ProjectIcon(props: ProjectIconProps) {
                     const abortController = new AbortController()
                     setOpenProjectAbortController(abortController)
                     await remoteBackend.waitUntilProjectIsReady(backend, item, abortController)
+                    setToastId(null)
                     if (!abortController.signal.aborted) {
                         setState(oldState =>
                             oldState === backendModule.ProjectState.openInProgress


### PR DESCRIPTION
### Pull Request Description
- Closes https://github.com/enso-org/cloud-v2/issues/647
  - Add handling for `Provisioned` project state to frontend

- Also fixes bug causing cloud project loading message to not disappear (oops...)

### Important Notes
- sometimes the editor opens fine, but the websocket times out
- when checking requests, I don't see a request that returns `Provisioned`, so I can't be 100% sure that the handling for the `Provisioned` state actually works

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
