### PR TITLE
Let logging to file respect log level

### DIFF
--- a/engine/language-server/src/main/resources/application.conf
+++ b/engine/language-server/src/main/resources/application.conf
@@ -37,9 +37,9 @@ logging-service {
     org.eclipse.jgit = error
     io.methvin.watcher = error
     # Log levels to limit during very verbose setting:
-    #org.enso.languageserver.protocol.json.JsonConnectionController = debug
-    #org.enso.jsonrpc.JsonRpcServer = debug
-    #org.enso.languageserver.runtime.RuntimeConnector = debug
+    org.enso.languageserver.protocol.json.JsonConnectionController = debug
+    org.enso.jsonrpc.JsonRpcServer = debug
+    org.enso.languageserver.runtime.RuntimeConnector = debug
   }
   appenders = [
     {

--- a/engine/language-server/src/main/resources/application.conf
+++ b/engine/language-server/src/main/resources/application.conf
@@ -56,7 +56,7 @@ logging-service {
   default-appender = socket
   default-appender = ${?ENSO_APPENDER_DEFAULT}
   log-to-file {
-    enable = false
+    enable = false ## Will have effect only if language server is not using socket appender
     enable = ${?ENSO_LOG_TO_FILE}
     log-level = debug
     log-level = ${?ENSO_LOG_TO_FILE_LOG_LEVEL}

--- a/lib/scala/logging-config/src/main/java/org/enso/logger/config/ConsoleAppender.java
+++ b/lib/scala/logging-config/src/main/java/org/enso/logger/config/ConsoleAppender.java
@@ -28,9 +28,11 @@ public final class ConsoleAppender extends Appender {
   @Override
   public boolean setupForPath(
       Level logLevel, Path logRoot, String logPrefix, LoggerSetup loggerSetup) {
-    if (loggerSetup.getConfig().logToFile().enabled()) {
-      loggerSetup.setupFileAppender(
-          loggerSetup.getConfig().logToFile().logLevel(), logRoot, logPrefix);
+    LogToFile logToFileOpt = loggerSetup.getConfig().logToFile();
+    if (logToFileOpt.enabled()) {
+      Level minLevel =
+          Level.intToLevel(Math.min(logToFileOpt.logLevel().toInt(), logLevel.toInt()));
+      loggerSetup.setupFileAppender(minLevel, logRoot, logPrefix);
     }
     return loggerSetup.setupConsoleAppender(logLevel);
   }

--- a/lib/scala/logging-service-logback/src/main/java/org/enso/logger/LogbackSetup.java
+++ b/lib/scala/logging-service-logback/src/main/java/org/enso/logger/LogbackSetup.java
@@ -115,9 +115,9 @@ public final class LogbackSetup extends LoggerSetup {
             int port) {
         Level targetLogLevel;
         // Modify log level if we were asked to always log to a file.
-        // The receiver needs to get all logs (up to `trace`) so as to be able to log all verbose messages.
+        // The receiver needs to get all logs (up to `trace`) to be able to log all verbose messages.
         if (logToFileEnabled()) {
-            int min = Math.min(Level.TRACE.toInt(), config.logToFile().logLevel().toInt());
+            int min = Math.min(logLevel.toInt(), config.logToFile().logLevel().toInt());
             targetLogLevel = Level.intToLevel(min);
         } else {
             targetLogLevel = logLevel;

--- a/lib/scala/logging-service-logback/src/main/java/org/enso/logger/LogbackSetup.java
+++ b/lib/scala/logging-service-logback/src/main/java/org/enso/logger/LogbackSetup.java
@@ -122,7 +122,7 @@ public final class LogbackSetup extends LoggerSetup {
         } else {
             targetLogLevel = logLevel;
         }
-        LoggerAndContext env = contextInit(targetLogLevel, config, !logToFileEnabled());
+        LoggerAndContext env = contextInit(targetLogLevel, config, true);
 
         org.enso.logger.config.SocketAppender appenderConfig = config.getSocketAppender();
 

--- a/lib/scala/logging-service/src/main/java/org/enso/logging/LoggingServiceManager.java
+++ b/lib/scala/logging-service/src/main/java/org/enso/logging/LoggingServiceManager.java
@@ -26,7 +26,17 @@ public class LoggingServiceManager {
       throw new LoggingServiceAlreadySetup();
     } else {
       if (config.appenders().containsKey(config.appender())) {
-        currentLevel = config.logToFile().enabled() ? config.logToFile().logLevel() : logLevel;
+        if (config.logToFile().enabled()) {
+          String envSetLogLevel = System.getenv("ENSO_LOG_TO_FILE_LOG_LEVEL");
+          if (envSetLogLevel != null) {
+            currentLevel = config.logToFile().logLevel();
+          } else {
+            int min = Math.min(config.logToFile().logLevel().toInt(), logLevel.toInt());
+            currentLevel = Level.intToLevel(min);
+          }
+        } else {
+          currentLevel = logLevel;
+        }
         return Future.apply(
             () -> {
               var server = LoggingServiceFactory.get().localServerFor(port);

--- a/lib/scala/project-manager/src/main/resources/application.conf
+++ b/lib/scala/project-manager/src/main/resources/application.conf
@@ -64,7 +64,8 @@ logging-service {
             max-file-size = "100MB"
             max-history = 30
             max-total-size = "2GB"
-          }
+          },
+          immediate-flush = true
         },
         {
           name = "sentry"


### PR DESCRIPTION
### Pull Request Description

This change fixes a regression introduced in #7918, which prevented the execution from setting the right log level either via env var or parameter.

Now passing either of the options returns logs of the expected level in the log file:
- `ENSO_LOG_TO_FILE_LOG_LEVEL = trace`
- ... `-vv` ...

Fixes #8274 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
