### PR TITLE
Dashboard improvements

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/cognito.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/cognito.ts
@@ -502,12 +502,20 @@ export function intoSignUpErrorOrThrow(error: AmplifyError): SignUpError {
 /** Internal IDs of errors that may occur when confirming registration. */
 export enum ConfirmSignUpErrorKind {
     userAlreadyConfirmed = 'UserAlreadyConfirmed',
+    userNotFound = 'UserNotFound',
 }
 
 const CONFIRM_SIGN_UP_USER_ALREADY_CONFIRMED_ERROR = {
     internalCode: 'NotAuthorizedException',
     internalMessage: 'User cannot be confirmed. Current status is CONFIRMED',
     kind: ConfirmSignUpErrorKind.userAlreadyConfirmed,
+}
+
+const CONFIRM_SIGN_UP_USER_NOT_FOUND_ERROR = {
+    internalCode: 'UserNotFoundException',
+    internalMessage: 'Username/client id combination not found.',
+    kind: ConfirmSignUpErrorKind.userNotFound,
+    message: 'Incorrect email or confirmation code.',
 }
 
 /** An error that may occur when confirming registration. */
@@ -530,6 +538,17 @@ export function intoConfirmSignUpErrorOrThrow(error: AmplifyError): ConfirmSignU
              * ambiguity. */
             kind: CONFIRM_SIGN_UP_USER_ALREADY_CONFIRMED_ERROR.kind,
             message: error.message,
+        }
+    } else if (
+        error.code === CONFIRM_SIGN_UP_USER_NOT_FOUND_ERROR.internalCode &&
+        error.message === CONFIRM_SIGN_UP_USER_NOT_FOUND_ERROR.internalMessage
+    ) {
+        return {
+            /** Don't re-use the original `error.code` here because Amplify overloads the same code
+             * for multiple kinds of errors. We replace it with a custom code that has no
+             * ambiguity. */
+            kind: CONFIRM_SIGN_UP_USER_NOT_FOUND_ERROR.kind,
+            message: CONFIRM_SIGN_UP_USER_NOT_FOUND_ERROR.message,
         }
     } else {
         throw error

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/components/registration.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/components/registration.tsx
@@ -23,6 +23,7 @@ import SubmitButton from './submitButton'
 // =================
 
 const REGISTRATION_QUERY_PARAMS = {
+    email: 'email',
     organizationId: 'organization_id',
     redirectTo: 'redirect_to',
 } as const
@@ -36,11 +37,11 @@ export default function Registration() {
     const auth = authModule.useAuth()
     const location = router.useLocation()
     const { localStorage } = localStorageProvider.useLocalStorage()
-    const [email, setEmail] = React.useState('')
+    const { email: urlEmail, organizationId, redirectTo } = parseUrlSearchParams(location.search)
+    const [email, setEmail] = React.useState(urlEmail ?? '')
     const [password, setPassword] = React.useState('')
     const [confirmPassword, setConfirmPassword] = React.useState('')
     const [isSubmitting, setIsSubmitting] = React.useState(false)
-    const { organizationId, redirectTo } = parseUrlSearchParams(location.search)
 
     React.useEffect(() => {
         if (redirectTo != null) {
@@ -109,7 +110,8 @@ export default function Registration() {
 /** Return an object containing the query parameters, with keys renamed to `camelCase`. */
 function parseUrlSearchParams(search: string) {
     const query = new URLSearchParams(search)
+    const email = query.get(REGISTRATION_QUERY_PARAMS.email)
     const organizationId = query.get(REGISTRATION_QUERY_PARAMS.organizationId)
     const redirectTo = query.get(REGISTRATION_QUERY_PARAMS.redirectTo)
-    return { organizationId, redirectTo }
+    return { email, organizationId, redirectTo }
 }

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/providers/auth.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/authentication/providers/auth.tsx
@@ -35,6 +35,7 @@ const REQUEST_DELAY_MS = 200
 const MESSAGES = {
     signUpSuccess: 'We have sent you an email with further instructions!',
     confirmSignUpSuccess: 'Your account has been confirmed! Please log in.',
+    confirmSignUpFailure: 'Incorrect email or confirmation code.',
     setUsernameLoading: 'Setting username...',
     setUsernameSuccess: 'Your username has been set!',
     setUsernameFailure: 'Could not set your username.',
@@ -426,6 +427,10 @@ export function AuthProvider(props: AuthProviderProps) {
             switch (result.val.kind) {
                 case cognitoModule.ConfirmSignUpErrorKind.userAlreadyConfirmed:
                     break
+                case cognitoModule.ConfirmSignUpErrorKind.userNotFound:
+                    toastError(MESSAGES.confirmSignUpFailure)
+                    navigate(app.LOGIN_PATH)
+                    return false
                 default:
                     throw new errorModule.UnreachableCaseError(result.val.kind)
             }
@@ -442,7 +447,8 @@ export function AuthProvider(props: AuthProviderProps) {
             toastSuccess(MESSAGES.signInWithPasswordSuccess)
         } else {
             if (result.val.kind === cognitoModule.SignInWithPasswordErrorKind.userNotFound) {
-                navigate(app.REGISTRATION_PATH)
+                // It may not be safe to pass the user's password in the URL.
+                navigate(app.REGISTRATION_PATH + '?' + new URLSearchParams({ email }).toString())
             }
             toastError(result.val.message)
         }

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/backend.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/backend.ts
@@ -379,6 +379,24 @@ export function lChColorToCssColor(color: LChColor): string {
         : `lch(${color.lightness}% ${color.chroma} ${color.hue})`
 }
 
+export const COLOR_STRING_TO_COLOR = new Map(
+    COLORS.map(color => [lChColorToCssColor(color), color])
+)
+
+export const INITIAL_COLOR_COUNTS = new Map(COLORS.map(color => [lChColorToCssColor(color), 0]))
+
+/** The color that is used for the least labels. Ties are broken by order. */
+export function leastUsedColor(labels: Iterable<Label>) {
+    const colorCounts = new Map(INITIAL_COLOR_COUNTS)
+    for (const label of labels) {
+        const colorString = lChColorToCssColor(label.color)
+        colorCounts.set(colorString, (colorCounts.get(colorString) ?? 0) + 1)
+    }
+    const min = Math.min(...colorCounts.values())
+    const [minColor] = [...colorCounts.entries()].find(kv => kv[1] === min) ?? []
+    return minColor == null ? COLORS[0] : COLOR_STRING_TO_COLOR.get(minColor) ?? COLORS[0]
+}
+
 // =================
 // === AssetType ===
 // =================

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/backend.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/backend.ts
@@ -347,7 +347,7 @@ export interface LChColor {
 }
 
 /** A pre-selected list of colors to be used in color pickers. */
-export const COLORS: readonly LChColor[] = [
+export const COLORS: readonly [LChColor, ...LChColor[]] = [
     /* eslint-disable @typescript-eslint/no-magic-numbers */
     // Red
     { lightness: 50, chroma: 66, hue: 7 },

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/assetRow.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/assetRow.tsx
@@ -25,6 +25,14 @@ import StatelessSpinner, * as statelessSpinner from './statelessSpinner'
 import AssetContextMenu from './assetContextMenu'
 import TableRow from './tableRow'
 
+// =================
+// === Constants ===
+// =================
+
+/** The amount of time (in milliseconds) the drag item must be held over this component
+ * to make a directory row expand. */
+const DRAG_EXPAND_DELAY_MS = 500
+
 // ================
 // === AssetRow ===
 // ================
@@ -58,6 +66,7 @@ export default function AssetRow(props: AssetRowProps) {
         dispatchAssetEvent,
         dispatchAssetListEvent,
         setAssetSettingsPanelProps,
+        doToggleDirectoryExpansion,
         doCut,
         doPaste,
     } = state
@@ -68,6 +77,7 @@ export default function AssetRow(props: AssetRowProps) {
     const toastAndLog = hooks.useToastAndLog()
     const [isDraggedOver, setIsDraggedOver] = React.useState(false)
     const [item, setItem] = React.useState(rawItem)
+    const dragOverTimeoutHandle = React.useRef<number | null>(null)
     const asset = item.item
     const [visibility, setVisibility] = React.useState(visibilityModule.Visibility.visible)
     const [rowState, setRowState] = React.useState<assetsTable.AssetRowState>(() => ({
@@ -453,6 +463,21 @@ export default function AssetRow(props: AssetRowProps) {
                         setItem={setItem}
                         initialRowState={rowState}
                         setRowState={setRowState}
+                        onDragEnter={() => {
+                            if (dragOverTimeoutHandle.current != null) {
+                                window.clearTimeout(dragOverTimeoutHandle.current)
+                            }
+                            if (backendModule.assetIsDirectory(asset)) {
+                                dragOverTimeoutHandle.current = window.setTimeout(() => {
+                                    doToggleDirectoryExpansion(
+                                        asset.id,
+                                        item.key,
+                                        asset.title,
+                                        true
+                                    )
+                                }, DRAG_EXPAND_DELAY_MS)
+                            }
+                        }}
                         onDragOver={event => {
                             props.onDragOver?.(event)
                             if (item.item.type === backendModule.AssetType.directory) {
@@ -471,6 +496,13 @@ export default function AssetRow(props: AssetRowProps) {
                             props.onDragEnd?.(event)
                         }}
                         onDragLeave={event => {
+                            if (
+                                dragOverTimeoutHandle.current != null &&
+                                (!(event.relatedTarget instanceof Node) ||
+                                    !event.currentTarget.contains(event.relatedTarget))
+                            ) {
+                                window.clearTimeout(dragOverTimeoutHandle.current)
+                            }
                             clearDragState()
                             props.onDragLeave?.(event)
                         }}

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/assetRow.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/assetRow.tsx
@@ -270,10 +270,19 @@ export default function AssetRow(props: AssetRowProps) {
                 }
                 break
             }
+            case assetEventModule.AssetEventType.download: {
+                if (event.ids.has(item.key)) {
+                    download.download(
+                        `./api/project-manager/projects/${asset.id}/enso-project`,
+                        `${asset.title}.enso-project`
+                    )
+                }
+                break
+            }
             case assetEventModule.AssetEventType.downloadSelected: {
                 if (selected) {
                     download.download(
-                        './api/project-manager/' + `projects/${asset.id}/enso-project`,
+                        `./api/project-manager/projects/${asset.id}/enso-project`,
                         `${asset.title}.enso-project`
                     )
                 }

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/assetsTable.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/assetsTable.tsx
@@ -165,7 +165,8 @@ export interface AssetsTableState {
     doToggleDirectoryExpansion: (
         directoryId: backendModule.DirectoryId,
         key: backendModule.AssetId,
-        title?: string
+        title?: string | null,
+        override?: boolean
     ) => void
     /** Called when the project is opened via the `ProjectActionButton`. */
     doOpenManually: (projectId: backendModule.ProjectId) => void
@@ -670,9 +671,21 @@ export default function AssetsTable(props: AssetsTableProps) {
         new Map<backendModule.DirectoryId, AbortController>()
     )
     const doToggleDirectoryExpansion = React.useCallback(
-        (directoryId: backendModule.DirectoryId, key: backendModule.AssetId, title?: string) => {
+        (
+            directoryId: backendModule.DirectoryId,
+            key: backendModule.AssetId,
+            title?: string | null,
+            override?: boolean
+        ) => {
             const directory = nodeMapRef.current.get(key)
-            if (directory?.children != null) {
+            const isExpanded = directory?.children != null
+            const shouldExpand = override ?? !isExpanded
+            if (shouldExpand === isExpanded) {
+                // This is fine, as this is near the top of a very long function.
+                // eslint-disable-next-line no-restricted-syntax
+                return
+            }
+            if (!shouldExpand) {
                 const abortController = directoryListAbortControllersRef.current.get(directoryId)
                 if (abortController != null) {
                     abortController.abort()

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/chat.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/chat.tsx
@@ -36,9 +36,9 @@ const MessageId = newtype.newtypeConstructor<chat.MessageId>()
 // The project shouldn't be jumped to automatically, since it may take a long time
 // to switch projects, and undo history may be lost.
 
-const HELP_CHAT_ID = 'enso-chat'
+export const HELP_CHAT_ID = 'enso-chat'
 export const ANIMATION_DURATION_MS = 200
-const WIDTH_PX = 336
+export const WIDTH_PX = 336
 /** The size (both width and height) of each reaction button. */
 const REACTION_BUTTON_SIZE = 20
 /** The size (both width and height) of each reaction on a message. */

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/chatPlaceholder.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/chatPlaceholder.tsx
@@ -1,0 +1,102 @@
+/** @file A placeholder component replacing `Chat` when a user is not logged in. */
+import * as React from 'react'
+import * as reactDom from 'react-dom'
+
+import CloseLargeIcon from 'enso-assets/close_large.svg'
+
+import * as animations from '../../animations'
+import * as app from '../../components/app'
+import * as hooks from '../../hooks'
+import * as loggerProvider from '../../providers/logger'
+
+import * as chat from './chat'
+import * as pageSwitcher from './pageSwitcher'
+
+/** Props for a {@link ChatPlaceholder}. */
+export interface ChatPlaceholderProps {
+    page: pageSwitcher.Page
+    /** This should only be false when the panel is closing. */
+    isOpen: boolean
+    doClose: () => void
+}
+
+/** A placeholder component replacing `Chat` when a user is not logged in. */
+export default function ChatPlaceholder(props: ChatPlaceholderProps) {
+    const { page, isOpen, doClose } = props
+    const logger = loggerProvider.useLogger()
+    const navigate = hooks.useNavigate()
+    const [right, setTargetRight] = animations.useInterpolateOverTime(
+        animations.interpolationFunctionEaseInOut,
+        chat.ANIMATION_DURATION_MS,
+        -chat.WIDTH_PX
+    )
+
+    const container = document.getElementById(chat.HELP_CHAT_ID)
+
+    React.useEffect(() => {
+        // The types come from a third-party API and cannot be changed.
+        // eslint-disable-next-line no-restricted-syntax
+        let handle: number | undefined
+        if (container != null) {
+            if (isOpen) {
+                container.style.display = ''
+                setTargetRight(0)
+            } else {
+                setTargetRight(-chat.WIDTH_PX)
+                handle = window.setTimeout(() => {
+                    container.style.display = 'none'
+                }, chat.ANIMATION_DURATION_MS)
+            }
+        }
+        return () => {
+            clearTimeout(handle)
+        }
+    }, [isOpen, container, setTargetRight])
+
+    if (container == null) {
+        logger.error('Chat container not found.')
+        return null
+    } else {
+        return reactDom.createPortal(
+            <div
+                style={{ right }}
+                className={`text-xs text-chat flex flex-col fixed top-0 right-0 backdrop-blur-3xl h-screen border-ide-bg-dark border-l-2 w-83.5 py-1 z-1 ${
+                    page === pageSwitcher.Page.editor ? 'bg-ide-bg' : 'bg-frame-selected'
+                }`}
+            >
+                <div className="flex text-sm font-semibold mx-4 mt-2">
+                    <div className="grow" />
+                    <button className="mx-1" onClick={doClose}>
+                        <img src={CloseLargeIcon} />
+                    </button>
+                </div>
+                <div className="grow grid place-items-center">
+                    <div className="flex flex-col gap-3 text-base text-center">
+                        <div>
+                            Login or register to access live chat
+                            <br />
+                            with our support team.
+                        </div>
+                        <button
+                            className="block self-center whitespace-nowrap text-base text-white bg-help rounded-full leading-170 h-8 py-px px-2 w-min"
+                            onClick={() => {
+                                navigate(app.LOGIN_PATH)
+                            }}
+                        >
+                            Login
+                        </button>
+                        <button
+                            className="block self-center whitespace-nowrap text-base text-white bg-help rounded-full leading-170 h-8 py-px px-2 w-min"
+                            onClick={() => {
+                                navigate(app.REGISTRATION_PATH)
+                            }}
+                        >
+                            Register
+                        </button>
+                    </div>
+                </div>
+            </div>,
+            container
+        )
+    }
+}

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/connectorNameColumn.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/connectorNameColumn.tsx
@@ -67,6 +67,7 @@ export default function ConnectorNameColumn(props: ConnectorNameColumnProps) {
             case assetEventModule.AssetEventType.move:
             case assetEventModule.AssetEventType.delete:
             case assetEventModule.AssetEventType.restore:
+            case assetEventModule.AssetEventType.download:
             case assetEventModule.AssetEventType.downloadSelected:
             case assetEventModule.AssetEventType.removeSelf:
             case assetEventModule.AssetEventType.temporarilyAddLabels:
@@ -75,8 +76,8 @@ export default function ConnectorNameColumn(props: ConnectorNameColumnProps) {
             case assetEventModule.AssetEventType.removeLabels:
             case assetEventModule.AssetEventType.deleteLabel: {
                 // Ignored. These events should all be unrelated to secrets.
-                // `deleteMultiple`, `restoreMultiple` and `downloadSelected` are handled by
-                // `AssetRow`.
+                // `deleteMultiple`, `restoreMultiple`, `download`,
+                // and `downloadSelected` are handled by `AssetRow`.
                 break
             }
             case assetEventModule.AssetEventType.newDataConnector: {

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/dashboard.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/dashboard.tsx
@@ -27,6 +27,7 @@ import * as pageSwitcher from './pageSwitcher'
 import type * as spinner from './spinner'
 import Chat, * as chat from './chat'
 import AssetSettingsPanel from './assetSettingsPanel'
+import ChatPlaceholder from './chatPlaceholder'
 import Drive from './drive'
 import Editor from './editor'
 import Home from './home'
@@ -472,8 +473,16 @@ export default function Dashboard(props: DashboardProps) {
                         appRunner={appRunner}
                     />
                     {/* `session.accessToken` MUST be present in order for the `Chat` component to work. */}
-                    {isHelpChatVisible && session.accessToken != null && (
+                    {isHelpChatVisible && session.accessToken != null ? (
                         <Chat
+                            page={page}
+                            isOpen={isHelpChatOpen}
+                            doClose={() => {
+                                setIsHelpChatOpen(false)
+                            }}
+                        />
+                    ) : (
+                        <ChatPlaceholder
                             page={page}
                             isOpen={isHelpChatOpen}
                             doClose={() => {

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/directoryNameColumn.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/directoryNameColumn.tsx
@@ -96,6 +96,7 @@ export default function DirectoryNameColumn(props: DirectoryNameColumnProps) {
             case assetEventModule.AssetEventType.move:
             case assetEventModule.AssetEventType.delete:
             case assetEventModule.AssetEventType.restore:
+            case assetEventModule.AssetEventType.download:
             case assetEventModule.AssetEventType.downloadSelected:
             case assetEventModule.AssetEventType.removeSelf:
             case assetEventModule.AssetEventType.temporarilyAddLabels:
@@ -104,8 +105,8 @@ export default function DirectoryNameColumn(props: DirectoryNameColumnProps) {
             case assetEventModule.AssetEventType.removeLabels:
             case assetEventModule.AssetEventType.deleteLabel: {
                 // Ignored. These events should all be unrelated to directories.
-                // `deleteMultiple`, `restoreMultiple` and `downloadSelected` are handled by
-                // `AssetRow`.
+                // `deleteMultiple`, `restoreMultiple`, `download`,
+                // and `downloadSelected` are handled by `AssetRow`.
                 break
             }
             case assetEventModule.AssetEventType.newFolder: {

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/fileNameColumn.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/fileNameColumn.tsx
@@ -67,6 +67,7 @@ export default function FileNameColumn(props: FileNameColumnProps) {
             case assetEventModule.AssetEventType.move:
             case assetEventModule.AssetEventType.delete:
             case assetEventModule.AssetEventType.restore:
+            case assetEventModule.AssetEventType.download:
             case assetEventModule.AssetEventType.downloadSelected:
             case assetEventModule.AssetEventType.removeSelf:
             case assetEventModule.AssetEventType.temporarilyAddLabels:
@@ -75,8 +76,8 @@ export default function FileNameColumn(props: FileNameColumnProps) {
             case assetEventModule.AssetEventType.removeLabels:
             case assetEventModule.AssetEventType.deleteLabel: {
                 // Ignored. These events should all be unrelated to projects.
-                // `deleteMultiple`, `restoreMultiple` and `downloadSelected` are handled by
-                // `AssetRow`.
+                // `deleteMultiple`, `restoreMultiple`, `download`, and `downloadSelected`
+                // are handled by `AssetRow`.
                 break
             }
             case assetEventModule.AssetEventType.uploadFiles: {

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/globalContextMenu.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/globalContextMenu.tsx
@@ -37,6 +37,7 @@ export default function GlobalContextMenu(props: GlobalContextMenuProps) {
     const { backend } = backendProvider.useBackend()
     const { setModal, unsetModal } = modalProvider.useSetModal()
     const filesInputRef = React.useRef<HTMLInputElement>(null)
+    const isCloud = backend.type === backendModule.BackendType.remote
     return (
         <ContextMenu hidden={hidden}>
             {!hidden && (
@@ -93,21 +94,23 @@ export default function GlobalContextMenu(props: GlobalContextMenuProps) {
                     }
                 }}
             />
-            <MenuEntry
-                hidden={hidden}
-                action={shortcuts.KeyboardAction.newProject}
-                doAction={() => {
-                    unsetModal()
-                    dispatchAssetListEvent({
-                        type: assetListEventModule.AssetListEventType.newProject,
-                        parentKey: directoryKey,
-                        parentId: directoryId,
-                        templateId: null,
-                        onSpinnerStateChange: null,
-                    })
-                }}
-            />
-            {backend.type !== backendModule.BackendType.local && (
+            {isCloud && (
+                <MenuEntry
+                    hidden={hidden}
+                    action={shortcuts.KeyboardAction.newProject}
+                    doAction={() => {
+                        unsetModal()
+                        dispatchAssetListEvent({
+                            type: assetListEventModule.AssetListEventType.newProject,
+                            parentKey: directoryKey,
+                            parentId: directoryId,
+                            templateId: null,
+                            onSpinnerStateChange: null,
+                        })
+                    }}
+                />
+            )}
+            {isCloud && (
                 <MenuEntry
                     hidden={hidden}
                     action={shortcuts.KeyboardAction.newFolder}
@@ -121,7 +124,7 @@ export default function GlobalContextMenu(props: GlobalContextMenuProps) {
                     }}
                 />
             )}
-            {backend.type !== backendModule.BackendType.local && (
+            {isCloud && (
                 <MenuEntry
                     hidden={hidden}
                     action={shortcuts.KeyboardAction.newDataConnector}
@@ -143,7 +146,7 @@ export default function GlobalContextMenu(props: GlobalContextMenuProps) {
                     }}
                 />
             )}
-            {directoryKey == null && hasCopyData && (
+            {isCloud && directoryKey == null && hasCopyData && (
                 <MenuEntry
                     hidden={hidden}
                     action={shortcuts.KeyboardAction.paste}

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/labels.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/labels.tsx
@@ -54,6 +54,7 @@ export default function Labels(props: LabelsProps) {
             <ul data-testid="labels-list" className="flex flex-col items-start gap-1">
                 {labels
                     .filter(label => !deletedLabelNames.has(label.value))
+                    .sort((a, b) => (a.value > b.value ? 1 : a.value < b.value ? -1 : 0))
                     .map(label => (
                         <li key={label.id} className="group flex items-center gap-1">
                             <Label

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/labels.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/labels.tsx
@@ -121,7 +121,7 @@ export default function Labels(props: LabelsProps) {
                             event.stopPropagation()
                             setModal(
                                 <NewLabelModal
-                                    labelNames={new Set(labels.map(label => label.value))}
+                                    labels={labels}
                                     eventTarget={event.currentTarget}
                                     doCreate={doCreateLabel}
                                 />

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/manageLabelsModal.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/manageLabelsModal.tsx
@@ -39,9 +39,13 @@ export default function ManageLabelsModal<
     const { backend } = backendProvider.useBackend()
     const { unsetModal } = modalProvider.useSetModal()
     const toastAndLog = hooks.useToastAndLog()
-    const [labels, setLabels] = React.useState(item.labels ?? [])
+    const [labels, setLabelsRaw] = React.useState(item.labels ?? [])
     const [query, setQuery] = React.useState('')
     const [color, setColor] = React.useState<backendModule.LChColor | null>(null)
+    const leastUsedColor = React.useMemo(
+        () => backendModule.leastUsedColor(allLabels.values()),
+        [allLabels]
+    )
     const position = React.useMemo(() => eventTarget?.getBoundingClientRect(), [eventTarget])
     const labelNames = React.useMemo(() => new Set(labels), [labels])
     const regex = React.useMemo(() => new RegExp(string.regexEscape(query), 'i'), [query])
@@ -51,11 +55,21 @@ export default function ManageLabelsModal<
             Array.from(allLabels.keys()).filter(label => regex.test(label)).length === 0,
         [allLabels, query, regex]
     )
-    const canCreateNewLabel = canSelectColor && color != null
+    const canCreateNewLabel = canSelectColor
 
-    React.useEffect(() => {
-        setItem(oldItem => ({ ...oldItem, labels }))
-    }, [labels, /* should never change */ setItem])
+    const setLabels = React.useCallback(
+        (valueOrUpdater: React.SetStateAction<backendModule.LabelName[]>) => {
+            setLabelsRaw(valueOrUpdater)
+            setItem(oldItem => {
+                if (typeof valueOrUpdater === 'function') {
+                    return { ...oldItem, labels: valueOrUpdater(oldItem.labels ?? []) }
+                } else {
+                    return { ...oldItem, labels: valueOrUpdater }
+                }
+            })
+        },
+        [/* should never change */ setItem]
+    )
 
     if (backend.type === backendModule.BackendType.local || organization == null) {
         // This should never happen - the local backend does not have the "labels" column,
@@ -83,6 +97,7 @@ export default function ManageLabelsModal<
                 item.id,
                 item.title,
                 backend,
+                /* should never change */ setLabels,
                 /* should never change */ toastAndLog,
             ]
         )
@@ -122,17 +137,19 @@ export default function ManageLabelsModal<
                         onSubmit={async event => {
                             event.preventDefault()
                             setLabels(oldLabels => [...oldLabels, backendModule.LabelName(query)])
+                            unsetModal()
                             try {
-                                if (color != null) {
-                                    await doCreateLabel(query, color)
-                                }
+                                await doCreateLabel(query, color ?? leastUsedColor)
+                                setLabels(newLabels => {
+                                    void backend.associateTag(item.id, newLabels, item.title)
+                                    return newLabels
+                                })
                             } catch (error) {
                                 toastAndLog(null, error)
                                 setLabels(oldLabels =>
                                     oldLabels.filter(oldLabel => oldLabel !== query)
                                 )
                             }
-                            unsetModal()
                         }}
                     >
                         <div>

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/manageLabelsModal.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/manageLabelsModal.tsx
@@ -118,7 +118,7 @@ export default function ManageLabelsModal<
                 >
                     <div className="absolute bg-frame-selected backdrop-blur-3xl rounded-2xl h-full w-full" />
                     <form
-                        className="relative flex flex-col gap-1 rounded-2xl gap-2 p-2"
+                        className="relative flex flex-col rounded-2xl gap-2 p-2"
                         onSubmit={async event => {
                             event.preventDefault()
                             setLabels(oldLabels => [...oldLabels, backendModule.LabelName(query)])
@@ -172,7 +172,7 @@ export default function ManageLabelsModal<
                             <div className="h-6 py-0.5">Create</div>
                         </button>
                         {canSelectColor && (
-                            <div className="flex gap-1">
+                            <div className="flex flex-col items-center">
                                 <div className="grow flex items-center gap-1">
                                     <ColorPicker setColor={setColor} />
                                 </div>
@@ -186,7 +186,9 @@ export default function ManageLabelsModal<
                                         <Label
                                             active={labels.includes(label.value)}
                                             color={label.color}
-                                            onClick={async () => {
+                                            onClick={async event => {
+                                                event.preventDefault()
+                                                event.stopPropagation()
                                                 await doToggleLabel(label.value)
                                             }}
                                         >

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/newLabelModal.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/newLabelModal.tsx
@@ -10,17 +10,6 @@ import * as modalProvider from '../../providers/modal'
 import ColorPicker from './colorPicker'
 import Modal from './modal'
 
-// =================
-// === Constants ===
-// =================
-
-const COLOR_STRING_TO_COLOR = new Map(
-    backend.COLORS.map(color => [backend.lChColorToCssColor(color), color])
-)
-const INITIAL_COLOR_COUNTS = new Map(
-    backend.COLORS.map(color => [backend.lChColorToCssColor(color), 0])
-)
-
 // =====================
 // === NewLabelModal ===
 // =====================
@@ -43,18 +32,7 @@ export default function NewLabelModal(props: NewLabelModalProps) {
         () => new Set<string>(labels.map(label => label.value)),
         [labels]
     )
-    const leastUsedColor = React.useMemo(() => {
-        const colorCounts = new Map(INITIAL_COLOR_COUNTS)
-        for (const label of labels) {
-            const colorString = backend.lChColorToCssColor(label.color)
-            colorCounts.set(colorString, (colorCounts.get(colorString) ?? 0) + 1)
-        }
-        const min = Math.min(...colorCounts.values())
-        const [minColor] = [...colorCounts.entries()].find(kv => kv[1] === min) ?? []
-        return minColor == null
-            ? backend.COLORS[0]
-            : COLOR_STRING_TO_COLOR.get(minColor) ?? backend.COLORS[0]
-    }, [labels])
+    const leastUsedColor = React.useMemo(() => backend.leastUsedColor(labels), [labels])
 
     const [value, setName] = React.useState('')
     const [color, setColor] = React.useState<backend.LChColor | null>(null)

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectIcon.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectIcon.tsx
@@ -247,6 +247,7 @@ export default function ProjectIcon(props: ProjectIconProps) {
             case assetEventModule.AssetEventType.move:
             case assetEventModule.AssetEventType.delete:
             case assetEventModule.AssetEventType.restore:
+            case assetEventModule.AssetEventType.download:
             case assetEventModule.AssetEventType.downloadSelected:
             case assetEventModule.AssetEventType.removeSelf:
             case assetEventModule.AssetEventType.temporarilyAddLabels:
@@ -255,8 +256,8 @@ export default function ProjectIcon(props: ProjectIconProps) {
             case assetEventModule.AssetEventType.removeLabels:
             case assetEventModule.AssetEventType.deleteLabel: {
                 // Ignored. Any missing project-related events should be handled by
-                // `ProjectNameColumn`. `deleteMultiple`, `restoreMultiple` and `downloadSelected`
-                // are handled by `AssetRow`.
+                // `ProjectNameColumn`. `deleteMultiple`, `restoreMultiple`, `download`,
+                // and`downloadSelected` are handled by `AssetRow`.
                 break
             }
             case assetEventModule.AssetEventType.openProject: {

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectNameColumn.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/projectNameColumn.tsx
@@ -110,6 +110,7 @@ export default function ProjectNameColumn(props: ProjectNameColumnProps) {
             case assetEventModule.AssetEventType.move:
             case assetEventModule.AssetEventType.delete:
             case assetEventModule.AssetEventType.restore:
+            case assetEventModule.AssetEventType.download:
             case assetEventModule.AssetEventType.downloadSelected:
             case assetEventModule.AssetEventType.removeSelf:
             case assetEventModule.AssetEventType.temporarilyAddLabels:
@@ -118,8 +119,8 @@ export default function ProjectNameColumn(props: ProjectNameColumnProps) {
             case assetEventModule.AssetEventType.removeLabels:
             case assetEventModule.AssetEventType.deleteLabel: {
                 // Ignored. Any missing project-related events should be handled by `ProjectIcon`.
-                // `deleteMultiple`, `restoreMultiple` and `downloadSelected` are handled by
-                // `AssetRow`.
+                // `deleteMultiple`, `restoreMultiple`, `download`, and `downloadSelected`
+                // are handled by `AssetRow`.
                 break
             }
             case assetEventModule.AssetEventType.newProject: {

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/samples.tsx
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/components/samples.tsx
@@ -197,15 +197,14 @@ function ProjectTile(props: InternalProjectTileProps) {
                     <SvgMask src={Logo} />
                     <span className="font-bold leading-144.5 pb-px">{author}</span>
                 </div>
-                <div className="flex gap-3">
-                    {/* Opens */}
-                    <div className="flex gap-1.5">
-                        <SvgMask src={OpenCountIcon} />
+                {/* Normally `flex` */}
+                <div className="gap-3 hidden">
+                    <div title="Views" className="flex gap-1.5">
+                        <SvgMask alt="Views" src={OpenCountIcon} />
                         <span className="font-bold leading-144.5 pb-px">{opens}</span>
                     </div>
-                    {/* Likes */}
-                    <div className="flex gap-1.5">
-                        <SvgMask src={HeartIcon} />
+                    <div title="Likes" className="flex gap-1.5">
+                        <SvgMask alt="Likes" src={HeartIcon} />
                         <span className="font-bold leading-144.5 pb-px">{likes}</span>
                     </div>
                 </div>

--- a/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/events/assetEvent.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/src/dashboard/events/assetEvent.ts
@@ -30,6 +30,7 @@ export enum AssetEventType {
     move = 'move',
     delete = 'delete',
     restore = 'restore',
+    download = 'download',
     downloadSelected = 'download-selected',
     removeSelf = 'remove-self',
     temporarilyAddLabels = 'temporarily-add-labels',
@@ -58,6 +59,7 @@ interface AssetEvents {
     move: AssetMoveEvent
     delete: AssetDeleteEvent
     restore: AssetRestoreEvent
+    download: AssetDownloadEvent
     downloadSelected: AssetDownloadSelectedEvent
     removeSelf: AssetRemoveSelfEvent
     temporarilyAddLabels: AssetTemporarilyAddLabelsEvent
@@ -134,13 +136,18 @@ export interface AssetMoveEvent extends AssetBaseEvent<AssetEventType.move> {
     ids: Set<backendModule.AssetId>
 }
 
-/** A signal to delete multiple assets. */
+/** A signal to delete assets. */
 export interface AssetDeleteEvent extends AssetBaseEvent<AssetEventType.delete> {
     ids: Set<backendModule.AssetId>
 }
 
-/** A signal to restore multiple assets from trash. */
+/** A signal to restore assets from trash. */
 export interface AssetRestoreEvent extends AssetBaseEvent<AssetEventType.restore> {
+    ids: Set<backendModule.AssetId>
+}
+
+/** A signal to download assets. */
+export interface AssetDownloadEvent extends AssetBaseEvent<AssetEventType.download> {
     ids: Set<backendModule.AssetId>
 }
 

--- a/app/ide-desktop/lib/dashboard/src/index.ts
+++ b/app/ide-desktop/lib/dashboard/src/index.ts
@@ -41,7 +41,7 @@ if (detect.IS_DEV_MODE && (!(typeof IS_VITE !== 'undefined') || !IS_VITE)) {
 authentication.run({
     logger: console,
     // This file is only included when building for the cloud.
-    supportsLocalBackend: false,
+    supportsLocalBackend: true,
     supportsDeepLinks: false,
     isAuthenticationDisabled: false,
     shouldShowDashboard: true,

--- a/app/ide-desktop/lib/dashboard/src/index.ts
+++ b/app/ide-desktop/lib/dashboard/src/index.ts
@@ -41,7 +41,7 @@ if (detect.IS_DEV_MODE && (!(typeof IS_VITE !== 'undefined') || !IS_VITE)) {
 authentication.run({
     logger: console,
     // This file is only included when building for the cloud.
-    supportsLocalBackend: true,
+    supportsLocalBackend: false,
     supportsDeepLinks: false,
     isAuthenticationDisabled: false,
     shouldShowDashboard: true,


### PR DESCRIPTION
### Pull Request Description
- Closes https://github.com/enso-org/cloud-v2/issues/799
  - Pressing return in the label name input creates a label with a color defaulting the color used by the fewest number of tags
  - Right click on a label brings up a context menu
  - If you drag into a folder the folder should be expanded - this should work for all kinds of drag, including labels and assets
  - :warning: Drag & drop in Mac likely still does not work - I currently cannot test on macOS
- Closes https://github.com/enso-org/cloud-v2/issues/800
  - Hide likes and the views on homepage view
  - Hide "New Project" (and other items that are not applicable) in context menu when on local backend
  - Download context menu option implemented for local mode
  - :warning: Copy not implemented as backend functionality does not yet exist.

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
