### PR TITLE
Avoid crash when new directory created in project root

### DIFF
--- a/app/gui2/ydoc-server/languageServerSession.ts
+++ b/app/gui2/ydoc-server/languageServerSession.ts
@@ -70,13 +70,16 @@ export class LanguageServerSession extends ObservableV2<Events> {
       }
     })
 
-    this.ls.on('file/event', (event) => {
+    this.ls.on('file/event', async (event) => {
       if (DEBUG_LOG_SYNC) {
         console.log('file/event', event)
       }
       switch (event.kind) {
         case 'Added':
-          this.getModuleModel(event.path).open()
+          const fileInfo = await this.ls.fileInfo(event.path)
+          if (fileInfo.attributes.kind.type == 'File') {
+            this.getModuleModel(event.path).open()
+          }
           break
         case 'Modified':
           this.getModuleModelIfExists(event.path)?.reload()

--- a/app/gui2/ydoc-server/languageServerSession.ts
+++ b/app/gui2/ydoc-server/languageServerSession.ts
@@ -76,9 +76,11 @@ export class LanguageServerSession extends ObservableV2<Events> {
       }
       switch (event.kind) {
         case 'Added':
-          const fileInfo = await this.ls.fileInfo(event.path)
-          if (fileInfo.attributes.kind.type == 'File') {
-            this.getModuleModel(event.path).open()
+          if (isSourceFile(event.path)) {
+            const fileInfo = await this.ls.fileInfo(event.path)
+            if (fileInfo.attributes.kind.type == 'File') {
+              this.getModuleModel(event.path).open()
+            }
           }
           break
         case 'Modified':
@@ -181,6 +183,10 @@ export class LanguageServerSession extends ObservableV2<Events> {
   getYDoc(guid: string): WSSharedDoc | undefined {
     return this.docs.get(guid)
   }
+}
+
+const isSourceFile = (path: Path): boolean => {
+  return path.segments[0] === 'src' && path.segments[path.segments.length - 1].endsWith('.enso')
 }
 
 const pathToModuleName = (path: Path): string => {


### PR DESCRIPTION
### Pull Request Description

While working on #8158, I noticed a crash when the `data` directory is created at the project root. Turns out it is the issue in the `ydoc-server`, which thinks every filesystem event is about files. Unfortunately, we don‘t have the needed info available, so we need to make the `file/info` request.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
