### PR TITLE
Use only a single node color (blue)

### DIFF
--- a/app/gui/view/graph-editor/src/component/node.rs
+++ b/app/gui/view/graph-editor/src/component/node.rs
@@ -883,18 +883,7 @@ impl Node {
             model.input.set_node_colors <+ node_colors;
         }
 
-
-        // TODO: handle color change. Will likely require moving the node background and backdrop
-        // into a widget, which is also necessary to later support "split" nodes, where '.' chains
-        // are displayed as separate shapes.
-        let colors = [
-            color::Lcha(0.4911, 0.3390, 0.72658, 1.0),
-            color::Lcha(0.4468, 0.3788, 0.96805, 1.0),
-            color::Lcha(0.4437, 0.1239, 0.70062, 1.0),
-        ];
-        let mut hasher = crate::DefaultHasher::new();
-        Rc::as_ptr(&model).hash(&mut hasher);
-        base_color_source.emit(colors[hasher.finish() as usize % colors.len()]);
+        base_color_source.emit(color::Lcha(0.4911, 0.3390, 0.72658, 1.0));
 
 
         // Init defaults.


### PR DESCRIPTION
### Pull Request Description

Closes #7456 by using a *completely random* color for all nodes. 

Proof of randomness, ensured with modern LLM:

<img width="720" alt="Screenshot 2023-09-07 at 1 46 41 PM" src="https://github.com/enso-org/enso/assets/6566674/fc3fecd8-c5f6-4167-a646-973c4efedc18">


<img width="1380" alt="Screenshot 2023-09-07 at 1 43 44 PM" src="https://github.com/enso-org/enso/assets/6566674/0b4a91c7-fac2-4bab-921f-39861f891898">


### Important Notes

We can peek any other color if you'd like.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
