### PR TITLE
Add more debugging info to a failed apply edit

### DIFF
--- a/lib/scala/text-buffer/src/main/scala/org/enso/text/editing/TextEditValidator.scala
+++ b/lib/scala/text-buffer/src/main/scala/org/enso/text/editing/TextEditValidator.scala
@@ -64,19 +64,35 @@ object TextEditValidator {
   ): Either[TextEditValidationFailure, Unit] = {
     val lineCount = TextEditor[A].getLineCount(buffer)
     if (position.line >= lineCount) {
+      var extraInfo = ""
+      val lastLine  = TextEditor[A].getLine(buffer, lineCount - 1)
+      if (lineCount > 0) {
+        extraInfo = s", last line '$lastLine`"
+      }
+      if (lastLine.endsWith(System.lineSeparator())) {
+        extraInfo += ", ends with newline"
+      }
       Left(
         InvalidPosition(
           position,
-          reason + s" line (${position.line}) outside of buffer's line count (${lineCount})"
+          reason + s" line (${position.line}) outside of buffer's line count ($lineCount$extraInfo)"
         )
       )
     } else {
       val line = TextEditor[A].getLine(buffer, position.line)
       if (position.character > line.length) {
+        var extraInfo = ""
+        val lastLine  = TextEditor[A].getLine(buffer, lineCount - 1)
+        if (lineCount > 0) {
+          extraInfo = s", last line '$lastLine`"
+        }
+        if (lastLine.endsWith(System.lineSeparator())) {
+          extraInfo += ", ends with newline"
+        }
         Left(
           InvalidPosition(
             position,
-            s" character (${position.character}) is outside of line's length (${line.length})"
+            s" character (${position.character}) is outside of line's length (${line.length}$extraInfo)"
           )
         )
       } else {

--- a/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/EditorOpsSpec.scala
+++ b/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/EditorOpsSpec.scala
@@ -42,7 +42,7 @@ class EditorOpsSpec extends AnyFlatSpec with Matchers with EitherValues {
     result mustBe Left(
       InvalidPosition(
         Position(5, 4),
-        "text edit start line (5) outside of buffer's line count (4)"
+        "text edit start line (5) outside of buffer's line count (4, last line '    result`)"
       )
     )
   }

--- a/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/TextEditValidatorSpec.scala
+++ b/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/TextEditValidatorSpec.scala
@@ -35,14 +35,14 @@ class TextEditValidatorSpec extends AnyFlatSpec with Matchers {
     validate(buffer, diff1) mustBe Left(
       InvalidPosition(
         Position(10, 2),
-        "text edit end line (10) outside of buffer's line count (2)"
+        "text edit end line (10) outside of buffer's line count (2, last line 'abcdefg`)"
       )
     )
     val diff2 = TextEdit(Range(Position(0, 10), Position(1, 2)), "a")
     validate(buffer, diff2) mustBe Left(
       InvalidPosition(
         Position(0, 10),
-        " character (10) is outside of line's length (8)"
+        " character (10) is outside of line's length (8, last line 'abcdefg`)"
       )
     )
   }


### PR DESCRIPTION
### Pull Request Description

Still unable to reproduce locally. Adding more info to confirm suspicion that the failure is related to line endings.
Relates to #7624.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
