### PR TITLE
Highlight matches in CB

### DIFF
--- a/app/gui2/src/components/ComponentBrowser.vue
+++ b/app/gui2/src/components/ComponentBrowser.vue
@@ -10,6 +10,7 @@ import { useResizeObserver } from '@/util/events'
 import type { useNavigator } from '@/util/navigator'
 import { Vec2 } from '@/util/vec2'
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { type QualifiedName } from '../util/qualifiedName'
 
 const ITEM_SIZE = 32
 const TOP_BAR_HEIGHT = 32
@@ -194,6 +195,62 @@ function selectLastAfterRefresh() {
   })
 }
 
+// === Highlight matches ===
+
+const fullQualifiedNameQuery = computed(() => {
+  if (input.filter.value.qualifiedNamePattern != null) {
+    return input.filter.value.pattern != null
+      ? `${input.filter.value.qualifiedNamePattern}.${input.filter.value.pattern}`
+      : input.filter.value.qualifiedNamePattern
+  } else {
+    return input.filter.value.pattern
+  }
+})
+
+/** The first and last match are the parts of the string that are outside of the match.
+ * The middle matches come in groups of three, and contain respectively:
+ * - the matched text
+ * - the unmatched text (an empty string if the entire qualified name segment was matched)
+ * - the separator (`.` or `_`, or the empty string if this is the last segment) */
+const extractMatchesRegex = computed(() => {
+  if (fullQualifiedNameQuery.value == null) return undefined
+  return new RegExp(
+    '(^|.*)' +
+      fullQualifiedNameQuery.value.replace(/(.+?)([._]|$)/g, (_m, text, sep) =>
+        sep === '.' ? `(${text})([^.]*)(\\.)` : `(${text})([^_.]*)(${sep})`,
+      ) +
+      '(.*|$)',
+    'i',
+  )
+})
+
+interface MatchHighlightSegment {
+  text: string
+  type: 'no-match' | 'match'
+}
+
+function* highlightMatches(name: QualifiedName): Generator<MatchHighlightSegment> {
+  const match =
+    extractMatchesRegex.value != null ? name.match(extractMatchesRegex.value) : undefined
+  if (match == undefined) {
+    yield { text: name, type: 'no-match' }
+    return
+  }
+  const prefix = match[1]
+  if (prefix) yield { text: prefix, type: 'no-match' }
+  const end = match.length - 3
+  for (let i = 2; i < end; i += 3) {
+    const matched = match[i]
+    if (matched) yield { text: matched, type: 'match' }
+    const unmatched = match[i + 1]
+    if (unmatched) yield { text: unmatched, type: 'no-match' }
+    const separator = match[i + 2]
+    if (separator) yield { text: separator, type: 'no-match' }
+  }
+  const suffix = match[match.length - 1]
+  if (suffix) yield { text: suffix, type: 'no-match' }
+}
+
 // === Scrolling ===
 
 const scroller = ref<HTMLElement>()
@@ -288,7 +345,15 @@ function handleKeydown(e: KeyboardEvent) {
                   :name="item.component.icon"
                   :style="{ color: componentColor(item.component) }"
                 />
-                {{ item.component.label }}
+                <span>
+                  <span
+                    v-for="segment in highlightMatches(item.component.label)"
+                    :key="segment.text"
+                    class="component-label-segment"
+                    :class="{ match: segment.type === 'match' }"
+                    v-text="segment.text"
+                  ></span>
+                </span>
               </div>
             </div>
             <div class="list-variant selected" :style="{ clipPath: highlightClipPath }">
@@ -302,7 +367,15 @@ function handleKeydown(e: KeyboardEvent) {
                 }"
               >
                 <SvgIcon :name="item.component.icon" />
-                {{ item.component.label }}
+                <span>
+                  <span
+                    v-for="segment in highlightMatches(item.component.label)"
+                    :key="segment.text"
+                    class="component-label-segment"
+                    :class="{ match: segment.type === 'match' }"
+                    v-text="segment.text"
+                  ></span>
+                </span>
               </div>
             </div>
           </div>
@@ -311,7 +384,12 @@ function handleKeydown(e: KeyboardEvent) {
       <div class="panel docs" :class="{ hidden: !docsVisible }">DOCS</div>
     </div>
     <div class="CBInput">
-      <input ref="inputField" v-model="input.code.value" @keyup="readInputFieldSelection" />
+      <input
+        ref="inputField"
+        v-model="input.code.value"
+        name="cb-input"
+        @keyup="readInputFieldSelection"
+      />
     </div>
   </div>
 </template>
@@ -394,6 +472,10 @@ function handleKeydown(e: KeyboardEvent) {
   & svg {
     color: white;
   }
+}
+
+.component-label-segment.match {
+  font-weight: bold;
 }
 
 .top-bar {

--- a/app/gui2/src/components/ComponentBrowser.vue
+++ b/app/gui2/src/components/ComponentBrowser.vue
@@ -303,7 +303,10 @@ function handleKeydown(e: KeyboardEvent) {
                   :style="{ color: componentColor(item.component) }"
                 />
                 <span>
-                  <span v-if="!item.component.matchedRanges" v-text="item.component.label"></span>
+                  <span
+                    v-if="!item.component.matchedRanges || item.component.matchedAlias"
+                    v-text="item.component.label"
+                  ></span>
                   <span
                     v-for="range in allRanges(item.component.label, item.component.matchedRanges)"
                     v-else
@@ -327,7 +330,10 @@ function handleKeydown(e: KeyboardEvent) {
               >
                 <SvgIcon :name="item.component.icon" />
                 <span>
-                  <span v-if="!item.component.matchedRanges" v-text="item.component.label"></span>
+                  <span
+                    v-if="!item.component.matchedRanges || item.component.matchedAlias"
+                    v-text="item.component.label"
+                  ></span>
                   <span
                     v-for="range in allRanges(item.component.label, item.component.matchedRanges)"
                     v-else

--- a/app/gui2/src/components/ComponentBrowser.vue
+++ b/app/gui2/src/components/ComponentBrowser.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { makeComponentList, type Component } from '@/components/ComponentBrowser/component'
-import { Filtering } from '@/components/ComponentBrowser/filtering'
+import { Filtering, type MatchRange } from '@/components/ComponentBrowser/filtering'
 import { Input } from '@/components/ComponentBrowser/input'
 import SvgIcon from '@/components/SvgIcon.vue'
 import ToggleIcon from '@/components/ToggleIcon.vue'
@@ -87,6 +87,20 @@ function handleDefocus(e: FocusEvent) {
     }
   } else {
     emit('finished')
+  }
+}
+
+// === Highlighting selected text ===
+
+function* allRanges(text: string, ranges: MatchRange[]) {
+  let lastEndIndex = 0
+  for (const range of ranges) {
+    yield { start: lastEndIndex, end: range.start, isMatch: false }
+    yield { ...range, isMatch: true }
+    lastEndIndex = range.end
+  }
+  if (lastEndIndex !== text.length) {
+    yield { start: lastEndIndex, end: text.length, isMatch: false }
   }
 }
 
@@ -289,12 +303,9 @@ function handleKeydown(e: KeyboardEvent) {
                   :style="{ color: componentColor(item.component) }"
                 />
                 <span>
+                  <span v-if="!item.component.matchedRanges" v-text="item.component.label"></span>
                   <span
-                    v-if="!item.component.match.matchedRanges"
-                    v-text="item.component.label"
-                  ></span>
-                  <span
-                    v-for="range in item.component.match.matchedRanges"
+                    v-for="range in allRanges(item.component.label, item.component.matchedRanges)"
                     v-else
                     :key="`${range.start},${range.end}`"
                     class="component-label-segment"
@@ -316,12 +327,9 @@ function handleKeydown(e: KeyboardEvent) {
               >
                 <SvgIcon :name="item.component.icon" />
                 <span>
+                  <span v-if="!item.component.matchedRanges" v-text="item.component.label"></span>
                   <span
-                    v-if="!item.component.match.matchedRanges"
-                    v-text="item.component.label"
-                  ></span>
-                  <span
-                    v-for="range in item.component.match.matchedRanges"
+                    v-for="range in allRanges(item.component.label, item.component.matchedRanges)"
                     v-else
                     :key="`${range.start},${range.end}`"
                     class="component-label-segment"

--- a/app/gui2/src/components/ComponentBrowser.vue
+++ b/app/gui2/src/components/ComponentBrowser.vue
@@ -216,16 +216,17 @@ const fullQualifiedNameQuery = computed(() => {
  * - the separator (`.` or `_`, or the empty string if this is the last segment) */
 const extractMatchesRegex = computed(() => {
   if (fullQualifiedNameQuery.value == null) return undefined
-  return new RegExp(
-    '^(.*?)' +
-      fullQualifiedNameQuery.value.replace(/(.+?)([._]|$)/g, (_m, text, sep) =>
-        sep === '_'
-          ? `(?:()(${text})([^_.]*)(_))?`
-          : `(?:([^.]*_)?(${text})([^.]*)(${sep === '.' ? '\\.' : ''}))?`,
-      ) +
-      '(.*)$',
-    'i',
-  )
+  let prefix = ''
+  let suffix = ''
+  for (const [, text, separator] of fullQualifiedNameQuery.value.matchAll(/(.+?)([._]|$)/g)) {
+    const segment =
+      separator === '_'
+        ? `()(${text})([^_.]*)(_)`
+        : `([^.]*_)?(${text})([^.]*)(${separator === '.' ? '\\.' : ''})`
+    prefix = '(?:' + prefix
+    suffix += segment + ')?'
+  }
+  return new RegExp('^(.*?)' + prefix + suffix + '(.*)$', 'i')
 })
 
 interface MatchHighlightSegment {

--- a/app/gui2/src/components/ComponentBrowser.vue
+++ b/app/gui2/src/components/ComponentBrowser.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { makeComponentList, type Component } from '@/components/ComponentBrowser/component'
-import { Filtering, type MatchRange } from '@/components/ComponentBrowser/filtering'
+import { Filtering } from '@/components/ComponentBrowser/filtering'
 import { Input } from '@/components/ComponentBrowser/input'
 import SvgIcon from '@/components/SvgIcon.vue'
 import ToggleIcon from '@/components/ToggleIcon.vue'
@@ -8,6 +8,7 @@ import { useSuggestionDbStore } from '@/stores/suggestionDatabase'
 import { useApproach } from '@/util/animation'
 import { useResizeObserver } from '@/util/events'
 import type { useNavigator } from '@/util/navigator'
+import { allRanges } from '@/util/range'
 import { Vec2 } from '@/util/vec2'
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 
@@ -87,20 +88,6 @@ function handleDefocus(e: FocusEvent) {
     }
   } else {
     emit('finished')
-  }
-}
-
-// === Highlighting selected text ===
-
-function* allRanges(text: string, ranges: MatchRange[]) {
-  let lastEndIndex = 0
-  for (const range of ranges) {
-    yield { start: lastEndIndex, end: range.start, isMatch: false }
-    yield { ...range, isMatch: true }
-    lastEndIndex = range.end
-  }
-  if (lastEndIndex !== text.length) {
-    yield { start: lastEndIndex, end: text.length, isMatch: false }
   }
 }
 
@@ -308,7 +295,10 @@ function handleKeydown(e: KeyboardEvent) {
                     v-text="item.component.label"
                   ></span>
                   <span
-                    v-for="range in allRanges(item.component.label, item.component.matchedRanges)"
+                    v-for="range in allRanges(
+                      item.component.matchedRanges,
+                      item.component.label.length,
+                    )"
                     v-else
                     :key="`${range.start},${range.end}`"
                     class="component-label-segment"
@@ -335,7 +325,10 @@ function handleKeydown(e: KeyboardEvent) {
                     v-text="item.component.label"
                   ></span>
                   <span
-                    v-for="range in allRanges(item.component.label, item.component.matchedRanges)"
+                    v-for="range in allRanges(
+                      item.component.matchedRanges,
+                      item.component.label.length,
+                    )"
                     v-else
                     :key="`${range.start},${range.end}`"
                     class="component-label-segment"

--- a/app/gui2/src/components/ComponentBrowser/__tests__/component.test.ts
+++ b/app/gui2/src/components/ComponentBrowser/__tests__/component.test.ts
@@ -109,19 +109,54 @@ test('Matched ranges are correct', () => {
     return parts.join('')
   }
 
+  function replaceAliasMatches(component: Component) {
+    if (!component.matchedRanges || !component.matchedAlias) return
+    const parts: string[] = []
+    for (const range of allRanges(component.matchedAlias, component.matchedRanges)) {
+      const text = component.matchedAlias.slice(range.start, range.end)
+      parts.push(range.isMatch ? `<${text}>` : text)
+    }
+    return parts.join('')
+  }
+
   const pattern = 'foo_bar'
   const filtering = new Filtering({ pattern })
   const matchedSorted = [
     { name: 'foo_bar', highlighted: 'Project.<foo><_bar>' }, // exact match
     { name: 'foo_xyz_barabc', highlighted: 'Project.<foo>_xyz<_bar>abc' }, // first word exact match
     { name: 'fooabc_barabc', highlighted: 'Project.<foo>abc<_bar>abc' }, // first word match
-    { name: 'bar', aliases: ['foo_bar', 'foo'], highlighted: 'Project.bar' }, // exact alias match
-    { name: 'bar', aliases: ['foo', 'foo_xyz_barabc'], highlighted: 'Project.bar' }, // alias first word exact match
-    { name: 'bar', aliases: ['foo', 'fooabc_barabc'], highlighted: 'Project.bar' }, // alias first word match
+    {
+      name: 'bar',
+      aliases: ['foo_bar', 'foo'],
+      highlighted: 'Project.bar',
+      highlightedAlias: '<foo><_bar>',
+    }, // exact alias match
+    {
+      name: 'bar',
+      aliases: ['foo', 'foo_xyz_barabc'],
+      highlighted: 'Project.bar',
+      highlightedAlias: '<foo>_xyz<_bar>abc',
+    }, // alias first word exact match
+    {
+      name: 'bar',
+      aliases: ['foo', 'fooabc_barabc'],
+      highlighted: 'Project.bar',
+      highlightedAlias: '<foo>abc<_bar>abc',
+    }, // alias first word match
     { name: 'xyz_foo_abc_bar_xyz', highlighted: 'Project.xyz_<foo>_abc<_bar>_xyz' }, // exact word match
     { name: 'xyz_fooabc_abc_barabc_xyz', highlighted: 'Project.xyz_<foo>abc_abc<_bar>abc_xyz' }, // non-exact word match
-    { name: 'bar', aliases: ['xyz_foo_abc_bar_xyz'], highlighted: 'Project.bar' }, // alias word exact match
-    { name: 'bar', aliases: ['xyz_fooabc_abc_barabc_xyz'], highlighted: 'Project.bar' }, // alias word start match
+    {
+      name: 'bar',
+      aliases: ['xyz_foo_abc_bar_xyz'],
+      highlighted: 'Project.bar',
+      highlightedAlias: 'xyz_<foo>_abc<_bar>_xyz',
+    }, // alias word exact match
+    {
+      name: 'bar',
+      aliases: ['xyz_fooabc_abc_barabc_xyz'],
+      highlighted: 'Project.bar',
+      highlightedAlias: 'xyz_<foo>abc_abc<_bar>abc_xyz',
+    }, // alias word start match
   ]
   const entries = Array.from(matchedSorted, ({ name, aliases }, id) => {
     const entry: SuggestionEntry = {
@@ -135,5 +170,9 @@ test('Matched ranges are correct', () => {
       replaceMatches(makeComponent(entries[i]!, filtering)),
       `replaceMatches(${JSON.stringify(matchedSorted[i])})`,
     ).toEqual(matchedSorted[i]!.highlighted)
+    expect(
+      replaceAliasMatches(makeComponent(entries[i]!, filtering)),
+      `replaceAliasMatches(${JSON.stringify(matchedSorted[i])})`,
+    ).toEqual(matchedSorted[i]!.highlightedAlias)
   }
 })

--- a/app/gui2/src/components/ComponentBrowser/__tests__/component.test.ts
+++ b/app/gui2/src/components/ComponentBrowser/__tests__/component.test.ts
@@ -26,8 +26,8 @@ test.each([
 ])("$name Component's label is valid", (suggestion, expected, mainExpected?) => {
   const mainView = new Filtering({})
   const filteredView = new Filtering({ pattern: 'e' })
-  expect(labelOfEntry(suggestion, filteredView)).toBe(expected)
-  expect(labelOfEntry(suggestion, mainView)).toBe(mainExpected ?? expected)
+  expect(labelOfEntry(suggestion, filteredView, { score: 0 }).label).toBe(expected)
+  expect(labelOfEntry(suggestion, mainView, { score: 0 }).label).toBe(mainExpected ?? expected)
 })
 
 test('Suggestions are ordered properly', () => {

--- a/app/gui2/src/components/ComponentBrowser/__tests__/component.test.ts
+++ b/app/gui2/src/components/ComponentBrowser/__tests__/component.test.ts
@@ -7,7 +7,7 @@ import {
   type Component,
   type MatchedSuggestion,
 } from '@/components/ComponentBrowser/component'
-import { Filtering, type MatchRange } from '@/components/ComponentBrowser/filtering'
+import { Filtering } from '@/components/ComponentBrowser/filtering'
 import {
   makeCon,
   makeMethod,
@@ -16,6 +16,7 @@ import {
   makeStaticMethod,
   type SuggestionEntry,
 } from '@/stores/suggestionDatabase/entry'
+import { allRanges } from '@/util/range'
 import shuffleSeed from 'shuffle-seed'
 
 test.each([
@@ -87,22 +88,10 @@ test('Suggestions are ordered properly', () => {
 })
 
 test('Matched ranges are correct', () => {
-  function* allRanges(text: string, ranges: MatchRange[]) {
-    let lastEndIndex = 0
-    for (const range of ranges) {
-      yield { start: lastEndIndex, end: range.start, isMatch: false }
-      yield { ...range, isMatch: true }
-      lastEndIndex = range.end
-    }
-    if (lastEndIndex !== text.length) {
-      yield { start: lastEndIndex, end: text.length, isMatch: false }
-    }
-  }
-
   function replaceMatches(component: Component) {
     if (!component.matchedRanges || component.matchedAlias) return component.label
     const parts: string[] = []
-    for (const range of allRanges(component.label, component.matchedRanges)) {
+    for (const range of allRanges(component.matchedRanges, component.label.length)) {
       const text = component.label.slice(range.start, range.end)
       parts.push(range.isMatch ? `<${text}>` : text)
     }
@@ -112,7 +101,7 @@ test('Matched ranges are correct', () => {
   function replaceAliasMatches(component: Component) {
     if (!component.matchedRanges || !component.matchedAlias) return
     const parts: string[] = []
-    for (const range of allRanges(component.matchedAlias, component.matchedRanges)) {
+    for (const range of allRanges(component.matchedRanges, component.matchedAlias.length)) {
       const text = component.matchedAlias.slice(range.start, range.end)
       parts.push(range.isMatch ? `<${text}>` : text)
     }

--- a/app/gui2/src/components/ComponentBrowser/__tests__/filtering.test.ts
+++ b/app/gui2/src/components/ComponentBrowser/__tests__/filtering.test.ts
@@ -21,7 +21,7 @@ test.each([
   makeModule('Standard.Base.Data'),
 ])('$name entry is in the CB main view', (entry) => {
   const filtering = new Filtering({})
-  expect(filtering.filter(entry)).not.toBeNull()
+  expect(filtering.filter(entry)).not.toBeUndefined()
 })
 
 test.each([
@@ -30,7 +30,7 @@ test.each([
   makeModule('Standard.Base.Data.Vector'), // Not top module
 ])('$name entry is not in the CB main view', (entry) => {
   const filtering = new Filtering({})
-  expect(filtering.filter(entry)).toBeNull()
+  expect(filtering.filter(entry)).toBeUndefined()
 })
 
 test.each([
@@ -43,8 +43,8 @@ test.each([
 ])('$name entry is in the local.Project.Module content', (entry) => {
   const filtering = new Filtering({ qualifiedNamePattern: 'local.Project.Module' })
   const substringFiltering = new Filtering({ qualifiedNamePattern: 'local.Proj.Mod' })
-  expect(filtering.filter(entry)).not.toBeNull()
-  expect(substringFiltering.filter(entry)).not.toBeNull()
+  expect(filtering.filter(entry)).not.toBeUndefined()
+  expect(substringFiltering.filter(entry)).not.toBeUndefined()
 })
 
 test.each([
@@ -58,8 +58,8 @@ test.each([
 ])('$name entry is not in the local.Project.Module content', (entry) => {
   const filtering = new Filtering({ qualifiedNamePattern: 'local.Project.Module' })
   const substringFiltering = new Filtering({ qualifiedNamePattern: 'local.Proj.Mod' })
-  expect(filtering.filter(entry)).toBeNull()
-  expect(substringFiltering.filter(entry)).toBeNull()
+  expect(filtering.filter(entry)).toBeUndefined()
+  expect(substringFiltering.filter(entry)).toBeUndefined()
 })
 
 test.each([
@@ -79,7 +79,7 @@ test.each([
       pattern: 'foo',
       qualifiedNamePattern: 'local.Project.Module',
     })
-    expect(filtering.filter(entry)).not.toBeNull()
+    expect(filtering.filter(entry)).not.toBeUndefined()
   },
 )
 
@@ -95,7 +95,7 @@ test.each([
       pattern: 'foo',
       qualifiedNamePattern: 'local.Project.Module',
     })
-    expect(filtering.filter(entry)).toBeNull()
+    expect(filtering.filter(entry)).toBeUndefined()
   },
 )
 
@@ -112,8 +112,8 @@ test.each([
     pattern: 'foo',
     qualifiedNamePattern: 'local.Project.Module.Type',
   })
-  expect(filtering.filter(entry)).not.toBeNull()
-  expect(filteringWithPattern.filter(entry)).not.toBeNull()
+  expect(filtering.filter(entry)).not.toBeUndefined()
+  expect(filteringWithPattern.filter(entry)).not.toBeUndefined()
 })
 
 test.each([
@@ -123,7 +123,7 @@ test.each([
   makeStaticMethod('local.Project.Another_Module.Type.another_module_type_method'),
 ])('$name entry is not in the local.Project.Module.Type content', (entry) => {
   const filtering = new Filtering({ qualifiedNamePattern: 'local.Project.Module.Type' })
-  expect(filtering.filter(entry)).toBeNull()
+  expect(filtering.filter(entry)).toBeUndefined()
 })
 
 test('An Instance method is shown when self type matches', () => {
@@ -131,9 +131,9 @@ test('An Instance method is shown when self type matches', () => {
   const filteringWithSelfType = new Filtering({
     selfType: 'Standard.Base.Data.Vector.Vector' as QualifiedName,
   })
-  expect(filteringWithSelfType.filter(entry)).not.toBeNull()
+  expect(filteringWithSelfType.filter(entry)).not.toBeUndefined()
   const filteringWithoutSelfType = new Filtering({ pattern: 'get' })
-  expect(filteringWithoutSelfType.filter(entry)).toBeNull()
+  expect(filteringWithoutSelfType.filter(entry)).toBeUndefined()
 })
 
 test.each([
@@ -148,14 +148,14 @@ test.each([
   const filtering = new Filtering({
     selfType: 'Standard.Base.Data.Vector.Vector' as QualifiedName,
   })
-  expect(filtering.filter(entry)).toBeNull()
+  expect(filtering.filter(entry)).toBeUndefined()
 })
 
 test.each(['bar', 'barfoo', 'fo', 'bar_fo_bar'])("%s is not matched by pattern 'foo'", (name) => {
   const pattern = 'foo'
   const entry = makeModuleMethod(`local.Project.${name}`)
   const filtering = new Filtering({ pattern })
-  expect(filtering.filter(entry)).toBeNull()
+  expect(filtering.filter(entry)).toBeUndefined()
 })
 
 test('Matching pattern without underscores', () => {
@@ -177,10 +177,16 @@ test('Matching pattern without underscores', () => {
     const entry = { ...makeModuleMethod(`local.Project.${name}`), aliases: aliases ?? [] }
     return filtering.filter(entry)
   })
-  expect(matchResults[0]).not.toBeNull()
+  expect(matchResults[0]).not.toBeUndefined()
   for (let i = 1; i < matchResults.length; i++) {
-    expect(matchResults[i]).not.toBeNull()
-    expect(matchResults[i]?.score).toBeGreaterThan(matchResults[i - 1]?.score ?? Infinity)
+    expect(
+      matchResults[i],
+      `\`matchResults\` for ${JSON.stringify(matchedSorted[i]!)}`,
+    ).not.toBeUndefined()
+    expect(
+      matchResults[i]!.score,
+      `score('${matchedSorted[i]!.name}') > score('${matchedSorted[i - 1]!.name}')`,
+    ).toBeGreaterThan(matchResults[i - 1]!.score)
   }
 })
 
@@ -203,10 +209,16 @@ test('Matching pattern with underscores', () => {
     const entry = { ...makeModuleMethod(`local.Project.${name}`), aliases: aliases ?? [] }
     return filtering.filter(entry)
   })
-  expect(matchResults[0]).not.toBeNull()
+  expect(matchResults[0]).not.toBeUndefined()
   for (let i = 1; i < matchResults.length; i++) {
-    expect(matchResults[i]).not.toBeNull()
-    expect(matchResults[i]?.score).toBeGreaterThan(matchResults[i - 1]?.score ?? Infinity)
+    expect(
+      matchResults[i],
+      `\`matchResults\` for ${JSON.stringify(matchedSorted[i]!)}`,
+    ).not.toBeUndefined()
+    expect(
+      matchResults[i]!.score,
+      `score('${matchedSorted[i]!.name}') > score('${matchedSorted[i - 1]!.name}')`,
+    ).toBeGreaterThan(matchResults[i - 1]!.score)
   }
 })
 
@@ -217,12 +229,12 @@ test('Unstable filtering', () => {
     isUnstable: true,
   }
   const stableFiltering = new Filtering({ qualifiedNamePattern: 'local.Project.Type' })
-  expect(stableFiltering.filter(stableEntry)).not.toBeNull()
-  expect(stableFiltering.filter(unstableEntry)).toBeNull()
+  expect(stableFiltering.filter(stableEntry)).not.toBeUndefined()
+  expect(stableFiltering.filter(unstableEntry)).toBeUndefined()
   const unstableFiltering = new Filtering({
     qualifiedNamePattern: 'local.Project.Type',
     showUnstable: true,
   })
-  expect(unstableFiltering.filter(stableEntry)).not.toBeNull()
-  expect(unstableFiltering.filter(unstableEntry)).not.toBeNull()
+  expect(unstableFiltering.filter(stableEntry)).not.toBeUndefined()
+  expect(unstableFiltering.filter(unstableEntry)).not.toBeUndefined()
 })

--- a/app/gui2/src/components/ComponentBrowser/__tests__/filtering.test.ts
+++ b/app/gui2/src/components/ComponentBrowser/__tests__/filtering.test.ts
@@ -21,7 +21,7 @@ test.each([
   makeModule('Standard.Base.Data'),
 ])('$name entry is in the CB main view', (entry) => {
   const filtering = new Filtering({})
-  expect(filtering.filter(entry)).not.toBeUndefined()
+  expect(filtering.filter(entry)).not.toBeNull()
 })
 
 test.each([
@@ -30,7 +30,7 @@ test.each([
   makeModule('Standard.Base.Data.Vector'), // Not top module
 ])('$name entry is not in the CB main view', (entry) => {
   const filtering = new Filtering({})
-  expect(filtering.filter(entry)).toBeUndefined()
+  expect(filtering.filter(entry)).toBeNull()
 })
 
 test.each([
@@ -43,8 +43,8 @@ test.each([
 ])('$name entry is in the local.Project.Module content', (entry) => {
   const filtering = new Filtering({ qualifiedNamePattern: 'local.Project.Module' })
   const substringFiltering = new Filtering({ qualifiedNamePattern: 'local.Proj.Mod' })
-  expect(filtering.filter(entry)).not.toBeUndefined()
-  expect(substringFiltering.filter(entry)).not.toBeUndefined()
+  expect(filtering.filter(entry)).not.toBeNull()
+  expect(substringFiltering.filter(entry)).not.toBeNull()
 })
 
 test.each([
@@ -58,8 +58,8 @@ test.each([
 ])('$name entry is not in the local.Project.Module content', (entry) => {
   const filtering = new Filtering({ qualifiedNamePattern: 'local.Project.Module' })
   const substringFiltering = new Filtering({ qualifiedNamePattern: 'local.Proj.Mod' })
-  expect(filtering.filter(entry)).toBeUndefined()
-  expect(substringFiltering.filter(entry)).toBeUndefined()
+  expect(filtering.filter(entry)).toBeNull()
+  expect(substringFiltering.filter(entry)).toBeNull()
 })
 
 test.each([
@@ -79,7 +79,7 @@ test.each([
       pattern: 'foo',
       qualifiedNamePattern: 'local.Project.Module',
     })
-    expect(filtering.filter(entry)).not.toBeUndefined()
+    expect(filtering.filter(entry)).not.toBeNull()
   },
 )
 
@@ -95,7 +95,7 @@ test.each([
       pattern: 'foo',
       qualifiedNamePattern: 'local.Project.Module',
     })
-    expect(filtering.filter(entry)).toBeUndefined()
+    expect(filtering.filter(entry)).toBeNull()
   },
 )
 
@@ -112,8 +112,8 @@ test.each([
     pattern: 'foo',
     qualifiedNamePattern: 'local.Project.Module.Type',
   })
-  expect(filtering.filter(entry)).not.toBeUndefined()
-  expect(filteringWithPattern.filter(entry)).not.toBeUndefined()
+  expect(filtering.filter(entry)).not.toBeNull()
+  expect(filteringWithPattern.filter(entry)).not.toBeNull()
 })
 
 test.each([
@@ -123,7 +123,7 @@ test.each([
   makeStaticMethod('local.Project.Another_Module.Type.another_module_type_method'),
 ])('$name entry is not in the local.Project.Module.Type content', (entry) => {
   const filtering = new Filtering({ qualifiedNamePattern: 'local.Project.Module.Type' })
-  expect(filtering.filter(entry)).toBeUndefined()
+  expect(filtering.filter(entry)).toBeNull()
 })
 
 test('An Instance method is shown when self type matches', () => {
@@ -131,9 +131,9 @@ test('An Instance method is shown when self type matches', () => {
   const filteringWithSelfType = new Filtering({
     selfType: 'Standard.Base.Data.Vector.Vector' as QualifiedName,
   })
-  expect(filteringWithSelfType.filter(entry)).not.toBeUndefined()
+  expect(filteringWithSelfType.filter(entry)).not.toBeNull()
   const filteringWithoutSelfType = new Filtering({ pattern: 'get' })
-  expect(filteringWithoutSelfType.filter(entry)).toBeUndefined()
+  expect(filteringWithoutSelfType.filter(entry)).toBeNull()
 })
 
 test.each([
@@ -148,14 +148,14 @@ test.each([
   const filtering = new Filtering({
     selfType: 'Standard.Base.Data.Vector.Vector' as QualifiedName,
   })
-  expect(filtering.filter(entry)).toBeUndefined()
+  expect(filtering.filter(entry)).toBeNull()
 })
 
 test.each(['bar', 'barfoo', 'fo', 'bar_fo_bar'])("%s is not matched by pattern 'foo'", (name) => {
   const pattern = 'foo'
   const entry = makeModuleMethod(`local.Project.${name}`)
   const filtering = new Filtering({ pattern })
-  expect(filtering.filter(entry)).toBeUndefined()
+  expect(filtering.filter(entry)).toBeNull()
 })
 
 test('Matching pattern without underscores', () => {
@@ -177,12 +177,12 @@ test('Matching pattern without underscores', () => {
     const entry = { ...makeModuleMethod(`local.Project.${name}`), aliases: aliases ?? [] }
     return filtering.filter(entry)
   })
-  expect(matchResults[0]).not.toBeUndefined()
+  expect(matchResults[0]).not.toBeNull()
   for (let i = 1; i < matchResults.length; i++) {
     expect(
       matchResults[i],
       `\`matchResults\` for ${JSON.stringify(matchedSorted[i]!)}`,
-    ).not.toBeUndefined()
+    ).not.toBeNull()
     expect(
       matchResults[i]!.score,
       `score('${matchedSorted[i]!.name}') > score('${matchedSorted[i - 1]!.name}')`,
@@ -209,12 +209,12 @@ test('Matching pattern with underscores', () => {
     const entry = { ...makeModuleMethod(`local.Project.${name}`), aliases: aliases ?? [] }
     return filtering.filter(entry)
   })
-  expect(matchResults[0]).not.toBeUndefined()
+  expect(matchResults[0]).not.toBeNull()
   for (let i = 1; i < matchResults.length; i++) {
     expect(
       matchResults[i],
       `\`matchResults\` for ${JSON.stringify(matchedSorted[i]!)}`,
-    ).not.toBeUndefined()
+    ).not.toBeNull()
     expect(
       matchResults[i]!.score,
       `score('${matchedSorted[i]!.name}') > score('${matchedSorted[i - 1]!.name}')`,
@@ -229,14 +229,14 @@ test('Unstable filtering', () => {
     isUnstable: true,
   }
   const stableFiltering = new Filtering({ qualifiedNamePattern: 'local.Project.Type' })
-  expect(stableFiltering.filter(stableEntry)).not.toBeUndefined()
-  expect(stableFiltering.filter(unstableEntry)).toBeUndefined()
+  expect(stableFiltering.filter(stableEntry)).not.toBeNull()
+  expect(stableFiltering.filter(unstableEntry)).toBeNull()
   const unstableFiltering = new Filtering({
     qualifiedNamePattern: 'local.Project.Type',
     showUnstable: true,
   })
-  expect(unstableFiltering.filter(stableEntry)).not.toBeUndefined()
-  expect(unstableFiltering.filter(unstableEntry)).not.toBeUndefined()
+  expect(unstableFiltering.filter(stableEntry)).not.toBeNull()
+  expect(unstableFiltering.filter(unstableEntry)).not.toBeNull()
 })
 
 test('Match ranges', () => {

--- a/app/gui2/src/components/ComponentBrowser/component.ts
+++ b/app/gui2/src/components/ComponentBrowser/component.ts
@@ -1,8 +1,4 @@
-import {
-  Filtering,
-  type MatchRange,
-  type MatchResult,
-} from '@/components/ComponentBrowser/filtering'
+import { Filtering, type MatchResult } from '@/components/ComponentBrowser/filtering'
 import { SuggestionDb } from '@/stores/suggestionDatabase'
 import {
   SuggestionKind,
@@ -12,11 +8,12 @@ import {
 import { compareOpt } from '@/util/compare'
 import { isSome } from '@/util/opt'
 import { qnIsTopElement, qnLastSegmentIndex } from '@/util/qualifiedName'
+import type { Range } from '@/util/range'
 
 interface ComponentLabel {
   label: string
   matchedAlias?: string | undefined
-  matchedRanges?: MatchRange[] | undefined
+  matchedRanges?: Range[] | undefined
 }
 
 export interface Component extends ComponentLabel {

--- a/app/gui2/src/components/ComponentBrowser/component.ts
+++ b/app/gui2/src/components/ComponentBrowser/component.ts
@@ -7,12 +7,12 @@ import {
 } from '@/stores/suggestionDatabase/entry'
 import { compareOpt } from '@/util/compare'
 import { isSome } from '@/util/opt'
-import { qnIsTopElement, qnLastSegment } from '@/util/qualifiedName'
+import { qnIsTopElement, qnLastSegment, type QualifiedName } from '@/util/qualifiedName'
 
 export interface Component {
   suggestionId: SuggestionId
   icon: string
-  label: string
+  label: QualifiedName
   match: MatchResult
   group?: number | undefined
 }
@@ -21,7 +21,7 @@ export function labelOfEntry(entry: SuggestionEntry, filtering: Filtering) {
   const isTopModule = entry.kind == SuggestionKind.Module && qnIsTopElement(entry.definedIn)
   if (filtering.isMainView() && isTopModule) return entry.definedIn
   else if (entry.memberOf && entry.selfType == null)
-    return `${qnLastSegment(entry.memberOf)}.${entry.name}`
+    return `${qnLastSegment(entry.memberOf)}.${entry.name}` as QualifiedName
   else return entry.name
 }
 

--- a/app/gui2/src/components/ComponentBrowser/component.ts
+++ b/app/gui2/src/components/ComponentBrowser/component.ts
@@ -7,12 +7,12 @@ import {
 } from '@/stores/suggestionDatabase/entry'
 import { compareOpt } from '@/util/compare'
 import { isSome } from '@/util/opt'
-import { qnIsTopElement, qnLastSegment, type QualifiedName } from '@/util/qualifiedName'
+import { qnIsTopElement, qnLastSegment } from '@/util/qualifiedName'
 
 export interface Component {
   suggestionId: SuggestionId
   icon: string
-  label: QualifiedName
+  label: string
   match: MatchResult
   group?: number | undefined
 }
@@ -21,7 +21,7 @@ export function labelOfEntry(entry: SuggestionEntry, filtering: Filtering) {
   const isTopModule = entry.kind == SuggestionKind.Module && qnIsTopElement(entry.definedIn)
   if (filtering.isMainView() && isTopModule) return entry.definedIn
   else if (entry.memberOf && entry.selfType == null)
-    return `${qnLastSegment(entry.memberOf)}.${entry.name}` as QualifiedName
+    return `${qnLastSegment(entry.memberOf)}.${entry.name}`
   else return entry.name
 }
 

--- a/app/gui2/src/components/ComponentBrowser/component.ts
+++ b/app/gui2/src/components/ComponentBrowser/component.ts
@@ -10,13 +10,13 @@ import {
   type SuggestionId,
 } from '@/stores/suggestionDatabase/entry'
 import { compareOpt } from '@/util/compare'
-import { isSome, type Opt } from '@/util/opt'
+import { isSome } from '@/util/opt'
 import { qnIsTopElement, qnLastSegmentIndex } from '@/util/qualifiedName'
 
 interface ComponentLabel {
   label: string
-  matchedAlias?: Opt<string>
-  matchedRanges?: MatchRange[]
+  matchedAlias?: string | undefined
+  matchedRanges?: MatchRange[] | undefined
 }
 
 export interface Component extends ComponentLabel {
@@ -36,8 +36,15 @@ export function labelOfEntry(
     const lastSegmentStart = qnLastSegmentIndex(entry.memberOf) + 1
     const parentModule = entry.memberOf.substring(lastSegmentStart)
     const nameOffset = parentModule.length + 1
-    if (!match.memberOfRanges && !match.definedInRanges && !match.nameRanges)
-      return { label: `${parentModule}.${entry.name}`, matchedAlias: match.matchedAlias }
+    if (
+      (!match.memberOfRanges && !match.definedInRanges && !match.nameRanges) ||
+      match.matchedAlias
+    )
+      return {
+        label: `${parentModule}.${entry.name}`,
+        matchedAlias: match.matchedAlias,
+        matchedRanges: match.nameRanges,
+      }
     return {
       label: `${parentModule}.${entry.name}`,
       matchedAlias: match.matchedAlias,

--- a/app/gui2/src/components/ComponentBrowser/filtering.ts
+++ b/app/gui2/src/components/ComponentBrowser/filtering.ts
@@ -149,7 +149,6 @@ class FilteringWithPattern {
       }
     }
     if (matchedAlias) {
-      const start = this.wordMatchRegex.lastIndex
       return {
         matchedAlias: matchedAlias.alias,
         score: this.matchedWordsScore(
@@ -157,7 +156,7 @@ class FilteringWithPattern {
           matchedAlias.alias,
           matchedAlias.match,
         ),
-        nameRanges: [{ start, end: start + matchedAlias.match[0].length }],
+        nameRanges: FilteringWithPattern.wordMatchRanges(matchedAlias.match),
       }
     }
     if (this.initialsMatchRegex) {

--- a/app/gui2/src/components/ComponentBrowser/filtering.ts
+++ b/app/gui2/src/components/ComponentBrowser/filtering.ts
@@ -75,8 +75,7 @@ class FilteringWithPattern {
     matches: RegExpExecArray,
   ): number {
     const words: string[] = []
-    const end = matches.length - 1
-    for (let i = 2; i < end; i += 3) {
+    for (let i = 2; i < matches.length; i += 3) {
       words.push(matches[i]!, matches[i + 1]!)
     }
     const matchedWords = words.join('_')
@@ -121,7 +120,7 @@ class FilteringWithPattern {
 
   tryMatch(entry: SuggestionEntry): Opt<MatchResult> {
     const nameWordsMatch = this.wordMatchRegex?.exec(entry.name)
-    if (nameWordsMatch?.index === 0) {
+    if (nameWordsMatch?.[1]?.length === 0) {
       return {
         score: this.matchedWordsScore(
           MatchTypeScore.NameWordMatchFirst,
@@ -132,7 +131,7 @@ class FilteringWithPattern {
       }
     }
     const matchedAlias = this.firstMatchingAlias(entry)
-    if (matchedAlias?.match.index === 0) {
+    if (matchedAlias?.match?.[1]?.length === 0) {
       return {
         matchedAlias: matchedAlias.alias,
         score: this.matchedWordsScore(
@@ -170,7 +169,7 @@ class FilteringWithPattern {
         }
       }
       for (const alias of entry.aliases) {
-        const initialsMatch = this.initialsMatchRegex.exec(entry.name)
+        const initialsMatch = this.initialsMatchRegex.exec(alias)
         if (initialsMatch) {
           return {
             matchedAlias: alias,

--- a/app/gui2/src/components/ComponentBrowser/filtering.ts
+++ b/app/gui2/src/components/ComponentBrowser/filtering.ts
@@ -1,6 +1,7 @@
 import { SuggestionKind, type SuggestionEntry } from '@/stores/suggestionDatabase/entry'
 import type { Opt } from '@/util/opt'
 import { qnIsTopElement, qnParent, type QualifiedName } from '@/util/qualifiedName'
+import type { Range } from '@/util/range'
 
 export interface Filter {
   pattern?: string
@@ -19,16 +20,11 @@ export enum MatchTypeScore {
   AliasInitialMatch = 5000,
 }
 
-export interface MatchRange {
-  start: number
-  end: number
-}
-
 interface MatchedParts {
   matchedAlias?: string
-  nameRanges?: MatchRange[]
-  definedInRanges?: MatchRange[]
-  memberOfRanges?: MatchRange[]
+  nameRanges?: Range[]
+  definedInRanges?: Range[]
+  memberOfRanges?: Range[]
 }
 
 export interface MatchResult extends MatchedParts {
@@ -94,7 +90,7 @@ class FilteringWithPattern {
   }
 
   private static wordMatchRanges(wordMatch: RegExpExecArray) {
-    const result: MatchRange[] = []
+    const result: Range[] = []
     for (let i = 1, pos = 0; i < wordMatch.length; i += 1) {
       // Matches come in groups of three, and the first matched part is `match[2]`.
       if (i % 3 === 2) {
@@ -106,7 +102,7 @@ class FilteringWithPattern {
   }
 
   private static initialsMatchRanges(initialsMatch: RegExpExecArray) {
-    const result: MatchRange[] = []
+    const result: Range[] = []
     for (let i = 1, pos = 0; i < initialsMatch.length; i += 1) {
       // Matches come in groups of two, and the first matched part is `match[2]` (= 0 mod 2).
       if (i % 2 === 0) {
@@ -202,7 +198,7 @@ class FilteringQualifiedName {
   }
 
   private static matchRanges(match: RegExpExecArray) {
-    const result: MatchRange[] = []
+    const result: Range[] = []
     for (let i = 1, pos = 0; i < match.length; i += 1) {
       // Matches come in groups of two, and the first matched part is `match[2]` (= 0 mod 2).
       if (i % 2 === 0) {

--- a/app/gui2/src/util/database/__tests__/reactiveDb.test.ts
+++ b/app/gui2/src/util/database/__tests__/reactiveDb.test.ts
@@ -38,21 +38,16 @@ test('Indexing is efficient', () => {
 
 test('Error reported when indexer implementation returns non-unique pairs', () => {
   const db = new ReactiveDb()
-  const actualConsoleError = console.error
   console.error = () => {}
-  try {
-    const consoleError = vi.spyOn(console, 'error')
-    // Invalid index
-    new ReactiveIndex(db, (_id, _entry) => [[1, 1]])
-    db.set(1, 1)
-    db.set(2, 2)
-    expect(consoleError).toHaveBeenCalledOnce()
-    expect(consoleError).toHaveBeenCalledWith(
-      'Attempt to repeatedly write the same key-value pair (1,1) to the index. Please check your indexer implementation.',
-    )
-  } finally {
-    console.error = actualConsoleError
-  }
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+  // Invalid index
+  new ReactiveIndex(db, (_id, _entry) => [[1, 1]])
+  db.set(1, 1)
+  db.set(2, 2)
+  expect(consoleError).toHaveBeenCalledOnce()
+  expect(consoleError).toHaveBeenCalledWith(
+    'Attempt to repeatedly write the same key-value pair (1,1) to the index. Please check your indexer implementation.',
+  )
 })
 
 test('Name to id index', () => {

--- a/app/gui2/src/util/database/__tests__/reactiveDb.test.ts
+++ b/app/gui2/src/util/database/__tests__/reactiveDb.test.ts
@@ -38,14 +38,18 @@ test('Indexing is efficient', () => {
 
 test('Error reported when indexer implementation returns non-unique pairs', () => {
   const db = new ReactiveDb()
+  const actualConsoleError = console.error
+  console.error = () => {}
   const consoleError = vi.spyOn(console, 'error')
-  const _invalidIndex = new ReactiveIndex(db, (_id, _entry) => [[1, 1]])
+  // Invalid index
+  new ReactiveIndex(db, (_id, _entry) => [[1, 1]])
   db.set(1, 1)
   db.set(2, 2)
   expect(consoleError).toHaveBeenCalledOnce()
   expect(consoleError).toHaveBeenCalledWith(
     'Attempt to repeatedly write the same key-value pair (1,1) to the index. Please check your indexer implementation.',
   )
+  console.error = actualConsoleError
 })
 
 test('Name to id index', () => {

--- a/app/gui2/src/util/database/__tests__/reactiveDb.test.ts
+++ b/app/gui2/src/util/database/__tests__/reactiveDb.test.ts
@@ -40,16 +40,19 @@ test('Error reported when indexer implementation returns non-unique pairs', () =
   const db = new ReactiveDb()
   const actualConsoleError = console.error
   console.error = () => {}
-  const consoleError = vi.spyOn(console, 'error')
-  // Invalid index
-  new ReactiveIndex(db, (_id, _entry) => [[1, 1]])
-  db.set(1, 1)
-  db.set(2, 2)
-  expect(consoleError).toHaveBeenCalledOnce()
-  expect(consoleError).toHaveBeenCalledWith(
-    'Attempt to repeatedly write the same key-value pair (1,1) to the index. Please check your indexer implementation.',
-  )
-  console.error = actualConsoleError
+  try {
+    const consoleError = vi.spyOn(console, 'error')
+    // Invalid index
+    new ReactiveIndex(db, (_id, _entry) => [[1, 1]])
+    db.set(1, 1)
+    db.set(2, 2)
+    expect(consoleError).toHaveBeenCalledOnce()
+    expect(consoleError).toHaveBeenCalledWith(
+      'Attempt to repeatedly write the same key-value pair (1,1) to the index. Please check your indexer implementation.',
+    )
+  } finally {
+    console.error = actualConsoleError
+  }
 })
 
 test('Name to id index', () => {

--- a/app/gui2/src/util/qualifiedName.ts
+++ b/app/gui2/src/util/qualifiedName.ts
@@ -143,7 +143,6 @@ if (import.meta.vitest) {
     ['local.Project.Module.elem', false],
   ])('qnIsTopElement(%s) returns %s', (name, result) => {
     const qn = unwrap(tryQualifiedName(name))
-    console.log('qn', qn)
     expect(qnIsTopElement(qn)).toBe(result)
   })
 }

--- a/app/gui2/src/util/qualifiedName.ts
+++ b/app/gui2/src/util/qualifiedName.ts
@@ -70,7 +70,7 @@ export function qnJoin(left: QualifiedName, right: QualifiedName): QualifiedName
  * The element is considered a top element if there is max 1 segment in the path.
  */
 export function qnIsTopElement(name: QualifiedName): boolean {
-  return !/[.].*?[.]/.test(name)
+  return !/[.].*?[.].*?[.]/.test(name)
 }
 
 if (import.meta.vitest) {
@@ -143,6 +143,7 @@ if (import.meta.vitest) {
     ['local.Project.Module.elem', false],
   ])('qnIsTopElement(%s) returns %s', (name, result) => {
     const qn = unwrap(tryQualifiedName(name))
+    console.log('qn', qn)
     expect(qnIsTopElement(qn)).toBe(result)
   })
 }

--- a/app/gui2/src/util/qualifiedName.ts
+++ b/app/gui2/src/util/qualifiedName.ts
@@ -34,9 +34,15 @@ export function tryQualifiedName(str: string): Result<QualifiedName> {
   return isQualifiedName(str) ? Ok(str) : Err(`"${str}" is not a valid qualified name`)
 }
 
+/** The index of the `.` between the last segment and all other segments.
+ * The start of the last segment is one higher than this index. */
+export function qnLastSegmentIndex(name: QualifiedName) {
+  return name.lastIndexOf('.')
+}
+
 /** Split the qualified name to parent and last segment (name). */
 export function qnSplit(name: QualifiedName): [Opt<QualifiedName>, Identifier] {
-  const separator = name.lastIndexOf('.')
+  const separator = qnLastSegmentIndex(name)
   const parent = separator > 0 ? (name.substring(0, separator) as QualifiedName) : null
   const lastSegment = name.substring(separator + 1) as Identifier
   return [parent, lastSegment]
@@ -44,13 +50,13 @@ export function qnSplit(name: QualifiedName): [Opt<QualifiedName>, Identifier] {
 
 /** Get the last segment of qualified name. */
 export function qnLastSegment(name: QualifiedName): Identifier {
-  const separator = name.lastIndexOf('.')
+  const separator = qnLastSegmentIndex(name)
   return name.substring(separator + 1) as Identifier
 }
 
 /** Get the parent qualified name (without last segment) */
 export function qnParent(name: QualifiedName): Opt<QualifiedName> {
-  const separator = name.lastIndexOf('.')
+  const separator = qnLastSegmentIndex(name)
   return separator > 1 ? (name.substring(0, separator) as QualifiedName) : null
 }
 
@@ -64,7 +70,7 @@ export function qnJoin(left: QualifiedName, right: QualifiedName): QualifiedName
  * The element is considered a top element if there is max 1 segment in the path.
  */
 export function qnIsTopElement(name: QualifiedName): boolean {
-  return (name.match(/\./g)?.length ?? 0) <= 2
+  return !/[.].*?[.]/.test(name)
 }
 
 if (import.meta.vitest) {

--- a/app/gui2/src/util/range.ts
+++ b/app/gui2/src/util/range.ts
@@ -1,0 +1,39 @@
+export interface Range {
+  start: number
+  end: number
+}
+
+export interface RangeWithMatch {
+  start: number
+  end: number
+  isMatch: boolean
+}
+
+/** Return the included ranges, in addition to the ranges before, between,
+ * and after the included ranges. */
+export function allRanges(ranges: Range[], end: number): Generator<RangeWithMatch>
+export function allRanges(ranges: Range[], start: number, end: number): Generator<RangeWithMatch>
+export function allRanges(
+  ranges: Range[],
+  startOrEnd: number,
+  end?: number,
+): Generator<RangeWithMatch>
+export function* allRanges(
+  ranges: Range[],
+  start: number,
+  end?: number,
+): Generator<RangeWithMatch> {
+  if (end == null) {
+    end = start
+    start = 0
+  }
+  let lastEndIndex = start
+  for (const range of ranges) {
+    yield { start: lastEndIndex, end: range.start, isMatch: false }
+    yield { ...range, isMatch: true }
+    lastEndIndex = range.end
+  }
+  if (lastEndIndex !== end) {
+    yield { start: lastEndIndex, end, isMatch: false }
+  }
+}

--- a/app/gui2/vitest.config.ts
+++ b/app/gui2/vitest.config.ts
@@ -10,6 +10,7 @@ export default mergeConfig(
       includeSource: ['./{src,shared,ydoc-server}/**/*.{ts,vue}'],
       exclude: [...configDefaults.exclude, 'e2e/*'],
       root: fileURLToPath(new URL('./', import.meta.url)),
+      restoreMocks: true,
     },
     define: {
       RUNNING_VITEST: true,


### PR DESCRIPTION
### Pull Request Description
- Closes #8062

### Important Notes
- This PR uses a completely separate implementation from the regexes used for the existing filtering. AFAICT, this is unavoidable, since this needs to retrieve matched text.
- I've come across a couple minor bugs related to the Component Browser:
  - When deleting text (backspacing), the full list of unfiltered entries momentarily reappear because the filtering is reset.
  - Things like `h.m` match `HTTP_Method` - if this is not intentional, it seems like it might be more difficult to fix, unfortunately.
    - Note that highlighting (I assume correctly?) *does not* highlight any part of `HTTP_Method`.

### Screencast

https://github.com/enso-org/enso/assets/4046547/cd369141-069e-4204-b255-016d10f510cd

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
