### PR TITLE
Avoid placing a new node over a visualization

### DIFF
--- a/app/gui2/src/components/ComponentBrowser/placement.ts
+++ b/app/gui2/src/components/ComponentBrowser/placement.ts
@@ -86,6 +86,7 @@ export function previousNodeDictatedPlacement(
   let initialLeft: number | undefined
   let top = -Infinity
   for (const rect of selectedNodeRects) {
+    console.log('selected', rect)
     initialLeft ??= rect.left
     const newTop = rect.bottom + verticalGap
     if (newTop > top) top = newTop
@@ -100,6 +101,7 @@ export function previousNodeDictatedPlacement(
   const sortedNodeRects = Array.from(nodeRects).sort((a, b) => a.left - b.left)
   for (const rect of sortedNodeRects) {
     if (initialRect.intersectsY(rect) && rect.right + horizontalGap > left) {
+      console.log('?', initialRect, rect)
       if (rect.left - right() < horizontalGap) {
         left = rect.right + horizontalGap
       }

--- a/app/gui2/src/components/ComponentBrowser/placement.ts
+++ b/app/gui2/src/components/ComponentBrowser/placement.ts
@@ -86,7 +86,6 @@ export function previousNodeDictatedPlacement(
   let initialLeft: number | undefined
   let top = -Infinity
   for (const rect of selectedNodeRects) {
-    console.log('selected', rect)
     initialLeft ??= rect.left
     const newTop = rect.bottom + verticalGap
     if (newTop > top) top = newTop
@@ -101,7 +100,6 @@ export function previousNodeDictatedPlacement(
   const sortedNodeRects = Array.from(nodeRects).sort((a, b) => a.left - b.left)
   for (const rect of sortedNodeRects) {
     if (initialRect.intersectsY(rect) && rect.right + horizontalGap > left) {
-      console.log('?', initialRect, rect)
       if (rect.left - right() < horizontalGap) {
         left = rect.right + horizontalGap
       }

--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -81,7 +81,6 @@ function placementPositionForSelection() {
   const hasNodeSelected = nodeSelection.selected.size > 0
   if (!hasNodeSelected) return
   const gapBetweenNodes = 48.0
-  console.log('pn', placementEnvironment.value)
   return previousNodeDictatedPlacement(DEFAULT_NODE_SIZE, placementEnvironment.value, {
     horizontalGap: gapBetweenNodes,
     verticalGap: gapBetweenNodes,
@@ -231,7 +230,6 @@ const creatingNode: Interaction = {
     componentBrowserInputContent.value = ''
     componentBrowserSourcePort.value = sourcePortForSelection()
     componentBrowserPosition.value = targetComponentBrowserPosition()
-    console.log('...', componentBrowserPosition.value)
     componentBrowserVisible.value = true
   },
 }

--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -65,7 +65,7 @@ const interactionBindingsHandler = interactionBindings.handler({
 // or the node that is being edited when creating from a port double click.
 function environmentForNodes(nodeIds: IterableIterator<ExprId>): Environment {
   const nodeRects = [...graphStore.nodeRects.values()]
-  const selectedNodeRects: Iterable<Rect> = [...nodeIds]
+  const selectedNodeRects = [...nodeIds]
     .map((id) => graphStore.nodeRects.get(id))
     .filter((item): item is Rect => item !== undefined)
   const screenBounds = graphNavigator.viewport
@@ -73,16 +73,15 @@ function environmentForNodes(nodeIds: IterableIterator<ExprId>): Environment {
   return { nodeRects, selectedNodeRects, screenBounds, mousePosition } as Environment
 }
 
-const placementEnvironment = computed(() => {
-  return environmentForNodes(nodeSelection.selected.values())
-})
+const placementEnvironment = computed(() => environmentForNodes(nodeSelection.selected.values()))
 
-// Return the position for a new node, assuming there are currently nodes selected. If there are no nodes
-// selected, return undefined.
+/** Return the position for a new node, assuming there are currently nodes selected. If there are no nodes
+ * selected, return `undefined`. */
 function placementPositionForSelection() {
   const hasNodeSelected = nodeSelection.selected.size > 0
-  if (!hasNodeSelected) return undefined
+  if (!hasNodeSelected) return
   const gapBetweenNodes = 48.0
+  console.log('pn', placementEnvironment.value)
   return previousNodeDictatedPlacement(DEFAULT_NODE_SIZE, placementEnvironment.value, {
     horizontalGap: gapBetweenNodes,
     verticalGap: gapBetweenNodes,
@@ -98,12 +97,10 @@ function targetComponentBrowserPosition() {
     const targetPos = targetNode?.position ?? Vec2.Zero
     return targetPos.add(COMPONENT_BROWSER_TO_NODE_OFFSET)
   } else {
-    const targetPos = placementPositionForSelection()
-    if (targetPos != undefined) {
-      return targetPos
-    } else {
-      return mouseDictatedPlacement(DEFAULT_NODE_SIZE, placementEnvironment.value).position
-    }
+    return (
+      placementPositionForSelection() ??
+      mouseDictatedPlacement(DEFAULT_NODE_SIZE, placementEnvironment.value).position
+    )
   }
 }
 
@@ -234,6 +231,7 @@ const creatingNode: Interaction = {
     componentBrowserInputContent.value = ''
     componentBrowserSourcePort.value = sourcePortForSelection()
     componentBrowserPosition.value = targetComponentBrowserPosition()
+    console.log('...', componentBrowserPosition.value)
     componentBrowserVisible.value = true
   },
 }

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -275,7 +275,7 @@ function portGroupStyle(port: PortData) {
       :typename="expressionInfo?.typename"
       @setVisualizationId="emit('setVisualizationId', $event)"
       @setVisualizationVisible="emit('setVisualizationVisible', $event)"
-      @update:size="emit('update:vizRect', $event)"
+      @update:rect="emit('update:vizRect', $event)"
     />
     <div
       class="node"

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -27,6 +27,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   updateRect: [rect: Rect]
+  'update:vizRect': [rect: Rect | undefined]
   updateContent: [updates: [range: ContentRange, content: string][]]
   dragging: [offset: Vec2]
   draggingCommited: []
@@ -267,12 +268,14 @@ function portGroupStyle(port: PortData) {
     <GraphVisualization
       v-if="isVisualizationVisible"
       :nodeSize="nodeSize"
+      :nodePosition="props.node.position"
       :isCircularMenuVisible="menuVisible"
       :currentType="props.node.vis"
       :expressionId="props.node.rootSpan.astId"
       :typename="expressionInfo?.typename"
       @setVisualizationId="emit('setVisualizationId', $event)"
       @setVisualizationVisible="emit('setVisualizationVisible', $event)"
+      @update:size="emit('update:vizRect', $event)"
     />
     <div
       class="node"

--- a/app/gui2/src/components/GraphEditor/GraphNodes.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNodes.vue
@@ -55,6 +55,7 @@ const uploadingFiles = computed<[FileName, File][]>(() => {
     :edited="id === graphStore.editedNodeInfo?.id"
     @update:edited="graphStore.setEditedNode(id, $event)"
     @updateRect="graphStore.updateNodeRect(id, $event)"
+    @update:vizRect="graphStore.updateVizRect(id, $event)"
     @delete="graphStore.deleteNode"
     @pointerenter="hoverNode(id)"
     @pointerleave="hoverNode(undefined)"

--- a/app/gui2/src/components/VisualizationContainer.vue
+++ b/app/gui2/src/components/VisualizationContainer.vue
@@ -3,7 +3,7 @@ import SvgIcon from '@/components/SvgIcon.vue'
 import VisualizationSelector from '@/components/VisualizationSelector.vue'
 import { useVisualizationConfig } from '@/providers/visualizationConfig'
 import { PointerButtonMask, isClick, usePointer } from '@/util/events'
-import { ref } from 'vue'
+import { ref, watchEffect } from 'vue'
 
 const props = defineProps<{
   /** If true, the visualization should be `overflow: visible` instead of `overflow: hidden`. */
@@ -15,6 +15,8 @@ const props = defineProps<{
 }>()
 
 const config = useVisualizationConfig()
+
+watchEffect(() => (config.isBelowToolbar = props.belowToolbar))
 
 const isSelectorVisible = ref(false)
 

--- a/app/gui2/src/providers/visualizationConfig.ts
+++ b/app/gui2/src/providers/visualizationConfig.ts
@@ -13,8 +13,9 @@ export interface VisualizationConfig {
   readonly icon: Icon | URLString | undefined
   readonly isCircularMenuVisible: boolean
   readonly nodeSize: Vec2
+  isBelowToolbar: boolean
   width: number | null
-  height: number | null
+  height: number
   fullscreen: boolean
   hide: () => void
   updateType: (type: VisualizationIdentifier) => void

--- a/app/gui2/src/stores/graph/index.ts
+++ b/app/gui2/src/stores/graph/index.ts
@@ -296,7 +296,7 @@ export const useGraphStore = defineStore('graph', () => {
       const { position } = nonDictatedPlacement(rect.size, {
         nodeRects: [...nodeRects.entries()]
           .filter(([id]) => db.nodeIdToNode.get(id))
-          .map(([, rect]) => vizRects.get(id) ?? rect),
+          .map(([id, rect]) => vizRects.get(id) ?? rect),
         // The rest of the properties should not matter.
         selectedNodeRects: [],
         screenBounds: Rect.Zero,

--- a/app/gui2/src/stores/graph/index.ts
+++ b/app/gui2/src/stores/graph/index.ts
@@ -52,6 +52,7 @@ export const useGraphStore = defineStore('graph', () => {
     proj.computedValueRegistry,
   )
   const nodeRects = reactive(new Map<ExprId, Rect>())
+  const vizRects = reactive(new Map<ExprId, Rect>())
   const exprRects = reactive(new Map<ExprId, Rect>())
   const editedNodeInfo = ref<NodeEditInfo>()
   const imports = ref<{ import: Import; span: ContentRange }[]>([])
@@ -295,7 +296,7 @@ export const useGraphStore = defineStore('graph', () => {
       const { position } = nonDictatedPlacement(rect.size, {
         nodeRects: [...nodeRects.entries()]
           .filter(([id]) => db.nodeIdToNode.get(id))
-          .map(([, rect]) => rect),
+          .map(([, rect]) => vizRects.get(id) ?? rect),
         // The rest of the properties should not matter.
         selectedNodeRects: [],
         screenBounds: Rect.Zero,
@@ -306,6 +307,11 @@ export const useGraphStore = defineStore('graph', () => {
     } else {
       nodeRects.set(id, rect)
     }
+  }
+
+  function updateVizRect(id: ExprId, rect: Rect | undefined) {
+    if (rect) vizRects.set(id, rect)
+    else vizRects.delete(id)
   }
 
   function updateExprRect(id: ExprId, rect: Rect | undefined) {
@@ -338,6 +344,7 @@ export const useGraphStore = defineStore('graph', () => {
     unconnectedEdge,
     edges,
     nodeRects,
+    vizRects,
     exprRects,
     createEdgeFromOutput,
     disconnectSource,
@@ -353,6 +360,7 @@ export const useGraphStore = defineStore('graph', () => {
     setNodeVisualizationVisible,
     stopCapturingUndo,
     updateNodeRect,
+    updateVizRect,
     updateExprRect,
     setEditedNode,
     createNodeFromSource,

--- a/app/gui2/src/util/selection.ts
+++ b/app/gui2/src/util/selection.ts
@@ -109,7 +109,7 @@ export function useSelection<T>(
     overrideElemsToSelect.value = undefined
   }
 
-  const pointer = usePointer((pos, event, eventType) => {
+  const pointer = usePointer((_pos, event, eventType) => {
     if (eventType === 'start') {
       readInitiallySelected()
     } else if (pointer.dragging && anchor.value == null) {
@@ -120,6 +120,7 @@ export function useSelection<T>(
     }
     selectionEventHandler(event)
   })
+
   return proxyRefs({
     selected,
     anchor,


### PR DESCRIPTION
### Pull Request Description
- Closes #8368

### Important Notes
Could not repro the leftwards drift of new nodes. It is possible that this has already been fixed by another PR.

### Screenshots

Taken when zoomed in (indicating that it ignores zoom as expected):
![image](https://github.com/enso-org/enso/assets/4046547/25d7e606-7260-4aea-974f-ff809d4601b2)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
