### PR TITLE
Fix build of engine benchmarks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,14 +12,13 @@ import src.main.scala.licenses.{
   DistributionDescription,
   SBTDistributionComponent
 }
-import sbt.librarymanagement.DependencyFilter
 
 // This import is unnecessary, but bit adds a proper code completion features
 // to IntelliJ.
 import JPMSPlugin.autoImport.*
 
+
 import java.io.File
-import scala.collection.mutable.ListBuffer
 
 // ============================================================================
 // === Global Configuration ===================================================
@@ -1687,15 +1686,88 @@ lazy val runtime = (project in file("engine/runtime"))
       .dependsOn(`std-aws` / Compile / packageBin)
       .value
   )
+  /** Benchmark settings */
   .settings(
+    inConfig(Benchmark)(Defaults.testSettings),
+    Benchmark / fork := true,
+    Benchmark / parallelExecution := false,
+    (Benchmark / modulePath) := {
+      val requiredModIds = GraalVM.modules ++ GraalVM.langsPkgs ++ Seq(
+        "org.slf4j" % "slf4j-api" % slf4jVersion,
+        "org.slf4j" % "slf4j-nop" % slf4jVersion
+      )
+      val requiredMods = JPMSUtils.filterModulesFromUpdate(
+        (Benchmark / update).value,
+        requiredModIds,
+        streams.value.log,
+        shouldContainAll = true
+      )
+      val runtimeMod =
+        (`runtime-fat-jar` / Compile / exportedProducts).value.head.data
+      requiredMods ++ Seq(runtimeMod)
+    },
+    (Benchmark / addModules) := Seq(
+      (`runtime-fat-jar` / javaModuleName).value
+    ),
+    (Benchmark / addReads) := Map(
+      (`runtime-fat-jar` / javaModuleName).value -> Seq("ALL-UNNAMED")
+    ),
+    (Benchmark / patchModules) := {
+      val modulesToPatchIntoRuntime: Seq[File] =
+        (LocalProject(
+          "runtime-instrument-common"
+        ) / Compile / productDirectories).value ++
+        (LocalProject(
+          "runtime-instrument-id-execution"
+        ) / Compile / productDirectories).value ++
+        (LocalProject(
+          "runtime-instrument-repl-debugger"
+        ) / Compile / productDirectories).value ++
+        (LocalProject(
+          "runtime-instrument-runtime-server"
+        ) / Compile / productDirectories).value ++
+        (LocalProject(
+          "runtime-language-epb"
+        ) / Compile / productDirectories).value ++
+        (LocalProject(
+          "runtime-compiler"
+        ) / Compile / productDirectories).value
+      Map(
+        (`runtime-fat-jar` / javaModuleName).value -> modulesToPatchIntoRuntime
+      )
+    },
+    // Reset javacOptions and javaOptions - do not inherit them from the Test scope
+    (Benchmark / javacOptions) := (Compile / javacOptions).value,
+    (Benchmark / javaOptions) := (Compile / javaOptions).value,
+    (Benchmark / javacOptions) ++= {
+      JPMSPlugin.constructOptions(
+        streams.value.log,
+        modulePath = (Benchmark / modulePath).value,
+        addModules = (Benchmark / addModules).value
+      )
+    },
+    (Benchmark / javaOptions) ++= {
+      JPMSPlugin.constructOptions(
+        streams.value.log,
+        (Benchmark / modulePath).value,
+        (Benchmark / addModules).value,
+        (Benchmark / patchModules).value,
+        (Benchmark / addExports).value,
+        (Benchmark / addReads).value
+      )
+    },
+    (Benchmark / javaOptions) ++= benchOnlyOptions,
+    // Override test log provider and its resource
+    (Benchmark / javaOptions) ++= Seq(
+      "-Dslf4j.provider=org.enso.logger.TestLogProvider",
+      "-Dconfig.resource=application-bench.conf"
+    ),
+    (Benchmark / compile) := (Benchmark / compile)
+      .dependsOn(`runtime-fat-jar` / Compile / compileModuleInfo)
+      .value,
     bench := (Benchmark / test)
       .tag(Exclusive)
-      .dependsOn(
-        // runtime.jar fat jar needs to be assembled as it is used in the
-        // benchmarks. This dependency is here so that `runtime/bench` works
-        // after clean build.
-        LocalProject("runtime-fat-jar") / assembly
-      )
+      .dependsOn(Benchmark / compile)
       .value,
     benchOnly := Def.inputTaskDyn {
       import complete.Parsers.spaceDelimited
@@ -1707,20 +1779,6 @@ lazy val runtime = (project in file("engine/runtime"))
         (Benchmark / testOnly).toTask(" -- -z " + name).value
       }
     }.evaluated
-  )
-  /** Benchmark settings */
-  .settings(
-    inConfig(Benchmark)(Defaults.testSettings),
-    Benchmark / javacOptions --= Seq(
-      "-source",
-      frgaalSourceLevel,
-      "--enable-preview"
-    ),
-    (Benchmark / javaOptions) :=
-      (LocalProject("std-benchmarks") / Benchmark / run / javaOptions).value,
-    (Benchmark / javaOptions) ++= benchOnlyOptions,
-    Benchmark / fork := true,
-    Benchmark / parallelExecution := false
   )
   .dependsOn(`common-polyglot-core-utils`)
   .dependsOn(`edition-updater`)

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,6 @@ import src.main.scala.licenses.{
 // to IntelliJ.
 import JPMSPlugin.autoImport.*
 
-
 import java.io.File
 
 // ============================================================================

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/ListBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/ListBenchmarks.java
@@ -57,7 +57,10 @@ public class ListBenchmarks {
 
     var benchmarkName = SrcUtil.findName(params);
     var code = """
+      from Standard.Base.Any import Any
       from Standard.Base.Data.List.List import Cons, Nil
+      from Standard.Base.Data.Text import Text
+      from Standard.Base.Data.Numbers import Float
       from Standard.Base import Integer
       import Standard.Base.IO
 

--- a/engine/runtime/src/bench/resources/application-bench.conf
+++ b/engine/runtime/src/bench/resources/application-bench.conf
@@ -1,0 +1,1 @@
+# Intentionally left empty - use the default settings for the log provider

--- a/project/JPMSPlugin.scala
+++ b/project/JPMSPlugin.scala
@@ -1,10 +1,5 @@
 import sbt.*
 import sbt.Keys.*
-import sbt.internal.inc.{CompileOutput, PlainVirtualFile}
-import sbt.util.CacheStore
-import sbtassembly.Assembly.{Dependency, JarEntry, Project}
-import sbtassembly.{CustomMergeStrategy, MergeStrategy}
-import xsbti.compile.IncToolOptionsUtil
 
 import java.io.File
 
@@ -50,10 +45,6 @@ object JPMSPlugin extends AutoPlugin {
         |""".stripMargin
     )
     val compileModuleInfo = taskKey[Unit]("Compile module-info.java")
-    val modulePathTestOptions_ = taskKey[Seq[String]](
-      "Assembles options for the JVM for running tests with all the required modules. " +
-      "Including truffle-compiler and org.enso.runtime modules and all their dependencies."
-    )
   }
 
   import autoImport.*


### PR DESCRIPTION
### Pull Request Description

After #8467, Engine benchmarks are broken, they cannot compile - https://github.com/enso-org/enso/actions/runs/7268987483/job/19805862815#logs

This PR fixes the benchmark build

### Important Notes

Apart from fixing the build of `engine/bench`:
- Don't assemble any fat jars in `runtime/bench`.
- Use our `TestLogProvider` in the benches instead of NOOP provider.
  - So that we can at least see warnings and errors in benchmarks.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Try to run benchmarks manually and ensure there are no regressions.
