### PR TITLE
Kill lingering FanOutReceiver actors when the connection is closed

### DIFF
--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/http/AkkaBasedWebSocketConnection.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/http/AkkaBasedWebSocketConnection.scala
@@ -1,7 +1,7 @@
 package org.enso.projectmanager.infrastructure.http
 
 import akka.NotUsed
-import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.actor.{ActorRef, ActorSystem, PoisonPill, Props}
 import akka.http.scaladsl.{ConnectionContext, Http}
 import akka.http.scaladsl.model.ws._
 import akka.pattern.pipe
@@ -124,7 +124,10 @@ class AkkaBasedWebSocketConnection(
   def send(message: String): Unit = outboundChannel ! message
 
   /** @inheritdoc */
-  def disconnect(): Unit = outboundChannel ! CloseWebSocket
+  def disconnect(): Unit = {
+    outboundChannel ! CloseWebSocket
+    receiver ! PoisonPill
+  }
 
 }
 

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/http/AkkaBasedWebSocketConnection.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/http/AkkaBasedWebSocketConnection.scala
@@ -83,7 +83,7 @@ class AkkaBasedWebSocketConnection(
     receiver ! Detach(listener)
 
   /** @inheritdoc */
-  def connect(): Unit = {
+  override def connect(): Unit = {
     val server = Http()
     secureConfig
       .flatMap { config =>
@@ -121,11 +121,17 @@ class AkkaBasedWebSocketConnection(
   }
 
   /** @inheritdoc */
-  def send(message: String): Unit = outboundChannel ! message
+  override def send(message: String): Unit = {
+    outboundChannel ! message
+  }
 
   /** @inheritdoc */
-  def disconnect(): Unit = {
+  override def disconnect(): Unit = {
     outboundChannel ! CloseWebSocket
+  }
+
+  /** @inheritdoc */
+  override def close(): Unit = {
     receiver ! PoisonPill
   }
 

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/http/WebSocketConnection.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/http/WebSocketConnection.scala
@@ -2,17 +2,17 @@ package org.enso.projectmanager.infrastructure.http
 
 import akka.actor.ActorRef
 
-/** An abstraction representing web socket connection.
-  */
+/** An abstraction representing web socket connection. */
 trait WebSocketConnection {
 
-  /** Connects to the server.
-    */
+  /** Connects to the server. */
   def connect(): Unit
 
-  /** Disconnects from the server.
-    */
+  /** Disconnects from the server. */
   def disconnect(): Unit
+
+  /** Close the connection and clean up resources. */
+  def close(): Unit
 
   /** Sends a message to the server.
     *
@@ -36,8 +36,7 @@ trait WebSocketConnection {
 
 object WebSocketConnection {
 
-  /** Signals that a connection was established.
-    */
+  /** Signals that a connection was established. */
   case object WebSocketConnected
 
   /** An envelope for text messages.
@@ -46,8 +45,7 @@ object WebSocketConnection {
     */
   case class WebSocketMessage(payload: String)
 
-  /** Signals that connection was closed.
-    */
+  /** Signals that connection was closed. */
   case object WebSocketStreamClosed
 
   /** Signals a connection failure.

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/HeartbeatSession.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/HeartbeatSession.scala
@@ -63,6 +63,10 @@ class HeartbeatSession(
     logger.debug("Heartbeat connection initialized [{}].", socket)
   }
 
+  override def postStop(): Unit = {
+    connection.close()
+  }
+
   override def receive: Receive = pingStage
 
   private def pingStage: Receive = {

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ProjectRenameAction.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ProjectRenameAction.scala
@@ -74,6 +74,10 @@ class ProjectRenameAction(
     maybeActionTimeoutCancellable = Some(cancellable)
   }
 
+  override def postStop(): Unit = {
+    connection.close()
+  }
+
   override def receive: Receive = unconnected()
 
   private def unconnected(): Receive = {


### PR DESCRIPTION
### Pull Request Description

close #8426

It is safe to kill the receiver actor when closing the connection. Otherwise, it will be cleaned up only on the actor system shutdown.

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
 