### PR TITLE
Benchmark downloader script should take the latest score, not the smallest

### DIFF
--- a/tools/performance/engine-benchmarks/bench_download.py
+++ b/tools/performance/engine-benchmarks/bench_download.py
@@ -280,8 +280,8 @@ def _parse_bench_report_from_xml(bench_report_xml_path: str, bench_run: JobRun) 
             scores_float = [float(score.text.strip()) for score in scores]
             if len(scores_float) > 1:
                 logging.warning(f"More than one score for benchmark {label}, "
-                                f"using the best one (the smallest one).")
-            label_score_dict[label] = min(scores_float)
+                                f"using the last one (the newest one).")
+            label_score_dict[label] = scores_float[len(scores_float) - 1]
     return JobReport(
         label_score_dict=label_score_dict,
         bench_run=bench_run


### PR DESCRIPTION
Thanks to the observations of @JaroslavTulach, I have noticed that on our benchmark results pages (for both [engine](https://enso-org.github.io/engine-benchmark-results/engine-benchs.html) and [stdlib](https://enso-org.github.io/engine-benchmark-results/stdlib-benchs.html)), we have a lot of nonsensical data.

## Problem description
Every benchmark run generates `bench-results.xml` file with a format like this:
```xml
        <case>
            <label>org.enso.benchmarks.generated.Startup.empty_startup</label>
            <scores>
                <score>2823.877618</score>
            </scores>
        </case>
```
If the runner is not clean, the `bench-results.xml` file is not rewritten, but rather a new score value is appended, like so:
```xml
        <case>
            <label>org.enso.benchmarks.generated.Startup.empty_startup</label>
            <scores>
                <score>2823.877618</score>
                <score>3206.157912</score>
            </scores>
        </case>
```
The procedure in the `bench_download.py` script used to choose the lowest of these numbers:
https://github.com/enso-org/enso/blob/develop/tools/performance/engine-benchmarks/bench_download.py#L280-L284
This is obviously wrong. This PR fixes this by choosing the latest score, that is the last value.

## TL;DR;
All our benchmark data from runners that were not clean are wrong! On this picture, on the right there is the old and wrong value, and on the left is the correct one:
![image](https://github.com/enso-org/enso/assets/14013887/825c5b34-d425-4070-8c2e-91acbc0feb10)

The data was fetched from this snippet:
![image](https://github.com/enso-org/enso/assets/14013887/bbd0feb7-e286-45ac-b66e-3beb1d72fd69)
