### PR TITLE
Make fill nothing return types tighter

### DIFF
--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Type/Enso_Types.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Type/Enso_Types.enso
@@ -35,10 +35,14 @@ most_specific_value_type value use_smallest=False =
                 True -> Value_Type.Decimal precision=Nothing scale=0
         text : Text     ->
             length = text.length
-            # Not using Char size=0 for empty strings, because that would be an invalid value.
-            case use_smallest && length > 0 of
-                True  -> Value_Type.Char size=text.length variable_length=False
+            case use_smallest of
                 False -> Value_Type.Char size=Nothing variable_length=True
+                True -> 
+                    case length > 0 of
+                        True  -> Value_Type.Char size=length variable_length=False
+                        # Not using Char size=0 for empty strings, because that would be an invalid value.
+                        False -> Value_Type.Char size=1 variable_length=True
+                
         ## TODO [RW] once we add Enso Native Object Type Value Type, we probably
            want to prefer it over Mixed
         _               -> Value_Type.Mixed

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -349,6 +349,22 @@ spec setup =
                 True -> actual.at "col0" . value_type . should_equal (Value_Type.Char size=3 variable_length=True)
                 False -> actual.at "col0" . value_type . should_equal (Value_Type.Char variable_length=True)
         
+        Test.specify "should allow to fill_nothing a fixed width of width 1 correctly expanding ouptut types" <|
+            t = table_builder [["col0", ["a", Nothing, " "]]] . cast "col0" (Value_Type.Char size=1 variable_length=False)
+            fillBlank = t.fill_nothing ["col0"] ""
+            fillOneSpace = t.fill_nothing ["col0"] " "
+            fillTwoSpaces = t.fill_nothing ["col0"] "  "
+            fillBlank.at "col0" . to_vector . should_equal ["a", "", " "]
+            fillOneSpace.at "col0" . to_vector . should_equal ["a", " ", " "]
+            fillTwoSpaces.at "col0" . to_vector . should_equal ["a", "  ", " "]
+            case setup.test_selection.length_restricted_text_columns of
+                True -> fillBlank.at "col0" . value_type . should_equal (Value_Type.Char size=1 variable_length=True)
+                    fillOneSpace.at "col0" . value_type . should_equal (Value_Type.Char size=1 variable_length=False)
+                    fillTwoSpaces.at "col0" . value_type . should_equal (Value_Type.Char size=2 variable_length=True)
+                False -> fillBlank.at "col0" . value_type . should_equal (Value_Type.Char variable_length=True)
+                    fillOneSpace.at "col0" . value_type . should_equal (Value_Type.Char variable_length=True)
+                    fillTwoSpaces.at "col0" . value_type . should_equal (Value_Type.Char variable_length=True)
+        
         Test.specify "should allow to fill_nothing a fixed width with a string of correct length without changing the type" <|
             t = table_builder [["col0", [Nothing, "200", Nothing, "400", "500", Nothing]]] . cast "col0" (Value_Type.Char size=3 variable_length=False)
             actual = t.fill_nothing ["col0"] "   "

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -331,8 +331,9 @@ spec setup =
             t = table_builder [["col0", ["0", Nothing, "4", "5", Nothing, Nothing]]] . cast "col0" (Value_Type.Char size=1 variable_length=False)
             actual = t.fill_nothing ["col0"] "ABCDE"
             actual.at "col0" . to_vector . should_equal ["0", "ABCDE", "4", "5", "ABCDE", "ABCDE"]
-            if setup.is_database.not then
-                actual.at "col0" . value_type . should_equal (Value_Type.Char size=5 variable_length=True)
+            case setup.test_selection.length_restricted_text_columns of
+                True -> actual.at "col0" . value_type . should_equal (Value_Type.Char size=5 variable_length=True)
+                False -> actual.at "col0" . value_type . should_equal (Value_Type.Char variable_length=True)
 
         Test.specify "should allow to fill_nothing from an empty string" <|
             t = table_builder [["col0", ["0", Nothing, "4", "5", Nothing, Nothing]], ["col1", [Nothing, "200", Nothing, "400", "500", Nothing]]]
@@ -344,14 +345,17 @@ spec setup =
             t = table_builder [["col0", [Nothing, "200", Nothing, "400", "500", Nothing]]] . cast "col0" (Value_Type.Char size=3 variable_length=False)
             actual = t.fill_nothing ["col0"] ""
             actual.at "col0" . to_vector . should_equal ["", "200", "", "400", "500", ""]  
-            actual.at "col0" . value_type . should_equal (Value_Type.Char variable_length=True)
+            case setup.test_selection.length_restricted_text_columns of
+                True -> actual.at "col0" . value_type . should_equal (Value_Type.Char size=3 variable_length=True)
+                False -> actual.at "col0" . value_type . should_equal (Value_Type.Char variable_length=True)
         
         Test.specify "should allow to fill_nothing a fixed width with a string of correct length without changing the type" <|
             t = table_builder [["col0", [Nothing, "200", Nothing, "400", "500", Nothing]]] . cast "col0" (Value_Type.Char size=3 variable_length=False)
             actual = t.fill_nothing ["col0"] "   "
             actual.at "col0" . to_vector . should_equal ["   ", "200", "   ", "400", "500", "   "]  
-            if setup.is_database.not then
-                actual.at "col0" . value_type . should_equal (Value_Type.Char size=3 variable_length=False)
+            case setup.test_selection.fixed_length_text_columns of
+                True -> actual.at "col0" . value_type . should_equal (Value_Type.Char size=3 variable_length=False)
+                False -> actual.at "col0" . value_type . should_equal (Value_Type.Char variable_length=True)
 
         Test.specify "should allow to fill_nothing from other columns" <|
             t = table_builder [["col0", [0, Nothing, 4, 5, Nothing, Nothing]], ["col1", [Nothing, 200, Nothing, 400, 500, Nothing]], ["def", [1, 2, 10, 20, Nothing, 30]]]

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -354,9 +354,6 @@ spec setup =
             fillBlank = t.fill_nothing ["col0"] ""
             fillOneSpace = t.fill_nothing ["col0"] " "
             fillTwoSpaces = t.fill_nothing ["col0"] "  "
-            fillBlank.at "col0" . to_vector . should_equal ["a", "", " "]
-            fillOneSpace.at "col0" . to_vector . should_equal ["a", " ", " "]
-            fillTwoSpaces.at "col0" . to_vector . should_equal ["a", "  ", " "]
             case setup.test_selection.length_restricted_text_columns of
                 True -> fillBlank.at "col0" . value_type . should_equal (Value_Type.Char size=1 variable_length=True)
                     fillOneSpace.at "col0" . value_type . should_equal (Value_Type.Char size=1 variable_length=False)
@@ -364,7 +361,17 @@ spec setup =
                 False -> fillBlank.at "col0" . value_type . should_equal (Value_Type.Char variable_length=True)
                     fillOneSpace.at "col0" . value_type . should_equal (Value_Type.Char variable_length=True)
                     fillTwoSpaces.at "col0" . value_type . should_equal (Value_Type.Char variable_length=True)
-        
+            
+            case setup.test_selection.removes_trailing_whitespace_casting_from_char_to_varchar of
+                True -> fillBlank.at "col0" . to_vector . should_equal ["a", "", ""]
+                False -> fillBlank.at "col0" . to_vector . should_equal ["a", "", " "]
+
+            fillOneSpace.at "col0" . to_vector . should_equal ["a", " ", " "]
+                   
+            case setup.test_selection.removes_trailing_whitespace_casting_from_char_to_varchar of
+                True -> fillTwoSpaces.at "col0" . to_vector . should_equal ["a", "", ""]
+                False -> fillTwoSpaces.at "col0" . to_vector . should_equal ["a", "  ", " "]
+                
         Test.specify "should allow to fill_nothing a fixed width with a string of correct length without changing the type" <|
             t = table_builder [["col0", [Nothing, "200", Nothing, "400", "500", Nothing]]] . cast "col0" (Value_Type.Char size=3 variable_length=False)
             actual = t.fill_nothing ["col0"] "   "

--- a/test/Table_Tests/src/Common_Table_Operations/Main.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Main.enso
@@ -97,6 +97,8 @@ type Test_Selection
        - date_time: Specifies if the backend supports date/time operations.
        - fixed_length_text_columns: Specifies if the backend supports fixed
          length text columns.
+       - length_restricted_text_columns: Specifies if the backend supports 
+         length restrictions for text columns.
        - different_size_integer_types: Specifies if the backend supports
          integer types of various sizes, like 16-bit or 32-bit integers.
        - supports_8bit_integer: Specifies if the backend supports 8-bit
@@ -111,7 +113,7 @@ type Test_Selection
          columns.
        - supported_replace_params: Specifies the possible values of
          Replace_Params that a backend supports.
-    Config supports_case_sensitive_columns=True order_by=True natural_ordering=False case_insensitive_ordering=True order_by_unicode_normalization_by_default=False case_insensitive_ascii_only=False allows_mixed_type_comparisons=True supports_unicode_normalization=False is_nan_and_nothing_distinct=True distinct_returns_first_row_from_group_if_ordered=True date_time=True fixed_length_text_columns=False different_size_integer_types=True supports_8bit_integer=False supports_decimal_type=False supports_time_duration=False supports_nanoseconds_in_time=False supports_mixed_columns=False supported_replace_params=Nothing
+    Config supports_case_sensitive_columns=True order_by=True natural_ordering=False case_insensitive_ordering=True order_by_unicode_normalization_by_default=False case_insensitive_ascii_only=False allows_mixed_type_comparisons=True supports_unicode_normalization=False is_nan_and_nothing_distinct=True distinct_returns_first_row_from_group_if_ordered=True date_time=True fixed_length_text_columns=False length_restricted_text_columns=True different_size_integer_types=True supports_8bit_integer=False supports_decimal_type=False supports_time_duration=False supports_nanoseconds_in_time=False supports_mixed_columns=False supported_replace_params=Nothing
 
 spec setup =
     Core_Spec.spec setup

--- a/test/Table_Tests/src/Common_Table_Operations/Main.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Main.enso
@@ -99,6 +99,9 @@ type Test_Selection
          length text columns.
        - length_restricted_text_columns: Specifies if the backend supports 
          length restrictions for text columns.
+       - removes_trailing_whitespace_casting_from_char_to_varchar: if
+         SELECT concat('X', CAST(CAST('   ' AS CHAR(3)) AS VARCHAR(3)), 'X')
+         returns XX then this should be set to True
        - different_size_integer_types: Specifies if the backend supports
          integer types of various sizes, like 16-bit or 32-bit integers.
        - supports_8bit_integer: Specifies if the backend supports 8-bit
@@ -113,7 +116,7 @@ type Test_Selection
          columns.
        - supported_replace_params: Specifies the possible values of
          Replace_Params that a backend supports.
-    Config supports_case_sensitive_columns=True order_by=True natural_ordering=False case_insensitive_ordering=True order_by_unicode_normalization_by_default=False case_insensitive_ascii_only=False allows_mixed_type_comparisons=True supports_unicode_normalization=False is_nan_and_nothing_distinct=True distinct_returns_first_row_from_group_if_ordered=True date_time=True fixed_length_text_columns=False length_restricted_text_columns=True different_size_integer_types=True supports_8bit_integer=False supports_decimal_type=False supports_time_duration=False supports_nanoseconds_in_time=False supports_mixed_columns=False supported_replace_params=Nothing
+    Config supports_case_sensitive_columns=True order_by=True natural_ordering=False case_insensitive_ordering=True order_by_unicode_normalization_by_default=False case_insensitive_ascii_only=False allows_mixed_type_comparisons=True supports_unicode_normalization=False is_nan_and_nothing_distinct=True distinct_returns_first_row_from_group_if_ordered=True date_time=True fixed_length_text_columns=False length_restricted_text_columns=True removes_trailing_whitespace_casting_from_char_to_varchar=False different_size_integer_types=True supports_8bit_integer=False supports_decimal_type=False supports_time_duration=False supports_nanoseconds_in_time=False supports_mixed_columns=False supported_replace_params=Nothing
 
 spec setup =
     Core_Spec.spec setup

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -518,7 +518,7 @@ run_tests connection db_name =
 
     Common_Spec.spec prefix connection
 
-    common_selection = Common_Table_Operations.Main.Test_Selection.Config supports_case_sensitive_columns=True order_by_unicode_normalization_by_default=True allows_mixed_type_comparisons=False fixed_length_text_columns=True supports_decimal_type=True supported_replace_params=supported_replace_params
+    common_selection = Common_Table_Operations.Main.Test_Selection.Config supports_case_sensitive_columns=True order_by_unicode_normalization_by_default=True allows_mixed_type_comparisons=False fixed_length_text_columns=True removes_trailing_whitespace_casting_from_char_to_varchar=True supports_decimal_type=True supported_replace_params=supported_replace_params
     aggregate_selection = Common_Table_Operations.Aggregate_Spec.Test_Selection.Config first_last_row_order=False aggregation_problems=False
     agg_in_memory_table = (enso_project.data / "data.csv") . read
     agg_table = agg_in_memory_table.select_into_database_table connection (Name_Generator.random_name "Agg1") primary_key=Nothing temporary=True

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -240,7 +240,7 @@ sqlite_spec connection prefix =
 
     Common_Spec.spec prefix connection
 
-    common_selection = Common_Table_Operations.Main.Test_Selection.Config supports_case_sensitive_columns=False order_by=True natural_ordering=False case_insensitive_ordering=True case_insensitive_ascii_only=True is_nan_and_nothing_distinct=False date_time=False supported_replace_params=supported_replace_params different_size_integer_types=False
+    common_selection = Common_Table_Operations.Main.Test_Selection.Config supports_case_sensitive_columns=False order_by=True natural_ordering=False case_insensitive_ordering=True case_insensitive_ascii_only=True is_nan_and_nothing_distinct=False date_time=False supported_replace_params=supported_replace_params different_size_integer_types=False length_restricted_text_columns=False
 
     ## For now `advanced_stats`, `first_last`, `text_shortest_longest` and
        `multi_distinct` remain disabled, because SQLite does not provide the


### PR DESCRIPTION
### Pull Request Description

This is the follow up PR addressing the last couple of points from https://github.com/enso-org/enso/pull/8643 around what the return type from fill_nothing. 

### Important Notes

The biggest change is changing what we size we need for an empty string. This change says a variable length string of length 1 and does it at a low enough level that it will effect the whole language. But I think that is correct.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
