### PR TITLE
Part II of making sure that tests clean up after each run

### DIFF
--- a/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/IncrementalUpdatesTest.java
+++ b/engine/runtime-with-instruments/src/test/java/org/enso/interpreter/test/instrument/IncrementalUpdatesTest.java
@@ -33,6 +33,8 @@ import org.enso.text.editing.model;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import scala.Option;
@@ -54,12 +56,18 @@ public class IncrementalUpdatesTest {
   public void initializeContext() {
     RuntimeServerTest t = new RuntimeServerTest();
     context = t.new TestContext("Test");
+    context.init();
     var initResponse = context.receive().get();
     assertEquals(Response(new Runtime$Api$InitializedNotification()), initResponse);
     var engine = context.executionContext().context().getEngine();
     var instr = engine.getInstruments().get(NodeCountingTestInstrument.INSTRUMENT_ID);
     assertNotNull("NodeCountingTestInstrument found", instr);
     nodeCountingInstrument = instr.lookup(NodeCountingTestInstrument.class);
+  }
+
+  @After
+  public void teardownContext() {
+    context.close();
   }
 
   @Test

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/BuiltinTypesTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/BuiltinTypesTest.scala
@@ -1,10 +1,7 @@
 package org.enso.interpreter.test.instrument
 
-import org.apache.commons.io.FileUtils
-import org.enso.distribution.locking.ThreadSafeFileLockManager
 import org.enso.interpreter.runtime.`type`.ConstantsGen
 import org.enso.interpreter.test.Metadata
-import org.enso.pkg.{Package, PackageManager}
 import org.enso.polyglot._
 import org.enso.polyglot.runtime.Runtime.Api
 import org.graalvm.polyglot.Context
@@ -13,11 +10,9 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.io.{ByteArrayOutputStream, File}
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.{Files, Paths}
 import java.util.UUID
 import java.util.logging.Level
-import scala.concurrent.Await
-import scala.concurrent.duration._
 
 @scala.annotation.nowarn("msg=multiarg infix syntax")
 class BuiltinTypesTest
@@ -29,17 +24,10 @@ class BuiltinTypesTest
 
   var context: TestContext = _
 
-  class TestContext(packageName: String) extends InstrumentTestContext {
-
-    val tmpDir: Path = Files.createTempDirectory("enso-test-packages")
-    val lockManager  = new ThreadSafeFileLockManager(tmpDir.resolve("locks"))
-    val runtimeServerEmulator =
-      new RuntimeServerEmulator(messageQueue, lockManager)
-
-    val pkg: Package[File] =
-      PackageManager.Default.create(tmpDir.toFile, packageName, "Enso_Test")
+  class TestContext(packageName: String)
+      extends InstrumentTestContext(packageName) {
     val out: ByteArrayOutputStream = new ByteArrayOutputStream()
-    val executionContext = new PolyglotContext(
+    val context =
       Context
         .newBuilder(LanguageInfo.ID)
         .allowExperimentalOptions(true)
@@ -68,8 +56,6 @@ class BuiltinTypesTest
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()
-    )
-    executionContext.context.initialize(LanguageInfo.ID)
 
     def writeMain(contents: String): File =
       Files.write(pkg.mainFile.toPath, contents.getBytes).toFile
@@ -96,16 +82,13 @@ class BuiltinTypesTest
 
   override protected def beforeEach(): Unit = {
     context = new TestContext("Test")
+    context.init()
     val Some(Api.Response(_, Api.InitializedNotification())) = context.receive
   }
   override protected def afterEach(): Unit = {
     if (context != null) {
-      context.reset()
-      context.executionContext.context.close()
-      Await.ready(context.runtimeServerEmulator.terminate(), 5.seconds)
-      context.lockManager.reset()
+      context.close()
       context.out.reset()
-      FileUtils.deleteQuietly(context.tmpDir.toFile)
       context = null
     }
   }

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
@@ -1,10 +1,7 @@
 package org.enso.interpreter.test.instrument
 
-import org.apache.commons.io.FileUtils
-import org.enso.distribution.locking.ThreadSafeFileLockManager
 import org.enso.interpreter.runtime.`type`.ConstantsGen
 import org.enso.interpreter.test.Metadata
-import org.enso.pkg.{Package, PackageManager}
 import org.enso.polyglot._
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.text.editing.model
@@ -16,11 +13,9 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.io.{ByteArrayOutputStream, File}
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.{Files, Paths}
 import java.util.UUID
 import java.util.logging.ConsoleHandler
-import scala.concurrent.Await
-import scala.concurrent.duration._
 
 @scala.annotation.nowarn("msg=multiarg infix syntax")
 class RuntimeErrorsTest
@@ -32,25 +27,15 @@ class RuntimeErrorsTest
 
   var context: TestContext = _
 
-  class TestContext(packageName: String) extends InstrumentTestContext {
+  class TestContext(packageName: String)
+      extends InstrumentTestContext(packageName) {
 
-    val tmpDir: Path = Files.createTempDirectory("enso-test-packages")
-    val lockManager  = new ThreadSafeFileLockManager(tmpDir.resolve("locks"))
-    val runtimeServerEmulator =
-      new RuntimeServerEmulator(messageQueue, lockManager)
-
-    val pkg: Package[File] =
-      PackageManager.Default.create(
-        tmpDir.toFile,
-        packageName,
-        namespace = "Enso_Test"
-      )
     val out: ByteArrayOutputStream = new ByteArrayOutputStream()
     val logHandler                 = new ConsoleHandler()
     val defaultLogLevel            = java.util.logging.Level.WARNING;
     logHandler.setLevel(defaultLogLevel)
 
-    val executionContext = new PolyglotContext(
+    val context =
       Context
         .newBuilder(LanguageInfo.ID)
         .allowExperimentalOptions(true)
@@ -80,8 +65,6 @@ class RuntimeErrorsTest
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()
-    )
-    executionContext.context.initialize(LanguageInfo.ID)
 
     def writeMain(contents: String): File =
       Files.write(pkg.mainFile.toPath, contents.getBytes).toFile
@@ -111,17 +94,14 @@ class RuntimeErrorsTest
 
   override protected def beforeEach(): Unit = {
     context = new TestContext("Test")
+    context.init()
     val Some(Api.Response(_, Api.InitializedNotification())) = context.receive
   }
 
   override protected def afterEach(): Unit = {
     if (context != null) {
-      context.reset()
-      context.executionContext.context.close()
-      Await.ready(context.runtimeServerEmulator.terminate(), 5.seconds)
-      context.lockManager.reset()
+      context.close()
       context.out.reset()
-      FileUtils.deleteQuietly(context.tmpDir.toFile)
       context = null
     }
   }

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
@@ -1,10 +1,7 @@
 package org.enso.interpreter.test.instrument
 
-import org.apache.commons.io.FileUtils
-import org.enso.distribution.locking.ThreadSafeFileLockManager
 import org.enso.interpreter.runtime.`type`.{Constants, ConstantsGen}
 import org.enso.interpreter.test.Metadata
-import org.enso.pkg.{Package, PackageManager}
 import org.enso.polyglot._
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.text.{ContentVersion, Sha3_224VersionCalculator}
@@ -14,10 +11,8 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.io.{ByteArrayOutputStream, File}
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.{Files, Paths}
 import java.util.UUID
-import scala.concurrent.Await
-import scala.concurrent.duration._
 
 @scala.annotation.nowarn("msg=multiarg infix syntax")
 class RuntimeInstrumentTest
@@ -29,16 +24,10 @@ class RuntimeInstrumentTest
 
   var context: TestContext = _
 
-  class TestContext(packageName: String) extends InstrumentTestContext {
-    val tmpDir: Path = Files.createTempDirectory("enso-test-packages")
-    val lockManager  = new ThreadSafeFileLockManager(tmpDir.resolve("locks"))
-    val runtimeServerEmulator =
-      new RuntimeServerEmulator(messageQueue, lockManager)
-
-    val pkg: Package[File] =
-      PackageManager.Default.create(tmpDir.toFile, packageName, "Enso_Test")
+  class TestContext(packageName: String)
+      extends InstrumentTestContext(packageName) {
     val out: ByteArrayOutputStream = new ByteArrayOutputStream()
-    val executionContext = new PolyglotContext(
+    val context =
       Context
         .newBuilder(LanguageInfo.ID)
         .allowExperimentalOptions(true)
@@ -67,8 +56,6 @@ class RuntimeInstrumentTest
         .logHandler(System.err)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()
-    )
-    executionContext.context.initialize(LanguageInfo.ID)
 
     def writeMain(contents: String): File =
       Files.write(pkg.mainFile.toPath, contents.getBytes).toFile
@@ -98,17 +85,14 @@ class RuntimeInstrumentTest
 
   override protected def beforeEach(): Unit = {
     context = new TestContext("Test")
+    context.init()
     val Some(Api.Response(_, Api.InitializedNotification())) = context.receive
   }
 
   override protected def afterEach(): Unit = {
     if (context != null) {
-      context.reset()
-      context.executionContext.context.close()
-      Await.ready(context.runtimeServerEmulator.terminate(), 5.seconds)
-      context.lockManager.reset()
+      context.close()
       context.out.reset()
-      FileUtils.deleteQuietly(context.tmpDir.toFile)
       context = null
     }
   }

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeProjectContextTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeProjectContextTest.scala
@@ -2,18 +2,34 @@ package org.enso.interpreter.test.instrument
 
 import org.enso.polyglot.{LanguageInfo, RuntimeOptions}
 import org.graalvm.polyglot.{Context, PolyglotException}
+import org.scalatest.{BeforeAndAfterEach, Suite}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import java.nio.file.Paths
 import java.util.logging.Level
 
-class RuntimeProjectContextTest extends AnyWordSpec with Matchers {
+trait WithContext extends BeforeAndAfterEach { this: Suite =>
+  var context: Context = null
+
+  override def afterEach(): Unit = {
+    if (context != null) {
+      context.close()
+    }
+    super.afterEach()
+  }
+
+}
+
+class RuntimeProjectContextTest
+    extends AnyWordSpec
+    with Matchers
+    with WithContext {
   "Runtime Context" should {
     "report an exception if ran in context of a project " +
     "which cannot be loaded" in {
       val thrown = intercept[PolyglotException] {
-        val context = Context
+        context = Context
           .newBuilder(LanguageInfo.ID)
           .allowExperimentalOptions(true)
           .allowAllAccess(true)

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -1,11 +1,8 @@
 package org.enso.interpreter.test.instrument
 
-import org.apache.commons.io.FileUtils
-import org.enso.distribution.locking.ThreadSafeFileLockManager
 import org.enso.interpreter.runtime.`type`.{Constants, ConstantsGen, Types}
 import org.enso.interpreter.runtime.EnsoContext
 import org.enso.interpreter.test.Metadata
-import org.enso.pkg.{Package, PackageManager}
 import org.enso.polyglot._
 import org.enso.polyglot.data.TypeGraph
 import org.enso.polyglot.runtime.Runtime.Api
@@ -17,12 +14,9 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.io.{ByteArrayOutputStream, File}
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.{Files, Paths}
 import java.util.UUID
 import org.apache.commons.io.output.TeeOutputStream
-
-import scala.concurrent.Await
-import scala.concurrent.duration._
 
 @scala.annotation.nowarn("msg=multiarg infix syntax")
 class RuntimeServerTest
@@ -34,18 +28,12 @@ class RuntimeServerTest
 
   var context: TestContext = _
 
-  class TestContext(packageName: String) extends InstrumentTestContext {
+  class TestContext(packageName: String)
+      extends InstrumentTestContext(packageName) {
 
-    val tmpDir: Path = Files.createTempDirectory("enso-test-packages")
-    val lockManager  = new ThreadSafeFileLockManager(tmpDir.resolve("locks"))
-    val runtimeServerEmulator =
-      new RuntimeServerEmulator(messageQueue, lockManager)
-
-    val pkg: Package[File] =
-      PackageManager.Default.create(tmpDir.toFile, packageName, "Enso_Test")
     val out: ByteArrayOutputStream    = new ByteArrayOutputStream()
     val logOut: ByteArrayOutputStream = new ByteArrayOutputStream()
-    val executionContext = new PolyglotContext(
+    val context =
       Context
         .newBuilder(LanguageInfo.ID)
         .allowExperimentalOptions(true)
@@ -77,10 +65,8 @@ class RuntimeServerTest
         .out(new TeeOutputStream(out, System.err))
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()
-    )
-    executionContext.context.initialize(LanguageInfo.ID)
 
-    val languageContext = executionContext.context
+    lazy val languageContext = executionContext.context
       .getBindings(LanguageInfo.ID)
       .invokeMember(MethodNames.TopScope.LEAK_CONTEXT)
       .asHostObject[EnsoContext]
@@ -366,17 +352,14 @@ class RuntimeServerTest
 
   override protected def beforeEach(): Unit = {
     context = new TestContext("Test")
+    context.init()
     val Some(Api.Response(_, Api.InitializedNotification())) = context.receive
   }
 
   override protected def afterEach(): Unit = {
     if (context != null) {
-      context.reset()
-      context.executionContext.context.close()
-      Await.ready(context.runtimeServerEmulator.terminate(), 5.seconds)
-      context.lockManager.reset()
+      context.close()
       context.out.reset()
-      FileUtils.deleteQuietly(context.tmpDir.toFile)
       context = null
     }
   }

--- a/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
+++ b/engine/runtime-with-instruments/src/test/scala/org/enso/interpreter/test/instrument/RuntimeSuggestionUpdatesTest.scala
@@ -1,9 +1,6 @@
 package org.enso.interpreter.test.instrument
 
-import org.apache.commons.io.FileUtils
-import org.enso.distribution.locking.ThreadSafeFileLockManager
 import org.enso.interpreter.runtime.`type`.ConstantsGen
-import org.enso.pkg.{Package, PackageManager}
 import org.enso.polyglot._
 import org.enso.polyglot.data.Tree
 import org.enso.polyglot.runtime.Runtime.Api
@@ -15,11 +12,9 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.io.{ByteArrayOutputStream, File}
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.{Files, Paths}
 import java.util.UUID
 import java.util.logging.Level
-import scala.concurrent.Await
-import scala.concurrent.duration._
 
 @scala.annotation.nowarn("msg=multiarg infix syntax")
 class RuntimeSuggestionUpdatesTest
@@ -29,17 +24,11 @@ class RuntimeSuggestionUpdatesTest
 
   var context: TestContext = _
 
-  class TestContext(packageName: String) extends InstrumentTestContext {
+  class TestContext(packageName: String)
+      extends InstrumentTestContext(packageName) {
 
-    val tmpDir: Path = Files.createTempDirectory("enso-test-packages")
-    val lockManager  = new ThreadSafeFileLockManager(tmpDir.resolve("locks"))
-    val runtimeServerEmulator =
-      new RuntimeServerEmulator(messageQueue, lockManager)
-
-    val pkg: Package[File] =
-      PackageManager.Default.create(tmpDir.toFile, packageName, "Enso_Test")
     val out: ByteArrayOutputStream = new ByteArrayOutputStream()
-    val executionContext = new PolyglotContext(
+    val context =
       Context
         .newBuilder(LanguageInfo.ID)
         .allowExperimentalOptions(true)
@@ -66,8 +55,6 @@ class RuntimeSuggestionUpdatesTest
         .logHandler(System.err)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()
-    )
-    executionContext.context.initialize(LanguageInfo.ID)
 
     def writeMain(contents: String): File =
       Files.write(pkg.mainFile.toPath, contents.getBytes).toFile
@@ -94,6 +81,7 @@ class RuntimeSuggestionUpdatesTest
 
   override protected def beforeEach(): Unit = {
     context = new TestContext("Test")
+    context.init()
     val Some(Api.Response(_, Api.InitializedNotification())) = context.receive
 
     context.send(
@@ -106,12 +94,8 @@ class RuntimeSuggestionUpdatesTest
 
   override protected def afterEach(): Unit = {
     if (context != null) {
-      context.reset()
-      context.executionContext.context.close()
-      Await.ready(context.runtimeServerEmulator.terminate(), 5.seconds)
-      context.lockManager.reset()
+      context.close()
       context.out.reset()
-      FileUtils.deleteQuietly(context.tmpDir.toFile)
       context = null
     }
   }

--- a/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -1,10 +1,8 @@
 package org.enso.interpreter.test.instrument
 
-import org.apache.commons.io.FileUtils
-import org.enso.distribution.locking.ThreadSafeFileLockManager
 import org.enso.interpreter.runtime.`type`.ConstantsGen
 import org.enso.interpreter.test.Metadata
-import org.enso.pkg.{Package, PackageManager, QualifiedName}
+import org.enso.pkg.QualifiedName
 import org.enso.polyglot._
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.text.editing.model
@@ -16,7 +14,7 @@ import org.scalatest.matchers.should.Matchers
 
 import java.io.{ByteArrayOutputStream, File}
 import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path, Paths}
+import java.nio.file.{Files, Paths}
 import java.util.UUID
 import java.util.logging.Level
 
@@ -30,16 +28,11 @@ class RuntimeVisualizationsTest
 
   var context: TestContext = _
 
-  class TestContext(packageName: String) extends InstrumentTestContext {
-    val tmpDir: Path = Files.createTempDirectory("enso-test-packages")
-    val lockManager  = new ThreadSafeFileLockManager(tmpDir.resolve("locks"))
-    val runtimeServerEmulator =
-      new RuntimeServerEmulator(messageQueue, lockManager)
+  class TestContext(packageName: String)
+      extends InstrumentTestContext(packageName) {
 
-    val pkg: Package[File] =
-      PackageManager.Default.create(tmpDir.toFile, packageName, "Enso_Test")
     val out: ByteArrayOutputStream = new ByteArrayOutputStream()
-    val executionContext = new PolyglotContext(
+    val context =
       Context
         .newBuilder()
         .allowExperimentalOptions(true)
@@ -65,8 +58,6 @@ class RuntimeVisualizationsTest
         .out(out)
         .serverTransport(runtimeServerEmulator.makeServerTransport)
         .build()
-    )
-    executionContext.context.initialize(LanguageInfo.ID)
 
     def writeMain(contents: String): File =
       Files.write(pkg.mainFile.toPath, contents.getBytes).toFile
@@ -312,17 +303,14 @@ class RuntimeVisualizationsTest
 
   override protected def beforeEach(): Unit = {
     context = new TestContext("Test")
+    context.init()
     val Some(Api.Response(_, Api.InitializedNotification())) = context.receive
   }
 
   override protected def afterEach(): Unit = {
     if (context != null) {
-      context.reset()
-      context.executionContext.context.close()
-      context.runtimeServerEmulator.terminate()
-      context.lockManager.reset()
+      context.close()
       context.out.reset()
-      FileUtils.deleteQuietly(context.tmpDir.toFile)
       context = null
     }
   }

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/IntegerTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/IntegerTest.java
@@ -10,6 +10,7 @@ import org.enso.interpreter.node.expression.builtin.number.integer.AddNode;
 import org.enso.interpreter.runtime.error.PanicException;
 import org.enso.interpreter.runtime.number.EnsoBigInteger;
 import org.graalvm.polyglot.Context;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.theories.Theories;
@@ -33,6 +34,11 @@ public class IntegerTest extends TestBase {
           addNode = AddNode.build();
           return null;
         });
+  }
+
+  @AfterClass
+  public static void teardown() {
+    ctx.close();
   }
 
   private static final EnsoBigInteger bigInt =

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/MetaIsATest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/MetaIsATest.java
@@ -42,6 +42,9 @@ public class MetaIsATest extends TestBase {
 
   @AfterClass
   public static void disposeCtx() {
+    if (generator != null) {
+      generator.dispose();
+    }
     ctx.close();
   }
 

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/MetaObjectTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/MetaObjectTest.java
@@ -34,6 +34,9 @@ public class MetaObjectTest extends TestBase {
 
   @AfterClass
   public static void disposeCtx() {
+    if (generator != null) {
+      generator.dispose();
+    }
     ctx.close();
   }
 

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/SharedEngineTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/SharedEngineTest.java
@@ -9,9 +9,13 @@ import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Engine;
 import org.graalvm.polyglot.Source;
 import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 
 public class SharedEngineTest extends TestBase {
   private static Engine sharedEngine;
@@ -36,6 +40,16 @@ public class SharedEngineTest extends TestBase {
   @Before
   public void initializeContext() {
     this.ctx = defaultContextBuilder().engine(sharedEngine).build();
+  }
+
+  @AfterClass
+  public static void disposeEngine() {
+    sharedEngine.close();
+  }
+
+  @After
+  public void disposeCtx() {
+    this.ctx.close();
   }
 
   private final Source typeCase = Source.newBuilder("enso", """

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/ValuesGenerator.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/ValuesGenerator.java
@@ -784,6 +784,13 @@ class ValuesGenerator {
     return v;
   }
 
+  public void dispose() {
+    values.clear();
+    multiValues.clear();
+    computed.clear();
+    languages.clear();
+  }
+
   public enum Language {
     ENSO, JAVASCRIPT, PYTHON, JAVA
   }

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/VectorSortTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/VectorSortTest.java
@@ -51,6 +51,7 @@ public class VectorSortTest extends TestBase {
 
   @AfterClass
   public static void disposeCtx() {
+    values.clear();
     context.close();
   }
 


### PR DESCRIPTION
### Pull Request Description

Follow up on #8418 that addressed the most pressing issue in #8408.

### Important Notes

`runtime/test` is pretty memory hungry but it appears that this is mostly because we run java tests in parallel.
Apart from the changes I made I couldn't find any more leaks.

Also addressed DRY comment mentioned in #8418.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
