### PR TITLE
Helper method to turn iterator to a Vector

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -73,6 +73,31 @@ type Vector a
 
     ## PRIVATE
        ADVANCED
+       Collects elements of a sequence into a new vector. Various structures can be
+       converted into vector of elements. This helper methods allows to do so in an
+       iterative fashion. Enough to describe how to extract value from current item
+       and how to advance to next item.
+
+       Arguments:
+       - seq: the sequence to process.
+       - element: A function taking the `seq` and follow ups and extracting the value to put into the vector
+       - next: A function to advance to next _item_ of the sequence
+       - limit: maximal number of elements to collect. Defaults to infinity.
+       - stop_at: optional function like `(_==List.Nil)` to check for _end of sequence condition_.
+          By default checks for `Nothing` being the terminal element of a collection.
+
+       > Example
+         Turn a list into a vector.
+             Vector.collect (List.Cons 1 <| List.Cons 2 <| List.Nil) .x .xs stop_at=(_==List.Nil)
+    collect seq element:(Any -> Any) next:(Any->Any) limit:(Integer|Nothing)=Nothing stop_at:(Any->Boolean)=(_==Nothing) =
+        b = Vector.new_builder (if limit.is_nothing then 10 else limit)
+        iterate item remaining = if remaining == 0 || (stop_at item) then b.to_vector else
+            b.append <| element item
+            @Tail_Call iterate (next item) (if remaining.is_nothing then Nothing else remaining-1)
+        iterate seq limit
+
+    ## PRIVATE
+       ADVANCED
 
        Converts an array into a vector by copying content of the array.
 

--- a/test/Tests/src/Data/Vector_Spec.enso
+++ b/test/Tests/src/Data/Vector_Spec.enso
@@ -813,6 +813,20 @@ spec =
             e.length . should_equal 1
             b.at 0 . should_equal 32
 
+        Test.specify "Vector.collect lazy" <|
+            seq = Fib.sequence
+            seq.take 5 . should_equal [1, 1, 2, 3, 5]
+
+        Test.specify "Vector.collect empty list" <|
+            l = List.Nil
+            v = Vector.collect l .x .xs limit=30 stop_at=(_==List.Nil)
+            v . should_equal []
+
+        Test.specify "Vector.collect finite" <|
+            l = List.Cons 1 <| List.Cons 2 <| List.Cons 3 <| List.Nil
+            v = Vector.collect l .x .xs limit=30 stop_at=(_==List.Nil)
+            v . should_equal [1, 2, 3]
+
     Test.group "Vector/Array equality" <|
         v1 = [1, 2, 3]
         a1 = v1.to_array
@@ -864,5 +878,19 @@ spec =
         sliced_vector = v2.slice 0 v.length
         sliced_array = sliced_vector.to_array
         sliced_array
+
+
+
+type Fib
+    Number n:Integer ~next:Fib
+
+    take self limit:Integer = Vector.collect self .n .next limit
+
+    sequence =
+        sum_two seq = Fib.Number seq.n+seq.next.n (sum_two seq.next)
+        start = Fib.Number 1 <| Fib.Number 1 (sum_two start)
+        start
+
+
 
 main = Test_Suite.run_main spec


### PR DESCRIPTION
### Pull Request Description

Often, when dealing with infinite data structures in Enso, I need to `take` first `n`  elements of them. The code is very verbose and complicated. It is not problem to write it, but it spoils [the demo](https://docs.google.com/presentation/d/1Vdy62v12noGaWtdZIhcV6eMtCwZoeCUtnanCVpisXYs). Helper method to simplify the code would be handy.

### Important Notes

Originally I had to write:
```ruby
    take self limit:Integer =
        b = Vector.new_builder limit

        acc fib x = if x == limit then b.to_vector else
            b.append <| fib.n
            @Tail_Call acc fib.next x+1

        acc self 0
```
now I can shorten that to a one liner: 
```ruby
take self limit:Integer = Vector.collect self .n .next limit
```
Not sure how frequent such a use-case can be, but it'd help with all my _infinite data structures_.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the Enso spec
- All code has been tested:
  - [x] Unit tests have been written where possible.
