### PR TITLE
Fix typo in `Match.enso`

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Match.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Match.enso
@@ -31,7 +31,7 @@ type Match
     ## PRIVATE
        Provides a human-readable representation of the `Match`.
     to_display_text : Text
-    to_display_text self = "Match {" + self.tet + "}"
+    to_display_text self = "Match {" + self.text + "}"
 
     ## PRIVATE
        Returns the start UTF16 character index of a group.

--- a/test/Tests/src/Data/Text/Regex_Spec.enso
+++ b/test/Tests/src/Data/Text/Regex_Spec.enso
@@ -516,10 +516,10 @@ spec =
     Test.group "Match.to_display_text" <|
         pattern = Regex.compile "(.. .. )(?<letters>.+)()??(?<empty>)??"
         input = "aa ab abc a bc bcd"
+
         Test.specify "should not error" <|
             match = pattern.match input
             match . should_be_a Match
-
             match.to_display_text . should_equal "Match {aa ab abc a bc bcd}"
 
     Test.group "caching" <|

--- a/test/Tests/src/Data/Text/Regex_Spec.enso
+++ b/test/Tests/src/Data/Text/Regex_Spec.enso
@@ -513,6 +513,15 @@ spec =
             match.utf_16_span 5 . should_fail_with No_Such_Group
             match.utf_16_span "nonexistent" . should_fail_with No_Such_Group
 
+    Test.group "Match.to_display_text" <|
+        pattern = Regex.compile "(.. .. )(?<letters>.+)()??(?<empty>)??"
+        input = "aa ab abc a bc bcd"
+        match = pattern.match input
+        match . should_be_a Match
+
+        Test.specify "should not error" <|
+            match.to_display_text . should_equal "Match {aa ab abc a bc bcd}"
+
     Test.group "caching" <|
         Test.specify "Replacer cache drops old values" <|
             pattern = Regex.compile('([a-c])')

--- a/test/Tests/src/Data/Text/Regex_Spec.enso
+++ b/test/Tests/src/Data/Text/Regex_Spec.enso
@@ -516,10 +516,10 @@ spec =
     Test.group "Match.to_display_text" <|
         pattern = Regex.compile "(.. .. )(?<letters>.+)()??(?<empty>)??"
         input = "aa ab abc a bc bcd"
-        match = pattern.match input
-        match . should_be_a Match
-
         Test.specify "should not error" <|
+            match = pattern.match input
+            match . should_be_a Match
+
             match.to_display_text . should_equal "Match {aa ab abc a bc bcd}"
 
     Test.group "caching" <|


### PR DESCRIPTION
### Pull Request Description
Fix issue causing visualizations to break:
![image](https://github.com/enso-org/enso/assets/4046547/d63239e2-3fde-424a-ba6c-3e163c6ce983)

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
