### PR TITLE
Avoid unnecessary conversions in favor of direct match

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/argument/ReadArgumentCheckNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/argument/ReadArgumentCheckNode.java
@@ -188,6 +188,14 @@ public abstract class ReadArgumentCheckNode extends Node {
     @ExplodeLoop
     Object executeCheckOrConversion(VirtualFrame frame, Object value) {
       for (var n : checks) {
+        if (n instanceof TypeCheckNode typeCheck) {
+          var result = typeCheck.findAmongTypes(value);
+          if (result != null) {
+            return result;
+          }
+        }
+      }
+      for (var n : checks) {
         var result = n.executeCheckOrConversion(frame, value);
         if (result != null) {
           return result;
@@ -218,11 +226,11 @@ public abstract class ReadArgumentCheckNode extends Node {
     }
 
     @Specialization
-  Object doPanicSentinel(VirtualFrame frame, PanicSentinel panicSentinel) {
-    throw panicSentinel;
-  }
+    Object doPanicSentinel(VirtualFrame frame, PanicSentinel panicSentinel) {
+      throw panicSentinel;
+    }
 
-  @Specialization(rewriteOn = InvalidAssumptionException.class)
+    @Specialization(rewriteOn = InvalidAssumptionException.class)
     Object doCheckNoConversionNeeded(VirtualFrame frame, Object v) throws InvalidAssumptionException {
       var ret = findAmongTypes(v);
       if (ret != null) {

--- a/test/Tests/src/Semantic/Conversion_Spec.enso
+++ b/test/Tests/src/Semantic/Conversion_Spec.enso
@@ -47,6 +47,21 @@ Integer.from (that:MultiNumber) = that.v * 19
 Number.from (that:MultiNumber) = that.v * 0.3
 Float.from (that:MultiNumber) = that.v * 0.7
 
+type Back
+    Times n:Integer
+
+    exchange : (Back | Forth) -> (Back | Forth)
+    exchange value:(Back | Forth) = value
+
+type Forth
+    Times n:Integer
+
+    exchange : (Forth | Back) -> (Forth | Back)
+    exchange value:(Forth | Back) = value
+
+Back.from (that:Forth) = Back.Times that.n+1
+Forth.from (that:Back) = Forth.Times that.n+1
+
 foreign js make_str x = """
    return "js string"
 
@@ -200,6 +215,21 @@ spec =
             Meta.type_of second . should_equal Blob
             once . should_equal second
             Meta.is_same_object once second . should_be_true
+
+        Test.specify "Avoid back and forth conversions" <|
+            one = Forth.Times 1
+
+            two = Back.exchange one
+            three = Forth.exchange two
+            four = Back.exchange three
+            five = Forth.exchange four
+            six = Forth.exchange five
+            seven = Back.exchange six
+            eight = Back.exchange seven
+            nine = Forth.exchange eight
+
+            # no conversions needed when calling `exchange` methods
+            nine . should_equal one
 
         Test.specify "Requesting Text & Foo" <|
             check a (n : Text & Foo) = case a of


### PR DESCRIPTION
### Pull Request Description

Fixes #7854 by checking all elements of a union type for direct match and only then, if direct match isn't available, applying conversions.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
