### PR TITLE
More robust against debris in the repository

### DIFF
--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoDataObject.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoDataObject.java
@@ -23,7 +23,8 @@ import org.openide.windows.TopComponent;
 @MIMEResolver.ExtensionRegistration(
         displayName = "#LBL_Enso_LOADER",
         mimeType = "application/x-enso",
-        extension = {"enso"}
+        extension = {"enso"},
+        position = 79753
 )
 @GrammarRegistration(mimeType = "application/x-enso", grammar = "enso.tmLanguage.json")
 @DataObject.Registration(

--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoSbtClassPathProvider.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoSbtClassPathProvider.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.swing.Icon;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.java.classpath.ClassPath;
@@ -35,6 +37,7 @@ import org.openide.util.ImageUtilities;
 final class EnsoSbtClassPathProvider extends ProjectOpenedHook
 implements ClassPathProvider, SourceLevelQueryImplementation2, CompilerOptionsQueryImplementation,
 Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSources>, SourceForBinaryQueryImplementation2 {
+    private static final Logger LOG = Logger.getLogger(EnsoSources.class.getName());
     private static final String BOOT = "classpath/boot";
     private static final String SOURCE = "classpath/source";
     private static final String COMPILE = "classpath/compile";
@@ -349,7 +352,12 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
     ) implements SourceGroup {
         @Override
         public FileObject getRootFolder() {
-            return srcCp.getRoots()[0];
+            var arr = srcCp.getRoots();
+            if (arr.length == 0) {
+                LOG.log(Level.SEVERE, "srcCp is empty for {0}", this);
+                return output;
+            }
+            return arr[0];
         }
 
         private FileObject[] getRoots() {

--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoSbtClassPathProvider.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoSbtClassPathProvider.java
@@ -354,7 +354,7 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
         public FileObject getRootFolder() {
             var arr = srcCp.getRoots();
             if (arr.length == 0) {
-                LOG.log(Level.SEVERE, "srcCp is empty for {0}", this);
+                LOG.log(Level.SEVERE, "Source classpath is empty for {0}", this);
                 return output;
             }
             return arr[0];


### PR DESCRIPTION
### Pull Request Description

Today Enso4Igv VSCode extension **crashed for me**. The reason is removal of `runtime-with-polyglot` & co. projects that leaves some debris (`.enso_source*` files) behind. The fix recognizes that and returns `output` folder instead and prints a warning.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides. 
- All code has been tested:
  - [x] Manually tested

CCing @ola-lis
