### PR TITLE
Fix node placement

### DIFF
--- a/app/gui2/src/components/ComponentBrowser/placement.ts
+++ b/app/gui2/src/components/ComponentBrowser/placement.ts
@@ -1,5 +1,4 @@
 import { bail } from '@/util/assert'
-import { MultiRange, Range } from '@/util/range'
 import { Rect } from '@/util/rect'
 import { Vec2 } from '@/util/vec2'
 
@@ -42,23 +41,12 @@ export function nonDictatedPlacement(
   const initialRect = new Rect(initialPosition, nodeSize)
   let top = initialPosition.y
   const height = nodeSize.y
-  const minimumVerticalSpace = height + gap * 2
   const bottom = () => top + height
-  const occupiedYRanges = new MultiRange()
-  for (const rect of nodeRects) {
+  const nodeRectsSorted = Array.from(nodeRects).sort((a, b) => a.top - b.top)
+  for (const rect of nodeRectsSorted) {
     if (initialRect.intersectsX(rect) && rect.bottom + gap > top) {
-      if (rect.top - bottom() >= gap) {
-        const range = new Range(rect.top, rect.bottom)
-        occupiedYRanges.insert(range, range.expand(gap))
-      } else {
+      if (rect.top - bottom() < gap) {
         top = rect.bottom + gap
-        const rangeIncludingTop = occupiedYRanges
-          .remove(new Range(-Infinity, rect.bottom + minimumVerticalSpace))
-          .at(-1)
-        if (rangeIncludingTop) {
-          top = Math.max(top, rangeIncludingTop.end + gap)
-          occupiedYRanges.remove(rangeIncludingTop)
-        }
       }
     }
   }
@@ -105,24 +93,13 @@ export function previousNodeDictatedPlacement(
   let left = initialLeft
   const width = nodeSize.x
   const right = () => left + width
-  const minimumHorizontalSpace = width + gap * 2
   const initialPosition = new Vec2(left, top)
   const initialRect = new Rect(initialPosition, nodeSize)
-  const occupiedXRanges = new MultiRange()
-  for (const rect of nodeRects) {
+  const sortedNodeRects = Array.from(nodeRects).sort((a, b) => a.left - b.left)
+  for (const rect of sortedNodeRects) {
     if (initialRect.intersectsY(rect) && rect.right + gap > left) {
-      if (rect.left - right() >= gap) {
-        const range = new Range(rect.left, rect.right)
-        occupiedXRanges.insert(range, range.expand(gap))
-      } else {
+      if (rect.left - right() < gap) {
         left = rect.right + gap
-        const rangeIncludingLeft = occupiedXRanges
-          .remove(new Range(-Infinity, rect.right + minimumHorizontalSpace))
-          .at(-1)
-        if (rangeIncludingLeft) {
-          left = Math.max(left, rangeIncludingLeft.end + gap)
-          occupiedXRanges.remove(rangeIncludingLeft)
-        }
       }
     }
   }


### PR DESCRIPTION
### Pull Request Description

Fixes: #8230 

Fixes some rare cases caught by property tests, involving nodes with 0 width. `MultiRange` does not handle those. The thing is fixed by not using MultiRange, but by sorting nodes by the axis along which we're searching for free place.

All three reported seeds seem to be fixed.

### Important Notes

`MultiRange` is not used now, but I decided to spare it, violating YAGNI rule, as it is tested, and I feel it's a structure which may be useful.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - ~~[ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
