### PR TITLE
Avoid duplicated conversion & search target type scope

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/Request_Body.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/Request_Body.enso
@@ -42,6 +42,4 @@ type Request_Body
 
 Request_Body.from (that:Text) = Request_Body.Text that
 Request_Body.from (that:File) = Request_Body.Binary that
-# TODO: determine if this is needed.
-Request_Body.from (that:Request_Body) = that
 Request_Body.from (that:Any) = Request_Body.Json that

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/argument/ReadArgumentCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/argument/ReadArgumentCheckNode.java
@@ -288,6 +288,9 @@ public abstract class ReadArgumentCheckNode extends Node {
     }
 
     private Pair<Function, Type> findConversion(Type from) {
+      if (expectedType == from) {
+        return null;
+      }
       var ctx = EnsoContext.get(this);
 
       if (getRootNode() instanceof EnsoRootNode root) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
@@ -203,17 +203,21 @@ public final class ModuleScope implements EnsoObject {
   }
 
   @TruffleBoundary
-  public Function lookupConversionDefinition(Type type, Type target) {
-    Function definedWithAtom = type.getDefinitionScope().getConversionsFor(target).get(type);
-    if (definedWithAtom != null) {
-      return definedWithAtom;
+  public Function lookupConversionDefinition(Type original, Type target) {
+    Function definedWithOriginal = original.getDefinitionScope().getConversionsFor(target).get(original);
+    if (definedWithOriginal != null) {
+      return definedWithOriginal;
     }
-    Function definedHere = getConversionsFor(target).get(type);
+    Function definedWithTarget = target.getDefinitionScope().getConversionsFor(target).get(original);
+    if (definedWithTarget != null) {
+      return definedWithTarget;
+    }
+    Function definedHere = getConversionsFor(target).get(original);
     if (definedHere != null) {
       return definedHere;
     }
     return imports.stream()
-        .map(scope -> scope.getExportedConversion(type, target))
+        .map(scope -> scope.getExportedConversion(original, target))
         .filter(Objects::nonNull)
         .findFirst()
         .orElse(null);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
@@ -204,11 +204,13 @@ public final class ModuleScope implements EnsoObject {
 
   @TruffleBoundary
   public Function lookupConversionDefinition(Type original, Type target) {
-    Function definedWithOriginal = original.getDefinitionScope().getConversionsFor(target).get(original);
+    Function definedWithOriginal =
+        original.getDefinitionScope().getConversionsFor(target).get(original);
     if (definedWithOriginal != null) {
       return definedWithOriginal;
     }
-    Function definedWithTarget = target.getDefinitionScope().getConversionsFor(target).get(original);
+    Function definedWithTarget =
+        target.getDefinitionScope().getConversionsFor(target).get(original);
     if (definedWithTarget != null) {
       return definedWithTarget;
     }

--- a/test/Tests/src/Network/Http_Spec.enso
+++ b/test/Tests/src/Network/Http_Spec.enso
@@ -485,7 +485,7 @@ spec =
             test_file = enso_project.data / "does_not_exist.txt"
             Data.post url_post (Request_Body.Binary test_file) . should_fail_with Request_Error
 
-    Test.group "Headers" <|
+    Test.group "Headers" pending=pending_has_url <|
         base_url_with_slash = if base_url.ends_with "/" then base_url else base_url + "/"
         url_post = base_url_with_slash + "post"
 

--- a/test/Tests/src/Semantic/Conversion_Spec.enso
+++ b/test/Tests/src/Semantic/Conversion_Spec.enso
@@ -65,6 +65,16 @@ type Fool
 
 Fool.from (that : Any) = Fool.Value that
 
+type Blob
+    Text c:Text
+    Binary b:File
+    Json anything
+
+
+Blob.from (that:Text) = Blob.Text that
+Blob.from (that:File) = Blob.Binary that
+Blob.from (that:Any) = Blob.Json that
+
 spec =
     Test.group "Conversion" <|
         Test.specify "should be able to convert atoms" <|
@@ -161,6 +171,37 @@ spec =
         Test.specify "Use Any.to in Conversion_Use module" <|
             Hello.formulate_with_to [ Hello.Say "Proper", Hello.Say "Type" ] . should_equal "ProperType"
             Hello.formulate_with_to [ Foo.Value "Perform", Bar.Value "Conversion" ] . should_equal "PERFORM conversion!"
+
+        Test.specify "Avoid parameter conversion of Blob into Blob" <|
+            blob_me (b:Blob) = b
+
+            once = blob_me "Ahoj"
+            second = blob_me once
+
+            Meta.type_of once . should_equal Blob
+            Meta.type_of second . should_equal Blob
+            once . should_equal second
+            Meta.is_same_object once second . should_be_true
+
+        Test.specify "Avoid Any.to conversion of Blob into Blob" <|
+            blob_me b = b.to Blob
+
+            once = blob_me "Ahoj"
+            second = blob_me once
+
+            Meta.type_of once . should_equal Blob
+            Meta.type_of second . should_equal Blob
+            once . should_equal second
+            Meta.is_same_object once second . should_be_true
+
+        Test.specify "Avoid inline conversion of Blob into Blob" <|
+            once = "Ahoj" : Blob
+            second = once : Blob
+
+            Meta.type_of once . should_equal Blob
+            Meta.type_of second . should_equal Blob
+            once . should_equal second
+            Meta.is_same_object once second . should_be_true
 
         Test.specify "Requesting Text & Foo" <|
             check a (n : Text & Foo) = case a of


### PR DESCRIPTION
### Pull Request Description

Fixes #7814 by avoiding conversion when the target type matches. Fixes #7770 by search the `targetType` scope for available conversion.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
