### PR TITLE
Unlock resources initialization asynchronously

### DIFF
--- a/engine/language-server/src/main/java/org/enso/languageserver/boot/resource/BlockingInitialization.java
+++ b/engine/language-server/src/main/java/org/enso/languageserver/boot/resource/BlockingInitialization.java
@@ -1,12 +1,14 @@
 package org.enso.languageserver.boot.resource;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Semaphore;
 
 /** Initialization component ensuring that only one initialization sequence is running at a time. */
 public final class BlockingInitialization implements InitializationComponent {
 
   private final InitializationComponent component;
+  private final Executor executor;
   private final Semaphore lock = new Semaphore(1);
 
   /**
@@ -14,8 +16,9 @@ public final class BlockingInitialization implements InitializationComponent {
    *
    * @param component the underlying initialization component to run
    */
-  public BlockingInitialization(InitializationComponent component) {
+  public BlockingInitialization(InitializationComponent component, Executor executor) {
     this.component = component;
+    this.executor = executor;
   }
 
   @Override
@@ -30,6 +33,6 @@ public final class BlockingInitialization implements InitializationComponent {
     } catch (InterruptedException e) {
       return CompletableFuture.failedFuture(e);
     }
-    return component.init().whenComplete((res, err) -> lock.release());
+    return component.init().whenCompleteAsync((res, err) -> lock.release(), executor);
   }
 }

--- a/engine/language-server/src/main/java/org/enso/languageserver/boot/resource/RepoInitialization.java
+++ b/engine/language-server/src/main/java/org/enso/languageserver/boot/resource/RepoInitialization.java
@@ -67,7 +67,7 @@ public class RepoInitialization implements InitializationComponent {
   public CompletableFuture<Void> init() {
     return initSqlDatabase()
         .thenComposeAsync(v -> initSuggestionsRepo(), executor)
-        .thenRun(() -> isInitialized = true);
+        .thenRunAsync(() -> isInitialized = true, executor);
   }
 
   private CompletableFuture<Void> initSqlDatabase() {
@@ -92,7 +92,8 @@ public class RepoInitialization implements InitializationComponent {
             () -> logger.info("Initializing suggestions repo [{}]...", sqlDatabase), executor)
         .thenComposeAsync(
             v ->
-                doInitSuggestionsRepo().exceptionallyComposeAsync(this::recoverInitializationError),
+                doInitSuggestionsRepo()
+                    .exceptionallyComposeAsync(this::recoverInitializationError, executor),
             executor)
         .thenRunAsync(
             () -> logger.info("Initialized Suggestions repo [{}].", sqlDatabase), executor)
@@ -171,6 +172,6 @@ public class RepoInitialization implements InitializationComponent {
   }
 
   private CompletionStage<Void> doInitSuggestionsRepo() {
-    return FutureConverters.asJava(sqlSuggestionsRepo.init()).thenAccept(res -> {});
+    return FutureConverters.asJava(sqlSuggestionsRepo.init()).thenAcceptAsync(res -> {}, executor);
   }
 }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/ResourcesInitialization.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/ResourcesInitialization.scala
@@ -61,7 +61,8 @@ object ResourcesInitialization {
           ),
           new TruffleContextInitialization(ec, truffleContext, eventStream)
         )
-      )
+      ),
+      ec
     )
   }
 }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Debugging the issue reported by @PabloBuchu when the language server initialization hangs in the cloud. I'm still not sure what is happening in the cloud because I was not able to reproduce it when trying to connect two clients simultaneously.

Another potential source of the issue may be the Scala Future -> Java CompletableFuture conversion, but I didn't find anything suspicious there.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
