### PR TITLE
Replace Jackson library by simple data I/O streams

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1557,7 +1557,7 @@ lazy val runtime = (project in file("engine/runtime"))
     ), // show timings for individual tests
     scalacOptions += "-Ymacro-annotations",
     scalacOptions ++= Seq("-Ypatmat-exhaust-depth", "off"),
-    libraryDependencies ++= jmh ++ jaxb ++ circe ++ GraalVM.langsPkgs ++ Seq(
+    libraryDependencies ++= jmh ++ jaxb ++ GraalVM.langsPkgs ++ Seq(
       "org.apache.commons"   % "commons-lang3"           % commonsLangVersion,
       "org.apache.tika"      % "tika-core"               % tikaVersion,
       "org.graalvm.polyglot" % "polyglot"                % graalMavenPackagesVersion % "provided",
@@ -1571,7 +1571,6 @@ lazy val runtime = (project in file("engine/runtime"))
       "org.scalactic"       %% "scalactic"               % scalacticVersion          % Test,
       "org.scalatest"       %% "scalatest"               % scalatestVersion          % Test,
       "org.graalvm.truffle"  % "truffle-api"             % graalMavenPackagesVersion % Benchmark,
-      "org.typelevel"       %% "cats-core"               % catsVersion,
       "junit"                % "junit"                   % junitVersion              % Test,
       "com.github.sbt"       % "junit-interface"         % junitIfVersion            % Test,
       "org.hamcrest"         % "hamcrest-all"            % hamcrestVersion           % Test,

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/Cache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/Cache.java
@@ -175,8 +175,10 @@ public abstract class Cache<T, M extends Cache.Metadata> {
    * @param blobDigest digest of serialized data
    * @param entry data to serialize
    * @return raw bytes representing serialized metadata
+   * @throws java.io.IOException in case of I/O error
    */
-  protected abstract byte[] metadata(String sourceDigest, String blobDigest, T entry);
+  protected abstract byte[] metadata(String sourceDigest, String blobDigest, T entry)
+      throws IOException;
 
   /**
    * Loads cache for this data, if possible.
@@ -333,9 +335,12 @@ public abstract class Cache<T, M extends Cache.Metadata> {
    * De-serializes raw bytes to data's metadata.
    *
    * @param bytes raw bytes representing metadata
+   * @param logger logger to use
    * @return non-empty metadata, if de-serialization was successful
+   * @throws IOException in case of I/O error
    */
-  protected abstract Optional<M> metadataFromBytes(byte[] bytes, TruffleLogger logger);
+  protected abstract Optional<M> metadataFromBytes(byte[] bytes, TruffleLogger logger)
+      throws IOException;
 
   /**
    * Compute digest of cache's data

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/Cache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/Cache.java
@@ -4,8 +4,6 @@ import com.oracle.truffle.api.TruffleFile;
 import com.oracle.truffle.api.TruffleLogger;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -513,8 +511,6 @@ public abstract class Cache<T, M extends Cache.Metadata> {
               });
     }
   }
-
-  protected static final Charset metadataCharset = StandardCharsets.UTF_8;
 
   /**
    * Roots encapsulates two possible locations where caches can be stored.

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/ModuleCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/ModuleCache.java
@@ -34,12 +34,9 @@ public final class ModuleCache extends Cache<ModuleCache.CachedModule, ModuleCac
   }
 
   @Override
-  protected byte[] metadata(String sourceDigest, String blobDigest, CachedModule entry) {
-    try {
-      return new Metadata(sourceDigest, blobDigest, entry.compilationStage().toString()).toBytes();
-    } catch (IOException e) {
-      throw raise(RuntimeException.class, e);
-    }
+  protected byte[] metadata(String sourceDigest, String blobDigest, CachedModule entry)
+      throws IOException {
+    return new Metadata(sourceDigest, blobDigest, entry.compilationStage().toString()).toBytes();
   }
 
   @Override
@@ -69,13 +66,9 @@ public final class ModuleCache extends Cache<ModuleCache.CachedModule, ModuleCac
   }
 
   @Override
-  protected Optional<Metadata> metadataFromBytes(byte[] bytes, TruffleLogger logger) {
-    try {
-      return Optional.of(Metadata.read(bytes));
-    } catch (IOException e) {
-      logger.log(logLevel, "Failed to deserialize module's metadata.", e);
-      return Optional.empty();
-    }
+  protected Optional<Metadata> metadataFromBytes(byte[] bytes, TruffleLogger logger)
+      throws IOException {
+    return Optional.of(Metadata.read(bytes));
   }
 
   private Optional<String> computeDigestOfModuleSources(Source source) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/ModuleCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/ModuleCache.java
@@ -8,6 +8,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Optional;
@@ -77,7 +78,7 @@ public final class ModuleCache extends Cache<ModuleCache.CachedModule, ModuleCac
       if (source.hasBytes()) {
         sourceBytes = source.getBytes().toByteArray();
       } else {
-        sourceBytes = source.getCharacters().toString().getBytes(metadataCharset);
+        sourceBytes = source.getCharacters().toString().getBytes(StandardCharsets.UTF_8);
       }
       return Optional.of(computeDigestFromBytes(sourceBytes));
     } else {


### PR DESCRIPTION
### Pull Request Description

Improving #8553 by using `DataOutputStream` and `DataInputStream` instead of complex JSON serialization and deserialization.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides.
- All code has been tested:
  - [x] Unit tests continue to pass
  - [x] Remove Jackson from **suggestion DB** cache - [done](https://github.com/enso-org/enso/pull/8693/commits/a8939391c269a749ae20282827a040b90006643e)
  - [x] Remove Jackson from **import/export** cache - [done](https://github.com/enso-org/enso/pull/8693/commits/9109ca03a9eef0f6317a226b61d311d6068a043e).
  - [x] Benchmarks look better: [first fix](https://github.com/enso-org/enso/actions/runs/7422691615)
  - [x] Benchmarks look even better with [three fixes](https://github.com/enso-org/enso/actions/runs/7432153138)
