### PR TITLE
Fix query parameters in `bench_download.py` tool

### DIFF
--- a/tools/performance/engine-benchmarks/bench_download.py
+++ b/tools/performance/engine-benchmarks/bench_download.py
@@ -65,6 +65,7 @@ from os import path
 from typing import List, Dict, Optional, Any, Union, Set
 from dataclasses import dataclass
 import xml.etree.ElementTree as ET
+from urllib.parse import urlencode
 
 
 if not (sys.version_info.major >= 3 and sys.version_info.minor >= 7):
@@ -300,12 +301,11 @@ def _read_json(json_file: str) -> Dict[Any, Any]:
 async def _invoke_gh_api(endpoint: str,
                    query_params: Dict[str, str] = {},
                    result_as_text: bool = True) -> Union[Dict[str, Any], bytes]:
-    query_str_list = [key + "=" + value for key, value in query_params.items()]
-    query_str = "&".join(query_str_list)
+    urlencode(query_params)
     cmd = [
         "gh",
         "api",
-        f"/repos/enso-org/enso{endpoint}" + ("" if len(query_str) == 0 else "?" + query_str)
+        f"/repos/enso-org/enso{endpoint}" + "?" + urlencode(query_params)
     ]
     logging.info(f"Starting subprocess `{' '.join(cmd)}`")
     proc = await asyncio.create_subprocess_exec("gh", *cmd[1:],


### PR DESCRIPTION
### Pull Request Description

URL query parameter construction in the `bench_donwload.py` tool uses `urllib` to properly quote, e.g., complex branch names.

### Important Notes

Fixes queries with complicated branch names, like `./bench_download.py -v -s stdlib --use-cache true -b develop wip/akirathan/6959-Integer.+-cannot-be-invoked-statically`

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
