### PR TITLE
More logs to debug failed edits

### DIFF
--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -14,6 +14,8 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.logging.Level;
+
 import org.enso.interpreter.instrument.profiling.ProfilingInfo;
 import org.enso.interpreter.node.MethodRootNode;
 import org.enso.interpreter.node.callable.FunctionCallInstrumentationNode;
@@ -376,7 +378,8 @@ public final class ExecutionService {
   public void modifyModuleSources(
       Module module,
       scala.collection.immutable.Seq<model.TextEdit> edits,
-      SimpleUpdate simpleUpdate) {
+      SimpleUpdate simpleUpdate,
+      TruffleLogger logger) {
     try {
       module.getSource();
     } catch (IOException e) {
@@ -391,6 +394,7 @@ public final class ExecutionService {
                     module.getName(), edits, failure, module.getLiteralSource());
               },
               rope -> {
+                logger.log(Level.FINE, "Applied edits. Source has {} lines, last line has {} characters", new Object[]{rope.lines().length(), rope.lines().drop(rope.lines().length() - 1).characters().length()});
                 module.setLiteralSource(rope, simpleUpdate);
                 return new Object();
               });

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/EditFileCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/EditFileCmd.scala
@@ -27,6 +27,11 @@ class EditFileCmd(request: Api.EditFileNotification)
     val fileLockTimestamp         = ctx.locking.acquireFileLock(request.path)
     val pendingEditsLockTimestamp = ctx.locking.acquirePendingEditsLock()
     try {
+      logger.log(
+        Level.FINE,
+        "Adding pending file edits: {}",
+        request.edits.map(e => (e.range, e.text.length))
+      )
       val edits =
         request.edits.map(edit => PendingEdit.ApplyEdit(edit, request.execute))
       ctx.state.pendingEdits.enqueue(request.path, edits)

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -288,7 +288,8 @@ final class EnsureCompiledJob(
       ctx.executionService.modifyModuleSources(
         module,
         edits,
-        changeset.simpleUpdate.orNull
+        changeset.simpleUpdate.orNull,
+        logger
       )
       Option.when(shouldExecute)(changeset)
     } finally {


### PR DESCRIPTION
Should help with understanding what text ranges are being requested and in what order.
