### PR TITLE
Add functionality to handle Expression Updates to GUI2

### DIFF
--- a/app/gui2/shared/languageServer.ts
+++ b/app/gui2/shared/languageServer.ts
@@ -250,7 +250,7 @@ export class LanguageServer extends ObservableV2<Notifications> {
     expressionId: ExpressionId,
     visualizationConfig: VisualizationConfiguration,
   ): Promise<void> {
-    return this.request('executionContext/interrupt', {
+    return this.request('executionContext/executeExpression', {
       visualizationId,
       expressionId,
       visualizationConfig,

--- a/app/gui2/shared/languageServerTypes.ts
+++ b/app/gui2/shared/languageServerTypes.ts
@@ -96,6 +96,7 @@ export type ExpressionUpdatePayload = Value | DataflowError | Panic | Pending
  * Indicates that the expression was computed to a value.
  */
 export interface Value {
+  type: 'Value'
   /**
    * Information about attached warnings.
    */
@@ -111,6 +112,7 @@ export interface Value {
  * Indicates that the expression was computed to an error.
  */
 export interface DataflowError {
+  type: 'DataflowError'
   /**
    * The list of expressions leading to the root error.
    */
@@ -121,6 +123,7 @@ export interface DataflowError {
  * Indicates that the expression failed with the runtime exception.
  */
 export interface Panic {
+  type: 'Panic'
   /**
    * The error message.
    */
@@ -137,6 +140,7 @@ export interface Panic {
  * provides description and percentage (`0.0-1.0`) of completeness.
  */
 export interface Pending {
+  type: 'Pending'
   /** Optional message describing current operation. */
   message?: string
   /** Optional amount of already done work as a number between `0.0` to `1.0`. */

--- a/app/gui2/shared/yjsModel.ts
+++ b/app/gui2/shared/yjsModel.ts
@@ -140,7 +140,7 @@ export class DistributedModule {
     return newId
   }
 
-  deleteNode(id: ExprId): void {
+  deleteExpression(id: ExprId): void {
     const rangeBuffer = this.doc.idMap.get(id)
     if (rangeBuffer == null) return
     const [relStart, relEnd] = decodeRange(rangeBuffer)

--- a/app/gui2/src/bindings/index.ts
+++ b/app/gui2/src/bindings/index.ts
@@ -12,7 +12,7 @@ export const graphBindings = defineKeybinds('graph-editor', {
   newNode: ['N'],
 })
 
-export const nodeBindings = defineKeybinds('node-selection', {
+export const nodeSelectionBindings = defineKeybinds('node-selection', {
   deleteSelected: ['Delete'],
   selectAll: ['Mod+A'],
   deselectAll: ['Escape', 'PointerMain'],
@@ -22,4 +22,8 @@ export const nodeBindings = defineKeybinds('node-selection', {
   toggle: ['Shift+PointerMain'],
   invert: ['Mod+Shift+Alt+PointerMain'],
   toggleVisualization: ['Space'],
+})
+
+export const nodeEditBindings = defineKeybinds('node-edit', {
+  selectAll: ['Mod+A'],
 })

--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { codeEditorBindings, graphBindings, nodeBindings } from '@/bindings'
+import { codeEditorBindings, graphBindings, nodeSelectionBindings } from '@/bindings'
 import CodeEditor from '@/components/CodeEditor.vue'
 import ComponentBrowser from '@/components/ComponentBrowser.vue'
 import GraphEdge from '@/components/GraphEdge.vue'
@@ -159,6 +159,7 @@ const graphBindingsHandler = graphBindings.handler({
     }
   },
   newNode() {
+    if (keyboardBusy()) return false
     if (navigator.sceneMousePos != null) {
       graphStore.createNode(navigator.sceneMousePos, 'hello "world"! 123 + x')
     }
@@ -174,7 +175,7 @@ const codeEditorHandler = codeEditorBindings.handler({
   },
 })
 
-const nodeSelectionHandler = nodeBindings.handler({
+const nodeSelectionHandler = nodeSelectionBindings.handler({
   deleteSelected() {
     graphStore.transact(() => {
       for (const node of selectedNodes.value) {
@@ -207,7 +208,7 @@ const nodeSelectionHandler = nodeBindings.handler({
   },
 })
 
-const mouseHandler = nodeBindings.handler({
+const mouseHandler = nodeSelectionBindings.handler({
   replace() {
     selectedNodes.value = new Set(intersectingNodes.value)
   },
@@ -371,13 +372,5 @@ svg {
   left: 0;
   width: 0;
   height: 0;
-}
-
-.circle {
-  position: absolute;
-  width: 10px;
-  height: 10px;
-  border-radius: 5px;
-  background-color: purple;
 }
 </style>

--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -11,10 +11,13 @@ import { useProjectStore } from '@/stores/project'
 import type { Rect } from '@/stores/rect'
 import { useSuggestionDbStore } from '@/stores/suggestionDatabase'
 import { colorFromString } from '@/util/colors'
+import { ComputedValueRegistry } from '@/util/computedValueRegistry'
 import { keyboardBusy, keyboardBusyExceptIn, usePointer, useWindowEvent } from '@/util/events'
 import { useNavigator } from '@/util/navigator'
 import { Vec2 } from '@/util/vec2'
+import type { IJSONRPCNotification } from '@open-rpc/client-js/build/Request'
 import * as set from 'lib0/set'
+import type { Notifications } from 'shared/languageServerTypes.ts'
 import type { ContentRange, ExprId } from 'shared/yjsModel'
 import { computed, onMounted, reactive, ref, shallowRef, watch } from 'vue'
 </script>
@@ -35,6 +38,33 @@ const nodeRects = reactive(new Map<ExprId, Rect>())
 const exprRects = reactive(new Map<ExprId, Rect>())
 const selectedNodes = ref(new Set<ExprId>())
 const latestSelectedNode = ref<ExprId>()
+const computedValueRegistry = new ComputedValueRegistry()
+
+onMounted(async () => {
+  const executionCtxPromise = projectStore.createExecutionContextForMain()
+  onUnmounted(async () => {
+    executionCtx.value = undefined
+    const ctx = await executionCtxPromise
+    if (ctx != null) ctx.destroy()
+  })
+  executionCtx.value = (await executionCtxPromise) ?? undefined
+
+  /// Init processing of expression updates.
+  projectStore.lsRpcConnection.then((rpc) => {
+    rpc.client.onNotification(handleExprUpdate)
+  })
+})
+
+function handleExprUpdate(data: IJSONRPCNotification) {
+  if (data.method === 'executionContext/expressionUpdates') {
+    const params = data.params as Parameters<Notifications['executionContext/expressionUpdates']>[0]
+    const updates = params.updates ?? []
+    for (let update of updates) {
+      const { exprId, info } = computedValueRegistry.processUpdate(update)
+      graphStore.updateNodeInfo(exprId, info)
+    }
+  }
+}
 
 function updateNodeRect(id: ExprId, rect: Rect) {
   nodeRects.set(id, rect)

--- a/app/gui2/src/components/GraphNode.vue
+++ b/app/gui2/src/components/GraphNode.vue
@@ -27,6 +27,7 @@ const MAXIMUM_CLICK_LENGTH_MS = 300
 
 const props = defineProps<{
   node: Node
+  // id: string & ExprId
   selected: boolean
   isLatestSelected: boolean
   fullscreenVis: boolean
@@ -395,6 +396,18 @@ const dragPointer = usePointer((pos, event, type) => {
     }
   }
 })
+
+const expressionInfo = computed(() => {
+  return projectStore.computedValueRegistry.getExpressionInfo(props.node.rootSpan.id)
+})
+
+const outputTypeName = computed(() => {
+  return expressionInfo.value?.typename ?? 'Unknown'
+})
+
+const executionState = computed(() => {
+  return expressionInfo.value?.payload.type ?? 'Unknown'
+})
 </script>
 
 <template>
@@ -406,6 +419,7 @@ const dragPointer = usePointer((pos, event, type) => {
       dragging: dragPointer.dragging,
       selected,
       visualizationVisible: isVisualizationVisible,
+      ['executionState-' + executionState]: true,
     }"
   >
     <div class="selection" v-on="dragPointer.events"></div>
@@ -444,7 +458,7 @@ const dragPointer = usePointer((pos, event, type) => {
         />
       </div>
     </div>
-    <div class="outputTypeName">{{ node.outputTypeName }}</div>
+    <div class="outputTypeName">{{ outputTypeName }}</div>
   </div>
 </template>
 
@@ -454,6 +468,24 @@ const dragPointer = usePointer((pos, event, type) => {
   --node-border-radius: calc(var(--node-height) * 0.5);
 
   --node-color-primary: #357ab9;
+
+  &.executionState-Unknown {
+    --node-color-primary: #999;
+  }
+
+  &.executionState-Error,
+  &.executionState-Panic {
+    /* --node-color-primary: ; */
+
+    .node {
+      outline: 8px solid rgba(255, 0, 0, 0.4);
+    }
+  }
+
+  &.executionState-Pending {
+    --node-color-primary: #5394d1;
+  }
+
   position: absolute;
   border-radius: var(--radius-full);
   transition: box-shadow 0.2s ease-in-out;
@@ -477,6 +509,10 @@ const dragPointer = usePointer((pos, event, type) => {
   white-space: nowrap;
   padding: 4px 8px;
   z-index: 2;
+  transition:
+    background 0.2s ease,
+    outline 0.2s ease;
+  outline: 0px solid transparent;
 }
 .GraphNode .selection {
   position: absolute;

--- a/app/gui2/src/components/GraphNode.vue
+++ b/app/gui2/src/components/GraphNode.vue
@@ -444,6 +444,7 @@ const dragPointer = usePointer((pos, event, type) => {
         />
       </div>
     </div>
+    <div class="outputTypeName">{{ node.outputTypeName }}</div>
   </div>
 </template>
 
@@ -547,5 +548,21 @@ const dragPointer = usePointer((pos, event, type) => {
 
 .CircularMenu {
   z-index: 1;
+}
+
+.outputTypeName {
+  user-select: none;
+  position: absolute;
+  left: 50%;
+  top: 110%;
+  transform: translateX(-50%);
+  opacity: 0;
+  transition: opacity 0.3s ease-in-out;
+  pointer-events: none;
+  color: var(--node-color-primary);
+}
+
+.GraphNode:hover .outputTypeName {
+  opacity: 1;
 }
 </style>

--- a/app/gui2/src/components/NodeSpan.vue
+++ b/app/gui2/src/components/NodeSpan.vue
@@ -82,14 +82,11 @@ watch(exprRect, (rect) => {
 .Span {
   color: white;
   white-space: pre;
+  align-items: center;
+  transition: background 0.2s ease;
 
   &.Root {
-    display: inline-block;
     color: white;
-  }
-
-  &.Ident {
-    /* color: #f97; */
   }
 
   &.Token {
@@ -98,6 +95,13 @@ watch(exprRect, (rect) => {
 
   &.Literal {
     font-weight: bold;
+  }
+
+  &.Ident {
+    background-color: var(--node-color-port);
+    border-radius: var(--node-border-radius);
+    margin: -2px -4px;
+    padding: 2px 4px;
   }
 }
 </style>

--- a/app/gui2/src/stores/graph.ts
+++ b/app/gui2/src/stores/graph.ts
@@ -146,6 +146,7 @@ export const useGraphStore = defineStore('graph', () => {
   function nodeInserted(stmt: Statement, text: Y.Text, content: string, meta: Opt<NodeMetadata>) {
     const nodeId = stmt.expression.id
     const node: Node = {
+      outerExprId: stmt.id,
       content,
       binding: stmt.binding ?? '',
       rootSpan: stmt.expression,
@@ -172,6 +173,9 @@ export const useGraphStore = defineStore('graph', () => {
       identDefinitions.delete(node.binding)
       node.binding = stmt.binding ?? ''
       identDefinitions.set(node.binding, nodeId)
+    }
+    if (node.outerExprId !== stmt.id) {
+      node.outerExprId = stmt.id
     }
     if (node.rootSpan.id === stmt.expression.id) {
       patchSpan(node.rootSpan, stmt.expression)
@@ -270,7 +274,9 @@ export const useGraphStore = defineStore('graph', () => {
   }
 
   function deleteNode(id: ExprId) {
-    proj.module?.deleteNode(id)
+    const node = nodes.get(id)
+    if (node == null) return
+    proj.module?.deleteExpression(node.outerExprId)
   }
 
   function setNodeContent(id: ExprId, content: string) {
@@ -359,6 +365,7 @@ function randomString() {
 }
 
 export interface Node {
+  outerExprId: ExprId
   content: string
   binding: string
   rootSpan: Span

--- a/app/gui2/src/stores/graph.ts
+++ b/app/gui2/src/stores/graph.ts
@@ -1,5 +1,4 @@
 import { assert, assertNever } from '@/util/assert'
-import type { ExpressionInfo } from '@/util/computedValueRegistry.ts'
 import { useObserveYjs } from '@/util/crdt'
 import { parseEnso, type Ast } from '@/util/ffi'
 import type { Opt } from '@/util/opt'
@@ -147,7 +146,6 @@ export const useGraphStore = defineStore('graph', () => {
   function nodeInserted(stmt: Statement, text: Y.Text, content: string, meta: Opt<NodeMetadata>) {
     const nodeId = stmt.expression.id
     const node: Node = {
-      outputTypeName: 'Unknown',
       content,
       binding: stmt.binding ?? '',
       rootSpan: stmt.expression,
@@ -335,12 +333,6 @@ export const useGraphStore = defineStore('graph', () => {
     proj.module?.updateNodeMetadata(nodeId, { vis: normalizeVisMetadata(node.vis, visible) })
   }
 
-  function updateNodeInfo(id: ExprId, info: ExpressionInfo) {
-    const node = nodes.get(id)
-    if (node == null) return
-    node.outputTypeName = info.typename ?? ''
-  }
-
   return {
     _parsed,
     _parsedEnso: _parsedEnso,
@@ -354,7 +346,6 @@ export const useGraphStore = defineStore('graph', () => {
     deleteNode,
     setNodeContent,
     setExpressionContent,
-    updateNodeInfo,
     replaceNodeSubexpression,
     setNodePosition,
     setNodeVisualizationId,
@@ -369,7 +360,6 @@ function randomString() {
 
 export interface Node {
   content: string
-  outputTypeName: string
   binding: string
   rootSpan: Span
   position: Vec2

--- a/app/gui2/src/stores/graph.ts
+++ b/app/gui2/src/stores/graph.ts
@@ -1,4 +1,5 @@
 import { assert, assertNever } from '@/util/assert'
+import type { ExpressionInfo } from '@/util/computedValueRegistry.ts'
 import { useObserveYjs } from '@/util/crdt'
 import { parseEnso, type Ast } from '@/util/ffi'
 import type { Opt } from '@/util/opt'
@@ -146,6 +147,7 @@ export const useGraphStore = defineStore('graph', () => {
   function nodeInserted(stmt: Statement, text: Y.Text, content: string, meta: Opt<NodeMetadata>) {
     const nodeId = stmt.expression.id
     const node: Node = {
+      outputTypeName: 'Unknown',
       content,
       binding: stmt.binding ?? '',
       rootSpan: stmt.expression,
@@ -333,6 +335,12 @@ export const useGraphStore = defineStore('graph', () => {
     proj.module?.updateNodeMetadata(nodeId, { vis: normalizeVisMetadata(node.vis, visible) })
   }
 
+  function updateNodeInfo(id: ExprId, info: ExpressionInfo) {
+    const node = nodes.get(id)
+    if (node == null) return
+    node.outputTypeName = info.typename ?? ''
+  }
+
   return {
     _parsed,
     _parsedEnso: _parsedEnso,
@@ -346,6 +354,7 @@ export const useGraphStore = defineStore('graph', () => {
     deleteNode,
     setNodeContent,
     setExpressionContent,
+    updateNodeInfo,
     replaceNodeSubexpression,
     setNodePosition,
     setNodeVisualizationId,
@@ -360,6 +369,7 @@ function randomString() {
 
 export interface Node {
   content: string
+  outputTypeName: string
   binding: string
   rootSpan: Span
   position: Vec2

--- a/app/gui2/src/stores/project.ts
+++ b/app/gui2/src/stores/project.ts
@@ -1,4 +1,5 @@
 import { useGuiConfig, type GuiConfig } from '@/providers/guiConfig'
+import { ComputedValueRegistry } from '@/util/computedValueRegistry'
 import { attachProvider } from '@/util/crdt'
 import { AsyncQueue, rpcWithRetries as lsRpcWithRetries } from '@/util/net'
 import { isSome, type Opt } from '@/util/opt'
@@ -6,6 +7,7 @@ import { Client, RequestManager, WebSocketTransport } from '@open-rpc/client-js'
 import { computedAsync } from '@vueuse/core'
 import * as array from 'lib0/array'
 import * as object from 'lib0/object'
+import { ObservableV2 } from 'lib0/observable'
 import * as random from 'lib0/random'
 import { defineStore } from 'pinia'
 import { OutboundPayload, VisualizationUpdate } from 'shared/binaryProtocol'
@@ -14,8 +16,11 @@ import { LanguageServer } from 'shared/languageServer'
 import type {
   ContentRoot,
   ContextId,
+  Diagnostic,
+  ExecutionEnvironment,
   ExplicitCall,
   ExpressionId,
+  ExpressionUpdate,
   StackItem,
   VisualizationConfiguration,
 } from 'shared/languageServerTypes'
@@ -118,6 +123,19 @@ function visualizationConfigEqual(
 
 type EntryPoint = Omit<ExplicitCall, 'type'>
 
+type ExecutionContextNotification = {
+  'expressionUpdates'(updates: ExpressionUpdate[]): void
+  'visualizationEvaluationFailed'(
+    visualizationId: Uuid,
+    expressionId: ExpressionId,
+    message: string,
+    diagnostic: Diagnostic | undefined,
+  ): void
+  'executionFailed'(message: string): void
+  'executionComplete'(): void
+  'executionStatus'(diagnostics: Diagnostic[]): void
+}
+
 /**
  * Execution Context
  *
@@ -127,7 +145,7 @@ type EntryPoint = Omit<ExplicitCall, 'type'>
  * It hides the asynchronous nature of the language server. Each call is scheduled and
  * run only when the previous call is done.
  */
-export class ExecutionContext {
+export class ExecutionContext extends ObservableV2<ExecutionContextNotification> {
   id: ContextId = random.uuidv4() as ContextId
   queue: AsyncQueue<ExecutionContextState>
   taskRunning = false
@@ -136,6 +154,12 @@ export class ExecutionContext {
   abortCtl = new AbortController()
 
   constructor(lsRpc: Promise<LanguageServer>, entryPoint: EntryPoint) {
+    super()
+
+    this.abortCtl.signal.addEventListener('abort', () => {
+      this.queue.clear()
+    })
+
     this.queue = new AsyncQueue(
       lsRpc.then((lsRpc) => ({
         lsRpc,
@@ -144,8 +168,10 @@ export class ExecutionContext {
         stack: [],
       })),
     )
+    this.registerHandlers()
     this.create()
     this.pushItem({ type: 'ExplicitCall', ...entryPoint })
+    this.recompute()
   }
 
   private withBackoff<T>(f: () => Promise<T>, message: string): Promise<T> {
@@ -297,16 +323,65 @@ export class ExecutionContext {
         return { ...state, created: true }
       }, 'Failed to create execution context')
     })
+    this.abortCtl.signal.addEventListener('abort', () => {
+      this.queue.pushTask(async (state) => {
+        if (!state.created) return state
+        await state.lsRpc.destroyExecutionContext(this.id)
+        return { ...state, created: false }
+      })
+    })
+  }
+
+  private registerHandlers() {
+    this.queue.pushTask(async (state) => {
+      const expressionUpdates = state.lsRpc.on('executionContext/expressionUpdates', (event) => {
+        if (event.contextId == this.id) this.emit('expressionUpdates', [event.updates])
+      })
+      const executionFailed = state.lsRpc.on('executionContext/executionFailed', (event) => {
+        if (event.contextId == this.id) this.emit('executionFailed', [event.message])
+      })
+      const executionComplete = state.lsRpc.on('executionContext/executionComplete', (event) => {
+        if (event.contextId == this.id) this.emit('executionComplete', [])
+      })
+      const executionStatus = state.lsRpc.on('executionContext/executionStatus', (event) => {
+        if (event.contextId == this.id) this.emit('executionStatus', [event.diagnostics])
+      })
+      const visualizationEvaluationFailed = state.lsRpc.on(
+        'executionContext/visualizationEvaluationFailed',
+        (event) => {
+          if (event.contextId == this.id)
+            this.emit('visualizationEvaluationFailed', [
+              event.visualizationId,
+              event.expressionId,
+              event.message,
+              event.diagnostic,
+            ])
+        },
+      )
+      this.abortCtl.signal.addEventListener('abort', () => {
+        state.lsRpc.off('executionContext/expressionUpdates', expressionUpdates)
+        state.lsRpc.off('executionContext/executionFailed', executionFailed)
+        state.lsRpc.off('executionContext/executionComplete', executionComplete)
+        state.lsRpc.off('executionContext/executionStatus', executionStatus)
+        state.lsRpc.off(
+          'executionContext/visualizationEvaluationFailed',
+          visualizationEvaluationFailed,
+        )
+      })
+      return state
+    })
+  }
+
+  recompute(expressionIds: 'all' | ExprId[] = 'all', executionEnvironment?: ExecutionEnvironment) {
+    this.queue.pushTask(async (state) => {
+      if (!state.created) return state
+      await state.lsRpc.recomputeExecutionContext(this.id, expressionIds, executionEnvironment)
+      return state
+    })
   }
 
   destroy() {
     this.abortCtl.abort()
-    this.queue.clear()
-    this.queue.pushTask(async (state) => {
-      if (!state.created) return state
-      await state.lsRpc.destroyExecutionContext(this.id)
-      return { ...state, created: false }
-    })
   }
 }
 
@@ -393,6 +468,7 @@ export const useProjectStore = defineStore('project', () => {
   }
 
   const executionContext = createExecutionContextForMain()
+  const computedValueRegistry = new ComputedValueRegistry(executionContext)
   const dataConnectionRef = computedAsync<DataServer | undefined>(() => dataConnection)
 
   function useVisualizationData(
@@ -436,11 +512,11 @@ export const useProjectStore = defineStore('project', () => {
       observedFileName.value = name
     },
     name: projectName,
-    createExecutionContextForMain,
     executionContext,
     module,
     contentRoots,
     awareness,
+    computedValueRegistry,
     lsRpcConnection: markRaw(lsRpcConnection),
     dataConnection: markRaw(dataConnection),
     useVisualizationData,

--- a/app/gui2/src/util/computedValueRegistry.ts
+++ b/app/gui2/src/util/computedValueRegistry.ts
@@ -24,6 +24,7 @@ export class ComputedValueRegistry {
   constructor(executionContext: ExecutionContext) {
     this.executionContext = executionContext
     this.expressionMap = reactive(new Map())
+
     executionContext.on('expressionUpdates', this._updateHandler)
   }
 
@@ -39,7 +40,6 @@ export class ComputedValueRegistry {
   }
 
   getExpressionInfo(exprId: ExpressionId): ExpressionInfo | undefined {
-    console.log('getExpressionInfo', exprId)
     return this.expressionMap.get(exprId)
   }
 

--- a/app/gui2/src/util/computedValueRegistry.ts
+++ b/app/gui2/src/util/computedValueRegistry.ts
@@ -1,0 +1,36 @@
+import type {
+  ExpressionId,
+  ExpressionUpdate,
+  ExpressionUpdatePayload,
+  MethodCall,
+} from '../../shared/languageServerTypes.ts'
+
+export interface ExpressionInfo {
+  typename: string | undefined
+  methodCall: MethodCall | undefined
+  payload: ExpressionUpdatePayload
+}
+
+//* This class holds the computed values that have been received from the language server. */
+export class ComputedValueRegistry {
+  private internalMap: Map<ExpressionId, ExpressionInfo>
+
+  constructor() {
+    this.internalMap = new Map()
+  }
+
+  processUpdate(update: ExpressionUpdate) {
+    const exprId = update.expressionId
+    const info = {
+      typename: update.type,
+      methodCall: update.methodCall,
+      payload: update.payload,
+    }
+    this.internalMap.set(exprId, info)
+    return { exprId, info }
+  }
+
+  getExpressionInfo(exprId: ExpressionId): ExpressionInfo | undefined {
+    return this.internalMap.get(exprId)
+  }
+}

--- a/app/gui2/src/util/visualizationDataRegistry.ts
+++ b/app/gui2/src/util/visualizationDataRegistry.ts
@@ -1,0 +1,66 @@
+import type { ExecutionContext } from '@/stores/project.ts'
+import { OutboundPayload, VisualizationUpdate } from 'shared/binaryProtocol.ts'
+import type { DataServer } from 'shared/dataServer.ts'
+import { reactive } from 'vue'
+import type {
+  ExpressionUpdatePayload,
+  MethodCall,
+  ProfilingInfo,
+  Uuid,
+} from '../../shared/languageServerTypes.ts'
+
+export interface ExpressionInfo {
+  typename: string | undefined
+  methodCall: MethodCall | undefined
+  payload: ExpressionUpdatePayload
+  profilingInfo: ProfilingInfo[]
+}
+
+//* This class holds the computed values that have been received from the language server. */
+export class VisualizationDataRegistry {
+  private visualizationValues: Map<Uuid, string | null>
+  private dataServer: Promise<DataServer>
+  private executionContext: ExecutionContext
+  private _reconfiguredHandler = this.visualizationsConfigured.bind(this)
+  private _dataHandler = this.visualizationUpdate.bind(this)
+
+  constructor(executionContext: ExecutionContext, dataServer: Promise<DataServer>) {
+    this.executionContext = executionContext
+    this.dataServer = dataServer
+    this.visualizationValues = reactive(new Map())
+
+    this.executionContext.on('visualizationsConfigured', this._reconfiguredHandler)
+    this.dataServer.then((data) => {
+      data.on(`${OutboundPayload.VISUALIZATION_UPDATE}`, this._dataHandler)
+    })
+  }
+
+  private visualizationsConfigured(uuids: Set<Uuid>) {
+    for (const key of this.visualizationValues.keys()) {
+      if (!uuids.has(key)) {
+        this.visualizationValues.delete(key)
+      }
+    }
+  }
+
+  private visualizationUpdate(update: VisualizationUpdate, uuid: Uuid | null) {
+    if (uuid) {
+      const newData = update.dataString()
+      const current = this.visualizationValues.get(uuid)
+      if (current !== newData) {
+        this.visualizationValues.set(uuid, newData)
+      }
+    }
+  }
+
+  getRawData(visualizationId: Uuid): string | null {
+    return this.visualizationValues.get(visualizationId) ?? null
+  }
+
+  destroy() {
+    this.executionContext.off('visualizationsConfigured', this._reconfiguredHandler)
+    this.dataServer.then((data) => {
+      data.off(`${OutboundPayload.VISUALIZATION_UPDATE}`, this._dataHandler)
+    })
+  }
+}


### PR DESCRIPTION
### Pull Request Description

Implements #7783. Adds functionality to handle and store expression updates, as well as show the output type of node.



https://github.com/enso-org/enso/assets/1428930/31ffff78-ff2c-4e0b-bcde-ddc507cc0226


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
