### PR TITLE
Avoid NPE during instrumentation

### DIFF
--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/service/ExecutionService.java
@@ -72,7 +72,7 @@ public final class ExecutionService {
   private final EnsoContext context;
   private final Optional<IdExecutionService> idExecutionInstrument;
   private final NotificationHandler.Forwarder notificationForwarder;
-  private final TruffleLogger logger = TruffleLogger.getLogger(LanguageInfo.ID);
+  private final TruffleLogger logger = TruffleLogger.getLogger(LanguageInfo.ID, ExecutionService.class);
   private final ConnectedLockManager connectedLockManager;
   private final ExecuteRootNode execute = new ExecuteRootNode();
   private final CallRootNode call = new CallRootNode();

--- a/engine/runtime-instrument-id-execution/src/main/java/org/enso/interpreter/instrument/IdExecutionInstrument.java
+++ b/engine/runtime-instrument-id-execution/src/main/java/org/enso/interpreter/instrument/IdExecutionInstrument.java
@@ -234,7 +234,7 @@ public class IdExecutionInstrument extends TruffleInstrument implements IdExecut
                   functionCallInstrumentationNode.getId(),
                   result,
                   nanoTimeElapsed,
-                  frame.materialize(),
+                  frame == null ? null : frame.materialize(),
                   node);
           Object cachedResult = callbacks.onFunctionReturn(info);
           if (cachedResult != null) {
@@ -243,7 +243,7 @@ public class IdExecutionInstrument extends TruffleInstrument implements IdExecut
         } else if (node instanceof ExpressionNode expressionNode) {
           Info info =
               new NodeInfo(
-                  expressionNode.getId(), result, nanoTimeElapsed, frame.materialize(), node);
+                  expressionNode.getId(), result, nanoTimeElapsed, frame == null ? null : frame.materialize(), node);
           callbacks.updateCachedResult(info);
 
           if (info.isPanic()) {

--- a/lib/scala/logging-service-logback/src/main/java/org/enso/logger/ApplicationFilter.java
+++ b/lib/scala/logging-service-logback/src/main/java/org/enso/logger/ApplicationFilter.java
@@ -23,7 +23,7 @@ public class ApplicationFilter extends Filter<ILoggingEvent> {
     this.loggers = loggers;
     this.level = level;
     this.prefix = prefix;
-    this.prefixLength = prefix != null ? prefix.length() + 1 : 0; // inlude `.` in `enso.`
+    this.prefixLength = prefix != null ? prefix.length() : 0;
   }
 
   @Override
@@ -48,7 +48,12 @@ public class ApplicationFilter extends Filter<ILoggingEvent> {
 
   private boolean loggerNameMatches(String validLoggerName, String eventLoggerName) {
     if (prefix != null && eventLoggerName.startsWith(prefix)) {
-      return eventLoggerName.substring(prefixLength).startsWith(validLoggerName);
+      String prefixLessLoggerName = eventLoggerName.substring(prefixLength);
+      String normalizedLoggerName =
+          prefixLessLoggerName.startsWith(".")
+              ? prefixLessLoggerName.substring(1)
+              : prefixLessLoggerName;
+      return normalizedLoggerName.startsWith(validLoggerName);
     } else {
       return eventLoggerName.startsWith(validLoggerName);
     }

--- a/lib/scala/logging-service-logback/src/main/java/org/enso/logger/ApplicationFilter.java
+++ b/lib/scala/logging-service-logback/src/main/java/org/enso/logger/ApplicationFilter.java
@@ -48,12 +48,9 @@ public class ApplicationFilter extends Filter<ILoggingEvent> {
 
   private boolean loggerNameMatches(String validLoggerName, String eventLoggerName) {
     if (prefix != null && eventLoggerName.startsWith(prefix)) {
-      String prefixLessLoggerName = eventLoggerName.substring(prefixLength);
-      String normalizedLoggerName =
-          prefixLessLoggerName.startsWith(".")
-              ? prefixLessLoggerName.substring(1)
-              : prefixLessLoggerName;
-      return normalizedLoggerName.startsWith(validLoggerName);
+      int normalizedLoggerNameIdx =
+          eventLoggerName.indexOf(".") == prefixLength ? prefixLength + 1 : prefixLength;
+      return eventLoggerName.substring(normalizedLoggerNameIdx).startsWith(validLoggerName);
     } else {
       return eventLoggerName.startsWith(validLoggerName);
     }


### PR DESCRIPTION
### Pull Request Description

Fixes a random crash (*) during instrumentation. Notice how `onTailCallReturn` calls `onReturnValue` with `null` frame.

Bonus: noticed that for some reason we weren't getting logs for `ExecutionService`. This turned out to be the problem with the logger name which by default was `[enso]` not
`[enso.org.enso.interpreter.service.ExecutionService`] and there is some logic there that normalizes the name and assumed a dot after `enso`. This change fixes the logic.

(*)
```
[enso.org.enso.interpreter.service.ExecutionService] Execution of function main failed (Cannot invoke "com.oracle.truffle.api.frame.VirtualFrame.materialize()" because "frame" is null).
java.lang.NullPointerException: Cannot invoke "com.oracle.truffle.api.frame.VirtualFrame.materialize()" because "frame" is null
	at org.enso.interpreter.instrument.IdExecutionInstrument$IdEventNodeFactory$IdExecutionEventNode.onReturnValue(IdExecutionInstrument.java:246)
	at org.enso.interpreter.instrument.IdExecutionInstrument$IdEventNodeFactory$IdExecutionEventNode.onTailCallReturn(IdExecutionInstrument.java:274)
	at org.enso.interpreter.instrument.IdExecutionInstrument$IdEventNodeFactory$IdExecutionEventNode.onReturnExceptional(IdExecutionInstrument.java:258)
	at org.graalvm.truffle/com.oracle.truffle.api.instrumentation.ProbeNode$EventProviderChainNode.innerOnReturnExceptional(ProbeNode.java:1395)
	at org.graalvm.truffle/com.oracle.truffle.api.instrumentation.ProbeNode$EventChainNode.onReturnExceptional(ProbeNode.java:1031)
	at org.graalvm.truffle/com.oracle.truffle.api.instrumentation.ProbeNode.onReturnExceptionalOrUnwind(ProbeNode.java:296)
	at org.enso.interpreter.node.ExpressionNodeWrapper.executeGeneric(ExpressionNodeWrapper.java:119)
	at org.enso.interpreter.node.ClosureRootNode.execute(ClosureRootNode.java:85)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.executeRootNode(OptimizedCallTarget.java:718)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.profiledPERoot(OptimizedCallTarget.java:641)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callBoundary(OptimizedCallTarget.java:574)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.doInvoke(OptimizedCallTarget.java:558)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callDirect(OptimizedCallTarget.java:504)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedDirectCallNode.call(OptimizedDirectCallNode.java:69)
	at org.enso.interpreter.node.callable.thunk.ThunkExecutorNode.doCached(ThunkExecutorNode.java:69)
	at org.enso.interpreter.node.callable.thunk.ThunkExecutorNodeGen.executeAndSpecialize(ThunkExecutorNodeGen.java:207)
	at org.enso.interpreter.node.callable.thunk.ThunkExecutorNodeGen.executeThunk(ThunkExecutorNodeGen.java:167)
...
```

### Important Notes

Fixes regressions introduced in #8148 and #8162

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
