### PR TITLE
Inline execution should support FQNs

### DIFF
--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Main.enso
@@ -7,4 +7,5 @@ import project.Preprocessor
 
 export project.Helpers
 export project.Id.Id
+export project.Preprocessor
 from project.File_Upload export file_uploading

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/context/InlineContext.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/context/InlineContext.scala
@@ -37,19 +37,23 @@ object InlineContext {
     * @param module the module defining the context
     * @param isInTailPosition whether or not the inline expression occurs in a
     *                         tail position
+    * @param compilerConfig the compiler configuration
+    * @param pkgRepo the compiler's package repository
     * @return the [[InlineContext]] instance corresponding to the arguments
     */
   def fromJava(
     localScope: LocalScope,
     module: CompilerContext.Module,
     isInTailPosition: Option[Boolean],
-    compilerConfig: CompilerConfig
+    compilerConfig: CompilerConfig,
+    pkgRepo: Option[PackageRepository]
   ): InlineContext = {
     InlineContext(
       localScope       = Option(localScope),
       module           = ModuleContext(module, compilerConfig),
       isInTailPosition = isInTailPosition,
-      compilerConfig   = compilerConfig
+      compilerConfig   = compilerConfig,
+      pkgRepo          = pkgRepo
     )
   }
 

--- a/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -3880,4 +3880,183 @@ class RuntimeVisualizationsTest
     }
     new String(data) shouldEqual "85"
   }
+
+  it should "execute default visualization preprocessor" in {
+    val contextId       = UUID.randomUUID()
+    val requestId       = UUID.randomUUID()
+    val visualizationId = UUID.randomUUID()
+    val moduleName      = "Enso_Test.Test.Main"
+    val metadata        = new Metadata
+
+    val idMain = metadata.addItem(60, 6)
+
+    val code =
+      """import Standard.Visualization.Preprocessor
+        |
+        |main =
+        |    fn = x -> x
+        |    fn
+        |""".stripMargin.linesIterator.mkString("\n")
+    val contents = metadata.appendToCode(code)
+    val mainFile = context.writeMain(contents)
+
+    // create context
+    context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
+    context.receive shouldEqual Some(
+      Api.Response(requestId, Api.CreateContextResponse(contextId))
+    )
+
+    // Open the new file
+    context.send(
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
+    )
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenFileResponse)
+    )
+
+    // push main
+    val item1 = Api.StackItem.ExplicitCall(
+      Api.MethodPointer(moduleName, moduleName, "main"),
+      None,
+      Vector()
+    )
+    context.send(
+      Api.Request(requestId, Api.PushContextRequest(contextId, item1))
+    )
+    context.receiveNIgnorePendingExpressionUpdates(
+      3
+    ) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PushContextResponse(contextId)),
+      TestMessages.update(
+        contextId,
+        idMain,
+        ConstantsGen.FUNCTION
+      ),
+      context.executionComplete(contextId)
+    )
+
+    // execute expression
+    context.send(
+      Api.Request(
+        requestId,
+        Api.ExecuteExpression(
+          contextId,
+          visualizationId,
+          idMain,
+          "Preprocessor.default_preprocessor 85"
+        )
+      )
+    )
+    val executeExpressionResponses =
+      context.receiveNIgnoreExpressionUpdates(3)
+    executeExpressionResponses should contain allOf (
+      Api.Response(requestId, Api.VisualizationAttached()),
+      context.executionComplete(contextId)
+    )
+    val Some(data) = executeExpressionResponses.collectFirst {
+      case Api.Response(
+            None,
+            Api.VisualizationUpdate(
+              Api.VisualizationContext(
+                `visualizationId`,
+                `contextId`,
+                `idMain`
+              ),
+              data
+            )
+          ) =>
+        data
+    }
+    new String(data) shouldEqual "85"
+  }
+
+  it should "execute default visualization preprocessor with a FQN" in {
+    val contextId       = UUID.randomUUID()
+    val requestId       = UUID.randomUUID()
+    val visualizationId = UUID.randomUUID()
+    val moduleName      = "Enso_Test.Test.Main"
+    val metadata        = new Metadata
+
+    val idMain = metadata.addItem(60, 6)
+
+    val code =
+      """import Standard.Visualization.Preprocessor
+        |
+        |main =
+        |    fn = x -> x
+        |    fn
+        |""".stripMargin.linesIterator.mkString("\n")
+    val contents = metadata.appendToCode(code)
+    val mainFile = context.writeMain(contents)
+
+    // create context
+    context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
+    context.receive shouldEqual Some(
+      Api.Response(requestId, Api.CreateContextResponse(contextId))
+    )
+
+    // Open the new file
+    context.send(
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
+    )
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenFileResponse)
+    )
+
+    // push main
+    val item1 = Api.StackItem.ExplicitCall(
+      Api.MethodPointer(moduleName, moduleName, "main"),
+      None,
+      Vector()
+    )
+    context.send(
+      Api.Request(requestId, Api.PushContextRequest(contextId, item1))
+    )
+    context.receiveNIgnorePendingExpressionUpdates(
+      3
+    ) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PushContextResponse(contextId)),
+      TestMessages.update(
+        contextId,
+        idMain,
+        ConstantsGen.FUNCTION
+      ),
+      context.executionComplete(contextId)
+    )
+
+    // execute expression
+    context.send(
+      Api.Request(
+        requestId,
+        Api.ExecuteExpression(
+          contextId,
+          visualizationId,
+          idMain,
+          "Standard.Visualization.Preprocessor.default_preprocessor 85"
+        )
+      )
+    )
+    val executeExpressionResponses =
+      context.receiveNIgnoreExpressionUpdates(3)
+    executeExpressionResponses should contain allOf (
+      Api.Response(requestId, Api.VisualizationAttached()),
+      context.executionComplete(contextId)
+    )
+    val Some(data) = executeExpressionResponses.collectFirst {
+      case Api.Response(
+            None,
+            Api.VisualizationUpdate(
+              Api.VisualizationContext(
+                `visualizationId`,
+                `contextId`,
+                `idMain`
+              ),
+              data
+            )
+          ) =>
+        data
+    }
+    new String(data) shouldEqual "85"
+  }
+
 }

--- a/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-with-polyglot/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -3977,10 +3977,11 @@ class RuntimeVisualizationsTest
     val moduleName      = "Enso_Test.Test.Main"
     val metadata        = new Metadata
 
-    val idMain = metadata.addItem(60, 6)
+    val idMain = metadata.addItem(90, 6)
 
     val code =
-      """import Standard.Visualization.Preprocessor
+      """import Standard.Visualization
+        |import Standard.Visualization.Preprocessor
         |
         |main =
         |    fn = x -> x

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/EvalNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/debug/EvalNode.java
@@ -64,13 +64,15 @@ public abstract class EvalNode extends BaseNode {
   RootCallTarget parseExpression(LocalScope scope, ModuleScope moduleScope, String expression) {
     EnsoContext context = EnsoContext.get(this);
     LocalScope localScope = scope.createChild();
+    var compiler = context.getCompiler();
     InlineContext inlineContext =
         InlineContext.fromJava(
             localScope,
             moduleScope.getModule().asCompilerModule(),
             scala.Option.apply(getTailStatus() != TailStatus.NOT_TAIL),
-            context.getCompilerConfig());
-    var compiler = context.getCompiler();
+            context.getCompilerConfig(),
+            scala.Option.apply(compiler.packageRepository()));
+
     var tuppleOption = compiler.runInline(expression, inlineContext);
     if (tuppleOption.isEmpty()) {
       throw new RuntimeException("Invalid code passed to `eval`: " + expression);

--- a/lib/scala/pkg/src/main/scala/org/enso/pkg/Package.scala
+++ b/lib/scala/pkg/src/main/scala/org/enso/pkg/Package.scala
@@ -241,6 +241,10 @@ class Package[F](
       .asScala
       .toList
   }
+
+  override def toString: String = {
+    s"Package[$name]"
+  }
 }
 
 /** A class responsible for creating and parsing package structures.


### PR DESCRIPTION
### Pull Request Description

Previously, there was no requirement that inline execution should allow
for FQNs. This meant that the omission of Package Repository info went
unnoticed.

Closes #8428.

### Important Notes

In order to be able to refer to `Standard.Visualization.Preprocessor` it
has to be exported as well in `Standard.Visualization.Main`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
