### PR TITLE
Fix "opened by" being missing for new projects

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/backend.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/backend.ts
@@ -156,7 +156,7 @@ export interface ProjectStateType {
     ec2_id?: string
     ec2_public_ip_address?: string
     current_session_id?: string
-    opened_by?: string
+    opened_by?: EmailAddress
     /* eslint-enable @typescript-eslint/naming-convention */
 }
 

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/assetsTable.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/assetsTable.tsx
@@ -598,8 +598,13 @@ export default function AssetsTable(props: AssetsTableProps) {
                     modifiedAt: dateTime.toRfc3339(new Date()),
                     parentId: event.parentId ?? backend.rootDirectoryId(organization),
                     permissions: permissions.tryGetSingletonOwnerPermission(organization, user),
-                    // eslint-disable-next-line @typescript-eslint/naming-convention
-                    projectState: { type: backendModule.ProjectState.placeholder, volume_id: '' },
+                    projectState: {
+                        type: backendModule.ProjectState.placeholder,
+                        // eslint-disable-next-line @typescript-eslint/naming-convention
+                        volume_id: '',
+                        // eslint-disable-next-line @typescript-eslint/naming-convention
+                        ...(organization != null ? { opened_by: organization.email } : {}),
+                    },
                     type: backendModule.AssetType.project,
                 }
                 if (
@@ -629,9 +634,8 @@ export default function AssetsTable(props: AssetsTableProps) {
             case assetListEventModule.AssetListEventType.uploadFiles: {
                 const reversedFiles = Array.from(event.files).reverse()
                 const parentId = event.parentId ?? backend.rootDirectoryId(organization)
-                const placeholderFiles: backendModule.FileAsset[] = reversedFiles
-                    .filter(backendModule.fileIsNotProject)
-                    .map(file => ({
+                const placeholderFiles = reversedFiles.filter(backendModule.fileIsNotProject).map(
+                    (file): backendModule.FileAsset => ({
                         type: backendModule.AssetType.file,
                         id: backendModule.FileId(uniqueString.uniqueString()),
                         title: file.name,
@@ -639,19 +643,25 @@ export default function AssetsTable(props: AssetsTableProps) {
                         permissions: permissions.tryGetSingletonOwnerPermission(organization, user),
                         modifiedAt: dateTime.toRfc3339(new Date()),
                         projectState: null,
-                    }))
-                const placeholderProjects: backendModule.ProjectAsset[] = reversedFiles
-                    .filter(backendModule.fileIsProject)
-                    .map(file => ({
+                    })
+                )
+                const placeholderProjects = reversedFiles.filter(backendModule.fileIsProject).map(
+                    (file): backendModule.ProjectAsset => ({
                         type: backendModule.AssetType.project,
                         id: backendModule.ProjectId(uniqueString.uniqueString()),
                         title: file.name,
                         parentId,
                         permissions: permissions.tryGetSingletonOwnerPermission(organization, user),
                         modifiedAt: dateTime.toRfc3339(new Date()),
-                        // eslint-disable-next-line @typescript-eslint/naming-convention
-                        projectState: { type: backendModule.ProjectState.new, volume_id: '' },
-                    }))
+                        projectState: {
+                            type: backendModule.ProjectState.new,
+                            // eslint-disable-next-line @typescript-eslint/naming-convention
+                            volume_id: '',
+                            // eslint-disable-next-line @typescript-eslint/naming-convention
+                            ...(organization != null ? { opened_by: organization.email } : {}),
+                        },
+                    })
+                )
                 if (
                     event.parentId != null &&
                     event.parentKey != null &&


### PR DESCRIPTION
### Pull Request Description
Fixes the project icon for new projects being disabled, because `opened_by` is missing, making the frontend think the current user was not the one that opened the project.

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
