### PR TITLE
Resolve imports and exports via cached BindingsMap

### DIFF
--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Module.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Module.scala
@@ -21,7 +21,7 @@ import java.util.UUID
   * @param diagnostics compiler diagnostics for this node
   */
 @SerialVersionUID(
-  8145L // Scala to Java
+  8160L // Use BindingsMap
 )       // prevents reading broken caches, see PR-3692 for details
 sealed case class Module(
   imports: List[Import],

--- a/engine/runtime/src/main/java/org/enso/compiler/Cache.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/Cache.java
@@ -257,8 +257,14 @@ public abstract class Cache<T, M extends Cache.Metadata> {
       if (sourceDigestValid && blobDigestValid) {
         T cachedObject = null;
         try {
+          long now = System.currentTimeMillis();
           cachedObject = deserialize(context, blobBytes, meta, logger);
+          long took = System.currentTimeMillis() - now;
           if (cachedObject != null) {
+            logger.log(
+                Level.FINEST,
+                "Loaded cache for {0} with {1} bytes in {2} ms",
+                new Object[] {logName, blobBytes.length, took});
             return Optional.of(cachedObject);
           } else {
             logger.log(logLevel, "`{0}` was corrupt on disk.", logName);

--- a/engine/runtime/src/main/java/org/enso/compiler/context/CompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/context/CompilerContext.java
@@ -104,6 +104,8 @@ public interface CompilerContext {
   <T> Optional<TruffleFile> saveCache(Cache<T, ?> cache, T entry, boolean useGlobalCacheLocations);
 
   public static interface Updater {
+    void bindingsMap(BindingsMap map);
+
     void ir(org.enso.compiler.core.ir.Module ir);
 
     void compilationStage(CompilationStage stage);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -258,8 +258,7 @@ final class TruffleCompilerContext implements CompilerContext {
 
 
   private final class ModuleUpdater implements Updater, AutoCloseable {
-    private final Module compilerModule;
-    private final org.enso.interpreter.runtime.Module module;
+    private final Module module;
     private BindingsMap map;
     private org.enso.compiler.core.ir.Module ir;
     private CompilationStage stage;
@@ -269,8 +268,7 @@ final class TruffleCompilerContext implements CompilerContext {
     private boolean invalidateCache;
 
     private ModuleUpdater(Module module) {
-      this.compilerModule = module;
-      this.module = module.module;
+      this.module = module;
     }
 
     @Override
@@ -311,29 +309,29 @@ final class TruffleCompilerContext implements CompilerContext {
     @Override
     public void close() {
       if (map != null) {
-        if (compilerModule.bindings != null) {
-          throw new IllegalStateException("Reassigining bindings to " + compilerModule);
+        if (module.bindings != null) {
+          throw new IllegalStateException("Reassigining bindings to " + module);
         }
-        compilerModule.bindings = map;
+        module.bindings = map;
       }
       if (ir != null) {
-        module.unsafeSetIr(ir);
+        module.module.unsafeSetIr(ir);
       }
       if (stage != null) {
-        module.unsafeSetCompilationStage(stage);
+        module.module.unsafeSetCompilationStage(stage);
       }
       if (loadedFromCache != null) {
-        module.setLoadedFromCache(loadedFromCache);
+        module.module.setLoadedFromCache(loadedFromCache);
       }
       if (hasCrossModuleLinks != null) {
-        module.setHasCrossModuleLinks(hasCrossModuleLinks);
+        module.module.setHasCrossModuleLinks(hasCrossModuleLinks);
       }
       if (resetScope) {
-        module.ensureScopeExists();
-        module.getScope().reset();
+        module.module.ensureScopeExists();
+        module.module.getScope().reset();
       }
       if (invalidateCache) {
-        module.getCache().invalidate(context);
+        module.module.getCache().invalidate(context);
       }
     }
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -311,6 +311,9 @@ final class TruffleCompilerContext implements CompilerContext {
     @Override
     public void close() {
       if (map != null) {
+        if (compilerModule.bindings != null) {
+          throw new IllegalStateException("Reassigining bindings to " + compilerModule);
+        }
         compilerModule.bindings = map;
       }
       if (ir != null) {

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -524,7 +524,6 @@ class Compiler(
             .map { concreteBindings =>
               concreteBindings
             }
-          ensureParsed(module)
           val currentLocal = module.getBindingsMap()
           currentLocal.resolvedImports =
             converted.map(_.resolvedImports).getOrElse(Nil)

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -524,6 +524,7 @@ class Compiler(
             .map { concreteBindings =>
               concreteBindings
             }
+          ensureParsed(module)
           val currentLocal = module.getBindingsMap()
           currentLocal.resolvedImports =
             converted.map(_.resolvedImports).getOrElse(Nil)

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -436,9 +436,8 @@ class Compiler(
           val shouldStoreCache =
             irCachingEnabled && !context.wasLoadedFromCache(module)
           if (
-            shouldStoreCache && !hasErrors(module) && !context.isInteractive(
-              module
-            )
+            shouldStoreCache && !hasErrors(module) &&
+            !context.isInteractive(module) && !context.isSynthetic(module)
           ) {
             if (isInteractiveMode) {
               context.notifySerializeModule(context.getModuleName(module))

--- a/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/Compiler.scala
@@ -297,6 +297,7 @@ class Compiler(
     var hasInvalidModuleRelink = false
     if (irCachingEnabled) {
       requiredModules.foreach { module =>
+        ensureParsed(module)
         if (!context.hasCrossModuleLinks(module)) {
           val flags =
             context
@@ -509,7 +510,9 @@ class Compiler(
   }
 
   private def ensureParsedAndAnalyzed(module: Module): Unit = {
-    ensureParsed(module)
+    if (module.getBindingsMap() == null) {
+      ensureParsed(module)
+    }
     if (context.isSynthetic(module)) {
       // Synthetic modules need to be import-analyzed
       // i.e. we need to fill in resolved{Imports/Exports} and exportedSymbols in bindings
@@ -522,11 +525,8 @@ class Compiler(
             .map { concreteBindings =>
               concreteBindings
             }
-          val ir = context.getIr(module)
-          val currentLocal = ir.unsafeGetMetadata(
-            BindingAnalysis,
-            "Synthetic parsed module missing bindings"
-          )
+          ensureParsed(module)
+          val currentLocal = module.getBindingsMap()
           currentLocal.resolvedImports =
             converted.map(_.resolvedImports).getOrElse(Nil)
           currentLocal.resolvedExports =

--- a/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
@@ -95,6 +95,9 @@ final class SerializationManager(compiler: Compiler) {
     useGlobalCacheLocations: Boolean,
     useThreadPool: Boolean = true
   ): Future[Boolean] = {
+    if (module.isSynthetic) {
+      throw new IllegalStateException();
+    }
     compiler.context.logSerializationManager(
       debugLogLevel,
       "Requesting serialization for module [{0}].",

--- a/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
@@ -96,7 +96,9 @@ final class SerializationManager(compiler: Compiler) {
     useThreadPool: Boolean = true
   ): Future[Boolean] = {
     if (module.isSynthetic) {
-      throw new IllegalStateException("Cannot serialize synthetic module [" + module.getName + "]");
+      throw new IllegalStateException(
+        "Cannot serialize synthetic module [" + module.getName + "]"
+      );
     }
     compiler.context.logSerializationManager(
       debugLogLevel,

--- a/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
@@ -96,7 +96,7 @@ final class SerializationManager(compiler: Compiler) {
     useThreadPool: Boolean = true
   ): Future[Boolean] = {
     if (module.isSynthetic) {
-      throw new IllegalStateException();
+      throw new IllegalStateException("Cannot serialize synthetic module [" + module.getName + "]");
     }
     compiler.context.logSerializationManager(
       debugLogLevel,

--- a/engine/runtime/src/main/scala/org/enso/compiler/data/BindingsMap.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/data/BindingsMap.scala
@@ -23,7 +23,7 @@ import scala.annotation.unused
   */
 
 @SerialVersionUID(
-  8145L // Scala to Java
+  8160L // Use BindingsMap
 )
 case class BindingsMap(
   definedEntities: List[DefinedEntity],

--- a/engine/runtime/src/main/scala/org/enso/compiler/phase/ImportResolver.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/phase/ImportResolver.scala
@@ -109,6 +109,10 @@ class ImportResolver(compiler: Compiler) {
                 val converted = bindings
                   .toConcrete(compiler.packageRepository.getModuleMap)
                   .map { concreteBindings =>
+                    compiler.context.updateModule(
+                      current,
+                      _.bindingsMap(concreteBindings)
+                    )
                     concreteBindings
                   }
                 (

--- a/engine/runtime/src/main/scala/org/enso/compiler/phase/ImportResolver.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/phase/ImportResolver.scala
@@ -111,7 +111,10 @@ class ImportResolver(compiler: Compiler) {
                   .map { concreteBindings =>
                     compiler.context.updateModule(
                       current,
-                      _.bindingsMap(concreteBindings)
+                      { u =>
+                        u.bindingsMap(concreteBindings)
+                        u.loadedFromCache(true)
+                      }
                     )
                     concreteBindings
                   }
@@ -143,7 +146,6 @@ class ImportResolver(compiler: Compiler) {
         }
       }
     }
-
     go(mutable.Stack(module), mutable.Set(), mutable.Set())
   }
 

--- a/engine/runtime/src/test/java/org/enso/compiler/SerdeCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/SerdeCompilerTest.java
@@ -90,7 +90,8 @@ public class SerdeCompilerTest {
       mockHandler.assertNoFailureMessage();
       assertEquals(result.compiledModules().exists(m -> m == module), true);
 
-      var methods = module.getScope().getAllMethods();
+      var methods =
+          org.enso.interpreter.runtime.Module.fromCompilerModule(module).getScope().getAllMethods();
       var main = methods.get(0);
 
       assertEquals("Main.main", main.getName());


### PR DESCRIPTION
### Pull Request Description

Addresses #6100 a bit. `org.enso.compiler.Compiler.runImportsAndExportsResolution` used to take up to three seconds as it triggered deserialization of megabytes of `IR` caches. Now it is faster as it uses _library bindings cache_. Alas, overall time isn't shortened, as further compiler passes still load (the same amount of) `IR` caches in.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests continue to pass
