### PR TITLE
Fix log output for suggestions' tests

### DIFF
--- a/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
@@ -13,6 +13,7 @@ import org.enso.languageserver.event.InitializedEvent
 import org.enso.languageserver.filemanager._
 import org.enso.languageserver.session.JsonSession
 import org.enso.languageserver.session.SessionRouter.DeliverToJsonController
+import org.enso.logger.LoggerSetup
 import org.enso.polyglot.data.{Tree, TypeGraph}
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.polyglot.{ExportedSymbol, ModuleExports, Suggestion}
@@ -26,7 +27,6 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import java.nio.file.Files
 import java.util.UUID
-
 import scala.collection.immutable.ListSet
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -43,6 +43,7 @@ class SuggestionsHandlerSpec
   import system.dispatcher
 
   val Timeout: FiniteDuration = 10.seconds
+  LoggerSetup.get().setup()
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)


### PR DESCRIPTION
### Pull Request Description

Very verbose log output discovered by @4e6.
Needed an explicit log setup call, similar to other language server's tests.


Before (tons of):
```
...
23:04:42.319 [TestSystem-akka.actor.default-dispatcher-6] DEBUG slick.compiler.CodeGen -- Compiled server-side to:
| CompiledStatement "select "id" from "suggestions_version"" : Vector[t10<(Long')>]
23:04:42.320 [TestSystem-akka.actor.default-dispatcher-6] DEBUG slick.compiler.QueryCompiler -- After phase codeGen:
| ResultSetMapping : Vector[Mapped[Option[Long']]]
|   from s8: CompiledStatement "select "id" from "suggestions_version"" : Vector[t10<(Long')>]
|   map: CompiledMapping : Mapped[Option[Long']]
|     converter: TypeMappingResultConverter
|       child: OptionResultConverter$mcJ$sp idx=1 : Long'

23:04:42.320 [TestSystem-akka.actor.default-dispatcher-6] DEBUG slick.compiler.QueryCompilerBenchmark -- ------------------- Phase: Time ---------
23:04:42.320 [TestSystem-akka.actor.default-dispatcher-6] DEBUG slick.compiler.QueryCompilerBenchmark --       assignUniqueSymbols:    0.101991 ms
23:04:42.320 [TestSystem-akka.actor.default-dispatcher-6] DEBUG slick.compiler.QueryCompilerBenchmark --           unrollTailBinds:    0.015431 ms
...
```
Now: Gone.