### PR TITLE
Allow IRPass to only access CompilerContext

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
@@ -11,6 +11,7 @@ import java.util.logging.Level;
 import org.enso.compiler.Compiler;
 import org.enso.compiler.PackageRepository;
 import org.enso.compiler.Passes;
+import org.enso.compiler.core.CompilerStub;
 import org.enso.compiler.data.BindingsMap;
 import org.enso.compiler.data.CompilerConfig;
 import org.enso.editions.LibraryName;
@@ -25,7 +26,7 @@ import org.enso.polyglot.data.TypeGraph;
  * Compiler} and the information it needs from the runtime. The ultimate state is to compile the
  * {@link Compiler} & co. classes separately without any dependency on Truffle API.
  */
-public interface CompilerContext {
+public interface CompilerContext extends CompilerStub {
   boolean isIrCachingDisabled();
 
   boolean isPrivateCheckDisabled();

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -9,7 +9,6 @@ import org.enso.compiler.context.{
 }
 import org.enso.compiler.context.CompilerContext.Module
 import org.enso.compiler.core.CompilerError
-import org.enso.compiler.core.CompilerStub
 import org.enso.compiler.core.Implicits.AsMetadata
 import org.enso.compiler.core.ir.{
   Diagnostic,
@@ -61,7 +60,7 @@ class Compiler(
   val context: CompilerContext,
   val packageRepository: PackageRepository,
   config: CompilerConfig
-) extends CompilerStub {
+) {
   private val freshNameSupply: FreshNameSupply = new FreshNameSupply
   private val passes: Passes                   = new Passes(config)
   private val passManager: PassManager         = passes.passManager
@@ -296,7 +295,7 @@ class Compiler(
             context
               .getIr(module)
               .preorder
-              .map(_.passData.restoreFromSerialization(this))
+              .map(_.passData.restoreFromSerialization(this.context))
 
           if (!flags.contains(false)) {
             context.log(

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/IRPass.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/IRPass.scala
@@ -117,7 +117,7 @@ object IRPass {
   trait IRMetadata extends ProcessingPass.Metadata {
 
     type Metadata = IRMetadata
-    type Compiler = org.enso.compiler.Compiler
+    type Compiler = org.enso.compiler.context.CompilerContext
 
     /** The name of the metadata as a string. */
     val metadataName: String

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/FullyQualifiedNames.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/FullyQualifiedNames.scala
@@ -1,7 +1,12 @@
 package org.enso.compiler.pass.resolve
 
-import org.enso.compiler.{Compiler, PackageRepository}
-import org.enso.compiler.context.{FreshNameSupply, InlineContext, ModuleContext}
+import org.enso.compiler.PackageRepository
+import org.enso.compiler.context.{
+  CompilerContext,
+  FreshNameSupply,
+  InlineContext,
+  ModuleContext
+}
 import org.enso.compiler.core.ir.{Expression, Module, Name, Type}
 import org.enso.compiler.core.ir.module.scope.Definition
 import org.enso.compiler.core.ir.module.scope.Export
@@ -429,30 +434,30 @@ case object FullyQualifiedNames extends IRPass {
   }
 
   sealed trait PartiallyResolvedFQN {
-    def prepareForSerialization(compiler: Compiler): PartiallyResolvedFQN
+    def prepareForSerialization(compiler: CompilerContext): PartiallyResolvedFQN
     def restoreFromSerialization(
-      compiler: Compiler
+      compiler: CompilerContext
     ): Option[PartiallyResolvedFQN]
   }
 
   case class ResolvedLibrary(namespace: String) extends PartiallyResolvedFQN {
     override def prepareForSerialization(
-      compiler: Compiler
+      compiler: CompilerContext
     ): PartiallyResolvedFQN = this
 
     override def restoreFromSerialization(
-      compiler: Compiler
+      compiler: CompilerContext
     ): Option[PartiallyResolvedFQN] = Some(this)
   }
   case class ResolvedModule(moduleRef: ModuleReference)
       extends PartiallyResolvedFQN {
     override def prepareForSerialization(
-      compiler: Compiler
+      compiler: CompilerContext
     ): PartiallyResolvedFQN =
       ResolvedModule(moduleRef.toAbstract)
 
     override def restoreFromSerialization(
-      compiler: Compiler
+      compiler: CompilerContext
     ): Option[PartiallyResolvedFQN] = {
       val packageRepository = compiler.getPackageRepository()
       moduleRef

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/CompilerStub.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/CompilerStub.java
@@ -1,3 +1,3 @@
 package org.enso.compiler.core;
 
-public abstract class CompilerStub {}
+public interface CompilerStub {}

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/SerializationManager.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/SerializationManager.scala
@@ -119,7 +119,9 @@ final class SerializationManager(private val context: TruffleCompilerContext) {
       module.getIr,
       module.getIr.duplicate(keepIdentifiers = true)
     )
-    duplicatedIr.preorder.foreach(_.passData.prepareForSerialization(compiler))
+    duplicatedIr.preorder.foreach(
+      _.passData.prepareForSerialization(compiler.context)
+    )
 
     val task = doSerializeModule(
       getCache(module),
@@ -211,7 +213,8 @@ final class SerializationManager(private val context: TruffleCompilerContext) {
               BindingAnalysis,
               "Non-parsed module used in ImportResolver"
             )
-            val abstractBindings = bindings.prepareForSerialization(compiler)
+            val abstractBindings =
+              bindings.prepareForSerialization(compiler.context)
             (module.getName, abstractBindings)
           }
           .toMap
@@ -410,7 +413,7 @@ final class SerializationManager(private val context: TruffleCompilerContext) {
         case Some(loadedCache) =>
           val relinkedIrChecks =
             loadedCache.moduleIR.preorder
-              .map(_.passData.restoreFromSerialization(compiler))
+              .map(_.passData.restoreFromSerialization(compiler.context))
           context.updateModule(
             module,
             { u =>

--- a/engine/runtime/src/test/scala/org/enso/compiler/test/semantic/ImportExportTest.scala
+++ b/engine/runtime/src/test/scala/org/enso/compiler/test/semantic/ImportExportTest.scala
@@ -911,7 +911,7 @@ class ImportExportTest
       val baos   = new ByteArrayOutputStream()
       val stream = new ObjectOutputStream(baos)
       mainIr.preorder.foreach(
-        _.passData.prepareForSerialization(langCtx.getCompiler)
+        _.passData.prepareForSerialization(langCtx.getCompiler.context)
       )
       stream.writeObject(mainIr)
       baos.toByteArray should not be empty
@@ -943,7 +943,7 @@ class ImportExportTest
       val baos   = new ByteArrayOutputStream()
       val stream = new ObjectOutputStream(baos)
       mainIr.preorder.foreach(
-        _.passData.prepareForSerialization(langCtx.getCompiler)
+        _.passData.prepareForSerialization(langCtx.getCompiler.context)
       )
       stream.writeObject(mainIr)
       baos.toByteArray should not be empty


### PR DESCRIPTION
### Pull Request Description

Right now the `IRPass` can access whole `Compiler` with all its functionality. That's an overkill. `IRPass` shall only query the environment - e.g. it should (just like `Compiler` itself) only access `CompilerContext`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides. 
- All code has been tested:
  - [x] Existing unit tests continue to pass
