### PR TITLE
Remove extra dot in error messages

### DIFF
--- a/app/gui/controller/engine-protocol/src/binary/connection.rs
+++ b/app/gui/controller/engine-protocol/src/binary/connection.rs
@@ -13,7 +13,7 @@ use crate::binary::API;
 
 #[allow(missing_docs)]
 #[derive(Fail, Debug)]
-#[fail(display = "Failed to initialize language server binary connection: {}.", _0)]
+#[fail(display = "Failed to initialize language server binary connection: {}", _0)]
 pub struct FailedToInitializeProtocol(failure::Error);
 
 

--- a/app/gui/controller/engine-protocol/src/language_server/connection.rs
+++ b/app/gui/controller/engine-protocol/src/language_server/connection.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 
 #[allow(missing_docs)]
 #[derive(Fail, Debug)]
-#[fail(display = "Failed to initialize language server RPC connection: {}.", _0)]
+#[fail(display = "Failed to initialize language server RPC connection: {}", _0)]
 pub struct FailedToInitializeProtocol(failure::Error);
 
 #[allow(missing_docs)]


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #7068

Fixes error messages with two dots at the end.

### Important Notes

![2023-10-04-194231_1391x336_scrot](https://github.com/enso-org/enso/assets/357683/4fe94174-807f-4f85-9bff-5374076c7cdf)


<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.