### PR TITLE
Switch Table viz to AG Grid Enterprise

### DIFF
--- a/app/gui2/package.json
+++ b/app/gui2/package.json
@@ -31,6 +31,9 @@
     "generate-metadata": "node scripts/generateIconMetadata.js",
     "download-fonts": "node scripts/downloadFonts.js"
   },
+  "//": [
+    "'ag-grid-community' is required as a peer dependency of 'ag-grid-enterprise'."
+  ],
   "dependencies": {
     "@ag-grid-community/client-side-row-model": "^30.2.0",
     "@ag-grid-community/core": "^30.2.0",
@@ -45,6 +48,8 @@
     "@open-rpc/client-js": "^1.8.1",
     "@pinia/testing": "^0.1.3",
     "@vueuse/core": "^10.4.1",
+    "ag-grid-community": "^30.2.1",
+    "ag-grid-enterprise": "^30.2.1",
     "codemirror": "^6.0.1",
     "culori": "^3.2.0",
     "enso-authentication": "^1.0.0",

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -60,6 +60,7 @@ interface UnknownTable {
 </script>
 
 <script setup lang="ts">
+import { useAutoBlur } from '@/util/autoBlur'
 import { VisualizationContainer } from '@/util/visualizationBuiltins'
 import type {
   ColDef,
@@ -70,19 +71,7 @@ import type {
 import '@ag-grid-community/styles/ag-grid.css'
 import '@ag-grid-community/styles/ag-theme-alpine.css'
 import { computed, onMounted, reactive, ref, watchEffect, type Ref } from 'vue'
-const [
-  { ClientSideRowModelModule },
-  { RangeSelectionModule },
-  { Grid, ModuleRegistry },
-  { LicenseManager },
-] = await Promise.all([
-  import('@ag-grid-community/client-side-row-model'),
-  import('@ag-grid-enterprise/range-selection'),
-  import('@ag-grid-community/core'),
-  import('@ag-grid-enterprise/core'),
-])
-
-ModuleRegistry.registerModules([ClientSideRowModelModule, RangeSelectionModule])
+const { Grid, LicenseManager } = await import('ag-grid-enterprise')
 
 const props = defineProps<{ data: Data }>()
 const emit = defineEmits<{
@@ -97,6 +86,7 @@ const pageLimit = ref(0)
 const rowCount = ref(0)
 const isTruncated = ref(false)
 const tableNode = ref<HTMLElement>()
+useAutoBlur(tableNode)
 const widths = reactive(new Map<string, number>())
 const defaultColDef = {
   editable: false,

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -57,19 +57,23 @@ interface UnknownTable {
   data: unknown[][] | undefined
   indices: unknown[][] | undefined
 }
+
+declare module 'ag-grid-enterprise' {
+  // These type parameters are defined on the original interface.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface AbstractColDef<TData, TValue> {
+    field: string
+  }
+}
 </script>
 
 <script setup lang="ts">
 import { useAutoBlur } from '@/util/autoBlur'
 import { VisualizationContainer } from '@/util/visualizationBuiltins'
-import type {
-  ColDef,
-  ColumnResizedEvent,
-  GridOptions,
-  HeaderValueGetterParams,
-} from '@ag-grid-community/core'
 import '@ag-grid-community/styles/ag-grid.css'
 import '@ag-grid-community/styles/ag-theme-alpine.css'
+import type { ColumnResizedEvent } from 'ag-grid-community'
+import type { ColDef, GridOptions, HeaderValueGetterParams } from 'ag-grid-enterprise'
 import { computed, onMounted, reactive, ref, watchEffect, type Ref } from 'vue'
 const { Grid, LicenseManager } = await import('ag-grid-enterprise')
 

--- a/app/gui2/src/components/visualizations/d3Types.ts
+++ b/app/gui2/src/components/visualizations/d3Types.ts
@@ -1,4 +1,4 @@
-// Fixes and extensions for dependencies' type definitions.
+// Fixes and extensions for D3's type definitions.
 
 import type { BaseType, Selection } from 'd3'
 
@@ -11,15 +11,5 @@ declare module 'd3' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface ScaleSequential<Output, Unknown = never> {
     ticks(): number[]
-  }
-}
-
-import '@ag-grid-community/core'
-
-declare module '@ag-grid-community/core' {
-  // These type parameters are defined on the original interface.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface AbstractColDef<TData, TValue> {
-    field: string
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,8 @@
         "@open-rpc/client-js": "^1.8.1",
         "@pinia/testing": "^0.1.3",
         "@vueuse/core": "^10.4.1",
+        "ag-grid-community": "^30.2.1",
+        "ag-grid-enterprise": "^30.2.1",
         "codemirror": "^6.0.1",
         "culori": "^3.2.0",
         "enso-authentication": "^1.0.0",
@@ -4910,6 +4912,16 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/ag-grid-community": {
+      "version": "30.2.1",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-30.2.1.tgz",
+      "integrity": "sha512-1slonXskJbbI9ybhTx//4YKfJpZVAEnHL8dui1rQJRSXKByUi+/f7XtvkLsbgBkawoWbqvRAySjYtvz80+kBfA=="
+    },
+    "node_modules/ag-grid-enterprise": {
+      "version": "30.2.1",
+      "resolved": "https://registry.npmjs.org/ag-grid-enterprise/-/ag-grid-enterprise-30.2.1.tgz",
+      "integrity": "sha512-sGeyAfZ416dBlJaxIHB6hGTJG6QzuajXnDAtVuQlOLUuV4/TXVQoh5SJkiKBpWXukZQJPE4VD/5IkQ1tXh96/w=="
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -17699,6 +17711,10 @@
         "vue": "^3"
       }
     },
+    "node_modules/vue-react-wrapper/node_modules/@types/react": {
+      "resolved": "node_modules/vue-react-wrapper/src/react-types/react",
+      "link": true
+    },
     "node_modules/vue-react-wrapper/node_modules/@types/react-dom": {
       "version": "18.0.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.3.tgz",
@@ -17707,6 +17723,9 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/vue-react-wrapper/src/react-types/react": {
+      "dev": true
     },
     "node_modules/vue-resize": {
       "version": "2.0.0-alpha.1",


### PR DESCRIPTION
### Pull Request Description
- Closes #8660
  - Switches Table viz to use AG Grid Enterprise

### Important Notes
- Not sure this is the proper way to enable full AG Grid Enterprise.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
