### PR TITLE
Fix bench-processor test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -309,7 +309,8 @@ lazy val enso = (project in file("."))
     `simple-httpbin`,
     `enso-test-java-helpers`,
     `exploratory-benchmark-java-helpers`,
-    `benchmark-java-helpers`
+    `benchmark-java-helpers`,
+    `bench-processor`
   )
   .settings(Global / concurrentRestrictions += Tags.exclusive(Exclusive))
   .settings(

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/BenchConfig.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/BenchConfig.java
@@ -1,10 +1,11 @@
 package org.enso.benchmarks;
 
 /**
- * A configuration for a {@link BenchGroup benchmark group}.
- * Corresponds to {@code Bench_Options} in {@code distribution/lib/Standard/Test/0.0.0-dev/src/Bench.enso}
+ * A configuration for a {@link BenchGroup benchmark group}. Corresponds to {@code Bench_Options} in
+ * {@code distribution/lib/Standard/Test/0.0.0-dev/src/Bench.enso}
  */
 public interface BenchConfig {
   PhaseConfig warmup();
+
   PhaseConfig measure();
 }

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/BenchGroup.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/BenchGroup.java
@@ -3,11 +3,13 @@ package org.enso.benchmarks;
 import java.util.List;
 
 /**
- * A group of benchmarks with its own name and configuration.
- * Corresponds to {@code Bench.Group} defined in {@code distribution/lib/Standard/Test/0.0.0-dev/src/Bench.enso}.
+ * A group of benchmarks with its own name and configuration. Corresponds to {@code Bench.Group}
+ * defined in {@code distribution/lib/Standard/Test/0.0.0-dev/src/Bench.enso}.
  */
 public interface BenchGroup {
   String name();
+
   BenchConfig configuration();
+
   List<BenchSpec> specs();
 }

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/BenchSpec.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/BenchSpec.java
@@ -3,10 +3,11 @@ package org.enso.benchmarks;
 import org.graalvm.polyglot.Value;
 
 /**
- * Specification of a single benchmark.
- * Corresponds to {@code Bench.Spec} defined in {@code distribution/lib/Standard/Test/0.0.0-dev/src/Bench.enso}.
+ * Specification of a single benchmark. Corresponds to {@code Bench.Spec} defined in {@code
+ * distribution/lib/Standard/Test/0.0.0-dev/src/Bench.enso}.
  */
 public interface BenchSpec {
   String name();
+
   Value code();
 }

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/BenchSuite.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/BenchSuite.java
@@ -3,8 +3,8 @@ package org.enso.benchmarks;
 import java.util.List;
 
 /**
- * Wraps all the groups of benchmarks specified in a single module.
- * Corresponds to {@code Bench.All} defined in {@code distribution/lib/Standard/Test/0.0.0-dev/src/Bench.enso}.
+ * Wraps all the groups of benchmarks specified in a single module. Corresponds to {@code Bench.All}
+ * defined in {@code distribution/lib/Standard/Test/0.0.0-dev/src/Bench.enso}.
  */
 public interface BenchSuite {
   List<BenchGroup> groups();

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/ModuleBenchSuite.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/ModuleBenchSuite.java
@@ -3,9 +3,7 @@ package org.enso.benchmarks;
 import java.util.List;
 import java.util.Optional;
 
-/**
- * A {@link BenchSuite} with a qualified name of the module it is defined in.
- */
+/** A {@link BenchSuite} with a qualified name of the module it is defined in. */
 public final class ModuleBenchSuite {
   private final BenchSuite suite;
   private final String moduleQualifiedName;
@@ -24,23 +22,17 @@ public final class ModuleBenchSuite {
   }
 
   public BenchGroup findGroupByName(String groupName) {
-    return suite
-        .groups()
-        .stream()
+    return suite.groups().stream()
         .filter(grp -> grp.name().equals(groupName))
         .findFirst()
         .orElse(null);
   }
 
   public BenchSpec findSpecByName(String groupName, String specName) {
-    Optional<BenchGroup> group = suite
-        .groups()
-        .stream()
-        .filter(grp -> grp.name().equals(groupName))
-        .findFirst();
+    Optional<BenchGroup> group =
+        suite.groups().stream().filter(grp -> grp.name().equals(groupName)).findFirst();
     if (group.isPresent()) {
-      return group.get().specs()
-          .stream()
+      return group.get().specs().stream()
           .filter(spec -> spec.name().equals(specName))
           .findFirst()
           .orElseGet(() -> null);

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/PhaseConfig.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/PhaseConfig.java
@@ -1,18 +1,14 @@
 package org.enso.benchmarks;
 
 /**
- * Configuration for one phase - either warmup or measure.
- * Corresponds to {@code Phase_Conf} in {@code distribution/lib/Standard/Test/0.0.0-dev/src/Bench.enso}.
+ * Configuration for one phase - either warmup or measure. Corresponds to {@code Phase_Conf} in
+ * {@code distribution/lib/Standard/Test/0.0.0-dev/src/Bench.enso}.
  */
 public interface PhaseConfig {
 
-  /**
-   * Number of iterations to run the phase for.
-   */
+  /** Number of iterations to run the phase for. */
   long iterations();
 
-  /**
-   * Number of minimal amount of seconds per iterations.
-   */
+  /** Number of minimal amount of seconds per iterations. */
   long seconds();
 }

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/GenerateBenchSources.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/GenerateBenchSources.java
@@ -6,27 +6,26 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Use this annotation to force the {@link BenchProcessor} to generate JMH sources
- * for all the collected Enso benchmarks. The location of the benchmarks is encoded
- * by the {@code projectRootPath}, {@code moduleName} and {@code variableName} parameters.
+ * Use this annotation to force the {@link BenchProcessor} to generate JMH sources for all the
+ * collected Enso benchmarks. The location of the benchmarks is encoded by the {@code
+ * projectRootPath}, {@code moduleName} and {@code variableName} parameters.
  */
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)
 public @interface GenerateBenchSources {
 
-  /**
-   * Path to the project root directory. Relative to the Enso repository root.
-   */
+  /** Path to the project root directory. Relative to the Enso repository root. */
   String projectRootPath();
 
   /**
-   * Fully qualified name of the module within the project that defines all the benchmark {@link org.enso.benchmarks.BenchSuite suites}.
-   * For example {@code local.Benchmarks.Main}.
+   * Fully qualified name of the module within the project that defines all the benchmark {@link
+   * org.enso.benchmarks.BenchSuite suites}. For example {@code local.Benchmarks.Main}.
    */
   String moduleName();
 
   /**
-   * Name of the variable that holds a list of all the benchmark {@link org.enso.benchmarks.BenchSuite suites}.
+   * Name of the variable that holds a list of all the benchmark {@link
+   * org.enso.benchmarks.BenchSuite suites}.
    */
   String variableName() default "all_benchmarks";
 }

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/SpecCollector.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/SpecCollector.java
@@ -8,14 +8,13 @@ import org.enso.benchmarks.ModuleBenchSuite;
 import org.enso.polyglot.MethodNames.Module;
 import org.graalvm.polyglot.Value;
 
-/**
- * Collect benchmark specifications from Enso source files.
- */
+/** Collect benchmark specifications from Enso source files. */
 public class SpecCollector {
   private SpecCollector() {}
 
   /**
    * Collects all the bench specifications from the given module in a variable with the given name.
+   *
    * @param varName Name of the variable that holds all the collected bench suites.
    * @return Empty list if no such variable exists, or if it is not a vector.
    */
@@ -32,9 +31,7 @@ public class SpecCollector {
       for (long i = 0; i < suitesValue.getArraySize(); i++) {
         Value suite = suitesValue.getArrayElement(i);
         BenchSuite benchSuite = suite.as(BenchSuite.class);
-        suites.add(
-            new ModuleBenchSuite(benchSuite, moduleQualifiedName)
-        );
+        suites.add(new ModuleBenchSuite(benchSuite, moduleQualifiedName));
       }
       return suites;
     }
@@ -43,11 +40,13 @@ public class SpecCollector {
 
   /**
    * Collects all the bench specifications from the given module in a variable with the given name.
+   *
    * @param groupName Name of the benchmark group
    * @param varName Name of the variable that holds all the collected bench suites.
    * @return null if no such group exists.
    */
-  public static BenchGroup collectBenchGroupFromModule(Value module, String groupName, String varName) {
+  public static BenchGroup collectBenchGroupFromModule(
+      Value module, String groupName, String varName) {
     var specs = collectBenchSpecsFromModule(module, varName);
     for (ModuleBenchSuite suite : specs) {
       BenchGroup group = suite.findGroupByName(groupName);

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/runner/BenchRunner.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/runner/BenchRunner.java
@@ -71,12 +71,10 @@ public class BenchRunner {
     }
   }
 
-  private static Collection<RunResult> runCompileOnly(List<String> includes) throws RunnerException {
+  private static Collection<RunResult> runCompileOnly(List<String> includes)
+      throws RunnerException {
     System.out.println("Running benchmarks " + includes + " in compileOnly mode");
-    var optsBuilder = new OptionsBuilder()
-        .measurementIterations(1)
-        .warmupIterations(0)
-        .forks(0);
+    var optsBuilder = new OptionsBuilder().measurementIterations(1).warmupIterations(0).forks(0);
     includes.forEach(optsBuilder::include);
     var opts = optsBuilder.build();
     var runner = new Runner(opts);
@@ -90,10 +88,11 @@ public class BenchRunner {
       var firstResult = results.iterator().next();
       return reportResult(label, firstResult);
     } else {
-      var opts = new OptionsBuilder()
-          .jvmArgsAppend("-Xss16M", "-Dpolyglot.engine.MultiTier=false")
-          .include(includeRegex)
-          .build();
+      var opts =
+          new OptionsBuilder()
+              .jvmArgsAppend("-Xss16M", "-Dpolyglot.engine.MultiTier=false")
+              .include(includeRegex)
+              .build();
       RunResult benchmarksResult = new Runner(opts).runSingle();
       return reportResult(label, benchmarksResult);
     }
@@ -107,8 +106,7 @@ public class BenchRunner {
       report = new Report();
     }
 
-    BenchmarkItem benchItem =
-        new BenchmarkResultProcessor().processResult(label, report, result);
+    BenchmarkItem benchItem = new BenchmarkResultProcessor().processResult(label, report, result);
 
     Report.writeToFile(report, REPORT_FILE);
     return benchItem;

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/runner/Report.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/runner/Report.java
@@ -1,9 +1,5 @@
 package org.enso.benchmarks.runner;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
@@ -11,6 +7,10 @@ import jakarta.xml.bind.Unmarshaller;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementWrapper;
 import jakarta.xml.bind.annotation.XmlRootElement;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 /** Historic runs report. Supports XML serialization. */
 @XmlRootElement

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/runner/ReportItem.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/runner/ReportItem.java
@@ -1,13 +1,13 @@
 package org.enso.benchmarks.runner;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalDouble;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementWrapper;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalDouble;
 
 /** Contains historic results for a single benchmark identified by label. */
 @XmlRootElement

--- a/lib/scala/bench-processor/src/test/java/org/enso/benchmarks/TestSpecCollector.java
+++ b/lib/scala/bench-processor/src/test/java/org/enso/benchmarks/TestSpecCollector.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.util.List;
 import org.enso.benchmarks.processor.SpecCollector;
 import org.enso.pkg.PackageManager;
@@ -30,18 +31,7 @@ public class TestSpecCollector {
 
   @Before
   public void setup() {
-    try {
-      ensoDir =
-          new File(
-              TestSpecCollector.class.getProtectionDomain().getCodeSource().getLocation().toURI());
-    } catch (URISyntaxException e) {
-      fail("ensoDir not found: " + e.getMessage());
-    }
-    for (; ensoDir != null; ensoDir = ensoDir.getParentFile()) {
-      if (ensoDir.getName().equals("enso")) {
-        break;
-      }
-    }
+    ensoDir = locateRootDirectory();
     assertNotNull("Could not find Enso root directory", ensoDir);
     assertTrue(ensoDir.exists());
     assertTrue(ensoDir.isDirectory());
@@ -71,19 +61,47 @@ public class TestSpecCollector {
     ctx.close();
   }
 
+  /**
+   * Locates the root of the Enso repository. Heuristic: we just keep going up the directory tree
+   * until we are in a directory containing ".git" subdirectory. Note that we cannot use the
+   * "enso" name, as users are free to name their cloned directories however they like.
+   */
+  private File locateRootDirectory() {
+    File rootDir = null;
+    try {
+      rootDir =
+          new File(
+              TestSpecCollector.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+    } catch (URISyntaxException e) {
+      fail("repository root directory not found: " + e.getMessage());
+    }
+    for (; rootDir != null; rootDir = rootDir.getParentFile()) {
+      // Check if rootDir contains ".git" subdirectory
+      if (Files.exists(rootDir.toPath().resolve(".git"))) {
+        break;
+      }
+    }
+    return rootDir;
+  }
+
   @Test
   public void testCollectAllSuitesFromMainModule() {
     List<ModuleBenchSuite> moduleBenchSuites =
         SpecCollector.collectBenchSpecsFromModule(testCollectorMainModule, "group_1");
     for (ModuleBenchSuite moduleBenchSuite : moduleBenchSuites) {
       assertEquals(1, moduleBenchSuite.getGroups().size());
-      assertEquals("Test Group", moduleBenchSuite.getGroups().get(0).name());
+      assertEquals("Test_Group", moduleBenchSuite.getGroups().get(0).name());
       List<BenchSpec> specs = moduleBenchSuite.getGroups().get(0).specs();
       assertEquals(1, specs.size());
-      assertEquals("Test Spec", specs.get(0).name());
+      assertEquals("Test_Spec", specs.get(0).name());
       Value code = specs.get(0).code();
       Value res = code.execute(Value.asValue(null));
       assertEquals(2, res.asInt());
+      var group = moduleBenchSuite.getGroups().get(0);
+      assertEquals(11, group.configuration().warmup().iterations());
+      assertEquals(12, group.configuration().warmup().seconds());
+      assertEquals(13, group.configuration().measure().iterations());
+      assertEquals(14, group.configuration().measure().seconds());
     }
     assertFalse(moduleBenchSuites.isEmpty());
   }

--- a/lib/scala/bench-processor/src/test/java/org/enso/benchmarks/TestSpecCollector.java
+++ b/lib/scala/bench-processor/src/test/java/org/enso/benchmarks/TestSpecCollector.java
@@ -63,8 +63,8 @@ public class TestSpecCollector {
 
   /**
    * Locates the root of the Enso repository. Heuristic: we just keep going up the directory tree
-   * until we are in a directory containing ".git" subdirectory. Note that we cannot use the
-   * "enso" name, as users are free to name their cloned directories however they like.
+   * until we are in a directory containing ".git" subdirectory. Note that we cannot use the "enso"
+   * name, as users are free to name their cloned directories however they like.
    */
   private File locateRootDirectory() {
     File rootDir = null;

--- a/lib/scala/bench-processor/src/test/resources/Test_Collector/src/Main.enso
+++ b/lib/scala/bench-processor/src/test/resources/Test_Collector/src/Main.enso
@@ -1,11 +1,11 @@
 from Standard.Base import all
 from Standard.Test import Bench
 
-options = Bench.options.size 10 . iter 10
+options = Bench.options . set_warmup (Bench.phase_conf 11 12) . set_measure (Bench.phase_conf 13 14)
 
 collect_benches = Bench.build builder->
-    builder.group "Test Group" options group_builder->
-        group_builder.specify "Test Spec" (1 + 1)
+    builder.group "Test_Group" options group_builder->
+        group_builder.specify "Test_Spec" (1 + 1)
 
 group_1 = [collect_benches]
 


### PR DESCRIPTION
### Pull Request Description

Adds `bench-processor` to the `enso` project aggregate in `build.sbt`, so that when `enso/test` command is invoked in sbt, `bench-processor/test` is invoked as well. Also, fixes the tests in `bench-processor` that were failing thanks to this oversight.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md)
- All code has been tested:
  - [X] Unit tests have been written where possible.
