### PR TITLE
Apply SectionsToBinOp pass to arguments of Section

### DIFF
--- a/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ExecCompilerTest.java
@@ -64,6 +64,46 @@ public class ExecCompilerTest {
   }
 
   @Test
+  public void testDesugarOperators() throws Exception {
+    var module = ctx.eval("enso", """
+    main =
+      ma ==ums==
+    """);
+    try {
+      var run = module.invokeMember("eval_expression", "main");
+      fail("Unexpected result: " + run);
+    } catch (PolyglotException ex) {
+      assertEquals("Compile error: The name `ma` could not be found.", ex.getMessage());
+    }
+  }
+
+  @Test
+  public void testDesugarOperatorsLeftRight() throws Exception {
+    var module = ctx.eval("enso", """
+    main = (+ (2 *))
+    """);
+    try {
+      var run = module.invokeMember("eval_expression", "main");
+      fail("Unexpected result: " + run);
+    } catch (PolyglotException ex) {
+      assertEquals("Method `+` of type Unnamed could not be found.", ex.getMessage());
+    }
+  }
+
+  @Test
+  public void testDesugarOperatorsRightLeft() throws Exception {
+    var module = ctx.eval("enso", """
+    main = ((* 2) +)
+    """);
+    try {
+      var run = module.invokeMember("eval_expression", "main");
+      fail("Unexpected result: " + run);
+    } catch (PolyglotException ex) {
+      assertEquals("Method `+` of type Function could not be found.", ex.getMessage());
+    }
+  }
+
+  @Test
   public void testHalfAssignment() throws Exception {
     var module =
         ctx.eval(


### PR DESCRIPTION
### Pull Request Description

Fixes #8436 by making sure that `SectionsToBinOp` pass is applied also to arguments of `Section`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
