### PR TITLE
Sync presenter state not only on abort, but also on commit

### DIFF
--- a/app/gui/src/presenter/searcher/component_browser.rs
+++ b/app/gui/src/presenter/searcher/component_browser.rs
@@ -194,6 +194,10 @@ impl Model {
                         if let Err(err) = self.graph_controller.remove_node(edited_node_id) {
                             error!("Error while removing a temporary node: {err}.");
                         }
+                        // Sync the view with the presenter state, updating the actual error and
+                        // pending state (as temporary node could receive some errors while
+                        // previewing suggestion).
+                        self.graph_presenter.force_view_update.emit(original_node_id);
                     }
                     Some(ast_id)
                 }


### PR DESCRIPTION
### Pull Request Description

Fixes #8336 (probably)

I couldn’t reproduce the issue after this change.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
