### PR TITLE
Tree traversal API

### DIFF
--- a/app/gui2/eslint.config.js
+++ b/app/gui2/eslint.config.js
@@ -26,7 +26,6 @@ const conf = [
           './tsconfig.server.json',
           './tsconfig.app.vitest.json',
           './tsconfig.server.vitest.json',
-          './parser-codegen/tsconfig.json',
         ],
       },
     },

--- a/app/gui2/parser-codegen/codegen.ts
+++ b/app/gui2/parser-codegen/codegen.ts
@@ -15,6 +15,7 @@ import {
   abstractTypeVariants,
   fieldDeserializer,
   fieldDynValue,
+  fieldVisitor,
   seekViewDyn,
   support,
   supportImports,
@@ -28,7 +29,7 @@ import {
   toCamel,
   toPascal,
 } from './util.js'
-const tsf = ts.factory
+const tsf: ts.NodeFactory = ts.factory
 
 const addressIdent = tsf.createIdentifier('address')
 const viewIdent = tsf.createIdentifier('view')
@@ -292,6 +293,60 @@ function makeDebugFunction(fields: Field[], typeName?: string): ts.MethodDeclara
   )
 }
 
+function makeVisitFunction(fields: Field[]): ts.MethodDeclaration {
+  const ident = tsf.createIdentifier('visitChildren')
+  const visitorParam = tsf.createIdentifier('visitor')
+  const visitorParamDecl = tsf.createParameterDeclaration(
+    undefined,
+    undefined,
+    visitorParam,
+    undefined,
+    support.ObjectVisitor,
+  )
+  const visitSuperChildren = tsf.createCallExpression(
+    tsf.createPropertyAccessExpression(tsf.createSuper(), ident),
+    undefined,
+    [visitorParam],
+  )
+  const fieldVisitations: ts.Expression[] = []
+  for (const field of fields) {
+    if (field.type.visitor === 'visitValue') {
+      fieldVisitations.push(
+        tsf.createCallExpression(visitorParam, undefined, [
+          tsf.createPropertyAccessExpression(tsf.createThis(), field.name),
+        ]),
+      )
+    } else if (field.type.visitor != null) {
+      fieldVisitations.push(
+        tsf.createCallExpression(
+          tsf.createPropertyAccessExpression(tsf.createThis(), toCamel('visit_' + field.name)),
+          undefined,
+          [visitorParam],
+        ),
+      )
+    }
+  }
+  const toBool = (value: ts.Expression) =>
+    tsf.createPrefixUnaryExpression(
+      ts.SyntaxKind.ExclamationToken,
+      tsf.createPrefixUnaryExpression(ts.SyntaxKind.ExclamationToken, value),
+    )
+  const expression = fieldVisitations.reduce(
+    (lhs, rhs) => tsf.createBinaryExpression(lhs, ts.SyntaxKind.BarBarToken, toBool(rhs)),
+    visitSuperChildren,
+  )
+  return tsf.createMethodDeclaration(
+    undefined,
+    undefined,
+    ident,
+    undefined,
+    undefined,
+    [visitorParamDecl],
+    tsf.createTypeReferenceNode('boolean'),
+    tsf.createBlock([tsf.createReturnStatement(expression)]),
+  )
+}
+
 function makeGetters(id: string, schema: Schema.Schema, typeName?: string): ts.ClassElement[] {
   const serialization = schema.serialization[id]
   const type = schema.types[id]
@@ -301,7 +356,18 @@ function makeGetters(id: string, schema: Schema.Schema, typeName?: string): ts.C
     if (field == null) throw new Error(`Invalid field name '${name}' for type '${type.name}'`)
     return makeField(name, field, offset, schema)
   })
-  return [...fields.map(makeGetter), makeDebugFunction(fields, typeName)]
+  return [
+    ...fields.map(makeGetter),
+    ...fields.map(makeElementVisitor).filter((v): v is ts.ClassElement => v != null),
+    makeVisitFunction(fields),
+    makeDebugFunction(fields, typeName),
+  ]
+}
+
+function makeElementVisitor(field: Field): ts.ClassElement | undefined {
+  if (field.type.visitor == null) return undefined
+  const ident = tsf.createIdentifier(toCamel('visit_' + field.name))
+  return fieldVisitor(ident, field.type, field.offset)
 }
 
 function makeClass(

--- a/app/gui2/parser-codegen/codegen.ts
+++ b/app/gui2/parser-codegen/codegen.ts
@@ -536,7 +536,6 @@ function makeIsInstance(type: ts.TypeNode, baseIdent: ts.Identifier): ts.Functio
     undefined,
     tsf.createTypeReferenceNode('unknown'),
   )
-  const baseType = tsf.createTypeReferenceNode(baseIdent)
   const returnValue = tsf.createBinaryExpression(param, ts.SyntaxKind.InstanceOfKeyword, baseIdent)
   return tsf.createFunctionDeclaration(
     [modifiers.export],

--- a/app/gui2/src/components/ComponentBrowser/input.ts
+++ b/app/gui2/src/components/ComponentBrowser/input.ts
@@ -49,7 +49,7 @@ export class Input {
       if (cursorPosition === 0) return { type: 'insert', position: 0 }
       const editedPart = cursorPosition - 1
       const inputAst = parseEnso(input)
-      const editedAst = astContainingChar(editedPart, inputAst)
+      const editedAst = astContainingChar(editedPart, inputAst).values()
       const leaf = editedAst.next()
       if (leaf.done) return { type: 'insert', position: cursorPosition }
       switch (leaf.value.type) {

--- a/app/gui2/src/util/ast/index.ts
+++ b/app/gui2/src/util/ast/index.ts
@@ -56,7 +56,7 @@ export function readTokenSpan(token: Token, code: string): string {
 export function childrenAstNodes(obj: LazyObject): Tree[] {
   const children: Tree[] = []
   const visitor = (obj: LazyObject) => {
-    if (isTree(obj)) {
+    if (Tree.isInstance(obj)) {
       children.push(obj)
     } else {
       obj.visitChildren(visitor)
@@ -64,16 +64,6 @@ export function childrenAstNodes(obj: LazyObject): Tree[] {
   }
   obj.visitChildren(visitor)
   return children
-}
-
-function isTree(obj: LazyObject): obj is Tree {
-  // Every descendant of `Tree.AbstractBase` is a member of the `Tree` union.
-  return obj instanceof Tree.AbstractBase
-}
-
-function isToken(obj: LazyObject): obj is Token {
-  // Every descendant of `Token.AbstractBase` is a member of the `Token` union.
-  return obj instanceof Token.AbstractBase
 }
 
 /** Returns all AST nodes from `root` tree containing given char, starting from the most nested. */
@@ -90,7 +80,7 @@ export function astContainingChar(charIndex: number, root: Tree): Tree[] {
 function treePath(obj: LazyObject, pred: (node: Tree) => boolean): Tree[] {
   const path: Tree[] = []
   const visitor = (obj: LazyObject) => {
-    if (isTree(obj)) {
+    if (Tree.isInstance(obj)) {
       const isMatch = pred(obj)
       if (isMatch) path.push(obj)
       return obj.visitChildren(visitor) || isMatch
@@ -261,12 +251,15 @@ if (import.meta.vitest) {
 function validateSpans(obj: LazyObject, initialPos?: number): number {
   const state = { pos: initialPos ?? 0 }
   const visitor = (value: LazyObject) => {
-    if (isToken(value) && !(value.whitespaceLengthInCodeBuffer + value.lengthInCodeBuffer === 0)) {
+    if (
+      Token.isInstance(value) &&
+      !(value.whitespaceLengthInCodeBuffer + value.lengthInCodeBuffer === 0)
+    ) {
       assert(value.whitespaceStartInCodeBuffer === state.pos)
       state.pos += value.whitespaceLengthInCodeBuffer
       assert(value.startInCodeBuffer === state.pos)
       state.pos += value.lengthInCodeBuffer
-    } else if (isTree(value)) {
+    } else if (Tree.isInstance(value)) {
       assert(value.whitespaceStartInCodeParsed === state.pos)
       state.pos += value.whitespaceLengthInCodeParsed
       const end = state.pos + value.childrenLengthInCodeParsed

--- a/app/gui2/src/util/ast/index.ts
+++ b/app/gui2/src/util/ast/index.ts
@@ -2,20 +2,20 @@ import * as Ast from '@/generated/ast'
 import { Token, Tree } from '@/generated/ast'
 import { assert } from '@/util/assert'
 import { parse } from '@/util/ffi'
-import { LazyObject, debug, validateSpans } from '@/util/parserSupport'
+import { LazyObject, debug } from '@/util/parserSupport'
 
 export { Ast }
 
-export function parseEnso(code: string): Ast.Tree {
+export function parseEnso(code: string): Tree {
   const blob = parse(code)
-  return Ast.Tree.read(new DataView(blob.buffer), blob.byteLength - 4)
+  return Tree.read(new DataView(blob.buffer), blob.byteLength - 4)
 }
 
 /** Read a single line of code
  *
  * Is meant to be a helper for tests. If the code is multilined, an exception is raised.
  */
-export function parseEnsoLine(code: string): Ast.Tree {
+export function parseEnsoLine(code: string): Tree {
   const block = parseEnso(code)
   assert(block.type === Tree.Type.BodyBlock)
   const statemets = block.statements[Symbol.iterator]()
@@ -53,47 +53,53 @@ export function readTokenSpan(token: Token, code: string): string {
 /**
  * Read direct AST children.
  */
-// TODO[ao] This is a very hacky way of implementing this. The better solution would be to generate
-// such a function from parser types schema. See parser-codegen package.
-export function* childrenAstNodes(obj: unknown): Generator<Tree> {
-  function* astNodeOrChildren(obj: unknown) {
-    if (obj instanceof Tree.AbstractBase) {
-      yield obj as Tree
+export function childrenAstNodes(obj: LazyObject): Tree[] {
+  const children: Tree[] = []
+  const visitor = (obj: LazyObject) => {
+    if (isTree(obj)) {
+      children.push(obj)
     } else {
-      yield* childrenAstNodes(obj)
+      obj.visitChildren(visitor)
     }
   }
-  if (obj == null) return
-  const maybeIterable = obj as Record<symbol, unknown>
-  const isIterator = typeof maybeIterable[Symbol.iterator] == 'function'
-  if (obj instanceof LazyObject) {
-    const prototype = Object.getPrototypeOf(obj)
-    const descriptors = Object.getOwnPropertyDescriptors(prototype)
-    const objWithProp = obj as unknown as Record<string, unknown>
+  obj.visitChildren(visitor)
+  return children
+}
 
-    for (const prop in descriptors) {
-      if (descriptors[prop]?.get == null) continue
-      const value = objWithProp[prop]
-      yield* astNodeOrChildren(value)
-    }
-  } else if (isIterator) {
-    const iterable = obj as Iterable<unknown>
-    for (const element of iterable) {
-      yield* astNodeOrChildren(element)
-    }
-  }
+function isTree(obj: LazyObject): obj is Tree {
+  // Every descendant of `Tree.AbstractBase` is a member of the `Tree` union.
+  return obj instanceof Tree.AbstractBase
+}
+
+function isToken(obj: LazyObject): obj is Token {
+  // Every descendant of `Token.AbstractBase` is a member of the `Token` union.
+  return obj instanceof Token.AbstractBase
 }
 
 /** Returns all AST nodes from `root` tree containing given char, starting from the most nested. */
-export function* astContainingChar(charIndex: number, root: Tree): Generator<Tree> {
-  for (const child of childrenAstNodes(root)) {
-    const begin = child.whitespaceStartInCodeParsed + child.whitespaceLengthInCodeParsed
-    const end = begin + child.childrenLengthInCodeParsed
-    if (charIndex >= begin && charIndex < end) {
-      yield* astContainingChar(charIndex, child)
+export function astContainingChar(charIndex: number, root: Tree): Tree[] {
+  return treePath(root, (node) => {
+    const begin = node.whitespaceStartInCodeParsed + node.whitespaceLengthInCodeParsed
+    const end = begin + node.childrenLengthInCodeParsed
+    return charIndex >= begin && charIndex < end
+  }).reverse()
+}
+
+/** Given a predicate, return a path from the root down the tree containing the
+ *  first node at each level found to satisfy the predicate. */
+function treePath(obj: LazyObject, pred: (node: Tree) => boolean): Tree[] {
+  const path: Tree[] = []
+  const visitor = (obj: LazyObject) => {
+    if (isTree(obj)) {
+      const isMatch = pred(obj)
+      if (isMatch) path.push(obj)
+      return obj.visitChildren(visitor) || isMatch
+    } else {
+      return obj.visitChildren(visitor)
     }
   }
-  yield root
+  obj.visitChildren(visitor)
+  return path
 }
 
 if (import.meta.vitest) {
@@ -241,7 +247,7 @@ if (import.meta.vitest) {
     ],
   ])("Reading AST from code '%s' and position %i", (code, position, expected) => {
     const ast = parseEnso(code)
-    const astAtPosition = Array.from(astContainingChar(position, ast))
+    const astAtPosition = astContainingChar(position, ast)
     const resultWithExpected = astAtPosition.map((ast, i) => {
       return { ast, expected: expected[i] }
     })
@@ -250,4 +256,26 @@ if (import.meta.vitest) {
       expect(readAstSpan(ast, code)).toBe(expected?.repr)
     }
   })
+}
+
+function validateSpans(obj: LazyObject, initialPos?: number): number {
+  const state = { pos: initialPos ?? 0 }
+  const visitor = (value: LazyObject) => {
+    if (isToken(value) && !(value.whitespaceLengthInCodeBuffer + value.lengthInCodeBuffer === 0)) {
+      assert(value.whitespaceStartInCodeBuffer === state.pos)
+      state.pos += value.whitespaceLengthInCodeBuffer
+      assert(value.startInCodeBuffer === state.pos)
+      state.pos += value.lengthInCodeBuffer
+    } else if (isTree(value)) {
+      assert(value.whitespaceStartInCodeParsed === state.pos)
+      state.pos += value.whitespaceLengthInCodeParsed
+      const end = state.pos + value.childrenLengthInCodeParsed
+      value.visitChildren(visitor)
+      assert(state.pos === end)
+    } else {
+      value.visitChildren(visitor)
+    }
+  }
+  visitor(obj)
+  return state.pos
 }

--- a/app/gui2/src/util/parserSupport.ts
+++ b/app/gui2/src/util/parserSupport.ts
@@ -40,6 +40,9 @@ export const Dyn = {
   }),
 } as const
 
+export type ObjectVisitor = (object: LazyObject) => boolean | void
+export type ObjectAddressVisitor = (view: DataView, address: number) => boolean | void
+
 /** Base class for objects that lazily deserialize fields when accessed. */
 export abstract class LazyObject {
   protected readonly _v: DataView
@@ -50,6 +53,18 @@ export abstract class LazyObject {
 
   fields(): [string, DynValue][] {
     return []
+  }
+
+  visitChildren(_visitor: ObjectVisitor): boolean {
+    return false
+  }
+
+  children(): LazyObject[] {
+    const children: LazyObject[] = []
+    this.visitChildren((child) => {
+      children.push(child)
+    })
+    return children
   }
 }
 
@@ -98,12 +113,24 @@ export function readOption<T>(
   address: number,
   readElement: Reader<T>,
 ): T | undefined {
+  let result = undefined
+  visitOption(view, address, (view, address) => {
+    result = readElement(view, address)
+  })
+  return result
+}
+
+export function visitOption(
+  view: DataView,
+  address: number,
+  visitor: ObjectAddressVisitor,
+): boolean {
   const discriminant = readU8(view, address)
   switch (discriminant) {
     case 0:
-      return undefined
+      return false
     case 1:
-      return readElement(readPointer(view, address + 1), 0)
+      return !!visitor(readPointer(view, address + 1), 0)
     default:
       throw new Error(`Invalid Option discriminant: 0x${discriminant.toString(16)}.`)
   }
@@ -126,14 +153,79 @@ export function readResult<Ok, Err>(
       throw new Error(`Invalid Result discriminant: 0x${discriminant.toString(16)}.`)
   }
 }
-export function* readSequence<T>(view: DataView, address: number, size: number, reader: Reader<T>) {
+
+export function visitResult(
+  view: DataView,
+  address: number,
+  visitOk: ObjectAddressVisitor | null,
+  visitErr: ObjectAddressVisitor | null,
+): boolean {
   const data = readPointer(view, address)
-  let count = readU32(data, 0)
+  const discriminant = readU32(data, 0)
+  switch (discriminant) {
+    case 0:
+      if (visitOk?.(data, 4)) return true
+      return false
+    case 1:
+      if (visitErr?.(data, 4)) return true
+      return false
+    default:
+      throw new Error(`Invalid Result discriminant: 0x${discriminant.toString(16)}.`)
+  }
+}
+
+export function visitSequence(
+  view: DataView,
+  address: number,
+  size: number,
+  visitor: ObjectAddressVisitor,
+): boolean {
+  const data = readPointer(view, address)
   let offset = 4
-  while (count > 0) {
-    yield reader(data, offset)
-    count--
+  let end = offset + size * readU32(data, 0)
+  while (offset != end) {
+    if (visitor(data, offset) === true) return true
     offset += size
+  }
+  return false
+}
+
+export function readSequence<T>(
+  view: DataView,
+  address: number,
+  size: number,
+  reader: Reader<T>,
+): Iterable<T> {
+  const data = readPointer(view, address)
+  const offset = 4
+  const end = offset + size * readU32(data, 0)
+  return new LazySequence(offset, size, end, (offset: number) => reader(data, offset))
+}
+
+class LazySequence<T> implements Iterator<T> {
+  private offset: number
+  private readonly step: number
+  private readonly end: number
+  private readonly read: (address: number) => T
+
+  constructor(offset: number, step: number, end: number, read: (address: number) => T) {
+    this.read = read
+    this.offset = offset
+    this.step = step
+    this.end = end
+  }
+
+  [Symbol.iterator]() {
+    return this
+  }
+
+  public next(): IteratorResult<T> {
+    if (this.offset >= this.end) {
+      return { done: true, value: undefined }
+    }
+    const value = this.read(this.offset)
+    this.offset += this.step
+    return { done: false, value: value }
   }
 }
 
@@ -188,63 +280,4 @@ function debug_(value: DynValue): any {
     case 'primitive':
       return value.value
   }
-}
-
-export function validateSpans(obj: LazyObject, initialPos?: number): number {
-  const state = { pos: initialPos ?? 0 }
-  validateSpans_(Dyn.Object(obj), state)
-  return state.pos
-}
-
-function validateSpans_(value: DynValue, state: { pos: number }) {
-  switch (value.type) {
-    case 'sequence':
-      for (const elem of value.value) validateSpans_(elem, state)
-      break
-    case 'result':
-      if (value.value.ok) validateSpans_(value.value.value, state)
-      else validateSpans_(value.value.error.payload, state)
-      break
-    case 'option':
-      if (value.value != null) validateSpans_(value.value, state)
-      break
-    case 'object':
-      return validateObjectSpans(value, state)
-    case 'primitive':
-      break
-  }
-}
-
-function validateObjectSpans(value: DynObject, state: { pos: number }) {
-  const fields = new Map(value.getFields())
-  const whitespaceStart =
-    fields.get('whitespaceStartInCodeParsed') ?? fields.get('whitespaceStartInCodeBuffer')
-  const whitespaceLength =
-    fields.get('whitespaceLengthInCodeParsed') ?? fields.get('whitespaceLengthInCodeBuffer')
-  const codeStart = fields.get('startInCodeBuffer')
-  const codeLength = fields.get('lengthInCodeBuffer')
-  const childrenCodeLength = fields.get('childrenLengthInCodeParsed')
-  if (
-    !(
-      whitespaceLength?.type === 'primitive' &&
-      whitespaceLength.value === 0 &&
-      codeLength?.type === 'primitive' &&
-      codeLength?.value === 0
-    )
-  ) {
-    if (whitespaceStart?.type === 'primitive' && whitespaceStart.value !== state.pos)
-      throw new Error(`Span error (whitespace) in: ${JSON.stringify(debug_(value))}.`)
-    if (whitespaceLength?.type === 'primitive') state.pos += whitespaceLength.value as number
-    if (codeStart?.type === 'primitive' && codeStart.value !== state.pos)
-      throw new Error('Span error (code).')
-    if (codeLength?.type === 'primitive') state.pos += codeLength.value as number
-  }
-  let endPos: number | undefined
-  if (childrenCodeLength?.type === 'primitive')
-    endPos = state.pos + (childrenCodeLength.value as number)
-  for (const entry of fields) {
-    const [_name, value] = entry
-    validateSpans_(value, state)
-  }
-  if (endPos != null && state.pos !== endPos) throw new Error('Span error (children).')
 }

--- a/app/gui2/src/util/parserSupport.ts
+++ b/app/gui2/src/util/parserSupport.ts
@@ -182,7 +182,7 @@ export function visitSequence(
 ): boolean {
   const data = readPointer(view, address)
   let offset = 4
-  let end = offset + size * readU32(data, 0)
+  const end = offset + size * readU32(data, 0)
   while (offset != end) {
     if (visitor(data, offset) === true) return true
     offset += size


### PR DESCRIPTION
### Pull Request Description

Implements #8025: `LazyObject` now has a `visitChildren` method that observes each direct-child `LazyObject`. `childrenAstNodes` is now a simple function that flattens non-Tree nodes out of the hierarchy; `validateSpans` visits both `Tree`s and `Token`s the same way we would use the `ItemVisitor` Rust API.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
