### PR TITLE
Make engine version optional

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/backend.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/backend.ts
@@ -182,10 +182,15 @@ export interface ProjectRaw extends ListedProjectRaw {
 
 /** A user/organization's project containing and/or currently executing code. */
 export interface Project extends ListedProject {
-    /** This must not be null as it is required to determine the base URL for backend assets. */
-    ideVersion: VersionNumber
+    ideVersion: VersionNumber | null
     engineVersion: VersionNumber | null
     openedBy?: EmailAddress
+}
+
+/** A user/organization's project containing and/or currently executing code. */
+export interface BackendProject extends Project {
+    /** This must not be null as it is required to determine the base URL for backend assets. */
+    ideVersion: VersionNumber
 }
 
 /** Information required to open a project. */

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/editor.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/editor.tsx
@@ -103,6 +103,12 @@ export default function Editor(props: EditorProps) {
                     let assetsRoot: string
                     switch (backendType) {
                         case backendModule.BackendType.remote: {
+                            if (project.ideVersion == null) {
+                                toastAndLog('Could not get the IDE version of the project')
+                                // This is too deeply nested to easily return from
+                                // eslint-disable-next-line no-restricted-syntax
+                                return
+                            }
                             assetsRoot = `${IDE_CDN_BASE_URL}/${project.ideVersion.value}/`
                             break
                         }

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/projectManager.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/projectManager.ts
@@ -113,6 +113,11 @@ export interface EngineVersion {
     markedAsBroken: boolean
 }
 
+/** The return value of the "list available engine versions" endpoint. */
+export interface VersionList {
+    versions: EngineVersion[]
+}
+
 // ================================
 // === Parameters for endpoints ===
 // ================================
@@ -272,9 +277,14 @@ export class ProjectManager extends EventTarget {
         return this.sendRequest('project/delete', params)
     }
 
+    /** List installed engine versions. */
+    public listInstalledEngineVersions(): Promise<VersionList> {
+        return this.sendRequest<VersionList>('engine/list-installed', {})
+    }
+
     /** List available engine versions. */
-    public listAvailableEngineVersions(): Promise<[EngineVersion, ...EngineVersion[]]> {
-        return this.sendRequest<[EngineVersion, ...EngineVersion[]]>('engine/list-available', {})
+    public listAvailableEngineVersions(): Promise<VersionList> {
+        return this.sendRequest<VersionList>('engine/list-available', {})
     }
 
     /** Remove all handlers for a specified request ID. */

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/projectManager.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/projectManager.ts
@@ -100,7 +100,7 @@ export interface CreateProject {
 
 /** The return value of the "open project" endpoint. */
 export interface OpenProject {
-    engineVersion?: string
+    engineVersion: string
     languageServerJsonAddress: IpWithSocket
     languageServerBinaryAddress: IpWithSocket
     projectName: ProjectName

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/projectManager.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/projectManager.ts
@@ -100,7 +100,7 @@ export interface CreateProject {
 
 /** The return value of the "open project" endpoint. */
 export interface OpenProject {
-    engineVersion: string
+    engineVersion?: string
     languageServerJsonAddress: IpWithSocket
     languageServerBinaryAddress: IpWithSocket
     projectName: ProjectName

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/remoteBackend.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/remoteBackend.ts
@@ -729,7 +729,7 @@ export class RemoteBackend extends backendModule.Backend {
         }
     }
 
-    /** Return list of backend or IDE versions.
+    /** Return a list of backend or IDE versions.
      *
      * @throws An error if a non-successful status code (not 200-299) was received. */
     override async listVersions(

--- a/app/ide-desktop/lib/dashboard/src/index.tsx
+++ b/app/ide-desktop/lib/dashboard/src/index.tsx
@@ -37,7 +37,7 @@ if (IS_DEV_MODE) {
 authentication.run({
     logger: console,
     // This file is only included when building for the cloud.
-    supportsLocalBackend: true,
+    supportsLocalBackend: false,
     supportsDeepLinks: false,
     isAuthenticationDisabled: false,
     shouldShowDashboard: true,

--- a/app/ide-desktop/lib/dashboard/src/index.tsx
+++ b/app/ide-desktop/lib/dashboard/src/index.tsx
@@ -37,7 +37,7 @@ if (IS_DEV_MODE) {
 authentication.run({
     logger: console,
     // This file is only included when building for the cloud.
-    supportsLocalBackend: false,
+    supportsLocalBackend: true,
     supportsDeepLinks: false,
     isAuthenticationDisabled: false,
     shouldShowDashboard: true,


### PR DESCRIPTION
### Pull Request Description
Fixes this issue:
- #7917

This is caused by the dashboard expecting `engineVersion` to be present, whereas it is actually optional.

### Important Notes
This may have been fixed on the Project Manager side, so the bug may not be reproducible. To properly test that this fix works, an older `project-manager` (e.g `2023.2.1-nightly.2023.9.30`) should be used.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
