### PR TITLE
Error on invalid capability acquire/release request

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/capability/CapabilityRouter.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/capability/CapabilityRouter.scala
@@ -4,6 +4,8 @@ import akka.actor.{Actor, ActorRef, Props}
 import com.typesafe.scalalogging.LazyLogging
 import org.enso.languageserver.capability.CapabilityProtocol.{
   AcquireCapability,
+  CapabilityAcquisitionBadRequest,
+  CapabilityReleaseBadRequest,
   ReleaseCapability
 }
 import org.enso.languageserver.data.{
@@ -65,6 +67,10 @@ class CapabilityRouter(
           CapabilityRegistration(ReceivesSuggestionsDatabaseUpdates())
         ) =>
       suggestionsHandler.forward(msg)
+    case AcquireCapability(_, _) =>
+      sender() ! CapabilityAcquisitionBadRequest
+    case ReleaseCapability(_, _) =>
+      sender() ! CapabilityReleaseBadRequest
   }
 
 }

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/CapabilitiesTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/CapabilitiesTest.scala
@@ -1,0 +1,81 @@
+package org.enso.languageserver.websocket.json
+
+import io.circe.literal._
+import io.circe.parser.parse
+import io.circe.syntax.EncoderOps
+import org.enso.polyglot.runtime.Runtime.Api
+
+import java.util.UUID
+
+class CapabilitiesTest extends BaseServerTest {
+
+  "capability/acquire" must {
+
+    "return an error response to the client when requesting it for `executionContext/canModify`" in {
+      val client    = getInitialisedWsClient()
+      val contextId = createExecutionContext(client)
+      client.send(json"""
+        { "jsonrpc": "2.0",
+          "method": "capability/acquire",
+          "id": 1,
+          "params": {
+            "method" : "executionContext/canModify",
+            "registerOptions": {
+             "contextId" : $contextId
+            }
+          }
+        }
+        """)
+      val response = parse(client.expectMessage()).rightValue.asObject.value
+      response("jsonrpc") shouldEqual Some("2.0".asJson)
+      response("id") shouldEqual Some(1.asJson)
+      val err = response("error").value.asObject.value
+      err("message") shouldEqual Some("Service error".asJson)
+    }
+  }
+
+  "capability/release" must {
+
+    "return an error response to the client when requesting it for `executionContext/canModify`" in {
+      val client    = getInitialisedWsClient()
+      val contextId = createExecutionContext(client)
+      client.send(json"""
+        { "jsonrpc": "2.0",
+          "method": "capability/release",
+          "id": 1,
+          "params": {
+            "method" : "executionContext/canModify",
+            "registerOptions": {
+             "contextId" : $contextId
+            }
+          }
+        }
+        """)
+      val response = parse(client.expectMessage()).rightValue.asObject.value
+      response("jsonrpc") shouldEqual Some("2.0".asJson)
+      response("id") shouldEqual Some(1.asJson)
+      val err = response("error").value.asObject.value
+      err("message") shouldEqual Some("Service error".asJson)
+    }
+  }
+
+  private def createExecutionContext(client: WsTestClient): UUID = {
+    client.send(ExecutionContextJsonMessages.executionContextCreateRequest(0))
+    val (requestId, contextId) =
+      runtimeConnectorProbe.receiveN(1).head match {
+        case Api.Request(requestId, Api.CreateContextRequest(contextId)) =>
+          (requestId, contextId)
+        case msg =>
+          fail(s"Unexpected message: $msg")
+      }
+
+    runtimeConnectorProbe.lastSender ! Api.Response(
+      requestId,
+      Api.CreateContextResponse(contextId)
+    )
+    client.expectJson(
+      ExecutionContextJsonMessages.executionContextCreateResponse(0, contextId)
+    )
+    contextId
+  }
+}


### PR DESCRIPTION
### Pull Request Description

`capability/acquire` with an invalid method `executionContext/canModify` would previously timeout because the capability router simply didn't support that kind of capability request.
Now rather than timing out, indicating a failure on LS, we report an error.

Closes #8038.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
