### PR TITLE
Runtime test build depends on fat jar classes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1657,7 +1657,10 @@ lazy val runtime = (project in file("engine/runtime"))
     Test / fork := true,
     Test / envVars ++= distributionEnvironmentOverrides ++ Map(
       "ENSO_TEST_DISABLE_IR_CACHE" -> "false"
-    )
+    ),
+    Test / compile := (Test / compile)
+      .dependsOn(`runtime-fat-jar` / Compile / compileModuleInfo)
+      .value
   )
   .settings(
     (Compile / javacOptions) ++= Seq(


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Followup to #8467

Fixes the issue when `runtime/test` command fails to compile without fat jar classes:
```
sbt:enso> runtime/test
[warn] JPMSPlugin: Directory /home/dbushev/projects/luna/enso/engine/runtime-fat-jar/target/scala-2.13/classes does not exist.
[warn] JPMSPlugin: Directory /home/dbushev/projects/luna/enso/engine/runtime-fat-jar/target/scala-2.13/classes does not exist.
[info] compiling 106 Scala sources and 60 Java sources to /home/dbushev/projects/luna/enso/engine/runtime/target/scala-2.13/test-classes ...
[warn] Unexpected javac output: error: module not found: org.enso.runtime
[warn] 1 error.
[warn] frgaal exited with exit code 1
[error] (runtime / Test / compileIncremental) javac returned non-zero exit code
```

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.