### PR TITLE
Add 404.html for static hosting

### DIFF
--- a/app/ide-desktop/lib/content/src/index.html
+++ b/app/ide-desktop/lib/content/src/index.html
@@ -39,11 +39,6 @@
     <link rel="stylesheet" href="./ensoFont.css" />
     <script type="module" src="./index.js" defer></script>
     <script type="module" src="./run.js" defer></script>
-    <script
-      src="https://cdn.jsdelivr.net/npm/@twemoji/api@14.1.2/dist/twemoji.min.js"
-      integrity="sha384-D6GSzpW7fMH86ilu73eB95ipkfeXcMPoOGVst/L04yqSSe+RTUY0jXcuEIZk0wrT"
-      crossorigin="anonymous"
-    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/app/ide-desktop/lib/dashboard/bundle.ts
+++ b/app/ide-desktop/lib/dashboard/bundle.ts
@@ -32,6 +32,7 @@ async function bundle() {
         })
         opts.entryPoints.push(
             path.resolve(THIS_PATH, 'src', 'index.html'),
+            path.resolve(THIS_PATH, 'src', '404.html'),
             path.resolve(THIS_PATH, 'src', 'index.ts')
         )
         opts.metafile = ANALYZE

--- a/app/ide-desktop/lib/dashboard/src/404.html
+++ b/app/ide-desktop/lib/dashboard/src/404.html
@@ -1,0 +1,1 @@
+index.html


### PR DESCRIPTION
### Pull Request Description
Adds a `404.html` to allow client-side routing to work when using static hosting.

### Important Notes
- The routing uses the existing logic to infer the base path. This means that if the user accesses an invalid path, the invalid path will be used as the base path.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
