### PR TITLE
Derive --in-project from --run source location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1018,6 +1018,7 @@
 - [Added opt-in type checks of return type][8502]
 - [Introduce Arrow language][8512]
 - [DataflowError.withoutTrace doesn't store stacktrace][8608]
+- [Derive --in-project from --run source location][8775]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -1171,6 +1172,7 @@
 [8502]: https://github.com/enso-org/enso/pull/8502
 [8512]: https://github.com/enso-org/enso/pull/8512
 [8608]: https://github.com/enso-org/enso/pull/8608
+[8775]: https://github.com/enso-org/enso/pull/8775
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/build.sbt
+++ b/build.sbt
@@ -2076,12 +2076,14 @@ lazy val `engine-runner` = project
     commands += WithDebugCommand.withDebug,
     inConfig(Compile)(truffleRunOptionsSettings),
     libraryDependencies ++= Seq(
-      "org.graalvm.sdk"     % "polyglot-tck" % graalMavenPackagesVersion % Provided,
-      "org.graalvm.truffle" % "truffle-api"  % graalMavenPackagesVersion % Provided,
-      "commons-cli"         % "commons-cli"  % commonsCliVersion,
-      "com.monovore"       %% "decline"      % declineVersion,
-      "org.jline"           % "jline"        % jlineVersion,
-      "org.typelevel"      %% "cats-core"    % catsVersion
+      "org.graalvm.sdk"     % "polyglot-tck"    % graalMavenPackagesVersion % Provided,
+      "org.graalvm.truffle" % "truffle-api"     % graalMavenPackagesVersion % Provided,
+      "commons-cli"         % "commons-cli"     % commonsCliVersion,
+      "com.monovore"       %% "decline"         % declineVersion,
+      "org.jline"           % "jline"           % jlineVersion,
+      "org.typelevel"      %% "cats-core"       % catsVersion,
+      "junit"               % "junit"           % junitVersion              % Test,
+      "com.github.sbt"      % "junit-interface" % junitIfVersion            % Test
     ),
     run / connectInput := true
   )

--- a/engine/runner/src/main/java/org/enso/runner/Utils.java
+++ b/engine/runner/src/main/java/org/enso/runner/Utils.java
@@ -1,0 +1,69 @@
+package org.enso.runner;
+
+import java.io.File;
+import java.io.IOException;
+import scala.Tuple3;
+
+final class Utils {
+  private Utils() {}
+
+  /**
+   * Verifies path and project path.
+   *
+   * @param path file or project to execute
+   * @param projectPath project path or {@code null} if it hasn't been specified
+   * @return tuple with boolean, File to execute and path for project to use or {@code null} if
+   *     execution shall finish
+   */
+  static scala.Tuple3<Boolean, File, String> findFileAndProject(String path, String projectPath)
+      throws IOException {
+    var file = new File(path);
+    if (!file.exists()) {
+      System.err.println("File " + file + " does not exist.");
+      return null;
+    }
+    var projectMode = file.isDirectory();
+    var canonicalFile = file.getCanonicalFile();
+    String projectRoot;
+    if (projectMode) {
+      if (projectPath != null) {
+        var canonicalProjectFile = new File(projectPath).getCanonicalFile();
+        if (!canonicalProjectFile.equals(canonicalFile)) {
+          var msg =
+              "It is not possible to run a project ("
+                  + canonicalFile
+                  + ") in context of another "
+                  + "project ("
+                  + canonicalProjectFile
+                  + "), please do not use the `--in-project` option for "
+                  + "running projects.";
+          System.err.println(msg);
+          return null;
+        }
+      }
+      projectRoot = canonicalFile.getPath();
+    } else {
+      if (projectPath != null) {
+        projectRoot = projectPath;
+      } else {
+        var f = canonicalFile;
+        for (; ; ) {
+          if (f == null) {
+            projectRoot = "";
+            break;
+          } else {
+            var p = f.getParentFile();
+            if ("src".equals(f.getName())) {
+              if (p != null && new File(p, "package.yaml").isFile()) {
+                projectRoot = p.getPath();
+                break;
+              }
+            }
+            f = p;
+          }
+        }
+      }
+    }
+    return Tuple3.apply(projectMode, canonicalFile, projectRoot);
+  }
+}

--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -602,27 +602,15 @@ object Main {
     executionEnvironment: Option[String],
     warningsLimit: Int
   ): Unit = {
-    val file = new File(path)
-    if (!file.exists) {
-      println(s"File $file does not exist.")
+    val fileAndProject =
+      Utils.findFileAndProject(path, projectPath.getOrElse(null))
+    if (fileAndProject == null) {
       exitFail()
     }
-    val projectMode = file.isDirectory
-    val projectRoot =
-      if (projectMode) {
-        projectPath match {
-          case Some(inProject) if inProject != path =>
-            println(
-              "It is not possible to run a project in context of another " +
-              "project, please do not use the `--in-project` option for " +
-              "running projects."
-            )
-            exitFail()
-          case _ =>
-        }
-        file.getAbsolutePath
-      } else projectPath.getOrElse("")
-    val options = new HashMap[String, String]()
+    val projectMode = fileAndProject._1
+    val file        = fileAndProject._2
+    val projectRoot = fileAndProject._3
+    val options     = new HashMap[String, String]()
     if (dump) {
       options.put("engine.TraceCompilation", "true")
       options.put("engine.MultiTier", "false")

--- a/engine/runner/src/test/java/org/enso/runner/UtilsTest.java
+++ b/engine/runner/src/test/java/org/enso/runner/UtilsTest.java
@@ -1,0 +1,103 @@
+package org.enso.runner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class UtilsTest {
+  @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+  public UtilsTest() {}
+
+  @Test
+  public void detectParentProject() throws Exception {
+    var dir = folder.newFolder("dir", "prj", "src", "some", "file");
+    var prj = dir.getParentFile().getParentFile().getParentFile();
+    assertEquals("prj", prj.getName());
+    var yaml = new File(prj, "package.yaml");
+    Files.writeString(yaml.toPath(), "enso pkg");
+    var src = new File(dir, "Main.enso");
+    Files.writeString(src.toPath(), "main = 42");
+
+    var found = Utils.findFileAndProject(src.getPath(), null);
+    assertNotNull("Project found", found);
+    assertFalse("No project mode for a source file", found._1());
+    assertEquals("Source detected", src, found._2());
+    assertEquals("Project folder found", prj.getPath(), found._3());
+  }
+
+  @Test
+  public void specifyProjectDir() throws Exception {
+    var dir = folder.newFolder("dir", "prj", "src", "some", "file");
+    var prj = dir.getParentFile().getParentFile().getParentFile();
+    assertEquals("prj", prj.getName());
+    var yaml = new File(prj, "package.yaml");
+    Files.writeString(yaml.toPath(), "enso pkg");
+    var src = new File(dir, "Main.enso");
+    Files.writeString(src.toPath(), "main = 42");
+
+    var found = Utils.findFileAndProject(prj.getPath(), null);
+    assertNotNull("Project found", found);
+    assertTrue("prj directory means project mode", found._1());
+    assertEquals("Source is the project", prj, found._2());
+    assertEquals("Project folder found", prj.getPath(), found._3());
+  }
+
+  @Test
+  public void specifyProjectAndFile() throws Exception {
+    var dir = folder.newFolder("dir", "prj", "src", "some", "file");
+    var prj = dir.getParentFile().getParentFile().getParentFile();
+    assertEquals("prj", prj.getName());
+    var yaml = new File(prj, "package.yaml");
+    Files.writeString(yaml.toPath(), "enso pkg");
+    var src = folder.newFile("Standalone.enso");
+    Files.writeString(src.toPath(), "main = 42");
+
+    var found = Utils.findFileAndProject(src.getPath(), prj.getPath());
+    assertNotNull("Project found", found);
+    assertFalse("source and project implies non-project mode", found._1());
+    assertEquals("Source is kept", src, found._2());
+    assertEquals("Project folder is kept", prj.getPath(), found._3());
+  }
+
+  @Test
+  public void dontDetectParentProjectIfMissingPackageYaml() throws Exception {
+    var dir = folder.newFolder("dir", "prj", "src", "some", "file");
+    var prj = dir.getParentFile().getParentFile().getParentFile();
+    assertEquals("prj", prj.getName());
+    var yamlInWrongDir = new File(dir.getParent(), "package.yaml");
+    Files.writeString(yamlInWrongDir.toPath(), "enso pkg");
+    var src = new File(dir, "Main.enso");
+    Files.writeString(src.toPath(), "main = 42");
+
+    var found = Utils.findFileAndProject(src.getPath(), null);
+    assertNotNull("Project found", found);
+    assertFalse("No project mode for a source file", found._1());
+    assertEquals("Source detected", src, found._2());
+    assertEquals("No project folder found", "", found._3());
+  }
+
+  @Test
+  public void dontDetectParentProjectWithoutSrcDir() throws Exception {
+    var dir = folder.newFolder("dir", "prj", "nosrc", "some", "file");
+    var prj = dir.getParentFile().getParentFile().getParentFile();
+    assertEquals("prj", prj.getName());
+    var yaml = new File(prj, "package.yaml");
+    Files.writeString(yaml.toPath(), "enso pkg");
+    var src = new File(dir, "Main.enso");
+    Files.writeString(src.toPath(), "main = 42");
+
+    var found = Utils.findFileAndProject(src.getPath(), null);
+    assertNotNull("Project found", found);
+    assertFalse("No project mode for a source file", found._1());
+    assertEquals("Source detected", src, found._2());
+    assertEquals("No project folder detected without src dir", "", found._3());
+  }
+}


### PR DESCRIPTION
### Pull Request Description

Tired of specifying `--run` as well as `--in-project` paths? Let the launcher detect the project for you. According to the [packaging structure](https://github.com/enso-org/enso/blob/f2cb1f097e25cd7a6cfa5679eb1f75b2c4fe0beb/docs/distribution/packaging.md#enso-package-structure) there is supposed to be `package.yaml` next to `src` folder (which hosts `.enso` source files). Let's traverse parent folders of `file` specified in `--run file` argument and if one of them is named `src` check, if there is also `package.yaml` sibling. If so, use it as an `--in-project` argument.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides. 
- All code has been tested:
  - [x] Unit tests have been written where possible.
