### PR TITLE
Store Graph as a reference

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
@@ -29,16 +29,10 @@ import scala.Option;
 @Persistable(clazz = DataflowAnalysis.DependencyMapping.class, id = 1113)
 @Persistable(clazz = GatherDiagnostics.DiagnosticsMeta.class, id = 1114)
 @Persistable(clazz = DocumentationComments.Doc.class, id = 1115)
-@Persistable(clazz = AliasAnalysis$Info$Occurrence.class, id = 1116)
 @Persistable(clazz = TypeSignatures.Signature.class, id = 2117)
 @Persistable(clazz = ModuleAnnotations.Annotations.class, id = 1118)
-@Persistable(clazz = AliasAnalysis$Info$Scope$Root.class, id = 1120)
 @Persistable(clazz = DataflowAnalysis$DependencyInfo$Type$Static.class, id = 1121)
 @Persistable(clazz = DataflowAnalysis$DependencyInfo$Type$Dynamic.class, id = 1122)
-@Persistable(clazz = AliasAnalysis$Info$Scope$Child.class, id = 1123)
-@Persistable(clazz = AliasAnalysis$Graph$Occurrence$Use.class, id = 1125)
-@Persistable(clazz = AliasAnalysis$Graph$Occurrence$Def.class, id = 1126)
-@Persistable(clazz = AliasAnalysis$Graph$Link.class, id = 1127)
 @Persistable(clazz = FullyQualifiedNames.FQNResolution.class, id = 1128)
 @Persistable(clazz = FullyQualifiedNames.ResolvedLibrary.class, id = 1129)
 @Persistable(clazz = FullyQualifiedNames.ResolvedModule.class, id = 1130)
@@ -60,6 +54,12 @@ import scala.Option;
 @Persistable(clazz = GenericAnnotations$.class, id = 1216)
 @Persistable(clazz = ExpressionAnnotations$.class, id = 1217)
 @Persistable(clazz = FullyQualifiedNames$.class, id = 1218)
+@Persistable(clazz = AliasAnalysis$Info$Occurrence.class, id = 1261, allowInlining = false)
+@Persistable(clazz = AliasAnalysis$Info$Scope$Root.class, id = 1262, allowInlining = false)
+@Persistable(clazz = AliasAnalysis$Info$Scope$Child.class, id = 1263, allowInlining = false)
+@Persistable(clazz = AliasAnalysis$Graph$Occurrence$Use.class, id = 1264, allowInlining = false)
+@Persistable(clazz = AliasAnalysis$Graph$Occurrence$Def.class, id = 1265, allowInlining = false)
+@Persistable(clazz = AliasAnalysis$Graph$Link.class, id = 1266, allowInlining = false)
 public final class PassPersistance {
   private PassPersistance() {}
 
@@ -109,7 +109,7 @@ public final class PassPersistance {
   public static final class PersistAliasAnalysisGraphScope
       extends Persistance<org.enso.compiler.pass.analyse.AliasAnalysis$Graph$Scope> {
     public PersistAliasAnalysisGraphScope() {
-      super(org.enso.compiler.pass.analyse.AliasAnalysis$Graph$Scope.class, false, 1124);
+      super(org.enso.compiler.pass.analyse.AliasAnalysis$Graph$Scope.class, false, 1267);
     }
 
     @Override
@@ -146,7 +146,7 @@ public final class PassPersistance {
   @org.openide.util.lookup.ServiceProvider(service = Persistance.class)
   public static final class PersistAliasAnalysisGraph extends Persistance<Graph> {
     public PersistAliasAnalysisGraph() {
-      super(Graph.class, false, 1131);
+      super(Graph.class, false, 1268);
     }
 
     @SuppressWarnings("unchecked")

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/data/BindingsMap.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/data/BindingsMap.scala
@@ -1079,7 +1079,7 @@ object BindingsMap {
         Some(this)
 
       /** @inheritdoc */
-      override def toAbstract: Abstract =
+      override lazy val toAbstract: Abstract =
         ModuleReference.Abstract(module.getName)
 
       /** @inheritdoc */

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/IrPersistance.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/IrPersistance.java
@@ -92,20 +92,29 @@ public final class IrPersistance {
   @ServiceProvider(service = Persistance.class)
   public static final class PersistUUID extends Persistance<UUID> {
     public PersistUUID() {
-      super(UUID.class, false, 73);
+      super(UUID.class, false, 473);
     }
 
     @Override
     protected void writeObject(UUID obj, Output out) throws IOException {
-      out.writeLong(obj.getLeastSignificantBits());
-      out.writeLong(obj.getMostSignificantBits());
+      if (obj == null) {
+        out.writeBoolean(false);
+      } else {
+        out.writeBoolean(true);
+        out.writeLong(obj.getLeastSignificantBits());
+        out.writeLong(obj.getMostSignificantBits());
+      }
     }
 
     @Override
     protected UUID readObject(Input in) throws IOException, ClassNotFoundException {
-      var least = in.readLong();
-      var most = in.readLong();
-      return new UUID(most, least);
+      if (in.readBoolean()) {
+        var least = in.readLong();
+        var most = in.readLong();
+        return new UUID(most, least);
+      } else {
+        return null;
+      }
     }
   }
 

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/IrPersistance.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/IrPersistance.java
@@ -265,13 +265,14 @@ public final class IrPersistance {
     protected scala.collection.mutable.Map readObject(Input in)
         throws IOException, ClassNotFoundException {
       var size = in.readInt();
-      var map = scala.collection.mutable.Map$.MODULE$.empty();
+      var mapBuilder = scala.collection.mutable.Map$.MODULE$.newBuilder();
+      mapBuilder.sizeHint(size);
       for (var i = 0; i < size; i++) {
         var key = in.readObject();
         var value = in.readObject();
-        map.put(key, value);
+        mapBuilder.addOne(Tuple2.apply(key, value));
       }
-      return map;
+      return mapBuilder.result();
     }
   }
 

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/module/scope/Import.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/module/scope/Import.scala
@@ -112,6 +112,7 @@ object Import {
       keepIdentifiers: Boolean = false
     ): Module =
       copy(
+        name = name.duplicate(keepLocations, keepMetadata, keepDiagnostics, keepIdentifiers),
         location = if (keepLocations) location else None,
         passData =
           if (keepMetadata) passData.duplicate else new MetadataStorage(),

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/module/scope/Import.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/module/scope/Import.scala
@@ -112,7 +112,22 @@ object Import {
       keepIdentifiers: Boolean = false
     ): Module =
       copy(
-        name = name.duplicate(keepLocations, keepMetadata, keepDiagnostics, keepIdentifiers),
+        name = name.duplicate(
+          keepLocations,
+          keepMetadata,
+          keepDiagnostics,
+          keepIdentifiers
+        ),
+        onlyNames = onlyNames.map(
+          _.map(
+            _.duplicate(
+              keepLocations,
+              keepMetadata,
+              keepDiagnostics,
+              keepIdentifiers
+            )
+          )
+        ),
         location = if (keepLocations) location else None,
         passData =
           if (keepMetadata) passData.duplicate else new MetadataStorage(),

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/ModuleCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/ModuleCache.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.logging.Level;
 import org.apache.commons.lang3.StringUtils;
 import org.enso.compiler.core.ir.Module;
@@ -59,6 +60,7 @@ public final class ModuleCache extends Cache<ModuleCache.CachedModule, ModuleCac
                           RuntimeException.class, new IOException("Cannot convert " + metadata));
                     }
                   }
+                  case null -> null;
                   default -> obj;
                 });
     var mod = ref.get(Module.class);
@@ -160,6 +162,8 @@ public final class ModuleCache extends Cache<ModuleCache.CachedModule, ModuleCac
                 switch (obj) {
                   case ProcessingPass.Metadata metadata -> metadata.prepareForSerialization(
                       context.getCompiler().context());
+                  case UUID uuid -> null;
+                  case null -> null;
                   default -> obj;
                 });
     return arr;

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/ModuleCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/ModuleCache.java
@@ -46,17 +46,19 @@ public final class ModuleCache extends Cache<ModuleCache.CachedModule, ModuleCac
   protected CachedModule deserialize(
       EnsoContext context, byte[] data, Metadata meta, TruffleLogger logger)
       throws ClassNotFoundException, IOException, ClassNotFoundException {
-    var counts = new HashMap<Class, int[]>();
+    var counts = logger.isLoggable(Level.FINE) ? new HashMap<Class, int[]>() : null;
     var ref =
         Persistance.read(
             data,
             (obj) -> {
-              var c = counts.get(obj.getClass());
-              if (c == null) {
-                c = new int[1];
-                counts.put(obj.getClass(), c);
+              if (counts != null) {
+                var c = counts.get(obj.getClass());
+                if (c == null) {
+                  c = new int[1];
+                  counts.put(obj.getClass(), c);
+                }
+                c[0]++;
               }
-              c[0]++;
               return switch (obj) {
                 case ProcessingPass.Metadata metadata -> {
                   var option = metadata.restoreFromSerialization(context.getCompiler().context());
@@ -72,22 +74,24 @@ public final class ModuleCache extends Cache<ModuleCache.CachedModule, ModuleCac
             });
     var mod = ref.get(Module.class);
 
-    var all = mod.preorder().size();
+    if (counts != null) {
+      var all = mod.preorder().size();
 
-    var arr = new ArrayList<>(counts.entrySet());
-    arr.sort(
-        (a, b) -> {
-          return a.getValue()[0] - b.getValue()[0];
-        });
+      var arr = new ArrayList<>(counts.entrySet());
+      arr.sort(
+          (a, b) -> {
+            return a.getValue()[0] - b.getValue()[0];
+          });
 
-    logger.log(Level.WARNING, "Loaded " + module.getName() + " with " + all + " IR elements");
-    for (var i = 0; i < arr.size(); i++) {
-      if (i == 30) {
-        break;
+      logger.log(Level.FINE, "Loaded " + module.getName() + " with " + all + " IR elements");
+      for (var i = 0; i < arr.size(); i++) {
+        if (i == 30) {
+          break;
+        }
+        var elem = arr.get(arr.size() - 1 - i);
+        logger.log(
+            Level.FINE, "  {0} {1}", new Object[] {elem.getValue()[0], elem.getKey().getName()});
       }
-      var elem = arr.get(arr.size() - 1 - i);
-      logger.log(
-          Level.WARNING, "  {0} {1}", new Object[] {elem.getValue()[0], elem.getKey().getName()});
     }
 
     return new CachedModule(

--- a/engine/runtime/src/test/java/org/enso/compiler/CompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/CompilerTest.java
@@ -86,7 +86,7 @@ public abstract class CompilerTest {
    * @return string representation of the IR
    */
   private static String simplifyIR(IR ir, boolean noIds, boolean noLocations, boolean lessDocs) {
-    String txt = ir.pretty();
+    String txt = ir.duplicate(!noLocations, true, true, !noIds).pretty();
     if (noIds) {
       txt =
           txt.replaceAll(

--- a/lib/java/persistance-dsl/src/main/java/org/enso/persist/impl/PersistableProcessor.java
+++ b/lib/java/persistance-dsl/src/main/java/org/enso/persist/impl/PersistableProcessor.java
@@ -82,6 +82,7 @@ public class PersistableProcessor extends AbstractProcessor {
     var eu = processingEnv.getElementUtils();
     var tu = processingEnv.getTypeUtils();
     String typeElemName = readAnnoValue(anno, "clazz");
+    var canInline = !"false".equals(readAnnoValue(anno, "allowInlining"));
     if (typeElemName == null) {
       typeElemName = ((TypeElement) orig).getQualifiedName().toString();
     }
@@ -185,7 +186,7 @@ public class PersistableProcessor extends AbstractProcessor {
             var type = tu.erasure(v.asType());
             var elem = (TypeElement) tu.asElement(type);
             var name = findFqn(elem);
-            if (shouldInline(elem)) {
+            if (canInline && shouldInline(elem)) {
               w.append("    var ")
                   .append(v.getSimpleName())
                   .append(" = in.readInline(")
@@ -244,7 +245,7 @@ public class PersistableProcessor extends AbstractProcessor {
             var type = tu.erasure(v.asType());
             var elem = (TypeElement) tu.asElement(type);
             var name = findFqn(elem);
-            if (shouldInline(elem)) {
+            if (canInline && shouldInline(elem)) {
               w.append("    out.writeInline(")
                   .append(name)
                   .append(".class, obj.")
@@ -313,6 +314,11 @@ public class PersistableProcessor extends AbstractProcessor {
             .getValue()
             .accept(
                 new SimpleAnnotationValueVisitor9<String, Object>() {
+                  @Override
+                  public String visitBoolean(boolean b, Object p) {
+                    return Boolean.toString(b);
+                  }
+
                   @Override
                   public String visitInt(int i, Object p) {
                     return Integer.toString(i);

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerGenerator.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerGenerator.java
@@ -79,11 +79,11 @@ final class PerGenerator {
   }
 
   final void writeIndirect(Object obj, Persistance.Output out) throws IOException {
+    obj = writeReplace.apply(obj);
     if (obj == null) {
       out.writeInt(-1);
       return;
     }
-    obj = writeReplace.apply(obj);
     org.enso.persist.Persistance<?> p = PerMap.DEFAULT.forType(obj.getClass());
     java.lang.Integer found = knownObjects.get(obj);
     if (found == null) {

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerMap.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerMap.java
@@ -6,8 +6,6 @@ import java.util.Map;
 import org.openide.util.lookup.Lookups;
 
 final class PerMap {
-
-  static final PerMap DEFAULT = new PerMap();
   private final Map<Integer, Persistance<?>> ids = new HashMap<>();
   private final Map<Class<?>, Persistance<?>> types = new HashMap<>();
   final int versionStamp;
@@ -15,7 +13,8 @@ final class PerMap {
   private PerMap() {
     int hash = 0;
     var loader = getClass().getClassLoader();
-    for (var p : Lookups.metaInfServices(loader).lookupAll(Persistance.class)) {
+    for (var orig : Lookups.metaInfServices(loader).lookupAll(Persistance.class)) {
+      var p = orig.newClone();
       org.enso.persist.Persistance<?> prevId = ids.put(p.id, p);
       if (prevId != null) {
         throw new IllegalStateException(
@@ -29,6 +28,10 @@ final class PerMap {
       }
     }
     versionStamp = hash;
+  }
+
+  static PerMap create() {
+    return new PerMap();
   }
 
   @SuppressWarnings(value = "unchecked")

--- a/lib/java/persistance/src/main/java/org/enso/persist/Persistable.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/Persistable.java
@@ -38,6 +38,15 @@ public @interface Persistable {
    */
   int id();
 
+  /**
+   * Should the generated code use {@link Persistance.Output#writeInline(Class<T>, T)} or not. By
+   * default all {@code final} or <em>sealed</em> classes are inlined. Inlining is however not very
+   * helpful when a single object is shared between multiple other objects.
+   *
+   * @return
+   */
+  boolean allowInlining() default true;
+
   /** Multiple {@link Persistable} annotations. */
   @Target(ElementType.TYPE)
   public @interface Group {

--- a/lib/java/persistance/src/main/java/org/enso/persist/Persistance.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/Persistance.java
@@ -32,7 +32,7 @@ import java.util.function.Function;
  *
  * @param <T>
  */
-public abstract class Persistance<T> {
+public abstract class Persistance<T> implements Cloneable {
   final Class<T> clazz;
   final boolean includingSubclasses;
   final int id;
@@ -63,6 +63,14 @@ public abstract class Persistance<T> {
     this.clazz = clazz;
     this.includingSubclasses = includingSubclasses;
     this.id = id;
+  }
+
+  final Persistance<?> newClone() {
+    try {
+      return (Persistance<?>) clone();
+    } catch (CloneNotSupportedException ex) {
+      throw raise(RuntimeException.class, ex);
+    }
   }
 
   protected abstract void writeObject(T obj, Output out) throws IOException;


### PR DESCRIPTION
### Pull Request Description

Fixes #8323 by lowering the size of `Table.ir` from 6MB to 3.5MB.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides. 
- All code has been tested:
  - [x] Unit tests continue to pass
  - [x] [Stdlib Benchmarks](https://github.com/enso-org/enso/actions/runs/7335924128) executed and [second run](https://github.com/enso-org/enso/tree/wip/jtulach/CacheSizes_8323) - by making the caches smaller, **startup got faster**
  - [x] [Engine Benchmarks](https://github.com/enso-org/enso/actions/runs/7335925337) executed - **done** - changing caching has no impact on engine benchmarks
