### PR TITLE
Throw UnsupportedMessageException when loosing BigInteger precision

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsNode.java
@@ -141,7 +141,7 @@ public abstract class EqualsNode extends Node {
   @Specialization
   @TruffleBoundary
   boolean equalsDoubleBigInt(double self, EnsoBigInteger other) {
-    return self == other.asDouble();
+    return self == other.getValue().doubleValue();
   }
 
   @Specialization(guards="interop.fitsInDouble(other)")
@@ -170,7 +170,7 @@ public abstract class EqualsNode extends Node {
   @Specialization
   @TruffleBoundary
   boolean equalsBitIntDouble(EnsoBigInteger self, double other) {
-    return self.asDouble() == other;
+    return self.getValue().doubleValue() == other;
   }
 
   @Specialization

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/integer/AddNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/number/integer/AddNode.java
@@ -52,8 +52,9 @@ public abstract class AddNode extends IntegerNode {
   }
 
   @Specialization
+  @TruffleBoundary
   double doBigIntDouble(EnsoBigInteger self, double that) {
-    return self.asDouble() + that;
+    return self.getValue().doubleValue() + that;
   }
 
   @Specialization(guards = "isForeignNumber(iop, that)")

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/number/EnsoBigInteger.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/number/EnsoBigInteger.java
@@ -89,39 +89,33 @@ public final class EnsoBigInteger implements EnsoObject {
   }
 
   @ExportMessage
-  @CompilerDirectives.TruffleBoundary
   final byte asByte() throws UnsupportedMessageException {
-    return value.byteValue();
+    throw UnsupportedMessageException.create();
   }
 
   @ExportMessage
-  @CompilerDirectives.TruffleBoundary
   final short asShort() throws UnsupportedMessageException {
-    return value.shortValue();
+    throw UnsupportedMessageException.create();
   }
 
   @ExportMessage
-  @CompilerDirectives.TruffleBoundary
   final int asInt() throws UnsupportedMessageException {
-    return value.intValue();
+    throw UnsupportedMessageException.create();
   }
 
   @ExportMessage
-  @CompilerDirectives.TruffleBoundary
   final long asLong() throws UnsupportedMessageException {
-    return value.longValue();
+    throw UnsupportedMessageException.create();
   }
 
   @ExportMessage
-  @CompilerDirectives.TruffleBoundary
-  final float asFloat() {
-    return value.floatValue();
+  final float asFloat() throws UnsupportedMessageException {
+    throw UnsupportedMessageException.create();
   }
 
   @ExportMessage
-  @CompilerDirectives.TruffleBoundary
-  public final double asDouble() {
-    return value.doubleValue();
+  public final double asDouble() throws UnsupportedMessageException {
+    throw UnsupportedMessageException.create();
   }
 
   @ExportMessage

--- a/test/Tests/src/Data/Numbers_Spec.enso
+++ b/test/Tests/src/Data/Numbers_Spec.enso
@@ -12,6 +12,7 @@ import Standard.Test.Extensions
 import project.Data.Round_Spec
 
 polyglot java import java.math.BigInteger
+polyglot java import java.math.BigDecimal
 
 Integer.is_even self = self % 2 == 0
 
@@ -571,6 +572,13 @@ spec =
                     _ : Integer -> Nothing
                     v -> Test.fail "Expecting Integer, but got: "+(Meta.type_of v).to_text
                 sum.div two_hundred.length . should_equal expected_value
+
+            Test.specify name+" BigInteger to BigDecimal test" <|
+                    h = 2^70
+                    bd1 = BigDecimal.new h 0
+                    bd2 = BigDecimal.new h
+                    bd1.to_text . should_equal bd2.to_text
+                    bd1 . should_equal bd2
 
         to_java_bigint n = BigInteger.new n.to_text
         java_bigint_mul a b =

--- a/test/Tests/src/Data/Numbers_Spec.enso
+++ b/test/Tests/src/Data/Numbers_Spec.enso
@@ -579,6 +579,7 @@ spec =
                     bd2 = BigDecimal.new h
                     bd1.to_text . should_equal bd2.to_text
                     bd1 . should_equal bd2
+                    bd1.toBigIntegerExact . should_equal h
 
         to_java_bigint n = BigInteger.new n.to_text
         java_bigint_mul a b =


### PR DESCRIPTION
### Pull Request Description

Fixes #7790 by throwing `UnsupportedMessageException` when `EnsoBigInteger` conversion would loose precision.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
