### PR TITLE
Update root `.prettierignore`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -35,6 +35,7 @@ app/ide-desktop/lib/dashboard/playwright-report/
 app/ide-desktop/lib/dashboard/playwright/.cache/
 app/gui/view/documentation/assets/stylesheet.css
 app/gui2/rust-ffi/pkg
+app/gui2/src/assets/font-*.css
 Cargo.lock
 build.json
 app/gui2/playwright-report/


### PR DESCRIPTION
### Pull Request Description
Should fix issues with lint CI when Prettier is checking style of generated CSS files

### Important Notes
Not sure why this is happening - I think the CSS files should have correct formatting.
Also not 100% sure that this fix works, as I cannot repro the problem locally for some weird reason. Maybe CI is using a specific version of prettier for which the CSS files do not pass.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
