### PR TITLE
Binary operator must have two arguments

### DIFF
--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Syntax.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Syntax.scala
@@ -236,8 +236,8 @@ object Syntax {
     override def explanation: String = "Named argument in operator section"
   }
 
-  case object InvalidOperatorName extends Reason {
-    override def explanation: String = "Invalid operator name"
+  case object InvalidOperator extends Reason {
+    override def explanation: String = "Operator must have two arguments"
   }
 
   case class InvalidForeignDefinition(details: String) extends Reason {

--- a/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
+++ b/engine/runtime/src/test/java/org/enso/compiler/ErrorCompilerTest.java
@@ -110,6 +110,26 @@ public class ErrorCompilerTest extends CompilerTest {
   }
 
   @Test
+  public void lessThanTwoArgumentsToAnOperator() throws Exception {
+    var ir = parse("""
+    type T
+       %& self = 0
+    """);
+    assertSingleSyntaxError(
+        ir, Syntax.InvalidOperator$.MODULE$, "Operator must have two arguments", 10, 21);
+  }
+
+  @Test
+  public void moreThanTwoArgumentsToAnOperator() throws Exception {
+    var ir = parse("""
+    type X
+       &% self one two = one+two
+    """);
+    assertSingleSyntaxError(
+        ir, Syntax.InvalidOperator$.MODULE$, "Operator must have two arguments", 10, 35);
+  }
+
+  @Test
   public void badCase1() throws Exception {
     var ir = parse("""
     foo = case x of


### PR DESCRIPTION
### Pull Request Description

Raises a syntax error when an operator doesn't have exactly two arguments.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
