### PR TITLE
Make sure that runtime/benchmarks are dry-run in CI tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1462,7 +1462,15 @@ lazy val runtime = (project in file("engine/runtime"))
       .value
   )
   .settings(
-    bench := (Benchmark / test).tag(Exclusive).value,
+    bench := (Benchmark / test)
+      .tag(Exclusive)
+      .dependsOn(
+        // runtime.jar fat jar needs to be assembled as it is used in the
+        // benchmarks. This dependency is here so that `runtime/bench` works
+        // after clean build.
+        LocalProject("runtime-with-instruments") / assembly
+      )
+      .value,
     benchOnly := Def.inputTaskDyn {
       import complete.Parsers.spaceDelimited
       val name = spaceDelimited("<name>").parsed match {

--- a/build.sbt
+++ b/build.sbt
@@ -1392,12 +1392,6 @@ lazy val runtime = (project in file("engine/runtime"))
     version := ensoVersion,
     commands += WithDebugCommand.withDebug,
     inConfig(Compile)(truffleRunOptionsSettings),
-    inConfig(Benchmark)(Defaults.testSettings),
-    Benchmark / javacOptions --= Seq(
-      "-source",
-      frgaalSourceLevel,
-      "--enable-preview"
-    ),
     Test / parallelExecution := false,
     Test / logBuffered := false,
     Test / testOptions += Tests.Argument(
@@ -1479,11 +1473,20 @@ lazy val runtime = (project in file("engine/runtime"))
         (Benchmark / testOnly).toTask(" -- -z " + name).value
       }
     }.evaluated,
-    Benchmark / parallelExecution := false
   )
+  /** Benchmark settings  */
   .settings(
+    inConfig(Benchmark)(Defaults.testSettings),
+    Benchmark / javacOptions --= Seq(
+      "-source",
+      frgaalSourceLevel,
+      "--enable-preview"
+    ),
     (Benchmark / javaOptions) :=
-      (LocalProject("std-benchmarks") / Benchmark / run / javaOptions).value
+      (LocalProject("std-benchmarks") / Benchmark / run / javaOptions).value,
+    (Benchmark / javaOptions) ++= benchOnlyOptions,
+    Benchmark / fork := true,
+    Benchmark / parallelExecution := false
   )
   .dependsOn(`common-polyglot-core-utils`)
   .dependsOn(`edition-updater`)

--- a/build.sbt
+++ b/build.sbt
@@ -1472,9 +1472,9 @@ lazy val runtime = (project in file("engine/runtime"))
       Def.task {
         (Benchmark / testOnly).toTask(" -- -z " + name).value
       }
-    }.evaluated,
+    }.evaluated
   )
-  /** Benchmark settings  */
+  /** Benchmark settings */
   .settings(
     inConfig(Benchmark)(Defaults.testSettings),
     Benchmark / javacOptions --= Seq(

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -165,9 +165,7 @@ In order to build and run Enso you will need the following tools:
   [`project/build.properties`](../project/build.properties).
 - [Maven](https://maven.apache.org/) with version at least 3.6.3.
 - [GraalVM](https://www.graalvm.org/) with the same version as described in the
-  [`build.sbt`](../build.sbt) file, configured as your default JVM. GraalVM is
-  distributed for different Java versions, so you need a GraalVM distribution
-  for the same Java version as specified in [`build.sbt`](../build.sbt).
+  [`build.sbt`](../build.sbt) file, configured as your default JVM.
 - [Flatbuffers Compiler](https://google.github.io/flatbuffers) with version
   1.12.0.
 - [Rustup](https://rustup.rs), the rust toolchain management utility.
@@ -258,24 +256,6 @@ working on modern macOS properly. Thus, we've developed a replacement, the
 [Cargo Watch Plus](https://github.com/enso-org/cargo-watch-plus). To use it,
 simply export the `USE_CARGO_WATCH_PLUS=1` in your shell and the build system
 will pick it up instead of the `cargo-watch`.
-
-### Getting Set Up (JVM)
-
-In order to properly build the `runtime` component, the JVM running SBT needs to
-have some dependency JARs available in its module path at startup. To ensure
-they are available, before running any compilation or other tasks, these
-dependencies should be prepared. To do so, run the following command in the
-repository root directory:
-
-```bash
-sbt bootstrap
-```
-
-It is preferred to not run this command from the sbt shell, but in batch mode,
-because SBT has to be launched again anyway to pick up these JARs at startup.
-
-Bootstrap has to be run only when building the project for the first time
-**and** after each change of Graal version.
 
 ### Getting Set Up (Documentation)
 


### PR DESCRIPTION
Follow-up of https://github.com/enso-org/enso/pull/7991 - some build config fixes

### Pull Request Description
Ensure that `-Dbench.compileOnly` system property is correctly forwarded to the benchmarks' runner. So that in the CI Engine tests, benchmarks are *dry run*.

### Important Notes
- Fixes dry run benchmarks in Engine Test Action
- Fixes Engine Benchmark Action

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
