### PR TITLE
Workaround crashes during regular execution

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsAtomNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsAtomNode.java
@@ -137,7 +137,7 @@ public abstract class EqualsAtomNode extends Node {
 
   @TruffleBoundary
   static Function findCompareMethod(Type comparator) {
-    var fn = comparator.getDefinitionScope().getMethods().get(comparator).get("compare");
+    var fn = comparator.getDefinitionScope().getMethodsForType(comparator).get("compare");
     if (fn == null) {
       throw new AssertionError("No compare function for " + comparator);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsAtomNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsAtomNode.java
@@ -137,7 +137,7 @@ public abstract class EqualsAtomNode extends Node {
 
   @TruffleBoundary
   static Function findCompareMethod(Type comparator) {
-    var fn = comparator.getDefinitionScope().getMethodsForType(comparator).get("compare");
+    var fn = comparator.getDefinitionScope().getMethodForType(comparator, "compare");
     if (fn == null) {
       throw new AssertionError("No compare function for " + comparator);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/GetTypeMethodsNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/GetTypeMethodsNode.java
@@ -27,7 +27,7 @@ public abstract class GetTypeMethodsNode extends Node {
   @Specialization
   @CompilerDirectives.TruffleBoundary
   EnsoObject allMethods(Type type) {
-    var methods = type.getDefinitionScope().getMethods().get(type);
+    var methods = type.getDefinitionScope().getMethodsForType(type);
     return methods == null
         ? ArrayLikeHelpers.empty()
         : ArrayLikeHelpers.wrapStrings(methods.keySet().toArray(new String[0]));

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/GetTypeMethodsNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/GetTypeMethodsNode.java
@@ -27,10 +27,10 @@ public abstract class GetTypeMethodsNode extends Node {
   @Specialization
   @CompilerDirectives.TruffleBoundary
   EnsoObject allMethods(Type type) {
-    var methods = type.getDefinitionScope().getMethodsForType(type);
+    var methods = type.getDefinitionScope().getMethodNamesForType(type);
     return methods == null
         ? ArrayLikeHelpers.empty()
-        : ArrayLikeHelpers.wrapStrings(methods.keySet().toArray(new String[0]));
+        : ArrayLikeHelpers.wrapStrings(methods.toArray(new String[0]));
   }
 
   @Fallback

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/HashCodeNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/HashCodeNode.java
@@ -279,7 +279,7 @@ public abstract class HashCodeNode extends Node {
 
   @TruffleBoundary
   static Function findHashMethod(Type comparator) {
-    var fn = comparator.getDefinitionScope().getMethods().get(comparator).get("hash");
+    var fn = comparator.getDefinitionScope().getMethodsForType(comparator).get("hash");
     if (fn == null) {
       throw new AssertionError("No hash method for type " + comparator);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/HashCodeNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/HashCodeNode.java
@@ -1,7 +1,6 @@
 package org.enso.interpreter.node.expression.builtin.meta;
 
 import com.google.common.base.Objects;
-import com.ibm.icu.text.Normalizer2;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Cached;
@@ -279,7 +278,7 @@ public abstract class HashCodeNode extends Node {
 
   @TruffleBoundary
   static Function findHashMethod(Type comparator) {
-    var fn = comparator.getDefinitionScope().getMethodsForType(comparator).get("hash");
+    var fn = comparator.getDefinitionScope().getMethodForType(comparator, "hash");
     if (fn == null) {
       throw new AssertionError("No hash method for type " + comparator);
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/ordering/HashCallbackNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/ordering/HashCallbackNode.java
@@ -79,7 +79,7 @@ public abstract class HashCallbackNode extends Node {
   Function getHashCallbackFunction() {
     var comparableType = EnsoContext.get(this).getBuiltins().comparable().getType();
     Function hashCallback =
-        comparableType.getDefinitionScope().getMethods().get(comparableType).get("hash_callback");
+        comparableType.getDefinitionScope().getMethodsForType(comparableType).get("hash_callback");
     assert hashCallback != null : "Comparable.hash_callback function must exist";
     return hashCallback;
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/ordering/HashCallbackNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/ordering/HashCallbackNode.java
@@ -79,7 +79,7 @@ public abstract class HashCallbackNode extends Node {
   Function getHashCallbackFunction() {
     var comparableType = EnsoContext.get(this).getBuiltins().comparable().getType();
     Function hashCallback =
-        comparableType.getDefinitionScope().getMethodsForType(comparableType).get("hash_callback");
+        comparableType.getDefinitionScope().getMethodForType(comparableType, "hash_callback");
     assert hashCallback != null : "Comparable.hash_callback function must exist";
     return hashCallback;
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -532,7 +532,7 @@ public final class Module implements EnsoObject {
       String name = arguments.getSecond();
 
       try {
-        return scope.getMethods().get(type).get(name);
+        return scope.getMethodsForType(type).get(name);
       } catch (NullPointerException npe) {
         TruffleLogger logger = TruffleLogger.getLogger(LanguageInfo.ID, Module.class);
         logger.log(

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/Module.java
@@ -532,7 +532,7 @@ public final class Module implements EnsoObject {
       String name = arguments.getSecond();
 
       try {
-        return scope.getMethodsForType(type).get(name);
+        return scope.getMethodForType(type, name);
       } catch (NullPointerException npe) {
         TruffleLogger logger = TruffleLogger.getLogger(LanguageInfo.ID, Module.class);
         logger.log(

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/PatchedModuleValues.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/PatchedModuleValues.java
@@ -51,9 +51,9 @@ final class PatchedModuleValues {
     if (values == null) {
       var scope = module.getScope();
       values = new HashMap<>();
-      var methods = scope.getMethods();
+      var methods = scope.getAllMethods();
       var conversions = scope.getConversions();
-      updateFunctionsMap(null, methods.values(), values);
+      updateFunctionsMap(null, methods, values);
       updateFunctionsMap(null, conversions.values(), values);
     }
     values.putAll(collect);
@@ -81,7 +81,7 @@ final class PatchedModuleValues {
    */
   boolean simpleUpdate(SimpleUpdate update) {
     var scope = module.getScope();
-    var methods = scope.getMethods();
+    var methods = scope.getAllMethods();
     var conversions = scope.getConversions();
     var collect = new HashMap<Node, Predicate<Expression>>();
     if (values != null) {
@@ -91,7 +91,7 @@ final class PatchedModuleValues {
     }
     if (collect.isEmpty()) {
       // only search for new literals when none have been found
-      updateFunctionsMap(update, methods.values(), collect);
+      updateFunctionsMap(update, methods, collect);
       updateFunctionsMap(update, conversions.values(), collect);
       if (collect.isEmpty()) {
         return false;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/PatchedModuleValues.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/PatchedModuleValues.java
@@ -4,11 +4,7 @@ import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.function.Predicate;
 import org.enso.compiler.context.SimpleUpdate;
 import org.enso.compiler.core.IR;
@@ -54,7 +50,7 @@ final class PatchedModuleValues {
       var methods = scope.getAllMethods();
       var conversions = scope.getConversions();
       updateFunctionsMap(null, methods, values);
-      updateFunctionsMap(null, conversions.values(), values);
+      updateFunctionsMap(null, conversions, values);
     }
     values.putAll(collect);
     if (delta == 0) {
@@ -92,7 +88,7 @@ final class PatchedModuleValues {
     if (collect.isEmpty()) {
       // only search for new literals when none have been found
       updateFunctionsMap(update, methods, collect);
-      updateFunctionsMap(update, conversions.values(), collect);
+      updateFunctionsMap(update, conversions, collect);
       if (collect.isEmpty()) {
         return false;
       }
@@ -114,11 +110,9 @@ final class PatchedModuleValues {
     return true;
   }
 
-  private static void updateFunctionsMap(SimpleUpdate edit, Collection<? extends Map<?, Function>> values, Map<Node, Predicate<Expression>> nodeValues) {
-    for (Map<?, Function> map : values) {
-      for (Function f : map.values()) {
-        updateNode(edit, f.getCallTarget().getRootNode(), nodeValues);
-      }
+  private static void updateFunctionsMap(SimpleUpdate edit, List<Function> values, Map<Node, Predicate<Expression>> nodeValues) {
+    for (Function f : values) {
+      updateNode(edit, f.getCallTarget().getRootNode(), nodeValues);
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/Atom.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/Atom.java
@@ -144,14 +144,14 @@ public abstract class Atom implements EnsoObject {
   @ExportMessage
   @CompilerDirectives.TruffleBoundary
   public EnsoObject getMembers(boolean includeInternal) {
-    Map<String, Function> members = constructor.getDefinitionScope().getMethodsForType(constructor.getType());
+    Set<String> members = constructor.getDefinitionScope().getMethodNamesForType(constructor.getType());
     Set<String> allMembers = new HashSet<>();
     if (members != null) {
-      allMembers.addAll(members.keySet());
+      allMembers.addAll(members);
     }
-    members = constructor.getType().getDefinitionScope().getMethodsForType(constructor.getType());
+    members = constructor.getType().getDefinitionScope().getMethodNamesForType(constructor.getType());
     if (members != null) {
-      allMembers.addAll(members.keySet());
+      allMembers.addAll(members);
     }
     String[] mems = allMembers.toArray(new String[0]);
     return ArrayLikeHelpers.wrapStrings(mems);
@@ -160,12 +160,12 @@ public abstract class Atom implements EnsoObject {
   @ExportMessage
   @CompilerDirectives.TruffleBoundary
   public boolean isMemberInvocable(String member) {
-    Map<String, ?> members = constructor.getDefinitionScope().getMethodsForType(constructor.getType());
-    if (members != null && members.containsKey(member)) {
+    Set<String> members = constructor.getDefinitionScope().getMethodNamesForType(constructor.getType());
+    if (members != null && members.contains(member)) {
       return true;
     }
-    members = constructor.getType().getDefinitionScope().getMethodsForType(constructor.getType());
-    return members != null && members.containsKey(member);
+    members = constructor.getType().getDefinitionScope().getMethodNamesForType(constructor.getType());
+    return members != null && members.contains(member);
   }
 
   @ExportMessage

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/Atom.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/atom/Atom.java
@@ -144,12 +144,12 @@ public abstract class Atom implements EnsoObject {
   @ExportMessage
   @CompilerDirectives.TruffleBoundary
   public EnsoObject getMembers(boolean includeInternal) {
-    Map<String, Function> members = constructor.getDefinitionScope().getMethods().get(constructor.getType());
+    Map<String, Function> members = constructor.getDefinitionScope().getMethodsForType(constructor.getType());
     Set<String> allMembers = new HashSet<>();
     if (members != null) {
       allMembers.addAll(members.keySet());
     }
-    members = constructor.getType().getDefinitionScope().getMethods().get(constructor.getType());
+    members = constructor.getType().getDefinitionScope().getMethodsForType(constructor.getType());
     if (members != null) {
       allMembers.addAll(members.keySet());
     }
@@ -160,11 +160,11 @@ public abstract class Atom implements EnsoObject {
   @ExportMessage
   @CompilerDirectives.TruffleBoundary
   public boolean isMemberInvocable(String member) {
-    Map<String, ?> members = constructor.getDefinitionScope().getMethods().get(constructor.getType());
+    Map<String, ?> members = constructor.getDefinitionScope().getMethodsForType(constructor.getType());
     if (members != null && members.containsKey(member)) {
       return true;
     }
-    members = constructor.getType().getDefinitionScope().getMethods().get(constructor.getType());
+    members = constructor.getType().getDefinitionScope().getMethodsForType(constructor.getType());
     return members != null && members.containsKey(member);
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Type.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Type.java
@@ -68,6 +68,10 @@ public final class Type implements EnsoObject {
     return result;
   }
 
+  public static Type noType() {
+    return new Type("null", null, null, null, false);
+  }
+
   private void generateQualifiedAccessor() {
     var node = new ConstantNode(null, this);
     var function =
@@ -94,7 +98,7 @@ public final class Type implements EnsoObject {
       // Some scopes won't have any methods at this point, e.g., Nil or Nothing, hence the null
       // check.
       CompilerAsserts.neverPartOfCompilation();
-      Map<String, Function> methods = this.definitionScope.getMethods().get(this);
+      Map<String, Function> methods = this.definitionScope.getMethodsForType(this);
       if (methods != null) {
         methods.forEach((name, fun) -> scope.registerMethod(this, name, fun));
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Type.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Type.java
@@ -98,10 +98,7 @@ public final class Type implements EnsoObject {
       // Some scopes won't have any methods at this point, e.g., Nil or Nothing, hence the null
       // check.
       CompilerAsserts.neverPartOfCompilation();
-      Map<String, Function> methods = this.definitionScope.getMethodsForType(this);
-      if (methods != null) {
-        methods.forEach((name, fun) -> scope.registerMethod(this, name, fun));
-      }
+      this.definitionScope.registerAllMethodsOfTypeToScope(this, scope);
       this.definitionScope = scope;
       if (generateAccessorsInTarget) {
         generateQualifiedAccessor();

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
@@ -301,7 +301,7 @@ public final class ModuleScope implements EnsoObject {
     Type tpeKey = tpe == null ? noTypeKey : tpe;
     Map<String, Function> allTypeMethods = methods.get(tpeKey);
     if (allTypeMethods != null) {
-      allTypeMethods.forEach((name, fun) -> scope.registerMethod(tpe, name, fun));
+      allTypeMethods.forEach((name, fun) -> scope.registerMethod(tpeKey, name, fun));
     }
   }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -244,7 +244,24 @@ class Compiler(
     shouldCompileDependencies: Boolean
   ): List[Module] = {
     initialize()
-    modules.foreach(m => parseModule(m))
+    modules.foreach(m =>
+      try {
+        parseModule(m)
+      } catch {
+        case e: Throwable =>
+          context.log(
+            Level.SEVERE,
+            "Encountered a critical failure while parsing module {0}: {1}",
+            m.getName,
+            e.getMessage
+          )
+          context.log(
+            Level.SEVERE,
+            "Contents of module: {0}",
+            m.getSource.getCharacters.toString
+          )
+      }
+    )
 
     var requiredModules = modules.flatMap { module =>
       val importedModules = runImportsAndExportsResolution(module, generateCode)

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -251,13 +251,13 @@ class Compiler(
         case e: Throwable =>
           context.log(
             Level.SEVERE,
-            "Encountered a critical failure while parsing module {0}: {1}",
-            m.getName,
-            e.getMessage
+            "Encountered a critical failure while parsing module",
+            e
           )
           context.log(
             Level.SEVERE,
-            "Contents of module: {0}",
+            "Contents of module {0}: {0}",
+            m.getPath,
             m.getSource.getCharacters.toString
           )
       }

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -878,8 +878,10 @@ class IrToTruffle(
             case BindingsMap.ResolvedMethod(module, method) =>
               val actualModule = module.unsafeAsModule()
               val fun = actualModule.getScope
-                .getMethodsForType(actualModule.getScope.getAssociatedType)
-                .get(method.name)
+                .getMethodForType(
+                  actualModule.getScope.getAssociatedType,
+                  method.name
+                )
               assert(
                 fun != null,
                 s"exported symbol `${method.name}` needs to be registered first in the module "
@@ -1236,8 +1238,7 @@ class IrToTruffle(
                   val polyglotSymbol = mod
                     .unsafeAsModule()
                     .getScope
-                    .getPolyglotSymbols
-                    .get(symbol.name)
+                    .getPolyglotSymbol(symbol.name)
                   Either.cond(
                     polyglotSymbol != null,
                     ObjectEqualityBranchNode
@@ -1257,8 +1258,7 @@ class IrToTruffle(
                   val polyClass = mod
                     .unsafeAsModule()
                     .getScope
-                    .getPolyglotSymbols
-                    .get(typ.symbol.name)
+                    .getPolyglotSymbol(typ.symbol.name)
 
                   val polyValueOrError =
                     if (polyClass == null)
@@ -1398,8 +1398,7 @@ class IrToTruffle(
                 mod
                   .unsafeAsModule()
                   .getScope
-                  .getPolyglotSymbols
-                  .get(symbol.name)
+                  .getPolyglotSymbol(symbol.name)
               if (polySymbol != null) {
                 val argOfType = List(
                   DefinitionArgument.Specified(
@@ -1642,16 +1641,14 @@ class IrToTruffle(
             module
               .unsafeAsModule()
               .getScope
-              .getPolyglotSymbols
-              .get(symbol.name)
+              .getPolyglotSymbol(symbol.name)
           )
         case BindingsMap.ResolvedPolyglotField(symbol, name) =>
           ConstantObjectNode.build(
             symbol.module
               .unsafeAsModule()
               .getScope
-              .getPolyglotSymbols
-              .get(name)
+              .getPolyglotSymbol(name)
           )
         case BindingsMap.ResolvedMethod(_, method) =>
           throw new CompilerError(

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -877,8 +877,8 @@ class IrToTruffle(
               )
             case BindingsMap.ResolvedMethod(module, method) =>
               val actualModule = module.unsafeAsModule()
-              val fun = actualModule.getScope.getMethods
-                .get(actualModule.getScope.getAssociatedType)
+              val fun = actualModule.getScope
+                .getMethodsForType(actualModule.getScope.getAssociatedType)
                 .get(method.name)
               assert(
                 fun != null,

--- a/engine/runtime/src/test/java/org/enso/compiler/SerdeCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/SerdeCompilerTest.java
@@ -91,8 +91,7 @@ public class SerdeCompilerTest {
       assertEquals(result.compiledModules().exists(m -> m == module), true);
 
       var methods = module.getScope().getAllMethods();
-      var methodsOfMain = methods.iterator().next();
-      var main = methodsOfMain.values().iterator().next();
+      var main = methods.get(0);
 
       assertEquals("Main.main", main.getName());
       var mainValue = ctx.asValue(main);

--- a/engine/runtime/src/test/java/org/enso/compiler/SerdeCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/SerdeCompilerTest.java
@@ -90,8 +90,8 @@ public class SerdeCompilerTest {
       mockHandler.assertNoFailureMessage();
       assertEquals(result.compiledModules().exists(m -> m == module), true);
 
-      var methods = module.getScope().getMethods();
-      var methodsOfMain = methods.values().iterator().next();
+      var methods = module.getScope().getAllMethods();
+      var methodsOfMain = methods.iterator().next();
       var main = methodsOfMain.values().iterator().next();
 
       assertEquals("Main.main", main.getName());


### PR DESCRIPTION
### Pull Request Description

This PR addresses two problems mentioned in #7766:
1. A random integer overflow, likely caused by a bug in Rust parser
2. A concurrent access to a methods' map

Re 1: Unable to reproduce but it doesn't mean it won't happen again. Added a try/catch to get in the logs source code that caused it **and** not crash hard when it occurs.

Re 2: Changing methods map from `HashMap` to `ConcurrentHashMap`. Due to a poor design we leaked the underlying structure in a number of places, unnecessairly. `ConcurrentHashMap` does not accept `null` keys therefore due to leaking implementation had to ensure that `methods` of `ModuleScope` never escapes as-is.

Both workarounds should ensure that we don't crash hard when they appear.

Closes #7766 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
