### PR TITLE
Fix annotation processing warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -168,11 +168,12 @@ Global / excludeLintKeys += logManager
 // ============================================================================
 
 ThisBuild / javacOptions ++= Seq(
-  "-encoding",       // Provide explicit encoding (the next line)
-  "UTF-8",           // Specify character encoding used by Java source files
-  "-deprecation",    // Shows a description of each use or override of a deprecated member or class
-  "-g",              // Include debugging information
-  "-Xlint:unchecked" // Enable additional warnings
+  "-encoding",        // Provide explicit encoding (the next line)
+  "UTF-8",            // Specify character encoding used by Java source files
+  "-deprecation",     // Shows a description of each use or override of a deprecated member or class
+  "-g",               // Include debugging information
+  "-Xlint:unchecked", // Enable additional warnings
+  "-proc:full"        // Annotation processing is enabled
 )
 
 ThisBuild / scalacOptions ++= Seq(
@@ -974,6 +975,7 @@ lazy val `json-rpc-server` = project
 lazy val `json-rpc-server-test` = project
   .in(file("lib/scala/json-rpc-server-test"))
   .settings(
+    frgaalJavaCompilerSetting,
     libraryDependencies ++= akka,
     libraryDependencies ++= circe,
     libraryDependencies ++= Seq(


### PR DESCRIPTION
Introduced in #8286.
```
[warn] Unexpected javac output: Note: Annotation processing is enabled because one or more processors were found
[warn]   on the class path. A future release of javac may disable annotation processing
[warn]   unless at least one processor is specified by name (-processor), or a search
[warn]   path is specified (--processor-path, --processor-module-path), or annotation
[warn]   processing is enabled explicitly (-proc:only, -proc:full).
[warn]   Use -Xlint:-options to suppress this message.
[warn]   Use -proc:none to disable annotation processing..
[info] Note: Annotation processing is enabled because one or more processors were found
```
