### PR TITLE
Ambiguous imports warnings/errors are serializable

### DIFF
--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -199,14 +199,15 @@ final class EnsureCompiledJob(
     module: Module,
     diagnostic: Diagnostic
   ): Api.ExecutionResult.Diagnostic = {
+    val source = module.getSource
     Api.ExecutionResult.Diagnostic(
       kind,
-      Option(diagnostic.formattedMessage),
+      Option(diagnostic.formattedMessage(source)),
       Option(module.getPath).map(new File(_)),
       diagnostic.location
         .map(loc =>
           LocationResolver
-            .locationToRange(loc.location, module.getSource.getCharacters)
+            .locationToRange(loc.location, source.getCharacters)
         ),
       diagnostic.location
         .flatMap(LocationResolver.getExpressionId(module.getIr, _))

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Diagnostic.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Diagnostic.scala
@@ -1,14 +1,19 @@
 package org.enso.compiler.core.ir
 
+import com.oracle.truffle.api.source.Source
+
 /** A representation of various kinds of diagnostic in the IR. */
 trait Diagnostic extends Serializable {
 
-  /** @return a human-readable description of this error condition.
+  /** @param source Location of the diagnostic.
+    * @return a human-readable description of this error condition.
     */
-  def message: String
+  def message(source: Source): String
 
-  /** @return a human-readable description of this error condition, formatted for immediate reporting. */
-  def formattedMessage: String = message
+  /** @param source Location of the diagnostic.
+    * @return a human-readable description of this error condition, formatted for immediate reporting.
+    */
+  def formattedMessage(source: Source): String = message(source)
 
   /** The location at which the diagnostic occurs. */
   val location: Option[IdentifiedLocation]

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Empty.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Empty.scala
@@ -1,5 +1,6 @@
 package org.enso.compiler.core.ir
 
+import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.IR
 import org.enso.compiler.core.IR.{randomId, ToStringHelper}
 
@@ -75,7 +76,7 @@ sealed case class Empty(
   override def children: List[IR] = List()
 
   /** @inheritdoc */
-  override def message: String =
+  override def message(source: Source): String =
     "Empty IR: Please report this as a compiler bug."
 
   /** @inheritdoc */

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Warning.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Warning.scala
@@ -12,10 +12,9 @@ object Warning {
   case class DuplicatedImport(
     override val location: Option[IdentifiedLocation],
     originalImport: ir.module.scope.Import,
-    symbolName: String,
-    source: Source
+    symbolName: String
   ) extends Warning {
-    override def message: String = {
+    override def message(source: Source): String = {
       val originalImportRepr =
         originalImport.location match {
           case Some(location) =>
@@ -35,7 +34,7 @@ object Warning {
     */
   case class WrongTco(override val location: Option[IdentifiedLocation])
       extends Warning {
-    override def message: String =
+    override def message(source: Source): String =
       "A @Tail_Call annotation was placed in a non-tail-call position."
 
     override def diagnosticKeys(): Array[Any] = Array()
@@ -49,7 +48,7 @@ object Warning {
   case class WrongBuiltinMethod(
     override val location: Option[IdentifiedLocation]
   ) extends Warning {
-    override def message: String =
+    override def message(source: Source): String =
       "A @Builtin_Method annotation allows only the name of the builtin node in the body."
 
     override def diagnosticKeys(): Array[Any] = Array()
@@ -68,7 +67,7 @@ object Warning {
   ) extends Warning {
     override val location: Option[IdentifiedLocation] = ir.location
 
-    override def message: String =
+    override def message(source: Source): String =
       s"${funName.name}: Self parameter should be declared as the first parameter. Instead its position is: ${paramPosition + 1}."
 
     override def diagnosticKeys(): Array[Any] =
@@ -87,7 +86,7 @@ object Warning {
   ) extends Warning {
     override val location: Option[IdentifiedLocation] = ir.location
 
-    override def message: String =
+    override def message(source: Source): String =
       s"The expression ${ir.showCode()} could not be parallelised: $reason."
 
     override def diagnosticKeys(): Array[Any] = Array(ir.showCode(), reason)
@@ -98,7 +97,7 @@ object Warning {
 
     /** @return a human-readable description of this error condition.
       */
-    override def message: String =
+    override def message(source: Source): String =
       s"A non-unit type ${ir.name} is used on value level (in ${context})." +
       " This is probably an error."
 

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/Error.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/Error.scala
@@ -1,6 +1,7 @@
 package org.enso.compiler.core.ir
 package expression
 
+import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.IR.{randomId, Identifier, ToStringHelper}
 import org.enso.compiler.core.ir.Expression
 import org.enso.compiler.core.{ir, IR}
@@ -107,7 +108,7 @@ object Error {
     override def children: List[IR] = List(ir)
 
     /** @inheritdoc */
-    override def message: String =
+    override def message(source: Source): String =
       "InvalidIR: Please report this as a compiler bug."
 
     override def diagnosticKeys(): Array[Any] = Array()

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Conversion.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Conversion.scala
@@ -2,6 +2,7 @@ package org.enso.compiler.core.ir
 package expression
 package errors
 
+import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.IR
 import org.enso.compiler.core.IR.{randomId, Identifier}
 
@@ -85,7 +86,7 @@ sealed case class Conversion(
     s"(Error: ${storedIr.showCode(indent)})"
 
   /** @inheritdoc */
-  override def message: String = reason.explain
+  override def message(source: Source): String = reason.explain
 
   override def diagnosticKeys(): Array[Any] = Array(reason.explain)
 

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Pattern.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Pattern.scala
@@ -2,6 +2,7 @@ package org.enso.compiler.core.ir
 package expression
 package errors
 
+import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.IR
 import org.enso.compiler.core.IR.{randomId, Identifier}
 
@@ -69,7 +70,7 @@ sealed case class Pattern(
       id = if (keepIdentifiers) id else randomId
     )
 
-  override def message: String = reason.explain
+  override def message(source: Source): String = reason.explain
 
   override def diagnosticKeys(): Array[Any] = Array(reason)
 

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Redefined.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Redefined.scala
@@ -2,6 +2,7 @@ package org.enso.compiler.core.ir
 package expression
 package errors
 
+import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.IR
 import org.enso.compiler.core.IR.{randomId, Identifier}
 
@@ -87,7 +88,7 @@ object Redefined {
       this
 
     /** @inheritdoc */
-    override def message: String =
+    override def message(source: Source): String =
       "Methods must have only one definition of the `this` argument, and " +
       "it must be the first."
 
@@ -186,7 +187,7 @@ object Redefined {
       copy(location = location)
 
     /** @inheritdoc */
-    override def message: String =
+    override def message(source: Source): String =
       s"Method overloads are not supported: ${targetType.map(_.name + ".").getOrElse("")}from " +
       s"${sourceType.showCode()} is defined multiple times in this module."
 
@@ -305,7 +306,7 @@ object Redefined {
       copy(location = location)
 
     /** @inheritdoc */
-    override def message: String =
+    override def message(source: Source): String =
       s"Method overloads are not supported: ${atomName.map(_.name + ".").getOrElse("")}" +
       s"${methodName.name} is defined multiple times in this module."
 
@@ -431,7 +432,7 @@ object Redefined {
       copy(location = location)
 
     /** @inheritdoc */
-    override def message: String =
+    override def message(source: Source): String =
       s"Method definitions with the same name as atoms are not supported. " +
       s"Method ${methodName.name} clashes with the atom ${atomName.name} in this module."
 
@@ -534,7 +535,7 @@ object Redefined {
       copy(location = location)
 
     /** @inheritdoc */
-    override def message: String =
+    override def message(source: Source): String =
       s"Redefining atoms is not supported: ${typeName.name} is " +
       s"defined multiple times in this module."
 
@@ -650,7 +651,7 @@ object Redefined {
     override def children: List[IR] = List(invalidBinding)
 
     /** @inheritdoc */
-    override def message: String =
+    override def message(source: Source): String =
       s"Variable ${invalidBinding.name.name} is being redefined."
 
     override def diagnosticKeys(): Array[Any] = Array(

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Resolution.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Resolution.scala
@@ -2,6 +2,7 @@ package org.enso.compiler.core.ir
 package expression
 package errors
 
+import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.IR
 import org.enso.compiler.core.IR.{randomId, Identifier}
 
@@ -83,10 +84,10 @@ sealed case class Resolution(
   override def showCode(indent: Int): String = originalName.showCode(indent)
 
   /** @inheritdoc */
-  override def message: String = reason.explain(originalName)
+  override def message(source: Source): String = reason.explain(originalName)
 
   /** @inheritdoc */
-  override def formattedMessage: String = s"${message}."
+  override def formattedMessage(source: Source): String = s"${message(source)}."
 
   override def diagnosticKeys(): Array[Any] = Array(reason)
 

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Syntax.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Syntax.scala
@@ -2,6 +2,7 @@ package org.enso.compiler.core.ir
 package expression
 package errors
 
+import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.IR
 import org.enso.compiler.core.IR.{randomId, Identifier, ToStringHelper}
 
@@ -89,10 +90,10 @@ sealed case class Syntax(
   override def children: List[IR] = List()
 
   /** @inheritdoc */
-  override def message: String = reason.explanation
+  override def message(source: Source): String = reason.explanation
 
   /** @inheritdoc */
-  override def formattedMessage: String = s"${message}."
+  override def formattedMessage(source: Source): String = s"${message(source)}."
 
   override def diagnosticKeys(): Array[Any] = Array(reason)
 

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Unexpected.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Unexpected.scala
@@ -2,6 +2,7 @@ package org.enso.compiler.core.ir
 package expression
 package errors
 
+import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.IR
 import org.enso.compiler.core.IR.{randomId, Identifier}
 
@@ -17,7 +18,7 @@ sealed trait Unexpected extends Error {
   override val location: Option[IdentifiedLocation] = ir.location
 
   /** @inheritdoc */
-  override def message: String = s"Unexpected $entity."
+  override def message(source: Source): String = s"Unexpected $entity."
 
   /** @inheritdoc */
   override def diagnosticKeys(): Array[Any] = Array(entity)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/warnings/Shadowed.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/warnings/Shadowed.scala
@@ -2,6 +2,7 @@ package org.enso.compiler.core.ir
 package expression
 package warnings
 
+import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.IR
 
 /** Warnings about shadowing names. */
@@ -25,7 +26,7 @@ object Shadowed {
     override val shadower: IR,
     override val location: Option[IdentifiedLocation]
   ) extends Shadowed {
-    override def message: String =
+    override def message(source: Source): String =
       s"The argument $shadowedName is shadowed by $shadower"
 
     override def diagnosticKeys(): Array[Any] =
@@ -44,7 +45,7 @@ object Shadowed {
     override val shadower: IR,
     override val location: Option[IdentifiedLocation]
   ) extends Shadowed {
-    override def message: String =
+    override def message(source: Source): String =
       s"The pattern field $shadowedName is shadowed by $shadower."
 
     override def diagnosticKeys(): Array[Any] =
@@ -65,7 +66,7 @@ object Shadowed {
     override val shadower: IR,
     override val location: Option[IdentifiedLocation]
   ) extends Shadowed {
-    override def message: String =
+    override def message(source: Source): String =
       s"""Declaration of type $typeName shadows module ${moduleName.name} making it inaccessible via a qualified name."""
 
     override def diagnosticKeys(): Array[Any] =
@@ -88,7 +89,7 @@ object Shadowed {
     override val shadower: IR,
     override val location: Option[IdentifiedLocation]
   ) extends Shadowed {
-    override def message: String =
+    override def message(source: Source): String =
       s"The exported type `$tpeName` in `$name` module will cause name conflict " +
       s"when attempting to use a fully qualified name of the `$firstConflict` module."
 

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/warnings/Unreachable.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/warnings/Unreachable.scala
@@ -2,6 +2,8 @@ package org.enso.compiler.core.ir
 package expression
 package warnings
 
+import com.oracle.truffle.api.source.Source
+
 /** Warnings for unreachable code. */
 sealed trait Unreachable extends Warning {
   val location: Option[IdentifiedLocation]
@@ -23,7 +25,8 @@ object Unreachable {
         ""
       }
 
-    override def message: String = s"Unreachable case branches$atLocation."
+    override def message(source: Source): String =
+      s"Unreachable case branches$atLocation."
 
     override def diagnosticKeys(): Array[Any] = Array(atLocation)
   }

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/warnings/Unused.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/warnings/Unused.scala
@@ -2,6 +2,8 @@ package org.enso.compiler.core.ir
 package expression
 package warnings
 
+import com.oracle.truffle.api.source.Source
+
 /** Warnings about unused language entities. */
 sealed trait Unused extends Warning {
   val name: Name
@@ -14,7 +16,8 @@ object Unused {
     * @param name the name that is unused
     */
   sealed case class FunctionArgument(override val name: Name) extends Unused {
-    override def message: String = s"Unused function argument ${name.name}."
+    override def message(source: Source): String =
+      s"Unused function argument ${name.name}."
 
     override def diagnosticKeys(): Array[Any] = Array(name.name)
 
@@ -24,7 +27,8 @@ object Unused {
   }
 
   sealed case class PatternBinding(override val name: Name) extends Unused {
-    override def message: String = s"Unused pattern binding ${name.name}."
+    override def message(source: Source): String =
+      s"Unused pattern binding ${name.name}."
 
     override def diagnosticKeys(): Array[Any] = Array(name.name)
 
@@ -38,7 +42,8 @@ object Unused {
     * @param name the name that is unused
     */
   sealed case class Binding(override val name: Name) extends Unused {
-    override def message: String = s"Unused variable ${name.name}."
+    override def message(source: Source): String =
+      s"Unused variable ${name.name}."
 
     override def diagnosticKeys(): Array[Any] = Array(name.name)
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -1085,7 +1085,7 @@ class Compiler(
               .Str(srcPath + ":" + lineNumber + ":" + startColumn + ": ")
               .overlay(fansi.Bold.On)
             str ++= fansi.Str(subject).overlay(textAttrs)
-            str ++= diagnostic.formattedMessage
+            str ++= diagnostic.formattedMessage(source)
             str ++= "\n"
             str ++= oneLineFromSourceColored(lineNumber, startColumn, endColumn)
             str ++= "\n"
@@ -1103,7 +1103,7 @@ class Compiler(
               )
               .overlay(fansi.Bold.On)
             str ++= fansi.Str(subject).overlay(textAttrs)
-            str ++= diagnostic.formattedMessage
+            str ++= diagnostic.formattedMessage(source)
             str ++= "\n"
             val printAllSourceLines =
               section.getEndLine - section.getStartLine <= maxSourceLinesToPrint
@@ -1138,7 +1138,7 @@ class Compiler(
             .overlay(fansi.Bold.On)
           str ++= ": "
           str ++= fansi.Str(subject).overlay(textAttrs)
-          str ++= diagnostic.formattedMessage
+          str ++= diagnostic.formattedMessage(source)
           if (outSupportsAnsiColors) {
             str.render.stripLineEnd
           } else {

--- a/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/codegen/IrToTruffle.scala
@@ -1738,43 +1738,43 @@ class IrToTruffle(
         case err: errors.Syntax =>
           context.getBuiltins
             .error()
-            .makeSyntaxError(Text.create(err.message))
+            .makeSyntaxError(Text.create(err.message(source)))
         case err: errors.Redefined.Binding =>
           context.getBuiltins
             .error()
-            .makeCompileError(Text.create(err.message))
+            .makeCompileError(Text.create(err.message(source)))
         case err: errors.Redefined.Method =>
           context.getBuiltins
             .error()
-            .makeCompileError(Text.create(err.message))
+            .makeCompileError(Text.create(err.message(source)))
         case err: errors.Redefined.MethodClashWithAtom =>
           context.getBuiltins
             .error()
-            .makeCompileError(Text.create(err.message))
+            .makeCompileError(Text.create(err.message(source)))
         case err: errors.Redefined.Conversion =>
           context.getBuiltins
             .error()
-            .makeCompileError(Text.create(err.message))
+            .makeCompileError(Text.create(err.message(source)))
         case err: errors.Redefined.Type =>
           context.getBuiltins
             .error()
-            .makeCompileError(Text.create(err.message))
+            .makeCompileError(Text.create(err.message(source)))
         case err: errors.Redefined.SelfArg =>
           context.getBuiltins
             .error()
-            .makeCompileError(Text.create(err.message))
+            .makeCompileError(Text.create(err.message(source)))
         case err: errors.Unexpected.TypeSignature =>
           context.getBuiltins
             .error()
-            .makeCompileError(Text.create(err.message))
+            .makeCompileError(Text.create(err.message(source)))
         case err: errors.Resolution =>
           context.getBuiltins
             .error()
-            .makeCompileError(Text.create(err.message))
+            .makeCompileError(Text.create(err.message(source)))
         case err: errors.Conversion =>
           context.getBuiltins
             .error()
-            .makeCompileError(Text.create(err.message))
+            .makeCompileError(Text.create(err.message(source)))
         case _: errors.Pattern =>
           throw new CompilerError(
             "Impossible here, should be handled in the pattern match."

--- a/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
@@ -424,7 +424,7 @@ public class ErrorCompilerTest extends CompilerTest {
     var errors = assertIR(ir, Syntax.class, 1);
     assertEquals(type, errors.head().reason());
     if (msg != null) {
-      assertEquals(msg, errors.head().message());
+      assertEquals(msg, errors.head().message(null));
     }
     assertEquals(new Location(start, end), errors.head().location().get().location());
   }

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/GatherDiagnosticsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/analyse/GatherDiagnosticsTest.scala
@@ -132,7 +132,9 @@ class GatherDiagnosticsTest extends CompilerTest {
         .unsafeGetMetadata(GatherDiagnostics, "Impossible")
         .diagnostics
       diagnostics should have size 2
-      diagnostics.map(_.message).toSet shouldEqual Set(
+      diagnostics
+        .map(_.message(null))
+        .toSet shouldEqual Set(
         "Unused variable unused.",
         "Unused function argument x."
       )


### PR DESCRIPTION
### Pull Request Description

`AmbgiuousImport` error and `DuplicatedImport` warning must not have `Source` as one of its fields or compiler will crash during a serialization attempt.
Changed the implementation to provide it as a parameter to the `message` method instead.

Fixes #8089 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
