### PR TITLE
First iteration of understanding self type in Component Browser 

### DIFF
--- a/app/gui2/package.json
+++ b/app/gui2/package.json
@@ -39,6 +39,7 @@
     "@lezer/highlight": "^1.1.6",
     "@noble/hashes": "^1.3.2",
     "@open-rpc/client-js": "^1.8.1",
+    "@pinia/testing": "^0.1.3",
     "@vueuse/core": "^10.4.1",
     "codemirror": "^6.0.1",
     "culori": "^3.2.0",

--- a/app/gui2/src/components/ComponentBrowser/__tests__/input.test.ts
+++ b/app/gui2/src/components/ComponentBrowser/__tests__/input.test.ts
@@ -74,7 +74,6 @@ test.each([
     }
     const computedValueRegistryMock = {
       getExpressionInfo(id: ExprId) {
-        // const payload: ExpressionUpdatePayload = { type: 'Value' }
         if (id === operator1Id)
           return {
             typename: 'Standard.Base.Number',

--- a/app/gui2/src/components/ComponentBrowser/filtering.ts
+++ b/app/gui2/src/components/ComponentBrowser/filtering.ts
@@ -1,11 +1,15 @@
-import { SuggestionKind, type SuggestionEntry } from '@/stores/suggestionDatabase/entry'
+import {
+  SuggestionKind,
+  type SuggestionEntry,
+  type Typename,
+} from '@/stores/suggestionDatabase/entry'
 import type { Opt } from '@/util/opt'
 import { qnIsTopElement, qnParent, type QualifiedName } from '@/util/qualifiedName'
 import { Range } from '@/util/range'
 
 export interface Filter {
   pattern?: string
-  selfType?: QualifiedName
+  selfType?: Typename
   qualifiedNamePattern?: string
   showUnstable?: boolean
   showLocal?: boolean
@@ -259,7 +263,7 @@ class FilteringQualifiedName {
  */
 export class Filtering {
   pattern?: FilteringWithPattern
-  selfType?: QualifiedName | undefined
+  selfType?: Typename | undefined
   qualifiedName?: FilteringQualifiedName
   fullPattern: string | undefined
   /** The first and last match are the parts of the string that are outside of the match.

--- a/app/gui2/src/components/ComponentBrowser/filtering.ts
+++ b/app/gui2/src/components/ComponentBrowser/filtering.ts
@@ -263,7 +263,7 @@ class FilteringQualifiedName {
  */
 export class Filtering {
   pattern?: FilteringWithPattern
-  selfType?: Typename | undefined
+  selfType?: Typename
   qualifiedName?: FilteringQualifiedName
   fullPattern: string | undefined
   /** The first and last match are the parts of the string that are outside of the match.
@@ -283,7 +283,7 @@ export class Filtering {
     if (pattern) {
       this.pattern = new FilteringWithPattern(pattern)
     }
-    this.selfType = selfType
+    if (selfType != null) this.selfType = selfType
     if (qualifiedNamePattern) {
       this.qualifiedName = new FilteringQualifiedName(qualifiedNamePattern)
       this.fullPattern = pattern ? `${qualifiedNamePattern}.${pattern}` : qualifiedNamePattern

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@lezer/highlight": "^1.1.6",
         "@noble/hashes": "^1.3.2",
         "@open-rpc/client-js": "^1.8.1",
+        "@pinia/testing": "^0.1.3",
         "@vueuse/core": "^10.4.1",
         "codemirror": "^6.0.1",
         "culori": "^3.2.0",
@@ -3125,6 +3126,20 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@pinia/testing": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@pinia/testing/-/testing-0.1.3.tgz",
+      "integrity": "sha512-D2Ds2s69kKFaRf2KCcP1NhNZEg5+we59aRyQalwRm7ygWfLM25nDH66267U3hNvRUOTx8ofL24GzodZkOmB5xw==",
+      "dependencies": {
+        "vue-demi": ">=0.14.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "pinia": ">=2.1.5"
       }
     },
     "node_modules/@pkgr/utils": {


### PR DESCRIPTION
### Pull Request Description

Simple understanding of self type, without using alias analysis. It will work for most cases, except:
* expressions where existing identifiers are overshadowed (like `operator1 -> operator1.`)
* input arguments

### Important Notes

I get some problems with mocking stores when testing input mechanics. The graph and project stores are big and have much logic on creation, which in turn require more dependencies etc. In Pinia I cannot mock the function defining stores. I wonder if we should not make separation between stores just keeping graph/document state and logic which synchronizes it with Yjs docs.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - ~~[ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
