### PR TITLE
Add disable-private-check option

### DIFF
--- a/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
+++ b/engine/polyglot-api/src/main/java/org/enso/polyglot/RuntimeOptions.java
@@ -21,6 +21,11 @@ public class RuntimeOptions {
   private static final OptionDescriptor DISABLE_INLINE_CACHES_DESCRIPTOR =
       OptionDescriptor.newBuilder(DISABLE_INLINE_CACHES_KEY, DISABLE_INLINE_CACHES).build();
 
+  public static final String DISABLE_PRIVATE_CHECK = optionName("disablePrivateCheck");
+  public static final OptionKey<Boolean> DISABLE_PRIVATE_CHECK_KEY = new OptionKey<>(false);
+  private static final OptionDescriptor DISABLE_PRIVATE_CHECK_DESCRIPTOR =
+      OptionDescriptor.newBuilder(DISABLE_PRIVATE_CHECK_KEY, DISABLE_PRIVATE_CHECK).build();
+
   public static final String ENABLE_AUTO_PARALLELISM = optionName("withAutoParallelism");
   public static final OptionKey<Boolean> ENABLE_AUTO_PARALLELISM_KEY = new OptionKey<>(false);
   private static final OptionDescriptor ENABLE_AUTO_PARALLELISM_DESCRIPTOR =
@@ -125,6 +130,7 @@ public class RuntimeOptions {
               STRICT_ERRORS_DESCRIPTOR,
               LOG_MASKING_DESCRIPTOR,
               DISABLE_INLINE_CACHES_DESCRIPTOR,
+              DISABLE_PRIVATE_CHECK_DESCRIPTOR,
               ENABLE_AUTO_PARALLELISM_DESCRIPTOR,
               ENABLE_PROJECT_SUGGESTIONS_DESCRIPTOR,
               ENABLE_GLOBAL_SUGGESTIONS_DESCRIPTOR,

--- a/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
@@ -26,6 +26,7 @@ class ContextFactory {
     * @param repl the Repl manager to use for this context
     * @param logLevel the log level for this context
     * @param enableIrCaches whether or not IR caching should be enabled
+   * @param disablePrivateCheck If `private` keyword should be disabled.
     * @param strictErrors whether or not to use strict errors
     * @param useGlobalIrCacheLocation whether or not to use the global IR cache
     *                                 location
@@ -42,6 +43,7 @@ class ContextFactory {
     logLevel: Level,
     logMasking: Boolean,
     enableIrCaches: Boolean,
+    disablePrivateCheck: Boolean           = false,
     strictErrors: Boolean                  = false,
     useGlobalIrCacheLocation: Boolean      = true,
     enableAutoParallelism: Boolean         = false,
@@ -76,6 +78,7 @@ class ContextFactory {
         useGlobalIrCacheLocation.toString
       )
       .option(RuntimeOptions.DISABLE_IR_CACHES, (!enableIrCaches).toString)
+      .option(RuntimeOptions.DISABLE_PRIVATE_CHECK, disablePrivateCheck.toString)
       .option(DebugServerInfo.ENABLE_OPTION, "true")
       .option(RuntimeOptions.LOG_MASKING, logMasking.toString)
       .options(options)

--- a/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/ContextFactory.scala
@@ -26,7 +26,7 @@ class ContextFactory {
     * @param repl the Repl manager to use for this context
     * @param logLevel the log level for this context
     * @param enableIrCaches whether or not IR caching should be enabled
-   * @param disablePrivateCheck If `private` keyword should be disabled.
+    * @param disablePrivateCheck If `private` keyword should be disabled.
     * @param strictErrors whether or not to use strict errors
     * @param useGlobalIrCacheLocation whether or not to use the global IR cache
     *                                 location
@@ -78,7 +78,10 @@ class ContextFactory {
         useGlobalIrCacheLocation.toString
       )
       .option(RuntimeOptions.DISABLE_IR_CACHES, (!enableIrCaches).toString)
-      .option(RuntimeOptions.DISABLE_PRIVATE_CHECK, disablePrivateCheck.toString)
+      .option(
+        RuntimeOptions.DISABLE_PRIVATE_CHECK,
+        disablePrivateCheck.toString
+      )
       .option(DebugServerInfo.ENABLE_OPTION, "true")
       .option(RuntimeOptions.LOG_MASKING, logMasking.toString)
       .options(options)

--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -67,6 +67,7 @@ object Main {
   private val IR_CACHES_OPTION               = "ir-caches"
   private val NO_IR_CACHES_OPTION            = "no-ir-caches"
   private val NO_READ_IR_CACHES_OPTION       = "no-read-ir-caches"
+  private val DISABLE_PRIVATE_CHECK_OPTION   = "disable-private-check"
   private val COMPILE_OPTION                 = "compile"
   private val NO_COMPILE_DEPENDENCIES_OPTION = "no-compile-dependencies"
   private val NO_GLOBAL_CACHE_OPTION         = "no-global-cache"
@@ -586,6 +587,7 @@ object Main {
     * @param logLevel       log level to set for the engine runtime
     * @param logMasking     is the log masking enabled
     * @param enableIrCaches are IR caches enabled
+    * @param disablePrivateCheck Is private modules check disabled. If yes, `private` keyword is ignored.
     * @param inspect        shall inspect option be enabled
     * @param dump           shall graphs be sent to the IGV
     * @param executionEnvironment optional name of the execution environment to use during execution
@@ -597,6 +599,7 @@ object Main {
     logLevel: Level,
     logMasking: Boolean,
     enableIrCaches: Boolean,
+    disablePrivateCheck: Boolean,
     enableAutoParallelism: Boolean,
     inspect: Boolean,
     dump: Boolean,
@@ -639,6 +642,7 @@ object Main {
       logLevel,
       logMasking,
       enableIrCaches,
+      disablePrivateCheck,
       strictErrors          = true,
       enableAutoParallelism = enableAutoParallelism,
       executionEnvironment  = executionEnvironment,
@@ -1171,6 +1175,7 @@ object Main {
         logLevel,
         logMasking,
         shouldEnableIrCaches(line),
+        line.hasOption(DISABLE_PRIVATE_CHECK_OPTION),
         line.hasOption(AUTO_PARALLELISM_OPTION),
         line.hasOption(INSPECT_OPTION),
         line.hasOption(DUMP_GRAPHS_OPTION),

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
@@ -27,6 +27,7 @@ import org.enso.polyglot.data.TypeGraph;
  */
 public interface CompilerContext {
   boolean isIrCachingDisabled();
+
   boolean isPrivateCheckDisabled();
 
   boolean isUseGlobalCacheLocations();

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
@@ -27,6 +27,7 @@ import org.enso.polyglot.data.TypeGraph;
  */
 public interface CompilerContext {
   boolean isIrCachingDisabled();
+  boolean isPrivateCheckDisabled();
 
   boolean isUseGlobalCacheLocations();
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Passes.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Passes.scala
@@ -49,11 +49,11 @@ class Passes(
       ImportSymbolAnalysis,
       AmbiguousImportsAnalysis
     ) ++ (if (config.privateCheckEnabled) {
-      List (
-        PrivateModuleAnalysis.INSTANCE
-      )
-      } else List())
-      ++ List(
+            List(
+              PrivateModuleAnalysis.INSTANCE
+            )
+          } else List())
+    ++ List(
       ExportSymbolAnalysis.INSTANCE,
       ShadowedPatternFields,
       UnreachableMatchBranches,

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Passes.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Passes.scala
@@ -47,8 +47,13 @@ class Passes(
       OperatorToFunction,
       LambdaShorthandToLambda,
       ImportSymbolAnalysis,
-      AmbiguousImportsAnalysis,
-      PrivateModuleAnalysis.INSTANCE,
+      AmbiguousImportsAnalysis
+    ) ++ (if (config.privateCheckEnabled) {
+      List (
+        PrivateModuleAnalysis.INSTANCE
+      )
+      } else List())
+      ++ List(
       ExportSymbolAnalysis.INSTANCE,
       ShadowedPatternFields,
       UnreachableMatchBranches,

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/data/CompilerConfig.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/data/CompilerConfig.scala
@@ -7,12 +7,14 @@ import java.io.PrintStream
   * @param autoParallelismEnabled whether or not automatic parallelism detection
   *                               is enabled.
   * @param warningsEnabled whether or not warnings are enabled
+  * @param privateCheckEnabled whether or not private keyword is enabled
   * @param isStrictErrors if true, presence of any Error in IR will result in an exception
   * @param outputRedirect redirection of the output of warnings and errors of compiler
   */
 case class CompilerConfig(
   autoParallelismEnabled: Boolean     = false,
   warningsEnabled: Boolean            = true,
+  privateCheckEnabled: Boolean        = true,
   isStrictErrors: Boolean             = false,
   outputRedirect: Option[PrintStream] = None
 ) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/EnsoLanguage.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/EnsoLanguage.java
@@ -243,6 +243,7 @@ public final class EnsoLanguage extends TruffleLanguage<EnsoContext> {
           false,
           false,
           true,
+          true,
           scala.Option.apply(new PrintStream(outputRedirect))
       );
       var moduleContext = new ModuleContext(

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -80,6 +80,7 @@ public final class EnsoContext {
   private final EnsoLanguage language;
   private final Env environment;
   private final boolean assertionsEnabled;
+  private final boolean isPrivateCheckDisabled;
   private @CompilationFinal
   Compiler compiler;
   private final PrintStream out;
@@ -140,6 +141,7 @@ public final class EnsoContext {
     var isParallelismEnabled = getOption(RuntimeOptions.ENABLE_AUTO_PARALLELISM_KEY);
     this.isIrCachingDisabled
             = getOption(RuntimeOptions.DISABLE_IR_CACHES_KEY) || isParallelismEnabled;
+    this.isPrivateCheckDisabled = getOption(RuntimeOptions.DISABLE_PRIVATE_CHECK_KEY);
     this.executionEnvironment = getOption(EnsoLanguage.EXECUTION_ENVIRONMENT);
     this.assertionsEnabled = shouldAssertionsBeEnabled();
     this.shouldWaitForPendingSerializationJobs
@@ -727,6 +729,13 @@ public final class EnsoContext {
    */
   public boolean isInlineCachingDisabled() {
     return isInlineCachingDisabled;
+  }
+
+  /**
+   * @return when {@code private} keyword should be checked.
+   */
+  public boolean isPrivateCheckDisabled() {
+    return isPrivateCheckDisabled;
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -150,6 +150,7 @@ public final class EnsoContext {
             = new CompilerConfig(
                     isParallelismEnabled,
                     true,
+                    !isPrivateCheckDisabled,
                     getOption(RuntimeOptions.STRICT_ERRORS_KEY),
                     scala.Option.empty());
     this.home = home;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -55,6 +55,11 @@ final class TruffleCompilerContext implements CompilerContext {
   }
 
   @Override
+  public boolean isPrivateCheckDisabled() {
+    return context.isPrivateCheckDisabled();
+  }
+
+  @Override
   public boolean isUseGlobalCacheLocations() {
     return context.isUseGlobalCache();
   }

--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ImportsTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/semantic/ImportsTest.scala
@@ -1,6 +1,7 @@
 package org.enso.interpreter.test.semantic
 
 import org.enso.interpreter.test.{InterpreterException, PackageTest}
+import org.enso.polyglot.RuntimeOptions
 
 class ImportsTest extends PackageTest {
   implicit def messagingNatureOInterpreterException
@@ -255,5 +256,19 @@ class ImportsTest extends PackageTest {
     evalTestProject(
       "Test_Private_Modules_5"
     ) shouldEqual 42
+  }
+
+  "Private modules" should "be able to mix private and public submodules when private checks are disabled" in {
+    evalTestProject(
+      "Test_Private_Modules_4",
+      Map(RuntimeOptions.DISABLE_PRIVATE_CHECK -> "true")
+    ) shouldEqual 42
+  }
+
+  "Private modules" should "be able to import private modules from different project when private checks are disabled" in {
+    evalTestProject(
+      "Test_Private_Modules_3",
+      Map(RuntimeOptions.DISABLE_PRIVATE_CHECK -> "true")
+    ) shouldEqual "Success"
   }
 }


### PR DESCRIPTION
Fixes #8140. Follow-up of #7840.

### Pull Request Description

Adds `--disable-private-check` option that essentialy disables `private` keyword.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
