### PR TITLE
Connection and visualization fixes

### DIFF
--- a/app/gui2/src/components/GraphEditor/GraphEdges.vue
+++ b/app/gui2/src/components/GraphEditor/GraphEdges.vue
@@ -20,19 +20,24 @@ const emits = defineEmits<{
 
 const editingEdge: Interaction = {
   cancel() {
-    const target = graph.unconnectedEdge?.disconnectedEdgeTarget
-    graph.transact(() => {
-      if (target != null) disconnectEdge(target)
-      graph.clearUnconnected()
-    })
+    graph.clearUnconnected()
   },
   click(_e: MouseEvent, graphNavigator: GraphNavigator): boolean {
     if (graph.unconnectedEdge == null) return false
-    const source = graph.unconnectedEdge.source ?? selection?.hoveredNode
+    let source: ExprId | undefined
+    let sourceNode: ExprId | undefined
+    if (graph.unconnectedEdge.source) {
+      source = graph.unconnectedEdge.source
+      sourceNode = graph.db.getPatternExpressionNodeId(source)
+    } else if (selection?.hoveredNode) {
+      sourceNode = selection.hoveredNode
+      source = graph.db.getNodeFirstOutputPort(sourceNode)
+    }
     const target = graph.unconnectedEdge.target ?? selection?.hoveredPort
     const targetNode = target && graph.getPortNodeId(target)
+    console.log(source, target, targetNode)
     graph.transact(() => {
-      if (source != null && source != targetNode) {
+      if (source != null && sourceNode != targetNode) {
         if (target == null) {
           if (graph.unconnectedEdge?.disconnectedEdgeTarget != null)
             disconnectEdge(graph.unconnectedEdge.disconnectedEdgeTarget)
@@ -40,6 +45,8 @@ const editingEdge: Interaction = {
         } else {
           createEdge(source, target)
         }
+      } else if (source == null && target != null) {
+        disconnectEdge(target)
       }
       graph.clearUnconnected()
     })

--- a/app/gui2/src/components/GraphEditor/GraphNodes.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNodes.vue
@@ -29,7 +29,6 @@ function nodeIsDragged(movedId: ExprId, offset: Vec2) {
 }
 
 function hoverNode(id: ExprId | undefined) {
-  console.log('hoverNode', id, selection != null)
   if (selection != null) selection.hoveredNode = id
 }
 

--- a/app/gui2/src/components/GraphEditor/GraphNodes.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNodes.vue
@@ -29,6 +29,7 @@ function nodeIsDragged(movedId: ExprId, offset: Vec2) {
 }
 
 function hoverNode(id: ExprId | undefined) {
+  console.log('hoverNode', id, selection != null)
   if (selection != null) selection.hoveredNode = id
 }
 

--- a/app/gui2/src/components/VisualizationContainer.vue
+++ b/app/gui2/src/components/VisualizationContainer.vue
@@ -200,6 +200,7 @@ const resizeBottomRight = usePointer((pos, _, type) => {
   min-width: 100%;
   width: min-content;
   border-radius: var(--radius-default);
+  cursor: default;
 }
 
 .VisualizationContainer.below-node {


### PR DESCRIPTION
### Pull Request Description

Fixes several points from #8745 
* Brought back cursor pointer in full screen visualization
* Changed behavior of edge disconnected from one side: Esc will bring the connection back, while click will remove it (and start creating new node if the source was connected).
* When hovering connection, the "active" part (i.e. the part which will be the hanging connection after click) is in normal color, and the rest is dimmed.

[Screencast from 2024-01-19 09-06-48.webm](https://github.com/enso-org/enso/assets/3919101/6df28a9c-51b3-4f98-be10-a35275eac800)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
