### PR TITLE
Add persistance to Operator.Binary

### DIFF
--- a/docs/runtime/ir-caching.md
+++ b/docs/runtime/ir-caching.md
@@ -167,6 +167,10 @@ recommended when making a change:
 That way the same version of Enso will recognize its `.ir` files. Different
 versions of Enso will realize that the files aren't in suitable form.
 
+Every `Persistance` class has a unique identifier. In order to keep definitions
+consistent one should not attempt to use smaller `id`s than previously assigned.
+One should also not delete any `Persistance` classes.
+
 ## Loading the IR
 
 Loading the IR is a multi-stage process that involves performing integrity

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/IrPersistance.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/IrPersistance.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.enso.compiler.core.ir.expression.Application;
 import org.enso.compiler.core.ir.expression.Case;
 import org.enso.compiler.core.ir.expression.Foreign;
+import org.enso.compiler.core.ir.expression.Operator;
 import org.enso.compiler.core.ir.expression.warnings.Unused;
 import org.enso.compiler.core.ir.module.scope.Definition;
 import org.enso.compiler.core.ir.module.scope.Export;
@@ -65,6 +66,7 @@ import scala.collection.immutable.Seq;
 @Persistable(clazz = Unused.FunctionArgument.class, id = 787)
 @Persistable(clazz = Warning.DuplicatedImport.class, id = 788)
 @Persistable(clazz = Warning.WrongBuiltinMethod.class, id = 789)
+@Persistable(clazz = Operator.Binary.class, id = 790)
 public final class IrPersistance {
   private IrPersistance() {}
 


### PR DESCRIPTION
Follow up on #8789.
Trying to avoid a spurious error
```
[ERROR] [2024-01-22T16:05:26+01:00] [enso.org.enso.interpreter.caches.ModuleCache] Failed to save cache for Standard.Base.Data.Base_64.
java.io.IOException: No persistance for org.enso.compiler.core.ir.expression.Operator$Binary
	at org.enso.runtime/org.enso.persist.PerMap.searchSupertype(PerMap.java:74)
	at org.enso.runtime/org.enso.persist.PerMap.searchSupertype(PerMap.java:67)
	at org.enso.runtime/org.enso.persist.PerMap.searchSupertype(PerMap.java:67)
	at org.enso.runtime/org.enso.persist.PerMap.forType(PerMap.java:84)
	at org.enso.runtime/org.enso.persist.PerGenerator.writeIndirect(PerGenerator.java:81)
	at org.enso.runtime/org.enso.persist.PerGenerator$ReferenceOutput.writeObject(PerGenerator.java:128)
	at org.enso.runtime/org.enso.compiler.pass.analyse.PersistTypeSignatures_Signature.writeObject(PersistTypeSignatures_Signature.java:21)
	at org.enso.runtime/org.enso.compiler.pass.analyse.PersistTypeSignatures_Signature.writeObject(PersistTypeSignatures_Signature.java:4)
	at org.enso.runtime/org.enso.persist.Persistance.writeInline(Persistance.java:147)
```
