### PR TITLE
Benchmark to measure startup time

### DIFF
--- a/test/Benchmarks/src/Main.enso
+++ b/test/Benchmarks/src/Main.enso
@@ -30,6 +30,7 @@ import project.Number_Parse
 import project.Numeric
 import project.Range
 import project.Sum
+import project.Startup
 import project.Runtime.Panics_And_Errors
 from Standard.Base.Runtime import Debug
 
@@ -83,6 +84,8 @@ all_benchmarks =
 
     # Runtime
     builder.append Panics_And_Errors.collect_benches
+
+    builder.append Startup.collect_benches
 
     builder.to_vector
 

--- a/test/Benchmarks/src/Startup.enso
+++ b/test/Benchmarks/src/Startup.enso
@@ -1,0 +1,52 @@
+from Standard.Base import all
+
+from Standard.Test import Bench
+
+polyglot java import java.lang.System as Java_System
+polyglot java import java.io.File as Java_File
+
+type Data
+    Value ~enso_bin:File ~empty_world:File ~hello_world:File
+
+    bench_empty self =
+        res = Process.run self.enso_bin.path [ "--run", self.empty_world.to_text ]
+
+    bench_hello self =
+        res = Process.run self.enso_bin.path [ "--run", self.hello_world.to_text ]
+
+
+collect_benches = Bench.build builder->
+    options = Bench.options . set_warmup (Bench.phase_conf 2 5) . set_measure (Bench.phase_conf 3 5)
+
+
+    data =
+        Data.Value enso_bin empty_file hello_file
+
+    builder.group "Startup" options group_builder->
+        group_builder.specify "empty_startup" data.bench_empty
+        group_builder.specify "hello_world_startup" data.bench_hello
+
+empty_file =
+    f = File.create_temporary_file "empty" "enso"
+    t = """
+        main = "Hello World"
+    t.write f
+    f
+
+hello_file =
+    f = File.create_temporary_file "hello" "enso"
+    t = """
+        from Standard.Base import IO
+
+        main = IO.println "Hello World"
+    t.write f
+    f
+
+enso_bin =
+    p = Java_System.getProperty "jdk.module.path"
+    s = p.split Java_File.separator
+    paths = s.take (Index_Sub_Range.While _!="..")
+    j = paths . join Java_File.separator
+    File.new j / if Platform.os == Platform.OS.Windows then "enso.bat" else "enso"
+
+main = collect_benches . run_main

--- a/test/Examples_Tests/src/Python_Examples_Spec.enso
+++ b/test/Examples_Tests/src/Python_Examples_Spec.enso
@@ -12,7 +12,7 @@ pending_python_missing = if Polyglot.is_language_installed "python" then Nothing
 
 spec = Test.group "Python Examples" <|
     enso_bin =
-        p = Java_System.getProperty "truffle.class.path.append"
+        p = Java_System.getProperty "jdk.module.path"
         s = p.split Java_File.separator
         paths = s.take (Index_Sub_Range.While _!="..")
         j = paths . join Java_File.separator


### PR DESCRIPTION
### Pull Request Description

While trying to speed `MetadataStorage` up - #8324 - I felt the need to have an independent (on my computer) measurement of startup time. Here is a benchmark that measures how long execution of two simple hello world programs take.

### Important Notes

There are two benchmarks:
- `empty_startup` measures the time needed to boot without using any `Standard` library - basically _an overhead of the JVM and engine_
- `hello_world_startup` measures the use of `IO.println` - it shall take longer than `empty_startup` and show the overhead we have while processing the standard library

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      style guides.
- All code has been tested:
  - [x] [Benchmarks](https://github.com/enso-org/enso/actions/runs/6974010888) have been executed.
