### PR TITLE
WithDebug command works for bench and for test

### DIFF
--- a/project/WithDebugCommand.scala
+++ b/project/WithDebugCommand.scala
@@ -103,15 +103,13 @@ object WithDebugCommand {
           // Append the java options also to the Benchmark configuration, in case we run `benchOnly`
           // task.
           val Benchmark = config("bench")
-          val withJavaOpts = extracted
-            .appendWithoutSession(
-              Seq(Compile / Keys.javaOptions ++= javaOpts),
-              state
-            )
-            .appendWithoutSession(
-              Seq(Benchmark / Keys.javaOptions ++= javaOpts),
-              state
-            )
+          val withJavaOpts = extracted.appendWithoutSession(
+            Seq(
+              Compile / Keys.javaOptions ++= javaOpts,
+              Benchmark / Keys.javaOptions ++= javaOpts
+            ),
+            state
+          )
           Project
             .extract(withJavaOpts)
             .runInputTask(taskKey, runArgs, withJavaOpts)


### PR DESCRIPTION
Partially revert #8769 to make sure that the `withDebug` command works for all the projects and all their configurations.

## Checklist
- [X] `sbt:runtime> withDebug --debugger testOnly -- *SignatureTest` works
- [X] `sbt:runtime> withDebug --dumpGraphs benchOnly -- benchSumListFallback` works
- [X] `sbt:runtime> withDebug --debugger benchOnly -- benchSumListFallback` works
  - Makes sense only if you set `@Fork(0)` in `AtomBenchmarks.java`.
- [X] `sbt:std-benchmarks> withDebug benchOnly --dumpGraphs -- Vector` works
- [X] `sbt:language-server> withDebug --debugger testOnly -- *FileSystemSpec` works