### PR TITLE
Make fill_nothing take an empty string

### DIFF
--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/Storage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/Storage.java
@@ -415,7 +415,20 @@ public abstract class Storage<T> {
   public Storage<?> fillMissing(
       Value arg, StorageType commonType, ProblemAggregator problemAggregator) {
     Builder builder = Builder.getForType(commonType, size(), problemAggregator);
-    return fillMissingHelper(arg, builder);
+    Object convertedFallback = Polyglot_Utils.convertPolyglotValue(arg);
+    Context context = Context.getCurrent();
+    for (int i = 0; i < size(); i++) {
+      Object it = getItemBoxed(i);
+      if (it == null) {
+        builder.appendNoGrow(convertedFallback);
+      } else {
+        builder.appendNoGrow(it);
+      }
+
+      context.safepoint();
+    }
+
+    return builder.seal();
   }
 
   /**
@@ -434,23 +447,6 @@ public abstract class Storage<T> {
         builder.appendNoGrow(other.getItemBoxed(i));
       } else {
         builder.appendNoGrow(getItemBoxed(i));
-      }
-
-      context.safepoint();
-    }
-
-    return builder.seal();
-  }
-
-  protected final Storage<?> fillMissingHelper(Value arg, Builder builder) {
-    Object convertedFallback = Polyglot_Utils.convertPolyglotValue(arg);
-    Context context = Context.getCurrent();
-    for (int i = 0; i < size(); i++) {
-      Object it = getItemBoxed(i);
-      if (it == null) {
-        builder.appendNoGrow(convertedFallback);
-      } else {
-        builder.appendNoGrow(it);
       }
 
       context.safepoint();

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/StringStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/StringStorage.java
@@ -1,7 +1,6 @@
 package org.enso.table.data.column.storage;
 
 import java.util.BitSet;
-
 import org.enso.base.Text_Utils;
 import org.enso.table.data.column.operation.map.BinaryMapOperation;
 import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
@@ -51,7 +50,7 @@ public final class StringStorage extends SpecializedStorage<String> {
   @Override
   public Storage<?> fillMissing(
       Value arg, StorageType commonType, ProblemAggregator problemAggregator) {
-      return super.fillMissing(arg, commonType, problemAggregator);
+    return super.fillMissing(arg, commonType, problemAggregator);
   }
 
   private static MapOperationStorage<String, SpecializedStorage<String>> buildOps() {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/StringStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/StringStorage.java
@@ -1,8 +1,8 @@
 package org.enso.table.data.column.storage;
 
 import java.util.BitSet;
+
 import org.enso.base.Text_Utils;
-import org.enso.table.data.column.builder.StringBuilder;
 import org.enso.table.data.column.operation.map.BinaryMapOperation;
 import org.enso.table.data.column.operation.map.MapOperationProblemAggregator;
 import org.enso.table.data.column.operation.map.MapOperationStorage;
@@ -51,14 +51,7 @@ public final class StringStorage extends SpecializedStorage<String> {
   @Override
   public Storage<?> fillMissing(
       Value arg, StorageType commonType, ProblemAggregator problemAggregator) {
-    if (arg.isString()) {
-      String strArg = arg.asString();
-      TextType newType =
-          strArg.isEmpty() ? type : TextType.maxType(type, TextType.preciseTypeForValue(strArg));
-      return fillMissingHelper(arg, new StringBuilder(size(), newType));
-    } else {
       return super.fillMissing(arg, commonType, problemAggregator);
-    }
   }
 
   private static MapOperationStorage<String, SpecializedStorage<String>> buildOps() {

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/StringStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/StringStorage.java
@@ -52,7 +52,9 @@ public final class StringStorage extends SpecializedStorage<String> {
   public Storage<?> fillMissing(
       Value arg, StorageType commonType, ProblemAggregator problemAggregator) {
     if (arg.isString()) {
-      TextType newType = TextType.maxType(type, TextType.preciseTypeForValue(arg.asString()));
+      String strArg = arg.asString();
+      TextType newType =
+          strArg.isEmpty() ? type : TextType.maxType(type, TextType.preciseTypeForValue(strArg));
       return fillMissingHelper(arg, new StringBuilder(size(), newType));
     } else {
       return super.fillMissing(arg, commonType, problemAggregator);

--- a/std-bits/table/src/main/java/org/enso/table/data/column/storage/StringStorage.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/storage/StringStorage.java
@@ -13,9 +13,7 @@ import org.enso.table.data.column.operation.map.text.StringIsInOp;
 import org.enso.table.data.column.operation.map.text.StringStringOp;
 import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.data.column.storage.type.TextType;
-import org.enso.table.problems.ProblemAggregator;
 import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Value;
 
 /** A column storing strings. */
 public final class StringStorage extends SpecializedStorage<String> {
@@ -45,12 +43,6 @@ public final class StringStorage extends SpecializedStorage<String> {
   @Override
   public TextType getType() {
     return type;
-  }
-
-  @Override
-  public Storage<?> fillMissing(
-      Value arg, StorageType commonType, ProblemAggregator problemAggregator) {
-    return super.fillMissing(arg, commonType, problemAggregator);
   }
 
   private static MapOperationStorage<String, SpecializedStorage<String>> buildOps() {

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -331,7 +331,7 @@ spec setup =
             t = table_builder [["col0", ["0", Nothing, "4", "5", Nothing, Nothing]]] . cast "col0" (Value_Type.Char size=1 variable_length=False)
             actual = t.fill_nothing ["col0"] "ABCDE"
             actual.at "col0" . to_vector . should_equal ["0", "ABCDE", "4", "5", "ABCDE", "ABCDE"]
-            if is_database.not then
+            if setup.is_database.not then
                 actual.at "col0" . value_type . should_equal (Value_Type.Char size=5 variable_length=True)
 
         Test.specify "should allow to fill_nothing from an empty string" <|
@@ -350,7 +350,7 @@ spec setup =
             t = table_builder [["col0", [Nothing, "200", Nothing, "400", "500", Nothing]]] . cast "col0" (Value_Type.Char size=3 variable_length=False)
             actual = t.fill_nothing ["col0"] "   "
             actual.at "col0" . to_vector . should_equal ["   ", "200", "   ", "400", "500", "   "]  
-            if is_database.not then
+            if setup.is_database.not then
                 actual.at "col0" . value_type . should_equal (Value_Type.Char size=3 variable_length=False)
 
         Test.specify "should allow to fill_nothing from other columns" <|

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -331,7 +331,8 @@ spec setup =
             t = table_builder [["col0", ["0", Nothing, "4", "5", Nothing, Nothing]]] . cast "col0" (Value_Type.Char size=1 variable_length=False)
             actual = t.fill_nothing ["col0"] "ABCDE"
             actual.at "col0" . to_vector . should_equal ["0", "ABCDE", "4", "5", "ABCDE", "ABCDE"]
-            actual.at "col0" . value_type . should_equal (Value_Type.Char size=5 variable_length=True)
+            if is_database.not then
+                actual.at "col0" . value_type . should_equal (Value_Type.Char size=5 variable_length=True)
 
         Test.specify "should allow to fill_nothing from an empty string" <|
             t = table_builder [["col0", ["0", Nothing, "4", "5", Nothing, Nothing]], ["col1", [Nothing, "200", Nothing, "400", "500", Nothing]]]
@@ -349,7 +350,8 @@ spec setup =
             t = table_builder [["col0", [Nothing, "200", Nothing, "400", "500", Nothing]]] . cast "col0" (Value_Type.Char size=3 variable_length=False)
             actual = t.fill_nothing ["col0"] "   "
             actual.at "col0" . to_vector . should_equal ["   ", "200", "   ", "400", "500", "   "]  
-            actual.at "col0" . value_type . should_equal (Value_Type.Char size=3 variable_length=False)
+            if is_database.not then
+                actual.at "col0" . value_type . should_equal (Value_Type.Char size=3 variable_length=False)
 
         Test.specify "should allow to fill_nothing from other columns" <|
             t = table_builder [["col0", [0, Nothing, 4, 5, Nothing, Nothing]], ["col1", [Nothing, 200, Nothing, 400, 500, Nothing]], ["def", [1, 2, 10, 20, Nothing, 30]]]

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -326,6 +326,12 @@ spec setup =
             actual = t.fill_nothing ["col0", "col1"] default
             actual.at "col0" . to_vector . should_equal [0, 1000, 4, 5, 1000, 1000]
             actual.at "col1" . to_vector . should_equal [1000, 200, 1000, 400, 500, 1000]
+        
+        Test.specify "should allow to fill_nothing from an empty string" <|
+            t = table_builder [["col0", ["0", Nothing, "4", "5", Nothing, Nothing]], ["col1", [Nothing, "200", Nothing, "400", "500", Nothing]]]
+            actual = t.fill_nothing ["col0", "col1"] ""
+            actual.at "col0" . to_vector . should_equal ["0", "", "4", "5", "", ""]
+            actual.at "col1" . to_vector . should_equal ["", "200", "", "400", "500", ""]
 
         Test.specify "should allow to fill_nothing from other columns" <|
             t = table_builder [["col0", [0, Nothing, 4, 5, Nothing, Nothing]], ["col1", [Nothing, 200, Nothing, 400, 500, Nothing]], ["def", [1, 2, 10, 20, Nothing, 30]]]

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -327,11 +327,29 @@ spec setup =
             actual.at "col0" . to_vector . should_equal [0, 1000, 4, 5, 1000, 1000]
             actual.at "col1" . to_vector . should_equal [1000, 200, 1000, 400, 500, 1000]
         
+        Test.specify "should allow to fill_nothing from larger string and expands type to fit" <|
+            t = table_builder [["col0", ["0", Nothing, "4", "5", Nothing, Nothing]]] . cast "col0" (Value_Type.Char size=1 variable_length=False)
+            actual = t.fill_nothing ["col0"] "ABCDE"
+            actual.at "col0" . to_vector . should_equal ["0", "ABCDE", "4", "5", "ABCDE", "ABCDE"]
+            actual.at "col0" . value_type . should_equal (Value_Type.Char size=5 variable_length=True)
+
         Test.specify "should allow to fill_nothing from an empty string" <|
             t = table_builder [["col0", ["0", Nothing, "4", "5", Nothing, Nothing]], ["col1", [Nothing, "200", Nothing, "400", "500", Nothing]]]
             actual = t.fill_nothing ["col0", "col1"] ""
             actual.at "col0" . to_vector . should_equal ["0", "", "4", "5", "", ""]
             actual.at "col1" . to_vector . should_equal ["", "200", "", "400", "500", ""]
+
+        Test.specify "should allow to fill_nothing a fixed width from an empty string" <|
+            t = table_builder [["col0", [Nothing, "200", Nothing, "400", "500", Nothing]]] . cast "col0" (Value_Type.Char size=3 variable_length=False)
+            actual = t.fill_nothing ["col0"] ""
+            actual.at "col0" . to_vector . should_equal ["", "200", "", "400", "500", ""]  
+            actual.at "col0" . value_type . should_equal (Value_Type.Char variable_length=True)
+        
+        Test.specify "should allow to fill_nothing a fixed width with a string of correct length without changing the type" <|
+            t = table_builder [["col0", [Nothing, "200", Nothing, "400", "500", Nothing]]] . cast "col0" (Value_Type.Char size=3 variable_length=False)
+            actual = t.fill_nothing ["col0"] "   "
+            actual.at "col0" . to_vector . should_equal ["   ", "200", "   ", "400", "500", "   "]  
+            actual.at "col0" . value_type . should_equal (Value_Type.Char size=3 variable_length=False)
 
         Test.specify "should allow to fill_nothing from other columns" <|
             t = table_builder [["col0", [0, Nothing, 4, 5, Nothing, Nothing]], ["col1", [Nothing, 200, Nothing, 400, 500, Nothing]], ["def", [1, 2, 10, 20, Nothing, 30]]]


### PR DESCRIPTION
### Pull Request Description

I think fill_nothing should work with an empty string. Currently TextType.preciseTypeForValue(arg.asString()) throws if you give it an empty string so this fix avoid that.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
