### PR TITLE
Fix initialization race-condition in runtime connector

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/RuntimeConnector.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/RuntimeConnector.scala
@@ -37,7 +37,7 @@ class RuntimeConnector(
         engine
       )
       unstashAll()
-      context.become(initialized(engine, Map()))
+      context.become(waitingOnEndpoint(engine))
     case _ => stash()
   }
 
@@ -45,6 +45,19 @@ class RuntimeConnector(
     eventsMonitor.registerEvent(event)
     event
   }
+
+  private def waitingOnEndpoint(engine: MessageEndpoint): Receive =
+    registerEvent.andThen(LoggingReceive {
+      case MessageFromRuntime(
+            Runtime.Api.Response(None, Api.InitializedNotification())
+          ) =>
+        logger.debug(
+          s"Message endpoint [{}] is initialized. Runtime connector can accept messages.",
+          engine
+        )
+        context.become(initialized(engine, Map()))
+      case _ => stash()
+    })
 
   /** Performs communication between runtime and language server.
     *

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/RuntimeConnector.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/RuntimeConnector.scala
@@ -55,6 +55,7 @@ class RuntimeConnector(
           s"Message endpoint [{}] is initialized. Runtime connector can accept messages.",
           engine
         )
+        unstashAll()
         context.become(initialized(engine, Map()))
       case _ => stash()
     })

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/SerializeModuleCommand.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/SerializeModuleCommand.java
@@ -10,7 +10,7 @@ import scala.concurrent.Future;
 import scala.runtime.BoxedUnit;
 
 /** The command to start the module serialization. */
-public final class SerializeModuleCommand extends Command {
+public final class SerializeModuleCommand extends AsynchronousCommand {
 
   private final QualifiedName moduleName;
 
@@ -20,7 +20,7 @@ public final class SerializeModuleCommand extends Command {
   }
 
   @Override
-  public Future<BoxedUnit> execute(RuntimeContext ctx, ExecutionContext ec) {
+  public Future<BoxedUnit> executeAsynchronously(RuntimeContext ctx, ExecutionContext ec) {
     ctx.jobProcessor().runBackground(new SerializeModuleJob(moduleName));
     return Future.successful(BoxedUnit.UNIT);
   }

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/SetExecutionEnvironmentCommand.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/SetExecutionEnvironmentCommand.java
@@ -16,7 +16,7 @@ import scala.concurrent.Future;
 import scala.runtime.BoxedUnit;
 
 /** The command to set the runtime execution environment. */
-public class SetExecutionEnvironmentCommand extends Command {
+public class SetExecutionEnvironmentCommand extends AsynchronousCommand {
 
   private final UUID contextId;
   private final Runtime$Api$ExecutionEnvironment executionEnvironment;
@@ -29,8 +29,7 @@ public class SetExecutionEnvironmentCommand extends Command {
   }
 
   @Override
-  public Future<BoxedUnit> execute(RuntimeContext ctx, ExecutionContext ec) {
-
+  public Future<BoxedUnit> executeAsynchronously(RuntimeContext ctx, ExecutionContext ec) {
     return Future.apply(
         () -> {
           setExecutionEnvironment(executionEnvironment, contextId, ctx);

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/Handler.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/Handler.scala
@@ -84,6 +84,7 @@ final class Handler {
 
   private case class HandlersContext(
     executionService: ExecutionService,
+    sequentialExecutionService: ExecutionService,
     truffleContext: TruffleContext,
     commandProcessor: CommandProcessor
   )
@@ -108,7 +109,12 @@ final class Handler {
         truffleContext
       )
     val commandProcessor = new CommandExecutionEngine(interpreterCtx)
-    ctx = HandlersContext(executionService, truffleContext, commandProcessor)
+    ctx = HandlersContext(
+      executionService,
+      executionService,
+      truffleContext,
+      commandProcessor
+    )
     executionService.initializeLanguageServerConnection(endpoint)
     endpoint.sendToClient(Api.Response(Api.InitializedNotification()))
   }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/Handler.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/Handler.scala
@@ -123,23 +123,26 @@ final class Handler {
     *
     * @param request the message to handle.
     */
-  def onMessage(request: Api.Request): Unit = request match {
-    case Api.Request(requestId, Api.ShutDownRuntimeServer()) =>
-      if (ctx != null) {
-        ctx.commandProcessor.stop()
-      }
-      endpoint.sendToClient(
-        Api.Response(requestId, Api.RuntimeServerShutDown())
-      )
-
-    case request: Api.Request =>
-      if (ctx != null) {
-        val cmd = CommandFactory.createCommand(request)
-        ctx.commandProcessor.invoke(cmd)
-      } else {
-        throw new IllegalStateException(
-          "received a request to handle with interpreter context not being initialized"
+  def onMessage(request: Api.Request): Unit = {
+    val localCtx = ctx
+    request match {
+      case Api.Request(requestId, Api.ShutDownRuntimeServer()) =>
+        if (localCtx != null) {
+          localCtx.commandProcessor.stop()
+        }
+        endpoint.sendToClient(
+          Api.Response(requestId, Api.RuntimeServerShutDown())
         )
-      }
+
+      case request: Api.Request =>
+        if (localCtx != null) {
+          val cmd = CommandFactory.createCommand(request)
+          localCtx.commandProcessor.invoke(cmd)
+        } else {
+          throw new IllegalStateException(
+            "received a request to handle with interpreter context not being initialized"
+          )
+        }
+    }
   }
 }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/Handler.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/Handler.scala
@@ -136,6 +136,10 @@ final class Handler {
       if (ctx != null) {
         val cmd = CommandFactory.createCommand(request)
         ctx.commandProcessor.invoke(cmd)
+      } else {
+        throw new IllegalStateException(
+          "received a request to handle with interpreter context not being initialized"
+        )
       }
   }
 }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/AsynchronousCommand.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/AsynchronousCommand.scala
@@ -13,7 +13,8 @@ import scala.util.{Failure, Success}
 
 abstract class AsynchronousCommand(maybeRequestId: Option[RequestId])
     extends Command(maybeRequestId) {
-  type Result[T] = Future[T]
+
+  override type Result[T] = Future[T]
 
   final override def execute(implicit
     ctx: RuntimeContext,

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/CloseFileCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/CloseFileCmd.scala
@@ -4,6 +4,7 @@ import org.enso.interpreter.instrument.execution.RuntimeContext
 import org.enso.polyglot.runtime.Runtime.Api
 
 import java.util.logging.Level
+import scala.concurrent.ExecutionContext
 
 /** A command that closes a file.
   *
@@ -12,7 +13,10 @@ import java.util.logging.Level
 class CloseFileCmd(request: Api.CloseFileNotification)
     extends SynchronousCommand(None) {
 
-  override def executeSynchronously(implicit ctx: RuntimeContext): Unit = {
+  override def executeSynchronously(implicit
+    ctx: RuntimeContext,
+    ec: ExecutionContext
+  ): Unit = {
     val logger                    = ctx.executionService.getLogger
     val readLockTimestamp         = ctx.locking.acquireReadCompilationLock()
     val fileLockTimestamp         = ctx.locking.acquireFileLock(request.path)

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/CloseFileCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/CloseFileCmd.scala
@@ -12,9 +12,7 @@ import java.util.logging.Level
 class CloseFileCmd(request: Api.CloseFileNotification)
     extends SynchronousCommand(None) {
 
-  override def executeSynchronously(implicit
-    ctx: RuntimeContext
-  ): Unit = {
+  override def executeSynchronously(implicit ctx: RuntimeContext): Unit = {
     val logger                    = ctx.executionService.getLogger
     val readLockTimestamp         = ctx.locking.acquireReadCompilationLock()
     val fileLockTimestamp         = ctx.locking.acquireFileLock(request.path)

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/CloseFileCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/CloseFileCmd.scala
@@ -12,7 +12,9 @@ import java.util.logging.Level
 class CloseFileCmd(request: Api.CloseFileNotification)
     extends SynchronousCommand(None) {
 
-  override def executeSynchronously(implicit ctx: RuntimeContext): Unit = {
+  override def executeSynchronously(implicit
+    ctx: RuntimeContext
+  ): Unit = {
     val logger                    = ctx.executionService.getLogger
     val readLockTimestamp         = ctx.locking.acquireReadCompilationLock()
     val fileLockTimestamp         = ctx.locking.acquireFileLock(request.path)

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/OpenFileCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/OpenFileCmd.scala
@@ -4,6 +4,7 @@ import org.enso.interpreter.instrument.execution.RuntimeContext
 import org.enso.polyglot.runtime.Runtime.Api
 
 import java.util.logging.Level
+import scala.concurrent.ExecutionContext
 
 /** A command that opens a file.
   *
@@ -14,7 +15,8 @@ class OpenFileCmd(request: Api.OpenFileNotification)
 
   /** @inheritdoc */
   override def executeSynchronously(implicit
-    ctx: RuntimeContext
+    ctx: RuntimeContext,
+    ec: ExecutionContext
   ): Unit = {
     val logger            = ctx.executionService.getLogger
     val readLockTimestamp = ctx.locking.acquireReadCompilationLock()

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/PopContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/PopContextCmd.scala
@@ -16,13 +16,13 @@ import scala.concurrent.{ExecutionContext, Future}
 class PopContextCmd(
   maybeRequestId: Option[RequestId],
   request: Api.PopContextRequest
-) extends AsynchronousCommand(maybeRequestId) {
+) extends SynchronousCommand(maybeRequestId) {
 
   /** @inheritdoc */
-  override def executeAsynchronously(implicit
+  override def executeSynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
-  ): Future[Unit] =
+  ): Unit =
     if (doesContextExist) {
       popItemFromStack() flatMap { _ => scheduleExecutionIfNeeded() }
     } else {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/PushContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/PushContextCmd.scala
@@ -15,13 +15,13 @@ import scala.concurrent.{ExecutionContext, Future}
 class PushContextCmd(
   maybeRequestId: Option[RequestId],
   request: Api.PushContextRequest
-) extends AsynchronousCommand(maybeRequestId) {
+) extends SynchronousCommand(maybeRequestId) {
 
   /** @inheritdoc */
-  override def executeAsynchronously(implicit
+  override def executeSynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
-  ): Future[Unit] =
+  ): Unit =
     if (doesContextExist) {
       pushItemOntoStack() flatMap (scheduleExecutionIfNeeded(_))
     } else {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/SynchronousCommand.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/SynchronousCommand.scala
@@ -6,11 +6,20 @@ import org.enso.interpreter.runtime.control.ThreadInterruptedException
 import org.enso.polyglot.runtime.Runtime.Api.RequestId
 
 import java.util.logging.Level
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext}
 
-abstract class SynchronousCommand(maybeRequestId: Option[RequestId])
-    extends Command(maybeRequestId) {
-  type Result[T] = T
+/** `SynchronousCommand`, despite its name,. will still execute asynchronously along with other commands except that
+  * the order of execution preserves the order of command's submission (for `SynchronousCommand` kind).
+  *
+  * The class was added since some commands cannot be executed in arbitrary order but they also must not be
+  * executed synchronously due to the possibility of deadlocks.
+  * Plain context locks do not necessarily guarantee the right order of such commands.
+  */
+abstract class SynchronousCommand(
+  maybeRequestId: Option[RequestId]
+) extends Command(maybeRequestId) {
+
+  override type Result[T] = T
 
   final override def execute(implicit
     ctx: RuntimeContext,

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/SynchronousCommand.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/SynchronousCommand.scala
@@ -6,7 +6,7 @@ import org.enso.interpreter.runtime.control.ThreadInterruptedException
 import org.enso.polyglot.runtime.Runtime.Api.RequestId
 
 import java.util.logging.Level
-import scala.concurrent.{ExecutionContext}
+import scala.concurrent.ExecutionContext
 
 /** `SynchronousCommand`, despite its name,. will still execute asynchronously along with other commands except that
   * the order of execution preserves the order of command's submission (for `SynchronousCommand` kind).
@@ -15,9 +15,8 @@ import scala.concurrent.{ExecutionContext}
   * executed synchronously due to the possibility of deadlocks.
   * Plain context locks do not necessarily guarantee the right order of such commands.
   */
-abstract class SynchronousCommand(
-  maybeRequestId: Option[RequestId]
-) extends Command(maybeRequestId) {
+abstract class SynchronousCommand(maybeRequestId: Option[RequestId])
+    extends Command(maybeRequestId) {
 
   override type Result[T] = T
 

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/SynchronousCommand.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/SynchronousCommand.scala
@@ -44,6 +44,9 @@ abstract class SynchronousCommand(maybeRequestId: Option[RequestId])
     }
   }
 
-  def executeSynchronously(implicit ctx: RuntimeContext): Unit
+  def executeSynchronously(implicit
+    ctx: RuntimeContext,
+    ec: ExecutionContext
+  ): Unit
 
 }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/CommandProcessor.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/CommandProcessor.scala
@@ -2,6 +2,8 @@ package org.enso.interpreter.instrument.execution
 
 import org.enso.interpreter.instrument.command.Command
 
+import scala.concurrent.Future
+
 /** Defines a uniform interface to execute commands.
   */
 trait CommandProcessor {
@@ -12,7 +14,7 @@ trait CommandProcessor {
     * @return if the command is asynchronous, a future signaling the completion of computations,
     *         a signal indicating the completion otherwise
     */
-  def invoke(cmd: Command): cmd.Result[Completion]
+  def invoke(cmd: Command): Future[Completion]
 
   /** Stops the command processor.
     */

--- a/engine/runtime-instrument-id-execution/src/main/java/org/enso/interpreter/instrument/IdExecutionInstrument.java
+++ b/engine/runtime-instrument-id-execution/src/main/java/org/enso/interpreter/instrument/IdExecutionInstrument.java
@@ -21,6 +21,7 @@ import com.oracle.truffle.api.instrumentation.TruffleInstrument;
 import com.oracle.truffle.api.interop.InteropException;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.source.SourceSection;
 
 import java.util.UUID;
 
@@ -257,9 +258,9 @@ public class IdExecutionInstrument extends TruffleInstrument implements IdExecut
             .tagIsNot(AvoidIdInstrumentationTag.class)
             .sourceIs(module::isModuleSource);
 
-    if (entryCallTarget instanceof RootCallTarget r && r.getRootNode() instanceof ClosureRootNode c && c.getSourceSection() != null) {
-      final int firstFunctionLine = c.getSourceSection().getStartLine();
-      final int afterFunctionLine = c.getSourceSection().getEndLine() + 1;
+    if (entryCallTarget instanceof RootCallTarget r && r.getRootNode() instanceof ClosureRootNode c && c.getSourceSection() instanceof SourceSection section && section != null) {
+      final int firstFunctionLine = section.getStartLine();
+      final int afterFunctionLine = section.getEndLine() + 1;
       builder.lineIn(SourceSectionFilter.IndexRange.between(firstFunctionLine, afterFunctionLine));
     }
     var filter = builder.build();

--- a/engine/runtime-instrument-runtime-server/src/main/java/org/enso/interpreter/instrument/RuntimeServerInstrument.java
+++ b/engine/runtime-instrument-runtime-server/src/main/java/org/enso/interpreter/instrument/RuntimeServerInstrument.java
@@ -40,11 +40,6 @@ public class RuntimeServerInstrument extends TruffleInstrument {
   private Handler handler;
   private EventBinding<Initializer> initializerEventBinding;
 
-  /** @return the handler instance. */
-  public Handler getHandler() {
-    return handler;
-  }
-
   private void initializeExecutionService(ExecutionService service, TruffleContext context) {
     initializerEventBinding.dispose();
     handler.initializeExecutionService(service, context);

--- a/lib/scala/distribution-manager/src/main/scala/org/enso/distribution/locking/FileLockManager.scala
+++ b/lib/scala/distribution-manager/src/main/scala/org/enso/distribution/locking/FileLockManager.scala
@@ -7,7 +7,7 @@ import com.typesafe.scalalogging.Logger
 
 import scala.util.control.NonFatal
 
-/** [[LockManager]] using file-based locks - allowing to synchornize locks
+/** [[LockManager]] using file-based locks - allowing to synchronize locks
   * between different processes.
   *
   * Under the hood, it uses the [[FileLock]] mechanism. This mechanism specifies

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/Package.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/Package.scala
@@ -337,9 +337,11 @@ class PackageManager[F](implicit val fileSystem: FileSystem[F]) {
           else Failure(PackageManager.PackageNotFound())
 
         val configFile = root.getChild(Package.configFileName)
-        for {
-          result <- readConfig(configFile)
-        } yield new Package(root, result, fileSystem)
+        if (configFile.exists) {
+          for {
+            result <- readConfig(configFile)
+          } yield new Package(root, result, fileSystem)
+        } else Failure(PackageManager.PackageNotFound())
       }
     result.recoverWith {
       case packageLoadingException: PackageManager.PackageLoadingException =>


### PR DESCRIPTION
### Pull Request Description

It seems that Runtime Connector wasn't respecting the protocol it defined itself. The connector should be waiting on the `Api.InitializedNotification` message and only then start forwarding messages. So far it seems this hasn't been a problem, or at least wasn't reported as such, because initialization was fast enough.

Modified `Handler` so that we are certain that its fields hold initialized values when being accessed by different threads.

Should fix problems mentioned in #7898.

### Important notest

Fixing the initial problem revealed some occasional deadlocks that can happen between command execution processor and context locks. Had to partially revert a fix in #6998 by making sure that all commands are executed in a non-blocking way while still preserving the order for some of them.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests continue to pass.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
