### PR TITLE
Native image should not be tied a particular hardware

### DIFF
--- a/project/NativeImage.scala
+++ b/project/NativeImage.scala
@@ -162,6 +162,7 @@ object NativeImage {
         quickBuildOption ++
         debugParameters ++ staticParameters ++ configs ++
         Seq("--no-fallback", "--no-server") ++
+        Seq("-march=compatibility") ++
         initializeAtBuildtimeOptions ++
         initializeAtRuntimeOptions ++
         buildMemoryLimitOptions ++


### PR DESCRIPTION
Added `-march=compatibility` argument to native image builds to ensure that we don't generate binaries that cannot be run on a target machine.
