### PR TITLE
Avoid null values in constant node

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/constant/ConstantObjectNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/constant/ConstantObjectNode.java
@@ -2,6 +2,7 @@ package org.enso.interpreter.node.expression.constant;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
+import java.util.Objects;
 import org.enso.interpreter.node.ExpressionNode;
 
 /** Represents a compile-time constant. */
@@ -10,7 +11,7 @@ public class ConstantObjectNode extends ExpressionNode {
   private final Object object;
 
   private ConstantObjectNode(Object object) {
-    this.object = object;
+    this.object = Objects.requireNonNull(object);
   }
 
   /**

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -1695,7 +1695,7 @@ class IrToTruffle(
             .getPolyglotSymbol(name)
           if (s == null) {
             throw new CompilerError(
-              s"No polyglot symbol for ${name}"
+              s"No polyglot field for ${name}"
             )
           }
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -1678,19 +1678,28 @@ class IrToTruffle(
             module.unsafeAsModule().getScope.getAssociatedType
           )
         case BindingsMap.ResolvedPolyglotSymbol(module, symbol) =>
-          ConstantObjectNode.build(
-            module
-              .unsafeAsModule()
-              .getScope
-              .getPolyglotSymbol(symbol.name)
-          )
+          val s = module
+            .unsafeAsModule()
+            .getScope
+            .getPolyglotSymbol(symbol.name)
+          if (s == null) {
+            throw new CompilerError(
+              s"No polyglot symbol for ${symbol.name}"
+            )
+          }
+          ConstantObjectNode.build(s)
         case BindingsMap.ResolvedPolyglotField(symbol, name) =>
-          ConstantObjectNode.build(
-            symbol.module
-              .unsafeAsModule()
-              .getScope
-              .getPolyglotSymbol(name)
-          )
+          val s = symbol.module
+            .unsafeAsModule()
+            .getScope
+            .getPolyglotSymbol(name)
+          if (s == null) {
+            throw new CompilerError(
+              s"No polyglot symbol for ${name}"
+            )
+          }
+
+          ConstantObjectNode.build(s)
         case BindingsMap.ResolvedMethod(_, method) =>
           throw new CompilerError(
             s"Impossible here, ${method.name} should be caught when translating application"

--- a/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
@@ -137,4 +137,47 @@ public class ExecCompilerTest {
     var err = run.execute(0);
     assertEquals("Error: Module is not a part of a package.", err.asString());
   }
+
+  @Test
+  public void testDoubledRandom() throws Exception {
+    var module =
+        ctx.eval(
+            "enso",
+          """
+          from Standard.Base import all
+          polyglot java import java.util.Random
+
+          run seed =
+              operator1 = Random.new seed
+          """);
+    var run = module.invokeMember("eval_expression", "run");
+    try {
+      var err = run.execute(1L);
+      fail("Not expecting any result: " + err);
+    } catch (PolyglotException ex) {
+      assertEquals("Compile error: Compiler Internal Error: No polyglot symbol for Random.", ex.getMessage());
+    }
+  }
+
+  @Test
+  public void testUnknownStaticField() throws Exception {
+    var module =
+        ctx.eval(
+            "enso",
+          """
+          from Standard.Base import all
+          polyglot java import java.util.Random as R
+
+          run seed = case seed of
+              R.NO_FIELD -> 0
+              _ -> -1
+          """);
+    var run = module.invokeMember("eval_expression", "run");
+    try {
+      var err = run.execute(1L);
+      fail("Not expecting any result: " + err);
+    } catch (PolyglotException ex) {
+      assertEquals("Compile error: NO_FIELD is not visible in this scope.", ex.getMessage());
+    }
+  }
 }


### PR DESCRIPTION
### Pull Request Description

Prevents [this NullPointerException](https://github.com/enso-org/enso/pull/8044#issuecomment-1763736570) by making sure `ConstantNode` rejects `null` during construction.

### Important Notes

```ruby
from Standard.Base import all
polyglot java import java.util.Random

main = 
    operator1 = Random.new
```

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
