### PR TITLE
Refactor `Input` class to be composable

### DIFF
--- a/app/gui2/src/components/ComponentBrowser.vue
+++ b/app/gui2/src/components/ComponentBrowser.vue
@@ -2,7 +2,6 @@
 import { componentBrowserBindings } from '@/bindings'
 import { makeComponentList, type Component } from '@/components/ComponentBrowser/component'
 import { Filtering } from '@/components/ComponentBrowser/filtering'
-import { Input } from '@/components/ComponentBrowser/input'
 import { default as DocumentationPanel } from '@/components/DocumentationPanel.vue'
 import SvgIcon from '@/components/SvgIcon.vue'
 import ToggleIcon from '@/components/ToggleIcon.vue'
@@ -18,6 +17,7 @@ import { Vec2 } from '@/util/vec2'
 import type { SuggestionId } from 'shared/languageServerTypes/suggestions'
 import type { ContentRange } from 'shared/yjsModel.ts'
 import { computed, nextTick, onMounted, ref, watch, type Ref } from 'vue'
+import { useComponentBrowserInput } from './ComponentBrowser/input'
 
 const ITEM_SIZE = 32
 const TOP_BAR_HEIGHT = 32
@@ -46,6 +46,7 @@ onMounted(() => {
 })
 
 const projectStore = useProjectStore()
+const suggestionDbStore = useSuggestionDbStore()
 
 // === Position ===
 
@@ -63,7 +64,7 @@ const transform = computed(() => {
 
 const cbRoot = ref<HTMLElement>()
 const inputField = ref<HTMLInputElement>()
-const input = new Input()
+const input = useComponentBrowserInput()
 const filterFlags = ref({ showUnstable: false, showLocal: false })
 
 const currentFiltering = computed(() => {
@@ -127,8 +128,6 @@ function handleDefocus(e: FocusEvent) {
 }
 
 // === Components List and Positions ===
-
-const suggestionDbStore = useSuggestionDbStore()
 
 const components = computed(() => {
   return makeComponentList(suggestionDbStore.entries, currentFiltering.value)

--- a/app/gui2/src/stores/suggestionDatabase/entry.ts
+++ b/app/gui2/src/stores/suggestionDatabase/entry.ts
@@ -8,11 +8,9 @@ import {
   qnLastSegment,
   qnParent,
   qnSplit,
-  tryQualifiedName,
   type Identifier,
   type QualifiedName,
 } from '@/util/qualifiedName'
-import { unwrap } from '@/util/result'
 import type {
   SuggestionEntryArgument,
   SuggestionEntryScope,
@@ -77,7 +75,7 @@ export function entryQn(entry: SuggestionEntry): QualifiedName {
   } else if (entry.memberOf) {
     return qnJoin(entry.memberOf, entry.name)
   } else {
-    return qnJoin(entry.definedIn, unwrap(tryQualifiedName(entry.name)))
+    return qnJoin(entry.definedIn, entry.name)
   }
 }
 


### PR DESCRIPTION
### Pull Request Description

Part of #7926 

I found myself wanting to use graph store in the `Input` class. As I learned about composables recently, I decided to refactor the class into a composable, to be more vue-like. Putting it in a separate PR because [other task may wanting to do the same](8066)

Also contains some preparations for my actual implementation.

### Important Notes


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - ~~[ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
