### PR TITLE
Benchmark shall loop correctly

### DIFF
--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/ListBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/ListBenchmarks.java
@@ -104,17 +104,17 @@ public class ListBenchmarks {
       sum_any list (acc:Any) =
           case list of
               Nil -> acc
-              Cons x xs -> @Tail_Call sum xs acc+x
+              Cons x xs -> @Tail_Call sum_any xs acc+x
 
       sum_int list (acc:Integer) =
           case list of
               Nil -> acc
-              Cons x xs -> @Tail_Call sum xs acc+x
+              Cons x xs -> @Tail_Call sum_int xs acc+x
 
       sum_multi list (acc:Text|Decimal|Integer|Any) =
           case list of
               Nil -> acc
-              Cons x xs -> @Tail_Call sum xs acc+x
+              Cons x xs -> @Tail_Call sum_multi xs acc+x
 
       generator n =
           go x v l = if x > n then l else


### PR DESCRIPTION
### Pull Request Description

Many `ListBenchmarks` were wrong. They were looping to `sum` instead of `sum_xyz`. Expect regressions, but more truthful results.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] [Benchmarks](https://github.com/enso-org/enso/actions/runs/6143024550) finish (yet they slow down)