### PR TITLE
Fix withDebug benchOnly command

### DIFF
--- a/project/WithDebugCommand.scala
+++ b/project/WithDebugCommand.scala
@@ -100,10 +100,18 @@ object WithDebugCommand {
           state.fail
         case Some(taskKey) =>
           val extracted = Project.extract(state)
-          val withJavaOpts = extracted.appendWithoutSession(
-            Seq(Compile / Keys.javaOptions ++= javaOpts),
-            state
-          )
+          // Append the java options also to the Benchmark configuration, in case we run `benchOnly`
+          // task.
+          val Benchmark = config("bench")
+          val withJavaOpts = extracted
+            .appendWithoutSession(
+              Seq(Compile / Keys.javaOptions ++= javaOpts),
+              state
+            )
+            .appendWithoutSession(
+              Seq(Benchmark / Keys.javaOptions ++= javaOpts),
+              state
+            )
           Project
             .extract(withJavaOpts)
             .runInputTask(taskKey, runArgs, withJavaOpts)


### PR DESCRIPTION
This PR fixes `withDebug` command in `runtime/bench`. For example the following commands:
```
sbt:runtime> withDebug benchOnly --dumpGraphs -- benchSumListFallback
sbt:std-benchmarks> withDebug benchOnly --dumpGraphs -- Vector
```

The problem was that the options created in `WithDebugCommand.scala` were not forwarded to the JVM process started in `sbt:runtime> benchOnly`.

