### PR TITLE
Encapsulate TruffleLanguage.Env in EnsoContext

### DIFF
--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/SerializeModuleJob.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/SerializeModuleJob.java
@@ -6,7 +6,6 @@ import org.enso.interpreter.instrument.execution.RuntimeContext;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.pkg.QualifiedName;
 import org.enso.polyglot.CompilationStage;
-import org.enso.polyglot.RuntimeOptions;
 
 /** The job that serializes module. */
 public final class SerializeModuleJob extends BackgroundJob<Void> {
@@ -24,11 +23,7 @@ public final class SerializeModuleJob extends BackgroundJob<Void> {
   public Void run(RuntimeContext ctx) {
     EnsoContext ensoContext = ctx.executionService().getContext();
     SerializationManager serializationManager = ensoContext.getCompiler().getSerializationManager();
-    boolean useGlobalCacheLocations =
-        ensoContext
-            .getEnvironment()
-            .getOptions()
-            .get(RuntimeOptions.USE_GLOBAL_IR_CACHE_LOCATION_KEY);
+    boolean useGlobalCacheLocations = ensoContext.isUseGlobalCache();
     var writeLockTimestamp = ctx.locking().acquireWriteCompilationLock();
     try {
       ctx.executionService()

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/CommandExecutionEngine.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/CommandExecutionEngine.scala
@@ -2,7 +2,6 @@ package org.enso.interpreter.instrument.execution
 
 import org.enso.interpreter.instrument.InterpreterContext
 import org.enso.interpreter.instrument.command.Command
-import org.enso.polyglot.RuntimeOptions
 import org.enso.text.Sha3_224VersionCalculator
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
@@ -17,9 +16,7 @@ class CommandExecutionEngine(interpreterContext: InterpreterContext)
     extends CommandProcessor {
 
   private val isSequential =
-    interpreterContext.executionService.getContext.getEnvironment.getOptions
-      .get(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION_KEY)
-      .booleanValue()
+    interpreterContext.executionService.getContext.isInterpreterSequentialCommandExection()
 
   private val locking = new ReentrantLocking(
     interpreterContext.executionService.getLogger

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/CommandExecutionEngine.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/CommandExecutionEngine.scala
@@ -16,7 +16,8 @@ class CommandExecutionEngine(interpreterContext: InterpreterContext)
     extends CommandProcessor {
 
   private val isSequential =
-    interpreterContext.executionService.getContext.isInterpreterSequentialCommandExection()
+    interpreterContext.executionService.getContext
+      .isInterpreterSequentialCommandExection()
 
   private val locking = new ReentrantLocking(
     interpreterContext.executionService.getLogger

--- a/engine/runtime/src/main/java/org/enso/interpreter/EnsoLanguage.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/EnsoLanguage.java
@@ -157,13 +157,6 @@ public final class EnsoLanguage extends TruffleLanguage<EnsoContext> {
   @SuppressWarnings("unchecked")
   protected void initializeContext(EnsoContext context) {
     context.initialize();
-    var env = context.getEnvironment();
-    var preinit = env.getOptions().get(RuntimeOptions.PREINITIALIZE_KEY);
-    if (preinit != null && preinit.length() > 0) {
-      var epb = env.getInternalLanguages().get(ForeignLanguage.ID);
-      var run = env.lookup(epb, Consumer.class);
-      run.accept(preinit);
-    }
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/PolyglotBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/PolyglotBranchNode.java
@@ -48,6 +48,6 @@ public abstract class PolyglotBranchNode extends BranchNode {
   void doFallback(VirtualFrame frame, Object state, Object target) {}
 
   boolean isPolyglotObject(Object o) {
-    return EnsoContext.get(this).getEnvironment().isHostObject(o);
+    return EnsoContext.get(this).isJavaPolyglotObject(o);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/GetSourceLocationNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/GetSourceLocationNode.java
@@ -24,7 +24,6 @@ public class GetSourceLocationNode extends Node {
   Object execute(Object value) {
     try {
       return EnsoContext.get(this)
-          .getEnvironment()
           .asGuestValue(new EnsoSourceSection(library.getSourceLocation(value)));
     } catch (UnsupportedMessageException e) {
       err.enter();

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/IsLanguageInstalledNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/interop/generic/IsLanguageInstalledNode.java
@@ -25,6 +25,6 @@ public abstract class IsLanguageInstalledNode extends Node {
   @CompilerDirectives.TruffleBoundary
   boolean doExecute(Object language_name, @Cached ExpectStringNode expectStringNode) {
     String name = expectStringNode.execute(language_name);
-    return EnsoContext.get(this).getEnvironment().getPublicLanguages().get(name) != null;
+    return EnsoContext.get(this).isLanguageInstalled(name);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EnsoProjectNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EnsoProjectNode.java
@@ -126,7 +126,7 @@ public abstract class EnsoProjectNode extends Node {
 
   private static Atom createProjectDescriptionAtom(EnsoContext ctx, Package<TruffleFile> pkg) {
     EnsoFile rootPath = new EnsoFile(pkg.root().normalize());
-    Object cfg = ctx.getEnvironment().asGuestValue(pkg.getConfig());
+    Object cfg = ctx.asGuestValue(pkg.getConfig());
     return ctx.getBuiltins()
         .getProjectDescription()
         .getUniqueConstructor()

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsComplexNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsComplexNode.java
@@ -417,7 +417,7 @@ public abstract class EqualsComplexNode extends Node {
     }
   }
 
-  @Specialization(guards = {"isHostObject(selfHostObject)", "isHostObject(otherHostObject)"})
+  @Specialization(guards = {"isJavaObject(selfHostObject)", "isJavaObject(otherHostObject)"})
   boolean equalsHostObjects(
       Object selfHostObject,
       Object otherHostObject,
@@ -434,7 +434,7 @@ public abstract class EqualsComplexNode extends Node {
 
   // HostFunction is identified by a qualified name, it is not a lambda.
   // It has well-defined equality based on the qualified name.
-  @Specialization(guards = {"isHostFunction(selfHostFunc)", "isHostFunction(otherHostFunc)"})
+  @Specialization(guards = {"isJavaFunction(selfHostFunc)", "isJavaFunction(otherHostFunc)"})
   boolean equalsHostFunctions(
       Object selfHostFunc,
       Object otherHostFunc,
@@ -467,10 +467,10 @@ public abstract class EqualsComplexNode extends Node {
     if (EqualsNode.isPrimitive(left, interop) && EqualsNode.isPrimitive(right, interop)) {
       return false;
     }
-    if (isHostObject(left) && isHostObject(right)) {
+    if (isJavaObject(left) && isJavaObject(right)) {
       return false;
     }
-    if (isHostFunction(left) && isHostFunction(right)) {
+    if (isJavaFunction(left) && isJavaFunction(right)) {
       return false;
     }
     if (left instanceof Atom && right instanceof Atom) {
@@ -540,7 +540,7 @@ public abstract class EqualsComplexNode extends Node {
     if (object instanceof Atom) {
       return false;
     }
-    if (isHostObject(object)) {
+    if (isJavaObject(object)) {
       return false;
     }
     if (interop.isDate(object)) {
@@ -562,13 +562,11 @@ public abstract class EqualsComplexNode extends Node {
     }
   }
 
-  @TruffleBoundary
-  boolean isHostObject(Object object) {
-    return EnsoContext.get(this).getEnvironment().isHostObject(object);
+  boolean isJavaObject(Object object) {
+    return EnsoContext.get(this).isJavaPolyglotObject(object);
   }
 
-  @TruffleBoundary
-  boolean isHostFunction(Object object) {
-    return EnsoContext.get(this).getEnvironment().isHostFunction(object);
+  boolean isJavaFunction(Object object) {
+    return EnsoContext.get(this).isJavaPolyglotFunction(object);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/GetPolyglotLanguageNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/GetPolyglotLanguageNode.java
@@ -23,7 +23,7 @@ public abstract class GetPolyglotLanguageNode extends Node {
 
   @Specialization
   Text doExecute(Object value) {
-    if (EnsoContext.get(this).getEnvironment().isHostObject(value)) {
+    if (EnsoContext.get(this).isJavaPolyglotObject(value)) {
       return java;
     } else {
       return unknown;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/HashCodeNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/HashCodeNode.java
@@ -556,7 +556,7 @@ public abstract class HashCodeNode extends Node {
 
   @Specialization(guards = {
       "!isAtom(objectWithMembers)",
-      "!isHostObject(objectWithMembers)",
+      "!isJavaObject(objectWithMembers)",
       "interop.hasMembers(objectWithMembers)",
       "!interop.hasArrayElements(objectWithMembers)",
       "!interop.isTime(objectWithMembers)",
@@ -602,7 +602,7 @@ public abstract class HashCodeNode extends Node {
     return 0;
   }
 
-  @Specialization(guards = "isHostObject(hostObject)")
+  @Specialization(guards = "isJavaObject(hostObject)")
   long hashCodeForHostObject(
       Object hostObject,
       @Shared("interop") @CachedLibrary(limit = "10") InteropLibrary interop) {
@@ -623,7 +623,7 @@ public abstract class HashCodeNode extends Node {
    * We get the hashcode from the qualified name.
    */
   @TruffleBoundary
-  @Specialization(guards = "isHostFunction(hostFunction)")
+  @Specialization(guards = "isJavaFunction(hostFunction)")
   long hashCodeForHostFunction(Object hostFunction,
       @Shared("interop") @CachedLibrary(limit = "10") InteropLibrary interop,
       @Shared("hashCodeNode") @Cached HashCodeNode hashCodeNode) {
@@ -634,13 +634,11 @@ public abstract class HashCodeNode extends Node {
     return object instanceof Atom;
   }
 
-  @TruffleBoundary
-  boolean isHostObject(Object object) {
-    return EnsoContext.get(this).getEnvironment().isHostObject(object);
+  boolean isJavaObject(Object object) {
+    return EnsoContext.get(this).isJavaPolyglotObject(object);
   }
 
-  @TruffleBoundary
-  boolean isHostFunction(Object object) {
-    return EnsoContext.get(this).getEnvironment().isHostFunction(object);
+  boolean isJavaFunction(Object object) {
+    return EnsoContext.get(this).isJavaPolyglotFunction(object);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsPolyglotNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/IsPolyglotNode.java
@@ -20,6 +20,6 @@ public abstract class IsPolyglotNode extends Node {
 
   @Specialization
   boolean doExecute(Object value) {
-    return EnsoContext.get(this).getEnvironment().isHostObject(value);
+    return EnsoContext.get(this).isJavaPolyglotObject(value);
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/special/RunThreadNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/special/RunThreadNode.java
@@ -24,9 +24,7 @@ public abstract class RunThreadNode extends Node {
   @Specialization
   Thread doExecute(MaterializedFrame frame, State state, Object self) {
     EnsoContext ctx = EnsoContext.get(this);
-    Thread thread =
-        ctx.getEnvironment()
-            .createThread(
+    Thread thread = ctx.createThread(false,
                 () -> {
                   Object p = ctx.getThreadManager().enter();
                   try {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/special/RunThreadNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/special/RunThreadNode.java
@@ -24,16 +24,18 @@ public abstract class RunThreadNode extends Node {
   @Specialization
   Thread doExecute(MaterializedFrame frame, State state, Object self) {
     EnsoContext ctx = EnsoContext.get(this);
-    Thread thread = ctx.createThread(false,
-                () -> {
-                  Object p = ctx.getThreadManager().enter();
-                  try {
-                    ThunkExecutorNodeGen.getUncached()
-                        .executeThunk(frame, self, state, BaseNode.TailStatus.NOT_TAIL);
-                  } finally {
-                    ctx.getThreadManager().leave(p);
-                  }
-                });
+    Thread thread =
+        ctx.createThread(
+            false,
+            () -> {
+              Object p = ctx.getThreadManager().enter();
+              try {
+                ThunkExecutorNodeGen.getUncached()
+                    .executeThunk(frame, self, state, BaseNode.TailStatus.NOT_TAIL);
+              } finally {
+                ctx.getThreadManager().leave(p);
+              }
+            });
     thread.start();
     return thread;
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/RegexCompileNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/RegexCompileNode.java
@@ -56,7 +56,6 @@ public abstract class RegexCompileNode extends Node {
   @TruffleBoundary
   Object compile(String pattern, String options) {
     var ctx = EnsoContext.get(this);
-    var env = ctx.getEnvironment();
     var s = "Flavor=ECMAScript/" + pattern + "/" + options;
     var src =
         Source.newBuilder("regex", s, "myRegex")
@@ -65,7 +64,7 @@ public abstract class RegexCompileNode extends Node {
             .build();
 
     try {
-      var regex = env.parseInternal(src).call();
+      var regex = ctx.parseInternal(src).call();
       return regex;
     } catch (AbstractTruffleException e) {
       Builtins builtins = ctx.getBuiltins();

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/ResourceManager.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/ResourceManager.java
@@ -111,7 +111,7 @@ public class ResourceManager {
                   items.remove(it);
                 }
               };
-          futureToCancel.set(context.getEnvironment().submitThreadLocal(null, performFinalizeNow));
+          futureToCancel.set(context.submitThreadLocal(null, performFinalizeNow));
         }
       }
     }
@@ -133,7 +133,7 @@ public class ResourceManager {
     }
     if (workerThread == null || !workerThread.isAlive()) {
       worker.setKilled(false);
-      workerThread = context.getEnvironment().createSystemThread(worker);
+      workerThread = context.createThread(true, worker);
       workerThread.start();
     }
     var resource = new ManagedResource(object, r -> new Item(r, object, function, referenceQueue));

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/ThreadExecutors.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/ThreadExecutors.java
@@ -59,10 +59,7 @@ final class ThreadExecutors {
 
     @Override
     public Thread newThread(Runnable r) {
-      var thread =
-          system
-              ? context.getEnvironment().createSystemThread(r)
-              : context.getEnvironment().createThread(r);
+      var thread = context.createThread(system, r);
       thread.setName(prefix + "-" + counter.incrementAndGet());
       return thread;
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -53,15 +53,12 @@ final class TruffleCompilerContext implements CompilerContext {
 
   @Override
   public boolean isUseGlobalCacheLocations() {
-    return context
-            .getEnvironment()
-            .getOptions()
-            .get(RuntimeOptions.USE_GLOBAL_IR_CACHE_LOCATION_KEY);
+    return context.isUseGlobalCache();
   }
 
   @Override
   public boolean isInteractiveMode() {
-    return context.getEnvironment().getOptions().get(RuntimeOptions.INTERACTIVE_MODE_KEY);
+    return context.isInteractiveMode();
   }
 
   @Override
@@ -101,17 +98,17 @@ final class TruffleCompilerContext implements CompilerContext {
 
   @Override
   public boolean isCreateThreadAllowed() {
-    return context.getEnvironment().isCreateThreadAllowed();
+    return context.isCreateThreadAllowed();
   }
 
   @Override
   public Thread createThread(Runnable r) {
-    return context.getEnvironment().createThread(r);
+    return context.createThread(false, r);
   }
 
   @Override
   public Thread createSystemThread(Runnable r) {
-    return context.getEnvironment().createSystemThread(r);
+    return context.createThread(true, r);
   }
 
   @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoFile.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/EnsoFile.java
@@ -87,14 +87,14 @@ public final class EnsoFile implements EnsoObject {
       hostArr = hostArrayCtor.apply(size);
       for (int i = 0; i < size; i++) {
         Object elem = interop.readArrayElement(arr, i);
-        if (!ctx.getEnvironment().isHostObject(elem)) {
+        if (!ctx.isJavaPolyglotObject(elem)) {
           var err = ctx.getBuiltins().error().makeUnsupportedArgumentsError(
               new Object[]{arr},
               "Arguments to opts should be host objects from java.io package"
           );
           throw new PanicException(err, interop);
         }
-        hostArr[i] = (T) ctx.getEnvironment().asHostObject(elem);
+        hostArr[i] = (T) ctx.asJavaPolyglotObject(elem);
       }
     } catch (UnsupportedMessageException | InvalidArrayIndexException e) {
       throw new IllegalStateException("Unreachable", e);
@@ -308,7 +308,7 @@ public final class EnsoFile implements EnsoObject {
   @Builtin.Specialize
   @CompilerDirectives.TruffleBoundary
   public static EnsoFile fromString(EnsoContext context, String path) {
-    TruffleFile file = context.getEnvironment().getPublicTruffleFile(path);
+    TruffleFile file = context.getPublicTruffleFile(path);
     return new EnsoFile(file);
   }
 
@@ -319,7 +319,7 @@ public final class EnsoFile implements EnsoObject {
   @Builtin.Specialize
   @CompilerDirectives.TruffleBoundary
   public static EnsoFile currentDirectory(EnsoContext context) {
-    TruffleFile file = context.getEnvironment().getCurrentWorkingDirectory();
+    TruffleFile file = context.getCurrentWorkingDirectory();
     return new EnsoFile(file);
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
@@ -162,17 +162,13 @@ public final class TopLevelScope implements EnsoObject {
     }
 
     private static Object leakContext(EnsoContext context) {
-      return context.getEnvironment().asGuestValue(context);
+      return context.asGuestValue(context);
     }
 
     @CompilerDirectives.TruffleBoundary
     private static Object compile(Object[] arguments, EnsoContext context)
         throws UnsupportedTypeException, ArityException {
-      boolean useGlobalCache =
-          context
-              .getEnvironment()
-              .getOptions()
-              .get(RuntimeOptions.USE_GLOBAL_IR_CACHE_LOCATION_KEY);
+      boolean useGlobalCache = context.isUseGlobalCache();
       boolean shouldCompileDependencies = Types.extractArguments(arguments, Boolean.class);
       try {
         return context.getCompiler().compile(shouldCompileDependencies, useGlobalCache).get();

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/TopLevelScope.java
@@ -26,7 +26,6 @@ import org.enso.interpreter.util.ScalaConversions;
 import org.enso.pkg.Package;
 import org.enso.pkg.QualifiedName;
 import org.enso.polyglot.MethodNames;
-import org.enso.polyglot.RuntimeOptions;
 
 /** Represents the top scope of Enso execution, containing all the importable modules. */
 @ExportLibrary(InteropLibrary.class)

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/system/System.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/system/System.java
@@ -81,7 +81,7 @@ public class System {
     for (int i = 1; i <= arrArguments.length; i++) {
       cmd[i] = expectStringNode.execute(arrArguments[i - 1]);
     }
-    TruffleProcessBuilder pb = ctx.getEnvironment().newProcessBuilder(cmd);
+    TruffleProcessBuilder pb = ctx.newProcessBuilder(cmd);
 
     Process p = pb.start();
     ByteArrayInputStream in = new ByteArrayInputStream(expectStringNode.execute(input).getBytes());

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -1864,8 +1864,7 @@ class IrToTruffle(
       argumentSlotIdxs: List[Int]
     ): RuntimeExpression = {
       val src = language.buildSource(code, scopeName)
-      val foreignCt = context.getEnvironment
-        .parseInternal(src, argumentNames: _*)
+      val foreignCt = context.parseInternal(src, argumentNames: _*)
       val argumentReaders = argumentSlotIdxs
         .map(slotIdx =>
           ReadLocalVariableNode.build(new FramePointer(0, slotIdx))

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -1863,7 +1863,7 @@ class IrToTruffle(
       argumentNames: List[String],
       argumentSlotIdxs: List[Int]
     ): RuntimeExpression = {
-      val src = language.buildSource(code, scopeName)
+      val src       = language.buildSource(code, scopeName)
       val foreignCt = context.parseInternal(src, argumentNames: _*)
       val argumentReaders = argumentSlotIdxs
         .map(slotIdx =>

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala
@@ -285,9 +285,7 @@ private class DefaultPackageRepository(
       s"Loading library $libraryName from " +
       s"[${MaskedPath(root.location).applyMasking()}]."
     )
-    val rootFile = context.getEnvironment.getInternalTruffleFile(
-      root.location.toAbsolutePath.normalize.toString
-    )
+    val rootFile = context.findLibraryRootPath(root)
     val pkg = packageManager.loadPackage(rootFile).get
     registerPackageInternal(
       libraryName    = libraryName,

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala
@@ -286,7 +286,7 @@ private class DefaultPackageRepository(
       s"[${MaskedPath(root.location).applyMasking()}]."
     )
     val rootFile = context.findLibraryRootPath(root)
-    val pkg = packageManager.loadPackage(rootFile).get
+    val pkg      = packageManager.loadPackage(rootFile).get
     registerPackageInternal(
       libraryName    = libraryName,
       libraryVersion = libraryVersion,

--- a/engine/runtime/src/test/java/org/enso/compiler/SerializationManagerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/SerializationManagerTest.java
@@ -64,8 +64,7 @@ public class SerializationManagerTest {
 
   private Package<TruffleFile> getLibraryPackage(LibraryName libraryName) {
     Path libraryPath = getLibraryPath(libraryName);
-    TruffleFile libraryFile =
-        ensoContext.getEnvironment().getInternalTruffleFile(libraryPath.toString());
+    TruffleFile libraryFile = ensoContext.getPublicTruffleFile(libraryPath.toString());
     return packageManager.loadPackage(libraryFile).get();
   }
 

--- a/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/Builtin.java
+++ b/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/Builtin.java
@@ -240,7 +240,7 @@ public @interface Builtin {
    *     try {
    *       return self.create(path)
    *     } catch (java.io.IOException e) {
-   *       throw new PanicException(EnsoContext.get(this).getEnvironment().asGuestValue(e), this);"
+   *       throw new PanicException(EnsoContext.get(this).asGuestValue(e), this);"
    *     }
    *   }
    * }
@@ -303,7 +303,6 @@ public @interface Builtin {
    * public class CreateFooNode extends Node {
    *   java.lang.Object execute(Foo self, Object item) {
    *     return context
-   *           .getEnvironment()
    *           .asGuestValue(self.foo(item));
    *   }
    * }

--- a/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/builtins/ExecuteMethodImplGenerator.java
+++ b/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/builtins/ExecuteMethodImplGenerator.java
@@ -139,7 +139,6 @@ public final class ExecuteMethodImplGenerator extends MethodGenerator {
             }
             return new String[] {
               "  return context",
-              "      .getEnvironment()",
               "      .asGuestValue(" + qual + "." + name + "(" + paramsApplied + "));"
             };
           }

--- a/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/builtins/SafeWrapException.java
+++ b/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/builtins/SafeWrapException.java
@@ -37,7 +37,7 @@ public record SafeWrapException(Attribute.Class from, Optional<Attribute.Class> 
             return List.of(
             "  } catch ("+from+" e) {",
             "    com.oracle.truffle.api.CompilerDirectives.transferToInterpreter();",
-            "    throw new PanicException(EnsoContext.get(this).getEnvironment().asGuestValue(e), this);"
+            "    throw new PanicException(EnsoContext.get(this).asGuestValue(e), this);"
             );
         } else {
             return List.of(

--- a/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/builtins/SpecializedMethodsGenerator.java
+++ b/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/builtins/SpecializedMethodsGenerator.java
@@ -291,7 +291,7 @@ public final class SpecializedMethodsGenerator extends MethodGenerator {
             methodBody.add("  return " + qual + "." + name + "(" + paramsApplied + ");");
           } else if (convertToGuestValue) {
             methodBody.add("  var result = " + qual + "." + name + "(" + paramsApplied + ");");
-            methodBody.add("  return EnsoContext.get(this).getEnvironment().asGuestValue(result);");
+            methodBody.add("  return EnsoContext.get(this).asGuestValue(result);");
           } else {
             processingEnvironment
                 .getMessager()


### PR DESCRIPTION
### Pull Request Description

Let's control the services that are exposed from `TruffleLanguage.Env` by hiding the reference in `private` field and only exposing just the necessary methods. This PR just directly exposes everything that was needed, but further work shall remove some of the exposed methods - the first candidate being `asGuestValue`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests continue to pass
