### PR TITLE
Fix visualization closing when cmd shortcut is pressed

### DIFF
--- a/app/gui/view/graph-editor/src/component/node.rs
+++ b/app/gui/view/graph-editor/src/component/node.rs
@@ -785,6 +785,8 @@ impl Node {
         frp::extend! { network
             output_hover <- model.output.on_port_hover.map(|s| s.is_on());
             visualization_hover <- bool(&model.visualization.on_event::<mouse::Out>(), &model.visualization.on_event::<mouse::Over>());
+            is_preview <- visualization.view_state.map(|s| s.is_preview());
+            visualization_hover <- visualization_hover.gate(&is_preview);
             hovered_for_preview <- output_hover || visualization_hover;
             // The debounce is needed for a case where user moves mouse cursor from output port to
             // visualization preview. Moving out of the port make `output_hover` emit `false`,

--- a/app/gui/view/graph-editor/src/component/node.rs
+++ b/app/gui/view/graph-editor/src/component/node.rs
@@ -786,8 +786,8 @@ impl Node {
             output_hover <- model.output.on_port_hover.map(|s| s.is_on());
             visualization_hover <- bool(&model.visualization.on_event::<mouse::Out>(), &model.visualization.on_event::<mouse::Over>());
             is_preview <- visualization.view_state.map(|s| s.is_preview());
-            visualization_hover <- visualization_hover.gate(&is_preview);
-            hovered_for_preview <- output_hover || visualization_hover;
+            preview_hover <- visualization_hover.gate(&is_preview);
+            hovered_for_preview <- output_hover || preview_hover;
             // The debounce is needed for a case where user moves mouse cursor from output port to
             // visualization preview. Moving out of the port make `output_hover` emit `false`,
             // making `hovered_for_preview` false for a brief moment - and that moment would cause

--- a/app/gui/view/graph-editor/src/component/visualization/container.rs
+++ b/app/gui/view/graph-editor/src/component/visualization/container.rs
@@ -125,9 +125,14 @@ impl ViewState {
         )
     }
 
-    /// Indicates whether the visualization is fullscreen mode.
+    /// Indicates whether the visualization is in fullscreen mode.
     pub fn is_fullscreen(&self) -> bool {
         matches!(self, ViewState::Fullscreen)
+    }
+
+    /// Indicates whether the visualization is in preview mode.
+    pub fn is_preview(&self) -> bool {
+        matches!(self, ViewState::Preview { .. })
     }
 
     /// Return a new state after considering (lack of) presence of the error.


### PR DESCRIPTION
### Pull Request Description

Fixes #7457 

The issue was caused by the FRP logic that assumed we wanted to close the preview even if it wasn't opened in the first place.

https://github.com/enso-org/enso/assets/6566674/ceb4996b-c878-4ff1-8bca-7d2a0b817769


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
