### PR TITLE
OpenFileCmd sends a reply when finished

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/TimingsConfig.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/TimingsConfig.scala
@@ -21,6 +21,14 @@ class TimingsConfig(
     */
   def requestTimeout: FiniteDuration = timeout
 
+  /** A (internal) request timeout.
+    * It should be smaller than the `requestTimeout` to properly propagate failure upwards rather
+    * than request handler timing out.
+    *
+    * @return a duration to wait for the request to runtime to be handled
+    */
+  def runtimeRequestTimeout: FiniteDuration = timeout * 3 / 4
+
   /** Auto-save delay.
     *
     * @return if non-empty, determines the delay when auto-save should be triggered after the last edit

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
@@ -34,10 +34,6 @@ import org.enso.languageserver.text.CollaborativeBuffer.{
 import org.enso.languageserver.text.TextProtocol._
 import org.enso.languageserver.util.UnhandledLogging
 import org.enso.polyglot.runtime.Runtime.Api
-import org.enso.polyglot.runtime.Runtime.Api.{
-  ExpressionId,
-  OpenedFileNotification
-}
 import org.enso.text.{ContentBasedVersioning, ContentVersion}
 import org.enso.text.editing._
 import org.enso.text.editing.model.TextEdit
@@ -161,7 +157,7 @@ class CollaborativeBuffer(
     case ServerConfirmationTimeout =>
       replyTo ! OpenFileResponse(Left(OperationTimeout))
       stop(Map.empty)
-    case Api.Response(Some(id), OpenedFileNotification) if id == requestId =>
+    case Api.Response(Some(id), Api.OpenFileResponse) if id == requestId =>
       timeout.cancel()
       val cap = CapabilityRegistration(CanEdit(bufferPath))
       replyTo ! OpenFileResponse(Right(OpenFileResult(buffer, Some(cap))))
@@ -703,7 +699,7 @@ class CollaborativeBuffer(
     lockHolder: Option[JsonSession],
     clientId: ClientId,
     change: FileEdit,
-    expressionId: ExpressionId,
+    expressionId: Api.ExpressionId,
     expressionValue: String,
     autoSave: Map[ClientId, (ContentVersion, Cancellable)]
   ): Unit = {
@@ -886,7 +882,7 @@ class CollaborativeBuffer(
     val requestId = UUID.randomUUID()
     runtimeConnector ! Api.Request(
       requestId,
-      Api.OpenFileNotification(file.path, file.content)
+      Api.OpenFileRequest(file.path, file.content)
     )
     val timeoutCancellable = context.system.scheduler
       .scheduleOnce(

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
@@ -429,7 +429,7 @@ class BaseServerTest
     fileName: Option[String]
   )(implicit pos: source.Position): Unit = {
     runtimeConnectorProbe.receiveN(1).head match {
-      case Api.Request(requestId, Api.OpenFileNotification(file, _)) =>
+      case Api.Request(requestId, Api.OpenFileRequest(file, _)) =>
         fileName match {
           case Some(f) if f != file.getName =>
             fail(
@@ -439,7 +439,7 @@ class BaseServerTest
         }
         runtimeConnectorProbe.lastSender ! Api.Response(
           requestId,
-          Api.OpenedFileNotification
+          Api.OpenFileResponse
         )
       case Api.Request(
             _,

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
@@ -441,13 +441,11 @@ class BaseServerTest
           requestId,
           Api.OpenedFileNotification
         )
-      case Api.Request(_, _: Api.GetTypeGraphRequest) =>
-        // ignore
-        receiveAndReplyToOpenFile(fileName)
-      case Api.Request(_, _: Api.EditFileNotification) =>
-        // ignore
-        receiveAndReplyToOpenFile(fileName)
-      case Api.Request(_, _: Api.CloseFileNotification) =>
+      case Api.Request(
+            _,
+            _: Api.GetTypeGraphRequest | _: Api.EditFileNotification |
+            _: Api.CloseFileNotification
+          ) =>
         // ignore
         receiveAndReplyToOpenFile(fileName)
       case msg =>

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/FileNotificationsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/FileNotificationsTest.scala
@@ -1,7 +1,6 @@
 package org.enso.languageserver.websocket.json
 
 import java.io.File
-
 import io.circe.literal._
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.testkit.FlakySpec
@@ -69,16 +68,7 @@ class FileNotificationsTest extends BaseServerTest with FlakySpec {
           }
           """)
       // 3
-      runtimeConnectorProbe.receiveN(1).head match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo.txt")
 
       // 4
       client1.expectJson(json"""

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
@@ -617,10 +617,10 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
           """)
 
       runtimeConnectorProbe.receiveN(1).head match {
-        case Api.Request(requestId, Api.OpenFileNotification(_, _)) =>
+        case Api.Request(requestId, Api.OpenFileRequest(_, _)) =>
           runtimeConnectorProbe.lastSender ! Api.Response(
             requestId,
-            Api.OpenedFileNotification
+            Api.OpenFileResponse
           )
         case msg =>
           fail("expected OpenFile notification got " + msg)

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
@@ -69,16 +69,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
           }
           """)
 
-      runtimeConnectorProbe.receiveN(1).head match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "grant_can_edit.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("grant_can_edit.txt")
 
       // 4
       client1.expectJson(json"""
@@ -192,16 +183,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
           }
           """)
 
-      runtimeConnectorProbe.receiveN(1).head match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "take_can_edit.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("take_can_edit.txt")
 
       client1.expectJson(json"""
           { "jsonrpc": "2.0",
@@ -333,16 +315,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
           }
           """)
 
-      runtimeConnectorProbe.receiveN(1).head match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "to_refactor.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("to_refactor.txt")
 
       client.expectJson(json"""
           {
@@ -507,16 +480,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
           }
           """)
 
-      runtimeConnectorProbe.receiveN(1).head match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo.txt")
 
       // 4
       client.expectJson(json"""
@@ -584,16 +548,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
           }
           """)
 
-      runtimeConnectorProbe.receiveN(1).head match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo.txt")
 
       // 4
       client1.expectJson(json"""
@@ -782,16 +737,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
           }
           """)
 
-      runtimeConnectorProbe.receiveN(1).head match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo.txt")
 
       client1.expectJson(json"""
           {
@@ -912,16 +858,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
           }
           """)
 
-      runtimeConnectorProbe.receiveN(1).head match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo.txt")
 
       client1.expectJson(json"""
           {
@@ -1003,16 +940,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
           }
           """)
 
-      runtimeConnectorProbe.receiveN(2)(1) match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo.txt")
 
       client1.expectJson(json"""
           {
@@ -1192,16 +1120,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
-      runtimeConnectorProbe.receiveN(2)(1) match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo.txt")
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -1293,16 +1212,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
-      runtimeConnectorProbe.receiveN(1).head match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo.txt")
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -1394,16 +1304,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
-      runtimeConnectorProbe.receiveN(1).head match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo.txt")
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -1496,16 +1397,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
-      runtimeConnectorProbe.receiveN(1).head match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo.txt")
       client1.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -1620,16 +1512,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
-      runtimeConnectorProbe.receiveN(1).head match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo.txt")
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -1726,16 +1609,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
-      runtimeConnectorProbe.receiveN(2)(1) match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo.txt")
       client1.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -1873,15 +1747,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
-      runtimeConnectorProbe.receiveN(2)(1) match {
-        case Api.Request(requestId, Api.OpenFileNotification(_, _)) =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile()
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -1971,16 +1837,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
-      runtimeConnectorProbe.receiveN(2)(1) match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo.txt")
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -2034,16 +1891,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
-      runtimeConnectorProbe.receiveN(2)(1) match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo.txt")
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -2143,16 +1991,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
-      runtimeConnectorProbe.receiveN(2)(1) match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo.txt")
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -2302,16 +2141,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
-      runtimeConnectorProbe.receiveN(2)(1) match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo.txt")
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -2391,16 +2221,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
-      runtimeConnectorProbe.receiveN(1).head match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo.txt")
       client1.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -2502,16 +2323,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
-      runtimeConnectorProbe.receiveN(1).head match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo.txt")
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -2626,15 +2438,7 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
-      runtimeConnectorProbe.receiveN(2)(1) match {
-        case Api.Request(requestId, Api.OpenFileNotification(_, _)) =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile()
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
@@ -69,6 +69,17 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
           }
           """)
 
+      runtimeConnectorProbe.receiveN(1).head match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "grant_can_edit.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
+
       // 4
       client1.expectJson(json"""
           { "jsonrpc": "2.0",
@@ -180,6 +191,17 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+
+      runtimeConnectorProbe.receiveN(1).head match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "take_can_edit.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
 
       client1.expectJson(json"""
           { "jsonrpc": "2.0",
@@ -310,6 +332,18 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+
+      runtimeConnectorProbe.receiveN(1).head match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "to_refactor.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
+
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -473,6 +507,17 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
           }
           """)
 
+      runtimeConnectorProbe.receiveN(1).head match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "foo.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
+
       // 4
       client.expectJson(json"""
           { "jsonrpc": "2.0",
@@ -539,6 +584,17 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
           }
           """)
 
+      runtimeConnectorProbe.receiveN(1).head match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "foo.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
+
       // 4
       client1.expectJson(json"""
           { "jsonrpc": "2.0",
@@ -604,6 +660,16 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+
+      runtimeConnectorProbe.receiveN(1).head match {
+        case Api.Request(requestId, Api.OpenFileNotification(_, _)) =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
 
       // 2
       client.expectJson(json"""
@@ -715,6 +781,18 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+
+      runtimeConnectorProbe.receiveN(1).head match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "foo.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
+
       client1.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -833,6 +911,18 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+
+      runtimeConnectorProbe.receiveN(1).head match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "foo.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
+
       client1.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -912,6 +1002,18 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+
+      runtimeConnectorProbe.receiveN(2)(1) match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "foo.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
+
       client1.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -1090,6 +1192,16 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+      runtimeConnectorProbe.receiveN(2)(1) match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "foo.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -1181,6 +1293,16 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+      runtimeConnectorProbe.receiveN(1).head match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "foo.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -1272,6 +1394,16 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+      runtimeConnectorProbe.receiveN(1).head match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "foo.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -1364,6 +1496,16 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+      runtimeConnectorProbe.receiveN(1).head match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "foo.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
       client1.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -1478,6 +1620,16 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+      runtimeConnectorProbe.receiveN(1).head match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "foo.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -1574,6 +1726,16 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+      runtimeConnectorProbe.receiveN(2)(1) match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "foo.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
       client1.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -1711,6 +1873,15 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+      runtimeConnectorProbe.receiveN(2)(1) match {
+        case Api.Request(requestId, Api.OpenFileNotification(_, _)) =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -1800,6 +1971,16 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+      runtimeConnectorProbe.receiveN(2)(1) match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "foo.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -1853,6 +2034,16 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+      runtimeConnectorProbe.receiveN(2)(1) match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "foo.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -1952,6 +2143,16 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+      runtimeConnectorProbe.receiveN(2)(1) match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "foo.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -2101,6 +2302,16 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+      runtimeConnectorProbe.receiveN(2)(1) match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "foo.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -2180,6 +2391,16 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+      runtimeConnectorProbe.receiveN(1).head match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "foo.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
       client1.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -2281,6 +2502,16 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+      runtimeConnectorProbe.receiveN(1).head match {
+        case Api.Request(requestId, Api.OpenFileNotification(file, _))
+            if file.getName == "foo.txt" =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",
@@ -2395,6 +2626,15 @@ class TextOperationsTest extends BaseServerTest with FlakySpec {
             }
           }
           """)
+      runtimeConnectorProbe.receiveN(2)(1) match {
+        case Api.Request(requestId, Api.OpenFileNotification(_, _)) =>
+          runtimeConnectorProbe.lastSender ! Api.Response(
+            requestId,
+            Api.OpenedFileNotification
+          )
+        case msg =>
+          fail("expected OpenFile notification got " + msg)
+      }
       client.expectJson(json"""
           {
             "jsonrpc" : "2.0",

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/VcsManagerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/VcsManagerTest.scala
@@ -90,7 +90,7 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
         .toFile should exist
     }
 
-    "fail to create a repository for an already existing project" taggedAs Retry in withCleanRoot {
+    "fail to create a repository for an already existing project" in withCleanRoot {
       client =>
         client.send(json"""
           { "jsonrpc": "2.0",
@@ -117,9 +117,8 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
   }
 
   "Save project" must {
-    "create a commit with a timestamp" taggedAs Retry in withCleanRoot {
-      client =>
-        client.send(json"""
+    "create a commit with a timestamp" in withCleanRoot { client =>
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/write",
             "id": 1,
@@ -132,14 +131,14 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
             }
           }
           """)
-        client.expectJson(json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 1,
             "result": null
           }
           """)
 
-        client.send(json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "vcs/save",
             "id": 2,
@@ -151,7 +150,7 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
             }
           }
           """)
-        client.fuzzyExpectJson(json"""
+      client.fuzzyExpectJson(json"""
           { "jsonrpc": "2.0",
             "id": 2,
             "result": {
@@ -160,9 +159,9 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
             }
           }
           """)
-        commits(testContentRoot.file) should have length 2
+      commits(testContentRoot.file) should have length 2
 
-        client.send(json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "file/write",
             "id": 3,
@@ -175,14 +174,14 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
             }
           }
           """)
-        client.expectJson(json"""
+      client.expectJson(json"""
           { "jsonrpc": "2.0",
             "id": 3,
             "result": null
           }
           """)
 
-        client.send(json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "vcs/save",
             "id": 4,
@@ -194,7 +193,7 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
             }
           }
           """)
-        client.fuzzyExpectJson(json"""
+      client.fuzzyExpectJson(json"""
           { "jsonrpc": "2.0",
             "id": 4,
             "result": {
@@ -203,14 +202,14 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
             }
           }
           """)
-        val allCommits = commits(testContentRoot.file)
-        allCommits should have length 3
-        val today = LocalDate.now(Clock.systemUTC())
+      val allCommits = commits(testContentRoot.file)
+      allCommits should have length 3
+      val today = LocalDate.now(Clock.systemUTC())
 
-        allCommits.head.getShortMessage should startWith(today.toString)
+      allCommits.head.getShortMessage should startWith(today.toString)
     }
 
-    "create a commit with a name" taggedAs Retry in withCleanRoot { client =>
+    "create a commit with a name" in withCleanRoot { client =>
       val saveName1 = "wip: my save"
       client.send(json"""
           { "jsonrpc": "2.0",
@@ -380,9 +379,8 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
   }
 
   "Status project" must {
-    "report changed files since last commit" taggedAs Retry in withCleanRoot {
-      client =>
-        client.send(json"""
+    "report changed files since last commit" in withCleanRoot { client =>
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "vcs/status",
             "id": 1,
@@ -394,7 +392,7 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
             }
           }
           """)
-        client.fuzzyExpectJson(json"""
+      client.fuzzyExpectJson(json"""
           { "jsonrpc": "2.0",
             "id": 1,
             "result": {
@@ -408,22 +406,22 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
           }
           """)
 
-        val srcDir = testContentRoot.file.toPath.resolve("src")
-        Files.createDirectory(srcDir)
-        val fooPath = srcDir.resolve("Foo.enso")
-        fooPath.toFile.createNewFile()
-        Files.write(
-          fooPath,
-          "file contents".getBytes(StandardCharsets.UTF_8)
-        )
-        val barPath = srcDir.resolve("Bar.enso")
-        barPath.toFile.createNewFile()
-        Files.write(
-          barPath,
-          "file contents b".getBytes(StandardCharsets.UTF_8)
-        )
+      val srcDir = testContentRoot.file.toPath.resolve("src")
+      Files.createDirectory(srcDir)
+      val fooPath = srcDir.resolve("Foo.enso")
+      fooPath.toFile.createNewFile()
+      Files.write(
+        fooPath,
+        "file contents".getBytes(StandardCharsets.UTF_8)
+      )
+      val barPath = srcDir.resolve("Bar.enso")
+      barPath.toFile.createNewFile()
+      Files.write(
+        barPath,
+        "file contents b".getBytes(StandardCharsets.UTF_8)
+      )
 
-        client.send(json"""
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "vcs/status",
             "id": 2,
@@ -435,7 +433,7 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
             }
           }
           """)
-        client.fuzzyExpectJson(json"""
+      client.fuzzyExpectJson(json"""
           { "jsonrpc": "2.0",
             "id": 2,
             "result": {
@@ -463,9 +461,9 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
             }
           }
           """)
-        add(testContentRoot.file, srcDir)
-        commit(testContentRoot.file, "Add missing files")
-        client.send(json"""
+      add(testContentRoot.file, srcDir)
+      commit(testContentRoot.file, "Add missing files")
+      client.send(json"""
           { "jsonrpc": "2.0",
             "method": "vcs/status",
             "id": 3,
@@ -477,7 +475,7 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
             }
           }
           """)
-        client.fuzzyExpectJson(json"""
+      client.fuzzyExpectJson(json"""
           { "jsonrpc": "2.0",
             "id": 3,
             "result": {
@@ -494,7 +492,7 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
   }
 
   "Restore project" must {
-    "reset to the last state with committed changes" taggedAs Retry in withCleanRoot {
+    "reset to the last state with committed changes" in withCleanRoot {
       client =>
         client.send(json"""
           { "jsonrpc": "2.0",
@@ -1109,7 +1107,7 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
           """)
     }
 
-    "reset to a named save and notify about removed files" taggedAs Retry in withCleanRoot {
+    "reset to a named save and notify about removed files" in withCleanRoot {
       client =>
         timingsConfig = timingsConfig.withAutoSave(0.5.seconds)
         val client2         = getInitialisedWsClient()
@@ -1360,7 +1358,7 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
   }
 
   "List project saves" must {
-    "return all explicit commits" taggedAs Retry in withCleanRoot { client =>
+    "return all explicit commits" in withCleanRoot { client =>
       val srcDir = testContentRoot.file.toPath.resolve("src")
       Files.createDirectory(srcDir)
       val fooPath = srcDir.resolve("Foo.enso")

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/VcsManagerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/VcsManagerTest.scala
@@ -10,7 +10,6 @@ import org.eclipse.jgit.storage.file.FileRepositoryBuilder
 import org.enso.languageserver.boot.{ProfilingConfig, StartupConfig}
 import org.enso.languageserver.data._
 import org.enso.languageserver.vcsmanager.VcsApi
-import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.testkit.{FlakySpec, RetrySpec}
 
 import java.io.File
@@ -331,16 +330,7 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
           }
           """)
 
-      runtimeConnectorProbe.receiveN(1).head match {
-        case Api.Request(requestId, Api.OpenFileNotification(file, _))
-            if file.getName == "foo_pending_save.txt" =>
-          runtimeConnectorProbe.lastSender ! Api.Response(
-            requestId,
-            Api.OpenedFileNotification
-          )
-        case msg =>
-          fail("expected OpenFile notification got " + msg)
-      }
+      receiveAndReplyToOpenFile("foo_pending_save.txt")
 
       client.expectJson(json"""
           {
@@ -1186,16 +1176,7 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
           }
       """)
 
-        runtimeConnectorProbe.receiveN(1).head match {
-          case Api.Request(requestId, Api.OpenFileNotification(file, _))
-              if file.getName == testFooFileName =>
-            runtimeConnectorProbe.lastSender ! Api.Response(
-              requestId,
-              Api.OpenedFileNotification
-            )
-          case msg =>
-            fail("expected OpenFile notification got " + msg)
-        }
+        receiveAndReplyToOpenFile(testFooFileName)
 
         client.expectJson(json"""
           { "jsonrpc": "2.0",
@@ -1229,16 +1210,7 @@ class VcsManagerTest extends BaseServerTest with RetrySpec with FlakySpec {
           }
       """)
 
-        runtimeConnectorProbe.receiveN(1).head match {
-          case Api.Request(requestId, Api.OpenFileNotification(file, _))
-              if file.getName == testBarFileName =>
-            runtimeConnectorProbe.lastSender ! Api.Response(
-              requestId,
-              Api.OpenedFileNotification
-            )
-          case msg =>
-            fail("expected OpenFile notification got " + msg)
-        }
+        receiveAndReplyToOpenFile(testBarFileName)
 
         client.expectJson(json"""
           { "jsonrpc": "2.0",

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -101,6 +101,10 @@ object Runtime {
         name  = "setModuleSourcesNotification"
       ),
       new JsonSubTypes.Type(
+        value = classOf[Api.OpenedFileNotification.type],
+        name  = "moduleSourcesSetNotification"
+      ),
+      new JsonSubTypes.Type(
         value = classOf[Api.EditFileNotification],
         name  = "editFileNotification"
       ),
@@ -1484,6 +1488,10 @@ object Runtime {
         s"contents=${MaskedString(contents).toLogString(shouldMask)}," +
         ")"
     }
+
+    /** A notification from the server confirming opening a file.
+      */
+    final case object OpenedFileNotification extends ApiResponse
 
     /** A notification sent to the server about in-memory file contents being
       * edited.

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -97,11 +97,11 @@ object Runtime {
         name  = "getComponentGroupsResponse"
       ),
       new JsonSubTypes.Type(
-        value = classOf[Api.OpenFileNotification],
+        value = classOf[Api.OpenFileRequest],
         name  = "setModuleSourcesNotification"
       ),
       new JsonSubTypes.Type(
-        value = classOf[Api.OpenedFileNotification.type],
+        value = classOf[Api.OpenFileResponse.type],
         name  = "moduleSourcesSetNotification"
       ),
       new JsonSubTypes.Type(
@@ -1470,12 +1470,12 @@ object Runtime {
       */
     final case class InvalidStackItemError(contextId: ContextId) extends Error
 
-    /** A notification sent to the server about opening a file.
+    /** A request sent to the server to open a file with a contents.
       *
       * @param path the file being moved to memory.
       * @param contents the current module's contents.
       */
-    final case class OpenFileNotification(
+    final case class OpenFileRequest(
       path: File,
       contents: String
     ) extends ApiRequest
@@ -1483,15 +1483,15 @@ object Runtime {
 
       /** @inheritdoc */
       override def toLogString(shouldMask: Boolean): String =
-        "OpenFileNotification(" +
+        "OpenFileRequest(" +
         s"path=${MaskedPath(path.toPath).toLogString(shouldMask)}," +
         s"contents=${MaskedString(contents).toLogString(shouldMask)}," +
         ")"
     }
 
-    /** A notification from the server confirming opening a file.
+    /** A response from the server confirming opening of a file.
       */
-    final case object OpenedFileNotification extends ApiResponse
+    final case object OpenFileResponse extends ApiResponse
 
     /** A notification sent to the server about in-memory file contents being
       * edited.

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/CommandFactory.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/CommandFactory.scala
@@ -49,7 +49,7 @@ object CommandFactory {
       case payload: Api.RenameSymbol =>
         new RenameSymbolCmd(request.requestId, payload)
 
-      case payload: Api.OpenFileNotification =>
+      case payload: Api.OpenFileRequest =>
         new OpenFileCmd(request.requestId, payload)
       case payload: Api.CloseFileNotification => new CloseFileCmd(payload)
       case payload: Api.EditFileNotification  => new EditFileCmd(payload)

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/CommandFactory.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/CommandFactory.scala
@@ -50,7 +50,7 @@ object CommandFactory {
         new RenameSymbolCmd(request.requestId, payload)
 
       case payload: Api.OpenFileNotification =>
-        new OpenFileCmd(payload)
+        new OpenFileCmd(request.requestId, payload)
       case payload: Api.CloseFileNotification => new CloseFileCmd(payload)
       case payload: Api.EditFileNotification  => new EditFileCmd(payload)
       case payload: Api.SetExpressionValueNotification =>

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/OpenFileCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/OpenFileCmd.scala
@@ -8,10 +8,13 @@ import scala.concurrent.ExecutionContext
 
 /** A command that opens a file.
   *
+  * @param maybeRequestId an option with request id
   * @param request a request for a service
   */
-class OpenFileCmd(request: Api.OpenFileNotification)
-    extends SynchronousCommand(None) {
+class OpenFileCmd(
+  maybeRequestId: Option[Api.RequestId],
+  request: Api.OpenFileNotification
+) extends SynchronousCommand(None) {
 
   /** @inheritdoc */
   override def executeSynchronously(implicit
@@ -25,6 +28,9 @@ class OpenFileCmd(request: Api.OpenFileNotification)
       ctx.executionService.setModuleSources(
         request.path,
         request.contents
+      )
+      ctx.endpoint.sendToClient(
+        Api.Response(maybeRequestId, Api.OpenedFileNotification)
       )
     } finally {
       ctx.locking.releaseFileLock(request.path)

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/OpenFileCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/OpenFileCmd.scala
@@ -13,7 +13,7 @@ import scala.concurrent.ExecutionContext
   */
 class OpenFileCmd(
   maybeRequestId: Option[Api.RequestId],
-  request: Api.OpenFileNotification
+  request: Api.OpenFileRequest
 ) extends SynchronousCommand(None) {
 
   /** @inheritdoc */
@@ -30,7 +30,7 @@ class OpenFileCmd(
         request.contents
       )
       ctx.endpoint.sendToClient(
-        Api.Response(maybeRequestId, Api.OpenedFileNotification)
+        Api.Response(maybeRequestId, Api.OpenFileResponse)
       )
     } finally {
       ctx.locking.releaseFileLock(request.path)

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/PushContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/PushContextCmd.scala
@@ -15,13 +15,13 @@ import scala.concurrent.{ExecutionContext, Future}
 class PushContextCmd(
   maybeRequestId: Option[RequestId],
   request: Api.PushContextRequest
-) extends SynchronousCommand(maybeRequestId) {
+) extends AsynchronousCommand(maybeRequestId) {
 
   /** @inheritdoc */
-  override def executeSynchronously(implicit
+  override def executeAsynchronously(implicit
     ctx: RuntimeContext,
     ec: ExecutionContext
-  ): Unit =
+  ): Future[Unit] =
     if (doesContextExist) {
       pushItemOntoStack() flatMap (scheduleExecutionIfNeeded(_))
     } else {

--- a/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/IncrementalUpdatesTest.java
+++ b/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/IncrementalUpdatesTest.java
@@ -26,6 +26,7 @@ import org.enso.polyglot.runtime.Runtime$Api$Request;
 import org.enso.polyglot.runtime.Runtime$Api$Response;
 import org.enso.polyglot.runtime.Runtime$Api$SetExpressionValueNotification;
 import org.enso.polyglot.runtime.Runtime$Api$OpenFileNotification;
+import org.enso.polyglot.runtime.Runtime$Api$OpenedFileNotification$;
 import org.enso.polyglot.runtime.Runtime$Api$StackItem$ExplicitCall;
 import org.enso.polyglot.runtime.Runtime$Api$StackItem$LocalCall;
 import org.enso.text.editing.model;
@@ -199,9 +200,12 @@ public class IncrementalUpdatesTest {
     );
     // Open the new file
     context.send(
-      Request(new Runtime$Api$OpenFileNotification(mainFile, contents))
+      Request(requestId, new Runtime$Api$OpenFileNotification(mainFile, contents))
     );
-    assertTrue("No reply", context.receiveNone().isEmpty());
+    response = context.receive().get();
+    assertEquals(response,
+            Response(requestId, Runtime$Api$OpenedFileNotification$.MODULE$)
+    );
 
     nodeCountingInstrument.assertNewNodes("No execution, no nodes yet", 0, 0);
 

--- a/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/IncrementalUpdatesTest.java
+++ b/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/IncrementalUpdatesTest.java
@@ -25,8 +25,8 @@ import org.enso.polyglot.runtime.Runtime$Api$PushContextResponse;
 import org.enso.polyglot.runtime.Runtime$Api$Request;
 import org.enso.polyglot.runtime.Runtime$Api$Response;
 import org.enso.polyglot.runtime.Runtime$Api$SetExpressionValueNotification;
-import org.enso.polyglot.runtime.Runtime$Api$OpenFileNotification;
-import org.enso.polyglot.runtime.Runtime$Api$OpenedFileNotification$;
+import org.enso.polyglot.runtime.Runtime$Api$OpenFileRequest;
+import org.enso.polyglot.runtime.Runtime$Api$OpenFileResponse$;
 import org.enso.polyglot.runtime.Runtime$Api$StackItem$ExplicitCall;
 import org.enso.polyglot.runtime.Runtime$Api$StackItem$LocalCall;
 import org.enso.text.editing.model;
@@ -200,11 +200,11 @@ public class IncrementalUpdatesTest {
     );
     // Open the new file
     context.send(
-      Request(requestId, new Runtime$Api$OpenFileNotification(mainFile, contents))
+      Request(requestId, new Runtime$Api$OpenFileRequest(mainFile, contents))
     );
     response = context.receive().get();
     assertEquals(response,
-            Response(requestId, Runtime$Api$OpenedFileNotification$.MODULE$)
+            Response(requestId, Runtime$Api$OpenFileResponse$.MODULE$)
     );
 
     nodeCountingInstrument.assertNewNodes("No execution, no nodes yet", 0, 0);

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/BuiltinTypesTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/BuiltinTypesTest.scala
@@ -115,10 +115,10 @@ class BuiltinTypesTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/BuiltinTypesTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/BuiltinTypesTest.scala
@@ -115,9 +115,11 @@ class BuiltinTypesTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
@@ -127,10 +127,10 @@ class RuntimeAsyncCommandsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -190,10 +190,10 @@ class RuntimeAsyncCommandsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
@@ -127,9 +127,11 @@ class RuntimeAsyncCommandsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -188,9 +190,11 @@ class RuntimeAsyncCommandsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeComponentsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeComponentsTest.scala
@@ -249,10 +249,10 @@ class RuntimeComponentsTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -334,10 +334,10 @@ class RuntimeComponentsTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeComponentsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeComponentsTest.scala
@@ -249,9 +249,11 @@ class RuntimeComponentsTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveOne shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -332,9 +334,11 @@ class RuntimeComponentsTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveOne shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
@@ -148,9 +148,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -244,9 +246,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -333,9 +337,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -409,9 +415,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -480,9 +488,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -564,9 +574,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -640,9 +652,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -725,9 +739,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -808,9 +824,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -982,9 +1000,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1084,9 +1104,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1173,9 +1195,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1253,9 +1277,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1366,9 +1392,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1487,9 +1515,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1634,9 +1664,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1752,9 +1784,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1820,9 +1854,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1924,9 +1960,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -2035,9 +2073,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -2147,9 +2187,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -2246,9 +2288,11 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
@@ -148,10 +148,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -246,10 +246,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -337,10 +337,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -415,10 +415,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -488,10 +488,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -574,10 +574,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -652,10 +652,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -739,10 +739,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -824,10 +824,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1000,10 +1000,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1104,10 +1104,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1195,10 +1195,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1277,10 +1277,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1392,10 +1392,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1515,10 +1515,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1664,10 +1664,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1784,10 +1784,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1854,10 +1854,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1960,10 +1960,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2073,10 +2073,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2187,10 +2187,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2288,10 +2288,10 @@ class RuntimeErrorsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeExecutionEnvironmentTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeExecutionEnvironmentTest.scala
@@ -160,9 +160,11 @@ class RuntimeExecutionEnvironmentTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -259,9 +261,11 @@ class RuntimeExecutionEnvironmentTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeExecutionEnvironmentTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeExecutionEnvironmentTest.scala
@@ -160,10 +160,10 @@ class RuntimeExecutionEnvironmentTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -261,10 +261,10 @@ class RuntimeExecutionEnvironmentTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
@@ -125,9 +125,11 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -172,9 +174,11 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -225,9 +229,11 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -287,9 +293,11 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -347,9 +355,11 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -407,9 +417,11 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -466,9 +478,11 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -523,9 +537,11 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -581,9 +597,11 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -650,9 +668,11 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -712,9 +732,11 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -771,9 +793,11 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -833,9 +857,11 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -893,9 +919,11 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -951,9 +979,11 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1022,9 +1052,11 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
@@ -125,10 +125,10 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -174,10 +174,10 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -229,10 +229,10 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -293,10 +293,10 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -355,10 +355,10 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -417,10 +417,10 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -478,10 +478,10 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -537,10 +537,10 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -597,10 +597,10 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -668,10 +668,10 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -732,10 +732,10 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -793,10 +793,10 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -857,10 +857,10 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -919,10 +919,10 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -979,10 +979,10 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1052,10 +1052,10 @@ class RuntimeInstrumentTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeRefactoringTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeRefactoringTest.scala
@@ -131,9 +131,11 @@ class RuntimeRefactoringTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -214,9 +216,11 @@ class RuntimeRefactoringTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -299,9 +303,11 @@ class RuntimeRefactoringTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -430,9 +436,11 @@ class RuntimeRefactoringTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -515,9 +523,11 @@ class RuntimeRefactoringTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -602,9 +612,11 @@ class RuntimeRefactoringTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -740,9 +752,11 @@ class RuntimeRefactoringTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -811,9 +825,11 @@ class RuntimeRefactoringTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeRefactoringTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeRefactoringTest.scala
@@ -131,10 +131,10 @@ class RuntimeRefactoringTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -216,10 +216,10 @@ class RuntimeRefactoringTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -303,10 +303,10 @@ class RuntimeRefactoringTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -436,10 +436,10 @@ class RuntimeRefactoringTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -523,10 +523,10 @@ class RuntimeRefactoringTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -612,10 +612,10 @@ class RuntimeRefactoringTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -752,10 +752,10 @@ class RuntimeRefactoringTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -825,10 +825,10 @@ class RuntimeRefactoringTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -386,10 +386,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push local item on top of the empty stack
@@ -495,10 +495,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -551,10 +551,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -657,14 +657,14 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
-    context.send(Api.Request(requestId, Api.OpenFileNotification(aFile, aCode)))
+    context.send(Api.Request(requestId, Api.OpenFileRequest(aFile, aCode)))
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -766,10 +766,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -842,10 +842,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -908,10 +908,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -986,10 +986,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1060,10 +1060,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1147,10 +1147,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1251,10 +1251,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1369,10 +1369,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1467,10 +1467,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1585,10 +1585,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1703,10 +1703,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1821,10 +1821,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1935,10 +1935,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2035,10 +2035,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2131,10 +2131,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2197,10 +2197,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2262,10 +2262,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2315,10 +2315,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2376,10 +2376,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2438,10 +2438,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2502,10 +2502,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2563,10 +2563,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2633,10 +2633,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2766,10 +2766,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2868,10 +2868,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2953,10 +2953,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -3054,10 +3054,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -3341,10 +3341,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -3594,10 +3594,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -3648,10 +3648,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -3696,10 +3696,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, code))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, code))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
     context.consumeOut shouldEqual List()
 
@@ -3770,10 +3770,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, code))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, code))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
     context.consumeOut shouldEqual List()
 
@@ -3812,10 +3812,10 @@ class RuntimeServerTest
 
     // Re-open the the file and apply the same operation
     context.send(
-      Api.Request(requestId2, Api.OpenFileNotification(mainFile, code))
+      Api.Request(requestId2, Api.OpenFileRequest(mainFile, code))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId2), Api.OpenedFileNotification)
+      Api.Response(Some(requestId2), Api.OpenFileResponse)
     )
     context.consumeOut shouldEqual List()
 
@@ -3859,10 +3859,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, code))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, code))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // Push new item on the stack to trigger the re-execution
@@ -3931,11 +3931,11 @@ class RuntimeServerTest
     context.send(
       Api.Request(
         requestId,
-        Api.OpenFileNotification(mainFile, context.Main.code)
+        Api.OpenFileRequest(mainFile, context.Main.code)
       )
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -4015,10 +4015,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, code))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, code))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
     context.consumeOut shouldEqual List()
 
@@ -4114,10 +4114,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, code))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, code))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
     context.consumeOut shouldEqual List()
 
@@ -4199,10 +4199,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -4247,10 +4247,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -4313,10 +4313,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
     context.receiveNone shouldEqual None
     // push main
@@ -4372,10 +4372,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -4443,10 +4443,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
     context.receiveNone shouldEqual None
     // push main
@@ -4488,10 +4488,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -4540,10 +4540,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -4599,10 +4599,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -4667,10 +4667,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -4734,10 +4734,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -4810,10 +4810,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -4885,10 +4885,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -4961,10 +4961,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -5037,10 +5037,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -5106,10 +5106,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -5183,10 +5183,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -5285,10 +5285,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -5376,10 +5376,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -5437,10 +5437,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -5497,10 +5497,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -5564,10 +5564,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -5633,10 +5633,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -5695,10 +5695,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -5747,10 +5747,10 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -5798,11 +5798,11 @@ class RuntimeServerTest
     context.send(
       Api.Request(
         requestId,
-        Api.OpenFileNotification(mainFile, contents)
+        Api.OpenFileRequest(mainFile, contents)
       )
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -5921,10 +5921,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -6065,10 +6065,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -6163,10 +6163,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -6247,10 +6247,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -6315,10 +6315,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -6483,10 +6483,10 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -386,9 +386,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push local item on top of the empty stack
     val invalidLocalItem = Api.StackItem.LocalCall(context.Main.idMainY)
@@ -493,9 +495,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -547,9 +551,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -651,11 +657,15 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
-    context.send(Api.Request(Api.OpenFileNotification(aFile, aCode)))
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
+    context.send(Api.Request(requestId, Api.OpenFileNotification(aFile, aCode)))
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -756,9 +766,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -830,9 +842,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -894,9 +908,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -970,9 +986,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1042,9 +1060,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1127,9 +1147,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1229,9 +1251,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1345,9 +1369,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1441,9 +1467,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1557,9 +1585,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1673,9 +1703,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1789,9 +1821,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1901,9 +1935,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1999,9 +2035,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -2093,9 +2131,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -2157,9 +2197,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -2220,9 +2262,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -2271,9 +2315,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -2330,9 +2376,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -2390,9 +2438,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -2452,9 +2502,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -2511,9 +2563,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -2579,9 +2633,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -2710,9 +2766,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -2810,9 +2868,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -2893,9 +2953,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -2992,9 +3054,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -3277,9 +3341,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -3528,9 +3594,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -3580,9 +3648,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -3625,8 +3695,12 @@ class RuntimeServerTest
     val mainFile = context.writeMain(code)
 
     // Set sources for the module
-    context.send(Api.Request(Api.OpenFileNotification(mainFile, code)))
-    context.receiveNone shouldEqual None
+    context.send(
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, code))
+    )
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
     context.consumeOut shouldEqual List()
 
     // Push new item on the stack to trigger the re-execution
@@ -3695,8 +3769,12 @@ class RuntimeServerTest
     val mainFile = context.writeMain(code)
 
     // Set sources for the module
-    context.send(Api.Request(Api.OpenFileNotification(mainFile, code)))
-    context.receiveNone shouldEqual None
+    context.send(
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, code))
+    )
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
     context.consumeOut shouldEqual List()
 
     // Push new item on the stack to trigger the re-execution
@@ -3733,8 +3811,12 @@ class RuntimeServerTest
     )
 
     // Re-open the the file and apply the same operation
-    context.send(Api.Request(Api.OpenFileNotification(mainFile, code)))
-    context.receiveNone shouldEqual None
+    context.send(
+      Api.Request(requestId2, Api.OpenFileNotification(mainFile, code))
+    )
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId2), Api.OpenedFileNotification)
+    )
     context.consumeOut shouldEqual List()
 
     // Modify the file
@@ -3776,8 +3858,12 @@ class RuntimeServerTest
     val mainFile = context.writeMain(code)
 
     // Set sources for the module
-    context.send(Api.Request(Api.OpenFileNotification(mainFile, code)))
-    context.receiveNone shouldEqual None
+    context.send(
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, code))
+    )
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // Push new item on the stack to trigger the re-execution
     context.send(
@@ -3843,9 +3929,14 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, context.Main.code))
+      Api.Request(
+        requestId,
+        Api.OpenFileNotification(mainFile, context.Main.code)
+      )
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -3923,8 +4014,12 @@ class RuntimeServerTest
     val mainFile = context.writeMain(code)
 
     // Set sources for the module
-    context.send(Api.Request(Api.OpenFileNotification(mainFile, code)))
-    context.receiveNone shouldEqual None
+    context.send(
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, code))
+    )
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
     context.consumeOut shouldEqual List()
 
     // Push new item on the stack to trigger the re-execution
@@ -4018,8 +4113,12 @@ class RuntimeServerTest
     val mainFile = context.writeMain(code)
 
     // Set sources for the module
-    context.send(Api.Request(Api.OpenFileNotification(mainFile, code)))
-    context.receiveNone shouldEqual None
+    context.send(
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, code))
+    )
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
     context.consumeOut shouldEqual List()
 
     // Push new item on the stack to trigger the re-execution
@@ -4100,9 +4199,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -4146,9 +4247,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -4210,9 +4313,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
     context.receiveNone shouldEqual None
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -4267,9 +4372,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -4336,9 +4443,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
     context.receiveNone shouldEqual None
     // push main
     context.send(
@@ -4379,9 +4488,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -4429,9 +4540,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -4486,9 +4599,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -4552,9 +4667,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -4617,9 +4734,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -4691,9 +4810,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -4764,9 +4885,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -4838,9 +4961,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -4912,9 +5037,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -4979,9 +5106,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -5054,9 +5183,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -5154,9 +5285,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -5243,9 +5376,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -5302,9 +5437,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -5360,9 +5497,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -5425,9 +5564,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -5492,9 +5633,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -5552,9 +5695,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -5602,9 +5747,11 @@ class RuntimeServerTest
 
     // Set sources for the module
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -5650,10 +5797,13 @@ class RuntimeServerTest
     // open file
     context.send(
       Api.Request(
+        requestId,
         Api.OpenFileNotification(mainFile, contents)
       )
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -5771,9 +5921,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -5913,9 +6065,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -6009,9 +6163,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -6091,9 +6247,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -6157,9 +6315,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -6323,9 +6483,11 @@ class RuntimeServerTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeStdlibTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeStdlibTest.scala
@@ -221,10 +221,10 @@ class RuntimeStdlibTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeStdlibTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeStdlibTest.scala
@@ -221,9 +221,11 @@ class RuntimeStdlibTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveOne shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
@@ -128,10 +128,10 @@ class RuntimeSuggestionUpdatesTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, code))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, code))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -667,10 +667,10 @@ class RuntimeSuggestionUpdatesTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, code))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, code))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -824,10 +824,10 @@ class RuntimeSuggestionUpdatesTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -999,16 +999,16 @@ class RuntimeSuggestionUpdatesTest
 
     // open files
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, mainCode))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, mainCode))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(aFile, aCode))
+      Api.Request(requestId, Api.OpenFileRequest(aFile, aCode))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1303,10 +1303,10 @@ class RuntimeSuggestionUpdatesTest
 
     // open file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, code))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, code))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
@@ -128,9 +128,11 @@ class RuntimeSuggestionUpdatesTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, code))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, code))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -665,9 +667,11 @@ class RuntimeSuggestionUpdatesTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, code))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, code))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -820,9 +824,11 @@ class RuntimeSuggestionUpdatesTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -993,13 +999,17 @@ class RuntimeSuggestionUpdatesTest
 
     // open files
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, mainCode))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, mainCode))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
     context.send(
-      Api.Request(Api.OpenFileNotification(aFile, aCode))
+      Api.Request(requestId, Api.OpenFileNotification(aFile, aCode))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(
@@ -1293,9 +1303,11 @@ class RuntimeSuggestionUpdatesTest
 
     // open file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, code))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, code))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     context.send(

--- a/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -330,14 +330,14 @@ class RuntimeVisualizationsTest
     context.send(
       Api.Request(
         requestId,
-        Api.OpenFileNotification(
+        Api.OpenFileRequest(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // create context
@@ -348,10 +348,10 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -455,14 +455,14 @@ class RuntimeVisualizationsTest
     context.send(
       Api.Request(
         requestId,
-        Api.OpenFileNotification(
+        Api.OpenFileRequest(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // create context
@@ -473,10 +473,10 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -596,20 +596,20 @@ class RuntimeVisualizationsTest
     context.send(
       Api.Request(
         requestId,
-        Api.OpenFileNotification(
+        Api.OpenFileRequest(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // create context
@@ -729,20 +729,20 @@ class RuntimeVisualizationsTest
     context.send(
       Api.Request(
         requestId,
-        Api.OpenFileNotification(
+        Api.OpenFileRequest(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // create context
@@ -862,20 +862,20 @@ class RuntimeVisualizationsTest
     context.send(
       Api.Request(
         requestId,
-        Api.OpenFileNotification(
+        Api.OpenFileRequest(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // create context
@@ -1103,23 +1103,23 @@ class RuntimeVisualizationsTest
 
     // open files
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
 
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
     context.send(
       Api.Request(
         requestId,
-        Api.OpenFileNotification(
+        Api.OpenFileRequest(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // create context
@@ -1238,22 +1238,22 @@ class RuntimeVisualizationsTest
 
     // open files
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
     context.send(
       Api.Request(
         requestId,
-        Api.OpenFileNotification(
+        Api.OpenFileRequest(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // create context
@@ -1387,20 +1387,20 @@ class RuntimeVisualizationsTest
     context.send(
       Api.Request(
         requestId,
-        Api.OpenFileNotification(
+        Api.OpenFileRequest(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // create context
@@ -1503,23 +1503,23 @@ class RuntimeVisualizationsTest
 
     // open files
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
 
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
     context.send(
       Api.Request(
         requestId,
-        Api.OpenFileNotification(
+        Api.OpenFileRequest(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // create context
@@ -1656,10 +1656,10 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1724,10 +1724,10 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1822,10 +1822,10 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -1905,10 +1905,10 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2005,14 +2005,14 @@ class RuntimeVisualizationsTest
     context.send(
       Api.Request(
         requestId,
-        Api.OpenFileNotification(
+        Api.OpenFileRequest(
           visualizationFile,
           visualizationCode
         )
       )
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // create context
@@ -2023,10 +2023,10 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2135,10 +2135,10 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2233,10 +2233,10 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2366,10 +2366,10 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2474,10 +2474,10 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2560,14 +2560,14 @@ class RuntimeVisualizationsTest
     context.send(
       Api.Request(
         requestId,
-        Api.OpenFileNotification(
+        Api.OpenFileRequest(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // create context
@@ -2578,10 +2578,10 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2693,14 +2693,14 @@ class RuntimeVisualizationsTest
     context.send(
       Api.Request(
         requestId,
-        Api.OpenFileNotification(
+        Api.OpenFileRequest(
           visualizationFile,
           context.AnnotatedVisualization.code
         )
       )
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // create context
@@ -2711,10 +2711,10 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -2873,14 +2873,14 @@ class RuntimeVisualizationsTest
     context.send(
       Api.Request(
         requestId,
-        Api.OpenFileNotification(
+        Api.OpenFileRequest(
           visualizationFile,
           context.AnnotatedVisualization.code
         )
       )
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // create context
@@ -2891,10 +2891,10 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -3054,10 +3054,10 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -3156,10 +3156,10 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -3262,10 +3262,10 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main
@@ -3399,10 +3399,10 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
     )
     context.receive shouldEqual Some(
-      Api.Response(Some(requestId), Api.OpenedFileNotification)
+      Api.Response(Some(requestId), Api.OpenFileResponse)
     )
 
     // push main

--- a/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -323,18 +323,22 @@ class RuntimeVisualizationsTest
     val visualizationFile =
       context.writeInSrcDir("Visualization", context.Visualization.code)
 
+    val contextId       = UUID.randomUUID()
+    val requestId       = UUID.randomUUID()
+    val visualizationId = UUID.randomUUID()
+
     context.send(
       Api.Request(
+        requestId,
         Api.OpenFileNotification(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
-
-    val contextId       = UUID.randomUUID()
-    val requestId       = UUID.randomUUID()
-    val visualizationId = UUID.randomUUID()
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // create context
     context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
@@ -344,9 +348,11 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -442,18 +448,22 @@ class RuntimeVisualizationsTest
     val visualizationFile =
       context.writeInSrcDir("Visualization", context.Visualization.code)
 
+    val contextId       = UUID.randomUUID()
+    val requestId       = UUID.randomUUID()
+    val visualizationId = UUID.randomUUID()
+
     context.send(
       Api.Request(
+        requestId,
         Api.OpenFileNotification(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
-
-    val contextId       = UUID.randomUUID()
-    val requestId       = UUID.randomUUID()
-    val visualizationId = UUID.randomUUID()
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // create context
     context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
@@ -463,9 +473,11 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -583,17 +595,22 @@ class RuntimeVisualizationsTest
     // open files
     context.send(
       Api.Request(
+        requestId,
         Api.OpenFileNotification(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
-    context.receiveNone shouldEqual None
-    context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
     )
-    context.receiveNone shouldEqual None
+    context.send(
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+    )
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // create context
     context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
@@ -711,17 +728,22 @@ class RuntimeVisualizationsTest
     // open files
     context.send(
       Api.Request(
+        requestId,
         Api.OpenFileNotification(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
-    context.receiveNone shouldEqual None
-    context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
     )
-    context.receiveNone shouldEqual None
+    context.send(
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+    )
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // create context
     context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
@@ -839,17 +861,22 @@ class RuntimeVisualizationsTest
     // open files
     context.send(
       Api.Request(
+        requestId,
         Api.OpenFileNotification(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
-    context.receiveNone shouldEqual None
-    context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
     )
-    context.receiveNone shouldEqual None
+    context.send(
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+    )
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // create context
     context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
@@ -1070,24 +1097,30 @@ class RuntimeVisualizationsTest
     val visualizationFile =
       context.writeInSrcDir("Visualization", context.Visualization.code)
 
+    val contextId       = UUID.randomUUID()
+    val requestId       = UUID.randomUUID()
+    val visualizationId = UUID.randomUUID()
+
     // open files
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
     context.send(
       Api.Request(
+        requestId,
         Api.OpenFileNotification(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
-    context.receiveNone shouldEqual None
-
-    val contextId       = UUID.randomUUID()
-    val requestId       = UUID.randomUUID()
-    val visualizationId = UUID.randomUUID()
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // create context
     context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
@@ -1199,23 +1232,29 @@ class RuntimeVisualizationsTest
     val visualizationFile =
       context.writeInSrcDir("Visualization", context.Visualization.code)
 
+    val contextId       = UUID.randomUUID()
+    val requestId       = UUID.randomUUID()
+    val visualizationId = UUID.randomUUID()
+
     // open files
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
     context.send(
       Api.Request(
+        requestId,
         Api.OpenFileNotification(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
-
-    val contextId       = UUID.randomUUID()
-    val requestId       = UUID.randomUUID()
-    val visualizationId = UUID.randomUUID()
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // create context
     context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
@@ -1347,17 +1386,22 @@ class RuntimeVisualizationsTest
     // open files
     context.send(
       Api.Request(
+        requestId,
         Api.OpenFileNotification(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
-    context.receiveNone shouldEqual None
-    context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
     )
-    context.receiveNone shouldEqual None
+    context.send(
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
+    )
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // create context
     context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
@@ -1453,24 +1497,30 @@ class RuntimeVisualizationsTest
     val visualizationFile =
       context.writeInSrcDir("Visualization", context.Visualization.code)
 
+    val contextId       = UUID.randomUUID()
+    val requestId       = UUID.randomUUID()
+    val visualizationId = UUID.randomUUID()
+
     // open files
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
     context.send(
       Api.Request(
+        requestId,
         Api.OpenFileNotification(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
-    context.receiveNone shouldEqual None
-
-    val contextId       = UUID.randomUUID()
-    val requestId       = UUID.randomUUID()
-    val visualizationId = UUID.randomUUID()
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // create context
     context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
@@ -1606,9 +1656,11 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -1672,9 +1724,11 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -1768,9 +1822,11 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -1849,9 +1905,11 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -1940,18 +1998,22 @@ class RuntimeVisualizationsTest
     val visualizationFile =
       context.writeInSrcDir("Visualization", visualizationCode)
 
+    val contextId       = UUID.randomUUID()
+    val requestId       = UUID.randomUUID()
+    val visualizationId = UUID.randomUUID()
+
     context.send(
       Api.Request(
+        requestId,
         Api.OpenFileNotification(
           visualizationFile,
           visualizationCode
         )
       )
     )
-
-    val contextId       = UUID.randomUUID()
-    val requestId       = UUID.randomUUID()
-    val visualizationId = UUID.randomUUID()
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // create context
     context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
@@ -1961,9 +2023,11 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -2071,9 +2135,11 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -2167,9 +2233,11 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -2298,9 +2366,11 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -2404,9 +2474,11 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -2481,18 +2553,22 @@ class RuntimeVisualizationsTest
     val visualizationFile =
       context.writeInSrcDir("Visualization", context.Visualization.code)
 
+    val contextId       = UUID.randomUUID()
+    val requestId       = UUID.randomUUID()
+    val visualizationId = UUID.randomUUID()
+
     context.send(
       Api.Request(
+        requestId,
         Api.OpenFileNotification(
           visualizationFile,
           context.Visualization.code
         )
       )
     )
-
-    val contextId       = UUID.randomUUID()
-    val requestId       = UUID.randomUUID()
-    val visualizationId = UUID.randomUUID()
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // create context
     context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
@@ -2502,9 +2578,11 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -2608,18 +2686,22 @@ class RuntimeVisualizationsTest
         context.AnnotatedVisualization.code
       )
 
+    val contextId       = UUID.randomUUID()
+    val requestId       = UUID.randomUUID()
+    val visualizationId = UUID.randomUUID()
+
     context.send(
       Api.Request(
+        requestId,
         Api.OpenFileNotification(
           visualizationFile,
           context.AnnotatedVisualization.code
         )
       )
     )
-
-    val contextId       = UUID.randomUUID()
-    val requestId       = UUID.randomUUID()
-    val visualizationId = UUID.randomUUID()
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // create context
     context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
@@ -2629,9 +2711,11 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -2782,18 +2866,22 @@ class RuntimeVisualizationsTest
         context.AnnotatedVisualization.code
       )
 
+    val contextId       = UUID.randomUUID()
+    val requestId       = UUID.randomUUID()
+    val visualizationId = UUID.randomUUID()
+
     context.send(
       Api.Request(
+        requestId,
         Api.OpenFileNotification(
           visualizationFile,
           context.AnnotatedVisualization.code
         )
       )
     )
-
-    val contextId       = UUID.randomUUID()
-    val requestId       = UUID.randomUUID()
-    val visualizationId = UUID.randomUUID()
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // create context
     context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
@@ -2803,9 +2891,11 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -2964,9 +3054,11 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -3064,9 +3156,11 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -3168,9 +3262,11 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(
@@ -3303,9 +3399,11 @@ class RuntimeVisualizationsTest
 
     // Open the new file
     context.send(
-      Api.Request(Api.OpenFileNotification(mainFile, contents))
+      Api.Request(requestId, Api.OpenFileNotification(mainFile, contents))
     )
-    context.receiveNone shouldEqual None
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenedFileNotification)
+    )
 
     // push main
     val item1 = Api.StackItem.ExplicitCall(

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -335,7 +335,7 @@ final class TruffleCompilerContext implements CompilerContext {
     public void close() {
       if (map != null) {
         if (module.bindings != null) {
-          loggerCompiler.log(Level.FINE, "Reassigining bindings to {0}", module);
+          loggerCompiler.log(Level.FINEST, "Reassigining bindings to {0}", module);
         }
         module.bindings = map;
       }


### PR DESCRIPTION
### Pull Request Description

Lack of reply and therefore a non-determinism on when OpenFile handler can finish, led to some sporadic instability. Once caches format got changed, things were taking such a long time that I wasn't able to start even a basic project (requests would start to timeout). The change also removes PushContextCmd from synchronous cmds (as introduced in #798 to remove initialization problems in tests as well as in real scenarions); the change did the job but was also a bit controversial.
The change can also help with randomly failing applies (#8174) as IDE kept closing and opening the project that might have exploited the race-condition.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
