### PR TITLE
Don't NPE on `op ._` when translating tree to IR

### DIFF
--- a/engine/language-server/src/main/resources/application.conf
+++ b/engine/language-server/src/main/resources/application.conf
@@ -40,6 +40,7 @@ logging-service {
     org.enso.languageserver.protocol.json.JsonConnectionController = debug
     org.enso.jsonrpc.JsonRpcServer = debug
     org.enso.languageserver.runtime.RuntimeConnector = debug
+    org.enso.interpreter.runtime.HostClassLoader = error
   }
   appenders = [
     {

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/context/CompilerContext.java
@@ -43,6 +43,8 @@ public interface CompilerContext extends CompilerStub {
 
   void log(Level level, String msg, Object... args);
 
+  void log(Level level, String msg, Throwable ex);
+
   void logSerializationManager(Level level, String msg, Object... args);
 
   void notifySerializeModule(QualifiedName moduleName);

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/AttachVisualizationCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/AttachVisualizationCmd.scala
@@ -26,7 +26,7 @@ class AttachVisualizationCmd(
   ): Future[Unit] = {
     ctx.executionService.getLogger.log(
       Level.FINE,
-      "Attach visualization cmd for request id [{}] and visualization id [{}]",
+      "Attach visualization cmd for request id [{0}] and visualization id [{1}]",
       Array(maybeRequestId, request.visualizationId)
     )
     ctx.endpoint.sendToClient(

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
@@ -139,7 +139,7 @@ class UpsertVisualizationJob(
   )(implicit ctx: RuntimeContext): Unit = {
     ctx.executionService.getLogger.log(
       Level.SEVERE,
-      "Visualization for expression {0} failed: {1} (evaluation result: {2}",
+      "Visualization for expression {0} failed: {1} (evaluation result: {2})",
       Array(expressionId, message, executionResult)
     )
     ctx.endpoint.sendToClient(

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
@@ -1438,7 +1438,11 @@ final class TreeToIr {
       } else {
         throw translateEntity(app, Syntax.UnexpectedExpression$.MODULE$);
       }
-      list = app.getLhs();
+      if (app.getLhs() != null) {
+        list = app.getLhs();
+      } else {
+        throw translateEntity(app, Syntax.UnexpectedExpression$.MODULE$);
+      }
     }
     segments.add(list);
     java.util.Collections.reverse(segments);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/TruffleCompilerContext.java
@@ -94,6 +94,11 @@ final class TruffleCompilerContext implements CompilerContext {
   }
 
   @Override
+  public void log(Level level, String msg, Throwable ex) {
+    loggerCompiler.log(level, msg, ex);
+  }
+
+  @Override
   public void logSerializationManager(Level level, String msg, Object... args) {
     loggerSerializationManager.log(level, msg, args);
   }

--- a/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
@@ -31,6 +31,16 @@ public class ErrorCompilerTest extends CompilerTest {
   }
 
   @Test
+  public void spaceDotUnderscore() throws Exception {
+    var ir = parse("""
+    run op =
+      op ._
+    """);
+
+    assertSingleSyntaxError(ir, Syntax.UnexpectedExpression$.MODULE$, "Unexpected expression", 14, 16);
+  }
+
+  @Test
   public void unaryMinus() throws Exception {
     var ir = parse("""
     from Standard.Base import all


### PR DESCRIPTION
### Pull Request Description

Encountered a random NPE when playing with bookclubs. Test case demonstrating the problem is attached.

Threw in a bunch of minor tweaks to logs to make life of the person debugging code more pleasant.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
