### PR TITLE
Detach oneshot visualization when the evaluation failed

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/ContextRegistryProtocol.scala
@@ -576,9 +576,7 @@ object ContextRegistryProtocol {
   /** Signals that an evaluation of a code responsible for generating
     * visualization data failed.
     *
-    * @param contextId a context identifier
-    * @param visualizationId a visualization identifier
-    * @param expressionId an identifier of a visualised expression
+    * @param ctx a visualization context
     * @param message the reason of the failure
     * @param diagnostic the detailed information about the error
     */

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -1437,9 +1437,7 @@ object Runtime {
     /** Signals that an evaluation of a code responsible for generating
       * visualization data failed.
       *
-      * @param contextId the context's id.
-      * @param visualizationId the visualization identifier
-      * @param expressionId the identifier of a visualised expression
+      * @param ctx the visualization context
       * @param message the reason of the failure
       * @param diagnostic the detailed information about the failure
       */
@@ -1453,9 +1451,7 @@ object Runtime {
       /** @inheritdoc */
       override def toLogString(shouldMask: Boolean): String =
         "VisualizationEvaluationFailed(" +
-        s"contextId=${ctx.contextId}," +
-        s"visualizationId=${ctx.visualizationId}," +
-        s"expressionId=${ctx.expressionId}," +
+        s"ctx=$ctx," +
         s"message=${MaskedString(message).toLogString(shouldMask)}," +
         s"diagnostic=${diagnostic.map(_.toLogString(shouldMask))}" +
         ")"


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #8429

Changelog:
- fix: detach oneshot visualization in case when the evaluation was failed

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
