### PR TITLE
Mark a JDBC test as pending if cloud not set up

### DIFF
--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -592,7 +592,7 @@ table_spec =
             Upload_Spec.spec connection_builder "[PostgreSQL] "
 
             cloud_setup = Cloud_Tests_Setup.prepare
-            cloud_setup.with_prepared_environment <| Test.group "[PostgreSQL] Secrets in connection settings" <|
+            cloud_setup.with_prepared_environment <| Test.group "[PostgreSQL] Secrets in connection settings" pending=cloud_setup.pending <|
                 Test.specify "should allow to set up a connection with the password passed as a secret" <|
                     with_secret "my_postgres_username" db_user username_secret-> with_secret "my_postgres_password" db_password password_secret->
                         my_secret_name = "Enso Test: My Secret App NAME " + (Random.uuid.take 5)


### PR DESCRIPTION
### Pull Request Description

Marking the test pending=cloud_setup.pending.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
