### PR TITLE
Download latest release instead of nightly

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/authentication/src/appInfo.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/appInfo.ts
@@ -113,25 +113,22 @@ async function getLatestRelease() {
     ) {
         return cachedRelease.gitHubRelease
     } else {
-        const response = await fetch(
-            'https://api.github.com/repos/enso-org/enso/releases?per_page=1',
-            {
-                headers: [
-                    ['Accept', 'application/vnd.github+json'],
-                    ['X-GitHub-Api-Version', '2022-11-28'],
-                ],
-            }
-        )
+        const response = await fetch('https://api.github.com/repos/enso-org/enso/releases/latest', {
+            headers: [
+                ['Accept', 'application/vnd.github+json'],
+                ['X-GitHub-Api-Version', '2022-11-28'],
+            ],
+        })
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const data: [GitHubRelease] = await response.json()
+        const data: GitHubRelease = await response.json()
         localStorage.setItem(
             LOCAL_STORAGE_KEY,
             JSON.stringify({
                 lastFetchEpochMs: Number(new Date()),
-                gitHubRelease: data[0],
+                gitHubRelease: data,
             } satisfies CachedRelease)
         )
-        return data[0]
+        return data
     }
 }
 


### PR DESCRIPTION
### Pull Request Description
The download button previously pointed to the latest nightly, instead of the latest stable release. This is bad, because (like now) the nightlies may be broken.

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
