### PR TITLE
Save logged in state as cookie; remove `.enso/credentials` when logging out

### DIFF
--- a/app/ide-desktop/lib/client/src/preload.ts
+++ b/app/ide-desktop/lib/client/src/preload.ts
@@ -146,7 +146,7 @@ const AUTHENTICATION_API = {
      *
      * The backend doesn't have access to Electron's `localStorage` so we need to save access token
      * to a file. Then the token will be used to sign cloud API requests. */
-    saveAccessToken: (accessToken: string) => {
+    saveAccessToken: (accessToken: string | null) => {
         electron.ipcRenderer.send(ipc.Channel.saveAccessToken, accessToken)
     },
 }

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/cognito.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/cognito.ts
@@ -181,8 +181,8 @@ export class Cognito {
     }
 
     /** Save the access token to a file for further reuse. */
-    saveAccessToken(accessToken: string) {
-        this.amplifyConfig.accessTokenSaver?.(accessToken)
+    saveAccessToken(accessToken: string | null) {
+        this.amplifyConfig.saveAccessToken?.(accessToken)
     }
 
     /** Return the current {@link UserSession}, or `None` if the user is not logged in.

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/config.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/config.ts
@@ -71,7 +71,7 @@ export const OAuthRedirect = newtype.newtypeConstructor<OAuthRedirect>()
 export type OAuthUrlOpener = (url: string, redirectUrl: string) => void
 /** A function used to save the access token to a credentials file. The token is used by the engine
  * to issue HTTP requests to the cloud API. */
-export type AccessTokenSaver = (accessToken: string) => void
+export type AccessTokenSaver = (accessToken: string | null) => void
 /** Function used to register a callback. The callback will get called when a deep link is received
  * by the app. This is only used in the desktop app (i.e., not in the cloud). This is used when the
  * user is redirected back to the app from the system browser, after completing an OAuth flow. */
@@ -96,7 +96,6 @@ export const OAUTH_RESPONSE_TYPE = OAuthResponseType('code')
 // === AmplifyConfig ===
 // =====================
 
-// Eslint does not like "etc.".
 /** Configuration for the AWS Amplify library.
  *
  * This details user pools, federated identity providers, etc. that are used to authenticate users.
@@ -107,7 +106,7 @@ export interface AmplifyConfig {
     userPoolId: UserPoolId
     userPoolWebClientId: UserPoolWebClientId
     urlOpener: OAuthUrlOpener | null
-    accessTokenSaver: AccessTokenSaver | null
+    saveAccessToken: AccessTokenSaver | null
     domain: OAuthDomain
     scope: OAuthScope[]
     redirectSignIn: OAuthRedirect

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/providers/auth.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/providers/auth.tsx
@@ -318,11 +318,15 @@ export function AuthProvider(props: AuthProviderProps) {
                         user,
                     }
 
-                    /** Save access token so can be reused by Enso backend. */
+                    // 34560000 is the recommended max cookie age.
+                    document.cookie =
+                        'logged_in=yes;max-age=34560000;domain=enso.org;samesite=strict;secure'
+
+                    // Save access token so can it be reused by the backend.
                     cognito.saveAccessToken(session.accessToken)
 
-                    /** Execute the callback that should inform the Electron app that the user has logged in.
-                     * This is done to transition the app from the authentication/dashboard view to the IDE. */
+                    // Execute the callback that should inform the Electron app that the user has logged in.
+                    // This is done to transition the app from the authentication/dashboard view to the IDE.
                     onAuthenticated(session.accessToken)
                 }
 
@@ -490,10 +494,12 @@ export function AuthProvider(props: AuthProviderProps) {
     }
 
     const signOut = async () => {
+        document.cookie = 'logged_in=no;max-age=0;domain=enso.org'
+        cognito.saveAccessToken(null)
+        localStorage.clearUserSpecificEntries()
         deinitializeSession()
         setInitialized(false)
         setUserSession(null)
-        localStorage.clearUserSpecificEntries()
         // This should not omit success and error toasts as it is not possible
         // to render this optimistically.
         await toast.toast.promise(cognito.signOut(), {

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/service.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/service.tsx
@@ -137,7 +137,7 @@ function loadAmplifyConfig(
     /** Load the environment-specific Amplify configuration. */
     const baseConfig = AMPLIFY_CONFIGS[config.ENVIRONMENT]
     let urlOpener: ((url: string) => void) | null = null
-    let accessTokenSaver: ((accessToken: string) => void) | null = null
+    let accessTokenSaver: ((accessToken: string | null) => void) | null = null
     if ('authenticationApi' in window) {
         /** When running on destop we want to have option to save access token to a file,
          * so it can be later reuse when issuing requests to Cloud API. */
@@ -164,7 +164,7 @@ function loadAmplifyConfig(
         ...baseConfig,
         ...platformConfig,
         urlOpener,
-        accessTokenSaver,
+        saveAccessToken: accessTokenSaver,
     }
 }
 
@@ -174,7 +174,7 @@ function openUrlWithExternalBrowser(url: string) {
 }
 
 /** Save the access token to a file. */
-function saveAccessToken(accessToken: string) {
+function saveAccessToken(accessToken: string | null) {
     window.authenticationApi.saveAccessToken(accessToken)
 }
 

--- a/app/ide-desktop/lib/types/globals.d.ts
+++ b/app/ide-desktop/lib/types/globals.d.ts
@@ -50,7 +50,7 @@ interface AuthenticationApi {
      * via a deep link. See {@link setDeepLinkHandler} for details. */
     setDeepLinkHandler: (callback: (url: string) => void) => void
     /** Saves the access token to a file. */
-    saveAccessToken: (access_token: string) => void
+    saveAccessToken: (accessToken: string | null) => void
 }
 
 // =====================================


### PR DESCRIPTION
### Pull Request Description
- Set a cookie named `logged_in` when logging in; unsets it when logging out.
- Remove `.enso/credentials` when logging out of the desktop app

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
