### PR TITLE
language server tests do not unnecessarily re-assemble fat jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1366,7 +1366,7 @@ lazy val `language-server` = (project in file("engine/language-server"))
   )
   .settings(
     Test / compile := (Test / compile)
-      .dependsOn(LocalProject("enso") / updateLibraryManifests)
+      .dependsOn(`runtime-fat-jar` / Compile / compileModuleInfo)
       .value,
     Test / envVars ++= Map(
       "ENSO_EDITION_PATH" -> file("distribution/editions").getCanonicalPath


### PR DESCRIPTION
Follow-up of #8467.

### Pull Request Description

`language-server / test` used to depend on `updateLibraryManifest`, which, in turn, depends on `runtime-fat-jar / assembly`, which is an expensive operation, that is not cache, so it is invoked even if no sources were changed. In this PR, I am trying to remove this dependency and thus speed up the language-server test invocation.

### Important Notes

Previous behavior (without changing any sources):
```
sbt:enso> language-server/testOnly *SuggestionsHandlerSpec
[warn] Caching disabled because of a custom merge strategy: 'Discard all module-info except for module-info from project runtime'
[info] 5453 file(s) merged using strategy 'First' (Run the task at debug level to see the details)
[info] 12 file(s) merged using strategy 'Concat' (Run the task at debug level to see the details)
[info] 5 file(s) merged using strategy 'Discard all module-info except for module-info from project runtime (Custom)' (Run the task at debug level to see the details)
[info] 48 file(s) merged using strategy 'Discard' (Run the task at debug level to see the details)
[info] Built: runtime.jar
[info] Jar hash: 9d75ba53f9fc7a8419bc32bddce1263bb9128521
[info] Assembly jar up to date: runner.jar
SLF4J: Attempting to load provider "org.enso.logger.TestLogProvider" specified via "slf4j.provider" system property
[info] SuggestionsHandlerSpec:
```

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
