### PR TITLE
Use TruffleLogger bound to the engine to prevent illegal usage

### DIFF
--- a/engine/interpreter-dsl-test/src/test/java/org/enso/interpreter/dsl/test/ThrowableCatchTest.java
+++ b/engine/interpreter-dsl-test/src/test/java/org/enso/interpreter/dsl/test/ThrowableCatchTest.java
@@ -70,7 +70,7 @@ public class ThrowableCatchTest {
             .allowExperimentalOptions(true)
             .allowIO(IOAccess.ALL)
             .allowAllAccess(true)
-            .logHandler(new ByteArrayOutputStream())
+            .logHandler(System.err)
             .option(RuntimeOptions.STRICT_ERRORS, "true")
             .option(
                     RuntimeOptions.LOG_LEVEL,

--- a/engine/interpreter-dsl-test/src/test/java/org/enso/interpreter/dsl/test/ThrowableCatchTest.java
+++ b/engine/interpreter-dsl-test/src/test/java/org/enso/interpreter/dsl/test/ThrowableCatchTest.java
@@ -8,6 +8,8 @@ import java.io.ByteArrayOutputStream;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.logging.Level;
+
 import org.enso.interpreter.EnsoLanguage;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.function.Function;
@@ -70,6 +72,10 @@ public class ThrowableCatchTest {
             .allowAllAccess(true)
             .logHandler(new ByteArrayOutputStream())
             .option(RuntimeOptions.STRICT_ERRORS, "true")
+            .option(
+                    RuntimeOptions.LOG_LEVEL,
+                    Level.WARNING.getName()
+            )
             .option(
                 RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
                 Paths.get("../../distribution/component").toFile().getAbsolutePath())

--- a/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/AvoidIdInstrumentationTagTest.java
+++ b/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/AvoidIdInstrumentationTagTest.java
@@ -7,6 +7,8 @@ import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.function.Predicate;
+import java.util.logging.Level;
+
 import org.enso.interpreter.node.ClosureRootNode;
 import org.enso.interpreter.runtime.tag.AvoidIdInstrumentationTag;
 import org.enso.interpreter.runtime.tag.IdentifiedTag;
@@ -37,6 +39,10 @@ public class AvoidIdInstrumentationTagTest {
         .option(
             RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
             Paths.get("../../distribution/component").toFile().getAbsolutePath()
+        )
+        .option(
+                RuntimeOptions.LOG_LEVEL,
+                Level.WARNING.getName()
         )
         .logHandler(OutputStream.nullOutputStream())
         .allowExperimentalOptions(true)

--- a/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/AvoidIdInstrumentationTagTest.java
+++ b/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/AvoidIdInstrumentationTagTest.java
@@ -44,7 +44,7 @@ public class AvoidIdInstrumentationTagTest {
                 RuntimeOptions.LOG_LEVEL,
                 Level.WARNING.getName()
         )
-        .logHandler(OutputStream.nullOutputStream())
+        .logHandler(System.err)
         .allowExperimentalOptions(true)
         .allowIO(IOAccess.ALL)
         .allowAllAccess(true)

--- a/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/WarningInstrumentationTest.java
+++ b/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/WarningInstrumentationTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.logging.Level;
 
 public class WarningInstrumentationTest {
 
@@ -34,6 +35,10 @@ public class WarningInstrumentationTest {
                 .option(
                         RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
                         Paths.get("../../distribution/component").toFile().getAbsolutePath()
+                )
+                .option(
+                        RuntimeOptions.LOG_LEVEL,
+                        Level.WARNING.getName()
                 )
                 .logHandler(OutputStream.nullOutputStream())
                 .allowExperimentalOptions(true)

--- a/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/WarningInstrumentationTest.java
+++ b/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/WarningInstrumentationTest.java
@@ -40,7 +40,7 @@ public class WarningInstrumentationTest {
                         RuntimeOptions.LOG_LEVEL,
                         Level.WARNING.getName()
                 )
-                .logHandler(OutputStream.nullOutputStream())
+                .logHandler(System.err)
                 .allowExperimentalOptions(true)
                 .allowIO(IOAccess.ALL)
                 .allowAllAccess(true)

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/BuiltinTypesTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/BuiltinTypesTest.scala
@@ -15,6 +15,7 @@ import org.scalatest.matchers.should.Matchers
 import java.io.{ByteArrayOutputStream, File}
 import java.nio.file.{Files, Path, Paths}
 import java.util.UUID
+import java.util.logging.Level
 
 @scala.annotation.nowarn("msg=multiarg infix syntax")
 class BuiltinTypesTest
@@ -44,7 +45,7 @@ class BuiltinTypesTest
         .allowExperimentalOptions(true)
         .allowAllAccess(true)
         .option(RuntimeOptions.PROJECT_ROOT, pkg.root.getAbsolutePath)
-        .option(RuntimeOptions.LOG_LEVEL, "WARNING")
+        .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
         .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
         .option(RuntimeOptions.ENABLE_PROJECT_SUGGESTIONS, "false")
         .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/BuiltinTypesTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/BuiltinTypesTest.scala
@@ -37,8 +37,7 @@ class BuiltinTypesTest
 
     val pkg: Package[File] =
       PackageManager.Default.create(tmpDir.toFile, packageName, "Enso_Test")
-    val out: ByteArrayOutputStream    = new ByteArrayOutputStream()
-    val logOut: ByteArrayOutputStream = new ByteArrayOutputStream()
+    val out: ByteArrayOutputStream = new ByteArrayOutputStream()
     val executionContext = new PolyglotContext(
       Context
         .newBuilder(LanguageInfo.ID)
@@ -64,7 +63,7 @@ class BuiltinTypesTest
             .getAbsolutePath
         )
         .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
-        .logHandler(logOut)
+        .logHandler(System.err)
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
@@ -15,6 +15,7 @@ import org.scalatest.matchers.should.Matchers
 import java.io.{ByteArrayOutputStream, File}
 import java.nio.file.{Files, Path, Paths}
 import java.util.UUID
+import java.util.logging.Level
 
 @scala.annotation.nowarn("msg=multiarg infix syntax")
 class RuntimeAsyncCommandsTest
@@ -42,7 +43,7 @@ class RuntimeAsyncCommandsTest
         .allowExperimentalOptions(true)
         .allowAllAccess(true)
         .option(RuntimeOptions.PROJECT_ROOT, pkg.root.getAbsolutePath)
-        .option(RuntimeOptions.LOG_LEVEL, "WARNING")
+        .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName)
         .option(
           RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION,
           "false"
@@ -65,6 +66,7 @@ class RuntimeAsyncCommandsTest
         )
         .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
         .out(out)
+        .logHandler(System.err)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()
     )

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeComponentsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeComponentsTest.scala
@@ -27,7 +27,7 @@ import java.io.{ByteArrayOutputStream, File}
 import java.nio.file.{Files, Path, Paths}
 import java.util.UUID
 import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
-
+import java.util.logging.Level
 import scala.concurrent.duration._
 
 @scala.annotation.nowarn("msg=multiarg infix syntax")
@@ -125,7 +125,7 @@ class RuntimeComponentsTest
           RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
           distributionHome.toString
         )
-        .option(RuntimeOptions.LOG_LEVEL, "WARNING")
+        .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName)
         .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
         .option(RuntimeServerInfo.ENABLE_OPTION, "true")
         .option(RuntimeOptions.INTERACTIVE_MODE, "true")
@@ -134,6 +134,7 @@ class RuntimeComponentsTest
           InstrumentTestContext.DISABLE_IR_CACHE
         )
         .out(out)
+        .logHandler(System.err)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()
     )

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeExecutionEnvironmentTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeExecutionEnvironmentTest.scala
@@ -59,8 +59,7 @@ class RuntimeExecutionEnvironmentTest
         "Enso_Test",
         edition = Some(edition)
       )
-    val out: ByteArrayOutputStream    = new ByteArrayOutputStream()
-    val logOut: ByteArrayOutputStream = new ByteArrayOutputStream()
+    val out: ByteArrayOutputStream = new ByteArrayOutputStream()
     val executionContext = new PolyglotContext(
       Context
         .newBuilder(LanguageInfo.ID)
@@ -82,7 +81,7 @@ class RuntimeExecutionEnvironmentTest
           RuntimeOptions.DISABLE_IR_CACHES,
           InstrumentTestContext.DISABLE_IR_CACHE
         )
-        //.logHandler(logOut)
+        .logHandler(System.err)
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeExecutionEnvironmentTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeExecutionEnvironmentTest.scala
@@ -18,7 +18,7 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import java.io.{ByteArrayOutputStream, File}
 import java.nio.file.{Files, Path, Paths}
 import java.util.UUID
-
+import java.util.logging.Level
 import scala.concurrent.duration._
 
 @scala.annotation.nowarn("msg=multiarg infix syntax")
@@ -71,7 +71,7 @@ class RuntimeExecutionEnvironmentTest
           RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
           distributionHome.toString
         )
-        .option(RuntimeOptions.LOG_LEVEL, "WARNING")
+        .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
         .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
         .option(RuntimeOptions.ENABLE_PROJECT_SUGGESTIONS, "false")
         .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
@@ -63,6 +63,7 @@ class RuntimeInstrumentTest
         )
         .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
         .out(out)
+        .logHandler(System.err)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()
     )

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeProjectContextTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeProjectContextTest.scala
@@ -6,6 +6,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import java.nio.file.Paths
+import java.util.logging.Level
 
 class RuntimeProjectContextTest extends AnyWordSpec with Matchers {
   "Runtime Context" should {
@@ -28,7 +29,8 @@ class RuntimeProjectContextTest extends AnyWordSpec with Matchers {
               .getAbsolutePath
           )
           .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
-          .option(RuntimeOptions.LOG_LEVEL, "WARNING")
+          .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName)
+          .logHandler(System.err)
           .build()
         context.initialize(LanguageInfo.ID)
       }

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeRefactoringTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeRefactoringTest.scala
@@ -19,6 +19,7 @@ import org.scalatest.matchers.should.Matchers
 import java.io.{ByteArrayOutputStream, File}
 import java.nio.file.{Files, Path, Paths}
 import java.util.UUID
+import java.util.logging.Level
 
 @scala.annotation.nowarn("msg=multiarg infix syntax")
 class RuntimeRefactoringTest
@@ -48,7 +49,7 @@ class RuntimeRefactoringTest
         .allowExperimentalOptions(true)
         .allowAllAccess(true)
         .option(RuntimeOptions.PROJECT_ROOT, pkg.root.getAbsolutePath)
-        .option(RuntimeOptions.LOG_LEVEL, "WARNING")
+        .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
         .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
         .option(RuntimeOptions.ENABLE_PROJECT_SUGGESTIONS, "false")
         .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeStdlibTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeStdlibTest.scala
@@ -17,7 +17,7 @@ import java.io.{ByteArrayOutputStream, File}
 import java.nio.file.{Files, Path, Paths}
 import java.util.UUID
 import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
-
+import java.util.logging.Level
 import scala.collection.mutable
 import scala.concurrent.duration._
 
@@ -73,7 +73,7 @@ class RuntimeStdlibTest
           RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
           distributionHome.toString
         )
-        .option(RuntimeOptions.LOG_LEVEL, "WARNING")
+        .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName)
         .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
         .option(RuntimeServerInfo.ENABLE_OPTION, "true")
         .option(RuntimeOptions.INTERACTIVE_MODE, "true")
@@ -82,6 +82,7 @@ class RuntimeStdlibTest
           InstrumentTestContext.DISABLE_IR_CACHE
         )
         .out(out)
+        .logHandler(System.err)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()
     )

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
@@ -17,6 +17,7 @@ import org.scalatest.matchers.should.Matchers
 import java.io.{ByteArrayOutputStream, File}
 import java.nio.file.{Files, Path, Paths}
 import java.util.UUID
+import java.util.logging.Level
 
 @scala.annotation.nowarn("msg=multiarg infix syntax")
 class RuntimeSuggestionUpdatesTest
@@ -43,7 +44,7 @@ class RuntimeSuggestionUpdatesTest
         .allowExperimentalOptions(true)
         .allowAllAccess(true)
         .option(RuntimeOptions.PROJECT_ROOT, pkg.root.getAbsolutePath)
-        .option(RuntimeOptions.LOG_LEVEL, "WARNING")
+        .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName)
         .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
         .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")
         .option(
@@ -61,6 +62,7 @@ class RuntimeSuggestionUpdatesTest
         )
         .option(RuntimeOptions.EDITION_OVERRIDE, "0.0.0-dev")
         .out(out)
+        .logHandler(System.err)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()
     )

--- a/engine/runtime-with-polyglot/src/test/java/org/enso/interpreter/test/InsightForEnsoTest.java
+++ b/engine/runtime-with-polyglot/src/test/java/org/enso/interpreter/test/InsightForEnsoTest.java
@@ -36,7 +36,7 @@ public class InsightForEnsoTest {
                         RuntimeOptions.LOG_LEVEL,
                         Level.WARNING.getName()
                 )
-                .logHandler(OutputStream.nullOutputStream())
+                .logHandler(System.err)
                 .allowExperimentalOptions(true)
                 .allowIO(IOAccess.ALL)
                 .out(out)

--- a/engine/runtime-with-polyglot/src/test/java/org/enso/interpreter/test/InsightForEnsoTest.java
+++ b/engine/runtime-with-polyglot/src/test/java/org/enso/interpreter/test/InsightForEnsoTest.java
@@ -5,6 +5,8 @@ import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.logging.Level;
+
 import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Language;
@@ -29,6 +31,10 @@ public class InsightForEnsoTest {
                 .option(
                         RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
                         Paths.get("../../distribution/component").toFile().getAbsolutePath()
+                )
+                .option(
+                        RuntimeOptions.LOG_LEVEL,
+                        Level.WARNING.getName()
                 )
                 .logHandler(OutputStream.nullOutputStream())
                 .allowExperimentalOptions(true)

--- a/engine/runtime-with-polyglot/src/test/java/org/enso/interpreter/test/instrument/VerifyJavaScriptIsAvailableTest.java
+++ b/engine/runtime-with-polyglot/src/test/java/org/enso/interpreter/test/instrument/VerifyJavaScriptIsAvailableTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.nio.file.Paths;
+import java.util.logging.Level;
 import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.io.IOAccess;
@@ -26,7 +27,7 @@ public class VerifyJavaScriptIsAvailableTest {
             .option(
                 RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
                 Paths.get("../../distribution/component").toFile().getAbsolutePath())
-            .option("log.level", "FINE")
+            .option(RuntimeOptions.LOG_LEVEL, Level.FINE.getName())
             .logHandler(handler)
             .allowAllAccess(true)
             .build();

--- a/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -39,8 +39,7 @@ class RuntimeVisualizationsTest
 
     val pkg: Package[File] =
       PackageManager.Default.create(tmpDir.toFile, packageName, "Enso_Test")
-    val out: ByteArrayOutputStream    = new ByteArrayOutputStream()
-    val logOut: ByteArrayOutputStream = new ByteArrayOutputStream()
+    val out: ByteArrayOutputStream = new ByteArrayOutputStream()
     val executionContext = new PolyglotContext(
       Context
         .newBuilder()
@@ -62,7 +61,7 @@ class RuntimeVisualizationsTest
           RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
           Paths.get("../../distribution/component").toFile.getAbsolutePath
         )
-        .logHandler(logOut)
+        .logHandler(System.err)
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()

--- a/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -18,6 +18,7 @@ import java.io.{ByteArrayOutputStream, File}
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
 import java.util.UUID
+import java.util.logging.Level
 
 @scala.annotation.nowarn("msg=multiarg infix syntax")
 class RuntimeVisualizationsTest
@@ -46,7 +47,7 @@ class RuntimeVisualizationsTest
         .allowExperimentalOptions(true)
         .allowAllAccess(true)
         .option(RuntimeOptions.PROJECT_ROOT, pkg.root.getAbsolutePath)
-        .option(RuntimeOptions.LOG_LEVEL, "WARNING")
+        .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
         .option(RuntimeOptions.INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION, "true")
         .option(RuntimeOptions.ENABLE_PROJECT_SUGGESTIONS, "false")
         .option(RuntimeOptions.ENABLE_GLOBAL_SUGGESTIONS, "false")

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/ArrayProxyBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/ArrayProxyBenchmarks.java
@@ -42,7 +42,7 @@ public class ArrayProxyBenchmarks {
                     RuntimeOptions.LOG_LEVEL,
                     Level.WARNING.getName()
             )
-            .logHandler(new ByteArrayOutputStream())
+            .logHandler(System.err)
             .option(
                 "enso.languageHomeOverride",
                 Paths.get("../../distribution/component").toFile().getAbsolutePath())

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/ArrayProxyBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/ArrayProxyBenchmarks.java
@@ -4,6 +4,9 @@ import java.io.ByteArrayOutputStream;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.logging.Level;
+
+import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Engine;
 import org.graalvm.polyglot.Value;
@@ -35,6 +38,10 @@ public class ArrayProxyBenchmarks {
     Engine eng =
         Engine.newBuilder()
             .allowExperimentalOptions(true)
+            .option(
+                    RuntimeOptions.LOG_LEVEL,
+                    Level.WARNING.getName()
+            )
             .logHandler(new ByteArrayOutputStream())
             .option(
                 "enso.languageHomeOverride",

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/CurriedFunctionBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/CurriedFunctionBenchmarks.java
@@ -42,7 +42,7 @@ public class CurriedFunctionBenchmarks {
               RuntimeOptions.LOG_LEVEL,
               Level.WARNING.getName()
       )
-      .logHandler(new ByteArrayOutputStream())
+      .logHandler(System.err)
       .allowIO(IOAccess.ALL)
       .allowAllAccess(true)
       .option(

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/CurriedFunctionBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/CurriedFunctionBenchmarks.java
@@ -4,6 +4,9 @@ import java.io.ByteArrayOutputStream;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.logging.Level;
+
+import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.io.IOAccess;
@@ -35,6 +38,10 @@ public class CurriedFunctionBenchmarks {
   public void initializeBenchmark(BenchmarkParams params) throws Exception {
     var ctx = Context.newBuilder()
       .allowExperimentalOptions(true)
+      .option(
+              RuntimeOptions.LOG_LEVEL,
+              Level.WARNING.getName()
+      )
       .logHandler(new ByteArrayOutputStream())
       .allowIO(IOAccess.ALL)
       .allowAllAccess(true)

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/EqualsBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/EqualsBenchmarks.java
@@ -68,7 +68,7 @@ public class EqualsBenchmarks {
                 RuntimeOptions.LOG_LEVEL,
                 Level.WARNING.getName()
         )
-        .logHandler(new ByteArrayOutputStream())
+        .logHandler(System.err)
         .allowIO(IOAccess.ALL)
         .allowAllAccess(true)
         .option(

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/EqualsBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/EqualsBenchmarks.java
@@ -9,7 +9,10 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+
 import org.enso.polyglot.MethodNames.Module;
+import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.io.IOAccess;
@@ -61,6 +64,10 @@ public class EqualsBenchmarks {
 
     var ctx = Context.newBuilder()
         .allowExperimentalOptions(true)
+        .option(
+                RuntimeOptions.LOG_LEVEL,
+                Level.WARNING.getName()
+        )
         .logHandler(new ByteArrayOutputStream())
         .allowIO(IOAccess.ALL)
         .allowAllAccess(true)

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/IfVsCaseBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/IfVsCaseBenchmarks.java
@@ -48,13 +48,14 @@ public class IfVsCaseBenchmarks extends TestBase {
 
   @Setup
   public void initializeBench(BenchmarkParams params) throws IOException {
+    OutputStream out = new ByteArrayOutputStream();
     ctx = Context.newBuilder("enso")
         .allowAllAccess(true)
         .option(
                 RuntimeOptions.LOG_LEVEL,
                 Level.WARNING.getName()
         )
-        .logHandler(out)
+        .logHandler(System.err)
         .out(out)
         .err(out)
         .allowIO(IOAccess.ALL)

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/IfVsCaseBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/IfVsCaseBenchmarks.java
@@ -8,9 +8,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 
 import org.enso.interpreter.test.TestBase;
 import org.enso.polyglot.MethodNames.Module;
+import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.io.IOAccess;
@@ -49,6 +51,10 @@ public class IfVsCaseBenchmarks extends TestBase {
   public void initializeBench(BenchmarkParams params) throws IOException {
     ctx = Context.newBuilder("enso")
         .allowAllAccess(true)
+        .option(
+                RuntimeOptions.LOG_LEVEL,
+                Level.WARNING.getName()
+        )
         .logHandler(out)
         .out(out)
         .err(out)

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/IfVsCaseBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/IfVsCaseBenchmarks.java
@@ -45,7 +45,6 @@ public class IfVsCaseBenchmarks extends TestBase {
   private Value caseBench6;
   private Value createVec;
   private Value inputVec;
-  private OutputStream out = new ByteArrayOutputStream();
 
   @Setup
   public void initializeBench(BenchmarkParams params) throws IOException {

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/ListBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/ListBenchmarks.java
@@ -49,7 +49,7 @@ public class ListBenchmarks {
               RuntimeOptions.LOG_LEVEL,
               Level.WARNING.getName()
       )
-      .logHandler(new ByteArrayOutputStream())
+      .logHandler(System.err)
       .option(
         "enso.languageHomeOverride",
         Paths.get("../../distribution/component").toFile().getAbsolutePath()

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/ListBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/ListBenchmarks.java
@@ -4,6 +4,9 @@ import java.io.ByteArrayOutputStream;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.logging.Level;
+
+import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.io.IOAccess;
@@ -42,6 +45,10 @@ public class ListBenchmarks {
       .allowExperimentalOptions(true)
       .allowIO(IOAccess.ALL)
       .allowAllAccess(true)
+      .option(
+              RuntimeOptions.LOG_LEVEL,
+              Level.WARNING.getName()
+      )
       .logHandler(new ByteArrayOutputStream())
       .option(
         "enso.languageHomeOverride",

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/NestedPatternCompilationBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/NestedPatternCompilationBenchmarks.java
@@ -48,7 +48,7 @@ public class NestedPatternCompilationBenchmarks {
                         RuntimeOptions.LOG_LEVEL,
                         Level.WARNING.getName()
                 )
-                .logHandler(new ByteArrayOutputStream())
+                .logHandler(System.err)
                 .option(
                         "enso.languageHomeOverride",
                         Paths.get("../../distribution/component").toFile().getAbsolutePath()

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/NestedPatternCompilationBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/NestedPatternCompilationBenchmarks.java
@@ -6,6 +6,9 @@ import java.nio.file.Paths;
 import java.util.AbstractList;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.logging.Level;
+
+import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.io.IOAccess;
@@ -41,6 +44,10 @@ public class NestedPatternCompilationBenchmarks {
                 .allowExperimentalOptions(true)
                 .allowIO(IOAccess.ALL)
                 .allowAllAccess(true)
+                .option(
+                        RuntimeOptions.LOG_LEVEL,
+                        Level.WARNING.getName()
+                )
                 .logHandler(new ByteArrayOutputStream())
                 .option(
                         "enso.languageHomeOverride",

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/SieveBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/SieveBenchmarks.java
@@ -3,6 +3,9 @@ package org.enso.interpreter.bench.benchmarks.semantic;
 import java.io.ByteArrayOutputStream;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+
+import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.io.IOAccess;
@@ -35,6 +38,10 @@ public class SieveBenchmarks {
       .allowExperimentalOptions(true)
       .allowIO(IOAccess.ALL)
       .allowAllAccess(true)
+      .option(
+              RuntimeOptions.LOG_LEVEL,
+              Level.WARNING.getName()
+      )
       .logHandler(new ByteArrayOutputStream())
       .option(
         "enso.languageHomeOverride",

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/SieveBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/SieveBenchmarks.java
@@ -42,7 +42,7 @@ public class SieveBenchmarks {
               RuntimeOptions.LOG_LEVEL,
               Level.WARNING.getName()
       )
-      .logHandler(new ByteArrayOutputStream())
+      .logHandler(System.err)
       .option(
         "enso.languageHomeOverride",
         Paths.get("../../distribution/component").toFile().getAbsolutePath()

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/StringBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/StringBenchmarks.java
@@ -4,6 +4,9 @@ import java.io.ByteArrayOutputStream;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.logging.Level;
+
+import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.io.IOAccess;
@@ -38,6 +41,10 @@ public class StringBenchmarks {
       .allowExperimentalOptions(true)
       .allowIO(IOAccess.ALL)
       .allowAllAccess(true)
+      .option(
+              RuntimeOptions.LOG_LEVEL,
+              Level.WARNING.getName()
+      )
       .logHandler(new ByteArrayOutputStream())
       .option(
         "enso.languageHomeOverride",

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/StringBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/StringBenchmarks.java
@@ -45,7 +45,7 @@ public class StringBenchmarks {
               RuntimeOptions.LOG_LEVEL,
               Level.WARNING.getName()
       )
-      .logHandler(new ByteArrayOutputStream())
+      .logHandler(System.err)
       .option(
         "enso.languageHomeOverride",
         Paths.get("../../distribution/component").toFile().getAbsolutePath()

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/TypePatternBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/TypePatternBenchmarks.java
@@ -1,6 +1,7 @@
 package org.enso.interpreter.bench.benchmarks.semantic;
 
 import org.enso.polyglot.MethodNames.Module;
+import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.io.IOAccess;
@@ -12,6 +13,7 @@ import java.io.ByteArrayOutputStream;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.logging.Level;
 
 
 @BenchmarkMode(Mode.AverageTime)
@@ -31,6 +33,10 @@ public class TypePatternBenchmarks {
       .allowExperimentalOptions(true)
       .allowIO(IOAccess.ALL)
       .allowAllAccess(true)
+      .option(
+              RuntimeOptions.LOG_LEVEL,
+              Level.WARNING.getName()
+      )
       .logHandler(new ByteArrayOutputStream())
       .option(
         "enso.languageHomeOverride",

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/TypePatternBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/TypePatternBenchmarks.java
@@ -37,7 +37,7 @@ public class TypePatternBenchmarks {
               RuntimeOptions.LOG_LEVEL,
               Level.WARNING.getName()
       )
-      .logHandler(new ByteArrayOutputStream())
+      .logHandler(System.err)
       .option(
         "enso.languageHomeOverride",
         Paths.get("../../distribution/component").toFile().getAbsolutePath()

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/VectorBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/VectorBenchmarks.java
@@ -46,7 +46,7 @@ public class VectorBenchmarks {
               RuntimeOptions.LOG_LEVEL,
               Level.WARNING.getName()
       )
-      .logHandler(new ByteArrayOutputStream())
+            .logHandler(System.err)
       .option(
         "enso.languageHomeOverride",
         Paths.get("../../distribution/component").toFile().getAbsolutePath()

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/VectorBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/VectorBenchmarks.java
@@ -5,6 +5,9 @@ import java.nio.file.Paths;
 import java.util.AbstractList;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.logging.Level;
+
+import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.io.IOAccess;
@@ -39,6 +42,10 @@ public class VectorBenchmarks {
       .allowExperimentalOptions(true)
       .allowIO(IOAccess.ALL)
       .allowAllAccess(true)
+      .option(
+              RuntimeOptions.LOG_LEVEL,
+              Level.WARNING.getName()
+      )
       .logHandler(new ByteArrayOutputStream())
       .option(
         "enso.languageHomeOverride",

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -765,23 +765,13 @@ public final class EnsoContext {
   }
 
   /**
-   * Gets a logger for the specified class.
-   *
-   * @param klass the class to name log entries with
-   * @return a new logger for the specified {@code path}
-   */
-  public TruffleLogger getLogger(Class<?> klass) {
-    return TruffleLogger.getLogger(LanguageInfo.ID, klass);
-  }
-
-  /**
    * Gets a logger for the specified class that is bound to this engine.
    * Such logger may then be safely used in threads defined in a thread-pool.
    *
    * @param clazz the class to name log entries with
    * @return a new logger for the specified {@code path}
    */
-  public TruffleLogger getLoggerBoundToEngine(Class<?> clazz) {
+  public TruffleLogger getLogger(Class<?> clazz) {
     return environment.getLogger(clazz);
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -775,6 +775,17 @@ public final class EnsoContext {
   }
 
   /**
+   * Gets a logger for the specified class that is bound to this engine.
+   * Such logger may then be safely used in threads defined in a thread-pool.
+   *
+   * @param clazz the class to name log entries with
+   * @return a new logger for the specified {@code path}
+   */
+  public TruffleLogger getLoggerBoundToEngine(Class<?> clazz) {
+    return environment.getLogger(clazz);
+  }
+
+  /**
    * Returns the current clock value and atomically increments the counter by
    * one.
    *

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -37,14 +37,14 @@ final class TruffleCompilerContext implements CompilerContext {
 
   private final EnsoContext context;
   private final TruffleLogger loggerCompiler;
-  private final TruffleLogger loggerManager;
+  private final TruffleLogger loggerSerializationManager;
   private final RuntimeStubsGenerator stubsGenerator;
   private final SerializationManager serializationManager;
 
   TruffleCompilerContext(EnsoContext context) {
     this.context = context;
     this.loggerCompiler = context.getLogger(Compiler.class);
-    this.loggerManager = context.getLogger(SerializationManager.class);
+    this.loggerSerializationManager = context.getLogger(SerializationManager.class);
     this.serializationManager = new SerializationManager(this);
     this.stubsGenerator = new RuntimeStubsGenerator(context.getBuiltins());
   }
@@ -90,7 +90,7 @@ final class TruffleCompilerContext implements CompilerContext {
 
   @Override
   public void logSerializationManager(Level level, String msg, Object... args) {
-    loggerManager.log(level, msg, args);
+    loggerSerializationManager.log(level, msg, args);
   }
 
   @Override

--- a/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
@@ -2,6 +2,7 @@ package org.enso.compiler;
 
 import java.io.OutputStream;
 import java.nio.file.Paths;
+import java.util.logging.Level;
 
 import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
@@ -28,6 +29,10 @@ public class ExecCompilerTest {
             Paths.get("../../distribution/component").toFile().getAbsolutePath()
         )
         .option(RuntimeOptions.STRICT_ERRORS, "false")
+        .option(
+                RuntimeOptions.LOG_LEVEL,
+                Level.WARNING.getName()
+        )
         .logHandler(OutputStream.nullOutputStream())
         .allowAllAccess(true)
         .build();

--- a/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
@@ -33,7 +33,7 @@ public class ExecCompilerTest {
                 RuntimeOptions.LOG_LEVEL,
                 Level.WARNING.getName()
         )
-        .logHandler(OutputStream.nullOutputStream())
+        .logHandler(System.err)
         .allowAllAccess(true)
         .build();
     assertNotNull("Enso language is supported", ctx.getEngine().getLanguages().get("enso"));

--- a/engine/runtime/src/test/java/org/enso/compiler/SerdeCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/SerdeCompilerTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
+import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.SimpleFormatter;
 import org.enso.compiler.core.ir.Module;
@@ -118,6 +119,7 @@ public class SerdeCompilerTest {
             .option(
                 RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
                 Paths.get("../../distribution/component").toFile().getAbsolutePath())
+            .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
             .logHandler(mockHandler)
             .option("log.enso.org.enso.compiler.Compiler.level", "FINE")
             .allowAllAccess(true)

--- a/engine/runtime/src/test/java/org/enso/compiler/SerializerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/SerializerTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.SerializationManager;
 import org.enso.pkg.PackageManager;
@@ -28,6 +29,7 @@ public class SerializerTest {
             .option(
                 RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
                 Paths.get("../../distribution/component").toFile().getAbsolutePath())
+            .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
             .logHandler(OutputStream.nullOutputStream())
             .allowAllAccess(true)
             .build();

--- a/engine/runtime/src/test/java/org/enso/compiler/SerializerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/SerializerTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -30,7 +29,7 @@ public class SerializerTest {
                 RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
                 Paths.get("../../distribution/component").toFile().getAbsolutePath())
             .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
-            .logHandler(OutputStream.nullOutputStream())
+            .logHandler(System.err)
             .allowAllAccess(true)
             .build();
     assertNotNull("Enso language is supported", ctx.getEngine().getLanguages().get("enso"));

--- a/engine/runtime/src/test/java/org/enso/interpreter/runtime/ModuleSourcesTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/runtime/ModuleSourcesTest.java
@@ -2,7 +2,6 @@ package org.enso.interpreter.runtime;
 
 import static org.junit.Assert.assertTrue;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -31,7 +30,7 @@ public class ModuleSourcesTest {
         Engine.newBuilder()
             .allowExperimentalOptions(true)
             .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
-            .logHandler(new ByteArrayOutputStream())
+            .logHandler(System.err)
             .option(
                 RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
                 Paths.get("../../distribution/component").toFile().getAbsolutePath())

--- a/engine/runtime/src/test/java/org/enso/interpreter/runtime/ModuleSourcesTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/runtime/ModuleSourcesTest.java
@@ -6,6 +6,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.logging.Level;
 import org.enso.polyglot.LanguageInfo;
 import org.enso.polyglot.MethodNames;
 import org.enso.polyglot.RuntimeOptions;
@@ -29,6 +30,7 @@ public class ModuleSourcesTest {
     Engine eng =
         Engine.newBuilder()
             .allowExperimentalOptions(true)
+            .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
             .logHandler(new ByteArrayOutputStream())
             .option(
                 RuntimeOptions.LANGUAGE_HOME_OVERRIDE,

--- a/engine/runtime/src/test/java/org/enso/interpreter/runtime/ModuleTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/runtime/ModuleTest.java
@@ -6,6 +6,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.logging.Level;
 import org.enso.pkg.QualifiedName;
 import org.enso.polyglot.LanguageInfo;
 import org.enso.polyglot.MethodNames;
@@ -29,6 +30,7 @@ public class ModuleTest {
     Engine eng =
         Engine.newBuilder()
             .allowExperimentalOptions(true)
+            .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
             .logHandler(new ByteArrayOutputStream())
             .option(
                 RuntimeOptions.LANGUAGE_HOME_OVERRIDE,

--- a/engine/runtime/src/test/java/org/enso/interpreter/runtime/ModuleTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/runtime/ModuleTest.java
@@ -2,7 +2,6 @@ package org.enso.interpreter.runtime;
 
 import static org.junit.Assert.assertTrue;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -31,7 +30,7 @@ public class ModuleTest {
         Engine.newBuilder()
             .allowExperimentalOptions(true)
             .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
-            .logHandler(new ByteArrayOutputStream())
+            .logHandler(System.err)
             .option(
                 RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
                 Paths.get("../../distribution/component").toFile().getAbsolutePath())

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/DebuggingEnsoTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/DebuggingEnsoTest.java
@@ -61,7 +61,7 @@ public class DebuggingEnsoTest {
                 RuntimeOptions.LOG_LEVEL,
                 Level.FINEST.getName()
         )
-        .logHandler(OutputStream.nullOutputStream())
+        .logHandler(System.err)
         .build();
 
     context = Context.newBuilder()

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/DebuggingEnsoTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/DebuggingEnsoTest.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 import org.enso.polyglot.MethodNames.Module;
@@ -58,7 +59,7 @@ public class DebuggingEnsoTest {
         )
         .option(
                 RuntimeOptions.LOG_LEVEL,
-                "FINEST"
+                Level.FINEST.getName()
         )
         .logHandler(OutputStream.nullOutputStream())
         .build();

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/SharedEngineTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/SharedEngineTest.java
@@ -19,14 +19,13 @@ public class SharedEngineTest extends TestBase {
 
   @BeforeClass
   public static void initializeSharedEngine() {
-    var out = new ByteArrayOutputStream();
     sharedEngine = Engine.newBuilder()
       .allowExperimentalOptions(true)
       .option(
               RuntimeOptions.LOG_LEVEL,
               Level.WARNING.getName()
       )
-      .logHandler(out)
+      .logHandler(System.err)
       .option(RuntimeOptions.STRICT_ERRORS, "true")
       .option(
         RuntimeOptions.LANGUAGE_HOME_OVERRIDE,

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/SharedEngineTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/SharedEngineTest.java
@@ -2,6 +2,7 @@ package org.enso.interpreter.test;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.file.Paths;
+import java.util.logging.Level;
 
 import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
@@ -21,6 +22,10 @@ public class SharedEngineTest extends TestBase {
     var out = new ByteArrayOutputStream();
     sharedEngine = Engine.newBuilder()
       .allowExperimentalOptions(true)
+      .option(
+              RuntimeOptions.LOG_LEVEL,
+              Level.WARNING.getName()
+      )
       .logHandler(out)
       .option(RuntimeOptions.STRICT_ERRORS, "true")
       .option(

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/TestBase.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/TestBase.java
@@ -14,6 +14,7 @@ import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.logging.Level;
 import org.enso.interpreter.EnsoLanguage;
 import org.enso.polyglot.MethodNames.Module;
 import org.enso.polyglot.RuntimeOptions;
@@ -44,6 +45,7 @@ public abstract class TestBase {
         .allowExperimentalOptions(true)
         .allowIO(IOAccess.ALL)
         .allowAllAccess(true)
+        .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
         .logHandler(new ByteArrayOutputStream())
         .option(RuntimeOptions.STRICT_ERRORS, "true")
         .option(

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/TestBase.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/TestBase.java
@@ -9,7 +9,6 @@ import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
-import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.util.Map;
@@ -46,7 +45,7 @@ public abstract class TestBase {
         .allowIO(IOAccess.ALL)
         .allowAllAccess(true)
         .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
-        .logHandler(new ByteArrayOutputStream())
+        .logHandler(System.err)
         .option(RuntimeOptions.STRICT_ERRORS, "true")
         .option(
             RuntimeOptions.LANGUAGE_HOME_OVERRIDE,

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/ModifiedTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/ModifiedTest.scala
@@ -12,6 +12,7 @@ import org.scalatest.matchers.should.Matchers
 
 import java.io.{ByteArrayOutputStream, File, FileFilter}
 import java.nio.file.{Files, Paths, StandardCopyOption}
+import java.util.logging.Level
 
 trait ModifiedTest
     extends AnyFlatSpec
@@ -62,7 +63,7 @@ trait ModifiedTest
       .option(RuntimeOptions.DISABLE_IR_CACHES, "false")
       .out(output)
       .in(System.in)
-      .option(RuntimeOptions.LOG_LEVEL, "WARNING")
+      .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
       .logHandler(System.err)
       .build()
     context.initialize(LanguageInfo.ID)

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/semantic/ImportExportTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/semantic/ImportExportTest.scala
@@ -17,6 +17,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 
 import java.io.{ByteArrayOutputStream, ObjectOutputStream}
 import java.nio.file.Paths
+import java.util.logging.Level
 
 /** Tests a single package with multiple modules for import/export resolution.
   * Checks whether the exported symbols and defined entities metadata of the modules
@@ -41,7 +42,7 @@ class ImportExportTest
     .allowCreateThread(false)
     .out(out)
     .err(out)
-    .option(RuntimeOptions.LOG_LEVEL, "WARNING")
+    .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
     .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
     .logHandler(System.err)
     .option(

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/InterpreterTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/InterpreterTest.scala
@@ -28,6 +28,7 @@ import java.io.{
 }
 import java.nio.file.Paths
 import java.util.UUID
+import java.util.logging.Level
 
 case class LocationsInstrumenter(instrument: CodeLocationsTestInstrument) {
   var bindings: List[EventBinding[LocationsEventListener]] = List()
@@ -122,7 +123,7 @@ class InterpreterContext(
       .allowCreateThread(false)
       .out(output)
       .err(err)
-      .option(RuntimeOptions.LOG_LEVEL, "WARNING")
+      .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
       .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
       .environment("NO_COLOR", "true")
       .logHandler(System.err)

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/PackageTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/PackageTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 import java.io.{ByteArrayOutputStream, File}
 import java.nio.file.Paths
+import java.util.logging.Level
 
 trait PackageTest extends AnyFlatSpec with Matchers with ValueEquality {
   val output = new ByteArrayOutputStream()
@@ -35,7 +36,7 @@ trait PackageTest extends AnyFlatSpec with Matchers with ValueEquality {
       .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
       .out(output)
       .in(System.in)
-      .option(RuntimeOptions.LOG_LEVEL, "WARNING")
+      .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
       .logHandler(System.err)
       .build()
     context.initialize(LanguageInfo.ID)

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
@@ -7,6 +7,7 @@ import java.io.PrintWriter;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.FilerException;
@@ -44,6 +45,7 @@ public class BenchProcessor extends AbstractProcessor {
           "import java.util.List;",
           "import java.util.Objects;",
           "import java.util.concurrent.TimeUnit;",
+          "import java.util.logging.Level;",
           "import org.openjdk.jmh.annotations.Benchmark;",
           "import org.openjdk.jmh.annotations.BenchmarkMode;",
           "import org.openjdk.jmh.annotations.Mode;",
@@ -113,6 +115,10 @@ public class BenchProcessor extends AbstractProcessor {
               .allowExperimentalOptions(true)
               .allowIO(IOAccess.ALL)
               .allowAllAccess(true)
+              .option(
+                      RuntimeOptions.LOG_LEVEL,
+                      Level.WARNING.getName()
+              )
               .logHandler(new ByteArrayOutputStream())
               .option(RuntimeOptions.PROJECT_ROOT, projectRootDir.getAbsolutePath())
               .option(RuntimeOptions.LANGUAGE_HOME_OVERRIDE, ensoHomeOverride.getAbsolutePath())
@@ -242,6 +248,7 @@ public class BenchProcessor extends AbstractProcessor {
     out.println("      .allowExperimentalOptions(true)");
     out.println("      .allowIO(IOAccess.ALL)");
     out.println("      .allowAllAccess(true)");
+    out.println("      .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())");
     out.println("      .logHandler(new ByteArrayOutputStream())");
     out.println("      .option(");
     out.println("        RuntimeOptions.LANGUAGE_HOME_OVERRIDE,");

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
@@ -119,7 +119,7 @@ public class BenchProcessor extends AbstractProcessor {
                       RuntimeOptions.LOG_LEVEL,
                       Level.WARNING.getName()
               )
-              .logHandler(new ByteArrayOutputStream())
+              .logHandler(System.err)
               .option(RuntimeOptions.PROJECT_ROOT, projectRootDir.getAbsolutePath())
               .option(RuntimeOptions.LANGUAGE_HOME_OVERRIDE, ensoHomeOverride.getAbsolutePath())
               .build()) {
@@ -249,7 +249,7 @@ public class BenchProcessor extends AbstractProcessor {
     out.println("      .allowIO(IOAccess.ALL)");
     out.println("      .allowAllAccess(true)");
     out.println("      .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())");
-    out.println("      .logHandler(new ByteArrayOutputStream())");
+    out.println("      .logHandler(System.err)");
     out.println("      .option(");
     out.println("        RuntimeOptions.LANGUAGE_HOME_OVERRIDE,");
     out.println("        languageHomeOverride.getAbsolutePath()");


### PR DESCRIPTION
### Pull Request Description

Using a `TruffleLogger` in `SerializationManager` that is bound to the engine rather than the context prevents reaching an illegal state when using thread pools. 

Also cleaned up some tests for consistency. 

To verify the fix
```diff
--- a/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/SerializationManager.scala
@@ -31,7 +31,7 @@ final class SerializationManager(compiler: Compiler) {
   import SerializationManager._
 
   /** The debug logging level. */
-  private val debugLogLevel = Level.FINE
+  private val debugLogLevel = Level.INFO
```
and run
`sbt:enso> runtime/test`

Closes #8147.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
