### PR TITLE
Deliver information about `Xyz.from` conversion methods to the IDE

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
@@ -43,7 +43,7 @@ type Array
          Get the last element of an array.
 
              [1, 2, 3].to_array.at -1 == 3
-    at : Integer -> Any ! Index_Out_Of_Bounds
+    at : Integer | Text -> Any ! Index_Out_Of_Bounds
     at self index = Array_Like_Helpers.at self index
 
     ## GROUP Metadata
@@ -764,3 +764,5 @@ type Array
              [1].to_array + [2].to_array
     + : Vector Any -> Vector Any
     + self that = Vector.+ self that
+
+Vector.from (that:Array) = that.to_vector

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
@@ -43,7 +43,7 @@ type Array
          Get the last element of an array.
 
              [1, 2, 3].to_array.at -1 == 3
-    at : Integer | Text -> Any ! Index_Out_Of_Bounds
+    at : Integer -> Any ! Index_Out_Of_Bounds
     at self index = Array_Like_Helpers.at self index
 
     ## GROUP Metadata

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -129,7 +129,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: LogLevel) {
     Sha3_224VersionCalculator
   log.trace("Created Version Calculator [{}].", versionCalculator)
 
-  val sqlDatabase = SqlDatabase.inmem("memdb")
+  val sqlDatabase = SqlDatabase(directoriesConfig.suggestionsDatabaseFile)
 
   val suggestionsRepo = new SqlSuggestionsRepo(sqlDatabase)(system.dispatcher)
   log.trace("Created SQL suggestions repo: [{}].", suggestionsRepo)

--- a/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
@@ -159,7 +159,7 @@ final class SuggestionBuilder[A: IndexedSource](
 
           case definition.Method
                 .Conversion(
-                  Name.MethodReference(_, _, _, _, _),
+                  Name.MethodReference(_, _, _, _, _), // don't ignore type pointer
                   Name.Literal(sourceTypeName, _, _, _, _),
                   Function.Lambda(args, body, _, _, _, _),
                   _,
@@ -746,7 +746,7 @@ final class SuggestionBuilder[A: IndexedSource](
 object SuggestionBuilder {
 
   /** TODO[DB] enable conversions when they get the runtime support. */
-  private val ConversionsEnabled: Boolean = false
+  private val ConversionsEnabled: Boolean = true
 
   /** Creates the suggestion builder for a module.
     *

--- a/lib/scala/searcher/src/main/java/org/enso/searcher/package-info.java
+++ b/lib/scala/searcher/src/main/java/org/enso/searcher/package-info.java
@@ -1,0 +1,2 @@
+package org.enso.searcher;
+


### PR DESCRIPTION
### Pull Request Description

With the introduction of [Any.to](https://github.com/enso-org/enso/pull/7704) method the `Xyz.from` conversions become first class citizen in Enso. We need to make sure IDE works well with them. The first step is to deliver information about all possible conversions to the IDE. 

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
