### PR TITLE
Change null to Nothing

### DIFF
--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/Column.enso
@@ -953,7 +953,7 @@ type Column
        this column contains a `Nothing`.
     is_nothing : Column
     is_nothing self =
-        new_name = self.naming_helper.concat [self.naming_helper.to_expression_text self, "is null"]
+        new_name = self.naming_helper.concat [self.naming_helper.to_expression_text self, "is Nothing"]
         self.make_unary_op "IS_NULL" new_name
 
     ## GROUP Standard.Base.Math

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -1018,7 +1018,7 @@ type Column
              example_is_nothing = Examples.decimal_column.is_nothing
     is_nothing : Column
     is_nothing self =
-        new_name = naming_helper.concat [naming_helper.to_expression_text self, "is null"]
+        new_name = naming_helper.concat [naming_helper.to_expression_text self, "is Nothing"]
         run_vectorized_unary_op self Java_Storage.Maps.IS_NOTHING new_name fallback_fn=(x-> x == Nothing) expected_result_type=Value_Type.Boolean skip_nulls=False
 
     ## GROUP Standard.Base.Math

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -1225,7 +1225,7 @@ spec setup =
 
         Test.specify "nulls" <|
             t.at "a" . coalesce [Nothing, 42] . name . should_equal "coalesce([a], Nothing, 42)"
-            t.at "a" . is_nothing . name . should_equal "[a] is null"
+            t.at "a" . is_nothing . name . should_equal "[a] is Nothing"
             t.at "a" . is_present . name . should_equal "is_present([a])"
             t.at "a" . is_blank . name . should_equal "is_blank([a])"
             t.at "a" . fill_nothing 100 . name . should_equal "a"


### PR DESCRIPTION
### Pull Request Description

Change the generated column name for is_nothing to "[a] is Nothing" from "[a] is null" as Nothing is our customer facing term.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
