### PR TITLE
Fix missing `index.html` when running `build-dashboard`

### DIFF
--- a/app/ide-desktop/lib/dashboard/bundle.ts
+++ b/app/ide-desktop/lib/dashboard/bundle.ts
@@ -32,12 +32,12 @@ async function bundle() {
         })
         opts.entryPoints.push(
             path.resolve(THIS_PATH, 'src', 'index.html'),
-            path.resolve(THIS_PATH, 'src', '404.html'),
             path.resolve(THIS_PATH, 'src', 'index.ts')
         )
         opts.metafile = ANALYZE
         opts.loader['.html'] = 'copy'
         const result = await esbuild.build(opts)
+        await fs.copyFile('build/index.html', 'build/404.html')
         if (result.metafile) {
             console.log(await esbuild.analyzeMetafile(result.metafile))
         }

--- a/app/ide-desktop/lib/dashboard/src/404.html
+++ b/app/ide-desktop/lib/dashboard/src/404.html
@@ -1,1 +1,0 @@
-index.html


### PR DESCRIPTION
### Pull Request Description
Fixes `index.html` being missing from `build/`.
This was caused by `404.html` being a symlink to `index.html`.

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
