### PR TITLE
Zoom to all/zoom to selected

### DIFF
--- a/app/gui2/src/bindings.ts
+++ b/app/gui2/src/bindings.ts
@@ -26,6 +26,7 @@ export const graphBindings = defineKeybinds('graph-editor', {
   newNode: ['N'],
   toggleVisualization: ['Space'],
   deleteSelected: ['Delete'],
+  zoomToSelected: ['Mod+Shift+A'],
   selectAll: ['Mod+A'],
   deselectAll: ['Escape', 'PointerMain'],
   copyNode: ['Mod+C'],

--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -24,7 +24,7 @@ import { useProjectStore } from '@/stores/project'
 import { groupColorVar, useSuggestionDbStore } from '@/stores/suggestionDatabase'
 import { colorFromString } from '@/util/colors'
 import { keyboardBusy, keyboardBusyExceptIn, useEvent } from '@/util/events'
-import type { Rect } from '@/util/rect.ts'
+import { Rect } from '@/util/rect.ts'
 import { Vec2 } from '@/util/vec2'
 import * as set from 'lib0/set'
 import type { ExprId, NodeMetadata } from 'shared/yjsModel.ts'
@@ -152,6 +152,28 @@ const graphBindingsHandler = graphBindings.handler({
         graphStore.deleteNode(node)
       }
     })
+  },
+  zoomToSelected() {
+    if (!viewportNode.value) return
+    let left = Infinity
+    let top = Infinity
+    let right = -Infinity
+    let bottom = -Infinity
+    const nodesToCenter =
+      nodeSelection.selected.size === 0 ? graphStore.nodeRects.keys() : nodeSelection.selected
+    for (const id of nodesToCenter) {
+      const rect = graphStore.nodeRects.get(id)
+      if (!rect) continue
+      left = Math.min(left, rect.left)
+      right = Math.max(right, rect.right)
+      top = Math.min(top, rect.top)
+      bottom = Math.max(bottom, rect.bottom)
+    }
+    graphNavigator.panAndZoomTo(
+      Rect.FromBounds(left, top, right, bottom),
+      0.1,
+      Math.max(1, graphNavigator.scale),
+    )
   },
   selectAll() {
     if (keyboardBusy()) return

--- a/app/gui2/src/components/VisualizationSelector.vue
+++ b/app/gui2/src/components/VisualizationSelector.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import SvgIcon from '@/components/SvgIcon.vue'
 import { useAutoBlur } from '@/util/autoBlur'
+import type { Icon } from '@/util/iconName'
+import type { URLString } from '@/util/urlString'
+import { computedAsync } from '@vueuse/core'
 import { visIdentifierEquals, type VisualizationIdentifier } from 'shared/yjsModel'
 import { onMounted, ref } from 'vue'
 
@@ -10,10 +13,21 @@ const props = defineProps<{
 }>()
 const emit = defineEmits<{ hide: []; 'update:modelValue': [type: VisualizationIdentifier] }>()
 
-// This dynamic import is required to break the circular import:
+// This dynamic import is required to break the circular import chain:
 // `VisualizationSelector.vue` -> `compilerMessaging.ts` -> `VisualizationContainer.vue` ->
 // `VisualizationSelector.vue`
-const visualizationStore = (await import('@/stores/visualization')).useVisualizationStore()
+const visualizationStore = computedAsync<{
+  icon: (type: VisualizationIdentifier) => Icon | URLString | undefined
+}>(
+  async () => {
+    return (await import('@/stores/visualization')).useVisualizationStore()
+  },
+  {
+    icon() {
+      return 'columns_increasing'
+    },
+  },
+)
 
 const rootNode = ref<HTMLElement>()
 useAutoBlur(rootNode)

--- a/app/gui2/src/util/navigator.ts
+++ b/app/gui2/src/util/navigator.ts
@@ -49,6 +49,19 @@ export function useNavigator(viewportNode: Ref<Element | undefined>) {
     return new Rect(pos, size)
   }
 
+  function panAndZoomTo(rect: Rect, minScale = 0.1, maxScale = 1) {
+    if (!viewportNode.value) return
+    scale.value = Math.max(
+      minScale,
+      Math.min(
+        maxScale,
+        viewportNode.value.clientHeight / rect.height,
+        viewportNode.value.clientWidth / rect.width,
+      ),
+    )
+    center.value = new Vec2(rect.left + rect.width / 2, rect.top + rect.height / 2)
+  }
+
   let zoomPivot = Vec2.Zero
   const zoomPointer = usePointer((pos, _event, ty) => {
     if (ty === 'start') {
@@ -189,6 +202,7 @@ export function useNavigator(viewportNode: Ref<Element | undefined>) {
     sceneMousePos,
     clientToScenePos,
     clientToSceneRect,
+    panAndZoomTo,
     viewport,
   })
 }

--- a/app/gui2/src/util/navigator.ts
+++ b/app/gui2/src/util/navigator.ts
@@ -1,3 +1,4 @@
+import { useApproach } from '@/util/animation'
 import { PointerButtonMask, useEvent, usePointer, useResizeObserver } from '@/util/events'
 import { Rect } from '@/util/rect'
 import { Vec2 } from '@/util/vec2'
@@ -14,8 +15,32 @@ function elemRect(target: Element | undefined): Rect {
 export type NavigatorComposable = ReturnType<typeof useNavigator>
 export function useNavigator(viewportNode: Ref<Element | undefined>) {
   const size = useResizeObserver(viewportNode)
-  const center = ref<Vec2>(Vec2.Zero)
-  const scale = ref(1)
+  const targetCenter = ref<Vec2>(Vec2.Zero)
+  const targetX = computed(() => targetCenter.value.x)
+  const targetY = computed(() => targetCenter.value.y)
+  const centerX = useApproach(targetX)
+  const centerY = useApproach(targetY)
+  const center = computed({
+    get() {
+      return new Vec2(centerX.value, centerY.value)
+    },
+    set(value) {
+      targetCenter.value = value
+      centerX.value = value.x
+      centerY.value = value.y
+    },
+  })
+  const targetScale = ref(1)
+  const animatedScale = useApproach(targetScale)
+  const scale = computed({
+    get() {
+      return animatedScale.value
+    },
+    set(value) {
+      targetScale.value = value
+      animatedScale.value = value
+    },
+  })
   const panPointer = usePointer((pos) => {
     center.value = center.value.addScaled(pos.delta, -1 / scale.value)
   }, PointerButtonMask.Auxiliary)
@@ -51,7 +76,7 @@ export function useNavigator(viewportNode: Ref<Element | undefined>) {
 
   function panAndZoomTo(rect: Rect, minScale = 0.1, maxScale = 1) {
     if (!viewportNode.value) return
-    scale.value = Math.max(
+    targetScale.value = Math.max(
       minScale,
       Math.min(
         maxScale,
@@ -59,7 +84,7 @@ export function useNavigator(viewportNode: Ref<Element | undefined>) {
         viewportNode.value.clientWidth / rect.width,
       ),
     )
-    center.value = new Vec2(rect.left + rect.width / 2, rect.top + rect.height / 2)
+    targetCenter.value = new Vec2(rect.left + rect.width / 2, rect.top + rect.height / 2)
   }
 
   let zoomPivot = Vec2.Zero

--- a/app/gui2/src/util/rect.ts
+++ b/app/gui2/src/util/rect.ts
@@ -47,6 +47,14 @@ export class Rect {
     return this.pos.x + this.size.x
   }
 
+  get width(): number {
+    return this.size.x
+  }
+
+  get height(): number {
+    return this.size.y
+  }
+
   equals(other: Rect): boolean {
     return this.pos.equals(other.pos) && this.size.equals(other.size)
   }

--- a/app/gui2/stories/UserDefinedVisualization.story.vue
+++ b/app/gui2/stories/UserDefinedVisualization.story.vue
@@ -56,6 +56,7 @@ const data = ref<any>({
   ],
 })
 
+const nodePosition = ref(new Vec2(0, 0))
 const nodeSize = ref(new Vec2(400, 32))
 const currentType = computed<VisualizationIdentifier>(() => ({
   module: { kind: 'CurrentProject' },
@@ -81,6 +82,8 @@ const mockFsWrapperProps = computed(() => ({
         <GraphVisualization
           :currentType="currentType"
           :data="data"
+          :scale="1"
+          :nodePosition="nodePosition"
           :nodeSize="nodeSize"
           :isCircularMenuVisible="isCircularMenuVisible"
           @setVisualizationId="$event.module.kind === 'CurrentProject' && (type = $event.name)"


### PR DESCRIPTION
### Pull Request Description
- Closes #6206
  - Zoom to all/zoom to selected in visualizations, are now both `Mod+A`
  - Implement Zoom to all/zoom to selected for the graph - shortcut is `Mod+Shift+A`, as `Mod+A` is "select all nodes"
    - Animate zoom+pan

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
