### PR TITLE
Allow `Test` asserts to be run outside of the test suite, still raising sensible Panics

### DIFF
--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Test.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Test.enso
@@ -177,7 +177,8 @@ type Test
     ## PRIVATE
     enrich_message_with_clue : Text -> Text
     enrich_message_with_clue message =
-        case State.get Clue of
+        clue = Panic.catch Uninitialized_State (State.get Clue) _->Nothing
+        case clue of
             Clue.Value add_clue -> add_clue message
             _                   -> message
 

--- a/test/Meta_Test_Suite_Tests/data/asserts_outside_of_tests/Main.enso
+++ b/test/Meta_Test_Suite_Tests/data/asserts_outside_of_tests/Main.enso
@@ -13,5 +13,6 @@ main =
     catch_and_print <| 2.should_fail_with Illegal_Argument
     catch_and_print <| False.should_be_true
     catch_and_print <| 2.should_contain 3
+    catch_and_print <| [1, 2, 3].should_not_contain 3
     catch_and_print <| Test.expect_panic Any <| 42
     catch_and_print <| Problems.assume_no_problems (Error.throw (Illegal_Argument.Error "foo"))

--- a/test/Meta_Test_Suite_Tests/data/asserts_outside_of_tests/Main.enso
+++ b/test/Meta_Test_Suite_Tests/data/asserts_outside_of_tests/Main.enso
@@ -1,0 +1,17 @@
+from Standard.Base import all
+import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
+
+from Standard.Test import Test, Problems
+import Standard.Test.Extensions
+
+catch_and_print ~action = Panic.catch Any action caught_panic->
+    IO.println "Panic: "+caught_panic.payload.to_text
+
+main =
+    catch_and_print <| 2.should_equal 3
+    catch_and_print <| 2.should_not_equal 2
+    catch_and_print <| 2.should_fail_with Illegal_Argument
+    catch_and_print <| False.should_be_true
+    catch_and_print <| 2.should_contain 3
+    catch_and_print <| Test.expect_panic Any <| 42
+    catch_and_print <| Problems.assume_no_problems (Error.throw (Illegal_Argument.Error "foo"))

--- a/test/Meta_Test_Suite_Tests/data/asserts_outside_of_tests/stdout.txt
+++ b/test/Meta_Test_Suite_Tests/data/asserts_outside_of_tests/stdout.txt
@@ -1,0 +1,8 @@
+Panic: (Failure '2 did not equal 3 (at ???).' Nothing)
+Panic: (Failure '2 did equal 2 (at ???).' Nothing)
+Panic: (Failure 'Expected an error Illegal_Argument but no error occurred, instead got: 2 (at ???).' Nothing)
+Panic: (Failure 'Expected False to be True (at ???).' Nothing)
+Panic: (Failure 'The value (2) does not support the method `contains` (at ???).' Nothing)
+Panic: (Failure 'The value ([1, 2, 3]) contained the element (3), but it was expected to not contain it (at ???).' Nothing)
+Panic: (Failure 'Expected a Any to be thrown, but the action succeeded and returned [42] (at ???).' Nothing)
+Panic: (Failure 'Expected the result to not be an error, but a dataflow error has been matched: Illegal Argument: foo (at ???).' Nothing)

--- a/test/Meta_Test_Suite_Tests/data/asserts_outside_of_tests/test_description.txt
+++ b/test/Meta_Test_Suite_Tests/data/asserts_outside_of_tests/test_description.txt
@@ -1,0 +1,1 @@
+test assertions that are run outside of tests should still raise a panic with a meaningful message

--- a/test/Meta_Test_Suite_Tests/src/Main.enso
+++ b/test/Meta_Test_Suite_Tests/src/Main.enso
@@ -6,9 +6,20 @@ import Standard.Test.Extensions
 type Setup
     Config command args
 
-make_expected_output_regex expected_output =
-    parts = expected_output.split "???" . map Regex.escape
-    Regex.compile (parts.join ".+")
+## Checks if the output matches expected output.
+   The expected output may contain `???` that will be matched with any text.
+check_match expected_output actual_output =
+    parts = expected_output.split "???"
+    result = parts.fold 0 pointer-> part->
+        if pointer < 0 then pointer else
+            index = actual_output.index_of part start=pointer
+            if index == Nothing then
+                IO.println "Part "+part.pretty+" not found at position "+pointer.pretty
+            if index == Nothing then -1 else index + part.length
+    result == actual_output.length
+
+normalize_lines text =
+    text.lines.join '\n'
 
 spec setup =
     run_test source_path =
@@ -26,8 +37,7 @@ spec setup =
             expected_output = expected_output_path.read_text
             Test.specify description <|
                 result = run_test source_path
-                regex = make_expected_output_regex expected_output
-                if regex.matches result.stdout . not then
+                if check_match (normalize_lines expected_output) (normalize_lines result.stdout) . not then
                     message = 'The program output did not match the expected output, stored at ['+expected_output_path.to_text+'].'
                     line = '-'*20 + '\n'
                     details = 'The STDOUT was:\n' + line + result.stdout + line


### PR DESCRIPTION
### Pull Request Description

- Fixes #5962 by defaulting to no Clue if run outside of tests, ensuring that the assertions still throw a sensible panic.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
