### PR TITLE
Fix flaky `partitionPoint` test

### DIFF
--- a/app/gui2/src/util/__tests__/array.test.ts
+++ b/app/gui2/src/util/__tests__/array.test.ts
@@ -18,7 +18,7 @@ fcTest.prop({
     const sorted = a.sort((a, b) => a - b)
     return fc.record({
       arr: fc.constant(sorted),
-      i: fc.nat({ max: sorted.length }).map((i) => Math.max(0, a.indexOf(a[i]!))),
+      i: fc.nat({ max: Math.max(sorted.length - 1, 0) }).map((i) => Math.max(0, a.indexOf(a[i]!))),
     })
   }),
 })('partitionPoint (ascending)', ({ arr: { arr, i } }) => {
@@ -31,7 +31,7 @@ fcTest.prop({
     const sorted = a.sort((a, b) => b - a)
     return fc.record({
       arr: fc.constant(sorted),
-      i: fc.nat({ max: sorted.length }).map((i) => Math.max(0, a.indexOf(a[i]!))),
+      i: fc.nat({ max: Math.max(sorted.length - 1, 0) }).map((i) => Math.max(0, a.indexOf(a[i]!))),
     })
   }),
 })('partitionPoint (descending)', ({ arr: { arr, i } }) => {

--- a/app/gui2/src/util/__tests__/array.test.ts
+++ b/app/gui2/src/util/__tests__/array.test.ts
@@ -14,20 +14,26 @@ fcTest.prop({
 })
 
 fcTest.prop({
-  arr: fc.array(fc.float({ noNaN: true })).map((a) => ({
-    arr: a.sort((a, b) => a - b),
-    i: Math.max(0, a.indexOf(a[Math.floor(Math.random() * a.length)]!)),
-  })),
+  arr: fc.array(fc.float({ noNaN: true })).chain((a) => {
+    const sorted = a.sort((a, b) => a - b)
+    return fc.record({
+      arr: fc.constant(sorted),
+      i: fc.nat({ max: sorted.length }).map((i) => Math.max(0, a.indexOf(a[i]!))),
+    })
+  }),
 })('partitionPoint (ascending)', ({ arr: { arr, i } }) => {
   const target = arr[i]!
   expect(partitionPoint(arr, (n) => n < target)).toEqual(i)
 })
 
 fcTest.prop({
-  arr: fc.array(fc.float({ noNaN: true })).map((a) => ({
-    arr: a.sort((a, b) => b - a),
-    i: Math.max(0, a.indexOf(a[Math.floor(Math.random() * a.length)]!)),
-  })),
+  arr: fc.array(fc.float({ noNaN: true })).chain((a) => {
+    const sorted = a.sort((a, b) => b - a)
+    return fc.record({
+      arr: fc.constant(sorted),
+      i: fc.nat({ max: sorted.length }).map((i) => Math.max(0, a.indexOf(a[i]!))),
+    })
+  }),
 })('partitionPoint (descending)', ({ arr: { arr, i } }) => {
   const target = arr[i]!
   expect(partitionPoint(arr, (n) => n > target)).toEqual(i)

--- a/app/gui2/src/util/__tests__/array.test.ts
+++ b/app/gui2/src/util/__tests__/array.test.ts
@@ -14,18 +14,20 @@ fcTest.prop({
 })
 
 fcTest.prop({
-  arr: fc
-    .array(fc.float())
-    .map((a) => ({ arr: a.sort((a, b) => a - b), i: Math.floor(Math.random() * a.length) })),
+  arr: fc.array(fc.float({ noNaN: true })).map((a) => ({
+    arr: a.sort((a, b) => a - b),
+    i: Math.max(0, a.indexOf(a[Math.floor(Math.random() * a.length)]!)),
+  })),
 })('partitionPoint (ascending)', ({ arr: { arr, i } }) => {
   const target = arr[i]!
   expect(partitionPoint(arr, (n) => n < target)).toEqual(i)
 })
 
 fcTest.prop({
-  arr: fc
-    .array(fc.float())
-    .map((a) => ({ arr: a.sort((a, b) => b - a), i: Math.floor(Math.random() * a.length) })),
+  arr: fc.array(fc.float({ noNaN: true })).map((a) => ({
+    arr: a.sort((a, b) => b - a),
+    i: Math.max(0, a.indexOf(a[Math.floor(Math.random() * a.length)]!)),
+  })),
 })('partitionPoint (descending)', ({ arr: { arr, i } }) => {
   const target = arr[i]!
   expect(partitionPoint(arr, (n) => n > target)).toEqual(i)


### PR DESCRIPTION
### Pull Request Description
The tests for `partitionPoint` were previously failing when `NaN` or duplicates were present in the array.

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
