### PR TITLE
Fix implicit conversion of foreign JS object to Text

### DIFF
--- a/engine/runtime-with-polyglot/src/test/java/org/enso/interpreter/test/JsInteropTest.java
+++ b/engine/runtime-with-polyglot/src/test/java/org/enso/interpreter/test/JsInteropTest.java
@@ -1,0 +1,45 @@
+package org.enso.interpreter.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class JsInteropTest extends TestBase {
+
+  private static final ByteArrayOutputStream out = new ByteArrayOutputStream();
+  private Context ctx;
+
+  @Before
+  public void initContext() {
+    ctx = createDefaultContext(out);
+    out.reset();
+  }
+  
+  @After
+  public void disposeCtx() {
+    ctx.close();
+  }
+
+  @Test
+  public void testDefaultJSPrint() {
+    var src = """
+      from Standard.Base import Json
+      
+      main =
+        json = Json.parse <| '''
+          {
+            "inner": {
+              "a": 1
+            }
+          }
+        json.get "inner"
+    """;
+    Value res = evalModule(ctx, src);
+    assertEquals("{\"a\":1}", res.toString());
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/Atom.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/Atom.java
@@ -242,6 +242,7 @@ public abstract class Atom implements EnsoObject {
       boolean allowSideEffects,
       @CachedLibrary("this") InteropLibrary atoms,
       @CachedLibrary(limit = "3") WarningsLibrary warnings,
+      @CachedLibrary(limit = "3") InteropLibrary interop,
       @Cached BranchProfile handleError
   ) {
     Object result = null;
@@ -255,6 +256,8 @@ public abstract class Atom implements EnsoObject {
         msg = this.toString("Error in method `to_text` of [", 10, "]: ", result);
       } else if (TypesGen.isText(result)) {
         return TypesGen.asText(result);
+      } else if (interop.isString(result)) {
+        return Text.create(interop.asString(result));
       } else {
         msg = this.toString("Error in method `to_text` of [", 10, "]: Expected Text but got ", result);
       }


### PR DESCRIPTION
Closes #7263

### Pull Request Description

Fixes implicit conversion of foreign JS object to `Text`.

### Important Notes


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md)
- All code has been tested:
  - [X] Unit tests have been written where possible.
