### PR TITLE
Do not lose focus when clicking fullscreen visualization

### DIFF
--- a/app/gui/view/graph-editor/src/component/visualization/container.rs
+++ b/app/gui/view/graph-editor/src/component/visualization/container.rs
@@ -788,7 +788,9 @@ impl Container {
         let scene_clicked = scene.on_event::<mouse::Down>();
         frp::extend! { network
             selected_by_click <- viz_clicked.map(f_!(model.activate()));
-            deselected_by_click <- scene_clicked.map(f!([model](event) model.deactivated_by_click(event)));
+            is_fullscreen <- output.view_state.map(|s| s.is_fullscreen());
+            deselect_click <- scene_clicked.gate_not(&is_fullscreen);
+            deselected_by_click <- deselect_click.map(f!([model](event) model.deactivated_by_click(event)));
             selected <- selected_by_click.on_true();
             deselected <- deselected_by_click.on_true();
             is_selected <- bool(&deselected, &selected).on_change();


### PR DESCRIPTION
### Pull Request Description

Fixes #7524 

The issue was caused by the fact that fullscreen visualization does not have hover area, so clicking anywhere was deactivating it because we used `deselect_click = scene.on_event::<mouse::Down>();`


https://github.com/enso-org/enso/assets/6566674/08a463f3-764f-4b2c-b41f-13521f5cfc56



### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
