### PR TITLE
More debug info for failed edits

### DIFF
--- a/engine/runtime-instrument-common/src/test/scala/org/enso/compiler/test/context/ChangesetBuilderTest.scala
+++ b/engine/runtime-instrument-common/src/test/scala/org/enso/compiler/test/context/ChangesetBuilderTest.scala
@@ -16,6 +16,7 @@ import org.enso.compiler.pass.PassManager
 import org.enso.compiler.test.CompilerTest
 import org.enso.interpreter.runtime.scope.LocalScope
 import org.enso.text.buffer.Rope
+import org.enso.text.editing.JavaEditorAdapter
 import org.enso.text.editing.model.{Position, Range, TextEdit}
 
 import java.util.UUID
@@ -334,6 +335,22 @@ class ChangesetBuilderTest extends CompilerTest {
         y.getId,
         plus.getId
       )
+    }
+
+    "multiple last line" in {
+      val code =
+        """foo x =
+          |    z = 1
+          |    y = z
+          |    y + x""".stripMargin.linesIterator.mkString("\n")
+      val edits = Seq(
+        TextEdit(Range(Position(3, 4), Position(3, 9)), "y + x + y"),
+        TextEdit(Range(Position(3, 4), Position(3, 13)), "y + x + y + x"),
+        TextEdit(Range(Position(3, 4), Position(3, 17)), "y + x + y + x + 1")
+      )
+      val source = Rope(code)
+      val result = JavaEditorAdapter.applyEdits(source, edits)
+      result.isRight shouldBe true
     }
 
     "module with undefined literal" in {

--- a/engine/runtime/src/main/java/org/enso/interpreter/service/error/FailedToApplyEditsException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/service/error/FailedToApplyEditsException.java
@@ -17,12 +17,14 @@ public class FailedToApplyEditsException extends RuntimeException implements Ser
    * @param source the source text.
    */
   public FailedToApplyEditsException(
-          QualifiedName module, Seq<model.TextEdit> edits, Object failure, Object source) {
+      QualifiedName module, Seq<model.TextEdit> edits, Object failure, Object source) {
     super(
         "Failed to apply edits for "
             + module
             + ", edits="
-            + edits.map(edit -> edit.copy(edit.range(), new MaskedString(edit.text()).applyMasking())).toString()
+            + edits
+                .map(edit -> edit.copy(edit.range(), new MaskedString(edit.text()).applyMasking()))
+                .toString()
             + ", failure="
             + failure
             + ", source='"

--- a/engine/runtime/src/main/java/org/enso/interpreter/service/error/FailedToApplyEditsException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/service/error/FailedToApplyEditsException.java
@@ -2,6 +2,8 @@ package org.enso.interpreter.service.error;
 
 import org.enso.logger.masking.MaskedString;
 import org.enso.pkg.QualifiedName;
+import org.enso.text.editing.model;
+import scala.collection.immutable.Seq;
 
 /** Thrown when the edits can not be applied to the source. */
 public class FailedToApplyEditsException extends RuntimeException implements ServiceException {
@@ -15,12 +17,12 @@ public class FailedToApplyEditsException extends RuntimeException implements Ser
    * @param source the source text.
    */
   public FailedToApplyEditsException(
-      QualifiedName module, Object edits, Object failure, Object source) {
+          QualifiedName module, Seq<model.TextEdit> edits, Object failure, Object source) {
     super(
         "Failed to apply edits for "
             + module
             + ", edits="
-            + new MaskedString(edits.toString()).applyMasking()
+            + edits.map(edit -> edit.copy(edit.range(), new MaskedString(edit.text()).applyMasking())).toString()
             + ", failure="
             + failure
             + ", source='"


### PR DESCRIPTION
### Pull Request Description

Unmasked position info for the failed edits so that it is possible to understand what edits are attempted at all. So far unable to locate the problem based solely on the logs and the stacktrace. Added a test confirming that making edits at the end of the file continues to be fine (that's where the problem usually manifests itself).

### Important Notes

References #7978 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
