### PR TITLE
VSCode JUnit classpath fix

### DIFF
--- a/.github/workflows/enso4igv.yml
+++ b/.github/workflows/enso4igv.yml
@@ -24,10 +24,19 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: maven
 
+      - name: Find out pom & micro versions
+        working-directory: tools/enso4igv
+        run: |
+          # Why do we subtract a number? Read versioning policy!
+          # https://github.com/enso-org/enso/pull/7861#discussion_r1333133490
+          echo "POM_VERSION=`mvn -q -DforceStdout help:evaluate -Dexpression=project.version | cut -f1 -d -`" >> "$GITHUB_ENV"
+          echo "MICRO_VERSION=`expr $GITHUB_RUN_NUMBER - 2100`" >> "$GITHUB_ENV"
+
       - name: Update project version
         working-directory: tools/enso4igv
         run: |
-          mvn versions:set -DnewVersion=`mvn -q -DforceStdout help:evaluate -Dexpression=project.version | cut -f1 -d -`.`expr $GITHUB_RUN_NUMBER - 2100`
+          echo "Setting version to $POM_VERSION.$MICRO_VERSION"
+          mvn versions:set -DnewVersion="$POM_VERSION.$MICRO_VERSION"
 
       - name: Build with Maven
         run: mvn -B -Pvsix package --file tools/enso4igv/pom.xml

--- a/.github/workflows/enso4igv.yml
+++ b/.github/workflows/enso4igv.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Update project version
         working-directory: tools/enso4igv
         run: |
-          mvn versions:set -DnewVersion=`mvn -q -DforceStdout help:evaluate -Dexpression=project.version | cut -f1 -d -`.`expr $GITHUB_RUN_NUMBER - 1666`
+          mvn versions:set -DnewVersion=`mvn -q -DforceStdout help:evaluate -Dexpression=project.version | cut -f1 -d -`.`expr $GITHUB_RUN_NUMBER - 2100`
 
       - name: Build with Maven
         run: mvn -B -Pvsix package --file tools/enso4igv/pom.xml

--- a/tools/enso4igv/pom.xml
+++ b/tools/enso4igv/pom.xml
@@ -63,16 +63,15 @@
                     <dependency>
                         <groupId>org.frgaal</groupId>
                         <artifactId>compiler-maven-plugin</artifactId>
-                        <version>19.0.0</version>
+                        <version>21.0.0</version>
                     </dependency>
                 </dependencies>
                 <configuration>
                     <compilerId>frgaal</compilerId>
-                    <source>19</source>
+                    <source>21</source>
                     <target>1.8</target>
                     <compilerArgs>
                         <arg>-Xlint:deprecation</arg>
-                        <arg>--enable-preview</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/tools/enso4igv/pom.xml
+++ b/tools/enso4igv/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>enso4igv</artifactId>
     <packaging>nbm</packaging>
     <name>Enso Language Support for NetBeans &amp; Ideal Graph Visualizer</name>
-    <version>1.15-SNAPSHOT</version>
+    <version>1.21-SNAPSHOT</version>
     <build>
         <plugins>
             <plugin>

--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoSbtClassPathProvider.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoSbtClassPathProvider.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Properties;
@@ -53,12 +54,13 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
     public ClassPath findClassPath(FileObject file, String type) {
         for (var g : sources) {
             if (g instanceof EnsoSources i && i.controlsSource(file)) {
-                return switch (type) {
+                var cp = switch (type) {
                     case SOURCE -> i.srcCp;
                     case COMPILE -> i.cp;
                     case BOOT -> i.platform.getBootstrapLibraries();
                     default -> null;
                 };
+                return cp;
             }
         }
         return null;
@@ -152,15 +154,15 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
                     inputDir = inputDir.getParent();
                   }
                   srcRoots.add(inputDir);
-                }
-
-                var srcDir = prj.getProjectDirectory().getFileObject("src");
-                if (srcDir != null) {
-                    for (var group : srcDir.getChildren()) {
-                        if (group.isFolder()) {
-                            for (var child : group.getChildren()) {
-                                if (child.isFolder()) {
-                                    srcRoots.add(child);
+                } else {
+                    var srcDir = prj.getProjectDirectory().getFileObject("src");
+                    if (srcDir != null) {
+                        for (var group : srcDir.getChildren()) {
+                            if (group.isFolder()) {
+                                for (var child : group.getChildren()) {
+                                    if (child.isFolder()) {
+                                        srcRoots.add(child);
+                                    }
                                 }
                             }
                         }

--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoSbtClassPathProvider.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/EnsoSbtClassPathProvider.java
@@ -90,10 +90,10 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
         var sources = new ArrayList<SourceGroup>();
         var platform = JavaPlatform.getDefault();
         var roots = new LinkedHashSet<>();
-        var generatedSources = new LinkedHashSet<>();
-        var source = "19";
+        var generatedSources = new LinkedHashSet<FileObject>();
+        var source = "21";
         var options = new ArrayList<String>();
-        for (FileObject ch : prj.getProjectDirectory().getChildren()) {
+        for (var ch : prj.getProjectDirectory().getChildren()) {
             if (ch.getNameExt().startsWith(".enso-sources-")) {
                 Properties p = new Properties();
                 try (InputStream is = ch.getInputStream()) {
@@ -144,29 +144,38 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
                     }
                     options.add(prop);
                 }
-                var srcRoots = new LinkedHashSet<>();
+                var srcRoots = new LinkedHashSet<FileObject>();
 
                 var inputSrc = p.getProperty("input");
-                FileObject inputDir = findProjectFileObject(prj, inputSrc);
+                var inputDir = findProjectFileObject(prj, inputSrc);
                 if (inputDir != null) {
+                  var addSibblings = true;
                   if (inputDir.getNameExt().equals("org")) {
                     // lib/rust/parser doesn't follow typical project conventions
                     inputDir = inputDir.getParent();
+                    addSibblings = false;
                   }
                   srcRoots.add(inputDir);
-                } else {
-                    var srcDir = prj.getProjectDirectory().getFileObject("src");
-                    if (srcDir != null) {
-                        for (var group : srcDir.getChildren()) {
-                            if (group.isFolder()) {
-                                for (var child : group.getChildren()) {
-                                    if (child.isFolder()) {
-                                        srcRoots.add(child);
-                                    }
-                                }
-                            }
-                        }
+                  if (addSibblings) {
+                    for (var sibbling : inputDir.getParent().getChildren()) {
+                      if (sibbling.isFolder() && sibbling != inputDir) {
+                        srcRoots.add(sibbling);
+                      }
                     }
+                  }
+                } else {
+                  var srcDir = prj.getProjectDirectory().getFileObject("src");
+                  if (srcDir != null) {
+                    for (var group : srcDir.getChildren()) {
+                      if (group.isFolder()) {
+                        for (var child : group.getChildren()) {
+                          if (child.isFolder()) {
+                            srcRoots.add(child);
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
                 srcRoots.addAll(generatedSources);
 
@@ -179,6 +188,9 @@ Sources, BinaryForSourceQueryImplementation2<EnsoSbtClassPathProvider.EnsoSource
                   srcRoots.add(generatedDir);
                 }
 
+                for (var r : srcRoots) {
+                  assert r.isFolder() : "Expecting folders in " + srcRoots;
+                }
 
                 var cp = ClassPathSupport.createClassPath(roots.toArray(new FileObject[0]));
                 var srcCp = ClassPathSupport.createClassPath(srcRoots.toArray(new FileObject[0]));

--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/scala/ScalaDataObject.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/scala/ScalaDataObject.java
@@ -25,7 +25,7 @@ import org.openide.windows.TopComponent;
         displayName = "#LBL_Scala_LOADER",
         mimeType = "text/x-scala",
         extension = {"scala", "sbt"},
-        position = 330
+        position = 333
 )
 @DataObject.Registration(
         mimeType = "text/x-scala",

--- a/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/EnsoSbtProjectTest.java
+++ b/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/EnsoSbtProjectTest.java
@@ -3,6 +3,7 @@ package org.enso.tools.enso4igv;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.Sources;
 import org.netbeans.junit.NbTestCase;
@@ -36,6 +37,23 @@ public class EnsoSbtProjectTest extends NbTestCase {
 
     var javaGroups = s.getSourceGroups("java");
     assertEquals("1 bench, 2 tests, 4 main: " + Arrays.toString(javaGroups), 7, javaGroups.length);
+
+    var javaFile = root.getFileObject("src/main/java/MainJava.java");
+    assertNotNull("Main java found", javaFile);
+    var javaCp = ClassPath.getClassPath(javaFile, ClassPath.SOURCE);
+    assertNotNull("java classpath found", javaCp);
+
+    assertNotNull("Main java is on source path", javaCp.findResource("MainJava.java"));
+    assertNotNull("Main scala is on source path", javaCp.findResource("MainScala.scala"));
+    assertNull("Test scala is not on source path", javaCp.findResource("TestScala.scala"));
+
+    var scalaTestFile = root.getFileObject("src/test/scala/TestScala.scala");
+    assertNotNull("Test scala found", scalaTestFile);
+    for (var g : javaGroups) {
+      if (g.contains(scalaTestFile)) {
+        assertEquals("test/scala", g.getName());
+      }
+    }
   }
 
   private static FileObject setLanguageServerProjectUp() throws IOException {
@@ -46,11 +64,14 @@ public class EnsoSbtProjectTest extends NbTestCase {
     var srcBenchScala = srcBench.createFolder("scala");
     var srcTest = src.createFolder("test");
     var srcTestScala = srcTest.createFolder("scala");
+    var srcTestScalaFile = srcTestScala.createData("TestScala.scala");
     var srcTestResources = srcTest.createFolder("resources");
     var srcMain = src.createFolder("main");
     var srcMainJava = srcMain.createFolder("java");
+    var srcMainJavaFile = srcMainJava.createData("MainJava.java");
     var srcMainResources = srcMain.createFolder("resources");
     var srcMainScala = srcMain.createFolder("scala");
+    var srcMainScalaFile = srcMainScala.createData("MainScala.scala");
     var srcMainSchema = srcMain.createFolder("schema");
     var ensoSources = root.createData(".enso-sources");
     try (var os = root.createAndOpen(".enso-sources-classes")) {


### PR DESCRIPTION
### Pull Request Description

Recently a classpath misconfiguration appeared in `engine/runtime` project:

![org.junit not found](https://github.com/enso-org/enso/assets/26887752/215a074b-1fad-4d4d-a5a8-a573b0d53e76)

The problem was caused by the `XyzTest.java` files being incorrectly assigned to `engine/runtime/src/main/java` source root and its classpath (which obviously doesn't contain JUnit). This PR restricts the `srcCp` to `inputDir`, when it is known. That properly assignes the `XyzTest.java` files to `engine/runtime/src/test/java` source root. The IGV as well as VSCode support seems to recognize unit test classpath properly now.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] @ola-lis releases the [enso4vscode-1.21.75.vsix](https://github.com/enso-org/enso/actions/runs/7567000717?pr=8795) on [VSCode marketplace](https://marketplace.visualstudio.com/items?itemName=Enso.enso4vscode)
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides.
- All code has been tested:
  - [x] [enso4vscode-1.21.75.vsix](https://github.com/enso-org/enso/actions/runs/7567000717?pr=8795) was manually tested
  - [x] Unit tests were enhanced in ec3fea9
