### PR TITLE
Disable opening projects that are already opened by other users

### DIFF
--- a/app/ide-desktop/eslint.config.js
+++ b/app/ide-desktop/eslint.config.js
@@ -392,7 +392,7 @@ export default [
             '@typescript-eslint/no-magic-numbers': [
                 'error',
                 {
-                    ignore: [0, 1, 2],
+                    ignore: [-1, 0, 1, 2],
                     ignoreArrayIndexes: true,
                     ignoreEnums: true,
                     detectObjects: true,

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/backend.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/backend.ts
@@ -88,7 +88,7 @@ export enum PermissionAction {
 }
 
 /** Whether each {@link PermissionAction} can execute a project. */
-export const PERMISSION_ACTION_CAN_EXECUTE_PROJECT: Record<PermissionAction, boolean> = {
+export const PERMISSION_ACTION_CAN_EXECUTE: Record<PermissionAction, boolean> = {
     [PermissionAction.own]: true,
     [PermissionAction.admin]: true,
     [PermissionAction.edit]: true,

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/backend.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/backend.ts
@@ -157,6 +157,7 @@ export interface Project extends ListedProject {
     /** This must not be null as it is required to determine the base URL for backend assets. */
     ideVersion: VersionNumber
     engineVersion: VersionNumber | null
+    openedBy?: EmailAddress
 }
 
 /** Information required to open a project. */

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/backend.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/backend.ts
@@ -5,15 +5,9 @@ import * as newtype from '../newtype'
 import * as permissions from './permissions'
 import * as uniqueString from '../uniqueString'
 
-// =============
-// === Types ===
-// =============
-
-/** The {@link Backend} variant. If a new variant is created, it should be added to this enum. */
-export enum BackendType {
-    local = 'local',
-    remote = 'remote',
-}
+// ================
+// === Newtypes ===
+// ================
 
 // These are constructor functions that construct values of the type they are named after.
 /* eslint-disable @typescript-eslint/no-redeclare */
@@ -75,6 +69,46 @@ export type Subject = newtype.Newtype<string, 'Subject'>
 export const Subject = newtype.newtypeConstructor<Subject>()
 
 /* eslint-enable @typescript-eslint/no-redeclare */
+
+// ========================
+// === PermissionAction ===
+// ========================
+
+/** Backend representation of user permission types. */
+export enum PermissionAction {
+    own = 'Own',
+    admin = 'Admin',
+    edit = 'Edit',
+    read = 'Read',
+    readAndDocs = 'Read_docs',
+    readAndExec = 'Read_exec',
+    view = 'View',
+    viewAndDocs = 'View_docs',
+    viewAndExec = 'View_exec',
+}
+
+/** Whether each {@link PermissionAction} can execute a project. */
+export const PERMISSION_ACTION_CAN_EXECUTE_PROJECT: Record<PermissionAction, boolean> = {
+    [PermissionAction.own]: true,
+    [PermissionAction.admin]: true,
+    [PermissionAction.edit]: true,
+    [PermissionAction.read]: false,
+    [PermissionAction.readAndDocs]: false,
+    [PermissionAction.readAndExec]: true,
+    [PermissionAction.view]: false,
+    [PermissionAction.viewAndDocs]: false,
+    [PermissionAction.viewAndExec]: true,
+}
+
+// =============
+// === Types ===
+// =============
+
+/** The {@link Backend} variant. If a new variant is created, it should be added to this enum. */
+export enum BackendType {
+    local = 'local',
+    remote = 'remote',
+}
 
 /** A user/organization in the application. These are the primary owners of a project. */
 export interface UserOrOrganization {
@@ -291,19 +325,6 @@ export interface SimpleUser {
     id: Subject
     name: string
     email: EmailAddress
-}
-
-/** Backend representation of user permission types. */
-export enum PermissionAction {
-    own = 'Own',
-    admin = 'Admin',
-    edit = 'Edit',
-    read = 'Read',
-    readAndDocs = 'Read_docs',
-    readAndExec = 'Read_exec',
-    view = 'View',
-    viewAndDocs = 'View_docs',
-    viewAndExec = 'View_exec',
 }
 
 /** User permission for a specific user. */

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/backend.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/backend.ts
@@ -146,6 +146,28 @@ export enum ProjectState {
 /** Wrapper around a project state value. */
 export interface ProjectStateType {
     type: ProjectState
+    /* eslint-disable @typescript-eslint/naming-convention */
+    volume_id: string
+    instance_id?: string
+    execute_async?: boolean
+    address?: string
+    security_group_id?: string
+    ec2_id?: string
+    ec2_public_ip_address?: string
+    current_session_id?: string
+    opened_by?: string
+    /* eslint-enable @typescript-eslint/naming-convention */
+}
+
+export const IS_PROJECT_STATE_OPENING_OR_OPENED: Record<ProjectState, boolean> = {
+    [ProjectState.created]: false,
+    [ProjectState.new]: false,
+    [ProjectState.openInProgress]: true,
+    [ProjectState.provisioned]: true,
+    [ProjectState.opened]: true,
+    [ProjectState.closed]: false,
+    [ProjectState.placeholder]: true,
+    [ProjectState.closing]: false,
 }
 
 /** Common `Project` fields returned by all `Project`-related endpoints. */

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/assetContextMenu.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/assetContextMenu.tsx
@@ -68,6 +68,8 @@ export default function AssetContextMenu(props: AssetContextMenuProps) {
     const managesThisAsset =
         self?.permission === backendModule.PermissionAction.own ||
         self?.permission === backendModule.PermissionAction.admin
+    const canExecute =
+        self?.permission != null && backendModule.PERMISSION_ACTION_CAN_EXECUTE[self.permission]
     const setAsset = React.useCallback(
         (valueOrUpdater: React.SetStateAction<backendModule.AnyAsset>) => {
             if (typeof valueOrUpdater === 'function') {
@@ -84,7 +86,7 @@ export default function AssetContextMenu(props: AssetContextMenuProps) {
     return (
         <ContextMenus hidden={hidden} key={asset.id} event={event}>
             <ContextMenu hidden={hidden}>
-                {asset.type === backendModule.AssetType.project && (
+                {asset.type === backendModule.AssetType.project && canExecute && (
                     <MenuEntry
                         hidden={hidden}
                         action={shortcuts.KeyboardAction.open}
@@ -146,21 +148,23 @@ export default function AssetContextMenu(props: AssetContextMenuProps) {
                             }}
                         />
                     )}
-                <MenuEntry
-                    hidden={hidden}
-                    disabled={
-                        asset.type !== backendModule.AssetType.project &&
-                        asset.type !== backendModule.AssetType.directory
-                    }
-                    action={shortcuts.KeyboardAction.rename}
-                    doAction={() => {
-                        setRowState(oldRowState => ({
-                            ...oldRowState,
-                            isEditingName: true,
-                        }))
-                        unsetModal()
-                    }}
-                />
+                {canExecute && (
+                    <MenuEntry
+                        hidden={hidden}
+                        disabled={
+                            asset.type !== backendModule.AssetType.project &&
+                            asset.type !== backendModule.AssetType.directory
+                        }
+                        action={shortcuts.KeyboardAction.rename}
+                        doAction={() => {
+                            setRowState(oldRowState => ({
+                                ...oldRowState,
+                                isEditingName: true,
+                            }))
+                            unsetModal()
+                        }}
+                    />
+                )}
                 <MenuEntry
                     hidden={hidden}
                     disabled
@@ -169,18 +173,20 @@ export default function AssetContextMenu(props: AssetContextMenuProps) {
                         // No backend support yet.
                     }}
                 />
-                <MenuEntry
-                    hidden={hidden}
-                    action={shortcuts.KeyboardAction.moveToTrash}
-                    doAction={() => {
-                        setModal(
-                            <ConfirmDeleteModal
-                                description={`the ${asset.type} '${asset.title}'`}
-                                doDelete={doDelete}
-                            />
-                        )
-                    }}
-                />
+                {managesThisAsset && (
+                    <MenuEntry
+                        hidden={hidden}
+                        action={shortcuts.KeyboardAction.moveToTrash}
+                        doAction={() => {
+                            setModal(
+                                <ConfirmDeleteModal
+                                    description={`the ${asset.type} '${asset.title}'`}
+                                    doDelete={doDelete}
+                                />
+                            )
+                        }}
+                    />
+                )}
                 <ContextMenuSeparator hidden={hidden} />
                 {managesThisAsset && (
                     <MenuEntry

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/assetRow.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/assetRow.tsx
@@ -94,7 +94,7 @@ export default function AssetRow(props: AssetRowProps) {
             })
         } catch (error) {
             setPresence(presenceModule.Presence.present)
-            toastAndLog('Unable to delete project', error)
+            toastAndLog(`Could not delete ${backendModule.ASSET_TYPE_NAME[asset.type]}`, error)
         }
     }, [
         backend,
@@ -146,7 +146,10 @@ export default function AssetRow(props: AssetRowProps) {
                         })
                     } catch (error) {
                         setPresence(presenceModule.Presence.present)
-                        toastAndLog('Unable to delete project', error)
+                        toastAndLog(
+                            `Could not delete ${backendModule.ASSET_TYPE_NAME[asset.type]}`,
+                            error
+                        )
                     }
                 }
                 break

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/assetsTable.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/assetsTable.tsx
@@ -538,7 +538,8 @@ export default function AssetsTable(props: AssetsTableProps) {
                     modifiedAt: dateTime.toRfc3339(new Date()),
                     parentId: event.parentId ?? backend.rootDirectoryId(organization),
                     permissions: permissions.tryGetSingletonOwnerPermission(organization, user),
-                    projectState: { type: backendModule.ProjectState.placeholder },
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    projectState: { type: backendModule.ProjectState.placeholder, volume_id: '' },
                     type: backendModule.AssetType.project,
                 }
                 if (
@@ -588,9 +589,8 @@ export default function AssetsTable(props: AssetsTableProps) {
                         parentId,
                         permissions: permissions.tryGetSingletonOwnerPermission(organization, user),
                         modifiedAt: dateTime.toRfc3339(new Date()),
-                        projectState: {
-                            type: backendModule.ProjectState.new,
-                        },
+                        // eslint-disable-next-line @typescript-eslint/naming-convention
+                        projectState: { type: backendModule.ProjectState.new, volume_id: '' },
                     }))
                 if (
                     event.parentId != null &&

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/managePermissionsModal.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/managePermissionsModal.tsx
@@ -91,7 +91,7 @@ export default function ManagePermissionsModal(props: ManagePermissionsModalProp
         // and `organization` is absent only when offline - in which case the user should only
         // be able to access the local backend.
         // This MUST be an error, otherwise the hooks below are considered as conditionally called.
-        throw new Error('Unable to share projects on the local backend.')
+        throw new Error('Cannot share projects on the local backend.')
     } else {
         const listedUsers = hooks.useAsyncEffect([], () => backend.listUsers(), [])
         const allUsers = React.useMemo(
@@ -190,7 +190,7 @@ export default function ManagePermissionsModal(props: ManagePermissionsModalProp
                     const usernames = addedUsersPermissions.map(
                         userPermissions => userPermissions.user.user_name
                     )
-                    toastAndLog(`Unable to set permissions for ${usernames.join(', ')}`, error)
+                    toastAndLog(`Could not set permissions for ${usernames.join(', ')}`, error)
                 }
             }
         }
@@ -221,7 +221,7 @@ export default function ManagePermissionsModal(props: ManagePermissionsModalProp
                             )
                         )
                     }
-                    toastAndLog(`Unable to set permissions of '${userToDelete.user_email}'`, error)
+                    toastAndLog(`Could not set permissions of '${userToDelete.user_email}'`, error)
                 }
             }
         }

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectIcon.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectIcon.tsx
@@ -11,6 +11,8 @@ import * as authProvider from '../../authentication/providers/auth'
 import * as backendModule from '../backend'
 import * as backendProvider from '../../providers/backend'
 import * as hooks from '../../hooks'
+import * as localStorageModule from '../localStorage'
+import * as localStorageProvider from '../../providers/localStorage'
 import * as modalProvider from '../../providers/modal'
 import * as remoteBackend from '../remoteBackend'
 
@@ -93,6 +95,7 @@ export default function ProjectIcon(props: ProjectIconProps) {
         },
         [/* should never change */ setItem]
     )
+    const { localStorage } = localStorageProvider.useLocalStorage()
     const [spinnerState, setSpinnerState] = React.useState(spinner.SpinnerState.initial)
     const [onSpinnerStateChange, setOnSpinnerStateChange] = React.useState<
         ((state: spinner.SpinnerState | null) => void) | null
@@ -269,6 +272,10 @@ export default function ProjectIcon(props: ProjectIconProps) {
     }, [shouldOpenWhenReady, shouldSwitchPage, state, openIde])
 
     const closeProject = async (triggerOnClose = true) => {
+        if (triggerOnClose) {
+            onClose()
+            localStorage.delete(localStorageModule.LocalStorageKey.projectStartupInfo)
+        }
         setToastId(null)
         setShouldOpenWhenReady(false)
         setState(backendModule.ProjectState.closing)
@@ -281,9 +288,6 @@ export default function ProjectIcon(props: ProjectIconProps) {
             state !== backendModule.ProjectState.closing &&
             state !== backendModule.ProjectState.closed
         ) {
-            if (triggerOnClose) {
-                onClose()
-            }
             try {
                 if (
                     backend.type === backendModule.BackendType.local &&
@@ -312,7 +316,7 @@ export default function ProjectIcon(props: ProjectIconProps) {
         case backendModule.ProjectState.closed:
             return (
                 <button
-                    className="w-6"
+                    className="w-6 disabled:opacity-50"
                     onClick={clickEvent => {
                         clickEvent.stopPropagation()
                         unsetModal()

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectIcon.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectIcon.tsx
@@ -236,7 +236,9 @@ export default function ProjectIcon(props: ProjectIconProps) {
             case assetEventModule.AssetEventType.openProject: {
                 if (event.id !== item.id) {
                     setShouldOpenWhenReady(false)
-                    void closeProject(false)
+                    if (!isSomeoneElseUsingProject) {
+                        void closeProject(false)
+                    }
                 } else {
                     setShouldOpenWhenReady(true)
                     setShouldSwitchPage(event.shouldAutomaticallySwitchPage)
@@ -250,7 +252,9 @@ export default function ProjectIcon(props: ProjectIconProps) {
                 setOnSpinnerStateChange(null)
                 openProjectAbortController?.abort()
                 setOpenProjectAbortController(null)
-                void closeProject(false)
+                if (!isSomeoneElseUsingProject) {
+                    void closeProject(false)
+                }
                 break
             }
             case assetEventModule.AssetEventType.newProject: {

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectIcon.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectIcon.tsx
@@ -79,6 +79,7 @@ export default function ProjectIcon(props: ProjectIconProps) {
     } = props
     const { backend } = backendProvider.useBackend()
     const { organization } = authProvider.useNonPartialUserSession()
+    const { localStorage } = localStorageProvider.useLocalStorage()
     const { unsetModal } = modalProvider.useSetModal()
     const toastAndLog = hooks.useToastAndLog()
     const state = item.projectState.type
@@ -95,7 +96,6 @@ export default function ProjectIcon(props: ProjectIconProps) {
         },
         [/* should never change */ setItem]
     )
-    const { localStorage } = localStorageProvider.useLocalStorage()
     const [spinnerState, setSpinnerState] = React.useState(spinner.SpinnerState.initial)
     const [onSpinnerStateChange, setOnSpinnerStateChange] = React.useState<
         ((state: spinner.SpinnerState | null) => void) | null

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectNameColumn.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectNameColumn.tsx
@@ -66,6 +66,7 @@ export default function ProjectNameColumn(props: ProjectNameColumnProps) {
     const canExecute =
         ownPermission != null &&
         backendModule.PERMISSION_ACTION_CAN_EXECUTE[ownPermission.permission]
+    const isOtherUserUsingProject = asset.projectState.opened_by !== organization?.email
 
     const doRename = async (newName: string) => {
         try {
@@ -114,7 +115,10 @@ export default function ProjectNameColumn(props: ProjectNameColumnProps) {
                         setAsset({
                             ...asset,
                             id: createdProject.projectId,
-                            projectState: { type: backendModule.ProjectState.placeholder },
+                            projectState: {
+                                ...asset.projectState,
+                                type: backendModule.ProjectState.placeholder,
+                            },
                         })
                         dispatchAssetEvent({
                             type: assetEventModule.AssetEventType.openProject,
@@ -214,7 +218,11 @@ export default function ProjectNameColumn(props: ProjectNameColumnProps) {
                 item.depth
             )}`}
             onClick={event => {
-                if (!rowState.isEditingName && eventModule.isDoubleClick(event)) {
+                if (
+                    !rowState.isEditingName &&
+                    !isOtherUserUsingProject &&
+                    eventModule.isDoubleClick(event)
+                ) {
                     // It is a double click; open the project.
                     dispatchAssetEvent({
                         type: assetEventModule.AssetEventType.openProject,
@@ -279,7 +287,11 @@ export default function ProjectNameColumn(props: ProjectNameColumnProps) {
                       }
                     : {})}
                 className={`bg-transparent grow px-2 ${
-                    rowState.isEditingName ? 'cursor-text' : canExecute ? 'cursor-pointer' : ''
+                    rowState.isEditingName
+                        ? 'cursor-text'
+                        : canExecute && !isOtherUserUsingProject
+                        ? 'cursor-pointer'
+                        : ''
                 }`}
             >
                 {asset.title}

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectNameColumn.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectNameColumn.tsx
@@ -63,9 +63,9 @@ export default function ProjectNameColumn(props: ProjectNameColumnProps) {
     const ownPermission =
         asset.permissions?.find(permission => permission.user.user_email === organization?.email) ??
         null
-    const hasPermissionsToOpenProject =
+    const canExecute =
         ownPermission != null &&
-        backendModule.PERMISSION_ACTION_CAN_EXECUTE_PROJECT[ownPermission.permission]
+        backendModule.PERMISSION_ACTION_CAN_EXECUTE[ownPermission.permission]
 
     const doRename = async (newName: string) => {
         try {
@@ -233,7 +233,7 @@ export default function ProjectNameColumn(props: ProjectNameColumnProps) {
                 }
             }}
         >
-            {!hasPermissionsToOpenProject ? (
+            {!canExecute ? (
                 <SvgMask src={NetworkIcon} className="m-1" />
             ) : (
                 <ProjectIcon
@@ -279,11 +279,7 @@ export default function ProjectNameColumn(props: ProjectNameColumnProps) {
                       }
                     : {})}
                 className={`bg-transparent grow px-2 ${
-                    rowState.isEditingName
-                        ? 'cursor-text'
-                        : hasPermissionsToOpenProject
-                        ? 'cursor-pointer'
-                        : ''
+                    rowState.isEditingName ? 'cursor-text' : canExecute ? 'cursor-pointer' : ''
                 }`}
             >
                 {asset.title}

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/userPermissions.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/userPermissions.tsx
@@ -48,7 +48,7 @@ export default function UserPermissions(props: UserPermissionsProps) {
             setUserPermissions(userPermissions)
             outerSetUserPermission(userPermissions)
             toastAndLog(
-                `Unable to set permissions of '${newUserPermissions.user.user_email}'`,
+                `Could not set permissions of '${newUserPermissions.user.user_email}'`,
                 error
             )
         }

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/localBackend.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/localBackend.ts
@@ -135,7 +135,7 @@ export class LocalBackend extends backend.Backend {
             return
         } catch (error) {
             throw new Error(
-                `Unable to close project ${
+                `Could not close project ${
                     title != null ? `'${title}'` : `with ID '${projectId}'`
                 }: ${errorModule.tryGetMessage(error) ?? 'unknown error'}.`
             )
@@ -223,7 +223,7 @@ export class LocalBackend extends backend.Backend {
                 return
             } catch (error) {
                 throw new Error(
-                    `Unable to open project ${
+                    `Could not open project ${
                         title != null ? `'${title}'` : `with ID '${projectId}'`
                     }: ${errorModule.tryGetMessage(error) ?? 'unknown error'}.`
                 )
@@ -291,7 +291,7 @@ export class LocalBackend extends backend.Backend {
             return
         } catch (error) {
             throw new Error(
-                `Unable to delete project ${
+                `Could not delete project ${
                     title != null ? `'${title}'` : `with ID '${projectId}'`
                 }: ${errorModule.tryGetMessage(error) ?? 'unknown error'}.`
             )
@@ -322,7 +322,7 @@ export class LocalBackend extends backend.Backend {
     /** @throws An error stating that the operation is intentionally unavailable on the local
      * backend. */
     invalidOperation(): never {
-        throw new Error('Unable to manage users, folders, files, and secrets on the local backend.')
+        throw new Error('Cannot manage users, folders, files, and secrets on the local backend.')
     }
 
     /** Return an empty array. This function should never need to be called. */

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/localBackend.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/localBackend.ts
@@ -76,6 +76,8 @@ export class LocalBackend extends backend.Backend {
                     : project.id === LocalBackend.currentlyOpeningProjectId
                     ? backend.ProjectState.openInProgress
                     : backend.ProjectState.closed,
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                volume_id: '',
             },
         }))
     }
@@ -92,6 +94,8 @@ export class LocalBackend extends backend.Backend {
             packageName: project.name,
             state: {
                 type: backend.ProjectState.closed,
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                volume_id: '',
             },
             jsonAddress: null,
             binaryAddress: null,
@@ -118,6 +122,8 @@ export class LocalBackend extends backend.Backend {
             packageName: body.projectName,
             state: {
                 type: backend.ProjectState.closed,
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                volume_id: '',
             },
         }
     }
@@ -178,6 +184,8 @@ export class LocalBackend extends backend.Backend {
                                 : project.lastOpened != null
                                 ? backend.ProjectState.closed
                                 : backend.ProjectState.created,
+                        // eslint-disable-next-line @typescript-eslint/naming-convention
+                        volume_id: '',
                     },
                 }
             }
@@ -199,6 +207,8 @@ export class LocalBackend extends backend.Backend {
                 projectId,
                 state: {
                     type: backend.ProjectState.opened,
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    volume_id: '',
                 },
             }
         }

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/remoteBackend.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/remoteBackend.ts
@@ -48,11 +48,7 @@ export async function waitUntilProjectIsReady(
     abortController: AbortController = new AbortController()
 ) {
     let project = await backend.getProjectDetails(item.id, item.title)
-    if (
-        project.state.type !== backendModule.ProjectState.openInProgress &&
-        project.state.type !== backendModule.ProjectState.provisioned &&
-        project.state.type !== backendModule.ProjectState.opened
-    ) {
+    if (!backendModule.IS_PROJECT_STATE_OPENING_OR_OPENED[project.state.type]) {
         await backend.openProject(item.id, null, item.title)
     }
     let nextCheckTimestamp = 0

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/remoteBackend.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/remoteBackend.ts
@@ -262,7 +262,7 @@ export class RemoteBackend extends backendModule.Backend {
     async listUsers(): Promise<backendModule.SimpleUser[]> {
         const response = await this.get<ListUsersResponseBody>(LIST_USERS_PATH)
         if (!responseIsSuccessful(response)) {
-            return this.throw(`Unable to list users in the organization.`)
+            return this.throw(`Could not list users in the organization.`)
         } else {
             return (await response.json()).users
         }
@@ -274,7 +274,7 @@ export class RemoteBackend extends backendModule.Backend {
     ): Promise<backendModule.UserOrOrganization> {
         const response = await this.post<backendModule.UserOrOrganization>(CREATE_USER_PATH, body)
         if (!responseIsSuccessful(response)) {
-            return this.throw('Unable to create user.')
+            return this.throw('Could not create user.')
         } else {
             return await response.json()
         }
@@ -284,7 +284,7 @@ export class RemoteBackend extends backendModule.Backend {
     async inviteUser(body: backendModule.InviteUserRequestBody): Promise<void> {
         const response = await this.post(INVITE_USER_PATH, body)
         if (!responseIsSuccessful(response)) {
-            return this.throw(`Unable to invite user '${body.userEmail}'.`)
+            return this.throw(`Could not invite user '${body.userEmail}'.`)
         } else {
             return
         }
@@ -297,7 +297,7 @@ export class RemoteBackend extends backendModule.Backend {
             body
         )
         if (!responseIsSuccessful(response)) {
-            return this.throw(`Unable to set permissions.`)
+            return this.throw(`Could not set permissions.`)
         } else {
             return
         }
@@ -336,12 +336,12 @@ export class RemoteBackend extends backendModule.Backend {
                 return []
             } else if (query.parentId != null) {
                 return this.throw(
-                    `Unable to list directory ${
+                    `Could not list folder ${
                         title != null ? `'${title}'` : `with ID '${query.parentId}'`
                     }.`
                 )
             } else {
-                return this.throw('Unable to list root directory.')
+                return this.throw('Could not list root folder.')
             }
         } else {
             return (await response.json()).assets
@@ -384,7 +384,7 @@ export class RemoteBackend extends backendModule.Backend {
             body
         )
         if (!responseIsSuccessful(response)) {
-            return this.throw(`Unable to create directory with name '${body.title}'.`)
+            return this.throw(`Could not create folder with name '${body.title}'.`)
         } else {
             return await response.json()
         }
@@ -404,7 +404,7 @@ export class RemoteBackend extends backendModule.Backend {
         )
         if (!responseIsSuccessful(response)) {
             return this.throw(
-                `Unable to update directory ${
+                `Could not update folder ${
                     title != null ? `'${title}'` : `with ID '${directoryId}'`
                 }.`
             )
@@ -420,7 +420,7 @@ export class RemoteBackend extends backendModule.Backend {
         const response = await this.delete(deleteDirectoryPath(directoryId))
         if (!responseIsSuccessful(response)) {
             return this.throw(
-                `Unable to delete directory ${
+                `Could not delete folder ${
                     title != null ? `'${title}'` : `with ID '${directoryId}'`
                 }.`
             )
@@ -435,7 +435,7 @@ export class RemoteBackend extends backendModule.Backend {
     async listProjects(): Promise<backendModule.ListedProject[]> {
         const response = await this.get<ListProjectsResponseBody>(LIST_PROJECTS_PATH)
         if (!responseIsSuccessful(response)) {
-            return this.throw('Unable to list projects.')
+            return this.throw('Could not list projects.')
         } else {
             return (await response.json()).projects.map(project => ({
                 ...project,
@@ -459,7 +459,7 @@ export class RemoteBackend extends backendModule.Backend {
     ): Promise<backendModule.CreatedProject> {
         const response = await this.post<backendModule.CreatedProject>(CREATE_PROJECT_PATH, body)
         if (!responseIsSuccessful(response)) {
-            return this.throw(`Unable to create project with name '${body.projectName}'.`)
+            return this.throw(`Could not create project with name '${body.projectName}'.`)
         } else {
             return await response.json()
         }
@@ -472,7 +472,7 @@ export class RemoteBackend extends backendModule.Backend {
         const response = await this.post(closeProjectPath(projectId), {})
         if (!responseIsSuccessful(response)) {
             return this.throw(
-                `Unable to close project ${
+                `Could not close project ${
                     title != null ? `'${title}'` : `with ID '${projectId}'`
                 }.`
             )
@@ -491,7 +491,7 @@ export class RemoteBackend extends backendModule.Backend {
         const response = await this.get<backendModule.ProjectRaw>(getProjectDetailsPath(projectId))
         if (!responseIsSuccessful(response)) {
             return this.throw(
-                `Unable to get details of project ${
+                `Could not get details of project ${
                     title != null ? `'${title}'` : `with ID '${projectId}'`
                 }.`
             )
@@ -539,7 +539,7 @@ export class RemoteBackend extends backendModule.Backend {
         )
         if (!responseIsSuccessful(response)) {
             return this.throw(
-                `Unable to open project ${title != null ? `'${title}'` : `with ID '${projectId}'`}.`
+                `Could not open project ${title != null ? `'${title}'` : `with ID '${projectId}'`}.`
             )
         } else {
             return
@@ -560,7 +560,7 @@ export class RemoteBackend extends backendModule.Backend {
         )
         if (!responseIsSuccessful(response)) {
             return this.throw(
-                `Unable to update project ${
+                `Could not update project ${
                     title != null ? `'${title}'` : `with ID '${projectId}'`
                 }.`
             )
@@ -576,7 +576,7 @@ export class RemoteBackend extends backendModule.Backend {
         const response = await this.delete(deleteProjectPath(projectId))
         if (!responseIsSuccessful(response)) {
             return this.throw(
-                `Unable to delete project ${
+                `Could not delete project ${
                     title != null ? `'${title}'` : `with ID '${projectId}'`
                 }.`
             )
@@ -595,7 +595,7 @@ export class RemoteBackend extends backendModule.Backend {
         const response = await this.get<backendModule.ResourceUsage>(checkResourcesPath(projectId))
         if (!responseIsSuccessful(response)) {
             return this.throw(
-                `Unable to get resource usage for project ${
+                `Could not get resource usage for project ${
                     title != null ? `'${title}'` : `with ID '${projectId}'`
                 }.`
             )
@@ -610,7 +610,7 @@ export class RemoteBackend extends backendModule.Backend {
     async listFiles(): Promise<backendModule.File[]> {
         const response = await this.get<ListFilesResponseBody>(LIST_FILES_PATH)
         if (!responseIsSuccessful(response)) {
-            return this.throw('Unable to list files.')
+            return this.throw('Could not list files.')
         } else {
             return (await response.json()).files
         }
@@ -666,7 +666,7 @@ export class RemoteBackend extends backendModule.Backend {
         const response = await this.delete(deleteFilePath(fileId))
         if (!responseIsSuccessful(response)) {
             return this.throw(
-                `Unable to delete file ${title != null ? `'${title}'` : `with ID '${fileId}'`}.`
+                `Could not delete file ${title != null ? `'${title}'` : `with ID '${fileId}'`}.`
             )
         } else {
             return
@@ -681,7 +681,7 @@ export class RemoteBackend extends backendModule.Backend {
     ): Promise<backendModule.SecretAndInfo> {
         const response = await this.post<backendModule.SecretAndInfo>(CREATE_SECRET_PATH, body)
         if (!responseIsSuccessful(response)) {
-            return this.throw(`Unable to create secret with name '${body.secretName}'.`)
+            return this.throw(`Could not create secret with name '${body.secretName}'.`)
         } else {
             return await response.json()
         }
@@ -697,7 +697,7 @@ export class RemoteBackend extends backendModule.Backend {
         const response = await this.get<backendModule.Secret>(getSecretPath(secretId))
         if (!responseIsSuccessful(response)) {
             return this.throw(
-                `Unable to get secret ${title != null ? `'${title}'` : `with ID '${secretId}'`}.`
+                `Could not get secret ${title != null ? `'${title}'` : `with ID '${secretId}'`}.`
             )
         } else {
             return await response.json()
@@ -710,7 +710,7 @@ export class RemoteBackend extends backendModule.Backend {
     async listSecrets(): Promise<backendModule.SecretInfo[]> {
         const response = await this.get<ListSecretsResponseBody>(LIST_SECRETS_PATH)
         if (!responseIsSuccessful(response)) {
-            return this.throw('Unable to list secrets.')
+            return this.throw('Could not list secrets.')
         } else {
             return (await response.json()).secrets
         }
@@ -723,7 +723,7 @@ export class RemoteBackend extends backendModule.Backend {
         const response = await this.delete(deleteSecretPath(secretId))
         if (!responseIsSuccessful(response)) {
             return this.throw(
-                `Unable to delete secret ${title != null ? `'${title}'` : `with ID '${secretId}'`}.`
+                `Could not delete secret ${title != null ? `'${title}'` : `with ID '${secretId}'`}.`
             )
         } else {
             return
@@ -743,7 +743,7 @@ export class RemoteBackend extends backendModule.Backend {
             /* eslint-enable @typescript-eslint/naming-convention */
         })
         if (!responseIsSuccessful(response)) {
-            return this.throw(`Unable to create create tag with name '${body.name}'.`)
+            return this.throw(`Could not create create tag with name '${body.name}'.`)
         } else {
             return await response.json()
         }
@@ -762,7 +762,7 @@ export class RemoteBackend extends backendModule.Backend {
                 }).toString()
         )
         if (!responseIsSuccessful(response)) {
-            return this.throw(`Unable to list tags of type '${params.tagType}'.`)
+            return this.throw(`Could not list tags of type '${params.tagType}'.`)
         } else {
             return (await response.json()).tags
         }
@@ -774,7 +774,7 @@ export class RemoteBackend extends backendModule.Backend {
     async deleteTag(tagId: backendModule.TagId): Promise<void> {
         const response = await this.delete(deleteTagPath(tagId))
         if (!responseIsSuccessful(response)) {
-            return this.throw(`Unable to delete tag with ID '${tagId}'.`)
+            return this.throw(`Could not delete tag with ID '${tagId}'.`)
         } else {
             return
         }
@@ -796,7 +796,7 @@ export class RemoteBackend extends backendModule.Backend {
                 }).toString()
         )
         if (!responseIsSuccessful(response)) {
-            return this.throw(`Unable to list versions of type '${params.versionType}'.`)
+            return this.throw(`Could not list versions of type '${params.versionType}'.`)
         } else {
             return (await response.json()).versions
         }

--- a/app/ide-desktop/lib/dashboard/watch.ts
+++ b/app/ide-desktop/lib/dashboard/watch.ts
@@ -20,7 +20,7 @@ const HTTP_STATUS_OK = 200
 // `outputPath` does not have to be a real directory because `write` is `false`,
 // meaning that files will not be written to the filesystem.
 // However, the path should still be non-empty in order for `esbuild.serve` to work properly.
-const ARGS: bundler.Arguments = { outputPath: '/', devMode: true }
+const ARGS: bundler.Arguments = { outputPath: '/', devMode: process.env.DEV_MODE !== 'false' }
 const OPTS = bundler.bundlerOptions(ARGS)
 OPTS.define.REDIRECT_OVERRIDE = JSON.stringify(`http://localhost:${PORT}`)
 OPTS.entryPoints.push(


### PR DESCRIPTION
### Pull Request Description
- Closes https://github.com/enso-org/cloud-v2/issues/568
  - Disable project with an `openedBy` that is not the current user

Fixes other issues:
- Fixes freshly restored saved projects not being unset when clicking stop before the editor first opens
- Changes "unable to" in errors to "could not", for consistency
- Users with insufficient permissions now see a network (node graph) icon instead of a play button:

![image](https://github.com/enso-org/enso/assets/4046547/0464ae66-4da7-4374-a4aa-80dd74fa1dc0)

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
