### PR TITLE
Removal of unused onExceptionalCallback

### DIFF
--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/IdExecutionService.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/IdExecutionService.java
@@ -54,11 +54,6 @@ public interface IdExecutionService {
      *   result.
      */
     Object onFunctionReturn(UUID nodeId, FunctionCallInstrumentationNode.FunctionCall result);
-
-    /** Notification on an exception.
-     * @param e the reported exception
-     */
-    void onExceptionalCallback(Exception e);
   }
 
 

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionCallbacks.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionCallbacks.java
@@ -32,7 +32,6 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
   private final Consumer<ExpressionValue> onCachedCallback;
   private final Consumer<ExpressionValue> onComputedCallback;
   private final Consumer<ExpressionCall> functionCallCallback;
-  private final Consumer<Exception> onExceptionalCallback;
 
   /** Creates callbacks instance.
    *
@@ -43,13 +42,12 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
    * @param functionCallCallback the consumer of function call events.
    * @param onComputedCallback the consumer of the computed value events.
    * @param onCachedCallback the consumer of the cached value events.
-   * @param onExceptionalCallback the consumer of the exceptional events.
    */
   ExecutionCallbacks(
           UUID nextExecutionItem,
           RuntimeCache cache, MethodCallsCache methodCallsCache, UpdatesSynchronizationState syncState,
           Consumer<ExpressionValue> onCachedCallback, Consumer<ExpressionValue> onComputedCallback,
-          Consumer<ExpressionCall> functionCallCallback, Consumer<Exception> onExceptionalCallback
+          Consumer<ExpressionCall> functionCallCallback
   ) {
     this.nextExecutionItem = nextExecutionItem;
     this.cache = cache;
@@ -58,7 +56,6 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
     this.onCachedCallback = onCachedCallback;
     this.onComputedCallback = onComputedCallback;
     this.functionCallCallback = functionCallCallback;
-    this.onExceptionalCallback = onExceptionalCallback;
   }
 
   @CompilerDirectives.TruffleBoundary

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionCallbacks.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionCallbacks.java
@@ -131,12 +131,6 @@ final class ExecutionCallbacks implements IdExecutionService.Callbacks {
   }
 
   @CompilerDirectives.TruffleBoundary
-  @Override
-  public final void onExceptionalCallback(Exception e) {
-    onExceptionalCallback.accept(e);
-  }
-
-  @CompilerDirectives.TruffleBoundary
   private void passExpressionValueToCallback(ExpressionValue expressionValue) {
     onComputedCallback.accept(expressionValue);
   }

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -154,17 +154,15 @@ public final class ExecutionService {
       UUID nextExecutionItem,
       Consumer<IdExecutionService.ExpressionCall> funCallCallback,
       Consumer<IdExecutionService.ExpressionValue> onComputedCallback,
-      Consumer<IdExecutionService.ExpressionValue> onCachedCallback,
-      Consumer<Exception> onExceptionalCallback)
-      throws ArityException, SourceNotFoundException, UnsupportedMessageException,
-          UnsupportedTypeException {
+      Consumer<IdExecutionService.ExpressionValue> onCachedCallback
+  ) throws ArityException, SourceNotFoundException, UnsupportedMessageException, UnsupportedTypeException {
     SourceSection src = call.getFunction().getSourceSection();
     if (src == null) {
       throw new SourceNotFoundException(call.getFunction().getName());
     }
     var callbacks = new ExecutionCallbacks(
       nextExecutionItem, cache, methodCallsCache, syncState,
-      onCachedCallback, onComputedCallback, funCallCallback, onExceptionalCallback
+      onCachedCallback, onComputedCallback, funCallCallback
     );
     Optional<EventBinding<ExecutionEventNodeFactory>> eventNodeFactory =
         idExecutionInstrument.map(service -> service.bind(
@@ -196,7 +194,6 @@ public final class ExecutionService {
    * @param funCallCallback the consumer for function call events.
    * @param onComputedCallback the consumer of the computed value events.
    * @param onCachedCallback the consumer of the cached value events.
-   * @param onExceptionalCallback the consumer of the exceptional events.
    */
   public void execute(
       String moduleName,
@@ -208,8 +205,8 @@ public final class ExecutionService {
       UUID nextExecutionItem,
       Consumer<IdExecutionService.ExpressionCall> funCallCallback,
       Consumer<IdExecutionService.ExpressionValue> onComputedCallback,
-      Consumer<IdExecutionService.ExpressionValue> onCachedCallback,
-      Consumer<Exception> onExceptionalCallback)
+      Consumer<IdExecutionService.ExpressionValue> onCachedCallback
+    )
       throws ArityException, TypeNotFoundException, MethodNotFoundException,
           ModuleNotFoundException, UnsupportedMessageException, UnsupportedTypeException {
     Module module =
@@ -225,8 +222,8 @@ public final class ExecutionService {
         nextExecutionItem,
         funCallCallback,
         onComputedCallback,
-        onCachedCallback,
-        onExceptionalCallback);
+        onCachedCallback
+    );
   }
 
   /**
@@ -307,7 +304,7 @@ public final class ExecutionService {
 
     var callbacks = new ExecutionCallbacks(
       nextExecutionItem, cache, methodCallsCache, syncState,
-      onCachedCallback, onComputedCallback, funCallCallback, onExceptionalCallback
+      onCachedCallback, onComputedCallback, funCallCallback
     );
     Optional<EventBinding<ExecutionEventNodeFactory>> eventNodeFactory =
         idExecutionInstrument.map(service -> service.bind(

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -81,11 +81,6 @@ object ProgramExecutionSupport {
       }
     }
 
-    val onExceptionalCallback: Consumer[Exception] = { value =>
-      logger.log(Level.FINEST, s"ON_ERROR $value")
-      sendErrorUpdate(contextId, value)
-    }
-
     val callablesCallback: Consumer[ExpressionCall] = fun =>
       if (callStack.headOption.exists(_.expressionId == fun.getExpressionId)) {
         enterables += fun.getExpressionId -> fun.getCall
@@ -107,8 +102,7 @@ object ProgramExecutionSupport {
           callStack.headOption.map(_.expressionId).orNull,
           callablesCallback,
           onComputedValueCallback,
-          onCachedValueCallback,
-          onExceptionalCallback
+          onCachedValueCallback
         )
       case ExecutionFrame(
             ExecutionItem.CallData(expressionId, callData),
@@ -130,8 +124,7 @@ object ProgramExecutionSupport {
           callStack.headOption.map(_.expressionId).orNull,
           callablesCallback,
           onComputedValueCallback,
-          onCachedValueCallback,
-          onExceptionalCallback
+          onCachedValueCallback
         )
     }
 
@@ -304,25 +297,6 @@ object ProgramExecutionSupport {
 
     case ex: ServiceException =>
       Api.ExecutionResult.Failure(ex.getMessage, None)
-  }
-
-  private def sendErrorUpdate(contextId: ContextId, error: Exception)(implicit
-    ctx: RuntimeContext
-  ): Unit = {
-    ctx.endpoint.sendToClient(
-      Api.Response(
-        Api.ExecutionUpdate(
-          contextId,
-          Seq(
-            getDiagnosticOutcome.applyOrElse(
-              error,
-              (ex: Exception) =>
-                Api.ExecutionResult.Diagnostic.error(ex.getMessage)
-            )
-          )
-        )
-      )
-    )
   }
 
   private def sendExpressionUpdate(

--- a/engine/runtime-instrument-id-execution/src/main/java/org/enso/interpreter/instrument/IdExecutionInstrument.java
+++ b/engine/runtime-instrument-id-execution/src/main/java/org/enso/interpreter/instrument/IdExecutionInstrument.java
@@ -28,6 +28,7 @@ import org.enso.interpreter.node.callable.FunctionCallInstrumentationNode;
 import org.enso.interpreter.runtime.Module;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.control.TailCallException;
+import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.error.PanicSentinel;
@@ -184,7 +185,7 @@ public class IdExecutionInstrument extends TruffleInstrument implements IdExecut
           Object result = InteropLibrary.getFactory().getUncached().execute(functionCall);
           onReturnValue(null, result);
         } catch (InteropException e) {
-          callbacks.onExceptionalCallback(e);
+          throw new PanicException(Text.create(e.getMessage()), this);
         }
       }
 


### PR DESCRIPTION
### Pull Request Description

While working on #7683 it turned out that `onExceptionCallback` isn't really used anywhere. Removing.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests continue to work
