### PR TITLE
Fix new node position

### DIFF
--- a/app/gui/view/graph-editor/src/component/node.rs
+++ b/app/gui/view/graph-editor/src/component/node.rs
@@ -69,7 +69,7 @@ pub const COMMENT_MARGIN: f32 = 10.0;
 
 const ERROR_VISUALIZATION_SIZE: Vector2 = visualization::container::DEFAULT_SIZE;
 
-/// Size of the gap between the lower edge of the node and the top of the visualization.
+/// Distance between the origin of the node and the top of the visualization.
 const VISUALIZATION_OFFSET_Y: f32 = 25.0;
 const VISUALIZATION_OFFSET: Vector2 = Vector2(0.0, -VISUALIZATION_OFFSET_Y);
 
@@ -947,12 +947,11 @@ fn bounding_box(
 ) -> BoundingBox {
     let x_offset_to_node_center = x_offset_to_node_center(node_size.x);
     let node_bbox_pos = node_position + Vector2(x_offset_to_node_center, 0.0) - node_size / 2.0;
-    let node_bbox = BoundingBox::from_position_and_size(node_bbox_pos, node_size);
+    let node_bbox = BoundingBox::from_bottom_left_position_and_size(node_bbox_pos, node_size);
     if let Some(visualization_size) = visualization_size {
         let visualization_pos = node_position + VISUALIZATION_OFFSET;
-        let visualization_bbox_pos = visualization_pos - visualization_size / 2.0;
         let visualization_bbox =
-            BoundingBox::from_position_and_size(visualization_bbox_pos, visualization_size);
+            BoundingBox::from_top_left_position_and_size(visualization_pos, visualization_size);
         node_bbox.concat_ref(visualization_bbox)
     } else {
         node_bbox

--- a/app/gui/view/project-view-top-bar/src/breadcrumbs.rs
+++ b/app/gui/view/project-view-top-bar/src/breadcrumbs.rs
@@ -6,12 +6,12 @@ use ensogl::prelude::*;
 use engine_protocol::language_server::MethodPointer;
 
 
-
 // ==============
 // === Export ===
 // ==============
 
 pub use ensogl_component::breadcrumbs::*;
+
 
 
 // ===========================

--- a/lib/rust/ensogl/component/list-editor/src/lib.rs
+++ b/lib/rust/ensogl/component/list-editor/src/lib.rs
@@ -451,7 +451,7 @@ impl<T: display::Object + CloneRef + Debug> ListEditor<T> {
 
             this_bbox <- on_resized.map(|t| BoundingBox::from_size(*t));
             dragged_item_bbox <- all_with3(&dragged_item_size, &dragged_item_offset, &pos_on_move,
-                |size, offset, pos| BoundingBox::from_position_and_size(*pos + *offset, *size)
+                |size, offset, pos| BoundingBox::from_bottom_left_position_and_size(*pos + *offset, *size)
             );
             is_close <- all_with(&this_bbox, &dragged_item_bbox, |a, b| a.intersects(b)).on_change();
             dragged_item_bbox_center <- dragged_item_bbox.map(|bbox| bbox.center());

--- a/lib/rust/ensogl/core/src/data/bounding_box.rs
+++ b/lib/rust/ensogl/core/src/data/bounding_box.rs
@@ -45,9 +45,15 @@ impl BoundingBox {
         BoundingBox { top, bottom, left, right }
     }
 
-    /// Constructor.
-    pub fn from_position_and_size(position: Vector2, size: Vector2) -> Self {
+    /// Construct from a bottom-left corner and a size.
+    pub fn from_bottom_left_position_and_size(position: Vector2, size: Vector2) -> Self {
         Self::from_corners(position, position + size)
+    }
+
+    /// Construct from a top-left corner and a size.
+    pub fn from_top_left_position_and_size(position: Vector2, size: Vector2) -> Self {
+        let bottom_right = Vector2(position.x + size.x, position.y - size.y);
+        Self::from_corners(position, bottom_right)
     }
 
     /// Construct from a bottom-left corner and a size. If either component of the size is negative,

--- a/lib/rust/ensogl/core/src/display/shape/primitive/system/cached/arrange_on_texture.rs
+++ b/lib/rust/ensogl/core/src/display/shape/primitive/system/cached/arrange_on_texture.rs
@@ -213,7 +213,7 @@ fn find_free_place(
         iter::once(0.0).chain(allowed_right_bounds).sorted_by_key(|&x| OrderedFloat(x));
     let candidate_positions = iproduct!(candidate_rows, candidate_cols);
     let mut candidate_bboxes = candidate_positions
-        .map(|(y, x)| BoundingBox::from_position_and_size(Vector2(x, y), shape_size));
+        .map(|(y, x)| BoundingBox::from_bottom_left_position_and_size(Vector2(x, y), shape_size));
     candidate_bboxes.find(|bbox| {
         let is_collision = placed_so_far.iter().any(|placed| placed.interior_intersects(bbox));
         !is_collision

--- a/lib/rust/font/src/lib.rs
+++ b/lib/rust/font/src/lib.rs
@@ -29,7 +29,6 @@ use derive_more::Deref;
 use derive_more::Display;
 
 
-
 // ==============
 // === Export ===
 // ==============


### PR DESCRIPTION
### Pull Request Description

Closes: #7309 

The changed origin of the visualization container caused the issue. Now, the origin is at the top left corner of the visualization, and bounding box abstraction expects the origin at the bottom left. Despite the comments in the code, the bounding box is designed to work with bottom-left origin only.


https://github.com/enso-org/enso/assets/6566674/273abfaa-45b6-4374-8d4c-3b8c4e2c1fc2


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
