### PR TITLE
CI: Don't dry-run (check) benchmarks on Windows.

### DIFF
--- a/build/cli/src/lib.rs
+++ b/build/cli/src/lib.rs
@@ -453,7 +453,15 @@ impl Processor {
                         ret
                     },
                     execute_benchmarks_once: true,
-                    check_enso_benchmarks: true,
+                    // Benchmarks are only checked on Linux because:
+                    // * they are then run only on Linux;
+                    // * checking takes time;
+                    // * this rather verifies the Enso code correctness which should not be platform
+                    //   specific.
+                    // Checking benchmarks on Windows has caused some CI issues, see
+                    // https://github.com/enso-org/enso/issues/8777#issuecomment-1895749820 for the
+                    // possible explanation.
+                    check_enso_benchmarks: TARGET_OS == OS::Linux,
                     verify_packages: true,
                     ..default()
                 };


### PR DESCRIPTION
### Pull Request Description
As [discussed on Discord](https://discord.com/channels/401396655599124480/1197160815040667779) the dry-run of benchmarks shall be performed only on Linux.

This is meant to avoid CI issues that currently block #[8781](https://github.com/enso-org/enso/pull/8781).

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
