### PR TITLE
Fix Java log initialization in `std-table`

### DIFF
--- a/engine/runtime/src/main/java/org/enso/ClassLoaderConstants.java
+++ b/engine/runtime/src/main/java/org/enso/ClassLoaderConstants.java
@@ -4,8 +4,21 @@ import java.util.List;
 
 public class ClassLoaderConstants {
 
-  public static final List<String> RESOURCE_DELEGATION_PATTERNS = List.of("org.slf4j", "ch.qos");
+  /**
+   * Prefix of names of classes that are know to be on the system module-path, i.e., on the boot
+   * module layer. Engine is started from {@link EngineRunnerBootLoader} with a custom class loader
+   * that is isolated form the system's module-path. Delegating to either system class loader, or
+   * any other class loader that has access to the boot module layer, ensures that the Truffle
+   * polyglot environment is properly initialized and also that the global logging configuration is
+   * consistent.
+   */
   public static final List<String> CLASS_DELEGATION_PATTERNS =
       List.of("org.graalvm", "java", "org.slf4j", "ch.qos");
+
+  public static final List<String> RESOURCE_DELEGATION_PATTERNS = List.of("org.slf4j", "ch.qos");
+  /**
+   * Path to the {@code runner.jar} fat jar. This must not be on the system's module-path, because
+   * the JVM would not be able to boot.
+   */
   static final String DEFAULT_RUNNER_JAR = "runner/runner.jar";
 }

--- a/engine/runtime/src/main/java/org/enso/ClassLoaderConstants.java
+++ b/engine/runtime/src/main/java/org/enso/ClassLoaderConstants.java
@@ -1,0 +1,11 @@
+package org.enso;
+
+import java.util.List;
+
+public class ClassLoaderConstants {
+
+  public static final List<String> RESOURCE_DELEGATION_PATTERNS = List.of("org.slf4j", "ch.qos");
+  public static final List<String> CLASS_DELEGATION_PATTERNS =
+      List.of("org.graalvm", "java", "org.slf4j", "ch.qos");
+  static final String DEFAULT_RUNNER_JAR = "runner/runner.jar";
+}


### PR DESCRIPTION
Fixes #8363

### Pull Request Description
When executing:
```
from Standard.Base import all
from Standard.Table import all


main =
    fil = "./test/Table_Tests/data/TestSheet.xlsx"
    f = File.new fil . read
    IO.println f

```
with `--log-level TRACE`, I can now see logs from, e.g., `org.apache.xmlbeans` that most likely come from polyglot Java sources in `std-table`. Moreover, there is no longer any warning message about using NOP org.slf4j logger as a fallback.


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [X] Unit tests have been written where possible.
  - [X] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
