### PR TITLE
Disable remote logging

### DIFF
--- a/app/ide-desktop/lib/content/src/index.ts
+++ b/app/ide-desktop/lib/content/src/index.ts
@@ -195,16 +195,16 @@ class Main implements AppRunner {
             },
         })
 
-        // We override the remote logger stub with the "real" one. Eventually the runner should not be aware of the
-        // remote logger at all, and it should be integrated with our logging infrastructure.
+        // We override the remote logger stub with the "real" one. Eventually the runner should not
+        // be aware of the remote logger at all, and it should be integrated with our logging infrastructure.
         const remoteLogger = accessToken != null ? new remoteLog.RemoteLogger(accessToken) : null
-        newApp.remoteLog = async (message: string, metadata: unknown) => {
+        newApp.remoteLog = (message: string, metadata: unknown) => {
             const metadataObject =
                 typeof metadata === 'object' && metadata != null ? metadata : { metadata }
             const actualMetadata =
                 loggingMetadata == null ? metadata : { ...loggingMetadata, ...metadataObject }
             if (newApp.config.options.dataCollection.value && remoteLogger != null) {
-                await remoteLogger.remoteLog(message, actualMetadata)
+                // await remoteLogger.remoteLog(message, actualMetadata)
             } else {
                 const logMessage = [
                     'Not sending log to remote server. Data collection is disabled.',
@@ -214,6 +214,7 @@ class Main implements AppRunner {
 
                 logger.log(logMessage)
             }
+            return Promise.resolve()
         }
         this.app = newApp
 

--- a/app/ide-desktop/lib/content/src/index.ts
+++ b/app/ide-desktop/lib/content/src/index.ts
@@ -204,6 +204,11 @@ class Main implements AppRunner {
             const actualMetadata =
                 loggingMetadata == null ? metadata : { ...loggingMetadata, ...metadataObject }
             if (newApp.config.options.dataCollection.value && remoteLogger != null) {
+                // FIXME [sb]: https://github.com/enso-org/cloud-v2/issues/735
+                // The current GUI sends a lot of logs (over 300) every time a project is opened.
+                // This severely degrades performance, and the logs generated do not appear to be
+                // useful. This should be re-enabled when the GUI no longer sends a large amount
+                // of logs.
                 // await remoteLogger.remoteLog(message, actualMetadata)
             } else {
                 const logMessage = [


### PR DESCRIPTION
### Pull Request Description
- Closes https://github.com/enso-org/cloud-v2/issues/722
  - Completely disables remote logging

### Important Notes
This is a temporary fix - GUI2 should have remote logging, but it may need a reimplemented entrypoint anyway.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
