### PR TITLE
Fix static methods in dropdowns

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -29,6 +29,7 @@ test/**/data
 app/ide-desktop/build.json
 app/ide-desktop/lib/client/electron-builder-config.json
 app/gui/view/documentation/assets/stylesheet.css
+app/gui2/rust-ffi/pkg
 Cargo.lock
 
 # Engine Builds can leave these nested working copies.

--- a/app/gui/src/controller/graph/executed.rs
+++ b/app/gui/src/controller/graph/executed.rs
@@ -513,8 +513,10 @@ impl Context for Handle {
         let info = self.computed_value_info_registry().get(&id)?;
         let method_call = info.method_call.as_ref()?;
         let suggestion_db = self.project.suggestion_db();
+        let in_module = self.module_qualified_name();
         let maybe_entry = suggestion_db.lookup_by_method_pointer(method_call).map(|(id, entry)| {
-            let invocation_info = entry.invocation_info(&suggestion_db, &self.parser());
+            let invocation_info =
+                entry.invocation_info(&suggestion_db, &self.parser(), in_module.as_ref());
             invocation_info.with_suggestion_id(id).with_called_on_type(false)
         });
 
@@ -526,7 +528,8 @@ impl Context for Handle {
             let defined_on_type = method_call.defined_on_type.strip_suffix(".type")?.to_owned();
             let method_call = MethodPointer { defined_on_type, ..method_call.clone() };
             let (id, entry) = suggestion_db.lookup_by_method_pointer(&method_call)?;
-            let invocation_info = entry.invocation_info(&suggestion_db, &self.parser());
+            let invocation_info =
+                entry.invocation_info(&suggestion_db, &self.parser(), in_module.as_ref());
             Some(invocation_info.with_suggestion_id(id).with_called_on_type(true))
         })
     }

--- a/app/gui/src/controller/graph/widget.rs
+++ b/app/gui/src/controller/graph/widget.rs
@@ -173,11 +173,13 @@ impl Model {
         data: VisualizationUpdateData,
     ) -> Option<(NodeId, CallWidgetsConfig)> {
         let query_data = self.widget_queries.get_mut(&target)?;
+        let in_module = self.graph.module_qualified_name();
 
         let (definitions, errors) = configuration::deserialize_widget_definitions(
             &data,
             &self.graph.suggestion_db(),
             &self.graph.parser(),
+            in_module.as_ref(),
         );
 
         for error in errors {

--- a/app/gui/src/test.rs
+++ b/app/gui/src/test.rs
@@ -460,8 +460,10 @@ pub fn assert_call_info(
     let parser = parser::Parser::new();
     let db = model::suggestion_database::SuggestionDatabase::new_empty();
     for (encountered, expected) in info.parameters.iter().zip(entry.arguments.iter()) {
-        let expected_info =
-            model::suggestion_database::entry::to_span_tree_param(expected, &db, &parser);
+        let in_module = default();
+        let expected_info = model::suggestion_database::entry::to_span_tree_param(
+            expected, &db, &parser, in_module,
+        );
         assert_eq!(encountered, &expected_info);
     }
 }

--- a/app/gui/suggestion-database/src/entry.rs
+++ b/app/gui/suggestion-database/src/entry.rs
@@ -575,11 +575,12 @@ impl Entry {
         &self,
         suggestion_db: &SuggestionDatabase,
         parser: &parser::Parser,
+        in_module: QualifiedNameRef,
     ) -> span_tree::generate::context::CalledMethodInfo {
         let parameters = self
             .arguments
             .iter()
-            .map(|arg| to_span_tree_param(arg, suggestion_db, parser))
+            .map(|arg| to_span_tree_param(arg, suggestion_db, parser, in_module.clone_ref()))
             .collect();
         span_tree::generate::context::CalledMethodInfo {
             is_static: self.is_static,
@@ -896,9 +897,14 @@ pub fn to_span_tree_param(
     param_info: &Argument,
     db: &SuggestionDatabase,
     parser: &parser::Parser,
+    in_module: QualifiedNameRef,
 ) -> span_tree::ArgumentInfo {
-    let tag_values =
-        argument_tag_values(param_info.tag_values.iter().map(|s| s.as_str()), db, parser);
+    let tag_values = argument_tag_values(
+        param_info.tag_values.iter().map(|s| s.as_str()),
+        db,
+        parser,
+        in_module,
+    );
     span_tree::ArgumentInfo {
         // TODO [mwu] Check if database actually do must always have both of these filled.
         name: Some(param_info.name.clone()),
@@ -955,6 +961,7 @@ pub fn argument_tag_values<'a, E>(
     raw_expressions: E,
     db: &SuggestionDatabase,
     parser: &parser::Parser,
+    in_module: QualifiedNameRef,
 ) -> Vec<span_tree::TagValue>
 where
     E: IntoIterator<Item = &'a str>,
@@ -973,11 +980,7 @@ where
                 let label = chain_to_label(&chain);
                 let qualified_name = entry.qualified_name();
                 let required_import = Some(qualified_name.to_string());
-                // Passing some meaningful module name instead of `default()` is preferable, but we
-                // can't access it in this method. This means we never use `Main` instead of
-                // project name in dropdowns.
-                let in_module = default();
-                let expression = entry.code_to_insert(true, in_module);
+                let expression = entry.code_to_insert(true, in_module.clone_ref());
                 let expression = if entry.arguments.is_empty() {
                     expression.to_string()
                 } else {
@@ -1464,7 +1467,8 @@ mod test {
         let parser = Parser::new();
         let db = SuggestionDatabase::new_empty();
         let expressions = expression_and_expected_label.iter().map(|(expr, _)| *expr);
-        let tag_values = argument_tag_values(expressions, &db, &parser);
+        let in_module = default();
+        let tag_values = argument_tag_values(expressions, &db, &parser, in_module);
         let expected_values = expression_and_expected_label
             .iter()
             .map(|(expression, label)| span_tree::TagValue {

--- a/app/gui/suggestion-database/src/entry.rs
+++ b/app/gui/suggestion-database/src/entry.rs
@@ -973,10 +973,11 @@ where
                 let label = chain_to_label(&chain);
                 let qualified_name = entry.qualified_name();
                 let required_import = Some(qualified_name.to_string());
-                // As we don't generate `this`, we will never follow the code path where
-                // `in_module` is used. That's why passing `default()` is valid.
+                // Passing some meaningful module name instead of `default()` is preferable, but we
+                // can't access it in this method. This means we never use `Main` instead of
+                // project name in dropdowns.
                 let in_module = default();
-                let expression = entry.code_to_insert(false, in_module);
+                let expression = entry.code_to_insert(true, in_module);
                 let expression = if entry.arguments.is_empty() {
                     expression.to_string()
                 } else {

--- a/lib/rust/ensogl/core/src/display/render/passes/cache_shapes.rs
+++ b/lib/rust/ensogl/core/src/display/render/passes/cache_shapes.rs
@@ -13,6 +13,7 @@ use crate::gui::component::AnyShapeView;
 use crate::system::gpu::context::ContextLost;
 
 
+
 // ==========================
 // === CacheShapesPassDef ===
 // ==========================

--- a/lib/rust/ensogl/core/src/display/render/passes/screen.rs
+++ b/lib/rust/ensogl/core/src/display/render/passes/screen.rs
@@ -8,6 +8,7 @@ use crate::display::symbol::Screen;
 use crate::system::gpu::context::ContextLost;
 
 
+
 // ========================
 // === ScreenRenderPass ===
 // ========================

--- a/lib/rust/ensogl/core/src/display/scene.rs
+++ b/lib/rust/ensogl/core/src/display/scene.rs
@@ -43,7 +43,6 @@ use std::any::TypeId;
 use web::HtmlElement;
 
 
-
 // ==============
 // === Export ===
 // ==============

--- a/lib/rust/ensogl/core/src/display/symbol/gpu.rs
+++ b/lib/rust/ensogl/core/src/display/symbol/gpu.rs
@@ -27,7 +27,6 @@ use web_sys::WebGlUniformLocation;
 use web_sys::WebGlVertexArrayObject;
 
 
-
 // ==============
 // === Export ===
 // ==============

--- a/lib/rust/ensogl/core/src/display/world.rs
+++ b/lib/rust/ensogl/core/src/display/world.rs
@@ -34,7 +34,6 @@ use web::JsCast;
 use web::JsValue;
 
 
-
 // ==============
 // === Export ===
 // ==============

--- a/lib/rust/ensogl/core/src/system/gpu/data/texture.rs
+++ b/lib/rust/ensogl/core/src/system/gpu/data/texture.rs
@@ -13,7 +13,6 @@ use crate::system::gpu::Context;
 use web_sys::WebGlTexture;
 
 
-
 // ==============
 // === Export ===
 // ==============
@@ -21,6 +20,7 @@ use web_sys::WebGlTexture;
 pub mod types;
 
 pub use types::*;
+
 
 
 /// Provides smart scope for item types.


### PR DESCRIPTION
### Pull Request Description

Fixes #7824

The issue was caused by me who didn't think that we can use static methods in dropdowns.


https://github.com/enso-org/enso/assets/6566674/5045c5ce-e33b-48ff-9488-4228c016b563


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
