### PR TITLE
Allow reassigning of BindingsMap

### DIFF
--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -114,7 +114,9 @@ final class EnsureCompiledJob(
             .map { _ =>
               invalidateCaches(module, changeset)
               if (module.isIndexed) {
-                ctx.jobProcessor.runBackground(AnalyzeModuleJob(module, changeset))
+                ctx.jobProcessor.runBackground(
+                  AnalyzeModuleJob(module, changeset)
+                )
               } else {
                 AnalyzeModuleJob.analyzeModule(module, changeset)
               }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -99,19 +99,29 @@ final class EnsureCompiledJob(
     ctx: RuntimeContext,
     logger: TruffleLogger
   ): Option[CompilationStatus] = {
-    compile(module)
-    applyEdits(new File(module.getPath)).map { changeset =>
-      compile(module)
-        .map { _ =>
-          invalidateCaches(module, changeset)
-          if (module.isIndexed) {
-            ctx.jobProcessor.runBackground(AnalyzeModuleJob(module, changeset))
-          } else {
-            AnalyzeModuleJob.analyzeModule(module, changeset)
-          }
-          runCompilationDiagnostics(module)
+    val result = compile(module)
+    result match {
+      case Left(ex) =>
+        logger.log(
+          Level.WARNING,
+          s"Error while ensureCompiledModule ${module.getName}",
+          ex
+        )
+        Some(CompilationStatus.Failure)
+      case _ =>
+        applyEdits(new File(module.getPath)).map { changeset =>
+          compile(module)
+            .map { _ =>
+              invalidateCaches(module, changeset)
+              if (module.isIndexed) {
+                ctx.jobProcessor.runBackground(AnalyzeModuleJob(module, changeset))
+              } else {
+                AnalyzeModuleJob.analyzeModule(module, changeset)
+              }
+              runCompilationDiagnostics(module)
+            }
+            .getOrElse(CompilationStatus.Failure)
         }
-        .getOrElse(CompilationStatus.Failure)
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/compiler/PackageRepositoryUtils.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/PackageRepositoryUtils.java
@@ -3,7 +3,6 @@ package org.enso.compiler;
 import com.oracle.truffle.api.TruffleFile;
 import java.util.Optional;
 import java.util.stream.StreamSupport;
-import org.enso.interpreter.util.ScalaConversions;
 import org.enso.pkg.Package;
 import org.enso.pkg.QualifiedName;
 
@@ -20,7 +19,8 @@ public final class PackageRepositoryUtils {
    */
   public static Optional<QualifiedName> getModuleNameForFile(
       PackageRepository packageRepository, TruffleFile file) {
-    return ScalaConversions.asJava(packageRepository.getLoadedPackages()).stream()
+    return scala.jdk.javaapi.CollectionConverters.asJava(packageRepository.getLoadedPackages())
+        .stream()
         .filter(pkg -> file.startsWith(pkg.sourceDir()))
         .map(pkg -> pkg.moduleNameForFile(file))
         .findFirst();

--- a/engine/runtime/src/main/java/org/enso/compiler/context/CompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/context/CompilerContext.java
@@ -119,8 +119,6 @@ public interface CompilerContext {
 
     public abstract Package<TruffleFile> getPackage();
 
-    public abstract boolean isSameAs(org.enso.interpreter.runtime.Module m);
-
     public abstract QualifiedName getName();
 
     public abstract BindingsMap getBindingsMap();

--- a/engine/runtime/src/main/java/org/enso/compiler/pass/analyse/ExportSymbolAnalysis.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/pass/analyse/ExportSymbolAnalysis.java
@@ -12,7 +12,6 @@ import org.enso.compiler.core.ir.expression.errors.ImportExport;
 import org.enso.compiler.core.ir.module.scope.Export;
 import org.enso.compiler.data.BindingsMap;
 import org.enso.compiler.pass.IRPass;
-import org.enso.interpreter.util.ScalaConversions;
 import scala.collection.immutable.Seq;
 import scala.jdk.javaapi.CollectionConverters;
 
@@ -49,8 +48,10 @@ public final class ExportSymbolAnalysis implements IRPass {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public Seq<IRPass> invalidatedPasses() {
-    return ScalaConversions.nil();
+    Object obj = scala.collection.immutable.Nil$.MODULE$;
+    return (scala.collection.immutable.List<IRPass>) obj;
   }
 
   @Override

--- a/engine/runtime/src/main/java/org/enso/compiler/pass/analyse/PrivateModuleAnalysis.java
+++ b/engine/runtime/src/main/java/org/enso/compiler/pass/analyse/PrivateModuleAnalysis.java
@@ -2,7 +2,6 @@ package org.enso.compiler.pass.analyse;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 import org.enso.compiler.context.InlineContext;
 import org.enso.compiler.context.ModuleContext;
@@ -14,7 +13,6 @@ import org.enso.compiler.core.ir.module.scope.Export;
 import org.enso.compiler.core.ir.module.scope.Import;
 import org.enso.compiler.data.BindingsMap;
 import org.enso.compiler.pass.IRPass;
-import org.enso.interpreter.util.ScalaConversions;
 import org.enso.pkg.QualifiedName;
 import scala.Option;
 import scala.collection.immutable.Seq;
@@ -55,8 +53,10 @@ public final class PrivateModuleAnalysis implements IRPass {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public Seq<IRPass> invalidatedPasses() {
-    return ScalaConversions.nil();
+    Object obj = scala.collection.immutable.Nil$.MODULE$;
+    return (scala.collection.immutable.List<IRPass>) obj;
   }
 
   @Override

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -330,7 +330,7 @@ final class TruffleCompilerContext implements CompilerContext {
     public void close() {
       if (map != null) {
         if (module.bindings != null) {
-          throw new IllegalStateException("Reassigining bindings to " + module);
+          loggerCompiler.log(Level.FINE, "Reassigining bindings to {0}", module);
         }
         module.bindings = map;
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -385,11 +385,6 @@ final class TruffleCompilerContext implements CompilerContext {
     }
 
     @Override
-    public boolean isSameAs(org.enso.interpreter.runtime.Module m) {
-      return module == m;
-    }
-
-    @Override
     public QualifiedName getName() {
       return module.getName();
     }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -907,7 +907,7 @@ class IrToTruffle(
         if (
           resolution.isInstanceOf[ResolvedConstructor] || !resolution.module
             .unsafeAsModule()
-            .isSameAs(moduleScope.getModule)
+            .equals(moduleScope.getModule.asCompilerModule)
         ) {
           resolution match {
             case BindingsMap.ResolvedType(module, tp) =>


### PR DESCRIPTION
### Pull Request Description

Fixes #8186 by turning `IllegalStateException` into log message. Re-assigning of `BindingsMap` can happen in the IDE where evaluation of modules is repeated again and again. In addition to that avoid dropping errors in compiler without them being noticed.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
