### PR TITLE
Fix serialization of alias analysis graph

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
@@ -160,6 +160,10 @@ public final class PassPersistance {
       var links =
           (scala.collection.immutable.Set) in.readInline(scala.collection.immutable.Set.class);
       g.links_$eq(links);
+
+      var nextIdCounter = in.readInt();
+      g.nextIdCounter_$eq(nextIdCounter);
+
       return g;
     }
 
@@ -168,6 +172,7 @@ public final class PassPersistance {
     protected void writeObject(Graph obj, Output out) throws IOException {
       out.writeObject(obj.rootScope());
       out.writeInline(scala.collection.immutable.Set.class, obj.links());
+      out.writeInt(obj.nextIdCounter());
     }
 
     private static void assignParents(AliasAnalysis$Graph$Scope scope) {

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
@@ -146,7 +146,7 @@ public final class PassPersistance {
   @org.openide.util.lookup.ServiceProvider(service = Persistance.class)
   public static final class PersistAliasAnalysisGraph extends Persistance<Graph> {
     public PersistAliasAnalysisGraph() {
-      super(Graph.class, false, 1119);
+      super(Graph.class, false, 1131);
     }
 
     @SuppressWarnings("unchecked")

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
@@ -940,10 +940,9 @@ case object AliasAnalysis extends IRPass {
   sealed class Graph extends Serializable {
     var rootScope: Graph.Scope = new Graph.Scope()
     var links: Set[Graph.Link] = Set()
+    var nextIdCounter = 0
 
     private var globalSymbols: Map[Graph.Symbol, Occurrence.Global] = Map()
-
-    private var nextIdCounter = 0
 
     /** @return a deep structural copy of `this` */
     def deepCopy(

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
@@ -69,7 +69,7 @@ import scala.reflect.ClassTag
   *
   * - A [[org.enso.compiler.pass.PassConfiguration]] containing an instance of
   *   [[AliasAnalysis.Configuration]].
-  * - A [[LocalScope]], where relevant.
+  * - A [[org.enso.compiler.context.LocalScope]], where relevant.
   */
 case object AliasAnalysis extends IRPass {
 
@@ -940,7 +940,7 @@ case object AliasAnalysis extends IRPass {
   sealed class Graph extends Serializable {
     var rootScope: Graph.Scope = new Graph.Scope()
     var links: Set[Graph.Link] = Set()
-    var nextIdCounter = 0
+    var nextIdCounter          = 0
 
     private var globalSymbols: Map[Graph.Symbol, Occurrence.Global] = Map()
 


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #8431 

Fixes the scenario:
- user sends `executionContext/executeExpression`
- program execution is scheduled
- during the compilation the already compiled `IR` is loaded from the cache (reading invalid alias analysis graph)
- during the codegen the local scope with that aliasing graph is propagated to the runtime
- `EvalNode` compiles the expression to execute with the local scope containing an invalid aliasing graph
- compilation fails in the `AliasAnalysis` pass because of the clashing IDs in the graph


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
 