### PR TITLE
Eliminate references to Truffle nodes & co. in the compiler

### DIFF
--- a/engine/runtime/src/main/java/org/enso/compiler/context/CompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/context/CompilerContext.java
@@ -19,6 +19,7 @@ import org.enso.compiler.data.CompilerConfig;
 import org.enso.pkg.Package;
 import org.enso.pkg.QualifiedName;
 import org.enso.polyglot.CompilationStage;
+import org.enso.polyglot.data.TypeGraph;
 
 /**
  * Interface that encapsulate all services {@link Compiler} needs from Truffle or other environment.
@@ -91,6 +92,8 @@ public interface CompilerContext {
   <T> Optional<T> loadCache(Cache<T, ?> cache);
 
   <T> Optional<TruffleFile> saveCache(Cache<T, ?> cache, T entry, boolean useGlobalCacheLocations);
+
+  TypeGraph getTypeHierarchy();
 
   public static interface Updater {
     void bindingsMap(BindingsMap map);

--- a/engine/runtime/src/main/java/org/enso/compiler/context/CompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/context/CompilerContext.java
@@ -14,13 +14,9 @@ import org.enso.compiler.ModuleCache;
 import org.enso.compiler.PackageRepository;
 import org.enso.compiler.Passes;
 import org.enso.compiler.SerializationManager;
-import org.enso.compiler.core.ir.Expression;
 import org.enso.compiler.data.BindingsMap;
 import org.enso.compiler.data.CompilerConfig;
-import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.data.Type;
-import org.enso.interpreter.runtime.scope.LocalScope;
-import org.enso.interpreter.runtime.scope.ModuleScope;
 import org.enso.pkg.Package;
 import org.enso.pkg.QualifiedName;
 import org.enso.polyglot.CompilationStage;
@@ -62,12 +58,6 @@ public interface CompilerContext {
   // Truffle related
 
   void truffleRunCodegen(Module module, CompilerConfig config) throws IOException;
-
-  void truffleRunCodegen(
-      Source source, ModuleScope scope, CompilerConfig config, org.enso.compiler.core.ir.Module ir);
-
-  ExpressionNode truffleRunInline(
-      Source source, LocalScope localScope, Module module, CompilerConfig config, Expression ir);
 
   // module related
 
@@ -127,8 +117,6 @@ public interface CompilerContext {
     public abstract Package<TruffleFile> getPackage();
 
     public abstract boolean isSameAs(org.enso.interpreter.runtime.Module m);
-
-    public abstract org.enso.interpreter.runtime.scope.ModuleScope getScope();
 
     public abstract QualifiedName getName();
 

--- a/engine/runtime/src/main/java/org/enso/compiler/context/CompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/context/CompilerContext.java
@@ -16,7 +16,6 @@ import org.enso.compiler.Passes;
 import org.enso.compiler.SerializationManager;
 import org.enso.compiler.data.BindingsMap;
 import org.enso.compiler.data.CompilerConfig;
-import org.enso.interpreter.runtime.data.Type;
 import org.enso.pkg.Package;
 import org.enso.pkg.QualifiedName;
 import org.enso.polyglot.CompilationStage;
@@ -119,8 +118,6 @@ public interface CompilerContext {
     public abstract boolean isSameAs(org.enso.interpreter.runtime.Module m);
 
     public abstract QualifiedName getName();
-
-    public abstract Type findType(String name);
 
     public abstract BindingsMap getBindingsMap();
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/Constants.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/Constants.java
@@ -3,19 +3,18 @@ package org.enso.interpreter;
 import org.enso.compiler.core.ConstantsNames;
 
 /** Language-level constants for use throughout the program. */
-public class Constants {
+public final class Constants {
+  private Constants() {}
+
   public static final String SCOPE_SEPARATOR = ".";
 
   /** Names for different language elements. */
-  public static class Names {
-    public static final String SELF_ARGUMENT = ConstantsNames.SELF_ARGUMENT;
-    public static final String SELF_TYPE_ARGUMENT = ConstantsNames.SELF_TYPE_ARGUMENT;
-    public static final String THAT_ARGUMENT = ConstantsNames.THAT_ARGUMENT;
-    public static final String FROM_MEMBER = ConstantsNames.FROM_MEMBER;
-  }
+  public static interface Names extends ConstantsNames {}
 
   /** Cache sizes for different AST nodes. */
   public static class CacheSizes {
+    private CacheSizes() {}
+
     public static final String ARGUMENT_SORTER_NODE = "10";
     public static final String FUNCTION_INTEROP_LIBRARY = "10";
     public static final String THUNK_EXECUTOR_NODE = "10";

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/EvalNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/EvalNode.java
@@ -66,7 +66,10 @@ public abstract class EvalNode extends BaseNode {
     LocalScope localScope = scope.createChild();
     InlineContext inlineContext =
         InlineContext.fromJava(
-            localScope, moduleScope, getTailStatus(), context.getCompilerConfig());
+            localScope,
+            moduleScope,
+            scala.Option.apply(getTailStatus() != TailStatus.NOT_TAIL),
+            context.getCompilerConfig());
     var compiler = context.getCompiler();
     var tuppleOption = compiler.runInline(expression, inlineContext);
     if (tuppleOption.isEmpty()) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/EvalNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/EvalNode.java
@@ -11,10 +11,10 @@ import org.enso.compiler.context.InlineContext;
 import org.enso.interpreter.Constants;
 import org.enso.interpreter.node.BaseNode;
 import org.enso.interpreter.node.ClosureRootNode;
-import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.node.callable.thunk.ThunkExecutorNode;
 import org.enso.interpreter.node.expression.builtin.text.util.ToJavaStringNode;
 import org.enso.interpreter.runtime.EnsoContext;
+import org.enso.interpreter.runtime.IrToTruffle;
 import org.enso.interpreter.runtime.callable.CallerInfo;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.data.text.Text;
@@ -67,11 +67,22 @@ public abstract class EvalNode extends BaseNode {
     InlineContext inlineContext =
         InlineContext.fromJava(
             localScope, moduleScope, getTailStatus(), context.getCompilerConfig());
-    ExpressionNode expr =
-        context.getCompiler().runInline(expression, inlineContext).getOrElse(() -> null);
-    if (expr == null) {
+    var compiler = context.getCompiler();
+    var tuppleOption = compiler.runInline(expression, inlineContext);
+    if (tuppleOption.isEmpty()) {
       throw new RuntimeException("Invalid code passed to `eval`: " + expression);
     }
+    var newInlineContext = tuppleOption.get()._1();
+    var ir = tuppleOption.get()._2();
+    var src = tuppleOption.get()._3();
+
+    var sco = newInlineContext.localScope().getOrElse(LocalScope::root);
+    var mod = newInlineContext.module$access$0().module$access$0();
+
+    var m = org.enso.interpreter.runtime.Module.fromCompilerModule(mod);
+    var toTruffle =
+        new IrToTruffle(context, src, m.getScope(), compiler.org$enso$compiler$Compiler$$config);
+    var expr = toTruffle.runInline(ir, sco, "<inline_source>");
 
     if (shouldCaptureResultScope) {
       expr = CaptureResultScopeNode.build(expr);

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/EvalNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/EvalNode.java
@@ -67,7 +67,7 @@ public abstract class EvalNode extends BaseNode {
     InlineContext inlineContext =
         InlineContext.fromJava(
             localScope,
-            moduleScope,
+            moduleScope.getModule().asCompilerModule(),
             scala.Option.apply(getTailStatus() != TailStatus.NOT_TAIL),
             context.getCompilerConfig());
     var compiler = context.getCompiler();

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -1,8 +1,6 @@
 package org.enso.interpreter.runtime;
 
 import org.enso.compiler.pass.analyse.BindingAnalysis$;
-import org.enso.compiler.codegen.IrToTruffle;
-import org.enso.compiler.codegen.RuntimeStubsGenerator;
 import org.enso.compiler.context.CompilerContext;
 import org.enso.compiler.context.FreshNameSupply;
 
@@ -113,18 +111,8 @@ final class TruffleCompilerContext implements CompilerContext {
 
   @Override
   public void truffleRunCodegen(CompilerContext.Module module, CompilerConfig config) throws IOException {
-    truffleRunCodegen(module.getSource(), module.getScope(), config, module.getIr());
-  }
-
-  @Override
-  public void truffleRunCodegen(Source source, ModuleScope scope, CompilerConfig config, org.enso.compiler.core.ir.Module ir) {
-    new IrToTruffle(context, source, scope, config).run(ir);
-  }
-
-  @Override
-  public ExpressionNode truffleRunInline(Source source, LocalScope localScope, CompilerContext.Module module, CompilerConfig config, Expression ir) {
-    return new IrToTruffle(context, source, module.getScope(), config)
-            .runInline(ir, localScope, "<inline_source>");
+    var m = org.enso.interpreter.runtime.Module.fromCompilerModule(module);
+    new IrToTruffle(context, module.getSource(), m.getScope(), config).run(module.getIr());
   }
 
   // module related
@@ -367,11 +355,6 @@ final class TruffleCompilerContext implements CompilerContext {
     @Override
     public boolean isSameAs(org.enso.interpreter.runtime.Module m) {
       return module == m;
-    }
-
-    // XXX
-    public org.enso.interpreter.runtime.scope.ModuleScope getScope() {
-      return module.getScope();
     }
 
     @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -28,10 +28,11 @@ import org.enso.compiler.data.CompilerConfig;
 import org.enso.interpreter.node.ExpressionNode;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.scope.LocalScope;
-import org.enso.interpreter.runtime.scope.ModuleScope;
+import org.enso.interpreter.runtime.type.Types;
 import org.enso.pkg.Package;
 import org.enso.pkg.QualifiedName;
 import org.enso.polyglot.CompilationStage;
+import org.enso.polyglot.data.TypeGraph;
 
 import scala.Option;
 
@@ -154,6 +155,11 @@ final class TruffleCompilerContext implements CompilerContext {
   @Override
   public CompilationStage getCompilationStage(CompilerContext.Module module) {
     return module.getCompilationStage();
+  }
+
+  @Override
+  public TypeGraph getTypeHierarchy() {
+    return Types.getTypeHierarchy();
   }
 
   @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -363,11 +363,6 @@ final class TruffleCompilerContext implements CompilerContext {
     }
 
     @Override
-    public Type findType(String name) {
-      return module.getScope().getTypes().get(name);
-    }
-
-    @Override
     public BindingsMap getBindingsMap() {
       if (module.getIr() != null) {
         var meta = module.getIr().passData();

--- a/engine/runtime/src/main/scala/org/enso/compiler/context/InlineContext.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/InlineContext.scala
@@ -3,7 +3,7 @@ package org.enso.compiler.context
 import org.enso.compiler.PackageRepository
 import org.enso.compiler.data.CompilerConfig
 import org.enso.compiler.pass.PassConfiguration
-import org.enso.interpreter.runtime.scope.{LocalScope, ModuleScope}
+import org.enso.interpreter.runtime.scope.LocalScope
 
 /** A type containing the information about the execution context for an inline
   * expression.
@@ -34,23 +34,20 @@ object InlineContext {
     * internally.
     *
     * @param localScope the local scope instance
-    * @param moduleScope the module scope instance
+    * @param module the module defining the context
     * @param isInTailPosition whether or not the inline expression occurs in a
     *                         tail position
     * @return the [[InlineContext]] instance corresponding to the arguments
     */
   def fromJava(
     localScope: LocalScope,
-    moduleScope: ModuleScope,
+    module: CompilerContext.Module,
     isInTailPosition: Option[Boolean],
     compilerConfig: CompilerConfig
   ): InlineContext = {
     InlineContext(
-      localScope = Option(localScope),
-      module = ModuleContext(
-        moduleScope.getModule().asCompilerModule(),
-        compilerConfig
-      ),
+      localScope       = Option(localScope),
+      module           = ModuleContext(module, compilerConfig),
       isInTailPosition = isInTailPosition,
       compilerConfig   = compilerConfig
     )

--- a/engine/runtime/src/main/scala/org/enso/compiler/context/InlineContext.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/InlineContext.scala
@@ -1,13 +1,10 @@
 package org.enso.compiler.context
 
-import org.enso.compiler.core.ir.Expression
 import org.enso.compiler.PackageRepository
 import org.enso.compiler.data.CompilerConfig
 import org.enso.compiler.pass.PassConfiguration
 import org.enso.interpreter.node.BaseNode.TailStatus
 import org.enso.interpreter.runtime.scope.{LocalScope, ModuleScope}
-import org.enso.interpreter.node.ExpressionNode
-import com.oracle.truffle.api.source.Source
 
 /** A type containing the information about the execution context for an inline
   * expression.
@@ -31,16 +28,6 @@ case class InlineContext(
   pkgRepo: Option[PackageRepository]           = None
 ) {
   def bindingsAnalysis() = module.bindingsAnalysis()
-
-  def truffleRunInline(
-    context: CompilerContext,
-    source: Source,
-    config: CompilerConfig,
-    ir: Expression
-  ): ExpressionNode = {
-    val s = localScope.getOrElse(LocalScope.root)
-    return module.truffleRunInline(context, source, s, config, ir)
-  }
 }
 object InlineContext {
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/context/InlineContext.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/InlineContext.scala
@@ -3,7 +3,6 @@ package org.enso.compiler.context
 import org.enso.compiler.PackageRepository
 import org.enso.compiler.data.CompilerConfig
 import org.enso.compiler.pass.PassConfiguration
-import org.enso.interpreter.node.BaseNode.TailStatus
 import org.enso.interpreter.runtime.scope.{LocalScope, ModuleScope}
 
 /** A type containing the information about the execution context for an inline
@@ -43,7 +42,7 @@ object InlineContext {
   def fromJava(
     localScope: LocalScope,
     moduleScope: ModuleScope,
-    isInTailPosition: TailStatus,
+    isInTailPosition: Option[Boolean],
     compilerConfig: CompilerConfig
   ): InlineContext = {
     InlineContext(
@@ -52,7 +51,7 @@ object InlineContext {
         moduleScope.getModule().asCompilerModule(),
         compilerConfig
       ),
-      isInTailPosition = Option(isInTailPosition != TailStatus.NOT_TAIL),
+      isInTailPosition = isInTailPosition,
       compilerConfig   = compilerConfig
     )
   }

--- a/engine/runtime/src/main/scala/org/enso/compiler/context/ModuleContext.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/ModuleContext.scala
@@ -1,13 +1,10 @@
 package org.enso.compiler.context
 
-import org.enso.compiler.core.ir.Expression
 import org.enso.compiler.PackageRepository
 import org.enso.compiler.data.CompilerConfig
 import org.enso.compiler.pass.PassConfiguration
 import org.enso.pkg.Package;
 import org.enso.pkg.QualifiedName;
-import org.enso.interpreter.runtime.scope.LocalScope
-import org.enso.interpreter.node.ExpressionNode
 import com.oracle.truffle.api.source.Source
 import org.enso.compiler.data.BindingsMap.ModuleReference
 
@@ -28,17 +25,8 @@ case class ModuleContext(
   isGeneratingDocs: Boolean                    = false,
   pkgRepo: Option[PackageRepository]           = None
 ) {
-  def isSynthetic()      = module.isSynthetic()
-  def bindingsAnalysis() = module.getBindingsMap()
-  def truffleRunInline(
-    context: CompilerContext,
-    source: Source,
-    s: LocalScope,
-    config: CompilerConfig,
-    ir: Expression
-  ): ExpressionNode = {
-    return context.truffleRunInline(source, s, module, config, ir)
-  }
+  def isSynthetic()            = module.isSynthetic()
+  def bindingsAnalysis()       = module.getBindingsMap()
   def getName(): QualifiedName = module.getName()
   def getPackage(): Package[_] = module.getPackage()
   def getSource(): Source      = module.getSource()

--- a/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/context/SuggestionBuilder.scala
@@ -25,7 +25,6 @@ import org.enso.compiler.pass.resolve.{
   TypeNames,
   TypeSignatures
 }
-import org.enso.interpreter.runtime.`type`.Types
 import org.enso.pkg.QualifiedName
 import org.enso.polyglot.Suggestion
 import org.enso.polyglot.data.{Tree, TypeGraph}
@@ -793,7 +792,11 @@ object SuggestionBuilder {
     source: A,
     compiler: Compiler
   ): SuggestionBuilder[A] =
-    new SuggestionBuilder[A](source, Types.getTypeHierarchy, compiler)
+    new SuggestionBuilder[A](
+      source,
+      compiler.context.getTypeHierarchy(),
+      compiler
+    )
 
   /** A single level of an `IR`.
     *

--- a/engine/runtime/src/main/scala/org/enso/compiler/data/BindingsMap.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/data/BindingsMap.scala
@@ -787,9 +787,6 @@ object BindingsMap {
 
     override lazy val exportedSymbols: Map[String, List[ResolvedName]] =
       tp.members.map(m => (m.name, List(ResolvedConstructor(this, m)))).toMap
-
-    def unsafeToRuntimeType(): org.enso.interpreter.runtime.data.Type =
-      module.unsafeAsModule().findType(tp.name)
   }
 
   /** A result of successful name resolution.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
@@ -68,7 +68,7 @@ import scala.reflect.ClassTag
   *
   * - A [[org.enso.compiler.pass.PassConfiguration]] containing an instance of
   *   [[AliasAnalysis.Configuration]].
-  * - A [[org.enso.interpreter.runtime.scope.LocalScope]], where relevant.
+  * - A [[LocalScope]], where relevant.
   */
 case object AliasAnalysis extends IRPass {
 

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
@@ -42,7 +42,7 @@ import scala.collection.mutable
   *
   * This pass requires the context to provide:
   *
-  * - A [[org.enso.interpreter.runtime.scope.LocalScope]], where relevant.
+  * - A [[LocalScope]], where relevant.
   *
   * It requires that all members of [[org.enso.compiler.core.ir.IRKind.Primitive]] have been removed
   * from the IR by the time it runs.

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/desugar/FunctionBinding.scala
@@ -1,6 +1,7 @@
 package org.enso.compiler.pass.desugar
 
 import org.enso.compiler.context.{InlineContext, ModuleContext}
+import org.enso.compiler.core.ConstantsNames
 import org.enso.compiler.core.Implicits.AsMetadata
 import org.enso.compiler.core.ir.module.scope.Definition
 import org.enso.compiler.core.ir.module.scope.definition
@@ -24,7 +25,6 @@ import org.enso.compiler.pass.analyse.{
 }
 import org.enso.compiler.pass.optimise.LambdaConsolidate
 import org.enso.compiler.pass.resolve.IgnoredBindings
-import org.enso.interpreter.Constants
 
 /** This pass handles the desugaring of long-form function and method
   * definitions into standard bindings using lambdas.
@@ -185,7 +185,7 @@ case object FunctionBinding extends IRPass {
                   else
                     Name
                       .Literal(
-                        Constants.Names.THAT_ARGUMENT,
+                        ConstantsNames.THAT_ARGUMENT,
                         firstArgumentName.isMethod,
                         firstArgumentName.location
                       )
@@ -203,7 +203,7 @@ case object FunctionBinding extends IRPass {
                 if (sndArgName.isInstanceOf[Name.Blank]) {
                   val newName = Name
                     .Literal(
-                      Constants.Names.THAT_ARGUMENT,
+                      ConstantsNames.THAT_ARGUMENT,
                       sndArgName.isMethod,
                       sndArgName.location
                     )
@@ -217,7 +217,7 @@ case object FunctionBinding extends IRPass {
                     ),
                     rest
                   )
-                } else if (snd.name.name != Constants.Names.THAT_ARGUMENT) {
+                } else if (snd.name.name != ConstantsNames.THAT_ARGUMENT) {
                   (None, restArgs)
                 } else {
                   (Some(snd), rest)
@@ -230,7 +230,7 @@ case object FunctionBinding extends IRPass {
               remainingArgs: List[DefinitionArgument]
             ): Either[Error, definition.Method] = {
               remaining
-                .filter(_.name.name != Constants.Names.SELF_ARGUMENT)
+                .filter(_.name.name != ConstantsNames.SELF_ARGUMENT)
                 .find(_.defaultValue.isEmpty) match {
                 case Some(nonDefaultedArg) =>
                   Left(
@@ -262,9 +262,9 @@ case object FunctionBinding extends IRPass {
             val failures = sndArgument match {
               case Some(newSndArgument) =>
                 if (
-                  newFirstArgument.name.name == Constants.Names.SELF_ARGUMENT
+                  newFirstArgument.name.name == ConstantsNames.SELF_ARGUMENT
                 ) {
-                  if (newSndArgument.name.name != Constants.Names.THAT_ARGUMENT)
+                  if (newSndArgument.name.name != ConstantsNames.THAT_ARGUMENT)
                     Left(
                       errors.Conversion(
                         newSndArgument,
@@ -275,7 +275,7 @@ case object FunctionBinding extends IRPass {
                     )
                   else Right(())
                 } else if (
-                  newFirstArgument.name.name != Constants.Names.THAT_ARGUMENT
+                  newFirstArgument.name.name != ConstantsNames.THAT_ARGUMENT
                 ) {
                   Left(
                     errors.Conversion(
@@ -288,7 +288,7 @@ case object FunctionBinding extends IRPass {
                 } else Right(())
               case None =>
                 if (
-                  newFirstArgument.name.name != Constants.Names.THAT_ARGUMENT
+                  newFirstArgument.name.name != ConstantsNames.THAT_ARGUMENT
                 ) {
                   Left(
                     errors.Conversion(

--- a/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/GlobalNames.scala
+++ b/engine/runtime/src/main/scala/org/enso/compiler/pass/resolve/GlobalNames.scala
@@ -23,10 +23,10 @@ import org.enso.compiler.data.BindingsMap.{
   ResolvedModule
 }
 import org.enso.compiler.core.CompilerError
+import org.enso.compiler.core.ConstantsNames
 import org.enso.compiler.core.ir.expression.Application
 import org.enso.compiler.pass.IRPass
 import org.enso.compiler.pass.analyse.{AliasAnalysis, BindingAnalysis}
-import org.enso.interpreter.Constants
 
 /** Resolves name occurences in non-pattern contexts.
   *
@@ -401,7 +401,7 @@ case object GlobalNames extends IRPass {
   private def findThisPosition(args: List[CallArgument]): Option[Int] = {
     val ix = args.indexWhere(arg =>
       arg.name.exists(
-        _.name == Constants.Names.SELF_ARGUMENT
+        _.name == ConstantsNames.SELF_ARGUMENT
       ) || arg.name.isEmpty
     )
     if (ix == -1) None else Some(ix)

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -4,6 +4,7 @@ import com.oracle.truffle.api.source.{Source, SourceSection}
 import com.oracle.truffle.api.interop.InteropLibrary
 import org.enso.compiler.context.CompilerContext
 import org.enso.compiler.core.CompilerError
+import org.enso.compiler.core.ConstantsNames
 import org.enso.compiler.core.Implicits.AsMetadata
 import org.enso.compiler.core.IR
 import org.enso.compiler.core.ir.{
@@ -873,7 +874,7 @@ class IrToTruffle(
         new FunctionSchema(
           new ArgumentDefinition(
             0,
-            Constants.Names.SELF_ARGUMENT,
+            ConstantsNames.SELF_ARGUMENT,
             null,
             null,
             ArgumentDefinition.ExecutionMode.EXECUTE
@@ -889,7 +890,7 @@ class IrToTruffle(
         new FunctionSchema(
           new ArgumentDefinition(
             0,
-            Constants.Names.SELF_ARGUMENT,
+            ConstantsNames.SELF_ARGUMENT,
             null,
             null,
             ArgumentDefinition.ExecutionMode.EXECUTE
@@ -1650,7 +1651,7 @@ class IrToTruffle(
           } else if (global.isDefined) {
             val resolution = global.get.target
             nodeForResolution(resolution)
-          } else if (nameStr == Constants.Names.FROM_MEMBER) {
+          } else if (nameStr == ConstantsNames.FROM_MEMBER) {
             ConstantObjectNode.build(UnresolvedConversion.build(moduleScope))
           } else {
             DynamicSymbolNode.build(
@@ -1660,7 +1661,7 @@ class IrToTruffle(
         case Name.Self(location, _, passData, _) =>
           processName(
             Name.Literal(
-              Constants.Names.SELF_ARGUMENT,
+              ConstantsNames.SELF_ARGUMENT,
               isMethod = false,
               location,
               None,
@@ -1916,7 +1917,7 @@ class IrToTruffle(
             val argName = arg.getName
 
             if (
-              argName != Constants.Names.SELF_ARGUMENT && seenArgNames.contains(
+              argName != ConstantsNames.SELF_ARGUMENT && seenArgNames.contains(
                 argName
               )
             ) {

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/RuntimeStubsGenerator.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/RuntimeStubsGenerator.scala
@@ -1,4 +1,4 @@
-package org.enso.compiler.codegen
+package org.enso.interpreter.runtime
 
 import org.enso.compiler.data.BindingsMap
 import org.enso.compiler.core.CompilerError

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/GenerateMethodBodiesTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/pass/desugar/GenerateMethodBodiesTest.scala
@@ -2,6 +2,7 @@ package org.enso.compiler.test.pass.desugar
 
 import org.enso.compiler.Passes
 import org.enso.compiler.context.ModuleContext
+import org.enso.compiler.core.ConstantsNames
 import org.enso.compiler.core.ir.{
   DefinitionArgument,
   Function,
@@ -15,7 +16,6 @@ import org.enso.compiler.core.ir.module.scope.definition
 import org.enso.compiler.pass.desugar.{FunctionBinding, GenerateMethodBodies}
 import org.enso.compiler.pass.{PassConfiguration, PassGroup, PassManager}
 import org.enso.compiler.test.CompilerTest
-import org.enso.interpreter.Constants
 
 class GenerateMethodBodiesTest extends CompilerTest {
 
@@ -338,7 +338,7 @@ class GenerateMethodBodiesTest extends CompilerTest {
       val nestedBody = body.body.asInstanceOf[Function.Lambda]
       nestedBody.arguments.length shouldEqual 1
       nestedBody.arguments.head.name shouldBe an[Name.Literal]
-      nestedBody.arguments.head.name.name shouldEqual Constants.Names.THAT_ARGUMENT
+      nestedBody.arguments.head.name.name shouldEqual ConstantsNames.THAT_ARGUMENT
     }
 
     "have report a warning when defining `self` at a wrong position" in {
@@ -352,7 +352,7 @@ class GenerateMethodBodiesTest extends CompilerTest {
       val body = conversion.body.asInstanceOf[Function.Lambda]
       body.arguments.length shouldEqual 1
       body.arguments.head.name shouldBe an[Name.Literal]
-      body.arguments.head.name.name shouldBe Constants.Names.THAT_ARGUMENT
+      body.arguments.head.name.name shouldBe ConstantsNames.THAT_ARGUMENT
 
       conversion.body.diagnostics.collect { case w: Warning =>
         w
@@ -370,7 +370,7 @@ class GenerateMethodBodiesTest extends CompilerTest {
       val body = conversion.body.asInstanceOf[Function.Lambda]
       body.arguments.length shouldEqual 1
       body.arguments.head.name shouldBe an[Name.Literal]
-      body.arguments.head.name.name shouldBe Constants.Names.THAT_ARGUMENT
+      body.arguments.head.name.name shouldBe ConstantsNames.THAT_ARGUMENT
 
       conversion.body.diagnostics.collect { case w: Warning =>
         w


### PR DESCRIPTION
### Pull Request Description

Work on #6100 has resulted in additional cleanups & refactorings of the Enso `Compiler` & `CompilerContext` abstraction.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] All tests continue to pass.
