### PR TITLE
400x faster with linear hashing of the hash map entries

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/HashCodeNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/HashCodeNode.java
@@ -55,6 +55,8 @@ import org.enso.interpreter.runtime.scope.ModuleScope;
 import org.enso.interpreter.runtime.state.State;
 import org.enso.polyglot.common_utils.Core_Text_Utils;
 
+import com.oracle.truffle.api.dsl.Fallback;
+
 /**
  * Implements {@code hash_code} functionality.
  *
@@ -628,6 +630,11 @@ public abstract class HashCodeNode extends Node {
       @Shared("interop") @CachedLibrary(limit = "10") InteropLibrary interop,
       @Shared("hashCodeNode") @Cached HashCodeNode hashCodeNode) {
     return hashCodeNode.execute(interop.toDisplayString(hostFunction));
+  }
+
+  @Fallback
+  long fallbackConstant(Object any) {
+    return 5343210;
   }
 
   static boolean isAtom(Object object) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMap.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMap.java
@@ -106,8 +106,8 @@ public final class EnsoHashMap implements EnsoObject {
       Object key,
       @Shared("hash") @Cached HashCodeNode hashCodeNode,
       @Shared("equals") @Cached EqualsNode equalsNode) {
-    var entry = mapBuilder.get(key, hashCodeNode, equalsNode);
-    return entry != null && entry.isVisible(generation);
+    var entry = mapBuilder.get(key, generation, hashCodeNode, equalsNode);
+    return entry != null;
   }
 
   @ExportMessage
@@ -124,8 +124,8 @@ public final class EnsoHashMap implements EnsoObject {
       @Shared("hash") @Cached HashCodeNode hashCodeNode,
       @Shared("equals") @Cached EqualsNode equalsNode)
       throws UnknownKeyException {
-    StorageEntry entry = mapBuilder.get(key, hashCodeNode, equalsNode);
-    if (entry != null && entry.isVisible(generation)) {
+    StorageEntry entry = mapBuilder.get(key, generation, hashCodeNode, equalsNode);
+    if (entry != null) {
       return entry.value();
     } else {
       throw UnknownKeyException.create(key);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMap.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMap.java
@@ -37,35 +37,31 @@ import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 @Builtin(stdlibName = "Standard.Base.Data.Map.Map", name = "Map")
 public final class EnsoHashMap implements EnsoObject {
   private final EnsoHashMapBuilder mapBuilder;
-  /**
-   * Size of this Map. Basically an index into {@link EnsoHashMapBuilder}'s storage. See {@link
-   * #isEntryInThisMap(StorageEntry)}.
-   */
   private final int generation;
+  private final int size;
 
   private Object cachedVectorRepresentation;
 
-  private EnsoHashMap(EnsoHashMapBuilder mapBuilder, int generation) {
+  private EnsoHashMap(EnsoHashMapBuilder mapBuilder) {
     this.mapBuilder = mapBuilder;
-    this.generation = generation;
-    assert generation <= mapBuilder.generation();
+    this.generation = mapBuilder.generation();
+    this.size = mapBuilder.size();
   }
 
-  static EnsoHashMap createWithBuilder(EnsoHashMapBuilder mapBuilder, int snapshotSize) {
-    return new EnsoHashMap(mapBuilder, snapshotSize);
+  static EnsoHashMap createWithBuilder(EnsoHashMapBuilder mapBuilder) {
+    return new EnsoHashMap(mapBuilder);
   }
 
   static EnsoHashMap createEmpty() {
-    return new EnsoHashMap(EnsoHashMapBuilder.create(), 0);
+    return new EnsoHashMap(EnsoHashMapBuilder.create());
   }
 
-  EnsoHashMapBuilder getMapBuilder(boolean readOnly) {
+  EnsoHashMapBuilder getMapBuilder(
+      boolean readOnly, HashCodeNode hashCodeNode, EqualsNode equalsNode) {
     if (readOnly) {
       return mapBuilder;
     } else {
-      return mapBuilder.generation() == generation
-          ? mapBuilder
-          : mapBuilder.duplicatePartial(generation);
+      return mapBuilder.asModifiable(generation, hashCodeNode, equalsNode);
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMap.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMap.java
@@ -98,7 +98,7 @@ public final class EnsoHashMap implements EnsoObject {
 
   @ExportMessage
   int getHashSize() {
-    return generation;
+    return size;
   }
 
   @ExportMessage

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMap.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMap.java
@@ -1,6 +1,5 @@
 package org.enso.interpreter.runtime.data.hash;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Cached.Shared;
@@ -11,7 +10,6 @@ import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.profiles.ConditionProfile;
-import java.util.ArrayList;
 import org.enso.interpreter.dsl.Builtin;
 import org.enso.interpreter.node.expression.builtin.meta.EqualsNode;
 import org.enso.interpreter.node.expression.builtin.meta.HashCodeNode;
@@ -71,18 +69,18 @@ public final class EnsoHashMap implements EnsoObject {
 
   Object getCachedVectorRepresentation(ConditionProfile isNotCachedProfile) {
     if (isNotCachedProfile.profile(cachedVectorRepresentation == null)) {
-      CompilerDirectives.transferToInterpreter();
-      var keys = new ArrayList<Object>();
-      var values = new ArrayList<Object>();
+      var keys = new Object[size];
+      var values = new Object[size];
+      var at = 0;
       for (var entry : mapBuilder) {
         if (entry.isVisible(generation)) {
-          keys.add(entry.key());
-          values.add(entry.value());
+          keys[at] = entry.key();
+          values[at] = entry.value();
+          at++;
         }
       }
-      cachedVectorRepresentation =
-          ArrayLikeHelpers.asVectorFromArray(
-              HashEntriesVector.createFromKeysAndValues(keys.toArray(), values.toArray()));
+      var pairs = HashEntriesVector.createFromKeysAndValues(keys, values);
+      cachedVectorRepresentation = ArrayLikeHelpers.asVectorFromArray(pairs);
     }
     return cachedVectorRepresentation;
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMap.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMap.java
@@ -17,7 +17,9 @@ import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.data.EnsoObject;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.data.hash.EnsoHashMapBuilder.StorageEntry;
+import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.data.vector.ArrayLikeHelpers;
+import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 
 /**
@@ -135,7 +137,7 @@ public final class EnsoHashMap implements EnsoObject {
     try {
       return interop.getIterator(getCachedVectorRepresentation());
     } catch (UnsupportedMessageException e) {
-      throw new IllegalStateException(e);
+      throw new PanicException(Text.create(e.getMessage()), interop);
     }
   }
 
@@ -197,7 +199,7 @@ public final class EnsoHashMap implements EnsoObject {
         keyStr = interop.asString(interop.toDisplayString(entry.key()));
         valStr = interop.asString(interop.toDisplayString(entry.value()));
       } catch (UnsupportedMessageException e) {
-        throw new IllegalStateException("Unreachable", e);
+        throw new PanicException(Text.create(e.getMessage()), interop);
       }
     } else {
       keyStr = entry.key().toString();

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMap.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMap.java
@@ -72,12 +72,10 @@ public final class EnsoHashMap implements EnsoObject {
       var keys = new Object[size];
       var values = new Object[size];
       var at = 0;
-      for (var entry : mapBuilder) {
-        if (entry.isVisible(generation)) {
-          keys[at] = entry.key();
-          values[at] = entry.value();
-          at++;
-        }
+      for (var entry : mapBuilder.getEntries(generation, size)) {
+        keys[at] = entry.key();
+        values[at] = entry.value();
+        at++;
       }
       var pairs = HashEntriesVector.createFromKeysAndValues(keys, values);
       cachedVectorRepresentation = ArrayLikeHelpers.asVectorFromArray(pairs);
@@ -178,11 +176,9 @@ public final class EnsoHashMap implements EnsoObject {
     var sb = new StringBuilder();
     sb.append("{");
     boolean empty = true;
-    for (StorageEntry entry : mapBuilder) {
-      if (entry.isVisible(generation)) {
-        empty = false;
-        sb.append(entryToString(entry, useInterop)).append(", ");
-      }
+    for (StorageEntry entry : mapBuilder.getEntries(generation, size)) {
+      empty = false;
+      sb.append(entryToString(entry, useInterop)).append(", ");
     }
     if (!empty) {
       // Delete last comma

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMapBuilder.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMapBuilder.java
@@ -193,7 +193,9 @@ public final class EnsoHashMapBuilder implements Iterable<EnsoHashMapBuilder.Sto
   private EnsoHashMapBuilder rehash(int size, HashCodeNode hashCodeNode, EqualsNode equalsNode) {
     var newBuilder = new EnsoHashMapBuilder(size);
     for (var entry : this) {
-      newBuilder.addImpl(entry.key(), entry.value(), hashCodeNode, equalsNode);
+      if (entry.isVisible(generation)) {
+        newBuilder.addImpl(entry.key(), entry.value(), hashCodeNode, equalsNode);
+      }
     }
     return newBuilder;
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMapBuilder.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMapBuilder.java
@@ -20,7 +20,7 @@ final class EnsoHashMapBuilder {
   * operations just add new entries into it using <em>linear hashing</em>.
   */
   private final StorageEntry[] byHash;
-  /** number of entries in the {@coede byHash} array. With every change to the builder,
+/** number of entries in the {@code byHash} array. With every change to the builder,
   * the generation increases by one. Once the generation reaches 75% of {@code byHash.length}
   * it is time to <em>rehash</em> into new builder.
   */

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMapBuilder.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMapBuilder.java
@@ -127,9 +127,11 @@ final class EnsoHashMapBuilder implements Iterable<EnsoHashMapBuilder.StorageEnt
     throw CompilerDirectives.shouldNotReachHere("byHash array is full!");
   }
 
-  /** Finds storage entry for given key or null */
+  /** Finds storage entry for given key or {@code null}.
+   * Searches only entries that are visible for given {@code generation}.
+   */
   public StorageEntry get(
-    Object key,
+    Object key, int generation,
     HashCodeNode hashCodeNode, EqualsNode equalsNode
   ) {
     var at = findWhereToStart(key, hashCodeNode);
@@ -137,8 +139,10 @@ final class EnsoHashMapBuilder implements Iterable<EnsoHashMapBuilder.StorageEnt
       if (byHash[at] == null) {
         return null;
       }
-      if (compare(equalsNode, key, byHash[at].key())) {
-        return byHash[at];
+      if (byHash[at].isVisible(generation)) {
+        if (compare(equalsNode, key, byHash[at].key())) {
+          return byHash[at];
+        }
       }
       if (++at == byHash.length) {
         at = 0;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMapBuilder.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMapBuilder.java
@@ -113,7 +113,7 @@ final class EnsoHashMapBuilder implements Iterable<EnsoHashMapBuilder.StorageEnt
         byHash[at] = new StorageEntry(key, value, nextGeneration);
         return;
       }
-      if (equalsNode.execute(byHash[at].key(), key)) {
+      if (compare(equalsNode, byHash[at].key(), key)) {
         var invalidatedEntry = byHash[at].markRemoved(nextGeneration);
         if (invalidatedEntry != byHash[at]) {
           byHash[at] = invalidatedEntry;
@@ -137,7 +137,7 @@ final class EnsoHashMapBuilder implements Iterable<EnsoHashMapBuilder.StorageEnt
       if (byHash[at] == null) {
         return null;
       }
-      if (equalsNode.execute(key, byHash[at].key())) {
+      if (compare(equalsNode, key, byHash[at].key())) {
         return byHash[at];
       }
       if (++at == byHash.length) {
@@ -170,7 +170,7 @@ final class EnsoHashMapBuilder implements Iterable<EnsoHashMapBuilder.StorageEnt
       if (byHash[at] == null) {
         return false;
       }
-      if (equalsNode.execute(key, byHash[at].key())) {
+      if (compare(equalsNode, key, byHash[at].key())) {
         var invalidatedEntry = byHash[at].markRemoved(nextGeneration);
         if (invalidatedEntry != byHash[at]) {
           byHash[at] = invalidatedEntry;
@@ -215,6 +215,14 @@ final class EnsoHashMapBuilder implements Iterable<EnsoHashMapBuilder.StorageEnt
   @Override
   public String toString() {
     return "EnsoHashMapBuilder{size = " + generation + ", storage = " + Arrays.toString(byHash) + "}";
+  }
+
+  private static boolean compare(EqualsNode equalsNode, Object a, Object b) {
+    if (a instanceof Double aDbl && b instanceof Double bDbl && aDbl.isNaN() && bDbl.isNaN()) {
+      return true;
+    } else {
+      return equalsNode.execute(a, b);
+    }
   }
 
   record StorageEntry(

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMapBuilder.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMapBuilder.java
@@ -238,11 +238,11 @@ final class EnsoHashMapBuilder {
     Object key,
     Object value,
     /**
-    * A sequential index of the entry within this map. {@link EnsoHashMap} uses it for checking
+    * A generation the entry got into this map. {@link EnsoHashMap} uses it for checking
     * whether a certain key belongs in that map.
     */
     int added,
-    /** Remove at */
+    /** Remove at a generation. */
     int removed
   ) {
     StorageEntry(Object key, Object value, int added) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMapBuilder.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMapBuilder.java
@@ -11,7 +11,7 @@ import com.oracle.truffle.api.CompilerDirectives;
  * A storage for a {@link EnsoHashMap}. For one builder, there may be many
  * {@link EnsoHashMap} instances that serve as a snapshot.
  *
- * There should be where most one snapshot for a given generation. All the snapshots should
+ * There should be at most one snapshot for a given generation. All the snapshots should
  have generation smaller than this builder generation.
  */
 final class EnsoHashMapBuilder {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMapBuilder.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/EnsoHashMapBuilder.java
@@ -1,72 +1,57 @@
 package org.enso.interpreter.runtime.data.hash;
 
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.stream.Stream;
+
 import org.enso.interpreter.node.expression.builtin.meta.EqualsNode;
 import org.enso.interpreter.node.expression.builtin.meta.HashCodeNode;
-import org.graalvm.collections.EconomicMap;
-import org.graalvm.collections.Equivalence;
 
 /**
  * A storage for a {@link EnsoHashMap}. For one builder, there may be many snapshots ({@link
- * EnsoHashMap}). There should be at most one snapshot for a given size. All the snapshots should
- * have size smaller than this builder size.
+ * EnsoHashMap}). There should be where most one snapshot for a given generation. All the snapshots should
+ have generation smaller than this builder generation.
  */
-public final class EnsoHashMapBuilder {
-  private final EconomicMap<Object, StorageEntry> storage;
-  /** All entries stored by their sequential index. */
-  private final List<StorageEntry> sequentialEntries;
-
-  private final HashCodeNode hashCodeNode;
-  private final EqualsNode equalsNode;
+public final class EnsoHashMapBuilder implements Iterable<EnsoHashMapBuilder.StorageEntry> {
+  private final StorageEntry[] byHash;
+  private int generation;
   private int size;
 
-  private EnsoHashMapBuilder(HashCodeNode hashCodeNode, EqualsNode equalsNode) {
-    this.storage = EconomicMap.create(new StorageStrategy(equalsNode, hashCodeNode));
-    this.sequentialEntries = new ArrayList<>();
-    this.hashCodeNode = hashCodeNode;
-    this.equalsNode = equalsNode;
+  private EnsoHashMapBuilder(int initialCapacity) {
+    this.byHash = new StorageEntry[initialCapacity];
   }
 
-  private EnsoHashMapBuilder(EnsoHashMapBuilder other, int numEntries) {
-    assert 0 < numEntries && numEntries <= other.size;
-    this.storage = EconomicMap.create(new StorageStrategy(other.equalsNode, other.hashCodeNode));
-    var entriesToBeDuplicated = other.sequentialEntries.subList(0, numEntries);
-    this.sequentialEntries = new ArrayList<>(entriesToBeDuplicated);
-    entriesToBeDuplicated.forEach(entry -> this.storage.put(entry.key, entry));
-    this.hashCodeNode = other.hashCodeNode;
-    this.equalsNode = other.equalsNode;
-    this.size = numEntries;
+  private EnsoHashMapBuilder(EnsoHashMapBuilder other, int generation) {
+    assert 0 < generation && generation <= other.generation;
+    this.byHash = other.byHash.clone();
+    this.generation = 0;
+    for (var i = 0; i < byHash.length; i++) {
+      if (byHash[i] != null) {
+        if (byHash[i].added() > generation || byHash[i].removed() <= generation) {
+          byHash[i] = null;
+        }
+      }
+      if (byHash[i] != null) {
+        this.generation++;
+      }
+    }
   }
 
   private EnsoHashMapBuilder(EnsoHashMapBuilder other) {
-    this.storage =
-        EconomicMap.create(
-            new StorageStrategy(other.equalsNode, other.hashCodeNode), other.storage);
-    this.sequentialEntries = new ArrayList<>(other.sequentialEntries);
-    this.hashCodeNode = other.hashCodeNode;
-    this.equalsNode = other.equalsNode;
-    this.size = other.size;
+    this.byHash = other.byHash.clone();
+    this.generation = other.generation;
   }
 
   /**
    * Create a new builder with stored nodes.
-   *
-   * @param hashCodeNode Node that will be stored in the storage for invoking `hash_code` on keys.
-   * @param equalsNode Node that will be stored in the storage for invoking `==` on keys.
    */
-  public static EnsoHashMapBuilder create(HashCodeNode hashCodeNode, EqualsNode equalsNode) {
-    return new EnsoHashMapBuilder(hashCodeNode, equalsNode);
+  public static EnsoHashMapBuilder create() {
+    return new EnsoHashMapBuilder(11);
   }
 
   /** Returns count of elements in the storage. */
-  public int getSize() {
-    return size;
-  }
-
-  public EconomicMap<Object, StorageEntry> getStorage() {
-    return storage;
+  public int generation() {
+    return generation;
   }
 
   /**
@@ -79,30 +64,85 @@ public final class EnsoHashMapBuilder {
   }
 
   /** Duplicates this builder with all its entries. */
-  @TruffleBoundary
   public EnsoHashMapBuilder duplicate() {
     return new EnsoHashMapBuilder(this);
   }
 
+  @Override
+  public Iterator<StorageEntry> iterator() {
+    return Stream.of(byHash).filter((e) -> e != null).iterator();
+  }
+
   /** Adds a key-value mapping, overriding any existing value. */
-  @TruffleBoundary(allowInlining = true)
-  public void add(Object key, Object value) {
-    var oldEntry = storage.get(key);
-    int newEntryIndex = oldEntry != null ? oldEntry.index : size;
-    var newEntry = new StorageEntry(key, value, newEntryIndex);
-    storage.put(key, newEntry);
-    if (oldEntry == null) {
-      assert newEntry.index == size;
-      sequentialEntries.add(newEntry);
-      size++;
+  public EnsoHashMapBuilder put(
+    Object key, Object value,
+    HashCodeNode hashCodeNode, EqualsNode equalsNode
+  ) {
+    if (generation * 4 > byHash.length * 3) {
+      var newBuilder = rehash(byHash.length * 2, hashCodeNode, equalsNode);
+      newBuilder.addImpl(key, value, hashCodeNode, equalsNode);
+      return newBuilder;
     } else {
-      sequentialEntries.set(newEntryIndex, newEntry);
+      this.addImpl(key, value, hashCodeNode, equalsNode);
+      return this;
     }
   }
 
-  @TruffleBoundary(allowInlining = true)
-  public StorageEntry get(Object key) {
-    return storage.get(key);
+  private void addImpl(
+    Object key, Object value,
+    HashCodeNode hashCodeNode, EqualsNode equalsNode
+  ) {
+    var where = new int[] { -1 };
+    var exists = find(key, where, hashCodeNode, equalsNode);
+    var at = where[0];
+    var nextGeneration = ++generation;
+    if (exists != null) {
+      for (var i = 0; i < byHash.length; i++) {
+        if (byHash[at] == null) {
+          break;
+        }
+        if (equalsNode.execute(byHash[at].key(), key)) {
+          byHash[at] = byHash[at].markRemoved(nextGeneration);
+        }
+        if (++at == byHash.length) {
+          at = 0;
+        }
+      }
+    }
+    byHash[at] = new StorageEntry(key, value, nextGeneration);
+  }
+
+  public StorageEntry get(
+    Object key,
+    HashCodeNode hashCodeNode, EqualsNode equalsNode
+  ) {
+    return find(key, null, hashCodeNode, equalsNode);
+  }
+
+  private StorageEntry find(
+    Object key, int[] where,
+    HashCodeNode hashCodeNode, EqualsNode equalsNode
+  ) {
+    var hash = Math.abs(hashCodeNode.execute(key));
+    var at = (int) (hash % byHash.length);
+    for (var i = 0; i < byHash.length; i++) {
+      if (byHash[at] == null) {
+        if (where != null) {
+          where[0] = at;
+        }
+        return null;
+      }
+      if (equalsNode.execute(key, byHash[at].key())) {
+        if (where != null) {
+          where[0] = at;
+        }
+        return byHash[at];
+      }
+      if (++at == byHash.length) {
+        at = 0;
+      }
+    }
+    return null;
   }
 
   /**
@@ -111,83 +151,79 @@ public final class EnsoHashMapBuilder {
    * @return true if the removal was successful, i.e., the key was in the map and was removed, false
    *     otherwise.
    */
-  @TruffleBoundary
-  public boolean remove(Object key) {
-    var oldEntry = storage.removeKey(key);
-    if (oldEntry == null) {
+  public boolean remove(
+    Object key,
+    HashCodeNode hashCodeNode, EqualsNode equalsNode
+  ) {
+    var at = new int[] { -1 };
+    var entry = find(key, at, hashCodeNode, equalsNode);
+    if (entry == null) {
       return false;
     } else {
-      sequentialEntries.remove(oldEntry.index);
-      // Rewrite rest of the sequentialEntries list and repair indexes in storage
-      for (int i = oldEntry.index; i < sequentialEntries.size(); i++) {
-        var entry = sequentialEntries.get(i);
-        StorageEntry newEntry = new StorageEntry(entry.key, entry.value, i);
-        sequentialEntries.set(i, newEntry);
-        storage.put(newEntry.key, newEntry);
-      }
-      size--;
+      byHash[at[0]] = entry.markRemoved(generation++);
       return true;
     }
   }
 
-  @TruffleBoundary(allowInlining = true)
-  public boolean containsKey(Object key) {
-    return storage.containsKey(key);
+  public boolean containsKey(
+    Object key,
+    HashCodeNode hashCodeNode, EqualsNode equalsNode
+  ) {
+    return find(key, null, hashCodeNode, equalsNode) != null;
   }
 
   /**
    * Creates a snapshot with the current size. The created snapshot contains all the entries that
    * are in the storage as of this moment, i.e., all the entries with their indexes lesser than
-   * {@code size}.
+   * {@code generation}.
    *
-   * <p>Should be called at most once for a particular {@code size}.
+   * <p>Should be called where most once for a particular {@code generation}.
    *
    * @return A new hash map snapshot.
    */
   public EnsoHashMap build() {
-    return EnsoHashMap.createWithBuilder(this, size);
+    return EnsoHashMap.createWithBuilder(this, generation);
   }
 
   @Override
   public String toString() {
-    return "EnsoHashMapBuilder{size = " + size + ", storage = " + storage + "}";
+    return "EnsoHashMapBuilder{size = " + generation + ", storage = " + Arrays.toString(byHash) + "}";
+  }
+
+  private EnsoHashMapBuilder rehash(int size, HashCodeNode hashCodeNode, EqualsNode equalsNode) {
+    var newBuilder = new EnsoHashMapBuilder(size);
+    for (var entry : this) {
+      newBuilder.addImpl(entry.key(), entry.value(), hashCodeNode, equalsNode);
+    }
+    return newBuilder;
   }
 
   record StorageEntry(
-      Object key,
-      Object value,
-      /**
-       * A sequential index of the entry within this map. {@link EnsoHashMap} uses it for checking
-       * whether a certain key belongs in that map.
-       */
-      int index) {}
-
-  /**
-   * Custom {@link Equivalence} used for the {@link EconomicMap} that delegates {@code equals} to
-   * {@link EqualsNode} and {@code hash_code} to {@link HashCodeNode}.
-   */
-  private static final class StorageStrategy extends Equivalence {
-    private final EqualsNode equalsNode;
-    private final HashCodeNode hashCodeNode;
-
-    private StorageStrategy(EqualsNode equalsNode, HashCodeNode hashCodeNode) {
-      this.equalsNode = equalsNode;
-      this.hashCodeNode = hashCodeNode;
+    Object key,
+    Object value,
+    /**
+    * A sequential index of the entry within this map. {@link EnsoHashMap} uses it for checking
+    * whether a certain key belongs in that map.
+    */
+    int added,
+    /** Remove at */
+    int removed
+  ) {
+    StorageEntry(Object key, Object value, int added) {
+      this(key, value, added, Integer.MAX_VALUE);
     }
 
-    @Override
-    public boolean equals(Object a, Object b) {
-      // Special handling for NaN added as a key inside a map.
-      if (a instanceof Double aDbl && b instanceof Double bDbl && aDbl.isNaN() && bDbl.isNaN()) {
-        return true;
+    boolean isVisible(int generation) {
+      return added() <= generation && generation < removed();
+    }
+
+    StorageEntry markRemoved(int when) {
+      if (removed() <= when) {
+        return this;
       } else {
-        return Boolean.TRUE.equals(equalsNode.execute(a, b));
+        return new StorageEntry(key(), value(), added(), when);
       }
     }
-
-    @Override
-    public int hashCode(Object o) {
-      return (int) hashCodeNode.execute(o);
-    }
   }
+
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/HashMapInsertNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/HashMapInsertNode.java
@@ -3,7 +3,10 @@ package org.enso.interpreter.runtime.data.hash;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.meta.EqualsNode;
 import org.enso.interpreter.node.expression.builtin.meta.HashCodeNode;
+import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.error.PanicException;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Cached.Shared;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -63,10 +66,9 @@ public abstract class HashMapInsertNode extends Node {
         mapBuilder.put(key, value, hashCodeNode, equalsNode);
       }
     } catch (UnsupportedMessageException | StopIterationException | InvalidArrayIndexException e) {
-      throw new IllegalStateException(
-          "Polyglot hash map " + foreignMap + " has wrongly specified Interop API (hash entries iterator)",
-          e
-      );
+      CompilerDirectives.transferToInterpreter();
+      var msg = "Polyglot hash map " + foreignMap + " has wrongly specified Interop API (hash entries iterator)";
+      throw new PanicException(Text.create(msg), this);
     }
     mapBuilder = mapBuilder.asModifiable(mapBuilder.generation(), hashCodeNode, equalsNode);
     mapBuilder.put(keyToInsert, valueToInsert, hashCodeNode, equalsNode);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/HashMapRemoveNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/HashMapRemoveNode.java
@@ -3,7 +3,9 @@ package org.enso.interpreter.runtime.data.hash;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.expression.builtin.meta.EqualsNode;
 import org.enso.interpreter.node.expression.builtin.meta.HashCodeNode;
+import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.error.DataflowError;
+import org.enso.interpreter.runtime.error.PanicException;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Cached;
@@ -65,7 +67,8 @@ public abstract class HashMapRemoveNode extends Node {
         Object key = interop.readArrayElement(keyValueArr, 0);
         if ((boolean) equalsNode.execute(keyToRemove, key)) {
           if (keyToRemoveFound) {
-            throw new IllegalStateException("Key " + key + " found twice");
+            CompilerDirectives.transferToInterpreter();
+            throw new PanicException(Text.create("Key " + key + " found twice"), this);
           } else {
             keyToRemoveFound = true;
           }
@@ -76,10 +79,9 @@ public abstract class HashMapRemoveNode extends Node {
         }
       }
     } catch (UnsupportedMessageException | StopIterationException | InvalidArrayIndexException e) {
-      throw new IllegalStateException(
-          "Polyglot hash map " + map + " has wrongly specified Interop API (hash entries iterator)",
-          e
-      );
+      CompilerDirectives.transferToInterpreter();
+      var msg = "Polyglot hash map " + map + " has wrongly specified Interop API (hash entries iterator)";
+      throw new PanicException(Text.create(msg), this);
     }
     if (keyToRemoveFound) {
       return EnsoHashMap.createWithBuilder(mapBuilder);

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/HashMapSizeNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/HashMapSizeNode.java
@@ -8,6 +8,8 @@ import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.error.PanicException;
 
 @BuiltinMethod(
     type = "Map",
@@ -28,7 +30,7 @@ public abstract class HashMapSizeNode extends Node {
     try {
       return interop.getHashSize(hashMap);
     } catch (UnsupportedMessageException e) {
-      throw new IllegalStateException(e);
+      throw new PanicException(Text.create(e.getMessage()), this);
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/HashMapToTextNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/HashMapToTextNode.java
@@ -8,7 +8,12 @@ import com.oracle.truffle.api.interop.StopIterationException;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
+
 import org.enso.interpreter.dsl.BuiltinMethod;
+import org.enso.interpreter.runtime.data.text.Text;
+import org.enso.interpreter.runtime.error.PanicException;
+
+import com.oracle.truffle.api.CompilerDirectives;
 
 @BuiltinMethod(
     type = "Map",
@@ -45,10 +50,9 @@ public abstract class HashMapToTextNode extends Node {
         sb.delete(sb.length() - 2, sb.length());
       }
     } catch (UnsupportedMessageException | StopIterationException | InvalidArrayIndexException e) {
-      throw new IllegalStateException(
-          "hashMap " + hashMap + " probably implements interop API incorrectly",
-          e
-      );
+      CompilerDirectives.transferToInterpreter();
+      var msg = "hashMap " + hashMap + " probably implements interop API incorrectly";
+      throw new PanicException(Text.create(msg), this);
     }
     sb.append("}");
     return sb.toString();

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/HashMapToVectorNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/hash/HashMapToVectorNode.java
@@ -42,6 +42,12 @@ public abstract class HashMapToVectorNode extends Node {
     return hashMap.getCachedVectorRepresentation(vectorReprNotCachedProfile);
   }
 
+  @Specialization(guards = "mapInterop.hasHashEntries(hashMap)", limit = "3")
+  Object foreignMapToVector(Object hashMap,
+      @CachedLibrary("hashMap") InteropLibrary mapInterop,
+      @CachedLibrary(limit = "3") InteropLibrary iteratorInterop) {
+    return createEntriesVectorFromForeignMap(hashMap, mapInterop, iteratorInterop);
+  }
 
   @Fallback
   Object fallback(Object object) {

--- a/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
@@ -425,7 +425,7 @@ spec setup =
             t2.should_fail_with Ambiguous_Column_Rename
             err = t2.catch
             err.column_name . should_equal "alpha"
-            err.new_names . should_equal ["StartsWithA", "EndsWithA"]
+            err.new_names . sort . should_equal ["EndsWithA", "StartsWithA"]
 
             t3 = table_builder [["aaa", [1]], ["bbb", [2]]]
             ## The rename patterns are deliberately prepared so that both will
@@ -459,7 +459,7 @@ spec setup =
         Test.specify "should correctly handle problems: duplicate names" <|
             map = ["Test", "Test", "Test", "Test"]
             action = table.rename_columns map on_problems=_
-            tester = expect_column_names ["Test", "Test 1", "Test 2", "Test 3"]
+            tester = expect_column_names ["Test 1", "Test 2", "Test 3", "Test"]
             problems = [Duplicate_Output_Column_Names.Error ["Test", "Test", "Test"]]
             Problems.test_problem_handling action problems tester
 

--- a/test/Tests/src/Data/Map_Spec.enso
+++ b/test/Tests/src/Data/Map_Spec.enso
@@ -264,7 +264,7 @@ spec =
 
         Test.specify "should convert the whole map to a vector" <|
             m = Map.empty . insert 0 0 . insert 3 -5 . insert 1 2
-            m.to_vector.should_equal [[0, 0], [3, -5], [1, 2]]
+            m.to_vector.sort on=_.first . should_equal [[0, 0], [1, 2], [3, -5]]
 
         Test.specify "should allow building the map from two vectors" <|
             expected = Map.empty . insert 0 0 . insert 3 -5 . insert 1 2
@@ -300,7 +300,9 @@ spec =
 
         Test.specify "should define a well-defined text conversion" <|
             m = Map.empty . insert 0 0 . insert 3 -5 . insert 1 2
-            m.to_text . should_equal "{0=0, 3=-5, 1=2}"
+            m.to_text . should_contain "0=0"
+            m.to_text . should_contain "3=-5"
+            m.to_text . should_contain "1=2"
 
         Test.specify "should define structural equality" <|
             map_1 = Map.empty . insert "1" 2 . insert "2" "1"
@@ -564,7 +566,7 @@ spec =
             js_dict = js_dict_from_vec ["A", 1, "B", 2]
             map = js_dict.insert "C" 3
             js_dict.to_vector.should_equal [["A", 1], ["B", 2]]
-            map.to_vector.should_equal [["A", 1], ["B", 2], ["C", 3]]
+            map.to_vector.sort on=_.first . should_equal [["A", 1], ["B", 2], ["C", 3]]
 
         Test.specify "should treat Java Map as Enso map" <|
             sort_by_keys vec = vec.sort by=x-> y-> Ordering.compare x.first y.first

--- a/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
+++ b/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
@@ -107,7 +107,7 @@ spec =
             data = json.get 'data'
             data.should_be_a Vector
             data.length . should_equal 10
-            (data.take (First 3)).to_text . should_equal '[{"x":0,"y":225}, {"x":29,"y":196}, {"x":15,"y":0}]'
+            (data.take (First 3) . sort on=(_.get "x")).to_text . should_equal '[{"x":0,"y":225}, {"x":15,"y":0}, {"x":29,"y":196}]'
 
         Test.specify "filter the elements" <|
             vector = [0,10,20,30]


### PR DESCRIPTION
### Pull Request Description

Fixes #5233 by removing `EconomicMap` & co. and using plain old good _linear hashing_. Fixes #8090 by introducing `StorageEntry.removed()` rather than copying the builder on each removal.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests continue to pass
  - [x] Check the effect on [benchmarks](https://github.com/enso-org/enso/actions/runs/7037249862)
