### PR TITLE
Ensure compilation is run with a compilation lock

### DIFF
--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/Locking.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/Locking.scala
@@ -29,6 +29,10 @@ trait Locking {
     */
   def releaseWriteCompilationLock(): Unit
 
+  /** Aseerts a compilation write lock is held by the current thread.
+    */
+  def assertWriteCompilationLock(): Unit
+
   /** Acquires a compilation read lock and returns a timestamp when it succeeded.
     *
     * @return timestamp of when the lock was acquired

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/ReentrantLocking.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/ReentrantLocking.scala
@@ -99,6 +99,12 @@ class ReentrantLocking(logger: TruffleLogger) extends Locking {
   override def releaseWriteCompilationLock(): Unit =
     compilationLock.writeLock().unlock()
 
+  override def assertWriteCompilationLock(): Unit =
+    assert(
+      compilationLock.writeLock().isHeldByCurrentThread,
+      "should already held write compilation lock during the operation"
+    )
+
   /** @inheritdoc */
   override def acquireReadCompilationLock(): Long = {
     // CloseFileCmd does:

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -378,7 +378,7 @@ final class EnsureCompiledJob(
   private def invalidateCaches(
     module: Module,
     changeset: Changeset[_]
-  )(implicit ctx: RuntimeContext, logger: TruffleLogger): Unit = {
+  )(implicit ctx: RuntimeContext): Unit = {
     val invalidationCommands =
       buildCacheInvalidationCommands(
         changeset,

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
@@ -295,6 +295,7 @@ object UpsertVisualizationJob {
   ): Either[EvaluationFailure, AnyRef] = {
     Either
       .catchNonFatal {
+        ctx.locking.assertWriteCompilationLock()
         ctx.executionService.evaluateExpression(module, argumentExpression)
       }
       .leftFlatMap {
@@ -325,7 +326,6 @@ object UpsertVisualizationJob {
           )
 
         case error =>
-          error.printStackTrace()
           ctx.executionService.getLogger.log(
             Level.SEVERE,
             "Evaluation of visualization argument [{0}] failed in module [{1}] with [{2}]: {3}",
@@ -366,6 +366,7 @@ object UpsertVisualizationJob {
       .catchNonFatal {
         expression match {
           case Api.VisualizationExpression.Text(_, expression) =>
+            ctx.locking.assertWriteCompilationLock()
             ctx.executionService.evaluateExpression(
               expressionModule,
               expression

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/UpsertVisualizationJob.scala
@@ -206,7 +206,7 @@ object UpsertVisualizationJob {
     */
   def upsertVisualization(
     visualization: Visualization
-  )(implicit ctx: RuntimeContext, logger: TruffleLogger): Unit =
+  )(implicit ctx: RuntimeContext): Unit =
     visualization match {
       case visualization: Visualization.AttachedVisualization =>
         val visualizationConfig = visualization.config
@@ -501,7 +501,7 @@ object UpsertVisualizationJob {
     visualizationConfig: Api.VisualizationConfiguration,
     callback: AnyRef,
     arguments: Vector[AnyRef]
-  )(implicit ctx: RuntimeContext, logger: TruffleLogger): Visualization = {
+  )(implicit ctx: RuntimeContext): Visualization = {
     val visualizationExpressionId =
       findVisualizationExpressionId(module, visualizationConfig.expression)
     val visualization =

--- a/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/EpbContext.java
+++ b/engine/runtime-language-epb/src/main/java/org/enso/interpreter/epb/EpbContext.java
@@ -69,9 +69,9 @@ public class EpbContext {
         (Consumer<TruffleContext>)
             (context) -> {
               var lock = innerContext.enter(null);
-              log.log(Level.FINEST, "Entering initialization thread");
-              cdl.countDown();
               try {
+                log.log(Level.FINEST, "Entering initialization thread");
+                cdl.countDown();
                 for (var l : langs.split(",")) {
                   log.log(Level.FINEST, "Initializing language {0}", l);
                   long then = System.currentTimeMillis();


### PR DESCRIPTION
### Pull Request Description

Evaluating visualization expression may trigger a full compilation. A change in #7042 went a bit too far and led to a situation when there could be compilations running at the same time leading to a rather obscure `RedefinedMethodException` when the compilation on one thread already finished. This will make the logic correct again at the price of potentially slowing the processing of visualization.

Closes #8296.

### Important Notes

Should make visualizations a bit more stable as well.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
