### PR TITLE
Display overriden non-default values

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
@@ -429,7 +429,9 @@ public final class Function implements EnsoObject {
     if (includeArguments) {
       for (var i = 0; i < schema.getArgumentsCount(); i++) {
         ArgumentDefinition info = schema.getArgumentInfos()[i];
-        if (info.hasDefaultValue()) {
+        if (info.hasDefaultValue()
+            && preAppliedArguments != null
+            && preAppliedArguments[i] == null) {
           continue;
         }
         var name = info.getName();

--- a/test/Tests/src/Semantic/Error_Spec.enso
+++ b/test/Tests/src/Semantic/Error_Spec.enso
@@ -373,6 +373,12 @@ spec =
             r . should_fail_with Type_Error
             r.to_display_text.should_contain "Try to apply y argument."
 
+        Test.specify "printed non-defaulted argument" <|
+            r = Panic.recover Type_Error <| neg (my_defaulted_func 33)
+            r . should_fail_with Type_Error
+            r.to_display_text.should_contain "Try to apply y argument."
+            r.to_display_text.should_contain "x=33"
+
         Test.specify "report unapplied constructor nicely" <|
             r = Panic.recover Type_Error <| extract My_Type.Value
             r . should_fail_with Type_Error
@@ -382,6 +388,12 @@ spec =
             r = Panic.recover Type_Error <| extract My_Type.Default_Value
             r . should_fail_with Type_Error
             r.to_display_text.should_contain "Try to apply bar argument."
+
+        Test.specify "report non-defaulted constructor argument" <|
+            r = Panic.recover Type_Error <| extract (My_Type.Default_Value foo=33)
+            r . should_fail_with Type_Error
+            r.to_display_text.should_contain "Try to apply bar argument."
+            r.to_display_text.should_contain "foo=33"
 
         Test.specify "report partially applied constructor nicely" <|
             r = Panic.recover Type_Error <| extract (My_Type.Multi_Value 42)


### PR DESCRIPTION
### Pull Request Description

Fixes #7723 by including overriden defaulted arguments in the function `toDisplayText` description.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
