### PR TITLE
Canonicalize file names before comparing them

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/DefaultPackageRepository.scala
@@ -653,7 +653,7 @@ private object DefaultPackageRepository {
 
     val projectRoot = projectPackage.map { pkg =>
       val root = pkg.root
-      Path.of(root.getAbsoluteFile.toUri)
+      Path.of(root.getCanonicalFile().toUri)
     }
 
     val resolvingLibraryProvider =


### PR DESCRIPTION
### Pull Request Description

While working on https://github.com/enso-org/enso/issues/8421#issuecomment-1876292807 I realized that `--in-project ./test/Table_Tests` doesn't work properly. This PR fixes the problem by canonicalizing the file names.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides. 
- All code has been tested:
  - [x] Tested manually
