### PR TITLE
Removing references to Builtins from Compiler

### DIFF
--- a/engine/runtime/src/main/java/org/enso/compiler/context/CompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/context/CompilerContext.java
@@ -10,6 +10,8 @@ import java.util.logging.Level;
 import org.enso.compiler.Cache;
 import org.enso.compiler.Compiler;
 import org.enso.compiler.PackageRepository;
+import org.enso.compiler.Passes;
+import org.enso.compiler.SerializationManager;
 import org.enso.compiler.core.IR;
 import org.enso.compiler.data.CompilerConfig;
 import org.enso.interpreter.node.ExpressionNode;
@@ -60,6 +62,17 @@ public interface CompilerContext {
       Source source, InlineContext scope, CompilerConfig config, IR.Expression ir);
 
   // module related
+
+  void runStubsGenerator(Module module);
+
+  boolean typeContainsValues(String name);
+
+  void initializeBuiltinsIr(
+      boolean irCachingEnabled,
+      SerializationManager serializationManager,
+      FreshNameSupply freshNameSupply,
+      Passes passes);
+
   QualifiedName getModuleName(Module module);
 
   CharSequence getCharacters(Module module) throws IOException;

--- a/engine/runtime/src/main/java/org/enso/compiler/context/CompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/context/CompilerContext.java
@@ -24,6 +24,9 @@ import org.enso.polyglot.CompilationStage;
 
 /**
  * Interface that encapsulate all services {@link Compiler} needs from Truffle or other environment.
+ * It is implemented by {@code TruffleCompilerContext}. This adds an abstraction between {@link
+ * Compiler} and the information it needs from the runtime. The ultimate state is to compile the
+ * {@link Compiler} & co. classes separately without any dependency on Truffle API.
  */
 public interface CompilerContext {
   boolean isIrCachingDisabled();

--- a/engine/runtime/src/main/java/org/enso/compiler/context/CompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/context/CompilerContext.java
@@ -16,6 +16,7 @@ import org.enso.compiler.core.IR;
 import org.enso.compiler.data.CompilerConfig;
 import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.Module;
+import org.enso.interpreter.runtime.scope.LocalScope;
 import org.enso.interpreter.runtime.scope.ModuleScope;
 import org.enso.interpreter.runtime.scope.TopLevelScope;
 import org.enso.pkg.QualifiedName;
@@ -59,7 +60,7 @@ public interface CompilerContext {
   void truffleRunCodegen(Source source, ModuleScope scope, CompilerConfig config, IR.Module ir);
 
   ExpressionNode truffleRunInline(
-      Source source, InlineContext scope, CompilerConfig config, IR.Expression ir);
+      Source source, LocalScope localScope, Module module, CompilerConfig config, IR.Expression ir);
 
   // module related
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/EnsoLanguage.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/EnsoLanguage.java
@@ -8,6 +8,7 @@ import java.util.function.Consumer;
 
 import org.enso.compiler.Compiler;
 import org.enso.compiler.context.InlineContext;
+import org.enso.compiler.context.ModuleContext;
 import org.enso.compiler.data.CompilerConfig;
 import org.enso.compiler.exception.CompilationAbortedException;
 import org.enso.compiler.exception.UnhandledEntity;
@@ -250,8 +251,15 @@ public final class EnsoLanguage extends TruffleLanguage<EnsoContext> {
           true,
           scala.Option.apply(new PrintStream(outputRedirect))
       );
+      var moduleContext = new ModuleContext(
+        module, redirectConfigWithStrictErrors,
+        scala.Option.empty(),
+        scala.Option.empty(),
+        false,
+        scala.Option.empty()
+      );
       var inlineContext = new InlineContext(
-          module,
+          moduleContext,
           redirectConfigWithStrictErrors,
           scala.Some.apply(localScope),
           scala.Some.apply(false),

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -176,7 +176,7 @@ public class EnsoContext {
             notificationHandler);
     topScope = new TopLevelScope(builtins, packageRepository);
     this.compiler =
-        new Compiler(new TruffleCompilerContext(this), builtins, packageRepository, compilerConfig);
+        new Compiler(new TruffleCompilerContext(this), packageRepository, compilerConfig);
 
     projectPackage.ifPresent(
         pkg -> packageRepository.registerMainProjectPackage(pkg.libraryName(), pkg));

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -19,7 +19,6 @@ import org.enso.compiler.codegen.IrToTruffle;
 import org.enso.compiler.codegen.RuntimeStubsGenerator;
 import org.enso.compiler.context.CompilerContext;
 import org.enso.compiler.context.FreshNameSupply;
-import org.enso.compiler.context.InlineContext;
 import org.enso.compiler.core.IR;
 import org.enso.compiler.data.CompilerConfig;
 import org.enso.interpreter.node.ExpressionNode;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -125,12 +125,8 @@ final class TruffleCompilerContext implements CompilerContext {
   }
 
   @Override
-  public ExpressionNode truffleRunInline(Source source, InlineContext inlineContext, CompilerConfig config, IR.Expression ir) {
-    var localScope
-            = inlineContext.localScope().isDefined()
-            ? inlineContext.localScope().get()
-            : LocalScope.root();
-    return new IrToTruffle(context, source, inlineContext.module().getScope(), config)
+  public ExpressionNode truffleRunInline(Source source, LocalScope localScope, Module module, CompilerConfig config, IR.Expression ir) {
+    return new IrToTruffle(context, source, module.getScope(), config)
             .runInline(ir, localScope, "<inline_source>");
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -3,17 +3,22 @@ package org.enso.interpreter.runtime;
 import com.oracle.truffle.api.TruffleFile;
 import com.oracle.truffle.api.TruffleLogger;
 import com.oracle.truffle.api.source.Source;
+
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.logging.Level;
+
 import org.enso.compiler.Cache;
 import org.enso.compiler.Compiler;
 import org.enso.compiler.PackageRepository;
+import org.enso.compiler.Passes;
 import org.enso.compiler.SerializationManager;
 import org.enso.compiler.codegen.IrToTruffle;
+import org.enso.compiler.codegen.RuntimeStubsGenerator;
 import org.enso.compiler.context.CompilerContext;
+import org.enso.compiler.context.FreshNameSupply;
 import org.enso.compiler.context.InlineContext;
 import org.enso.compiler.core.IR;
 import org.enso.compiler.data.CompilerConfig;
@@ -25,15 +30,20 @@ import org.enso.pkg.QualifiedName;
 import org.enso.polyglot.CompilationStage;
 import org.enso.polyglot.RuntimeOptions;
 
+import scala.Some;
+
 final class TruffleCompilerContext implements CompilerContext {
+
   private final EnsoContext context;
   private final TruffleLogger compiler;
   private final TruffleLogger serializationManager;
+  private final RuntimeStubsGenerator stubsGenerator;
 
   TruffleCompilerContext(EnsoContext context) {
     this.context = context;
     this.compiler = context.getLogger(Compiler.class);
     this.serializationManager = context.getLogger(SerializationManager.class);
+    this.stubsGenerator = new RuntimeStubsGenerator(context.getBuiltins());
   }
 
   @Override
@@ -44,9 +54,9 @@ final class TruffleCompilerContext implements CompilerContext {
   @Override
   public boolean isUseGlobalCacheLocations() {
     return context
-        .getEnvironment()
-        .getOptions()
-        .get(RuntimeOptions.USE_GLOBAL_IR_CACHE_LOCATION_KEY);
+            .getEnvironment()
+            .getOptions()
+            .get(RuntimeOptions.USE_GLOBAL_IR_CACHE_LOCATION_KEY);
   }
 
   @Override
@@ -110,20 +120,18 @@ final class TruffleCompilerContext implements CompilerContext {
   }
 
   @Override
-  public void truffleRunCodegen(
-      Source source, ModuleScope scope, CompilerConfig config, IR.Module ir) {
+  public void truffleRunCodegen(Source source, ModuleScope scope, CompilerConfig config, IR.Module ir) {
     new IrToTruffle(context, source, scope, config).run(ir);
   }
 
   @Override
-  public ExpressionNode truffleRunInline(
-      Source source, InlineContext inlineContext, CompilerConfig config, IR.Expression ir) {
-    var localScope =
-        inlineContext.localScope().isDefined()
+  public ExpressionNode truffleRunInline(Source source, InlineContext inlineContext, CompilerConfig config, IR.Expression ir) {
+    var localScope
+            = inlineContext.localScope().isDefined()
             ? inlineContext.localScope().get()
             : LocalScope.root();
     return new IrToTruffle(context, source, inlineContext.module().getScope(), config)
-        .runInline(ir, localScope, "<inline_source>");
+            .runInline(ir, localScope, "<inline_source>");
   }
 
   // module related
@@ -181,11 +189,74 @@ final class TruffleCompilerContext implements CompilerContext {
 
   @Override
   public <T> Optional<TruffleFile> saveCache(
-      Cache<T, ?> cache, T entry, boolean useGlobalCacheLocations) {
+          Cache<T, ?> cache, T entry, boolean useGlobalCacheLocations) {
     return cache.save(entry, context, useGlobalCacheLocations);
   }
 
+  @Override
+  public boolean typeContainsValues(String name) {
+    var type = context.getBuiltins().getBuiltinType(name);
+    return type != null && type.containsValues();
+  }
+
+  /**
+   * Lazy-initializes the IR for the builtins module.
+   */
+  @Override
+  public void initializeBuiltinsIr(
+          boolean irCachingEnabled, SerializationManager serializationManager,
+          FreshNameSupply freshNameSupply, Passes passes
+  ) {
+    var builtins = context.getBuiltins();
+    var builtinsModule = builtins.getModule();
+    if (!builtins.isIrInitialized()) {
+      log(
+              Level.FINE,
+              "Initialising IR for [{0}].",
+              builtinsModule.getName()
+      );
+
+      builtins.initializeBuiltinsSource();
+
+      if (irCachingEnabled) {
+        switch (serializationManager.deserialize(builtinsModule)) {
+          case Some x when (boolean) x.get() ->
+            // Ensure that builtins doesn't try and have codegen run on it.
+            updateModule(
+                    builtinsModule,
+                    u -> u.compilationStage(CompilationStage.AFTER_CODEGEN)
+            );
+          default -> {
+            builtins.initializeBuiltinsIr(this, freshNameSupply, passes);
+            updateModule(
+                    builtinsModule,
+                    u -> u.hasCrossModuleLinks(true)
+            );
+          }
+        }
+      } else {
+        builtins.initializeBuiltinsIr(this, freshNameSupply, passes);
+        updateModule(
+                builtinsModule,
+                u -> u.hasCrossModuleLinks(true)
+        );
+      }
+
+      if (irCachingEnabled && !wasLoadedFromCache(builtinsModule)) {
+        serializationManager.serializeModule(
+                builtinsModule, true, true
+        );
+      }
+    }
+  }
+
+  @Override
+  public void runStubsGenerator(Module module) {
+    stubsGenerator.run(module);
+  }
+
   private final class ModuleUpdater implements Updater, AutoCloseable {
+
     private final Module module;
     private IR.Module ir;
     private CompilationStage stage;
@@ -230,10 +301,18 @@ final class TruffleCompilerContext implements CompilerContext {
 
     @Override
     public void close() {
-      if (ir != null) module.unsafeSetIr(ir);
-      if (stage != null) module.unsafeSetCompilationStage(stage);
-      if (loadedFromCache != null) module.setLoadedFromCache(loadedFromCache);
-      if (hasCrossModuleLinks != null) module.setHasCrossModuleLinks(hasCrossModuleLinks);
+      if (ir != null) {
+        module.unsafeSetIr(ir);
+      }
+      if (stage != null) {
+        module.unsafeSetCompilationStage(stage);
+      }
+      if (loadedFromCache != null) {
+        module.setLoadedFromCache(loadedFromCache);
+      }
+      if (hasCrossModuleLinks != null) {
+        module.setHasCrossModuleLinks(hasCrossModuleLinks);
+      }
       if (resetScope) {
         module.ensureScopeExists();
         module.getScope().reset();

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -672,7 +672,7 @@ class Compiler(
     ensoCompiler.generateIRInline(tree).flatMap { ir =>
       val compilerOutput = runCompilerPhasesInline(ir, newContext)
       runErrorHandlingInline(compilerOutput, source, newContext)
-      Some(truffleCodegenInline(compilerOutput, source, newContext))
+      Some(newContext.truffleRunInline(context, source, config, compilerOutput))
     }
   }
 
@@ -1212,22 +1212,6 @@ class Compiler(
     scope: ModuleScope
   ): Unit = {
     context.truffleRunCodegen(source, scope, config, ir)
-  }
-
-  /** Generates code for the truffle interpreter in an inline context.
-    *
-    * @param ir the prorgam to translate
-    * @param source the source code of the program represented by `ir`
-    * @param inlineContext a context object that contains the information needed
-    *                      for inline evaluation
-    * @return the runtime representation of the program represented by `ir`
-    */
-  def truffleCodegenInline(
-    ir: IR.Expression,
-    source: Source,
-    inlineContext: InlineContext
-  ): RuntimeExpression = {
-    context.truffleRunInline(source, inlineContext, config, ir);
   }
 
   /** Performs shutdown actions for the compiler.

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -1,7 +1,6 @@
 package org.enso.compiler
 
 import com.oracle.truffle.api.source.{Source, SourceSection}
-import org.enso.compiler.codegen.RuntimeStubsGenerator
 import org.enso.compiler.context.{
   CompilerContext,
   FreshNameSupply,
@@ -23,7 +22,6 @@ import org.enso.compiler.phase.{
 }
 import org.enso.editions.LibraryName
 import org.enso.interpreter.node.{ExpressionNode => RuntimeExpression}
-import org.enso.interpreter.runtime.builtin.Builtins
 import org.enso.interpreter.runtime.scope.ModuleScope
 import org.enso.interpreter.runtime.Module
 import org.enso.pkg.QualifiedName
@@ -51,7 +49,6 @@ import scala.jdk.OptionConverters._
   */
 class Compiler(
   val context: CompilerContext,
-  val builtins: Builtins,
   val packageRepository: PackageRepository,
   config: CompilerConfig
 ) extends CompilerStub {
@@ -59,11 +56,9 @@ class Compiler(
   private val passes: Passes                   = new Passes(config)
   private val passManager: PassManager         = passes.passManager
   private val importResolver: ImportResolver   = new ImportResolver(this)
-  private val stubsGenerator: RuntimeStubsGenerator =
-    new RuntimeStubsGenerator(builtins)
-  private val irCachingEnabled        = !context.isIrCachingDisabled
-  private val useGlobalCacheLocations = context.isUseGlobalCacheLocations
-  private val isInteractiveMode       = context.isInteractiveMode()
+  private val irCachingEnabled                 = !context.isIrCachingDisabled
+  private val useGlobalCacheLocations          = context.isUseGlobalCacheLocations
+  private val isInteractiveMode                = context.isInteractiveMode()
   private val serializationManager: SerializationManager =
     new SerializationManager(this)
   private val output: PrintStream =
@@ -92,7 +87,6 @@ class Compiler(
   def duplicateWithConfig(newConfig: CompilerConfig): Compiler = {
     new Compiler(
       context,
-      builtins,
       packageRepository,
       newConfig
     )
@@ -100,53 +94,13 @@ class Compiler(
 
   /** Run the initialization sequence. */
   def initialize(): Unit = {
-    initializeBuiltinsIr()
+    context.initializeBuiltinsIr(
+      irCachingEnabled,
+      serializationManager,
+      freshNameSupply,
+      passes
+    )
     packageRepository.initialize().left.foreach(reportPackageError)
-  }
-
-  /** Lazy-initializes the IR for the builtins module. */
-  private def initializeBuiltinsIr(): Unit = {
-    if (!builtins.isIrInitialized) {
-      context.log(
-        Compiler.defaultLogLevel,
-        "Initialising IR for [{0}].",
-        builtins.getModule.getName
-      )
-
-      builtins.initializeBuiltinsSource()
-
-      if (irCachingEnabled) {
-        serializationManager.deserialize(builtins.getModule) match {
-          case Some(true) =>
-            // Ensure that builtins doesn't try and have codegen run on it.
-            context.updateModule(
-              builtins.getModule,
-              { u =>
-                u.compilationStage(CompilationStage.AFTER_CODEGEN)
-              }
-            )
-          case _ =>
-            builtins.initializeBuiltinsIr(context, freshNameSupply, passes)
-            context.updateModule(
-              builtins.getModule,
-              u => u.hasCrossModuleLinks(true)
-            )
-        }
-      } else {
-        builtins.initializeBuiltinsIr(context, freshNameSupply, passes)
-        context.updateModule(
-          builtins.getModule,
-          u => u.hasCrossModuleLinks(true)
-        )
-      }
-
-      if (irCachingEnabled && !context.wasLoadedFromCache(builtins.getModule)) {
-        serializationManager.serializeModule(
-          builtins.getModule,
-          useGlobalCacheLocations = true // Builtins can't have a local cache.
-        )
-      }
-    }
   }
 
   /** @return the serialization manager instance. */
@@ -413,7 +367,7 @@ class Compiler(
             CompilationStage.AFTER_RUNTIME_STUBS
           )
       ) {
-        stubsGenerator.run(module)
+        context.runStubsGenerator(module)
         context.updateModule(
           module,
           { u =>

--- a/engine/runtime/src/main/scala/org/enso/compiler/context/InlineContext.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/InlineContext.scala
@@ -30,9 +30,9 @@ case class InlineContext(
   passConfiguration: Option[PassConfiguration] = None,
   pkgRepo: Option[PackageRepository]           = None
 ) {
-  final def bindingsAnalysis() = module.bindingsAnalysis()
+  def bindingsAnalysis() = module.bindingsAnalysis()
 
-  final def truffleRunInline(
+  def truffleRunInline(
     context: CompilerContext,
     source: Source,
     config: CompilerConfig,

--- a/engine/runtime/src/main/scala/org/enso/compiler/context/ModuleContext.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/ModuleContext.scala
@@ -1,9 +1,17 @@
 package org.enso.compiler.context
 
+import org.enso.compiler.core.IR
 import org.enso.compiler.PackageRepository
 import org.enso.compiler.data.CompilerConfig
 import org.enso.compiler.pass.PassConfiguration
+import org.enso.compiler.pass.analyse.BindingAnalysis
+import org.enso.pkg.Package;
+import org.enso.pkg.QualifiedName;
 import org.enso.interpreter.runtime.Module
+import org.enso.interpreter.runtime.scope.LocalScope
+import org.enso.interpreter.node.ExpressionNode
+import com.oracle.truffle.api.source.Source
+import org.enso.compiler.data.BindingsMap.ModuleReference
 
 /** A type containing the information about the execution context for a module.
   *
@@ -15,10 +23,30 @@ import org.enso.interpreter.runtime.Module
   * @param pkgRepo the compiler's package repository
   */
 case class ModuleContext(
-  module: Module,
+  private val module: Module,
   compilerConfig: CompilerConfig,
   freshNameSupply: Option[FreshNameSupply]     = None,
   passConfiguration: Option[PassConfiguration] = None,
   isGeneratingDocs: Boolean                    = false,
   pkgRepo: Option[PackageRepository]           = None
-)
+) {
+  final def isSynthetic() = module.isSynthetic()
+  final def bindingsAnalysis() = module.getIr.unsafeGetMetadata(
+    BindingAnalysis,
+    "No binding analysis on the module"
+  )
+  final def truffleRunInline(
+    context: CompilerContext,
+    source: Source,
+    s: LocalScope,
+    config: CompilerConfig,
+    ir: IR.Expression
+  ): ExpressionNode = {
+    return context.truffleRunInline(source, s, module, config, ir)
+  }
+  final def getName(): QualifiedName = module.getName()
+  final def getPackage(): Package[_] = module.getPackage()
+  final def getSource(): Source      = module.getSource()
+  final def moduleReference(): ModuleReference.Concrete =
+    ModuleReference.Concrete(module)
+}

--- a/engine/runtime/src/main/scala/org/enso/compiler/context/ModuleContext.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/ModuleContext.scala
@@ -30,12 +30,12 @@ case class ModuleContext(
   isGeneratingDocs: Boolean                    = false,
   pkgRepo: Option[PackageRepository]           = None
 ) {
-  final def isSynthetic() = module.isSynthetic()
-  final def bindingsAnalysis() = module.getIr.unsafeGetMetadata(
+  def isSynthetic() = module.isSynthetic()
+  def bindingsAnalysis() = module.getIr.unsafeGetMetadata(
     BindingAnalysis,
     "No binding analysis on the module"
   )
-  final def truffleRunInline(
+  def truffleRunInline(
     context: CompilerContext,
     source: Source,
     s: LocalScope,
@@ -44,9 +44,9 @@ case class ModuleContext(
   ): ExpressionNode = {
     return context.truffleRunInline(source, s, module, config, ir)
   }
-  final def getName(): QualifiedName = module.getName()
-  final def getPackage(): Package[_] = module.getPackage()
-  final def getSource(): Source      = module.getSource()
-  final def moduleReference(): ModuleReference.Concrete =
+  def getName(): QualifiedName = module.getName()
+  def getPackage(): Package[_] = module.getPackage()
+  def getSource(): Source      = module.getSource()
+  def moduleReference(): ModuleReference.Concrete =
     ModuleReference.Concrete(module)
 }

--- a/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
@@ -428,8 +428,7 @@ final class SuggestionBuilder[A: IndexedSource](
           case 0 =>
             val isBuiltinTypeWithValues =
               tp.tp.builtinType &&
-              Option(compiler.builtins.getBuiltinType(tp.tp.name))
-                .exists(_.containsValues())
+              compiler.context.typeContainsValues(tp.tp.name)
             if (isBuiltinTypeWithValues) {
               TypeArg.Sum(Some(tp.qualifiedName), Seq())
             } else {

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AmbiguousImportsAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AmbiguousImportsAnalysis.scala
@@ -1,6 +1,5 @@
 package org.enso.compiler.pass.analyse
 
-import org.enso.interpreter.runtime.Module
 import org.enso.compiler.context.{InlineContext, ModuleContext}
 import org.enso.compiler.core.IR
 import org.enso.compiler.core.IR.Module.Scope.Import
@@ -56,8 +55,7 @@ case object AmbiguousImportsAnalysis extends IRPass {
     ir: IR.Module,
     moduleContext: ModuleContext
   ): IR.Module = {
-    val module = moduleContext.module
-    if (module.isSynthetic) {
+    if (moduleContext.isSynthetic()) {
       ir
     } else {
       val bindingMap = ir.unsafeGetMetadata(
@@ -69,7 +67,7 @@ case object AmbiguousImportsAnalysis extends IRPass {
         imports = ir.imports.flatMap(imp => {
           analyseAmbiguousSymbols(
             imp,
-            module,
+            moduleContext,
             bindingMap,
             encounteredSymbols
           ).fold(identity, imp => List(imp))
@@ -87,7 +85,7 @@ case object AmbiguousImportsAnalysis extends IRPass {
     */
   private def analyseAmbiguousSymbols(
     imp: IR.Module.Scope.Import,
-    module: Module,
+    module: ModuleContext,
     bindingMap: BindingsMap,
     encounteredSymbols: EncounteredSymbols
   ): Either[List[IR.Error.ImportExport], IR.Module.Scope.Import] = {
@@ -294,7 +292,7 @@ case object AmbiguousImportsAnalysis extends IRPass {
     * @return
     */
   private def tryAddEncounteredSymbol(
-    module: Module,
+    module: ModuleContext,
     encounteredSymbols: EncounteredSymbols,
     currentImport: IR.Module.Scope.Import,
     symbolName: String,
@@ -333,7 +331,7 @@ case object AmbiguousImportsAnalysis extends IRPass {
   }
 
   private def createErrorForAmbiguousImport(
-    module: Module,
+    module: ModuleContext,
     originalImport: IR.Module.Scope.Import,
     originalSymbolPath: String,
     duplicatingImport: IR.Module.Scope.Import,
@@ -347,13 +345,13 @@ case object AmbiguousImportsAnalysis extends IRPass {
         originalSymbolPath,
         ambiguousSymbol,
         ambiguousSymbolPath,
-        module.getSource
+        module.getSource()
       )
     )
   }
 
   private def createWarningForDuplicatedImport(
-    module: Module,
+    module: ModuleContext,
     originalImport: IR.Module.Scope.Import,
     duplicatingImport: IR.Module.Scope.Import,
     duplicatedSymbol: String
@@ -362,7 +360,7 @@ case object AmbiguousImportsAnalysis extends IRPass {
       duplicatingImport.location,
       originalImport,
       duplicatedSymbol,
-      module.getSource
+      module.getSource()
     )
   }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/BindingAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/BindingAnalysis.scala
@@ -4,7 +4,7 @@ import org.enso.compiler.context.{InlineContext, ModuleContext}
 import org.enso.compiler.core.IR
 import org.enso.compiler.core.ir.MetadataStorage.ToPair
 import org.enso.compiler.data.BindingsMap
-import org.enso.compiler.data.BindingsMap.{Cons, ModuleReference}
+import org.enso.compiler.data.BindingsMap.Cons
 import org.enso.compiler.pass.IRPass
 import org.enso.compiler.pass.desugar.{
   ComplexType,
@@ -77,12 +77,12 @@ case object BindingAnalysis extends IRPass {
             Some(ref.methodName.name)
           case Some(IR.Name.Qualified(List(n), _, _, _)) =>
             val shadowed = definedSumTypes.exists(_.name == n.name)
-            if (!shadowed && n.name == moduleContext.module.getName.item)
+            if (!shadowed && n.name == moduleContext.getName().item)
               Some(ref.methodName.name)
             else None
           case Some(IR.Name.Literal(n, _, _, _, _)) =>
             val shadowed = definedSumTypes.exists(_.name == n)
-            if (!shadowed && n == moduleContext.module.getName.item)
+            if (!shadowed && n == moduleContext.getName().item)
               Some(ref.methodName.name)
             else None
           case None => Some(ref.methodName.name)
@@ -94,7 +94,7 @@ case object BindingAnalysis extends IRPass {
     ir.updateMetadata(
       this -->> BindingsMap(
         definedSumTypes ++ importedPolyglot ++ moduleMethods,
-        ModuleReference.Concrete(moduleContext.module)
+        moduleContext.moduleReference()
       )
     )
   }

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DemandAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DemandAnalysis.scala
@@ -49,7 +49,7 @@ case object DemandAnalysis extends IRPass {
           runExpression(
             _,
             InlineContext(
-              moduleContext.module,
+              moduleContext,
               compilerConfig = moduleContext.compilerConfig
             )
           )

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/Imports.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/Imports.scala
@@ -120,7 +120,7 @@ case object Imports extends IRPass {
   ): Option[IR.Name.Qualified] = {
     name.parts match {
       case head :: _ if head.name == currentProjectAlias =>
-        val pkg = Option(context.module.getPackage)
+        val pkg = Option(context.getPackage())
         pkg.map { pkg =>
           val namespace = IR.Name.Literal(
             pkg.namespace,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambda.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambda.scala
@@ -72,7 +72,7 @@ case object LambdaShorthandToLambda extends IRPass {
           runExpression(
             _,
             InlineContext(
-              moduleContext.module,
+              moduleContext,
               freshNameSupply = moduleContext.freshNameSupply,
               compilerConfig  = moduleContext.compilerConfig
             )

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/OperatorToFunction.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/OperatorToFunction.scala
@@ -48,7 +48,7 @@ case object OperatorToFunction extends IRPass {
         runExpression(
           _,
           new InlineContext(
-            moduleContext.module,
+            moduleContext,
             compilerConfig = moduleContext.compilerConfig
           )
         )

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/SectionsToBinOp.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/SectionsToBinOp.scala
@@ -48,7 +48,7 @@ case object SectionsToBinOp extends IRPass {
       runExpression(
         _,
         new InlineContext(
-          moduleContext.module,
+          moduleContext,
           freshNameSupply = moduleContext.freshNameSupply,
           compilerConfig  = moduleContext.compilerConfig
         )

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/ModuleNameConflicts.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/ModuleNameConflicts.scala
@@ -45,7 +45,7 @@ case object ModuleNameConflicts extends IRPass {
             ) =>
           Some(mod)
         case mod: IR.Module.Scope.Export.Module
-            if moduleContext.module.isSynthetic =>
+            if moduleContext.isSynthetic() =>
           Some(mod)
         case _ =>
           None

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/UnusedBindings.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/UnusedBindings.scala
@@ -49,7 +49,7 @@ case object UnusedBindings extends IRPass {
       runExpression(
         _,
         InlineContext(
-          moduleContext.module,
+          moduleContext,
           compilerConfig = moduleContext.compilerConfig
         )
       )

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/ApplicationSaturation.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/ApplicationSaturation.scala
@@ -57,7 +57,7 @@ case object ApplicationSaturation extends IRPass {
       runExpression(
         _,
         new InlineContext(
-          moduleContext.module,
+          moduleContext,
           passConfiguration = passConfig,
           compilerConfig    = moduleContext.compilerConfig
         )

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/LambdaConsolidate.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/LambdaConsolidate.scala
@@ -80,7 +80,7 @@ case object LambdaConsolidate extends IRPass {
       runExpression(
         _,
         new InlineContext(
-          moduleContext.module,
+          moduleContext,
           freshNameSupply = moduleContext.freshNameSupply,
           compilerConfig  = moduleContext.compilerConfig
         )

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/FullyQualifiedNames.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/FullyQualifiedNames.scala
@@ -144,10 +144,7 @@ case object FullyQualifiedNames extends IRPass {
     ir: IR.Expression,
     inlineContext: InlineContext
   ): IR.Expression = {
-    val scopeMap = inlineContext.module.getIr.unsafeGetMetadata(
-      BindingAnalysis,
-      "No binding analysis on the module"
-    )
+    val scopeMap = inlineContext.bindingsAnalysis()
     val freshNameSupply = inlineContext.freshNameSupply.getOrElse(
       throw new CompilerError(
         "No fresh name supply passed to UppercaseNames resolver."

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/FullyQualifiedNames.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/FullyQualifiedNames.scala
@@ -17,7 +17,6 @@ import org.enso.compiler.pass.IRPass
 import org.enso.compiler.pass.analyse.{AliasAnalysis, BindingAnalysis}
 import org.enso.compiler.pass.desugar.Imports
 import org.enso.editions.LibraryName
-import org.enso.interpreter.runtime.Module
 
 /** Partially resolves fully qualified names corresponding to the library names
   *
@@ -80,7 +79,7 @@ case object FullyQualifiedNames extends IRPass {
     // `Standard.Base.Error.Foo`, then accessing it via a fully qualified name,
     // `Standard.Base.Error.Foo`, will always lead to name conflicts with
     // the exported type `Error`.
-    if (isMainModule(moduleContext.module)) {
+    if (isMainModule(moduleContext)) {
       scopeMap.resolvedExports.foreach {
         case ExportedModule(
               resolution @ ResolvedType(exportedModuleRef, tpe),
@@ -127,8 +126,10 @@ case object FullyQualifiedNames extends IRPass {
     ir.copy(bindings = new_bindings)
   }
 
-  private def isMainModule(module: Module): Boolean = {
-    module.getName.item == Imports.mainModuleName.name && module.getName.path.length == 2
+  private def isMainModule(module: ModuleContext): Boolean = {
+    module
+      .getName()
+      .item == Imports.mainModuleName.name && module.getName().path.length == 2
   }
 
   /** Executes the pass on the provided `ir`, and returns a possibly transformed

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/GlobalNames.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/GlobalNames.scala
@@ -80,10 +80,7 @@ case object GlobalNames extends IRPass {
     ir: IR.Expression,
     inlineContext: InlineContext
   ): IR.Expression = {
-    val scopeMap = inlineContext.module.getIr.unsafeGetMetadata(
-      BindingAnalysis,
-      "No binding analysis on the module"
-    )
+    val scopeMap = inlineContext.bindingsAnalysis()
     val freshNameSupply = inlineContext.freshNameSupply.getOrElse(
       throw new CompilerError(
         "No fresh name supply passed to UppercaseNames resolver."

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/IgnoredBindings.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/IgnoredBindings.scala
@@ -62,7 +62,7 @@ case object IgnoredBindings extends IRPass {
       runExpression(
         _,
         InlineContext(
-          moduleContext.module,
+          moduleContext,
           freshNameSupply = moduleContext.freshNameSupply,
           compilerConfig  = moduleContext.compilerConfig
         )

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/Patterns.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/Patterns.scala
@@ -53,10 +53,7 @@ object Patterns extends IRPass {
     ir: IR.Expression,
     inlineContext: InlineContext
   ): IR.Expression = {
-    val bindings = inlineContext.module.getIr.unsafeGetMetadata(
-      BindingAnalysis,
-      "Binding resolution was not run before pattern resolution"
-    )
+    val bindings = inlineContext.bindingsAnalysis()
     doExpression(ir, bindings, None)
   }
 

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/CompilerTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/CompilerTest.scala
@@ -202,14 +202,37 @@ trait CompilerRunner {
     passConfiguration: Option[PassConfiguration] = None,
     compilerConfig: CompilerConfig               = defaultConfig,
     isGeneratingDocs: Boolean                    = false
-  ): ModuleContext = {
-    ModuleContext(
-      module            = Module.empty(moduleName, null),
+  ) = buildModuleContextModule(
+    moduleName,
+    freshNameSupply,
+    passConfiguration,
+    compilerConfig,
+    isGeneratingDocs
+  )._1
+
+  /** Builds a module context with a mocked module for testing purposes.
+    *
+    * @param moduleName the name of the test module.
+    * @param freshNameSupply the fresh name supply to use in tests.
+    * @param passConfiguration any additional pass configuration.
+    * @return an pair of module context and module.
+    */
+  def buildModuleContextModule(
+    moduleName: QualifiedName                    = QualifiedName.simpleName("Test_Module"),
+    freshNameSupply: Option[FreshNameSupply]     = None,
+    passConfiguration: Option[PassConfiguration] = None,
+    compilerConfig: CompilerConfig               = defaultConfig,
+    isGeneratingDocs: Boolean                    = false
+  ): (ModuleContext, Module) = {
+    val mod = Module.empty(moduleName, null)
+    val ctx = ModuleContext(
+      module            = mod,
       freshNameSupply   = freshNameSupply,
       passConfiguration = passConfiguration,
       compilerConfig    = compilerConfig,
       isGeneratingDocs  = isGeneratingDocs
     )
+    (ctx, mod)
   }
 
   /** Builds an inline context with a mocked module for testing purposes.
@@ -243,8 +266,12 @@ trait CompilerRunner {
       mod,
       CompilationStage.AFTER_CODEGEN
     )
+    val mc = ModuleContext(
+      module         = mod,
+      compilerConfig = compilerConfig
+    )
     InlineContext(
-      module            = mod,
+      module            = mc,
       freshNameSupply   = freshNameSupply,
       passConfiguration = passConfiguration,
       localScope        = localScope,

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/BindingAnalysisTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/BindingAnalysisTest.scala
@@ -7,7 +7,6 @@ import org.enso.compiler.data.BindingsMap
 import org.enso.compiler.data.BindingsMap.{
   Cons,
   ModuleMethod,
-  ModuleReference,
   PolyglotSymbol,
   Type
 }
@@ -85,12 +84,12 @@ class BindingAnalysisTest extends CompilerTest {
         PolyglotSymbol("Renamed_Class"),
         ModuleMethod("foo")
       )
-      metadata.currentModule shouldEqual ModuleReference.Concrete(ctx.module)
+      metadata.currentModule shouldEqual ctx.moduleReference()
     }
 
     "properly assign module-level methods when a type with the same name as module is defined" in {
       implicit val ctx: ModuleContext = mkModuleContext
-      val moduleName                  = ctx.module.getName.item
+      val moduleName                  = ctx.getName().item
       val ir =
         s"""
            |type $moduleName

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/resolve/MethodDefinitionsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/resolve/MethodDefinitionsTest.scala
@@ -4,7 +4,7 @@ import org.enso.compiler.Passes
 import org.enso.compiler.context.{FreshNameSupply, ModuleContext}
 import org.enso.compiler.core.IR
 import org.enso.compiler.data.BindingsMap
-import org.enso.compiler.data.BindingsMap.{ModuleReference, Type}
+import org.enso.compiler.data.BindingsMap.Type
 import org.enso.compiler.pass.resolve.MethodDefinitions
 import org.enso.compiler.pass.{PassConfiguration, PassGroup, PassManager}
 import org.enso.compiler.test.CompilerTest
@@ -78,7 +78,7 @@ class MethodDefinitionsTest extends CompilerTest {
         .getMetadata(MethodDefinitions) shouldEqual Some(
         BindingsMap.Resolution(
           BindingsMap.ResolvedType(
-            ModuleReference.Concrete(ctx.module),
+            ctx.moduleReference(),
             Type("Foo", List(), false)
           )
         )
@@ -95,7 +95,7 @@ class MethodDefinitionsTest extends CompilerTest {
         .get
         .getMetadata(MethodDefinitions) shouldEqual Some(
         BindingsMap.Resolution(
-          BindingsMap.ResolvedModule(ModuleReference.Concrete(ctx.module))
+          BindingsMap.ResolvedModule(ctx.moduleReference())
         )
       )
 
@@ -113,7 +113,7 @@ class MethodDefinitionsTest extends CompilerTest {
       ) shouldEqual Some(
         BindingsMap.Resolution(
           BindingsMap.ResolvedType(
-            ModuleReference.Concrete(ctx.module),
+            ctx.moduleReference(),
             Type("Foo", List(), false)
           )
         )
@@ -121,7 +121,7 @@ class MethodDefinitionsTest extends CompilerTest {
       conv1.sourceTypeName.getMetadata(MethodDefinitions) shouldEqual Some(
         BindingsMap.Resolution(
           BindingsMap.ResolvedType(
-            ModuleReference.Concrete(ctx.module),
+            ctx.moduleReference(),
             Type("Bar", List(), false)
           )
         )
@@ -135,7 +135,7 @@ class MethodDefinitionsTest extends CompilerTest {
       ) shouldEqual Some(
         BindingsMap.Resolution(
           BindingsMap.ResolvedType(
-            ModuleReference.Concrete(ctx.module),
+            ctx.moduleReference(),
             Type("Bar", List(), false)
           )
         )
@@ -149,7 +149,7 @@ class MethodDefinitionsTest extends CompilerTest {
       conv3.sourceTypeName.getMetadata(MethodDefinitions) shouldEqual Some(
         BindingsMap.Resolution(
           BindingsMap.ResolvedType(
-            ModuleReference.Concrete(ctx.module),
+            ctx.moduleReference(),
             Type("Foo", List(), false)
           )
         )


### PR DESCRIPTION
### Pull Request Description

Another step on the road of splitting the `runtime` code base into `runtime/compiler`. Avoiding references to `Builtins` runtime class from the main `Compiler` class. Replacing direct usage of runtime `Module` by `ModuleContext` and `InlineContext`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] All tests continue to pass
