### PR TITLE
Make Random.Seed private. Remove unused TEXT_ONLY

### DIFF
--- a/app/gui2/src/components/DocumentationPanel/DocsTags.vue
+++ b/app/gui2/src/components/DocumentationPanel/DocsTags.vue
@@ -5,7 +5,7 @@ import { computed, ref, watch } from 'vue'
 
 const props = defineProps<{ tags: Doc.Section.Tag[]; groupColor: string }>()
 
-const skipTags: Doc.Tag[] = ['Icon', 'TextOnly']
+const skipTags: Doc.Tag[] = ['Icon']
 const tags = computed<Doc.Section.Tag[]>(() => {
   return props.tags.flatMap((tag) => {
     if (tag.tag === 'Alias') {

--- a/app/gui2/src/util/docParser.ts
+++ b/app/gui2/src/util/docParser.ts
@@ -17,7 +17,6 @@ export namespace Doc {
     | 'Modified'
     | 'Private'
     | 'Removed'
-    | 'TextOnly'
     | 'Unstable'
     | 'Upcoming'
   export type Mark = 'Important' | 'Info' | 'Example'

--- a/app/gui2/stories/mockSuggestions.json
+++ b/app/gui2/stories/mockSuggestions.json
@@ -53,7 +53,7 @@
     "selfType": "Standard.Base.Data",
     "returnType": "Standard.Base.Any.Any",
     "isStatic": true,
-    "documentation": " ADDED 0.1\nADVANCED\nALIAS alias1, alias2\nDEPRECATED\nICON select_row\nGROUP Output\nMODIFIED 0.9\nREMOVED 1.2\nTEXT_ONLY\nUNSTABLE\nUPCOMING\nThis is a test entry that has every tag set, except for `PRIVATE` (as it would hide the entry from the documentation).",
+    "documentation": " ADDED 0.1\nADVANCED\nALIAS alias1, alias2\nDEPRECATED\nICON select_row\nGROUP Output\nMODIFIED 0.9\nREMOVED 1.2\nUNSTABLE\nUPCOMING\nThis is a test entry that has every tag set, except for `PRIVATE` (as it would hide the entry from the documentation).",
     "annotations": ["format"]
   },
   {

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Random.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Random.enso
@@ -45,8 +45,8 @@ type Random
     new_generator : Integer | Nothing -> Random_Generator
     new_generator seed:(Integer | Nothing)=Nothing = Random_Generator.new seed
 
-    ## GROUP Random
-       TEXT_ONLY
+    ## PRIVATE
+       GROUP Random
 
        Set the seed of the default `Random_Generator` instance.
 

--- a/docs/syntax/comments.md
+++ b/docs/syntax/comments.md
@@ -120,7 +120,6 @@ noted. The documentation syntax supports the following tags:
 - `PRIVATE`: Used to describe constructs that are private in the language.
 - `REMOVED`: Used to describe constructs that have been removed and are no
   longer functional.
-- `TEXT_ONLY`: Items that do not apply to the graphical mode.
 - `UNSTABLE`: Used for items that are not yet considered stable.
 - `UPCOMING`: Used to describe constructs that will be added in future versions
   of the library.

--- a/lib/rust/parser/doc-parser/src/lib.rs
+++ b/lib/rust/parser/doc-parser/src/lib.rs
@@ -68,7 +68,6 @@ pub enum Tag {
     Modified,
     Private,
     Removed,
-    TextOnly,
     Unstable,
     Upcoming,
 }

--- a/lib/rust/parser/doc-parser/src/lib.rs
+++ b/lib/rust/parser/doc-parser/src/lib.rs
@@ -98,7 +98,6 @@ impl Tag {
             "MODIFIED" => Some(Modified),
             "PRIVATE" => Some(Private),
             "REMOVED" => Some(Removed),
-            "TEXT_ONLY" => Some(TextOnly),
             "UNSTABLE" => Some(Unstable),
             "UPCOMING" => Some(Upcoming),
             _ => None,
@@ -117,7 +116,6 @@ impl Tag {
             Tag::Modified => "MODIFIED",
             Tag::Private => "PRIVATE",
             Tag::Removed => "REMOVED",
-            Tag::TextOnly => "TEXT_ONLY",
             Tag::Unstable => "UNSTABLE",
             Tag::Upcoming => "UPCOMING",
         }


### PR DESCRIPTION
### Pull Request Description

Random.Seed doesn't work in the GUI and the TEXT_ONLY tag doesn't do anything so it was incorrectly showing up in the component browser.

This MR makes Random.Seed private to hide it from the GUI and completely removes the TEXT_ONLY tag which is unused and unimplemented.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
