### PR TITLE
Enabling enterprise version of AG Grid

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -227,6 +227,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: ./run  --upload-artifacts ${{ runner.os == 'Linux' }} wasm build
         env:
+          ENSO_AG_GRID_LICENSE_KEY: ${{ secrets.ENSO_AG_GRID_LICENSE_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: failure() && runner.os == 'Windows'
         name: List files if failed (Windows)
@@ -283,6 +284,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: ./run  --upload-artifacts ${{ runner.os == 'Linux' }} wasm build
         env:
+          ENSO_AG_GRID_LICENSE_KEY: ${{ secrets.ENSO_AG_GRID_LICENSE_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: failure() && runner.os == 'Windows'
         name: List files if failed (Windows)
@@ -341,6 +343,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: ./run  --upload-artifacts ${{ runner.os == 'Linux' }} wasm build
         env:
+          ENSO_AG_GRID_LICENSE_KEY: ${{ secrets.ENSO_AG_GRID_LICENSE_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: failure() && runner.os == 'Windows'
         name: List files if failed (Windows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: ./run  --upload-artifacts ${{ runner.os == 'Linux' }} wasm build
         env:
+          ENSO_AG_GRID_LICENSE_KEY: ${{ secrets.ENSO_AG_GRID_LICENSE_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: failure() && runner.os == 'Windows'
         name: List files if failed (Windows)

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script.rs
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script.rs
@@ -3,6 +3,8 @@
 // TODO remove once we have proper visualizations or replace with a nice d3 example.
 // These implementations are neither efficient nor pretty, but get the idea across.
 
+use crate::prelude::*;
+
 use crate::component::visualization;
 use crate::component::visualization::java_script::source::from_files;
 
@@ -14,11 +16,15 @@ use crate::component::visualization::java_script::source::from_files;
 
 /// Return a `JavaScript` Table visualization.
 pub fn table_visualization() -> visualization::java_script::FallibleDefinition {
-    let source = from_files!(
-        "java_script/helpers/loading.js",
-        "java_script/helpers/scrollable.js",
-        "java_script/table.js"
-    );
+    let mut source =
+        from_files!("java_script/helpers/loading.js", "java_script/helpers/scrollable.js");
+
+    let ag_grid_license_key = option_env!("AG_GRID_LICENSE_KEY");
+    let initializer = ag_grid_license_key.map_or_default(|ag_grid_license_key| {
+        format!(r#"const AG_GRID_LICENSE_KEY = '{ag_grid_license_key}'\n"#)
+    });
+    let content = format!("{initializer}\n{}", include_str!("java_script/table.js"));
+    source.add_file("java_script/table.js", &content);
 
     visualization::java_script::Definition::new_builtin(source)
 }

--- a/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
+++ b/app/gui/view/graph-editor/src/builtin/visualization/java_script/table.js
@@ -1,7 +1,6 @@
 /** Table visualization. */
-loadScript('https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.js')
-// Use the following line instead of the above one to use the enterprise version of ag-grid.
-// loadScript('https://cdn.jsdelivr.net/npm/ag-grid-enterprise@29.1.0/dist/ag-grid-enterprise.min.js')
+
+loadScript('https://cdn.jsdelivr.net/npm/ag-grid-enterprise/dist/ag-grid-enterprise.min.js')
 
 // ============================
 // === Style Initialisation ===
@@ -153,6 +152,13 @@ class TableVisualization extends Visualization {
                 onColumnResized: e => this.lockColumnSize(e),
                 suppressFieldDotNotation: true,
             }
+
+            if (typeof AG_GRID_LICENSE_KEY !== 'undefined') {
+                agGrid.LicenseManager.setLicenseKey(AG_GRID_LICENSE_KEY)
+            } else {
+                console.warn('The AG_GRID_LICENSE_KEY is not defined.')
+            }
+
             this.agGrid = new agGrid.Grid(tabElem, this.agGridOptions)
         }
 

--- a/app/gui/view/project-view-top-bar/src/breadcrumbs.rs
+++ b/app/gui/view/project-view-top-bar/src/breadcrumbs.rs
@@ -6,12 +6,12 @@ use ensogl::prelude::*;
 use engine_protocol::language_server::MethodPointer;
 
 
-
 // ==============
 // === Export ===
 // ==============
 
 pub use ensogl_component::breadcrumbs::*;
+
 
 
 // ===========================

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -129,10 +129,11 @@ impl JobArchetype for IntegrationTest {
 pub struct BuildWasm;
 impl JobArchetype for BuildWasm {
     fn job(&self, os: OS) -> Job {
-        plain_job(
+        plain_job_customized(
             &os,
             "Build GUI (WASM)",
             " --upload-artifacts ${{ runner.os == 'Linux' }} wasm build",
+            |step| vec![step.with_secret_exposed(crate::env::ENSO_AG_GRID_LICENSE_KEY)],
         )
     }
 }

--- a/build/build/src/env.rs
+++ b/build/build/src/env.rs
@@ -16,4 +16,7 @@ define_env_var! {
 
     /// Static token for admin requests on our Lambdas.
     ENSO_ADMIN_TOKEN, String;
+
+    /// License key for the AG Grid library.
+    ENSO_AG_GRID_LICENSE_KEY, String;
 }

--- a/build/ci_utils/src/actions/workflow/definition.rs
+++ b/build/ci_utils/src/actions/workflow/definition.rs
@@ -23,6 +23,11 @@ pub fn wrap_expression(expression: impl AsRef<str>) -> String {
     format!("${{{{ {} }}}}", expression.as_ref())
 }
 
+/// An expression that accesses a secret with a given name.
+pub fn secret_expression(secret_name: impl AsRef<str>) -> String {
+    wrap_expression(format!("secrets.{}", secret_name.as_ref()))
+}
+
 pub fn env_expression(environment_variable: &impl RawVariable) -> String {
     wrap_expression(format!("env.{}", environment_variable.name()))
 }
@@ -811,12 +816,20 @@ pub struct Step {
 }
 
 impl Step {
+    /// Expose a secret as an environment variable with the same name.
+    pub fn with_secret_exposed(self, secret: impl AsRef<str>) -> Self {
+        let secret_name = secret.as_ref();
+        let env_name = secret_name.to_owned();
+        self.with_secret_exposed_as(secret_name, env_name)
+    }
+
+    /// Expose a secret as an environment variable with a given name.
     pub fn with_secret_exposed_as(
         self,
         secret: impl AsRef<str>,
         given_name: impl Into<String>,
     ) -> Self {
-        let secret_expr = wrap_expression(format!("secrets.{}", secret.as_ref()));
+        let secret_expr = secret_expression(&secret);
         self.with_env(given_name, secret_expr)
     }
 

--- a/lib/rust/font/src/lib.rs
+++ b/lib/rust/font/src/lib.rs
@@ -29,7 +29,6 @@ use derive_more::Deref;
 use derive_more::Display;
 
 
-
 // ==============
 // === Export ===
 // ==============


### PR DESCRIPTION
### Pull Request Description
This PR switches the AG Grid to the Enterprise version that our company has licensed. The key is stored in  the GH organization's secret storage and exposed to the CI.
Then the key is exposed to the visualization, as it is loaded.

Fixes #7720.

### Important Notes
When building locally, the key is not available. The Grid control in such situation will miss license key, triggering a warning. However, the control will retain all the functionality.
Alternatively, we could switch between community and enterprise versions depending on the build type. However, in such keys the local builds would end up having a different feature set than the official ones, possibly causing confusion when testing. 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
