### PR TITLE
Avoid classloading deadlock by delaying computations of other passes

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
@@ -75,7 +75,7 @@ case object AliasAnalysis extends IRPass {
   override type Metadata = Info
   override type Config   = Configuration
 
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     FunctionBinding,
     GenerateMethodBodies,
     SectionsToBinOp,
@@ -83,7 +83,7 @@ case object AliasAnalysis extends IRPass {
     LambdaShorthandToLambda
   )
 
-  override val invalidatedPasses: Seq[IRPass] =
+  override lazy val invalidatedPasses: Seq[IRPass] =
     List(DataflowAnalysis, UnusedBindings)
 
   /** Performs alias analysis on a module.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AmbiguousImportsAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AmbiguousImportsAnalysis.scala
@@ -37,10 +37,10 @@ case object AmbiguousImportsAnalysis extends IRPass {
 
   override type Config = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] =
+  override lazy val precursorPasses: Seq[IRPass] =
     Seq(BindingAnalysis, ImportSymbolAnalysis)
 
-  override val invalidatedPasses: Seq[IRPass] =
+  override lazy val invalidatedPasses: Seq[IRPass] =
     Seq()
 
   /** @inheritdoc

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AutomaticParallelism.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AutomaticParallelism.scala
@@ -41,11 +41,11 @@ import scala.annotation.{tailrec, unused}
 object AutomaticParallelism extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
-  override val precursorPasses: Seq[IRPass] = Seq(
+  override lazy val precursorPasses: Seq[IRPass] = Seq(
     AliasAnalysis,
     ComplexType
   )
-  override val invalidatedPasses: Seq[IRPass] = Seq(
+  override lazy val invalidatedPasses: Seq[IRPass] = Seq(
     AliasAnalysis,
     DataflowAnalysis
   )

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/BindingAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/BindingAnalysis.scala
@@ -31,11 +31,11 @@ case object BindingAnalysis extends IRPass {
   override type Config = IRPass.Configuration.Default
 
   /** The passes that this pass depends _directly_ on to run. */
-  override val precursorPasses: Seq[IRPass] =
+  override lazy val precursorPasses: Seq[IRPass] =
     Seq(ComplexType, FunctionBinding, GenerateMethodBodies)
 
   /** The passes that are invalidated by running this pass. */
-  override val invalidatedPasses: Seq[IRPass] =
+  override lazy val invalidatedPasses: Seq[IRPass] =
     Seq(MethodDefinitions, Patterns)
 
   /** Executes the pass on the provided `ir`, and returns a possibly transformed

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/CachePreferenceAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/CachePreferenceAnalysis.scala
@@ -35,7 +35,7 @@ case object CachePreferenceAnalysis extends IRPass {
   override type Metadata = WeightInfo
 
   /** Run desugaring passes first. */
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     ComplexType,
     FunctionBinding,
     GenerateMethodBodies,
@@ -44,7 +44,7 @@ case object CachePreferenceAnalysis extends IRPass {
     SectionsToBinOp
   )
 
-  override val invalidatedPasses: Seq[IRPass] = List()
+  override lazy val invalidatedPasses: Seq[IRPass] = List()
 
   /** Performs the cache preference analysis on a module.
     *

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
@@ -52,13 +52,13 @@ case object DataflowAnalysis extends IRPass {
   override type Metadata = DependencyInfo
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     AliasAnalysis,
     DemandAnalysis,
     TailCall
   )
 
-  override val invalidatedPasses: Seq[IRPass] = List()
+  override lazy val invalidatedPasses: Seq[IRPass] = List()
 
   /** Executes the dataflow analysis process on an Enso module.
     *

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DemandAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DemandAnalysis.scala
@@ -41,13 +41,13 @@ case object DemandAnalysis extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     AliasAnalysis,
     LambdaConsolidate,
     OverloadsResolution
   )
 
-  override val invalidatedPasses: Seq[IRPass] = List(AliasAnalysis)
+  override lazy val invalidatedPasses: Seq[IRPass] = List(AliasAnalysis)
 
   /** Executes the demand analysis process on an Enso module.
     *

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/GatherDiagnostics.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/GatherDiagnostics.scala
@@ -24,8 +24,8 @@ case object GatherDiagnostics extends IRPass {
   override type Metadata = DiagnosticsMeta
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass]   = List(TypeSignatures)
-  override val invalidatedPasses: Seq[IRPass] = List()
+  override lazy val precursorPasses: Seq[IRPass]   = List(TypeSignatures)
+  override lazy val invalidatedPasses: Seq[IRPass] = List()
 
   /** Executes the pass on the provided `ir`, and attaches all the encountered
     * diagnostics to its metadata storage.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/ImportSymbolAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/ImportSymbolAnalysis.scala
@@ -19,10 +19,10 @@ case object ImportSymbolAnalysis extends IRPass {
 
   override type Config = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] =
+  override lazy val precursorPasses: Seq[IRPass] =
     Seq(BindingAnalysis, GenerateMethodBodies)
 
-  override val invalidatedPasses: Seq[IRPass] =
+  override lazy val invalidatedPasses: Seq[IRPass] =
     Seq()
 
   /** @inheritdoc

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/TailCall.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/TailCall.scala
@@ -49,7 +49,7 @@ case object TailCall extends IRPass {
 
   override type Config = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     FunctionBinding,
     GenerateMethodBodies,
     SectionsToBinOp,
@@ -58,7 +58,7 @@ case object TailCall extends IRPass {
     GlobalNames
   )
 
-  override val invalidatedPasses: Seq[IRPass] = List()
+  override lazy val invalidatedPasses: Seq[IRPass] = List()
 
   /** Analyses tail call state for expressions in a module.
     *

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/ComplexType.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/ComplexType.scala
@@ -53,8 +53,8 @@ case object ComplexType extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = List(ModuleAnnotations)
-  override val invalidatedPasses: Seq[IRPass] =
+  override lazy val precursorPasses: Seq[IRPass] = List(ModuleAnnotations)
+  override lazy val invalidatedPasses: Seq[IRPass] =
     List(
       AliasAnalysis,
       ApplicationSaturation,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
@@ -41,8 +41,8 @@ case object FunctionBinding extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = List(ComplexType)
-  override val invalidatedPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(ComplexType)
+  override lazy val invalidatedPasses: Seq[IRPass] = List(
     AliasAnalysis,
     DataflowAnalysis,
     DemandAnalysis,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/GenerateMethodBodies.scala
@@ -48,9 +48,9 @@ case object GenerateMethodBodies extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] =
+  override lazy val precursorPasses: Seq[IRPass] =
     List(ComplexType, FunctionBinding)
-  override val invalidatedPasses: Seq[IRPass] = List(
+  override lazy val invalidatedPasses: Seq[IRPass] = List(
     AliasAnalysis,
     DataflowAnalysis,
     LambdaConsolidate,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/Imports.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/Imports.scala
@@ -18,10 +18,10 @@ case object Imports extends IRPass {
   override type Config = IRPass.Configuration.Default
 
   /** The passes that this pass depends _directly_ on to run. */
-  override val precursorPasses: Seq[IRPass] = Seq()
+  override lazy val precursorPasses: Seq[IRPass] = Seq()
 
   /** The passes that are invalidated by running this pass. */
-  override val invalidatedPasses: Seq[IRPass] = Seq()
+  override lazy val invalidatedPasses: Seq[IRPass] = Seq()
 
   val mainModuleName =
     Name.Literal(

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambda.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambda.scala
@@ -43,7 +43,7 @@ case object LambdaShorthandToLambda extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     ComplexType,
     DocumentationComments,
     FunctionBinding,
@@ -51,7 +51,7 @@ case object LambdaShorthandToLambda extends IRPass {
     OperatorToFunction,
     SectionsToBinOp
   )
-  override val invalidatedPasses: Seq[IRPass] = List(
+  override lazy val invalidatedPasses: Seq[IRPass] = List(
     AliasAnalysis,
     ApplicationSaturation,
     DataflowAnalysis,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/NestedPatternMatch.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/NestedPatternMatch.scala
@@ -72,14 +72,14 @@ case object NestedPatternMatch extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     ComplexType,
     DocumentationComments,
     FunctionBinding,
     GenerateMethodBodies,
     LambdaShorthandToLambda
   )
-  override val invalidatedPasses: Seq[IRPass] = List(
+  override lazy val invalidatedPasses: Seq[IRPass] = List(
     AliasAnalysis,
     DataflowAnalysis,
     DemandAnalysis,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/OperatorToFunction.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/OperatorToFunction.scala
@@ -22,11 +22,11 @@ case object OperatorToFunction extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     GenerateMethodBodies,
     SectionsToBinOp
   )
-  override val invalidatedPasses: Seq[IRPass] = List(
+  override lazy val invalidatedPasses: Seq[IRPass] = List(
     AliasAnalysis,
     DataflowAnalysis,
     DemandAnalysis

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/SectionsToBinOp.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/SectionsToBinOp.scala
@@ -27,10 +27,10 @@ case object SectionsToBinOp extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     GenerateMethodBodies
   )
-  override val invalidatedPasses: Seq[IRPass] = List(
+  override lazy val invalidatedPasses: Seq[IRPass] = List(
     AliasAnalysis,
     CachePreferenceAnalysis,
     DataflowAnalysis,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/ModuleNameConflicts.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/ModuleNameConflicts.scala
@@ -16,10 +16,10 @@ case object ModuleNameConflicts extends IRPass {
   override type Config   = IRPass.Configuration.Default
 
   /** The passes that this pass depends _directly_ on to run. */
-  override val precursorPasses: Seq[IRPass] = Seq(ComplexType)
+  override lazy val precursorPasses: Seq[IRPass] = Seq(ComplexType)
 
   /** The passes that are invalidated by running this pass. */
-  override val invalidatedPasses: Seq[IRPass] = Seq()
+  override lazy val invalidatedPasses: Seq[IRPass] = Seq()
 
   /** Lints a module
     *

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/NoSelfInStatic.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/NoSelfInStatic.scala
@@ -23,10 +23,10 @@ object NoSelfInStatic extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] =
+  override lazy val precursorPasses: Seq[IRPass] =
     Seq(GenerateMethodBodies)
 
-  override val invalidatedPasses: Seq[IRPass] = List()
+  override lazy val invalidatedPasses: Seq[IRPass] = List()
 
   override def runModule(
     ir: Module,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/ShadowedPatternFields.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/ShadowedPatternFields.scala
@@ -33,10 +33,10 @@ case object ShadowedPatternFields extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     GenerateMethodBodies
   )
-  override val invalidatedPasses: Seq[IRPass] = List(
+  override lazy val invalidatedPasses: Seq[IRPass] = List(
     AliasAnalysis,
     DataflowAnalysis,
     DemandAnalysis,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/UnusedBindings.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/lint/UnusedBindings.scala
@@ -30,7 +30,7 @@ case object UnusedBindings extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     ComplexType,
     GenerateMethodBodies,
     IgnoredBindings,
@@ -40,7 +40,7 @@ case object UnusedBindings extends IRPass {
     OperatorToFunction,
     SectionsToBinOp
   )
-  override val invalidatedPasses: Seq[IRPass] = List()
+  override lazy val invalidatedPasses: Seq[IRPass] = List()
 
   /** Lints a module.
     *

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/ApplicationSaturation.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/ApplicationSaturation.scala
@@ -27,7 +27,7 @@ case object ApplicationSaturation extends IRPass {
   override type Metadata = CallSaturation
   override type Config   = Configuration
 
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     AliasAnalysis,
     ComplexType,
     FunctionBinding,
@@ -38,7 +38,7 @@ case object ApplicationSaturation extends IRPass {
     OperatorToFunction,
     SectionsToBinOp
   )
-  override val invalidatedPasses: Seq[IRPass] = List()
+  override lazy val invalidatedPasses: Seq[IRPass] = List()
 
   /** Executes the analysis pass, marking functions with information about their
     * argument saturation.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/LambdaConsolidate.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/LambdaConsolidate.scala
@@ -57,7 +57,7 @@ case object LambdaConsolidate extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     AliasAnalysis,
     ComplexType,
     FunctionBinding,
@@ -67,7 +67,7 @@ case object LambdaConsolidate extends IRPass {
     OperatorToFunction,
     SectionsToBinOp
   )
-  override val invalidatedPasses: Seq[IRPass] = List(
+  override lazy val invalidatedPasses: Seq[IRPass] = List(
     AliasAnalysis,
     DataflowAnalysis,
     DemandAnalysis,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/UnreachableMatchBranches.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/optimise/UnreachableMatchBranches.scala
@@ -46,14 +46,14 @@ case object UnreachableMatchBranches extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     ComplexType,
     DocumentationComments,
     FunctionBinding,
     GenerateMethodBodies,
     LambdaShorthandToLambda
   )
-  override val invalidatedPasses: Seq[IRPass] = List(
+  override lazy val invalidatedPasses: Seq[IRPass] = List(
     AliasAnalysis,
     DataflowAnalysis,
     DemandAnalysis,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/DocumentationComments.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/DocumentationComments.scala
@@ -36,8 +36,8 @@ case object DocumentationComments extends IRPass {
   override type Metadata = Doc
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = Seq()
-  override val invalidatedPasses: Seq[IRPass] = Seq(
+  override lazy val precursorPasses: Seq[IRPass] = Seq()
+  override lazy val invalidatedPasses: Seq[IRPass] = Seq(
     ComplexType,
     GenerateMethodBodies
   )

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/ExpressionAnnotations.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/ExpressionAnnotations.scala
@@ -23,10 +23,10 @@ case object ExpressionAnnotations extends IRPass {
   override type Config = IRPass.Configuration.Default
 
   /** The passes that this pass depends _directly_ on to run. */
-  override val precursorPasses: Seq[IRPass] = Seq(ModuleAnnotations)
+  override lazy val precursorPasses: Seq[IRPass] = Seq(ModuleAnnotations)
 
   /** The passes that are invalidated by running this pass. */
-  override val invalidatedPasses: Seq[IRPass] = Seq(AliasAnalysis)
+  override lazy val invalidatedPasses: Seq[IRPass] = Seq(AliasAnalysis)
 
   /** Executes the pass on the provided `ir`, and returns a possibly transformed
     * or annotated version of `ir`.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/FullyAppliedFunctionUses.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/FullyAppliedFunctionUses.scala
@@ -16,9 +16,9 @@ object FullyAppliedFunctionUses extends IRPass {
   override type Metadata = BindingsMap.Resolution
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] =
+  override lazy val precursorPasses: Seq[IRPass] =
     Seq(GlobalNames)
-  override val invalidatedPasses: Seq[IRPass] = Seq()
+  override lazy val invalidatedPasses: Seq[IRPass] = Seq()
 
   /** Executes the pass on the provided `ir`, and returns a possibly transformed
     * or annotated version of `ir`.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/FullyQualifiedNames.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/FullyQualifiedNames.scala
@@ -38,11 +38,11 @@ case object FullyQualifiedNames extends IRPass {
   override type Config = IRPass.Configuration.Default
 
   /** The passes that this pass depends _directly_ on to run. */
-  override val precursorPasses: Seq[IRPass] =
+  override lazy val precursorPasses: Seq[IRPass] =
     Seq(AliasAnalysis, BindingAnalysis)
 
   /** The passes that are invalidated by running this pass. */
-  override val invalidatedPasses: Seq[IRPass] = Nil
+  override lazy val invalidatedPasses: Seq[IRPass] = Nil
 
   /** Executes the pass on the provided `ir`, and returns a possibly transformed
     * or annotated version of `ir`.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/GenericAnnotations.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/GenericAnnotations.scala
@@ -24,8 +24,8 @@ import org.enso.compiler.pass.IRPass
 case object GenericAnnotations extends IRPass {
   override type Metadata = ModuleAnnotations.Annotations
   override type Config   = IRPass.Configuration.Default
-  override val precursorPasses: Seq[IRPass]   = Seq()
-  override val invalidatedPasses: Seq[IRPass] = Seq()
+  override lazy val precursorPasses: Seq[IRPass]   = Seq()
+  override lazy val invalidatedPasses: Seq[IRPass] = Seq()
 
   /** Resolves annotations.
     *

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/GlobalNames.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/GlobalNames.scala
@@ -46,11 +46,11 @@ case object GlobalNames extends IRPass {
   override type Config = IRPass.Configuration.Default
 
   /** The passes that this pass depends _directly_ on to run. */
-  override val precursorPasses: Seq[IRPass] =
+  override lazy val precursorPasses: Seq[IRPass] =
     Seq(AliasAnalysis, BindingAnalysis, FullyQualifiedNames)
 
   /** The passes that are invalidated by running this pass. */
-  override val invalidatedPasses: Seq[IRPass] = Seq(AliasAnalysis)
+  override lazy val invalidatedPasses: Seq[IRPass] = Seq(AliasAnalysis)
 
   /** Executes the pass on the provided `ir`, and returns a possibly transformed
     * or annotated version of `ir`.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/IgnoredBindings.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/IgnoredBindings.scala
@@ -41,13 +41,13 @@ case object IgnoredBindings extends IRPass {
   override type Metadata = State
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     ComplexType,
     GenerateMethodBodies,
     LambdaShorthandToLambda,
     NestedPatternMatch
   )
-  override val invalidatedPasses: Seq[IRPass] = List(
+  override lazy val invalidatedPasses: Seq[IRPass] = List(
     AliasAnalysis,
     DataflowAnalysis,
     DemandAnalysis,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/MethodCalls.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/MethodCalls.scala
@@ -18,9 +18,9 @@ object MethodCalls extends IRPass {
   override type Metadata = BindingsMap.Resolution
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] =
+  override lazy val precursorPasses: Seq[IRPass] =
     Seq(BindingAnalysis, GlobalNames)
-  override val invalidatedPasses: Seq[IRPass] = Seq()
+  override lazy val invalidatedPasses: Seq[IRPass] = Seq()
 
   /** Executes the pass on the provided `ir`, and returns a possibly transformed
     * or annotated version of `ir`.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/MethodDefinitions.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/MethodDefinitions.scala
@@ -31,10 +31,10 @@ case object MethodDefinitions extends IRPass {
 
   override type Config = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] =
+  override lazy val precursorPasses: Seq[IRPass] =
     List(ComplexType, FunctionBinding, GenerateMethodBodies, BindingAnalysis)
 
-  override val invalidatedPasses: Seq[IRPass] = List()
+  override lazy val invalidatedPasses: Seq[IRPass] = List()
 
   /** Executes the pass on the provided `ir`, and returns a possibly transformed
     * or annotated version of `ir`.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/ModuleAnnotations.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/ModuleAnnotations.scala
@@ -19,8 +19,8 @@ import org.enso.compiler.pass.desugar.{
 case object ModuleAnnotations extends IRPass {
   override type Metadata = Annotations
   override type Config   = IRPass.Configuration.Default
-  override val precursorPasses: Seq[IRPass] = Seq()
-  override val invalidatedPasses: Seq[IRPass] = Seq(
+  override lazy val precursorPasses: Seq[IRPass] = Seq()
+  override lazy val invalidatedPasses: Seq[IRPass] = Seq(
     DocumentationComments,
     ComplexType,
     FunctionBinding,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/OverloadsResolution.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/OverloadsResolution.scala
@@ -32,11 +32,11 @@ case object OverloadsResolution extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     ComplexType,
     GenerateMethodBodies
   )
-  override val invalidatedPasses: Seq[IRPass] = List()
+  override lazy val invalidatedPasses: Seq[IRPass] = List()
 
   /** Performs static detection of method overloads within a given module.
     *

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/Patterns.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/Patterns.scala
@@ -19,9 +19,9 @@ object Patterns extends IRPass {
   override type Metadata = BindingsMap.Resolution
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] =
+  override lazy val precursorPasses: Seq[IRPass] =
     Seq(NestedPatternMatch, GenerateMethodBodies, BindingAnalysis)
-  override val invalidatedPasses: Seq[IRPass] = Seq(AliasAnalysis)
+  override lazy val invalidatedPasses: Seq[IRPass] = Seq(AliasAnalysis)
 
   /** Executes the pass on the provided `ir`, and returns a possibly transformed
     * or annotated version of `ir`.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/SuspendedArguments.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/SuspendedArguments.scala
@@ -50,12 +50,12 @@ case object SuspendedArguments extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     ComplexType,
     TypeSignatures,
     LambdaConsolidate
   )
-  override val invalidatedPasses: Seq[IRPass] = List(
+  override lazy val invalidatedPasses: Seq[IRPass] = List(
     AliasAnalysis,
     CachePreferenceAnalysis,
     DataflowAnalysis,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/TypeFunctions.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/TypeFunctions.scala
@@ -37,14 +37,14 @@ case object TypeFunctions extends IRPass {
   override type Metadata = IRPass.Metadata.Empty
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     IgnoredBindings,
     LambdaShorthandToLambda,
     OperatorToFunction,
     SectionsToBinOp
   )
 
-  override val invalidatedPasses: Seq[IRPass] = List(
+  override lazy val invalidatedPasses: Seq[IRPass] = List(
     AliasAnalysis,
     CachePreferenceAnalysis,
     DataflowAnalysis,

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/TypeNames.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/TypeNames.scala
@@ -24,11 +24,11 @@ case object TypeNames extends IRPass {
   override type Config = IRPass.Configuration.Default
 
   /** The passes that this pass depends _directly_ on to run. */
-  override val precursorPasses: Seq[IRPass] =
+  override lazy val precursorPasses: Seq[IRPass] =
     Seq(BindingAnalysis)
 
   /** The passes that are invalidated by running this pass. */
-  override val invalidatedPasses: Seq[IRPass] = Seq()
+  override lazy val invalidatedPasses: Seq[IRPass] = Seq()
 
   /** Executes the pass on the provided `ir`, and returns a possibly transformed
     * or annotated version of `ir`.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/TypeSignatures.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/TypeSignatures.scala
@@ -33,11 +33,11 @@ case object TypeSignatures extends IRPass {
   override type Metadata = Signature
   override type Config   = IRPass.Configuration.Default
 
-  override val precursorPasses: Seq[IRPass] = List(
+  override lazy val precursorPasses: Seq[IRPass] = List(
     TypeFunctions,
     ModuleAnnotations
   )
-  override val invalidatedPasses: Seq[IRPass] = List(
+  override lazy val invalidatedPasses: Seq[IRPass] = List(
     AliasAnalysis,
     CachePreferenceAnalysis,
     DataflowAnalysis,

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/PassesTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/PassesTest.scala
@@ -24,8 +24,8 @@ class PassesTest extends CompilerTest {
     override type Metadata = IRPass.Metadata.Empty
     override type Config   = IRPass.Configuration.Default
 
-    override val precursorPasses: Seq[IRPass]   = List()
-    override val invalidatedPasses: Seq[IRPass] = List()
+    override lazy val precursorPasses: Seq[IRPass]   = List()
+    override lazy val invalidatedPasses: Seq[IRPass] = List()
 
     override def runModule(
       ir: Module,

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/core/ir/MetadataStorageTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/core/ir/MetadataStorageTest.scala
@@ -18,8 +18,8 @@ class MetadataStorageTest extends CompilerTest {
     override type Metadata = Metadata1
     override type Config   = IRPass.Configuration.Default
 
-    override val precursorPasses: Seq[IRPass]   = List()
-    override val invalidatedPasses: Seq[IRPass] = List()
+    override lazy val precursorPasses: Seq[IRPass]   = List()
+    override lazy val invalidatedPasses: Seq[IRPass] = List()
 
     override def runModule(
       ir: Module,
@@ -50,8 +50,8 @@ class MetadataStorageTest extends CompilerTest {
     override type Metadata = Metadata2
     override type Config   = IRPass.Configuration.Default
 
-    override val precursorPasses: Seq[IRPass]   = List()
-    override val invalidatedPasses: Seq[IRPass] = List()
+    override lazy val precursorPasses: Seq[IRPass]   = List()
+    override lazy val invalidatedPasses: Seq[IRPass] = List()
 
     override def runModule(
       ir: Module,

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/PassConfigurationTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/PassConfigurationTest.scala
@@ -16,8 +16,8 @@ class PassConfigurationTest extends CompilerTest {
     override type Metadata = IRPass.Metadata.Empty
     override type Config   = Configuration1
 
-    override val precursorPasses: Seq[IRPass]   = List()
-    override val invalidatedPasses: Seq[IRPass] = List()
+    override lazy val precursorPasses: Seq[IRPass]   = List()
+    override lazy val invalidatedPasses: Seq[IRPass] = List()
 
     override def runModule(
       ir: Module,
@@ -38,8 +38,8 @@ class PassConfigurationTest extends CompilerTest {
     override type Metadata = IRPass.Metadata.Empty
     override type Config   = Configuration2
 
-    override val precursorPasses: Seq[IRPass]   = List()
-    override val invalidatedPasses: Seq[IRPass] = List()
+    override lazy val precursorPasses: Seq[IRPass]   = List()
+    override lazy val invalidatedPasses: Seq[IRPass] = List()
 
     override def runModule(
       ir: Module,


### PR DESCRIPTION
### Pull Request Description

Fixes #7850 by computing other passes lazily. 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
- All code has been tested:
  - [x] Everything continues to run.
