### PR TITLE
Fixed node icons and colors, derived from suggestions DB groups

### DIFF
--- a/app/gui2/src/components/GraphNode.vue
+++ b/app/gui2/src/components/GraphNode.vue
@@ -26,8 +26,6 @@ import type { Vec2 } from '@/util/vec2'
 import type { ContentRange, ExprId, VisualizationIdentifier } from 'shared/yjsModel'
 import { computed, onUpdated, reactive, ref, shallowRef, watch, watchEffect } from 'vue'
 import { useSuggestionDbStore } from '../stores/suggestionDatabase'
-import type { QualifiedName } from '../util/qualifiedName'
-import { Filtering } from './ComponentBrowser/filtering'
 
 const MAXIMUM_CLICK_LENGTH_MS = 300
 
@@ -427,20 +425,7 @@ const executionState = computed(() => expressionInfo.value?.payload.type ?? 'Unk
 const suggestionEntry = computed(() => {
   const method = expressionInfo.value?.methodCall?.methodPointer
   if (method == null) return undefined
-  const filtering = new Filtering({
-    pattern: method.name,
-    qualifiedNamePattern: method.module,
-    selfType: method.definedOnType as QualifiedName,
-    showLocal: true,
-    showUnstable: true,
-  })
-  if (filtering == null) return undefined
-  for (const entry of suggestionDbStore.entries.values()) {
-    if (filtering.filter(entry)) {
-      return entry
-    }
-  }
-  return undefined
+  return suggestionDbStore.methodPointerToEntry.get(method.module)?.get(method.name)
 })
 const icon = computed(() => {
   if (suggestionEntry.value?.iconName) {

--- a/app/gui2/src/stores/suggestionDatabase/index.ts
+++ b/app/gui2/src/stores/suggestionDatabase/index.ts
@@ -88,6 +88,7 @@ export const useSuggestionDbStore = defineStore('suggestionDatabase', () => {
   const groups = ref<Group[]>([])
   const methodPointerToEntry = reactive(new Map<string, Map<string, SuggestionEntry>>())
 
+  // FIXME: Replace this inefficient watcher with reactive index, once we have it developed.
   watchEffect(() => {
     methodPointerToEntry.clear()
     for (const entry of entries.values()) {

--- a/app/gui2/src/stores/suggestionDatabase/index.ts
+++ b/app/gui2/src/stores/suggestionDatabase/index.ts
@@ -1,8 +1,9 @@
 import { AsyncQueue, rpcWithRetries } from '@/util/net'
 import { type QualifiedName } from '@/util/qualifiedName'
+import * as map from 'lib0/map'
 import { defineStore } from 'pinia'
 import { LanguageServer } from 'shared/languageServer'
-import { reactive, ref, type Ref } from 'vue'
+import { reactive, ref, watchEffect, type Ref } from 'vue'
 import { useProjectStore } from '../project'
 import { type SuggestionEntry, type SuggestionId } from './entry'
 import { applyUpdates, entryFromLs } from './lsUpdate'
@@ -85,7 +86,20 @@ class Synchronizer {
 export const useSuggestionDbStore = defineStore('suggestionDatabase', () => {
   const entries = reactive(new SuggestionDb())
   const groups = ref<Group[]>([])
+  const methodPointerToEntry = reactive(new Map<string, Map<string, SuggestionEntry>>())
+
+  watchEffect(() => {
+    methodPointerToEntry.clear()
+    for (const entry of entries.values()) {
+      const methodNameToEntry = map.setIfUndefined(
+        methodPointerToEntry,
+        entry.definedIn as string,
+        () => new Map<string, SuggestionEntry>(),
+      )
+      methodNameToEntry.set(entry.name, entry)
+    }
+  })
 
   const synchronizer = new Synchronizer(entries, groups)
-  return { entries, groups, _synchronizer: synchronizer }
+  return { entries, groups, methodPointerToEntry, _synchronizer: synchronizer }
 })

--- a/app/gui2/src/stores/visualization.ts
+++ b/app/gui2/src/stores/visualization.ts
@@ -154,7 +154,6 @@ export const useVisualizationStore = defineStore('visualization', () => {
       type === undefined
         ? allVisualizations
         : visualizationsForType.get(type) ?? visualizationsForAny.value
-    console.log(type, ret, allVisualizations, visualizationsForType, visualizationsForAny)
     return ret
   }
 


### PR DESCRIPTION
### Pull Request Description
- Closes #8015
  - Note that the (few) fallback icons are still present, as most CB entries are still missing icons. *However*, now the `iconName` from the libraries take priority over the fallback icon names.
- Also fixes a minor regression, where nodes pending execution were no longer faded out. This was introduced in #7988 because the wrong CSS variable was set.

### Important Notes
None
### Screenshot

![image](https://github.com/enso-org/enso/assets/4046547/3bb558ca-84f7-4f35-bc38-088c3f4df73a)

![image](https://github.com/enso-org/enso/assets/4046547/bd54fcab-2bd0-4cc5-82db-de055b3b975d)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
