### PR TITLE
Dump more details when two objects at the same locations are read

### DIFF
--- a/lib/java/persistance/src/main/java/org/enso/persist/PerGenerator.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerGenerator.java
@@ -13,8 +13,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 final class PerGenerator {
-  private static final Logger LOG = Logger.getLogger(Persistance.class.getPackageName());
-
   static final byte[] HEADER = new byte[] {0x0a, 0x0d, 0x03, 0x0f};
   private final OutputStream main;
   private final Map<Object, Integer> knownObjects = new IdentityHashMap<>();
@@ -33,7 +31,7 @@ final class PerGenerator {
   }
 
   static byte[] writeObject(Object obj, Function<Object, Object> writeReplace) throws IOException {
-    var histogram = LOG.isLoggable(Level.FINE) ? new Histogram() : null;
+    var histogram = PerUtils.LOG.isLoggable(Level.FINE) ? new Histogram() : null;
 
     var out = new ByteArrayOutputStream();
     var data = new DataOutputStream(out);
@@ -50,7 +48,7 @@ final class PerGenerator {
     arr[11] = (byte) (at & 0xff);
 
     if (histogram != null) {
-      histogram.dump(LOG, arr.length);
+      histogram.dump(PerUtils.LOG, arr.length);
     }
     return arr;
   }

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerUtils.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerUtils.java
@@ -1,7 +1,11 @@
 package org.enso.persist;
 
+import java.util.logging.Logger;
+
 final class PerUtils {
   private PerUtils() {}
+
+  static final Logger LOG = Logger.getLogger(Persistance.class.getPackageName());
 
   @SuppressWarnings("unchecked")
   static <E extends Throwable> E raise(Class<E> clazz, Throwable t) throws E {


### PR DESCRIPTION
### Pull Request Description

Closes #8792 by dumping more information about the incident and in the (likely) case both objects are equal, just logging the exception without terminating the execution.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:
- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides. 
- All code has been tested:
  - [x] Existing unit tests continue to pass
