### PR TITLE
Always create events log when profiling

### DIFF
--- a/docs/profiler/engine-startup.md
+++ b/docs/profiler/engine-startup.md
@@ -15,7 +15,7 @@ Start `project-manager` with following options to record first 20s of the Enso
 engine startup sequence:
 
 ```
-$ project-manager --profiling-events-log-path=start.log --profiling-path=start.npss --profiling-time=20
+$ project-manager --profiling-path=start.npss --profiling-time=20
 ```
 
 Let the IDE connect to just launched `project-manager` - e.g. start the IDE with

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -171,7 +171,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
   )
 
   val runtimeEventsMonitor =
-    languageServerConfig.profiling.runtimeEventsLogPath match {
+    languageServerConfig.profiling.profilingEventsLogPath match {
       case Some(path) =>
         val out = new PrintStream(path.toFile, StandardCharsets.UTF_8)
         new RuntimeEventsMonitor(out)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/ProfilingConfig.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/ProfilingConfig.scala
@@ -1,18 +1,41 @@
 package org.enso.languageserver.boot
 
+import org.apache.commons.io.FilenameUtils
+
 import java.nio.file.Path
 
 import scala.concurrent.duration.FiniteDuration
 
 /** Application profiling configuration.
   *
-  * @param runtimeEventsLogPath the path to the runtime events log file
   * @param profilingPath the path to the profiling output file
   * @param profilingTime limit the profiling duration, as an infinite profiling
   * duration may cause out-of-memory errors.
   */
 case class ProfilingConfig(
-  runtimeEventsLogPath: Option[Path]    = None,
   profilingPath: Option[Path]           = None,
   profilingTime: Option[FiniteDuration] = None
-)
+) {
+
+  /** Creates the path to the runtime events log with the same name as
+    * `profilingPath` but with the `.log` extension.
+    *
+    * @return the path to the runtime events log file
+    */
+  def profilingEventsLogPath: Option[Path] =
+    profilingPath.map { path =>
+      val profilingDirectory     = path.getParent
+      val profilingFileName      = path.getFileName.toString
+      val profilingFileExtension = FilenameUtils.getExtension(profilingFileName)
+      val eventsLogFileName =
+        profilingFileName.stripSuffix(
+          profilingFileExtension
+        ) + ProfilingConfig.EventsLogExtension
+
+      profilingDirectory.resolve(eventsLogFileName)
+    }
+}
+object ProfilingConfig {
+
+  private val EventsLogExtension = "log"
+}

--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -54,8 +54,6 @@ object Main {
   private val PROFILING_PATH                 = "profiling-path"
   private val PROFILING_TIME                 = "profiling-time"
   private val LANGUAGE_SERVER_OPTION         = "server"
-  private val LANGUAGE_SERVER_PROFILING_EVENTS_LOG_PATH =
-    "server-profiling-events-log-path"
   private val DAEMONIZE_OPTION               = "daemon"
   private val INTERFACE_OPTION               = "interface"
   private val RPC_PORT_OPTION                = "rpc-port"
@@ -201,16 +199,9 @@ object Main {
       .longOpt(PROFILING_TIME)
       .desc("The duration in seconds limiting the profiling time.")
       .build()
-    val lsProfilingEventsLogPathOption = CliOption.builder
-      .hasArg(true)
-      .numberOfArgs(1)
-      .argName("file")
-      .longOpt(LANGUAGE_SERVER_PROFILING_EVENTS_LOG_PATH)
-      .desc("The path to the runtime events log file.")
-      .build()
     val deamonizeOption = CliOption.builder
       .longOpt(DAEMONIZE_OPTION)
-      .desc("Deamonize Language Server")
+      .desc("Daemonize Language Server")
       .build()
     val interfaceOption = CliOption.builder
       .longOpt(INTERFACE_OPTION)
@@ -427,7 +418,6 @@ object Main {
       .addOption(lsOption)
       .addOption(lsProfilingPathOption)
       .addOption(lsProfilingTimeOption)
-      .addOption(lsProfilingEventsLogPathOption)
       .addOption(deamonizeOption)
       .addOption(interfaceOption)
       .addOption(rpcPortOption)
@@ -1026,16 +1016,7 @@ object Main {
       profilingTime <- Either
         .catchNonFatal(profilingTimeStr.map(_.toInt.seconds))
         .leftMap(_ => "Profiling time should be an integer")
-      profilingEventsLogPathStr =
-        Option(line.getOptionValue(LANGUAGE_SERVER_PROFILING_EVENTS_LOG_PATH))
-      profilingEventsLogPath <- Either
-        .catchNonFatal(profilingEventsLogPathStr.map(Paths.get(_)))
-        .leftMap(_ => "Profiling events log path is invalid")
-    } yield ProfilingConfig(
-      profilingEventsLogPath,
-      profilingPath,
-      profilingTime
-    )
+    } yield ProfilingConfig(profilingPath, profilingTime)
   }
 
   /** Prints the version of the Enso executable.

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/Cli.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/Cli.scala
@@ -7,14 +7,13 @@ import scala.util.Try
 
 object Cli {
 
-  val JSON_OPTION               = "json"
-  val HELP_OPTION               = "help"
-  val NO_LOG_MASKING            = "no-log-masking"
-  val VERBOSE_OPTION            = "verbose"
-  val VERSION_OPTION            = "version"
-  val PROFILING_PATH            = "profiling-path"
-  val PROFILING_TIME            = "profiling-time"
-  val PROFILING_EVENTS_LOG_PATH = "profiling-events-log-path"
+  val JSON_OPTION    = "json"
+  val HELP_OPTION    = "help"
+  val NO_LOG_MASKING = "no-log-masking"
+  val VERBOSE_OPTION = "verbose"
+  val VERSION_OPTION = "version"
+  val PROFILING_PATH = "profiling-path"
+  val PROFILING_TIME = "profiling-time"
 
   object option {
 
@@ -64,16 +63,6 @@ object Cli {
       .longOpt(PROFILING_TIME)
       .desc("The duration in seconds limiting the application profiling time.")
       .build()
-
-    val profilingEventsLogPath: cli.Option = cli.Option.builder
-      .hasArg(true)
-      .numberOfArgs(1)
-      .argName("file")
-      .longOpt(PROFILING_EVENTS_LOG_PATH)
-      .desc(
-        "The path to the runtime events log file. Enables the runtime events logging."
-      )
-      .build()
   }
 
   val options: cli.Options =
@@ -85,7 +74,6 @@ object Cli {
       .addOption(option.noLogMasking)
       .addOption(option.profilingPath)
       .addOption(option.profilingTime)
-      .addOption(option.profilingEventsLogPath)
 
   /** Parse the command line options. */
   def parse(args: Array[String]): Either[String, cli.CommandLine] = {

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManagerOptions.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/ProjectManagerOptions.scala
@@ -6,12 +6,10 @@ import scala.concurrent.duration.FiniteDuration
 
 /** The runtime options.
   *
-  * @param profilingRuntimeEventsLog the path to the runtime events log file
   * @param profilingPath the path to the profiling output file
   * @param profilingTime the time limiting the profiling duration
   */
 case class ProjectManagerOptions(
-  profilingRuntimeEventsLog: Option[Path],
   profilingPath: Option[Path],
   profilingTime: Option[FiniteDuration]
 )

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/configuration.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/boot/configuration.scala
@@ -12,13 +12,11 @@ object configuration {
     *  main project manager process.
     *
     *  @param logLevel the logging level
-    *  @param profilingEventsLogPath the path to the runtime events log file
     *  @param profilingPath the path to the profiling out file
     *  @param profilingTime the time limiting the profiling duration
     */
   case class MainProcessConfig(
     logLevel: Level,
-    profilingEventsLogPath: Option[Path],
     profilingPath: Option[Path],
     profilingTime: Option[FiniteDuration]
   )

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ExecutorWithUnlimitedPool.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ExecutorWithUnlimitedPool.scala
@@ -107,18 +107,12 @@ object ExecutorWithUnlimitedPool extends LanguageServerExecutor {
     val profilingTimeArguments =
       descriptor.profilingTime.toSeq
         .flatMap(time => Seq("--profiling-time", time.toSeconds.toString))
-    val profilingEventsLogPathArguments =
-      descriptor.profilingEventsLogPath.toSeq
-        .flatMap(path =>
-          Seq("--server-profiling-events-log-path", path.toString)
-        )
     val startupArgs =
       if (descriptor.skipGraalVMUpdater) Seq("--skip-graalvm-updater")
       else Seq()
     val additionalArguments =
       profilingPathArguments ++
       profilingTimeArguments ++
-      profilingEventsLogPathArguments ++
       startupArgs
     val runSettings = runner
       .startLanguageServer(

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerController.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerController.scala
@@ -86,7 +86,6 @@ class LanguageServerController(
       engineVersion                  = engineVersion,
       jvmSettings                    = distributionConfiguration.defaultJVMSettings,
       discardOutput                  = distributionConfiguration.shouldDiscardChildOutput,
-      profilingEventsLogPath         = processConfig.profilingEventsLogPath,
       profilingPath                  = processConfig.profilingPath,
       profilingTime                  = processConfig.profilingTime,
       deferredLoggingServiceEndpoint = loggingServiceDescriptor.getEndpoint,

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerDescriptor.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerDescriptor.scala
@@ -24,7 +24,6 @@ import scala.concurrent.duration.FiniteDuration
   * @param jvmSettings settings to use for the JVM that will host the engine
   * @param discardOutput specifies if the process output should be discarded or
   *                      printed to parent's streams
-  * @param profilingEventsLogPath the path to the runtime events log file
   * @param profilingPath the language server profiling file path
   * @param profilingTime the time limiting the profiling duration
   * @param deferredLoggingServiceEndpoint a future that is completed once the
@@ -44,7 +43,6 @@ case class LanguageServerDescriptor(
   engineVersion: SemVer,
   jvmSettings: JVMSettings,
   discardOutput: Boolean,
-  profilingEventsLogPath: Option[Path],
   profilingPath: Option[Path],
   profilingTime: Option[FiniteDuration],
   deferredLoggingServiceEndpoint: Future[Option[URI]],

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/BaseServerSpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/BaseServerSpec.scala
@@ -87,10 +87,9 @@ class BaseServerSpec extends JsonRpcServerTestKit with BeforeAndAfterAll {
 
   val processConfig: MainProcessConfig =
     MainProcessConfig(
-      logLevel               = if (debugLogs) Level.TRACE else Level.ERROR,
-      profilingPath          = profilingPath,
-      profilingTime          = None,
-      profilingEventsLogPath = None
+      logLevel      = if (debugLogs) Level.TRACE else Level.ERROR,
+      profilingPath = profilingPath,
+      profilingTime = None
     )
 
   val testClock =


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Changelog:
- update: always create an event log next to the profiling file when the engine is started with the `--profiling-path` flag
- remove: `--profiling-events-log-path` flag

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.