### PR TITLE
Fix `on` argument for Vector.sort

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/ordering/SortVectorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/ordering/SortVectorNode.java
@@ -719,8 +719,6 @@ public abstract class SortVectorNode extends Node {
     private final MethodResolverNode methodResolverNode;
     private final TypesLibrary typesLibrary;
 
-    private @CompilerDirectives.CompilationFinal Function resolvedFunction;
-
     private CompareFromUnresolvedSymbol(UnresolvedSymbol unresolvedSymbol,
                                         MethodResolverNode methodResolvedNode,
                                         TypesLibrary typesLibrary) {
@@ -732,7 +730,7 @@ public abstract class SortVectorNode extends Node {
 
     @Override
     boolean hasFunctionSelfArgument(Object definedOn) {
-      ensureSymbolIsResolved(definedOn);
+      var resolvedFunction = methodResolverNode.expectNonNull(definedOn, typesLibrary.getType(definedOn), unresolvedSymbol);
       return resolvedFunction.getSchema().getArgumentsCount() > 0 &&
         resolvedFunction.getSchema().getArgumentInfos()[0].getName().equals("self");
 
@@ -740,14 +738,7 @@ public abstract class SortVectorNode extends Node {
 
     @Override
     Function get(Object arg) {
-      ensureSymbolIsResolved(arg);
-      return resolvedFunction;
-    }
-
-    private void ensureSymbolIsResolved(Object definedOn) {
-      if (resolvedFunction == null) {
-        resolvedFunction = methodResolverNode.expectNonNull(definedOn, typesLibrary.getType(definedOn), unresolvedSymbol);
-      }
+      return methodResolverNode.expectNonNull(arg, typesLibrary.getType(arg), unresolvedSymbol);
     }
   }
 

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -767,9 +767,9 @@ type_spec name alter = Test.group name <|
 
     Test.specify "should be able to sort a heterogenous vector" <|
         arr = [ 1, 1.3, "hi", Date.today, Date_Time.now, [ 0 ] ]
-        (arr.map .to_text . sort) . should_equal (arr.sort on=(.to_text) . map .to_text)
-        (arr.map .to_text . sort) . should_equal (arr.sort on=(_.to_text) . map .to_text)
-        (arr.map .to_text . sort) . should_equal (arr.sort on=(x-> x.to_text) . map .to_text)
+        (arr.sort on=(.to_text) . map .to_text) . should_equal (arr.map .to_text . sort)
+        (arr.sort on=(_.to_text) . map .to_text) . should_equal (arr.map .to_text . sort)
+        (arr.sort on=(x-> x.to_text) . map .to_text) . should_equal (arr.map .to_text . sort)
 
     Test.specify "should be able to sort a polyglot vector" <|
         input = "beta".utf_8

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -765,6 +765,12 @@ type_spec name alter = Test.group name <|
     Test.specify "should return a vector containing only unique elements up to some criteria" <|
         alter [Pair.new 1 "a", Pair.new 2 "b", Pair.new 1 "c"] . distinct (on = _.first) . should_equal [Pair.new 1 "a", Pair.new 2 "b"]
 
+    Test.specify "should be able to sort a heterogenous vector" <|
+        arr = [ 1, 1.3, "hi", Date.today, Date_Time.now, [ 0 ] ]
+        (arr.map .to_text . sort) . should_equal (arr.sort on=(.to_text) . map .to_text)
+        (arr.map .to_text . sort) . should_equal (arr.sort on=(_.to_text) . map .to_text)
+        (arr.map .to_text . sort) . should_equal (arr.sort on=(x-> x.to_text) . map .to_text)
+
     Test.specify "should be able to sort a polyglot vector" <|
         input = "beta".utf_8
         expected = "abet".utf_8


### PR DESCRIPTION
Closes #7702

### Pull Request Description

Fix treatment of the `on` argument of `Vector.sort`.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md)
- All code has been tested:
  - [x] Unit tests have been written where possible.
