### PR TITLE
Replacing usage of Source by (Location => String)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1517,7 +1517,6 @@ lazy val `runtime-parser` =
   (project in file("engine/runtime-parser"))
     .settings(
       frgaalJavaCompilerSetting,
-      instrumentationSettings,
       commands += WithDebugCommand.withDebug,
       fork := true,
       Test / javaOptions ++= Seq(

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -689,7 +689,7 @@ class Compiler(
   ): Unit = {
     val module = Option(context.findTopScopeModule(qualifiedName))
       .getOrElse {
-        val locStr = fileLocationFromSection(loc, source)
+        val locStr = fileLocationFromSectionOption(loc, source)
         throw new CompilerError(
           s"Attempted to import the unresolved module $qualifiedName " +
           s"during code generation. Defined at $locStr."
@@ -1012,6 +1012,16 @@ class Compiler(
       case _: Warning => (fansi.Color.Yellow ++ fansi.Bold.On, "warning: ")
       case _          => throw new IllegalStateException("Unexpected diagnostic type")
     }
+
+    def fileLocationFromSection(loc: IdentifiedLocation) = {
+      val section =
+        source.createSection(loc.location().start(), loc.location().length());
+      val locStr = "" + section.getStartLine() + ":" + section
+        .getStartColumn() + "-" + section.getEndLine() + ":" + section
+        .getEndColumn()
+      source.getName() + "[" + locStr + "]";
+    }
+
     private val sourceSection: Option[SourceSection] =
       diagnostic.location match {
         case Some(location) =>
@@ -1045,7 +1055,7 @@ class Compiler(
               .Str(srcPath + ":" + lineNumber + ":" + startColumn + ": ")
               .overlay(fansi.Bold.On)
             str ++= fansi.Str(subject).overlay(textAttrs)
-            str ++= diagnostic.formattedMessage(source)
+            str ++= diagnostic.formattedMessage(fileLocationFromSection)
             str ++= "\n"
             str ++= oneLineFromSourceColored(lineNumber, startColumn, endColumn)
             str ++= "\n"
@@ -1063,7 +1073,7 @@ class Compiler(
               )
               .overlay(fansi.Bold.On)
             str ++= fansi.Str(subject).overlay(textAttrs)
-            str ++= diagnostic.formattedMessage(source)
+            str ++= diagnostic.formattedMessage(fileLocationFromSection)
             str ++= "\n"
             val printAllSourceLines =
               section.getEndLine - section.getStartLine <= maxSourceLinesToPrint
@@ -1090,15 +1100,16 @@ class Compiler(
           // There is no source section associated with the diagnostics
           var str = fansi.Str()
           val fileLocation = diagnostic.location match {
-            case Some(_) => fileLocationFromSection(diagnostic.location, source)
-            case None    => source.getPath
+            case Some(_) =>
+              fileLocationFromSectionOption(diagnostic.location, source)
+            case None => source.getPath
           }
           str ++= fansi
             .Str(fileLocation)
             .overlay(fansi.Bold.On)
           str ++= ": "
           str ++= fansi.Str(subject).overlay(textAttrs)
-          str ++= diagnostic.formattedMessage(source)
+          str ++= diagnostic.formattedMessage(fileLocationFromSection)
           if (outSupportsAnsiColors) {
             str.render.stripLineEnd
           } else {
@@ -1169,7 +1180,7 @@ class Compiler(
     }
   }
 
-  private def fileLocationFromSection(
+  private def fileLocationFromSectionOption(
     loc: Option[IdentifiedLocation],
     source: Source
   ): String = {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/EnsureCompiledJob.scala
@@ -6,7 +6,7 @@ import org.enso.compiler.CompilerResult
 import org.enso.compiler.context._
 import org.enso.compiler.core.Implicits.AsMetadata
 import org.enso.compiler.core.CompilerError
-import org.enso.compiler.core.ir.{Diagnostic, Warning}
+import org.enso.compiler.core.ir.{Diagnostic, IdentifiedLocation, Warning}
 import org.enso.compiler.core.ir.expression.Error
 import org.enso.compiler.pass.analyse.{
   CachePreferenceAnalysis,
@@ -218,9 +218,18 @@ final class EnsureCompiledJob(
     diagnostic: Diagnostic
   ): Api.ExecutionResult.Diagnostic = {
     val source = module.getSource
+
+    def fileLocationFromSection(loc: IdentifiedLocation) = {
+      val section =
+        source.createSection(loc.location().start(), loc.location().length());
+      val locStr = "" + section.getStartLine() + ":" + section
+        .getStartColumn() + "-" + section.getEndLine() + ":" + section
+        .getEndColumn()
+      source.getName() + "[" + locStr + "]";
+    }
     Api.ExecutionResult.Diagnostic(
       kind,
-      Option(diagnostic.formattedMessage(source)),
+      Option(diagnostic.formattedMessage(fileLocationFromSection)),
       Option(module.getPath).map(new File(_)),
       diagnostic.location
         .map(loc =>

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/IR.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/IR.java
@@ -1,6 +1,5 @@
 package org.enso.compiler.core;
 
-import com.oracle.truffle.api.source.Source;
 import java.io.Serializable;
 import java.util.UUID;
 import java.util.function.Function;
@@ -163,18 +162,4 @@ public interface IR extends Serializable {
 
   /** The size of a single indentation level. */
   int indentLevel = 4;
-
-  static String fileLocationFromSection(IdentifiedLocation loc, Source source) {
-    var section = source.createSection(loc.location().start(), loc.location().length());
-    var locStr =
-        ""
-            + section.getStartLine()
-            + ":"
-            + section.getStartColumn()
-            + "-"
-            + section.getEndLine()
-            + ":"
-            + section.getEndColumn();
-    return source.getName() + "[" + locStr + "]";
-  }
 }

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Diagnostic.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Diagnostic.scala
@@ -1,19 +1,18 @@
 package org.enso.compiler.core.ir
 
-import com.oracle.truffle.api.source.Source
-
 /** A representation of various kinds of diagnostic in the IR. */
 trait Diagnostic extends Serializable {
 
   /** @param source Location of the diagnostic.
     * @return a human-readable description of this error condition.
     */
-  def message(source: Source): String
+  def message(source: (IdentifiedLocation => String)): String
 
   /** @param source Location of the diagnostic.
     * @return a human-readable description of this error condition, formatted for immediate reporting.
     */
-  def formattedMessage(source: Source): String = message(source)
+  def formattedMessage(source: (IdentifiedLocation => String)): String =
+    message(source)
 
   /** The location at which the diagnostic occurs. */
   val location: Option[IdentifiedLocation]

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Empty.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Empty.scala
@@ -1,6 +1,5 @@
 package org.enso.compiler.core.ir
 
-import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.Implicits.{ShowPassData, ToStringHelper}
 import org.enso.compiler.core.{IR, Identifier}
 import org.enso.compiler.core.IR.randomId
@@ -82,7 +81,7 @@ sealed case class Empty(
   override def children: List[IR] = List()
 
   /** @inheritdoc */
-  override def message(source: Source): String =
+  override def message(source: (IdentifiedLocation => String)): String =
     "Empty IR: Please report this as a compiler bug."
 
   /** @inheritdoc */

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Warning.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Warning.scala
@@ -1,7 +1,5 @@
 package org.enso.compiler.core.ir
 
-import com.oracle.truffle.api.source.Source
-import org.enso.compiler.core.IR.fileLocationFromSection
 import org.enso.compiler.core.{ir, IR}
 
 /** A trait for all warnings in Enso's IR. */
@@ -14,11 +12,11 @@ object Warning {
     originalImport: ir.module.scope.Import,
     symbolName: String
   ) extends Warning {
-    override def message(source: Source): String = {
+    override def message(source: (IdentifiedLocation => String)): String = {
       val originalImportRepr =
         originalImport.location match {
           case Some(location) =>
-            s"'${originalImport.showCode()}' in ${fileLocationFromSection(location, source)}"
+            s"'${originalImport.showCode()}' in ${source(location)}"
           case None => originalImport.showCode()
         }
       s"Duplicated import of $symbolName. The original import is ${originalImportRepr}."
@@ -34,7 +32,7 @@ object Warning {
     */
   case class WrongTco(override val location: Option[IdentifiedLocation])
       extends Warning {
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       "A @Tail_Call annotation was placed in a non-tail-call position."
 
     override def diagnosticKeys(): Array[Any] = Array()
@@ -48,7 +46,7 @@ object Warning {
   case class WrongBuiltinMethod(
     override val location: Option[IdentifiedLocation]
   ) extends Warning {
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       "A @Builtin_Method annotation allows only the name of the builtin node in the body."
 
     override def diagnosticKeys(): Array[Any] = Array()
@@ -67,7 +65,7 @@ object Warning {
   ) extends Warning {
     override val location: Option[IdentifiedLocation] = ir.location
 
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       s"${funName.name}: Self parameter should be declared as the first parameter. Instead its position is: ${paramPosition + 1}."
 
     override def diagnosticKeys(): Array[Any] =
@@ -86,7 +84,7 @@ object Warning {
   ) extends Warning {
     override val location: Option[IdentifiedLocation] = ir.location
 
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       s"The expression ${ir.showCode()} could not be parallelised: $reason."
 
     override def diagnosticKeys(): Array[Any] = Array(ir.showCode(), reason)
@@ -97,7 +95,7 @@ object Warning {
 
     /** @return a human-readable description of this error condition.
       */
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       s"A non-unit type ${ir.name} is used on value level (in ${context})." +
       " This is probably an error."
 

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/Error.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/Error.scala
@@ -1,7 +1,6 @@
 package org.enso.compiler.core.ir
 package expression
 
-import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.Implicits.{ShowPassData, ToStringHelper}
 import org.enso.compiler.core.IR.randomId
 import org.enso.compiler.core.ir.Expression
@@ -116,7 +115,7 @@ object Error {
     override def children: List[IR] = List(ir)
 
     /** @inheritdoc */
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       "InvalidIR: Please report this as a compiler bug."
 
     override def diagnosticKeys(): Array[Any] = Array()

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Conversion.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Conversion.scala
@@ -2,7 +2,6 @@ package org.enso.compiler.core.ir
 package expression
 package errors
 
-import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.{IR, Identifier}
 import org.enso.compiler.core.IR.randomId
 
@@ -91,7 +90,8 @@ sealed case class Conversion(
     s"(Error: ${storedIr.showCode(indent)})"
 
   /** @inheritdoc */
-  override def message(source: Source): String = reason.explain
+  override def message(source: (IdentifiedLocation => String)): String =
+    reason.explain
 
   override def diagnosticKeys(): Array[Any] = Array(reason.explain)
 

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Pattern.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Pattern.scala
@@ -2,7 +2,6 @@ package org.enso.compiler.core.ir
 package expression
 package errors
 
-import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.{IR, Identifier}
 import org.enso.compiler.core.IR.randomId
 
@@ -75,7 +74,8 @@ sealed case class Pattern(
       id = if (keepIdentifiers) id else randomId
     )
 
-  override def message(source: Source): String = reason.explain
+  override def message(source: (IdentifiedLocation => String)): String =
+    reason.explain
 
   override def diagnosticKeys(): Array[Any] = Array(reason)
 

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Redefined.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Redefined.scala
@@ -2,7 +2,6 @@ package org.enso.compiler.core.ir
 package expression
 package errors
 
-import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.Implicits.ShowPassData
 import org.enso.compiler.core.{IR, Identifier}
 import org.enso.compiler.core.IR.randomId
@@ -96,7 +95,7 @@ object Redefined {
       this
 
     /** @inheritdoc */
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       "Methods must have only one definition of the `this` argument, and " +
       "it must be the first."
 
@@ -196,7 +195,7 @@ object Redefined {
       copy(location = location)
 
     /** @inheritdoc */
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       s"Ambiguous conversion: ${targetType.map(_.name + ".").getOrElse("")}from " +
       s"${sourceType.showCode()} is defined multiple times in this module."
 
@@ -318,7 +317,7 @@ object Redefined {
       copy(location = location)
 
     /** @inheritdoc */
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       s"Method overloads are not supported: ${atomName.map(_.name + ".").getOrElse("")}" +
       s"${methodName.name} is defined multiple times in this module."
 
@@ -447,7 +446,7 @@ object Redefined {
       copy(location = location)
 
     /** @inheritdoc */
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       s"Method definitions with the same name as atoms are not supported. " +
       s"Method ${methodName.name} clashes with the atom ${atomName.name} in this module."
 
@@ -551,7 +550,7 @@ object Redefined {
       copy(location = location)
 
     /** @inheritdoc */
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       s"Redefining atoms is not supported: ${typeName.name} is " +
       s"defined multiple times in this module."
 
@@ -672,7 +671,7 @@ object Redefined {
     override def children: List[IR] = List(invalidBinding)
 
     /** @inheritdoc */
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       s"Variable ${invalidBinding.name.name} is being redefined."
 
     override def diagnosticKeys(): Array[Any] = Array(

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Resolution.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Resolution.scala
@@ -2,7 +2,6 @@ package org.enso.compiler.core.ir
 package expression
 package errors
 
-import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.{IR, Identifier}
 import org.enso.compiler.core.IR.randomId
 
@@ -89,10 +88,13 @@ sealed case class Resolution(
   override def showCode(indent: Int): String = originalName.showCode(indent)
 
   /** @inheritdoc */
-  override def message(source: Source): String = reason.explain(originalName)
+  override def message(source: (IdentifiedLocation => String)): String =
+    reason.explain(originalName)
 
   /** @inheritdoc */
-  override def formattedMessage(source: Source): String = s"${message(source)}."
+  override def formattedMessage(
+    source: (IdentifiedLocation => String)
+  ): String = s"${message(source)}."
 
   override def diagnosticKeys(): Array[Any] = Array(reason)
 

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Syntax.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Syntax.scala
@@ -2,7 +2,6 @@ package org.enso.compiler.core.ir
 package expression
 package errors
 
-import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.Implicits.{ShowPassData, ToStringHelper}
 import org.enso.compiler.core.{IR, Identifier}
 import org.enso.compiler.core.IR.randomId
@@ -95,10 +94,13 @@ sealed case class Syntax(
   override def children: List[IR] = List()
 
   /** @inheritdoc */
-  override def message(source: Source): String = reason.explanation
+  override def message(source: (IdentifiedLocation => String)): String =
+    reason.explanation
 
   /** @inheritdoc */
-  override def formattedMessage(source: Source): String = s"${message(source)}."
+  override def formattedMessage(
+    source: (IdentifiedLocation => String)
+  ): String = s"${message(source)}."
 
   override def diagnosticKeys(): Array[Any] = Array(reason)
 

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Unexpected.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Unexpected.scala
@@ -2,7 +2,6 @@ package org.enso.compiler.core.ir
 package expression
 package errors
 
-import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.{IR, Identifier}
 import org.enso.compiler.core.IR.randomId
 
@@ -20,7 +19,8 @@ sealed trait Unexpected extends Error {
   override val location: Option[IdentifiedLocation] = ir.location
 
   /** @inheritdoc */
-  override def message(source: Source): String = s"Unexpected $entity."
+  override def message(source: (IdentifiedLocation => String)): String =
+    s"Unexpected $entity."
 
   /** @inheritdoc */
   override def diagnosticKeys(): Array[Any] = Array(entity)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/warnings/Shadowed.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/warnings/Shadowed.scala
@@ -2,7 +2,6 @@ package org.enso.compiler.core.ir
 package expression
 package warnings
 
-import com.oracle.truffle.api.source.Source
 import org.enso.compiler.core.IR
 
 /** Warnings about shadowing names. */
@@ -26,7 +25,7 @@ object Shadowed {
     override val shadower: IR,
     override val location: Option[IdentifiedLocation]
   ) extends Shadowed {
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       s"The argument '$shadowedName' is shadowed by another one with the same name."
 
     override def diagnosticKeys(): Array[Any] =
@@ -45,7 +44,7 @@ object Shadowed {
     override val shadower: IR,
     override val location: Option[IdentifiedLocation]
   ) extends Shadowed {
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       s"The pattern field '$shadowedName' is shadowed by another one with the same name."
 
     override def diagnosticKeys(): Array[Any] =
@@ -66,7 +65,7 @@ object Shadowed {
     override val shadower: IR,
     override val location: Option[IdentifiedLocation]
   ) extends Shadowed {
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       s"""Declaration of type $typeName shadows module ${moduleName.name} making it inaccessible via a qualified name."""
 
     override def diagnosticKeys(): Array[Any] =
@@ -89,7 +88,7 @@ object Shadowed {
     override val shadower: IR,
     override val location: Option[IdentifiedLocation]
   ) extends Shadowed {
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       s"The exported type `$tpeName` in `$name` module will cause name conflict " +
       s"when attempting to use a fully qualified name of the `$firstConflict` module."
 

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/warnings/Unreachable.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/warnings/Unreachable.scala
@@ -2,8 +2,6 @@ package org.enso.compiler.core.ir
 package expression
 package warnings
 
-import com.oracle.truffle.api.source.Source
-
 /** Warnings for unreachable code. */
 sealed trait Unreachable extends Warning {
   val location: Option[IdentifiedLocation]
@@ -25,7 +23,7 @@ object Unreachable {
         ""
       }
 
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       s"Unreachable case branches$atLocation."
 
     override def diagnosticKeys(): Array[Any] = Array(atLocation)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/warnings/Unused.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/warnings/Unused.scala
@@ -2,8 +2,6 @@ package org.enso.compiler.core.ir
 package expression
 package warnings
 
-import com.oracle.truffle.api.source.Source
-
 /** Warnings about unused language entities. */
 sealed trait Unused extends Warning {
   val name: Name
@@ -16,7 +14,7 @@ object Unused {
     * @param name the name that is unused
     */
   sealed case class FunctionArgument(override val name: Name) extends Unused {
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       s"Unused function argument ${name.name}."
 
     override def diagnosticKeys(): Array[Any] = Array(name.name)
@@ -27,7 +25,7 @@ object Unused {
   }
 
   sealed case class PatternBinding(override val name: Name) extends Unused {
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       s"Unused pattern binding ${name.name}."
 
     override def diagnosticKeys(): Array[Any] = Array(name.name)
@@ -42,7 +40,7 @@ object Unused {
     * @param name the name that is unused
     */
   sealed case class Binding(override val name: Name) extends Unused {
-    override def message(source: Source): String =
+    override def message(source: (IdentifiedLocation => String)): String =
       s"Unused variable ${name.name}."
 
     override def diagnosticKeys(): Array[Any] = Array(name.name)

--- a/engine/runtime-parser/src/test/java/org/enso/compiler/core/EnsoParserTest.java
+++ b/engine/runtime-parser/src/test/java/org/enso/compiler/core/EnsoParserTest.java
@@ -1,18 +1,17 @@
 package org.enso.compiler.core;
 
-import com.oracle.truffle.api.source.Source;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.function.Function;
+
 import org.enso.compiler.core.ir.Module;
 import org.junit.AfterClass;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -1304,8 +1303,7 @@ public class EnsoParserTest {
   }
 
   public static Module compile(EnsoParser c, String code) {
-    var src = Source.newBuilder("enso", code, "test-" + Integer.toHexString(code.hashCode()) + ".enso").build();
-    var ir = c.compile(src.getCharacters());
+    var ir = c.compile(code);
     assertNotNull("IR was generated", ir);
     return ir;
   }

--- a/engine/runtime-parser/src/test/java/org/enso/compiler/core/ParserDependenciesTest.java
+++ b/engine/runtime-parser/src/test/java/org/enso/compiler/core/ParserDependenciesTest.java
@@ -17,4 +17,24 @@ public class ParserDependenciesTest {
       // correct
     }
   }
+
+  @Test
+  public void avoidTruffleDependency() {
+    try {
+      var clazz = Class.forName("com.oracle.truffle.api.source.Source");
+      assertNull("No Truffle classes shall be available in the parser project", clazz);
+    } catch (ClassNotFoundException ex) {
+      // correct
+    }
+  }
+
+  @Test
+  public void avoidPolyglotDependency() {
+    try {
+      var clazz = Class.forName("org.graalvm.polyglot.Source");
+      assertNull("No GraalVM polyglot classes shall be available in the parser project", clazz);
+    } catch (ClassNotFoundException ex) {
+      // correct
+    }
+  }
 }

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -1796,6 +1796,15 @@ class IrToTruffle(
           setLocation(LiteralNode.build(text), location)
       }
 
+    private def fileLocationFromSection(loc: IdentifiedLocation) = {
+      val section =
+        source.createSection(loc.location().start(), loc.location().length());
+      val locStr = "" + section.getStartLine() + ":" + section
+        .getStartColumn() + "-" + section.getEndLine() + ":" + section
+        .getEndColumn()
+      source.getName() + "[" + locStr + "]";
+    }
+
     /** Generates a runtime implementation for compile error nodes.
       *
       * @param error the IR representing a compile error.
@@ -1808,43 +1817,43 @@ class IrToTruffle(
         case err: errors.Syntax =>
           context.getBuiltins
             .error()
-            .makeSyntaxError(Text.create(err.message(source)))
+            .makeSyntaxError(Text.create(err.message(fileLocationFromSection)))
         case err: errors.Redefined.Binding =>
           context.getBuiltins
             .error()
-            .makeCompileError(Text.create(err.message(source)))
+            .makeCompileError(Text.create(err.message(fileLocationFromSection)))
         case err: errors.Redefined.Method =>
           context.getBuiltins
             .error()
-            .makeCompileError(Text.create(err.message(source)))
+            .makeCompileError(Text.create(err.message(fileLocationFromSection)))
         case err: errors.Redefined.MethodClashWithAtom =>
           context.getBuiltins
             .error()
-            .makeCompileError(Text.create(err.message(source)))
+            .makeCompileError(Text.create(err.message(fileLocationFromSection)))
         case err: errors.Redefined.Conversion =>
           context.getBuiltins
             .error()
-            .makeCompileError(Text.create(err.message(source)))
+            .makeCompileError(Text.create(err.message(fileLocationFromSection)))
         case err: errors.Redefined.Type =>
           context.getBuiltins
             .error()
-            .makeCompileError(Text.create(err.message(source)))
+            .makeCompileError(Text.create(err.message(fileLocationFromSection)))
         case err: errors.Redefined.SelfArg =>
           context.getBuiltins
             .error()
-            .makeCompileError(Text.create(err.message(source)))
+            .makeCompileError(Text.create(err.message(fileLocationFromSection)))
         case err: errors.Unexpected.TypeSignature =>
           context.getBuiltins
             .error()
-            .makeCompileError(Text.create(err.message(source)))
+            .makeCompileError(Text.create(err.message(fileLocationFromSection)))
         case err: errors.Resolution =>
           context.getBuiltins
             .error()
-            .makeCompileError(Text.create(err.message(source)))
+            .makeCompileError(Text.create(err.message(fileLocationFromSection)))
         case err: errors.Conversion =>
           context.getBuiltins
             .error()
-            .makeCompileError(Text.create(err.message(source)))
+            .makeCompileError(Text.create(err.message(fileLocationFromSection)))
         case _: errors.Pattern =>
           throw new CompilerError(
             "Impossible here, should be handled in the pattern match."


### PR DESCRIPTION
### Pull Request Description

Before we can cleanup the `runtime-compiler` dependencies (as requested by #8210) we need to clean `runtime-parser` ones.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides. 
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] Existing tests continue to work
