### PR TITLE
Forbid node pasting when editing

### DIFF
--- a/app/gui/view/graph-editor/src/shortcuts.rs
+++ b/app/gui/view/graph-editor/src/shortcuts.rs
@@ -81,7 +81,7 @@ pub const SHORTCUTS: &[(ensogl::application::shortcut::ActionType, &str, &str, &
     (Release, "!read_only", "cmd left-mouse-button", "edit_mode_off"),
     // === Copy-paste ===
     (Press, "!node_editing", "cmd c", "copy_selected_node"),
-    (Press, "!read_only", "cmd v", "paste_node"),
+    (Press, "!read_only & !node_editing", "cmd v", "paste_node"),
     // === Debug ===
     (Press, "debug_mode", "ctrl d", "debug_set_test_visualization_data_for_selected_node"),
     (Press, "debug_mode", "ctrl n", "add_node_at_cursor"),


### PR DESCRIPTION
### Pull Request Description

Closes #7759. The reason was a missing condition in the shortcut setup.

https://github.com/enso-org/enso/assets/6566674/d4475d48-f459-4dd9-ba9b-42e8110b541c


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
