### PR TITLE
ReactiveDb and ReactiveIndex

### DIFF
--- a/app/gui2/src/stores/suggestionDatabase/entry.ts
+++ b/app/gui2/src/stores/suggestionDatabase/entry.ts
@@ -3,12 +3,15 @@ import type { Doc } from '@/util/docParser'
 import {
   isIdentifier,
   isQualifiedName,
+  qnJoin,
   qnLastSegment,
   qnParent,
   qnSplit,
+  tryQualifiedName,
   type Identifier,
   type QualifiedName,
 } from '@/util/qualifiedName'
+import { unwrap } from '@/util/result'
 import type {
   SuggestionEntryArgument,
   SuggestionEntryScope,
@@ -62,6 +65,19 @@ export interface SuggestionEntry {
   iconName?: string
   /// An index of a group from group list in suggestionDb store this entry belongs to.
   groupIndex?: number
+}
+
+/**
+ * Get the fully qualified name of the `SuggestionEntry`, disregarding reexports.
+ */
+export function entryQn(entry: SuggestionEntry): QualifiedName {
+  if (entry.kind == SuggestionKind.Module) {
+    return entry.definedIn
+  } else if (entry.memberOf) {
+    return qnJoin(entry.memberOf, entry.name)
+  } else {
+    return qnJoin(entry.definedIn, unwrap(tryQualifiedName(entry.name)))
+  }
 }
 
 function makeSimpleEntry(

--- a/app/gui2/src/util/database/__tests__/reactiveDb.test.ts
+++ b/app/gui2/src/util/database/__tests__/reactiveDb.test.ts
@@ -1,0 +1,105 @@
+import { ReactiveDb, ReactiveIndex } from '@/util/database/reactiveDb'
+import { expect, test, vi } from 'vitest'
+import { nextTick, reactive, watch } from 'vue'
+
+test('Basic add/remove', () => {
+  const db = new ReactiveDb()
+  expect(db.size).toEqual(0)
+  db.set('Key 1', 10)
+  db.set('Key 2', 20)
+  expect(db.size).toEqual(2)
+  expect(db.get('Key 1')).toStrictEqual(10)
+  expect(db.get('Key 2')).toStrictEqual(20)
+  db.delete('Key 1')
+  expect(db.size).toEqual(1)
+  expect(db.get('Key 1')).toBeUndefined()
+})
+
+test('Indexing is efficient', () => {
+  const db = new ReactiveDb()
+  const index = new ReactiveIndex(db, (id, entry, index) => index(entry.name, id))
+  const adding = vi.spyOn(index, 'writeToIndex')
+  const removing = vi.spyOn(index, 'removeFromIndex')
+  db.set(1, { name: 'abc' })
+  db.set(2, { name: 'xyz' })
+  db.set(3, { name: 'abc' })
+  db.delete(2)
+  expect(adding).toHaveBeenCalledTimes(3)
+  expect(removing).toHaveBeenCalledTimes(1)
+  db.set(1, { name: 'qdr' })
+  expect(adding).toHaveBeenCalledTimes(4)
+  expect(removing).toHaveBeenCalledTimes(2)
+})
+
+test('Name to id index', () => {
+  const db = new ReactiveDb()
+  const index = new ReactiveIndex(db, (id, entry, index) => index(entry.name, id))
+  db.set(1, { name: 'abc' })
+  db.set(2, { name: 'xyz' })
+  db.set(3, { name: 'abc' })
+  expect(index.lookup('abc')).toEqual(new Set([1, 3]))
+  expect(index.lookup('xyz')).toEqual(new Set([2]))
+  expect(index.lookup('qdr')).toEqual(new Set())
+  expect(index.reverseLookup(1)).toEqual(new Set(['abc']))
+  expect(index.reverseLookup(2)).toEqual(new Set(['xyz']))
+  expect(index.reverseLookup(3)).toEqual(new Set(['abc']))
+
+  db.delete(2)
+  expect(index.lookup('xyz')).toEqual(new Set([]))
+  db.delete(1)
+  expect(index.lookup('abc')).toEqual(new Set([3]))
+  db.set(3, { name: 'qdr' })
+  expect(index.lookup('abc')).toEqual(new Set())
+  expect(index.lookup('qdr')).toEqual(new Set([3]))
+})
+
+test('Parent index', async () => {
+  const db = new ReactiveDb()
+  const qnIndex = reactive(
+    new ReactiveIndex(db, (id, entry, index) => {
+      console.log('index qnIndex')
+      index(entry.name, id)
+    }),
+  )
+  const children = new ReactiveIndex(db, (id, entry, index, onDelete) => {
+    console.log('index children')
+    const stop = watch(
+      qnIndex,
+      (qnIndex) => {
+        qnIndex.lookup(entry.definedIn).forEach((parentId) => index(parentId, id))
+      },
+      { immediate: true },
+    )
+    onDelete(() => stop())
+  })
+  //const lookupQn = vi.spyOn(qnIndex, 'lookup')
+  //const adding = vi.spyOn(children, 'writeToIndex')
+  //const removing = vi.spyOn(children, 'removeFromIndex')
+  db.set(1, { name: 'foo', definedIn: 'A' })
+  db.set(2, { name: 'A' })
+  db.set(3, { name: 'bar', definedIn: 'A' })
+  await nextTick()
+  expect(qnIndex.lookup('foo')).toEqual(new Set([1]))
+  expect(qnIndex.lookup('A')).toEqual(new Set([2]))
+  expect(qnIndex.lookup('bar')).toEqual(new Set([3]))
+  // expect(children.lookup(1)).toEqual(new Set())
+  // expect(children.lookup(2)).toEqual(new Set([1, 3]))
+  // expect(children.lookup(3)).toEqual(new Set())
+  // expect(children.reverseLookup(1)).toStrictEqual(new Set([2]))
+  // expect(children.reverseLookup(2)).toEqual(new Set())
+  // expect(children.reverseLookup(3)).toStrictEqual(new Set([2]))
+  //expect(adding).toHaveBeenCalledTimes(2)
+  //expect(removing).toHaveBeenCalledTimes(0)
+  //expect(lookupQn).toHaveBeenCalledTimes(5)
+
+  db.delete(3)
+  await nextTick()
+  expect(qnIndex.lookup('foo')).toEqual(new Set([1]))
+  expect(qnIndex.lookup('A')).toEqual(new Set([2]))
+  expect(qnIndex.lookup('bar')).toEqual(new Set([]))
+  // expect(children.lookup(2)).toEqual(new Set([1]))
+  // expect(children.reverseLookup(3)).toEqual(new Set())
+  // expect(adding).toHaveBeenCalledTimes(2)
+  // expect(removing).toHaveBeenCalledTimes(1)
+  // expect(lookupQn).toHaveBeenCalledTimes(5)
+})

--- a/app/gui2/src/util/database/__tests__/reactiveDb.test.ts
+++ b/app/gui2/src/util/database/__tests__/reactiveDb.test.ts
@@ -1,6 +1,6 @@
 import { ReactiveDb, ReactiveIndex } from '@/util/database/reactiveDb'
 import { expect, test, vi } from 'vitest'
-import { nextTick, reactive, watch } from 'vue'
+import { nextTick, reactive } from 'vue'
 
 test('Basic add/remove', () => {
   const db = new ReactiveDb()
@@ -17,23 +17,28 @@ test('Basic add/remove', () => {
 
 test('Indexing is efficient', () => {
   const db = new ReactiveDb()
-  const index = new ReactiveIndex(db, (id, entry, index) => index(entry.name, id))
+  const index = new ReactiveIndex(db, (id, entry) => [[entry.name, id]])
   const adding = vi.spyOn(index, 'writeToIndex')
   const removing = vi.spyOn(index, 'removeFromIndex')
-  db.set(1, { name: 'abc' })
-  db.set(2, { name: 'xyz' })
-  db.set(3, { name: 'abc' })
+  db.set(1, reactive({ name: 'abc' }))
+  db.set(2, reactive({ name: 'xyz' }))
+  db.set(3, reactive({ name: 'abc' }))
   db.delete(2)
   expect(adding).toHaveBeenCalledTimes(3)
   expect(removing).toHaveBeenCalledTimes(1)
   db.set(1, { name: 'qdr' })
   expect(adding).toHaveBeenCalledTimes(4)
   expect(removing).toHaveBeenCalledTimes(2)
+  db.get(3).name = 'xyz'
+  expect(adding).toHaveBeenCalledTimes(4)
+  expect(removing).toHaveBeenCalledTimes(2)
+  expect(index.lookup('qdr')).toEqual(new Set([1]))
+  expect(index.lookup('xyz')).toEqual(new Set([3]))
 })
 
 test('Name to id index', () => {
   const db = new ReactiveDb()
-  const index = new ReactiveIndex(db, (id, entry) => new Map([[entry.name, id]]))
+  const index = new ReactiveIndex(db, (id, entry) => [[entry.name, id]])
   db.set(1, { name: 'abc' })
   db.set(2, { name: 'xyz' })
   db.set(3, { name: 'abc' })
@@ -55,50 +60,40 @@ test('Name to id index', () => {
 
 test('Parent index', async () => {
   const db = new ReactiveDb()
-  const qnIndex = 
-    new ReactiveIndex(db, (id, entry, index) => {
-      console.log('index qnIndex')
-      index(entry.name, id)
-    })
-  const children = new ReactiveIndex(db, (id, entry, index, onDelete) => {
-    console.log('index children')
-    const stop = watch(
-      () => qnIndex,
-      (qnIndex) => {
-        qnIndex.lookup(entry.definedIn).forEach((parentId) => index(parentId, id))
-      },
-      { immediate: true },
-    )
-    onDelete(() => stop())
+  const qnIndex = new ReactiveIndex(db, (id, entry) => [[entry.name, id]])
+
+  const parent = new ReactiveIndex(db, (id, entry) => {
+    if (entry.definedIn) {
+      const parents = Array.from(qnIndex.lookup(entry.definedIn))
+      return Array.from(parents.map((parent) => [id, parent]))
+    }
+    return []
   })
-  //const lookupQn = vi.spyOn(qnIndex, 'lookup')
-  //const adding = vi.spyOn(children, 'writeToIndex')
-  //const removing = vi.spyOn(children, 'removeFromIndex')
+  const lookupQn = vi.spyOn(qnIndex, 'lookup')
+  const adding = vi.spyOn(parent, 'writeToIndex')
+  const removing = vi.spyOn(parent, 'removeFromIndex')
   db.set(1, { name: 'foo', definedIn: 'A' })
   db.set(2, { name: 'A' })
   db.set(3, { name: 'bar', definedIn: 'A' })
-  await nextTick()
+
   expect(qnIndex.lookup('foo')).toEqual(new Set([1]))
   expect(qnIndex.lookup('A')).toEqual(new Set([2]))
   expect(qnIndex.lookup('bar')).toEqual(new Set([3]))
-  // expect(children.lookup(1)).toEqual(new Set())
-  // expect(children.lookup(2)).toEqual(new Set([1, 3]))
-  // expect(children.lookup(3)).toEqual(new Set())
-  // expect(children.reverseLookup(1)).toStrictEqual(new Set([2]))
-  // expect(children.reverseLookup(2)).toEqual(new Set())
-  // expect(children.reverseLookup(3)).toStrictEqual(new Set([2]))
-  //expect(adding).toHaveBeenCalledTimes(2)
-  //expect(removing).toHaveBeenCalledTimes(0)
-  //expect(lookupQn).toHaveBeenCalledTimes(5)
+  expect(parent.lookup(1)).toEqual(new Set([2]))
+  expect(parent.lookup(2)).toEqual(new Set())
+  expect(parent.lookup(3)).toEqual(new Set([2]))
+  expect(parent.reverseLookup(1)).toStrictEqual(new Set())
+  expect(parent.reverseLookup(2)).toEqual(new Set([1, 3]))
+  expect(parent.reverseLookup(3)).toStrictEqual(new Set())
+  expect(adding).toHaveBeenCalledTimes(2)
+  expect(removing).toHaveBeenCalledTimes(0)
+  expect(lookupQn).toHaveBeenCalledTimes(6)
 
   db.delete(3)
   await nextTick()
-  expect(qnIndex.lookup('foo')).toEqual(new Set([1]))
-  expect(qnIndex.lookup('A')).toEqual(new Set([2]))
-  expect(qnIndex.lookup('bar')).toEqual(new Set([]))
-  // expect(children.lookup(2)).toEqual(new Set([1]))
-  // expect(children.reverseLookup(3)).toEqual(new Set())
-  // expect(adding).toHaveBeenCalledTimes(2)
-  // expect(removing).toHaveBeenCalledTimes(1)
-  // expect(lookupQn).toHaveBeenCalledTimes(5)
+  expect(parent.lookup(3)).toEqual(new Set())
+  expect(parent.reverseLookup(2)).toEqual(new Set([1]))
+  expect(adding).toHaveBeenCalledTimes(2)
+  expect(removing).toHaveBeenCalledTimes(1)
+  expect(lookupQn).toHaveBeenCalledTimes(6)
 })

--- a/app/gui2/src/util/database/__tests__/reactiveDb.test.ts
+++ b/app/gui2/src/util/database/__tests__/reactiveDb.test.ts
@@ -33,7 +33,7 @@ test('Indexing is efficient', () => {
 
 test('Name to id index', () => {
   const db = new ReactiveDb()
-  const index = new ReactiveIndex(db, (id, entry, index) => index(entry.name, id))
+  const index = new ReactiveIndex(db, (id, entry) => new Map([[entry.name, id]]))
   db.set(1, { name: 'abc' })
   db.set(2, { name: 'xyz' })
   db.set(3, { name: 'abc' })
@@ -55,16 +55,15 @@ test('Name to id index', () => {
 
 test('Parent index', async () => {
   const db = new ReactiveDb()
-  const qnIndex = reactive(
+  const qnIndex = 
     new ReactiveIndex(db, (id, entry, index) => {
       console.log('index qnIndex')
       index(entry.name, id)
-    }),
-  )
+    })
   const children = new ReactiveIndex(db, (id, entry, index, onDelete) => {
     console.log('index children')
     const stop = watch(
-      qnIndex,
+      () => qnIndex,
       (qnIndex) => {
         qnIndex.lookup(entry.definedIn).forEach((parentId) => index(parentId, id))
       },

--- a/app/gui2/src/util/database/__tests__/reactiveDb.test.ts
+++ b/app/gui2/src/util/database/__tests__/reactiveDb.test.ts
@@ -36,6 +36,18 @@ test('Indexing is efficient', () => {
   expect(index.lookup('xyz')).toEqual(new Set([3]))
 })
 
+test('Error reported when indexer implementation returns non-unique pairs', () => {
+  const db = new ReactiveDb()
+  const consoleError = vi.spyOn(console, 'error')
+  const _invalidIndex = new ReactiveIndex(db, (_id, _entry) => [[1, 1]])
+  db.set(1, 1)
+  db.set(2, 2)
+  expect(consoleError).toHaveBeenCalledOnce()
+  expect(consoleError).toHaveBeenCalledWith(
+    'Attempt to repeatedly write the same key-value pair (1,1) to the index. Please check your indexer implementation.',
+  )
+})
+
 test('Name to id index', () => {
   const db = new ReactiveDb()
   const index = new ReactiveIndex(db, (id, entry) => [[entry.name, id]])

--- a/app/gui2/src/util/database/reactiveDb.ts
+++ b/app/gui2/src/util/database/reactiveDb.ts
@@ -154,6 +154,14 @@ export class ReactiveIndex<K, V, IK, IV> {
    */
   writeToIndex(key: IK, value: IV): void {
     const forward = setIfUndefined(this.forward, key, () => new Set())
+    if (forward.has(value)) {
+      console.error(
+        `Attempt to repeatedly write the same key-value pair (${[
+          key,
+          value,
+        ]}) to the index. Please check your indexer implementation.`,
+      )
+    }
     forward.add(value)
     const reverse = setIfUndefined(this.reverse, value, () => new Set())
     reverse.add(key)

--- a/app/gui2/src/util/database/reactiveDb.ts
+++ b/app/gui2/src/util/database/reactiveDb.ts
@@ -85,6 +85,15 @@ export class ReactiveDb<K, V> extends ObservableV2<{
   get size(): number {
     return this.internal.size
   }
+
+  /**
+   * Retrieves an iterator over entries in the database, equivalent to `Map.entries`.
+   *
+   * @returns An iterator that yields key-value pairs in the database.
+   */
+  entries(): IterableIterator<[K, V]> {
+    return this.internal.entries()
+  }
 }
 
 /**

--- a/app/gui2/src/util/database/reactiveDb.ts
+++ b/app/gui2/src/util/database/reactiveDb.ts
@@ -1,126 +1,188 @@
-/*
-   Reactive-friendly key-value database.
+/**
+ * Tools for managing reactive key-value databases.
+ *
+ * 1. `ReactiveDb`: This is a reactivity-friendly database that serves as a thin adapter around a standard `Map`.
+ *    It offers the basic functionality of a `Map` while also emitting events that allow observers to track changes efficiently.
+ *
+ * 2. `ReactiveIndex`: This is an abstraction, that allows constructing arbitrary database indexes.
+ *    Indexes update reactively, can depend on each other, and defer updates until the next lookup for efficiency.
+ */
 
-   `ReactiveDb` is a database itself, a thin adapter around ordinary `Map`.
-
-   `ReactiveIndex` is an abstraction for building arbitrary database indexing with reactive updates.
-*/
-
+import { LazySyncEffectSet } from '@/util/reactivity'
 import { setIfUndefined } from 'lib0/map'
 import { ObservableV2 } from 'lib0/observable'
-import { reactive, watch } from 'vue'
+import { reactive } from 'vue'
 
-export type CleanupFn = (() => void) | null
-export type OnCleanup = (cleanupFn: CleanupFn) => void
+export type OnDelete = (cleanupFn: () => void) => void
 
-export class ReactiveDb<Key, Value> extends ObservableV2<{
-  entryAdded(key: Key, value: Value, onCleanup: OnCleanup): void
+/**
+ * Represents a reactive database adapter that extends the behaviors of `Map`.
+ * It emits an `entryAdded` event when a new entry is added to the database,
+ * facilitating reactive tracking of database insertions and deletions.
+ *
+ * @typeParam K - The key type for the database entries.
+ * @typeParam V - The value type for the database entries.
+ */
+export class ReactiveDb<K, V> extends ObservableV2<{
+  entryAdded(key: K, value: V, onDelete: OnDelete): void
 }> {
-  internal: Map<Key, Value>
-  onCleanup: Map<Key, CleanupFn>
+  internal: Map<K, V>
+  onDelete: Map<K, Set<() => void>>
+
   constructor() {
     super()
     this.internal = new Map()
-    this.onCleanup = new Map()
+    this.onDelete = new Map()
   }
-  /* Same as `Map.set`. Also emits `entryAdded` event. */
-  set(key: Key, value: Value) {
-    if (this.internal.has(key)) {
-      this.delete(key)
-    }
+
+  /**
+   * Sets a new key-value pair in the database, equivalent to `Map.set`.
+   * The function also emits an `entryAdded` event after the addition.
+   *
+   * @param key - The key for the new entry.
+   * @param value - The value for the new entry.
+   */
+  set(key: K, value: V) {
+    // Trigger a reactive update when replacing one entry with another.
+    this.delete(key)
+
     this.internal.set(key, value)
-    const onCleanup: OnCleanup = (callback) => {
-      this.onCleanup.set(key, callback)
+    const onDelete: OnDelete = (callback) => {
+      const callbacks = setIfUndefined(this.onDelete, key, () => new Set())
+      callbacks.add(callback)
     }
-    this.emit('entryAdded', [key, value, onCleanup])
+    this.emit('entryAdded', [key, value, onDelete])
   }
-  /* Same as `Map.get` */
-  get(key: Key): Value | undefined {
+
+  /**
+   * Retrieves the value corresponding to a specified key in the database, equivalent to `Map.get`.
+   *
+   * @param key - The key for which to retrieve the value.
+   * @returns The value associated with the key, or undefined if the key is not found.
+   */
+  /** Same as `Map.get` */
+  get(key: K): V | undefined {
     return this.internal.get(key)
   }
-  /* Same as `Map.delete` */
-  delete(key: Key): boolean {
-    const callback = this.onCleanup.get(key)
-    if (callback) {
-      callback()
-      this.onCleanup.delete(key)
-    }
+
+  /**
+   * Deletes the key-value pair identified by the specified key from the database, equivalent to `Map.delete`.
+   *
+   * @param key - The key for which to delete the corresponding key-value pair.
+   * @returns True if the deletion was successful, or false if the key was not found.
+   */
+  delete(key: K): boolean {
+    this.onDelete.get(key)?.forEach((callback) => callback())
+    this.onDelete.delete(key)
     return this.internal.delete(key)
   }
-  /* Same as `Map.size` */
+
+  /**
+   * Retrieves the number of key-value pairs currently in the database, equivalent to `Map.size`.
+   *
+   * @returns The number of key-value pairs in the database.
+   */
   get size(): number {
     return this.internal.size
   }
 }
 
-export type IndexFn<IndexKey, IndexValue> = (key: IndexKey, value: IndexValue) => void
-export type Indexer<Key, Value, IndexKey, IndexValue> = (
-  key: Key,
-  value: Value,
-  index: IndexFn<IndexKey, IndexValue>,
-  onDelete: OnCleanup,
-) => void
+/**
+ * A function type representing an indexer for a `ReactiveDb`.
+ *
+ * An `Indexer` takes a key-value pair from the `ReactiveDb` and produces an array of index key-value pairs,
+ * defining how the input key and value maps to keys and values in the index.
+ *
+ * @param key - The key from the `ReactiveDb`.
+ * @param value - The value from the `ReactiveDb`.
+ *
+ * @returns An Array representing multiple key-value pair(s) ([IK, IV]) for the index.
+ */
+export type Indexer<K, V, IK, IV> = (key: K, value: V) => [IK, IV][]
 
-/* Automatic indexing facility for `ReactiveDb` */
-export class ReactiveIndex<Key, Value, IndexKey, IndexValue> {
-  forward: Map<IndexKey, Set<IndexValue>>
-  reverse: Map<IndexValue, Set<IndexKey>>
-  indexer: Indexer | null
-  constructor(db: ReactiveDb<Key, Value>, indexer: Indexer<Key, Value, IndexKey, IndexValue>) {
+/**
+ * Provides automatic indexing for a `ReactiveDb` instance.
+ * Utilizes both forward and reverse mapping for efficient lookups and reverse lookups.
+ *
+ * @typeParam K - The key type of the ReactiveDb.
+ * @typeParam V - The value type of the ReactiveDb.
+ * @typeParam IK - The key type of the index.
+ * @typeParam IV - The value type of the index.
+ */
+export class ReactiveIndex<K, V, IK, IV> {
+  /** Forward map from index keys to a set of index values */
+  forward: Map<IK, Set<IV>>
+  /** Reverse map from index values to a set of index keys */
+  reverse: Map<IV, Set<IK>>
+  /** Collections of effects to sync data between ReactiveDB and ReactiveIndex */
+  effects: LazySyncEffectSet
+
+  /**
+   * Constructs a new ReactiveIndex for the given ReactiveDb and an indexer function.
+   *
+   * @param db - The ReactiveDb to index.
+   * @param indexer - The indexer function defining how db keys and values map to index keys and values.
+   */
+  constructor(db: ReactiveDb<K, V>, indexer: Indexer<K, V, IK, IV>) {
     this.forward = reactive(new Map())
     this.reverse = reactive(new Map())
-	this.indexer = indexer
+    this.effects = new LazySyncEffectSet()
     db.on('entryAdded', (key, value, onDelete) => {
-      const keyValues = indexer(key, value)
-	  const stop = watch(() => indexer(key, value),
-						 (keyValues, _, cleanup) => {
-						   keyValues.forEach((value, key) => {
-							 this.writeToIndex(key, value)
-						   })
-						   cleanup(() => keyValues.forEach((value, key) => this.removeFromIndex(key, value)))
-						 }, { immediate: true })
-	  onDelete(() => stop())
+      const stopEffect = this.effects.lazyEffect((onCleanup) => {
+        const keyValues = indexer(key, value)
+        keyValues.forEach(([key, value]) => this.writeToIndex(key, value))
+        onCleanup(() => keyValues.forEach(([key, value]) => this.removeFromIndex(key, value)))
+      })
+      onDelete(() => stopEffect())
     })
   }
-  updateEntryIndex(closure: () => Map<IndexKey, IndexValue>) {
-	const stop = watch(closure, (keyValues, _, onCleanup) => {
-	  keyValues.forEach((value, key) => {
-		this.writeToIndex(key, value)
-	  })
-	  onCleanup(() => {
-		keyValues.forEach((value, key) => this.removeFromIndex(key, value))
-		stop()
-		invalidatedClosures.add(closure)
-	  })
 
-	  
-	}, { immediate: true, flush: 'sync' })
-  }
-  flush() {
-	runAllInvalidatedClosures()
-  }
-  /* Internal method for adding a new key-value relation to the index. */
-  writeToIndex(key: IndexKey, value: IndexValue): void {
+  /**
+   * Adds a new key-value pair to the forward and reverse index.
+   *
+   * @param key - The key to add to the index.
+   * @param value - The value to associate with the key.
+   */
+  writeToIndex(key: IK, value: IV): void {
     const forward = setIfUndefined(this.forward, key, () => new Set())
     forward.add(value)
     const reverse = setIfUndefined(this.reverse, value, () => new Set())
     reverse.add(key)
   }
-  /* Internal method for removing a certain key-value relation from the index */
-  removeFromIndex(key: IndexKey, value: IndexValue): void {
-    // @ts-ignore
-    const remove = (map, key, value) => {
+
+  /**
+   * Removes a key-value pair from the forward and reverse index.
+   *
+   * @param key - The key to remove from the index.
+   * @param value - The value associated with the key.
+   */
+  removeFromIndex(key: IK, value: IV): void {
+    const remove = <K, V>(map: Map<K, Set<V>>, key: K, value: V) => {
       map.get(key)?.delete(value)
     }
     remove(this.forward, key, value)
     remove(this.reverse, value, key)
   }
-  /* Look for key in the forward index. */
-  lookup(key: IndexKey): Set<IndexValue> {
+
+  /** Look for key in the forward index. */ /**
+   * Returns a set of values associated with the given index key.
+   *
+   * @param key - The index key to look up values for.
+   * @return A set of values corresponding to the key or an empty set if the key is not present in the index.
+   */
+  lookup(key: IK): Set<IV> {
+    this.effects.flush()
     return this.forward.get(key) ?? new Set()
   }
-  /* Look for value in the reverse index, returning a set of all keys with this value. */
-  reverseLookup(value: IndexValue): Set<IndexKey> {
+
+  /**
+   * Returns a set of keys associated with the given index value.
+   *
+   * @param value - The index value to reverse look up keys for.
+   * @return A set of keys corresponding to the value or an empty set if the value is not present in the index.
+   */
+  reverseLookup(value: IV): Set<IK> {
+    this.effects.flush()
     return this.reverse.get(value) ?? new Set()
   }
 }

--- a/app/gui2/src/util/database/reactiveDb.ts
+++ b/app/gui2/src/util/database/reactiveDb.ts
@@ -1,0 +1,110 @@
+/*
+   Reactive-friendly key-value database.
+
+   `ReactiveDb` is a database itself, a thin adapter around ordinary `Map`.
+
+   `ReactiveIndex` is an abstraction for building arbitrary database indexing with reactive updates.
+*/
+
+import { setIfUndefined } from 'lib0/map'
+import { ObservableV2 } from 'lib0/observable'
+import { reactive } from 'vue'
+
+export type CleanupFn = (() => void) | null
+export type OnCleanup = (cleanupFn: CleanupFn) => void
+
+export class ReactiveDb<Key, Value> extends ObservableV2<{
+  entryAdded(key: Key, value: Value, onCleanup: OnCleanup): void
+}> {
+  internal: Map<Key, Value>
+  onCleanup: Map<Key, CleanupFn>
+  constructor() {
+    super()
+    this.internal = new Map()
+    this.onCleanup = new Map()
+  }
+  /* Same as `Map.set`. Also emits `entryAdded` event. */
+  set(key: Key, value: Value) {
+    if (this.internal.has(key)) {
+      this.delete(key)
+    }
+    this.internal.set(key, value)
+    const onCleanup: OnCleanup = (callback) => {
+      this.onCleanup.set(key, callback)
+    }
+    this.emit('entryAdded', [key, value, onCleanup])
+  }
+  /* Same as `Map.get` */
+  get(key: Key): Value | undefined {
+    return this.internal.get(key)
+  }
+  /* Same as `Map.delete` */
+  delete(key: Key): boolean {
+    const callback = this.onCleanup.get(key)
+    if (callback) {
+      callback()
+      this.onCleanup.delete(key)
+    }
+    return this.internal.delete(key)
+  }
+  /* Same as `Map.size` */
+  get size(): number {
+    return this.internal.size
+  }
+}
+
+export type IndexFn<IndexKey, IndexValue> = (key: IndexKey, value: IndexValue) => void
+export type Indexer<Key, Value, IndexKey, IndexValue> = (
+  key: Key,
+  value: Value,
+  index: IndexFn<IndexKey, IndexValue>,
+  onDelete: OnCleanup,
+) => void
+
+/* Automatic indexing facility for `ReactiveDb` */
+export class ReactiveIndex<Key, Value, IndexKey, IndexValue> {
+  forward: Map<IndexKey, Set<IndexValue>>
+  reverse: Map<IndexValue, Set<IndexKey>>
+  constructor(db: ReactiveDb<Key, Value>, indexer: Indexer<Key, Value, IndexKey, IndexValue>) {
+    this.forward = reactive(new Map())
+    this.reverse = reactive(new Map())
+    db.on('entryAdded', (key, value, onDelete) => {
+      let indexOnDeleteCb: CleanupFn = null
+      const index: IndexFn<IndexKey, IndexValue> = (key, value) => {
+        this.writeToIndex(key, value)
+        onDelete(() => {
+          if (indexOnDeleteCb) indexOnDeleteCb()
+          this.removeFromIndex(key, value)
+        })
+      }
+      const userOnDelete: OnCleanup = (callback) => {
+        indexOnDeleteCb = callback
+      }
+      indexer(key, value, index, userOnDelete)
+    })
+  }
+  /* Internal method for adding a new key-value relation to the index. */
+  writeToIndex(key: IndexKey, value: IndexValue): void {
+    const forward = setIfUndefined(this.forward, key, () => new Set())
+    forward.add(value)
+    const reverse = setIfUndefined(this.reverse, value, () => new Set())
+    reverse.add(key)
+  }
+  /* Internal method for removing a certain key-value relation from the index */
+  removeFromIndex(key: IndexKey, value: IndexValue): void {
+    // @ts-ignore
+    const remove = (map, key, value) => {
+      map.get(key)?.delete(value)
+    }
+    remove(this.forward, key, value)
+    remove(this.reverse, value, key)
+  }
+  /* Look for key in the forward index. */
+  lookup(key: IndexKey): Set<IndexValue> {
+    return this.forward.get(key) ?? new Set()
+  }
+  /* Look for value in the reverse index, returning a set of all keys with this value. */
+  reverseLookup(value: IndexValue): Set<IndexKey> {
+    return this.reverse.get(value) ?? new Set()
+  }
+}

--- a/app/gui2/src/util/database/reactiveDb.ts
+++ b/app/gui2/src/util/database/reactiveDb.ts
@@ -181,7 +181,7 @@ export class ReactiveIndex<K, V, IK, IV> {
     remove(this.reverse, value, key)
   }
 
-  /** Look for key in the forward index. */ /**
+  /** Look for key in the forward index.
    * Returns a set of values associated with the given index key.
    *
    * @param key - The index key to look up values for.

--- a/app/gui2/src/util/reactivity.ts
+++ b/app/gui2/src/util/reactivity.ts
@@ -30,8 +30,8 @@ export type StopEffect = () => void
  * until next time that data structure is queried.
  */
 export class LazySyncEffectSet {
-  private dirtyRunners = new Set<() => void>()
-  private scope = effectScope()
+  dirtyRunners = new Set<() => void>()
+  scope = effectScope()
 
   /**
    * Add an effect to the lazy set. The effect will run once immediately, and any subsequent runs

--- a/app/gui2/src/util/reactivity.ts
+++ b/app/gui2/src/util/reactivity.ts
@@ -1,4 +1,15 @@
-import { computed, isRef, type Ref, type WatchSource } from 'vue'
+import { nop } from 'lib0/function'
+import {
+  callWithErrorHandling,
+  computed,
+  effect,
+  effectScope,
+  isRef,
+  reactive,
+  ref,
+  type Ref,
+  type WatchSource,
+} from 'vue'
 
 /** Cast watch source to an observable ref. */
 export function watchSourceToRef<T>(src: WatchSource<T>): Ref<T> {
@@ -8,4 +19,224 @@ export function watchSourceToRef<T>(src: WatchSource<T>): Ref<T> {
 /** Get the value behind a watch source at the current time. */
 export function evalWatchSource<T>(src: WatchSource<T>): T {
   return isRef(src) ? src.value : src()
+}
+
+/**
+ * A set of effects that will defer their re-execution until an explicit flush. This is useful for
+ * implementing incremental updates to an external data structure, while delaying the update logic
+ * until next time that data structure is queried.
+ */
+export class LazySyncEffectSet {
+  private dirtyRunners = new Set<() => void>()
+  private scope = effectScope()
+
+  /**
+   * Add an effect to the lazy set. The effect will run once immediately, and any subsequent runs
+   * will be delayed until the next flush. Only effects that were notified about a dependency change
+   * will be re-run on flush.
+   *
+   * Returns a function that can be used to manually stop the effect.
+   */
+  lazyEffect(fn: (onCleanup: (cleanupFn: () => void) => void) => void): () => void {
+    return (
+      this.scope.run(() => {
+        let dirty = true
+        let userCleanup: (() => void) | null = null
+        const callUserCleanup = () => {
+          if (userCleanup != null) {
+            callWithErrorHandling(userCleanup, null, 4 /* ErrorCodes.WATCH_CLEANUP */)
+            userCleanup = null
+          }
+        }
+
+        function onCleanup(cleanupFn: () => void) {
+          userCleanup = cleanupFn
+        }
+
+        const runner = effect(
+          () => {
+            if (dirty) {
+              dirty = false
+              callUserCleanup()
+              fn(onCleanup)
+            }
+          },
+          {
+            scheduler: () => {
+              if (!dirty) {
+                dirty = true
+                this.dirtyRunners.add(runner)
+              }
+            },
+            onStop: () => {
+              this.dirtyRunners.delete(runner)
+              callUserCleanup()
+            },
+          },
+        )
+        return () => runner.effect.stop()
+      }) ?? nop
+    )
+  }
+
+  /**
+   * Run all effects that are currently dirty. In case any effect causes other effects to become
+   * dirty, they will be rerun during the same flush.
+   */
+  flush() {
+    while (this.dirtyRunners.size !== 0) {
+      const runners = [...this.dirtyRunners]
+      this.dirtyRunners.clear()
+      for (let i = 0; i < runners.length; ++i) runners[i]!()
+    }
+  }
+
+  // Immediately stops all effects and clears the dirty set.
+  stop() {
+    this.scope.stop()
+  }
+}
+
+if (import.meta.vitest) {
+  const { test, expect, vi } = import.meta.vitest
+
+  test('LazySyncEffectSet', () => {
+    const lazySet = new LazySyncEffectSet()
+
+    const key1 = ref(0)
+    const key2 = ref(100)
+    const lazilyUpdatedMap = reactive(new Map<number, string>())
+
+    let runCount = 0
+    const stopA = lazySet.lazyEffect((onCleanup) => {
+      const currentValue = key1.value
+      lazilyUpdatedMap.set(currentValue, 'a' + runCount++)
+      onCleanup(() => lazilyUpdatedMap.delete(currentValue))
+    })
+
+    lazySet.lazyEffect((onCleanup) => {
+      const currentValue = key2.value
+      lazilyUpdatedMap.set(currentValue, 'b' + runCount++)
+      onCleanup(() => lazilyUpdatedMap.delete(currentValue))
+    })
+
+    // Dependant watcher, notices when -1 key is inserted into the map by another effect.
+    const cleanupSpy = vi.fn()
+    lazySet.lazyEffect((onCleanup) => {
+      const negOne = lazilyUpdatedMap.get(-1)
+      if (negOne != null) {
+        lazilyUpdatedMap.set(-2, `noticed ${negOne}!`)
+        onCleanup(() => {
+          cleanupSpy()
+          lazilyUpdatedMap.delete(-2)
+        })
+      }
+    })
+
+    expect(lazilyUpdatedMap, 'The effects should run immediately after registration').toEqual(
+      new Map([
+        [0, 'a0'],
+        [100, 'b1'],
+      ]),
+    )
+
+    key1.value = 1
+    expect(lazilyUpdatedMap, 'The effects should not perform any updates until flush').toEqual(
+      new Map([
+        [0, 'a0'],
+        [100, 'b1'],
+      ]),
+    )
+
+    key1.value = 2
+    lazySet.flush()
+    expect(
+      lazilyUpdatedMap,
+      'A cleanup and update should run on flush, but only for the updated key',
+    ).toEqual(
+      new Map([
+        [2, 'a2'],
+        [100, 'b1'],
+      ]),
+    )
+
+    key1.value = 3
+    key2.value = 103
+    stopA()
+    expect(
+      lazilyUpdatedMap,
+      'Stop should immediately trigger cleanup, but only for stopped effect',
+    ).toEqual(new Map([[100, 'b1']]))
+
+    lazySet.flush()
+    expect(
+      lazilyUpdatedMap,
+      'Flush should trigger remaining updates, but not run the stopped watchers',
+    ).toEqual(new Map([[103, 'b3']]))
+
+    key1.value = 4
+    key2.value = 104
+    lazySet.lazyEffect((onCleanup) => {
+      const currentValue = key1.value
+      lazilyUpdatedMap.set(currentValue, 'c' + runCount++)
+      onCleanup(() => lazilyUpdatedMap.delete(currentValue))
+    })
+    expect(
+      lazilyUpdatedMap,
+      'Newly registered effect should run immediately, but not flush other effects',
+    ).toEqual(
+      new Map([
+        [4, 'c4'],
+        [103, 'b3'],
+      ]),
+    )
+
+    key1.value = 5
+    key2.value = 105
+    lazySet.flush()
+    expect(
+      lazilyUpdatedMap,
+      'Flush should trigger both effects when their dependencies change',
+    ).toEqual(
+      new Map([
+        [105, 'b5'],
+        [5, 'c6'],
+      ]),
+    )
+
+    lazySet.flush()
+    expect(lazilyUpdatedMap, 'Flush should have no effect when no dependencies changed').toEqual(
+      new Map([
+        [105, 'b5'],
+        [5, 'c6'],
+      ]),
+    )
+
+    key2.value = -1
+    lazySet.flush()
+    expect(
+      lazilyUpdatedMap,
+      'Effects depending on one another should run in the same flush',
+    ).toEqual(
+      new Map([
+        [5, 'c6'],
+        [-1, 'b7'],
+        [-2, 'noticed b7!'],
+      ]),
+    )
+
+    key2.value = 1
+    lazySet.flush()
+    expect(cleanupSpy).toHaveBeenCalledTimes(1)
+    expect(lazilyUpdatedMap, 'Dependant watcher is cleaned up.').toEqual(
+      new Map([
+        [1, 'b8'],
+        [5, 'c6'],
+      ]),
+    )
+
+    key2.value = 2
+    lazySet.flush()
+    expect(cleanupSpy, 'Cleanup runs only once.').toHaveBeenCalledTimes(1)
+  })
 }


### PR DESCRIPTION
### Pull Request Description

SuggestionDb refactoring to facilitate documentation panel development and other features. 

Now SuggestionDb uses `ReactiveDb` + `ReactiveIndex`es under the hood. There are no visual changes to the IDE. Everything still works the same. 

You can now use two reactive indexes built on top of the SuggestionDb:
1. `db.nameToId` is a `QualifiedName→SuggestionId` relation. Reverse lookup allows you to get the qualified name by ID.
2. `db.parent` is a `SuggestionId→SuggestionId` relation, representing parent-children relations between entries. The rules are the following:
  - If the `memberOf` field is present, it is used as a parent.
  - Otherwise, a parent’s qualified name is used (through the `qnParent` function)
  You can use reverse lookup to get the children of the entry. 

You can easily add your own indexes if needed.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
