### PR TITLE
Increase warmup for `EqualsBenchmarks`.

### DIFF
--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/EqualsBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/EqualsBenchmarks.java
@@ -35,8 +35,8 @@ import org.openjdk.jmh.infra.Blackhole;
  */
 @BenchmarkMode(Mode.AverageTime)
 @Fork(1)
-@Warmup(iterations = 3)
-@Measurement(iterations = 2)
+@Warmup(iterations = 5)
+@Measurement(iterations = 3)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 public class EqualsBenchmarks {

--- a/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/EqualsBenchmarks.java
+++ b/engine/runtime/src/bench/java/org/enso/interpreter/bench/benchmarks/semantic/EqualsBenchmarks.java
@@ -35,7 +35,7 @@ import org.openjdk.jmh.infra.Blackhole;
  */
 @BenchmarkMode(Mode.AverageTime)
 @Fork(1)
-@Warmup(iterations = 5)
+@Warmup(iterations = 7)
 @Measurement(iterations = 3)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)


### PR DESCRIPTION
Increase warmup for `EqualsBenchmarks`. Also increase measurement so that JMH provides some reasonable statistics.

### Pull Request Description

After #8620, there is a noticeable slowdown in `EqualsBenchmarks.equalsTrees` as suggested in https://github.com/enso-org/enso/pull/8620#issuecomment-1870776609. After some digging, I realized that the number of warmup iterations is most probably insufficient. Let's increase the warmup for this benchmark and see if we can get its score down again.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Manually run benchmarks and compare results of `EqualsBenchmarks` to develop.
