### PR TITLE
Add profiling shortcuts to GUI2

### DIFF
--- a/app/gui2/shared/languageServer.ts
+++ b/app/gui2/shared/languageServer.ts
@@ -380,6 +380,16 @@ export class LanguageServer extends ObservableV2<Notifications> {
     return this.request('runtime/getComponentGroups', {})
   }
 
+  /** [Documentation](https://github.com/enso-org/enso/blob/develop/docs/language-server/protocol-language-server.md#profilingstart) */
+  profilingStart(memorySnapshot?: boolean): Promise<void> {
+    return this.request('profiling/start', { memorySnapshot })
+  }
+
+  /** [Documentation](https://github.com/enso-org/enso/blob/develop/docs/language-server/protocol-language-server.md#profilingstop) */
+  profilingStop(): Promise<void> {
+    return this.request('profiling/stop', {})
+  }
+
   /** A helper function to subscribe to file updates.
    * Please use `ls.on('file/event')` directly if the initial `'Added'` notifications are not
    * needed. */

--- a/app/gui2/src/bindings.ts
+++ b/app/gui2/src/bindings.ts
@@ -30,6 +30,8 @@ export const graphBindings = defineKeybinds('graph-editor', {
   deselectAll: ['Escape', 'PointerMain'],
   copyNode: ['Mod+C'],
   pasteNode: ['Mod+V'],
+  startProfiling: ['Mod+Alt+,'],
+  stopProfiling: ['Mod+Alt+.'],
 })
 
 export const selectionMouseBindings = defineKeybinds('selection', {

--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -132,6 +132,12 @@ const graphBindingsHandler = graphBindings.handler({
   redo() {
     projectStore.module?.undoManager.redo()
   },
+  startProfiling() {
+    projectStore.lsRpcConnection.then((ls) => ls.profilingStart(true))
+  },
+  stopProfiling() {
+    projectStore.lsRpcConnection.then((ls) => ls.profilingStop())
+  },
   openComponentBrowser() {
     if (keyboardBusy()) return false
     if (graphNavigator.sceneMousePos != null && !componentBrowserVisible.value) {


### PR DESCRIPTION
### Pull Request Description
- Closes #8404

### Important Notes
- All relevant documentation has already been updated in #8358.
- I've tested that the keyboard shortcuts send appropriate messages over the LS connection, and have confirmed that a non-error response is received, but I'm not sure that the profiling actually works.
  - There seem to be no entries in `~/.enso/`, nor in `~/enso/`

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
