### PR TITLE
Improve shutdown logic of language server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -957,6 +957,7 @@
 - [Support runtime checks of intersection types][7769]
 - [Merge `Small_Integer` and `Big_Integer` types][7636]
 - [Inline type ascriptions][7796]
+- [New `project/status` route for reporting LS state][7801]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -1098,6 +1099,7 @@
 [7769]: https://github.com/enso-org/enso/pull/7769
 [7636]: https://github.com/enso-org/enso/pull/7636
 [7796]: https://github.com/enso-org/enso/pull/7796
+[7801]: https://github.com/enso-org/enso/pull/7801
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/docs/language-server/protocol-project-manager.md
+++ b/docs/language-server/protocol-project-manager.md
@@ -23,6 +23,7 @@ transport formats, please look [here](./protocol-architecture.md).
   - [`MissingComponentAction`](#missingcomponentaction)
   - [`ProgressUnit`](#progressunit)
   - [`EngineVersion`](#engineversion)
+  - [`RunningState`](#runningstate)
 - [Project Management Operations](#project-management-operations)
   - [`project/open`](#projectopen)
   - [`project/close`](#projectclose)
@@ -31,6 +32,7 @@ transport formats, please look [here](./protocol-architecture.md).
   - [`project/rename`](#projectrename)
   - [`project/delete`](#projectdelete)
   - [`project/listSample`](#projectlistsample)
+  - [`project/status`](#projectstatus)
 - [Action Progress Reporting](#action-progress-reporting)
   - [`task/started`](#taskstarted)
   - [`task/progress-update`](#taskprogress-update)
@@ -159,6 +161,29 @@ interface EngineVersion {
 
   /** Specifies if that version is marked as broken. */
   markedAsBroken: bool;
+}
+```
+
+### `RunningState`
+
+This type represents information about a state of the (potentially) running
+project.
+
+#### Format
+
+```typescript
+interface RunningStatus {
+  /**
+   * If true, the project is open and (still) accepting new connections.
+   * False, if the project is currently shutdown.
+   */
+  open: bool;
+
+  /**
+   * If true, the project is currently running but in a soft shutdown mode.
+   * False, if the project is either not running or it is not shutting down.
+   */
+  shuttingDown: bool;
 }
 ```
 
@@ -494,6 +519,31 @@ interface ProjectListSampleResponse {
 #### Errors
 
 TBC
+
+### `project/status`
+
+This request asks for the current state of the project.
+
+- **Type:** Request
+- **Direction:** Client -> Server
+- **Connection:** Protocol
+- **Visibility:** Public
+
+#### Parameters
+
+```typescript
+interface ProjectStatusRequest {
+  projectID: UUID;
+}
+```
+
+#### Result
+
+```typescript
+interface ProjectStatusResponse {
+  status: RunningStatus;
+}
+```
 
 ## Action Progress Reporting
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
@@ -141,7 +141,7 @@ class JsonConnectionController(
   }
 
   override def receive: Receive = {
-    case JsonRpcServer.WebConnect(webActor) =>
+    case JsonRpcServer.WebConnect(webActor, _) =>
       unstashAll()
       context.become(connected(webActor))
     case _ => stash()
@@ -180,7 +180,7 @@ class JsonConnectionController(
     case Request(_, id, _) =>
       sender() ! ResponseError(Some(id), SessionNotInitialisedError)
 
-    case MessageHandler.Disconnected =>
+    case MessageHandler.Disconnected(_) =>
       context.stop(self)
   }
 
@@ -304,7 +304,7 @@ class JsonConnectionController(
     case Request(InitProtocolConnection, id, _) =>
       sender() ! ResponseError(Some(id), SessionAlreadyInitialisedError)
 
-    case MessageHandler.Disconnected =>
+    case MessageHandler.Disconnected(_) =>
       logger.info("Json session terminated [{}].", rpcSession.clientId)
       context.system.eventStream.publish(JsonSessionTerminated(rpcSession))
       context.stop(self)

--- a/lib/scala/json-rpc-server/src/main/scala/org/enso/jsonrpc/JsonRpcServer.scala
+++ b/lib/scala/json-rpc-server/src/main/scala/org/enso/jsonrpc/JsonRpcServer.scala
@@ -36,11 +36,15 @@ class JsonRpcServer(
 
   implicit val ec: ExecutionContext = system.dispatcher
 
-  private def newUser(): Flow[Message, Message, NotUsed] = {
+  private def newUser(port: Int): Flow[Message, Message, NotUsed] = {
     val messageHandler =
       system.actorOf(
         Props(
-          new MessageHandlerSupervisor(clientControllerFactory, protocolFactory)
+          new MessageHandlerSupervisor(
+            clientControllerFactory,
+            protocolFactory,
+            port
+          )
         ),
         s"message-handler-supervisor-${UUID.randomUUID()}"
       )
@@ -61,9 +65,11 @@ class JsonRpcServer(
         .to(
           Sink.actorRef[MessageHandler.WebMessage](
             messageHandler,
-            MessageHandler.Disconnected,
-            { _: Any =>
-              MessageHandler.Disconnected
+            MessageHandler.Disconnected(port),
+            { _: Throwable =>
+              // TODO: If enabled, the warning would produce too much noise in tests
+              // logger.warn(s"Connection closed abruptly: ${e.getMessage}", e)
+              MessageHandler.Disconnected(port)
             }
           )
         )
@@ -77,7 +83,7 @@ class JsonRpcServer(
           OverflowStrategy.fail
         )
         .mapMaterializedValue { outActor =>
-          messageHandler ! MessageHandler.Connected(outActor)
+          messageHandler ! MessageHandler.Connected(outActor, port)
           NotUsed
         }
         .map((outMsg: MessageHandler.WebMessage) => TextMessage(outMsg.message))
@@ -88,10 +94,10 @@ class JsonRpcServer(
     Flow.fromSinkAndSource(incomingMessages, outgoingMessages)
   }
 
-  private val route: Route = {
+  private def route(port: Int): Route = {
     val webSocketEndpoint =
       path(config.path) {
-        get { handleWebSocketMessages(newUser()) }
+        get { handleWebSocketMessages(newUser(port)) }
       }
 
     optionalEndpoints.foldLeft(webSocketEndpoint) { (chain, next) =>
@@ -109,7 +115,7 @@ class JsonRpcServer(
   def bind(interface: String, port: Int): Future[Http.ServerBinding] =
     Http()
       .newServerAt(interface, port)
-      .bind(route)
+      .bind(route(port))
 }
 
 object JsonRpcServer {
@@ -138,6 +144,6 @@ object JsonRpcServer {
       Config(outgoingBufferSize = 1000, lazyMessageTimeout = 10.seconds)
   }
 
-  case class WebConnect(webActor: ActorRef)
+  case class WebConnect(webActor: ActorRef, port: Int)
 
 }

--- a/lib/scala/json-rpc-server/src/main/scala/org/enso/jsonrpc/JsonRpcServer.scala
+++ b/lib/scala/json-rpc-server/src/main/scala/org/enso/jsonrpc/JsonRpcServer.scala
@@ -67,8 +67,6 @@ class JsonRpcServer(
             messageHandler,
             MessageHandler.Disconnected(port),
             { _: Throwable =>
-              // TODO: If enabled, the warning would produce too much noise in tests
-              // logger.warn(s"Connection closed abruptly: ${e.getMessage}", e)
               MessageHandler.Disconnected(port)
             }
           )

--- a/lib/scala/json-rpc-server/src/main/scala/org/enso/jsonrpc/MessageHandler.scala
+++ b/lib/scala/json-rpc-server/src/main/scala/org/enso/jsonrpc/MessageHandler.scala
@@ -20,7 +20,7 @@ class MessageHandler(protocolFactory: ProtocolFactory, controller: ActorRef)
     * @return the actor behavior.
     */
   override def receive: Receive = {
-    case MessageHandler.Connected(webConnection) =>
+    case MessageHandler.Connected(webConnection, _) =>
       unstashAll()
       context.become(established(webConnection, Map()))
     case _ => stash()
@@ -38,8 +38,8 @@ class MessageHandler(protocolFactory: ProtocolFactory, controller: ActorRef)
   ): Receive = {
     case MessageHandler.WebMessage(msg) =>
       handleWebMessage(msg, webConnection, awaitingResponses)
-    case MessageHandler.Disconnected =>
-      controller ! MessageHandler.Disconnected
+    case MessageHandler.Disconnected(port) =>
+      controller ! MessageHandler.Disconnected(port)
       context.stop(self)
     case request: Request[Method, Any] =>
       issueRequest(request, webConnection, awaitingResponses)
@@ -192,10 +192,10 @@ object MessageHandler {
   /** A control message used for [[MessageHandler]] initializations
     * @param webConnection the actor representing the web.
     */
-  case class Connected(webConnection: ActorRef)
+  case class Connected(webConnection: ActorRef, port: Int)
 
   /** A control message used to notify the controller about
     * the connection being closed.
     */
-  case object Disconnected
+  case class Disconnected(port: Int)
 }

--- a/lib/scala/json-rpc-server/src/main/scala/org/enso/jsonrpc/MessageHandlerSupervisor.scala
+++ b/lib/scala/json-rpc-server/src/main/scala/org/enso/jsonrpc/MessageHandlerSupervisor.scala
@@ -19,7 +19,8 @@ import java.util.UUID
   */
 final class MessageHandlerSupervisor(
   clientControllerFactory: ClientControllerFactory,
-  protocolFactory: ProtocolFactory
+  protocolFactory: ProtocolFactory,
+  port: Int
 ) extends Actor
     with LazyLogging
     with Stash {
@@ -58,7 +59,7 @@ final class MessageHandlerSupervisor(
           Props(new MessageHandler(protocolFactory, clientActor)),
           s"message-handler-$clientId"
         )
-      clientActor ! JsonRpcServer.WebConnect(messageHandler)
+      clientActor ! JsonRpcServer.WebConnect(messageHandler, port)
       context.become(initialized(messageHandler))
       unstashAll()
 

--- a/lib/scala/json-rpc-server/src/test/scala/org/enso/jsonrpc/MessageHandlerSpec.scala
+++ b/lib/scala/json-rpc-server/src/test/scala/org/enso/jsonrpc/MessageHandlerSpec.scala
@@ -95,7 +95,7 @@ class MessageHandlerSpec
     handler = system.actorOf(
       Props(new MessageHandler(MyProtocolFactory, controller.ref))
     )
-    handler ! Connected(out.ref)
+    handler ! Connected(out.ref, 0)
   }
 
   "Message handler" must {

--- a/lib/scala/project-manager/src/main/resources/application.conf
+++ b/lib/scala/project-manager/src/main/resources/application.conf
@@ -117,7 +117,7 @@ project-manager {
     request-timeout = 10 seconds
     boot-timeout = 40 seconds
     shutdown-timeout = 20 seconds
-    delayed-shutdown-timeout = 8 seconds
+    delayed-shutdown-timeout = 3 seconds
     socket-close-timeout = 15 seconds
     retries = 5
   }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/data/LanguageServerStatus.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/data/LanguageServerStatus.scala
@@ -1,0 +1,3 @@
+package org.enso.projectmanager.data
+
+case class LanguageServerStatus(open: Boolean, shuttingDown: Boolean)

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/data/RunningStatus.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/data/RunningStatus.scala
@@ -1,0 +1,3 @@
+package org.enso.projectmanager.data
+
+case class RunningStatus(open: Boolean, shuttingDown: Boolean)

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/event/ClientEvent.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/event/ClientEvent.scala
@@ -11,14 +11,16 @@ object ClientEvent {
   /** Notifies the Language Server about a new client connecting.
     *
     * @param clientId an object representing a client
+    * @param port the port number to which the client connected
     */
-  case class ClientConnected(clientId: UUID) extends ClientEvent
+  case class ClientConnected(clientId: UUID, port: Int) extends ClientEvent
 
   /** Notifies the Language Server about a client disconnecting.
     * The client may not send any further messages after this one.
     *
     * @param clientId the internal id of this client
+    * @param port the port number from which the client disconnected
     */
-  case class ClientDisconnected(clientId: UUID) extends ClientEvent
+  case class ClientDisconnected(clientId: UUID, port: Int) extends ClientEvent
 
 }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerController.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerController.scala
@@ -15,7 +15,10 @@ import nl.gn0s1s.bump.SemVer
 import org.enso.logger.akka.ActorMessageLogging
 import org.enso.projectmanager.boot.configuration._
 import org.enso.projectmanager.data.{LanguageServerSockets, Socket}
-import org.enso.projectmanager.event.ClientEvent.ClientDisconnected
+import org.enso.projectmanager.event.ClientEvent.{
+  ClientConnected,
+  ClientDisconnected
+}
 import org.enso.projectmanager.event.ProjectEvent.ProjectClosed
 import org.enso.projectmanager.infrastructure.http.AkkaBasedWebSocketConnectionFactory
 import org.enso.projectmanager.infrastructure.languageserver.LanguageServerBootLoader.{
@@ -24,7 +27,11 @@ import org.enso.projectmanager.infrastructure.languageserver.LanguageServerBootL
 }
 import org.enso.projectmanager.infrastructure.languageserver.LanguageServerController._
 import org.enso.projectmanager.infrastructure.languageserver.LanguageServerProtocol._
-import org.enso.projectmanager.infrastructure.languageserver.LanguageServerRegistry.ServerShutDown
+import org.enso.projectmanager.infrastructure.languageserver.LanguageServerRegistry.{
+  LanguageServerStatus,
+  LanguageServerStatusRequest,
+  ServerShutDown
+}
 import org.enso.projectmanager.model.Project
 import org.enso.projectmanager.service.LoggingServiceDescriptor
 import org.enso.projectmanager.util.UnhandledLogging
@@ -93,6 +100,7 @@ class LanguageServerController(
 
   override def preStart(): Unit = {
     context.system.eventStream.subscribe(self, classOf[ClientDisconnected])
+    context.system.eventStream.subscribe(self, classOf[ClientConnected])
     self ! Boot
   }
 
@@ -160,12 +168,12 @@ class LanguageServerController(
   private def supervising(
     connectionInfo: LanguageServerConnectionInfo,
     serverProcessManager: ActorRef,
-    clients: Set[UUID]                     = Set.empty,
-    scheduledShutdown: Option[Cancellable] = None
+    clients: Set[UUID]                            = Set.empty,
+    scheduledShutdown: Option[(Cancellable, Int)] = None
   ): Receive =
     LoggingReceive.withLabel("supervising") {
       case StartServer(clientId, _, requestedEngineVersion, _, _) =>
-        scheduledShutdown.foreach(_.cancel())
+        scheduledShutdown.foreach(_._1.cancel())
         if (requestedEngineVersion != engineVersion) {
           sender() ! ServerBootFailed(
             new IllegalStateException(
@@ -192,7 +200,7 @@ class LanguageServerController(
           )
         }
       case Terminated(_) =>
-        scheduledShutdown.foreach(_.cancel())
+        scheduledShutdown.foreach(_._1.cancel())
         logger.debug("Bootloader for {} terminated.", project)
 
       case StopServer(clientId, _) =>
@@ -202,28 +210,49 @@ class LanguageServerController(
           clients,
           clientId,
           Some(sender()),
+          explicitShutdownRequested = true,
+          None,
           scheduledShutdown
         )
 
       case ScheduledShutdown(requester) =>
         shutDownServer(requester)
 
+      case LanguageServerStatusRequest =>
+        sender() ! LanguageServerStatus(project.id, scheduledShutdown.isDefined)
+
       case ShutDownServer =>
-        scheduledShutdown.foreach(_.cancel())
+        scheduledShutdown.foreach(_._1.cancel())
         shutDownServer(None)
 
-      case ClientDisconnected(clientId) =>
+      case ClientDisconnected(clientId, port) =>
         removeClient(
           connectionInfo,
           serverProcessManager,
           clients,
           clientId,
           None,
+          explicitShutdownRequested = false,
+          atPort                    = Some(port),
           scheduledShutdown
         )
+      case ClientConnected(clientId, clientPort) =>
+        scheduledShutdown match {
+          case Some((cancellable, port)) if clientPort == port =>
+            cancellable.cancel()
+            context.become(
+              supervising(
+                connectionInfo,
+                serverProcessManager,
+                clients ++ Set(clientId),
+                None
+              )
+            )
+          case _ =>
+        }
 
       case RenameProject(_, namespace, oldName, newName) =>
-        scheduledShutdown.foreach(_.cancel())
+        scheduledShutdown.foreach(_._1.cancel())
         val socket = Socket(connectionInfo.interface, connectionInfo.rpcPort)
         context.actorOf(
           ProjectRenameAction
@@ -241,7 +270,7 @@ class LanguageServerController(
         )
 
       case ServerDied =>
-        scheduledShutdown.foreach(_.cancel())
+        scheduledShutdown.foreach(_._1.cancel())
         logger.error("Language server died [{}].", connectionInfo)
         context.stop(self)
 
@@ -253,30 +282,39 @@ class LanguageServerController(
     clients: Set[UUID],
     clientId: UUID,
     maybeRequester: Option[ActorRef],
-    shutdownTimeout: Option[Cancellable]
+    explicitShutdownRequested: Boolean,
+    atPort: Option[Int],
+    shutdownTimeout: Option[(Cancellable, Int)]
   ): Unit = {
     val updatedClients = clients - clientId
     if (updatedClients.isEmpty) {
-      logger.debug("Delaying shutdown for project {}.", project.id)
-      val scheduledShutdown =
-        shutdownTimeout.orElse(
-          Some(
-            context.system.scheduler
-              .scheduleOnce(
-                timeoutConfig.delayedShutdownTimeout,
-                self,
-                ScheduledShutdown(maybeRequester)
+      if (!explicitShutdownRequested) {
+        logger.debug("Delaying shutdown for project {}.", project.id)
+        val scheduledShutdown: Option[(Cancellable, Int)] =
+          shutdownTimeout.orElse(
+            Some(
+              (
+                context.system.scheduler.scheduleOnce(
+                  timeoutConfig.delayedShutdownTimeout,
+                  self,
+                  ScheduledShutdown(maybeRequester)
+                ),
+                atPort.getOrElse(0)
               )
+            )
+          )
+        context.become(
+          supervising(
+            connectionInfo,
+            serverProcessManager,
+            Set.empty,
+            scheduledShutdown
           )
         )
-      context.become(
-        supervising(
-          connectionInfo,
-          serverProcessManager,
-          Set.empty,
-          scheduledShutdown
-        )
-      )
+      } else {
+        shutdownTimeout.foreach(_._1.cancel())
+        shutDownServer(maybeRequester)
+      }
     } else {
       sender() ! CannotDisconnectOtherClients
       context.become(
@@ -329,7 +367,7 @@ class LanguageServerController(
         maybeRequester.foreach(_ ! ServerShutdownTimedOut)
         stop()
 
-      case ClientDisconnected(clientId) =>
+      case ClientDisconnected(clientId, _) =>
         logger.debug(
           s"Received client ($clientId) disconnect request during shutdown. Ignoring."
         )

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerController.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerController.scala
@@ -165,6 +165,14 @@ class LanguageServerController(
       case _ => stash()
     }
 
+  /** In supervising mode, the language server has already been setup and can handle requests for shutdown.
+    *
+    * @param connectionInfo language server connection info
+    * @param serverProcessManager an actor that manages the lifecycle of the server process
+    * @param clients list of connected clients
+    * @param scheduledShutdown cancellable timeout of the hard shutdown event and a port number of the client that initiated it
+    * @return current supervising actor state
+    */
   private def supervising(
     connectionInfo: LanguageServerConnectionInfo,
     serverProcessManager: ActorRef,

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerGateway.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerGateway.scala
@@ -54,7 +54,7 @@ trait LanguageServerGateway[F[+_, +_]] {
     * @param projectId a project id
     * @return true if project is open
     */
-  def isRunning(projectId: UUID): F[CheckTimeout.type, Boolean]
+  def isRunning(projectId: UUID): F[CheckTimeout.type, (Boolean, Boolean)]
 
   /** Request a language server to rename project.
     *

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerGateway.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerGateway.scala
@@ -38,7 +38,7 @@ trait LanguageServerGateway[F[+_, +_]] {
     version: SemVer
   ): F[ServerStartupFailure, LanguageServerSockets]
 
-  /** Stops a lang. server.
+  /** Stops a language server.
     *
     * @param clientId a requester id
     * @param projectId a project id to stop
@@ -49,10 +49,10 @@ trait LanguageServerGateway[F[+_, +_]] {
     projectId: UUID
   ): F[ServerShutdownFailure, Unit]
 
-  /** Checks if server is running for project.
+  /** Checks if server is running or shutting down for project.
     *
     * @param projectId a project id
-    * @return true if project is open
+    * @return a tuple of booleans where the first element is true if project is open, and the second element is true if the project is currently shutting down
     */
   def isRunning(projectId: UUID): F[CheckTimeout.type, (Boolean, Boolean)]
 

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerGatewayImpl.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerGatewayImpl.scala
@@ -85,12 +85,14 @@ class LanguageServerGatewayImpl[
   }
 
   /** @inheritdoc */
-  override def isRunning(projectId: UUID): F[CheckTimeout.type, Boolean] = {
+  override def isRunning(
+    projectId: UUID
+  ): F[CheckTimeout.type, (Boolean, Boolean)] = {
     implicit val timeout: Timeout = Timeout(timeoutConfig.requestTimeout)
 
     Async[F]
       .fromFuture { () =>
-        (registry ? CheckIfServerIsRunning(projectId)).mapTo[Boolean]
+        (registry ? CheckIfServerIsRunning(projectId)).mapTo[(Boolean, Boolean)]
       }
       .mapError(_ => CheckTimeout)
   }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/protocol/JsonRpc.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/protocol/JsonRpc.scala
@@ -18,6 +18,7 @@ object JsonRpc {
   lazy val protocol: Protocol =
     Protocol.empty
       .registerRequest(ProjectCreate)
+      .registerRequest(ProjectStatus)
       .registerRequest(ProjectDelete)
       .registerRequest(ProjectOpen)
       .registerRequest(ProjectClose)

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/protocol/ProjectManagementApi.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/protocol/ProjectManagementApi.scala
@@ -1,7 +1,6 @@
 package org.enso.projectmanager.protocol
 
 import java.util.UUID
-
 import io.circe.Json
 import io.circe.syntax._
 import nl.gn0s1s.bump.SemVer
@@ -11,6 +10,7 @@ import org.enso.projectmanager.data.{
   EngineVersion,
   MissingComponentAction,
   ProjectMetadata,
+  RunningStatus,
   Socket
 }
 
@@ -96,6 +96,25 @@ object ProjectManagementApi {
     implicit val hasResult: HasResult.Aux[this.type, ProjectOpen.Result] =
       new HasResult[this.type] {
         type Result = ProjectOpen.Result
+      }
+  }
+
+  case object ProjectStatus extends Method("project/status") {
+
+    case class Params(
+      projectId: UUID
+    )
+
+    case class Result(status: RunningStatus)
+
+    implicit val hasParams: HasParams.Aux[this.type, ProjectStatus.Params] =
+      new HasParams[this.type] {
+        type Params = ProjectStatus.Params
+      }
+
+    implicit val hasResult: HasResult.Aux[this.type, ProjectStatus.Result] =
+      new HasResult[this.type] {
+        type Result = ProjectStatus.Result
       }
   }
 
@@ -310,6 +329,9 @@ object ProjectManagementApi {
 
   case object CannotRemoveOpenProjectError
       extends Error(4008, "Cannot remove open project")
+
+  case object CannotRemoveClosingProjectError
+      extends Error(4014, "Cannot remove closing project")
 
   case class ProjectCloseError(msg: String) extends Error(4009, msg)
 

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectServiceFailureMapper.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectServiceFailureMapper.scala
@@ -25,6 +25,7 @@ object ProjectServiceFailureMapper {
     case ProjectNotOpen             => ProjectNotOpenError
     case ProjectOpenByOtherPeers    => ProjectOpenByOtherPeersError
     case CannotRemoveOpenProject    => CannotRemoveOpenProjectError
+    case CannotRemoveClosingProject => CannotRemoveClosingProjectError
     case ProjectOperationTimeout    => ServiceError
     case LanguageServerFailure(msg) => LanguageServerError(msg)
     case ProjectManagerUpgradeRequiredFailure(current, required) =>

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectStatusHandler.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectStatusHandler.scala
@@ -1,0 +1,83 @@
+package org.enso.projectmanager.requesthandler
+
+import akka.actor.Props
+import org.enso.projectmanager.control.core.CovariantFlatMap
+import org.enso.projectmanager.control.core.syntax._
+import org.enso.projectmanager.control.effect.Exec
+import org.enso.projectmanager.data.RunningStatus
+import org.enso.projectmanager.protocol.ProjectManagementApi.ProjectStatus
+import org.enso.projectmanager.requesthandler.ProjectServiceFailureMapper.failureMapper
+import org.enso.projectmanager.service.{
+  ProjectServiceApi,
+  ProjectServiceFailure
+}
+
+import java.util.UUID
+import scala.concurrent.duration.FiniteDuration
+
+/** A request handler for `project/status` commands.
+  *
+  * @param clientId the requester id
+  * @param projectService a project service
+  * @param requestTimeout a request timeout
+  * @param timeoutRetries a number of timeouts to wait until a failure is reported
+  */
+class ProjectStatusHandler[F[+_, +_]: Exec: CovariantFlatMap](
+  clientId: UUID,
+  projectService: ProjectServiceApi[F],
+  requestTimeout: FiniteDuration,
+  timeoutRetries: Int
+) extends RequestHandler[
+      F,
+      ProjectServiceFailure,
+      ProjectStatus.type,
+      ProjectStatus.Params,
+      ProjectStatus.Result
+    ](
+      ProjectStatus,
+      // TODO [RW] maybe we can get rid of this timeout since boot timeout is
+      //  handled by the LanguageServerProcess; still the ? message of
+      //  LanguageServerGateway will result in timeouts (#1315)
+      Some(requestTimeout),
+      timeoutRetries
+    ) {
+
+  override def handleRequest = { params =>
+    for {
+      server <- projectService.getProjectStatus(
+        clientId  = clientId,
+        projectId = params.projectId
+      )
+    } yield ProjectStatus.Result(status =
+      RunningStatus(server.open, server.shuttingDown)
+    )
+  }
+
+}
+
+object ProjectStatusHandler {
+
+  /** Creates a configuration object used to create a [[ProjectStatusHandler]].
+    *
+    * @param clientId the requester id
+    * @param projectService a project service
+    * @param requestTimeout a request timeout
+    * @param timeoutRetries a number of timeouts to wait until a failure is reported
+    * @return a configuration object
+    */
+  def props[F[+_, +_]: Exec: CovariantFlatMap](
+    clientId: UUID,
+    projectService: ProjectServiceApi[F],
+    requestTimeout: FiniteDuration,
+    timeoutRetries: Int
+  ): Props =
+    Props(
+      new ProjectStatusHandler(
+        clientId,
+        projectService,
+        requestTimeout,
+        timeoutRetries
+      )
+    )
+
+}

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectStatusHandler.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/requesthandler/ProjectStatusHandler.scala
@@ -35,9 +35,6 @@ class ProjectStatusHandler[F[+_, +_]: Exec: CovariantFlatMap](
       ProjectStatus.Result
     ](
       ProjectStatus,
-      // TODO [RW] maybe we can get rid of this timeout since boot timeout is
-      //  handled by the LanguageServerProcess; still the ? message of
-      //  LanguageServerGateway will result in timeouts (#1315)
       Some(requestTimeout),
       timeoutRetries
     ) {

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectServiceApi.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectServiceApi.scala
@@ -1,10 +1,10 @@
 package org.enso.projectmanager.service
 
 import java.util.UUID
-
 import akka.actor.ActorRef
 import nl.gn0s1s.bump.SemVer
 import org.enso.projectmanager.data.{
+  LanguageServerStatus,
   MissingComponentAction,
   ProjectMetadata,
   RunningLanguageServerInfo
@@ -66,6 +66,17 @@ trait ProjectServiceApi[F[+_, +_]] {
     projectId: UUID,
     missingComponentAction: MissingComponentAction
   ): F[ProjectServiceFailure, RunningLanguageServerInfo]
+
+  /** Retrieve project status.
+    *
+    * @param clientId  the requester id
+    * @param projectId the project id
+    * @return either failure or [[LanguageServerStatus]] representing success
+    */
+  def getProjectStatus(
+    clientId: UUID,
+    projectId: UUID
+  ): F[ProjectServiceFailure, LanguageServerStatus]
 
   /** Closes a project. Tries to shut down the Language Server.
     *

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectServiceFailure.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectServiceFailure.scala
@@ -59,6 +59,10 @@ object ProjectServiceFailure {
     */
   case object CannotRemoveOpenProject extends ProjectServiceFailure
 
+  /** Signals that removal of project failed because project is still shutting down.
+    */
+  case object CannotRemoveClosingProject extends ProjectServiceFailure
+
   /** Signals operation timeout.
     */
   case object ProjectOperationTimeout extends ProjectServiceFailure

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerGatewaySpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerGatewaySpec.scala
@@ -2,6 +2,7 @@ package org.enso.projectmanager.infrastructure.languageserver
 
 import akka.testkit.TestDuration
 import nl.gn0s1s.bump.SemVer
+import io.circe.literal._
 import org.enso.projectmanager.test.Net._
 import org.enso.projectmanager.{BaseServerSpec, ProjectManagementOps}
 import org.enso.testkit.{FlakySpec, RetrySpec}
@@ -41,6 +42,35 @@ class LanguageServerGatewaySpec
       deleteProject(fooId)
       deleteProject(barId)
       deleteProject(bazId)
+    }
+
+    "report language server status" in {
+      implicit val client = new WsTestClient(address)
+      val fooId           = createProject("foo")
+      //val fooSocket       =
+      openProject(fooId)
+      client.send(s"""
+          { "jsonrpc": "2.0",
+            "method": "project/status",
+            "id": 1,
+            "params": {
+              "projectId": "$fooId"
+            }
+          }
+          """)
+      client.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+              "status" : {
+                 "open" : true,
+                 "shuttingDown" : false
+              }
+            }
+          }
+          """)
+      closeProject(fooId)
+      deleteProject(fooId)
     }
 
   }

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectShutdownSpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/protocol/ProjectShutdownSpec.scala
@@ -1,6 +1,7 @@
 package org.enso.projectmanager.protocol
 
 import akka.actor.ActorRef
+import io.circe.literal._
 import nl.gn0s1s.bump.SemVer
 import org.enso.jsonrpc.ClientControllerFactory
 import org.enso.projectmanager.boot.configuration.TimeoutConfig
@@ -51,28 +52,97 @@ class ProjectShutdownSpec
     config.timeout.copy(delayedShutdownTimeout = delayedShutdown)
   }
 
+  "ensure language server shuts down immediately when requesting to close the project" in {
+    val client1   = new WsTestClient(address)
+    val projectId = createProject("Foo")(client1)
+    openProject(projectId)(client1)
+    closeProject(projectId)(client1)
+    deleteProject(projectId)(client1)
+  }
+
   "ensure language server does not shutdown immediately after last client disconnects" in {
     val client1   = new WsTestClient(address)
     val projectId = createProject("Foo")(client1)
     val socket1   = openProject(projectId)(client1)
     system.eventStream.publish(
-      ClientDisconnected(clientUUID)
+      ClientDisconnected(clientUUID, socket1.port)
     )
+    client1.send(s"""
+        { "jsonrpc": "2.0",
+          "method": "project/status",
+          "id": 1,
+          "params": {
+            "projectId": "$projectId"
+          }
+        }
+        """)
+    client1.expectJson(json"""
+        { "jsonrpc": "2.0",
+          "id": 1,
+          "result": {
+            "status" : {
+               "open" : true,
+               "shuttingDown" : true
+            }
+          }
+        }
+        """)
     val client2 = new WsTestClient(address)
     val socket2 = openProject(projectId)(client2)
     socket2 shouldBe socket1
+
+    client2.send(s"""
+        { "jsonrpc": "2.0",
+          "method": "project/status",
+          "id": 1,
+          "params": {
+            "projectId": "$projectId"
+          }
+        }
+        """)
+    client2.expectJson(json"""
+        { "jsonrpc": "2.0",
+          "id": 1,
+          "result": {
+            "status" : {
+               "open" : true,
+               "shuttingDown" : false
+            }
+          }
+        }
+        """)
 
     closeProject(projectId)(client2)
     deleteProject(projectId)(client2)
   }
 
   "ensure language server does eventually shutdown after last client disconnects" in {
-    val client1   = new WsTestClient(address)
-    val projectId = createProject("Foo")(client1)
-    val socket1   = openProject(projectId)(client1)
+    val client    = new WsTestClient(address)
+    val projectId = createProject("Foo")(client)
+    val socket1   = openProject(projectId)(client)
     system.eventStream.publish(
-      ClientDisconnected(clientUUID)
+      ClientDisconnected(clientUUID, socket1.port)
     )
+    client.send(s"""
+        { "jsonrpc": "2.0",
+          "method": "project/status",
+          "id": 1,
+          "params": {
+            "projectId": "$projectId"
+          }
+        }
+        """)
+    client.expectJson(json"""
+        { "jsonrpc": "2.0",
+          "id": 1,
+          "result": {
+            "status" : {
+               "open" : true,
+               "shuttingDown" : true
+            }
+          }
+        }
+        """)
     Thread.sleep(
       (timeoutConfig.delayedShutdownTimeout + timeoutConfig.shutdownTimeout + 1.second).toMillis
     )


### PR DESCRIPTION
### Pull Request Description

This PR addresses problems mentioned in #7470 and #7729:
- shutting a language server explicitly will not lead to a soft shutdown
- `project/status` endpoint returns the state of the language server

`LanguageServerController` now also signed up for `ClientConnect` messages. For it to be unambiguous, we need to carry around the port number of the language server as a way of identifying the right one.

One can now use `project/status` to additionally determine the state of the language server.

Also relies on a proper fix for #7765.

### Important Notes

Relies on a proper fix for #7765.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
