### PR TITLE
CI: Enable sanity test for native Runner

### DIFF
--- a/build/build/paths.yaml
+++ b/build/build/paths.yaml
@@ -84,7 +84,7 @@
     enso.bundle.template:
     launcher-manifest.yaml:
   engine/:
-    runner-native/:
+    runner/:
       src/:
         test/:
           resources/:

--- a/build/build/src/engine/context.rs
+++ b/build/build/src/engine/context.rs
@@ -19,13 +19,13 @@ use crate::paths::cache_directory;
 use crate::paths::Paths;
 use crate::paths::TargetTriple;
 use crate::paths::ENSO_DATA_DIRECTORY;
+use crate::paths::ENSO_JAVA;
 use crate::paths::ENSO_TEST_JUNIT_DIR;
 use crate::project::ProcessWrapper;
 
 use ide_ci::actions::workflow::is_in_env;
 use ide_ci::actions::workflow::MessageLevel;
 use ide_ci::cache;
-use ide_ci::define_env_var;
 use ide_ci::github::release::IsReleaseExt;
 use ide_ci::platform::DEFAULT_SHELL;
 use ide_ci::programs::sbt;

--- a/build/build/src/engine/context.rs
+++ b/build/build/src/engine/context.rs
@@ -525,7 +525,7 @@ impl RunContext {
         }
 
 
-        for enso_java in [None, Some("espresso"), None] {
+        for enso_java in [None, Some("espresso")] {
             let factorial_input = "6";
             let factorial_expected_output = "720";
             if build_native_runner {

--- a/build/build/src/engine/context.rs
+++ b/build/build/src/engine/context.rs
@@ -525,10 +525,10 @@ impl RunContext {
         }
 
 
-        for enso_java in [None, Some("espresso")] {
+        if build_native_runner {
             let factorial_input = "6";
             let factorial_expected_output = "720";
-            if build_native_runner {
+            for enso_java in [None, Some("espresso")] {
                 let output = Command::new(&self.repo_root.runner)
                     .args([
                         "--run",

--- a/build/build/src/engine/context.rs
+++ b/build/build/src/engine/context.rs
@@ -18,6 +18,7 @@ use crate::enso::IrCaches;
 use crate::paths::cache_directory;
 use crate::paths::Paths;
 use crate::paths::TargetTriple;
+use crate::paths::ENSO_DATA_DIRECTORY;
 use crate::paths::ENSO_TEST_JUNIT_DIR;
 use crate::project::ProcessWrapper;
 
@@ -523,24 +524,26 @@ impl RunContext {
         }
 
 
-        // if build_native_runner {
-        //     let factorial_input = "6";
-        //     let factorial_expected_output = "720";
-        //     let output = Command::new(&self.repo_root.runner)
-        //         .args([
-        //             "--run",
-        //
-        // self.repo_root.engine.runner_native.src.test.resources.factorial_enso.as_str(),
-        //             factorial_input,
-        //         ])
-        //         .env(ENSO_DATA_DIRECTORY.name(), &self.paths.engine.dir)
-        //         .run_stdout()
-        //         .await?;
-        //     ensure!(
-        //         output.contains(factorial_expected_output),
-        //         "Native runner output does not contain expected result."
-        //     );
-        // }
+        if build_native_runner {
+            let factorial_input = "6";
+            let factorial_expected_output = "720";
+            let output = Command::new(&self.repo_root.runner)
+                .args([
+                    "--run",
+                    self.repo_root.engine.runner_native.src.test.resources.factorial_enso.as_str(),
+                    factorial_input,
+                ])
+                .set_env(
+                    ENSO_DATA_DIRECTORY,
+                    self.repo_root.built_distribution.enso_engine_triple.engine_package.as_path(),
+                )?
+                .run_stdout()
+                .await?;
+            ensure!(
+                output.contains(factorial_expected_output),
+                "Native runner output does not contain expected result."
+            );
+        }
 
 
         // Verify License Packages in Distributions

--- a/build/build/src/engine/context.rs
+++ b/build/build/src/engine/context.rs
@@ -526,6 +526,7 @@ impl RunContext {
 
 
         if build_native_runner {
+            debug!("Building and testing native engine runners");
             runner_sanity_test(&self.repo_root, None).await?;
             ide_ci::fs::remove_file_if_exists(&self.repo_root.runner)?;
             let enso_java = "espresso";

--- a/build/build/src/engine/context.rs
+++ b/build/build/src/engine/context.rs
@@ -526,9 +526,6 @@ impl RunContext {
 
 
         for enso_java in [None, Some("espresso"), None] {
-            define_env_var! {
-                ENSO_JAVA, String;
-            }
             let factorial_input = "6";
             let factorial_expected_output = "720";
             if build_native_runner {

--- a/build/build/src/paths.rs
+++ b/build/build/src/paths.rs
@@ -33,6 +33,7 @@ ide_ci::define_env_var! {
     /// If Enso-specific assertions should be enabled.
     ENSO_ENABLE_ASSERTIONS, String;
 
+    /// Can be set to `"espresso"` to enable Espresso interpreter support.
     ENSO_JAVA, String;
 }
 

--- a/build/build/src/paths.rs
+++ b/build/build/src/paths.rs
@@ -32,6 +32,8 @@ ide_ci::define_env_var! {
 
     /// If Enso-specific assertions should be enabled.
     ENSO_ENABLE_ASSERTIONS, String;
+
+    ENSO_JAVA, String;
 }
 
 pub const EDITION_FILE_ARTIFACT_NAME: &str = "Edition File";


### PR DESCRIPTION
### Pull Request Description
If the native image of the runner was built, it will receive some basic sanity test. Then, an espresso-enabled variant of the runner will be compiled and tested as well.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
