### PR TITLE
Fix Benchmark processor when run from a root directory with different name than "enso"

### DIFF
--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
@@ -20,6 +21,7 @@ import javax.tools.Diagnostic.Kind;
 import org.enso.benchmarks.BenchGroup;
 import org.enso.benchmarks.BenchSpec;
 import org.enso.benchmarks.ModuleBenchSuite;
+import org.enso.benchmarks.Utils;
 import org.enso.polyglot.LanguageInfo;
 import org.enso.polyglot.MethodNames.TopScope;
 import org.enso.polyglot.RuntimeOptions;
@@ -71,27 +73,12 @@ public class BenchProcessor extends AbstractProcessor {
           "import org.enso.benchmarks.Utils;");
 
   public BenchProcessor() {
-    File currentDir = null;
-    try {
-      currentDir =
-          new File(
-              BenchProcessor.class.getProtectionDomain().getCodeSource().getLocation().toURI());
-    } catch (URISyntaxException e) {
-      failWithMessage("ensoDir not found: " + e.getMessage());
-    }
-    for (; currentDir != null; currentDir = currentDir.getParentFile()) {
-      if (currentDir.getName().equals("enso")) {
-        break;
-      }
-    }
-    if (currentDir == null) {
-      failWithMessage("Unreachable: Could not find Enso root directory");
-    }
-    ensoDir = currentDir;
+    ensoDir = Utils.findRepoRootDir();
 
     // Note that ensoHomeOverride does not have to exist, only its parent directory
     ensoHomeOverride = ensoDir.toPath().resolve("distribution").resolve("component").toFile();
   }
+
 
   @Override
   public SourceVersion getSupportedSourceVersion() {


### PR DESCRIPTION
Fix Benchmark processor when run from a root directory with different name than "enso"

### Pull Request Description

This PR fixes commands like `std-benchmarks/benchOnly Startup` for users that have `enso` clonned in multiple directories with different names.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [X] Unit tests have been written where possible.
  - [X] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
