### PR TITLE
Add special handling for Dataflow_Error passed to Runtime.assert

### DIFF
--- a/test/Tests/src/Runtime/Asserts_Spec.enso
+++ b/test/Tests/src/Runtime/Asserts_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 
 from Standard.Base.Errors.Common import Assertion_Error
+from Standard.Base.Errors.Common import Type_Error
 
 from Standard.Test import Test, Test_Suite
 import Standard.Test.Extensions
@@ -23,5 +24,12 @@ spec = Test.group "Asserts" pending=on_ci <|
     Test.specify "should be able to take lambdas as expressions" <|
         Runtime.assert <|
             4 == 2 + 2
+
+    Test.specify "should fail with type error when given dataflow error as expression" <|
+        p = Panic.catch Assertion_Error (Runtime.assert (Error.throw "foo")) err->
+            err.payload
+        Meta.type_of p . should_be_a Assertion_Error
+        p.message . should_start_with "Result of assert action is a dataflow error"
+
 
 main = Test_Suite.run_main spec

--- a/test/Tests/src/Runtime/Asserts_Spec.enso
+++ b/test/Tests/src/Runtime/Asserts_Spec.enso
@@ -9,8 +9,7 @@ import Standard.Test.Extensions
 foreign js js_check = """
     return (4 == 2 + 2)
 
-#on_ci = if Environment.get "ENSO_RUNNER_CONTAINER_NAME" . is_nothing . not then Nothing else "Not in CI"
-on_ci = Nothing
+on_ci = if Environment.get "ENSO_RUNNER_CONTAINER_NAME" . is_nothing . not then Nothing else "Not in CI"
 
 spec = Test.group "Asserts" pending=on_ci <|
     Test.specify "should be enabled on the CI" <|

--- a/test/Tests/src/Runtime/Asserts_Spec.enso
+++ b/test/Tests/src/Runtime/Asserts_Spec.enso
@@ -9,7 +9,8 @@ import Standard.Test.Extensions
 foreign js js_check = """
     return (4 == 2 + 2)
 
-on_ci = if Environment.get "ENSO_RUNNER_CONTAINER_NAME" . is_nothing . not then Nothing else "Not in CI"
+#on_ci = if Environment.get "ENSO_RUNNER_CONTAINER_NAME" . is_nothing . not then Nothing else "Not in CI"
+on_ci = Nothing
 
 spec = Test.group "Asserts" pending=on_ci <|
     Test.specify "should be enabled on the CI" <|
@@ -30,6 +31,10 @@ spec = Test.group "Asserts" pending=on_ci <|
             err.payload
         Meta.type_of p . should_be_a Assertion_Error
         p.message . should_start_with "Result of assert action is a dataflow error"
+
+    Test.specify "should be able to take values with warnings" <|
+        foo x = Warning.attach "My warning" (x+2)
+        Runtime.assert (foo 2 > 2) . should_be_a Nothing
 
 
 main = Test_Suite.run_main spec

--- a/test/Tests/src/Runtime/Asserts_Spec.enso
+++ b/test/Tests/src/Runtime/Asserts_Spec.enso
@@ -22,9 +22,10 @@ spec = Test.group "Asserts" pending=on_ci <|
         ret = Runtime.assert js_check
         ret . should_be_a Nothing
 
-    Test.specify "should be able to take lambdas as expressions" <|
-        Runtime.assert <|
+    Test.specify "should be able to take a block as expressions" <|
+        ret = Runtime.assert <|
             4 == 2 + 2
+        ret . should_be_a Nothing
 
     Test.specify "should fail with type error when given dataflow error as expression" <|
         p = Panic.catch Assertion_Error (Runtime.assert (Error.throw "foo")) err->


### PR DESCRIPTION
Fixes #8164

### Pull Request Description

Add special handling for `Dataflow_Error` passed as action to `Runtime.assert`. It caused an infinite recursion.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md)
- All code has been tested:
  - [X] Unit tests have been written where possible.
