### PR TITLE
Small fixes for GUI2

### DIFF
--- a/app/gui2/src/bindings.ts
+++ b/app/gui2/src/bindings.ts
@@ -25,7 +25,7 @@ export const graphBindings = defineKeybinds('graph-editor', {
   openComponentBrowser: ['Enter'],
   newNode: ['N'],
   toggleVisualization: ['Space'],
-  deleteSelected: ['Delete'],
+  deleteSelected: ['OsDelete'],
   zoomToSelected: ['Mod+Shift+A'],
   selectAll: ['Mod+A'],
   deselectAll: ['Escape', 'PointerMain'],

--- a/app/gui2/src/components/CodeEditor.vue
+++ b/app/gui2/src/components/CodeEditor.vue
@@ -201,6 +201,7 @@ const editorStyle = computed(() => {
     class="CodeEditor"
     :style="editorStyle"
     @keydown.enter.stop
+    @keydown.backspace.stop
     @wheel.stop.passive
     @pointerdown.stop
     @contextmenu.stop

--- a/app/gui2/src/components/ComponentBrowser.vue
+++ b/app/gui2/src/components/ComponentBrowser.vue
@@ -490,6 +490,7 @@ const handler = componentBrowserBindings.handler({
           v-model="input.code.value"
           name="cb-input"
           autocomplete="off"
+          @keydown.backspace.stop
           @keyup="readInputFieldSelection"
         />
       </div>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetFunction.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetFunction.vue
@@ -88,8 +88,8 @@ const visualizationConfig = computed<Opt<NodeVisualizationConfiguration>>(() => 
 const visualizationData = project.useVisualizationData(visualizationConfig)
 const widgetConfiguration = computed(() => {
   const data = visualizationData.value
-  if (data != null) {
-    const parseResult = widgetConfigurationSchema.safeParse(data)
+  if (data != null && data.ok) {
+    const parseResult = widgetConfigurationSchema.safeParse(data.value)
     if (parseResult.success) {
       return parseResult.data
     } else {

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
@@ -72,6 +72,10 @@ const selectedValue = computed(() => {
   if (selectedIndex.value == null) return props.input.info?.defaultValue ?? ''
   return tagValues.value[selectedIndex.value] ?? ''
 })
+const selectedLabel = computed(() => {
+  if (selectedIndex.value == null) return props.input.info?.defaultValue ?? ''
+  return tagLabels.value[selectedIndex.value] ?? ''
+})
 const showDropdownWidget = ref(false)
 const showArgumentValue = ref(true)
 
@@ -114,7 +118,7 @@ export const widgetDefinition = defineWidget([ArgumentPlaceholder, ArgumentAst],
         v-if="showDropdownWidget"
         :color="parentColor ?? 'white'"
         :values="tagLabels"
-        :selectedValue="selectedValue"
+        :selectedValue="selectedLabel"
         @click="selectedIndex = $event"
       />
     </div>

--- a/app/gui2/src/components/widgets/DropdownWidget.vue
+++ b/app/gui2/src/components/widgets/DropdownWidget.vue
@@ -90,6 +90,19 @@ const NEXT_SORT_DIRECTION: Record<SortDirection, SortDirection> = {
   padding: 4px 0;
 }
 
+li {
+  text-align: left;
+  transition: transform 0.2s ease;
+}
+
+.selectable-item:hover {
+  transform: translateX(8px);
+}
+
+.list span {
+  vertical-align: text-bottom;
+}
+
 .list::-webkit-scrollbar {
   -webkit-appearance: none;
   width: 8px;

--- a/app/gui2/src/components/widgets/ListWidget.vue
+++ b/app/gui2/src/components/widgets/ListWidget.vue
@@ -459,6 +459,10 @@ watchPostEffect(() => {
   }
 }
 
+div {
+  display: inline-block;
+}
+
 .vector-literal {
   display: flex;
   align-items: center;

--- a/app/gui2/src/util/shortcuts.ts
+++ b/app/gui2/src/util/shortcuts.ts
@@ -182,7 +182,7 @@ const normalizedKeyboardSegmentLookup = Object.fromEntries<string>(
 )
 normalizedKeyboardSegmentLookup[''] = '+'
 normalizedKeyboardSegmentLookup['space'] = ' '
-normalizedKeyboardSegmentLookup['osdelete'] = isMacLike ? 'Delete' : 'Backspace'
+normalizedKeyboardSegmentLookup['osdelete'] = isMacLike ? 'Backspace' : 'Delete'
 type NormalizeKeybindSegment = {
   [K in KeybindSegment as Lowercase<K>]: K
 }


### PR DESCRIPTION
### Pull Request Description

Includes the following fixes:

1. Closes #8472 
Adding animation when hovering entries, align them to the left, improve vertical alignment, make sure the currently selected entry is marked with rounded background shape.


https://github.com/enso-org/enso/assets/6566674/322748de-1321-4b32-8eef-a80a07cf8215

2. <kbd>Backspace</kbd> is now used on MacOS for deleting nodes, instead of awkward combination <kbd>Fn+Backspace</kbd>.
3. Fixed layout for vector editor.

Before:
<img width="529" alt="Screenshot 2023-12-06 at 3 23 39 PM" src="https://github.com/enso-org/enso/assets/6566674/f3d3573c-c2c0-41c4-aba3-d7350b585c8d">
After:
<img width="509" alt="Screenshot 2023-12-06 at 6 21 56 PM" src="https://github.com/enso-org/enso/assets/6566674/b4581097-e555-4d07-a812-5c6d0e7a7f62">

Also includes the fix for dynamic dropdowns from #8474. Closes #8473 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
