### PR TITLE
Accept type argument in instance method signatures

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/compiler/data/BindingsMap.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/data/BindingsMap.scala
@@ -731,6 +731,7 @@ object BindingsMap {
     */
   case class Type(
     override val name: String,
+    params: Seq[String],
     members: Seq[Cons],
     builtinType: Boolean
   ) extends DefinedEntity {

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/BindingAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/BindingAnalysis.scala
@@ -57,6 +57,7 @@ case object BindingAnalysis extends IRPass {
         .exists(_.annotations.exists(_.name == "@Builtin_Type"))
       BindingsMap.Type(
         sumType.name.name,
+        sumType.params.map(_.name.name),
         sumType.members.map(m =>
           Cons(
             m.name.name,

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/SignatureTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/SignatureTest.java
@@ -401,6 +401,25 @@ public class SignatureTest extends TestBase {
   }
 
   @Test
+  public void ascribedWithAParameterAndMethod() throws Exception {
+    final URI uri = new URI("memory://getter.enso");
+    final Source src = Source.newBuilder("enso", """
+    type Maybe a
+        Nothing
+        Some unwrap:a
+
+        get : a
+        get self = self.unwrap
+    """,uri.getAuthority())
+            .uri(uri)
+            .buildLiteral();
+
+    var module = ctx.eval(src);
+    var some = module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "Maybe.Some 10");
+    assertEquals("Can get ten", 10, some.invokeMember("get").asInt());
+  }
+
+  @Test
   public void suspendedAscribedParameter() throws Exception {
     final URI uri = new URI("memory://suspended.enso");
     final Source src = Source.newBuilder("enso", """

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/BindingAnalysisTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/BindingAnalysisTest.scala
@@ -77,9 +77,9 @@ class BindingAnalysisTest extends CompilerTest {
       val metadata = ir.unsafeGetMetadata(BindingAnalysis, "Should exist.")
 
       metadata.definedEntities should contain theSameElementsAs List(
-        Type("Foo", List(Cons("Mk_Foo", 3, false)), false),
-        Type("Bar", List(), false),
-        Type("Baz", List(), false),
+        Type("Foo", List(), List(Cons("Mk_Foo", 3, false)), false),
+        Type("Bar", List(), List(), false),
+        Type("Baz", List("x", "y"), List(), false),
         PolyglotSymbol("MyClass"),
         PolyglotSymbol("Renamed_Class"),
         ModuleMethod("foo")

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/resolve/MethodDefinitionsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/resolve/MethodDefinitionsTest.scala
@@ -81,7 +81,7 @@ class MethodDefinitionsTest extends CompilerTest {
         BindingsMap.Resolution(
           BindingsMap.ResolvedType(
             ctx.moduleReference(),
-            Type("Foo", List(), false)
+            Type("Foo", List("a", "b", "c"), List(), false)
           )
         )
       )
@@ -116,7 +116,7 @@ class MethodDefinitionsTest extends CompilerTest {
         BindingsMap.Resolution(
           BindingsMap.ResolvedType(
             ctx.moduleReference(),
-            Type("Foo", List(), false)
+            Type("Foo", List("a", "b", "c"), List(), false)
           )
         )
       )
@@ -124,7 +124,7 @@ class MethodDefinitionsTest extends CompilerTest {
         BindingsMap.Resolution(
           BindingsMap.ResolvedType(
             ctx.moduleReference(),
-            Type("Bar", List(), false)
+            Type("Bar", List(), List(), false)
           )
         )
       )
@@ -138,7 +138,7 @@ class MethodDefinitionsTest extends CompilerTest {
         BindingsMap.Resolution(
           BindingsMap.ResolvedType(
             ctx.moduleReference(),
-            Type("Bar", List(), false)
+            Type("Bar", List(), List(), false)
           )
         )
       )
@@ -152,7 +152,7 @@ class MethodDefinitionsTest extends CompilerTest {
         BindingsMap.Resolution(
           BindingsMap.ResolvedType(
             ctx.moduleReference(),
-            Type("Foo", List(), false)
+            Type("Foo", List("a", "b", "c"), List(), false)
           )
         )
       )


### PR DESCRIPTION
### Pull Request Description

Fixes #6885 by remembering type arguments in `BindingsMap.Type` and using them when resolving type signature of `Method.Explicit`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
