### PR TITLE
Fix runtime dataflow error tests

### DIFF
--- a/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/TestMessages.scala
+++ b/engine/runtime/src/test/scala/org/enso/interpreter/test/instrument/TestMessages.scala
@@ -158,19 +158,24 @@ object TestMessages {
     * @param contextId an identifier of the context
     * @param expressionId an identifier of the expression
     * @param payload the error payload
+    * @param fromCache whether or not the value for this expression came
+    * from the cache
+    * @param typeChanged a flag indicating whether the the type of expression has changed
     * @return the expression update response
     */
   def error(
     contextId: UUID,
     expressionId: UUID,
-    payload: Api.ExpressionUpdate.Payload
+    payload: Api.ExpressionUpdate.Payload,
+    fromCache: Boolean   = false,
+    typeChanged: Boolean = true
   ): Api.Response =
     errorBuilder(
       contextId,
       expressionId,
       None,
-      false,
-      true,
+      fromCache,
+      typeChanged,
       payload
     )
 


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

@radeusgd pointed out that tests are checking that the engine does not send updates when the dataflow error changes. In the end, it turned out that those tests were not checking what they said, and the engine sent the proper updates.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.