### PR TITLE
Refactor for YJs AST

### DIFF
--- a/app/gui2/mock/index.ts
+++ b/app/gui2/mock/index.ts
@@ -5,9 +5,7 @@ import { GraphDb, mockNode } from '@/stores/graph/graphDatabase'
 import { useProjectStore } from '@/stores/project'
 import { ComputedValueRegistry } from '@/stores/project/computedValueRegistry'
 import { MockTransport, MockWebSocket } from '@/util/net'
-import * as random from 'lib0/random'
 import { getActivePinia } from 'pinia'
-import type { ExprId } from 'shared/yjsModel'
 import { ref, type App } from 'vue'
 import { mockDataHandler, mockLSHandler } from './engine'
 export * as providers from './providers'
@@ -74,10 +72,6 @@ export function projectStore() {
 /** The stores should be initialized in this order, as `graphStore` depends on `projectStore`. */
 export function projectStoreAndGraphStore() {
   return [projectStore(), graphStore()] satisfies [] | unknown[]
-}
-
-export function newExprId() {
-  return random.uuidv4() as ExprId
 }
 
 /** This should only be used for supplying as initial props when testing.

--- a/app/gui2/shared/languageServerTypes.ts
+++ b/app/gui2/shared/languageServerTypes.ts
@@ -2,7 +2,7 @@ import type {
   SuggestionsDatabaseEntry,
   SuggestionsDatabaseUpdate,
 } from './languageServerTypes/suggestions'
-import type { ExprId, Uuid } from './yjsModel'
+import type { ExternalId, Uuid } from './yjsModel'
 
 export type { Uuid }
 
@@ -11,7 +11,7 @@ declare const brandChecksum: unique symbol
 export type Checksum = string & { [brandChecksum]: never }
 declare const brandContextId: unique symbol
 export type ContextId = Uuid & { [brandContextId]: never }
-export type ExpressionId = ExprId
+export type ExpressionId = ExternalId
 declare const brandUtcDateTime: unique symbol
 export type UTCDateTime = string & { [brandUtcDateTime]: never }
 

--- a/app/gui2/shared/yjsModel.ts
+++ b/app/gui2/shared/yjsModel.ts
@@ -170,6 +170,15 @@ export class DistributedModule {
 }
 
 export type SourceRange = readonly [start: number, end: number]
+declare const brandSourceRangeKey: unique symbol
+export type SourceRangeKey = string & { [brandSourceRangeKey]: never }
+
+export function sourceRangeKey(range: SourceRange): SourceRangeKey {
+  return `${range[0].toString(16)}:${range[1].toString(16)}` as SourceRangeKey
+}
+export function sourceRangeFromKey(key: SourceRangeKey): SourceRange {
+  return key.split(':').map((x) => parseInt(x, 16)) as [number, number]
+}
 
 export class IdMap {
   private readonly rangeToExpr: Map<string, ExternalId>
@@ -182,26 +191,18 @@ export class IdMap {
     return new IdMap([])
   }
 
-  public static keyForRange(range: SourceRange): string {
-    return `${range[0].toString(16)}:${range[1].toString(16)}`
-  }
-
-  public static rangeForKey(key: string): SourceRange {
-    return key.split(':').map((x) => parseInt(x, 16)) as [number, number]
-  }
-
   insertKnownId(range: SourceRange, id: ExternalId) {
-    const key = IdMap.keyForRange(range)
+    const key = sourceRangeKey(range)
     this.rangeToExpr.set(key, id)
   }
 
   getIfExist(range: SourceRange): ExternalId | undefined {
-    const key = IdMap.keyForRange(range)
+    const key = sourceRangeKey(range)
     return this.rangeToExpr.get(key)
   }
 
   getOrInsertUniqueId(range: SourceRange): ExternalId {
-    const key = IdMap.keyForRange(range)
+    const key = sourceRangeKey(range)
     const val = this.rangeToExpr.get(key)
     if (val !== undefined) {
       return val

--- a/app/gui2/shared/yjsModel.ts
+++ b/app/gui2/shared/yjsModel.ts
@@ -3,8 +3,10 @@ import * as random from 'lib0/random'
 import * as Y from 'yjs'
 
 export type Uuid = `${string}-${string}-${string}-${string}-${string}`
-declare const brandExprId: unique symbol
-export type ExprId = Uuid & { [brandExprId]: never }
+
+declare const brandExternalId: unique symbol
+/** Identifies an AST node or token. Used in module serialization and communication with the language server. */
+export type ExternalId = Uuid & { [brandExternalId]: never }
 
 export type VisualizationModule =
   | { kind: 'Builtin' }
@@ -149,12 +151,12 @@ export class DistributedModule {
     return this.doc.ydoc.transact(fn, 'local')
   }
 
-  updateNodeMetadata(id: ExprId, meta: Partial<NodeMetadata>): void {
+  updateNodeMetadata(id: ExternalId, meta: Partial<NodeMetadata>): void {
     const existing = this.doc.metadata.get(id) ?? { x: 0, y: 0, vis: null }
     this.transact(() => this.doc.metadata.set(id, { ...existing, ...meta }))
   }
 
-  getNodeMetadata(id: ExprId): NodeMetadata | null {
+  getNodeMetadata(id: ExternalId): NodeMetadata | null {
     return this.doc.metadata.get(id) ?? null
   }
 
@@ -170,9 +172,9 @@ export class DistributedModule {
 export type SourceRange = readonly [start: number, end: number]
 
 export class IdMap {
-  private readonly rangeToExpr: Map<string, ExprId>
+  private readonly rangeToExpr: Map<string, ExternalId>
 
-  constructor(entries?: [string, ExprId][]) {
+  constructor(entries?: [string, ExternalId][]) {
     this.rangeToExpr = new Map(entries ?? [])
   }
 
@@ -188,29 +190,29 @@ export class IdMap {
     return key.split(':').map((x) => parseInt(x, 16)) as [number, number]
   }
 
-  insertKnownId(range: SourceRange, id: ExprId) {
+  insertKnownId(range: SourceRange, id: ExternalId) {
     const key = IdMap.keyForRange(range)
     this.rangeToExpr.set(key, id)
   }
 
-  getIfExist(range: SourceRange): ExprId | undefined {
+  getIfExist(range: SourceRange): ExternalId | undefined {
     const key = IdMap.keyForRange(range)
     return this.rangeToExpr.get(key)
   }
 
-  getOrInsertUniqueId(range: SourceRange): ExprId {
+  getOrInsertUniqueId(range: SourceRange): ExternalId {
     const key = IdMap.keyForRange(range)
     const val = this.rangeToExpr.get(key)
     if (val !== undefined) {
       return val
     } else {
-      const newId = random.uuidv4() as ExprId
+      const newId = random.uuidv4() as ExternalId
       this.rangeToExpr.set(key, newId)
       return newId
     }
   }
 
-  entries(): [string, ExprId][] {
+  entries(): [string, ExternalId][] {
     return [...this.rangeToExpr]
   }
 

--- a/app/gui2/shared/yjsModel.ts
+++ b/app/gui2/shared/yjsModel.ts
@@ -213,8 +213,8 @@ export class IdMap {
     }
   }
 
-  entries(): [string, ExternalId][] {
-    return [...this.rangeToExpr]
+  entries(): [SourceRangeKey, ExternalId][] {
+    return [...this.rangeToExpr] as [SourceRangeKey, ExternalId][]
   }
 
   get size(): number {

--- a/app/gui2/src/components/CodeEditor.vue
+++ b/app/gui2/src/components/CodeEditor.vue
@@ -53,7 +53,7 @@ const expressionUpdatesDiagnostics = computed(() => {
   for (const id of chain(panics, errors)) {
     const update = updates.get(id)
     if (!update) continue
-    const node = nodeMap.get(asNodeId(graphStore.idFromExternal(id)))
+    const node = nodeMap.get(asNodeId(graphStore.db.idFromExternal(id)))
     if (!node) continue
     if (!node.rootSpan.span) continue
     const [from, to] = node.rootSpan.span

--- a/app/gui2/src/components/CodeEditor.vue
+++ b/app/gui2/src/components/CodeEditor.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import type { Diagnostic, Highlighter } from '@/components/CodeEditor/codemirror'
 import { usePointer } from '@/composables/events'
-import { useGraphStore } from '@/stores/graph'
+import { useGraphStore, type NodeId } from '@/stores/graph'
+import { asNodeId } from '@/stores/graph/graphDatabase'
 import { useProjectStore } from '@/stores/project'
 import { useSuggestionDbStore } from '@/stores/suggestionDatabase'
 import { useAutoBlur } from '@/util/autoBlur'
@@ -9,7 +10,7 @@ import { chain } from '@/util/data/iterable'
 import { unwrap } from '@/util/data/result'
 import { qnJoin, tryQualifiedName } from '@/util/qualifiedName'
 import { useLocalStorage } from '@vueuse/core'
-import { rangeEncloses, type ExprId } from 'shared/yjsModel'
+import { rangeEncloses } from 'shared/yjsModel'
 import { computed, onMounted, ref, watch, watchEffect } from 'vue'
 
 // Use dynamic imports to aid code splitting. The codemirror dependency is quite large.
@@ -52,7 +53,7 @@ const expressionUpdatesDiagnostics = computed(() => {
   for (const id of chain(panics, errors)) {
     const update = updates.get(id)
     if (!update) continue
-    const node = nodeMap.get(id)
+    const node = nodeMap.get(asNodeId(graphStore.idFromExternal(id)))
     if (!node) continue
     if (!node.rootSpan.span) continue
     const [from, to] = node.rootSpan.span
@@ -100,7 +101,7 @@ watchEffect(() => {
         hoverTooltip((ast, syn) => {
           const dom = document.createElement('div')
           const astSpan = ast.span()
-          let foundNode: ExprId | undefined
+          let foundNode: NodeId | undefined
           for (const [id, node] of graphStore.db.nodeIdToNode.entries()) {
             if (node.rootSpan.span && rangeEncloses(node.rootSpan.span, astSpan)) {
               foundNode = id

--- a/app/gui2/src/components/ComponentBrowser.vue
+++ b/app/gui2/src/components/ComponentBrowser.vue
@@ -177,7 +177,7 @@ const previewDataSource: ComputedRef<VisualizationDataSource | undefined> = comp
   return {
     type: 'expression',
     expression: previewedExpression.value,
-    contextId: body.exprId,
+    contextId: body.id,
   }
 })
 

--- a/app/gui2/src/components/ComponentBrowser.vue
+++ b/app/gui2/src/components/ComponentBrowser.vue
@@ -177,7 +177,7 @@ const previewDataSource: ComputedRef<VisualizationDataSource | undefined> = comp
   return {
     type: 'expression',
     expression: previewedExpression.value,
-    contextId: body.id,
+    contextId: body.externalId,
   }
 })
 

--- a/app/gui2/src/components/ComponentBrowser/__tests__/input.test.ts
+++ b/app/gui2/src/components/ComponentBrowser/__tests__/input.test.ts
@@ -14,9 +14,10 @@ import {
   makeType,
   type SuggestionEntry,
 } from '@/stores/suggestionDatabase/entry'
+import type { AstId } from '@/util/ast/abstract'
 import { unwrap } from '@/util/data/result'
 import { tryIdentifier, tryQualifiedName } from '@/util/qualifiedName'
-import type { ExprId } from 'shared/yjsModel'
+import type { ExternalId, Uuid } from 'shared/yjsModel'
 import { expect, test } from 'vitest'
 
 test.each([
@@ -97,10 +98,11 @@ test.each([
       selfArg?: { type: string; typename?: string }
     },
   ) => {
-    const operator1Id: ExprId = '3d0e9b96-3ca0-4c35-a820-7d3a1649de55' as ExprId
-    const operator2Id: ExprId = '5eb16101-dd2b-4034-a6e2-476e8bfa1f2b' as ExprId
+    const operator1Id = '3d0e9b96-3ca0-4c35-a820-7d3a1649de55' as AstId
+    const operator1ExternalId = operator1Id as Uuid as ExternalId
+    const operator2Id = '5eb16101-dd2b-4034-a6e2-476e8bfa1f2b' as AstId
     const computedValueRegistryMock = ComputedValueRegistry.Mock()
-    computedValueRegistryMock.db.set(operator1Id, {
+    computedValueRegistryMock.db.set(operator1ExternalId, {
       typename: 'Standard.Base.Number',
       methodCall: undefined,
       payload: { type: 'Value' },

--- a/app/gui2/src/components/ComponentBrowser/input.ts
+++ b/app/gui2/src/components/ComponentBrowser/input.ts
@@ -1,5 +1,5 @@
 import type { Filter } from '@/components/ComponentBrowser/filtering'
-import { useGraphStore } from '@/stores/graph'
+import { useGraphStore, type NodeId } from '@/stores/graph'
 import type { GraphDb } from '@/stores/graph/graphDatabase'
 import { requiredImportEquals, requiredImports, type RequiredImport } from '@/stores/graph/imports'
 import { useSuggestionDbStore, type SuggestionDb } from '@/stores/suggestionDatabase'
@@ -10,6 +10,7 @@ import {
   type Typename,
 } from '@/stores/suggestionDatabase/entry'
 import { RawAst, RawAstExtended, astContainingChar } from '@/util/ast'
+import type { AstId } from '@/util/ast/abstract.ts'
 import { AliasAnalyzer } from '@/util/ast/aliasAnalysis'
 import { GeneralOprApp, type OperatorChain } from '@/util/ast/opr'
 import { MappedSet } from '@/util/containers'
@@ -21,13 +22,13 @@ import {
   type QualifiedName,
 } from '@/util/qualifiedName'
 import { equalFlat } from 'lib0/array'
-import { IdMap, type ExprId, type SourceRange } from 'shared/yjsModel'
+import { IdMap, type SourceRange } from 'shared/yjsModel'
 import { computed, ref, type ComputedRef } from 'vue'
 
 /** Information how the component browser is used, needed for proper input initializing. */
 export type Usage =
-  | { type: 'newNode'; sourcePort?: ExprId | undefined }
-  | { type: 'editNode'; node: ExprId; cursorPos: number }
+  | { type: 'newNode'; sourcePort?: AstId | undefined }
+  | { type: 'editNode'; node: NodeId; cursorPos: number }
 
 /** Input's editing context.
  *

--- a/app/gui2/src/components/ComponentBrowser/input.ts
+++ b/app/gui2/src/components/ComponentBrowser/input.ts
@@ -22,7 +22,7 @@ import {
   type QualifiedName,
 } from '@/util/qualifiedName'
 import { equalFlat } from 'lib0/array'
-import { IdMap, type SourceRange } from 'shared/yjsModel'
+import { sourceRangeKey, type SourceRange } from 'shared/yjsModel'
 import { computed, ref, type ComputedRef } from 'vue'
 
 /** Information how the component browser is used, needed for proper input initializing. */
@@ -117,7 +117,7 @@ export function useComponentBrowserInput(
         yield* usages
       }
     }
-    return new MappedSet(IdMap.keyForRange, internalUsages())
+    return new MappedSet(sourceRangeKey, internalUsages())
   })
 
   // Filter deduced from the access (`.` operator) chain written by user.

--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -23,17 +23,18 @@ import { provideGraphNavigator } from '@/providers/graphNavigator'
 import { provideGraphSelection } from '@/providers/graphSelection'
 import { provideInteractionHandler, type Interaction } from '@/providers/interactionHandler'
 import { provideWidgetRegistry } from '@/providers/widgetRegistry'
-import { useGraphStore } from '@/stores/graph'
+import { useGraphStore, type NodeId } from '@/stores/graph'
 import type { RequiredImport } from '@/stores/graph/imports'
 import { useProjectStore } from '@/stores/project'
 import { groupColorVar, useSuggestionDbStore } from '@/stores/suggestionDatabase'
 import { bail } from '@/util/assert'
+import type { AstId } from '@/util/ast/abstract.ts'
 import { colorFromString } from '@/util/colors'
 import { Rect } from '@/util/data/rect'
 import { Vec2 } from '@/util/data/vec2'
 import * as set from 'lib0/set'
 import { toast } from 'react-toastify'
-import type { ExprId, NodeMetadata } from 'shared/yjsModel'
+import type { NodeMetadata } from 'shared/yjsModel'
 import { computed, onMounted, onScopeDispose, onUnmounted, ref, watch } from 'vue'
 import { ProjectManagerEvents } from '../../../ide-desktop/lib/dashboard/src/utilities/projectManager'
 import { type Usage } from './ComponentBrowser/input'
@@ -117,7 +118,7 @@ const interactionBindingsHandler = interactionBindings.handler({
 // Return the environment for the placement of a new node. The passed nodes should be the nodes that are
 // used as the source of the placement. This means, for example, the selected nodes when creating from a selection
 // or the node that is being edited when creating from a port double click.
-function environmentForNodes(nodeIds: IterableIterator<ExprId>): Environment {
+function environmentForNodes(nodeIds: IterableIterator<NodeId>): Environment {
   const nodeRects = [...graphStore.nodeRects.values()]
   const selectedNodeRects = [...nodeIds]
     .map((id) => graphStore.nodeRects.get(id))
@@ -577,7 +578,7 @@ async function readNodeFromExcelClipboard(
   return undefined
 }
 
-function handleNodeOutputPortDoubleClick(id: ExprId) {
+function handleNodeOutputPortDoubleClick(id: AstId) {
   componentBrowserUsage.value = { type: 'newNode', sourcePort: id }
   const srcNode = graphStore.db.getPatternExpressionNodeId(id)
   if (srcNode == null) {
@@ -598,7 +599,7 @@ function handleNodeOutputPortDoubleClick(id: ExprId) {
 
 const stackNavigator = useStackNavigator()
 
-function handleEdgeDrop(source: ExprId, position: Vec2) {
+function handleEdgeDrop(source: AstId, position: Vec2) {
   componentBrowserUsage.value = { type: 'newNode', sourcePort: source }
   componentBrowserNodePosition.value = position
   interaction.setCurrent(creatingNodeFromEdgeDrop)

--- a/app/gui2/src/components/GraphEditor/GraphEdges.vue
+++ b/app/gui2/src/components/GraphEditor/GraphEdges.vue
@@ -6,16 +6,17 @@ import { injectInteractionHandler, type Interaction } from '@/providers/interact
 import type { PortId } from '@/providers/portInfo'
 import { useGraphStore } from '@/stores/graph'
 import { Ast } from '@/util/ast'
+import type { AstId } from '@/util/ast/abstract.ts'
 import { Vec2 } from '@/util/data/vec2'
 import { toast } from 'react-toastify'
-import { isUuid, type ExprId } from 'shared/yjsModel.ts'
+import { isUuid } from 'shared/yjsModel.ts'
 
 const graph = useGraphStore()
 const selection = injectGraphSelection(true)
 const interaction = injectInteractionHandler()
 
 const emits = defineEmits<{
-  createNodeFromEdge: [source: ExprId, position: Vec2]
+  createNodeFromEdge: [source: AstId, position: Vec2]
 }>()
 
 const editingEdge: Interaction = {
@@ -55,7 +56,7 @@ function disconnectEdge(target: PortId) {
       const targetStr: string = target
       if (isUuid(targetStr)) {
         console.warn(`Failed to disconnect edge from port ${target}, falling back to direct edit.`)
-        edit.replaceRef(Ast.asNodeId(targetStr as ExprId), Ast.Wildcard.new())
+        edit.replaceRef(targetStr as AstId, Ast.Wildcard.new())
       } else {
         console.error(`Failed to disconnect edge from port ${target}, no fallback possible.`)
       }
@@ -63,7 +64,7 @@ function disconnectEdge(target: PortId) {
   })
 }
 
-function createEdge(source: ExprId, target: PortId) {
+function createEdge(source: AstId, target: PortId) {
   const ident = graph.db.getOutputPortIdentifier(source)
   if (ident == null) return
   const identAst = Ast.parse(ident)
@@ -84,7 +85,7 @@ function createEdge(source: ExprId, target: PortId) {
     if (!graph.updatePortValue(edit, target, identAst)) {
       if (isUuid(target)) {
         console.warn(`Failed to connect edge to port ${target}, falling back to direct edit.`)
-        edit.replaceValue(Ast.asNodeId(target), identAst)
+        edit.replaceValue(Ast.asAstId(target), identAst)
         graph.commitEdit(edit)
       } else {
         console.error(`Failed to connect edge to port ${target}, no fallback possible.`)

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -74,6 +74,7 @@ const outputPortsSet = computed(() => {
 
 const widthOverridePx = ref<number>()
 const nodeId = computed(() => asNodeId(props.node.rootSpan.id))
+const externalId = computed(() => props.node.rootSpan.externalId)
 
 onUnmounted(() => graph.unregisterNodeRect(nodeId.value))
 
@@ -204,7 +205,7 @@ const isOutputContextOverridden = computed({
 
 // FIXME [sb]: https://github.com/enso-org/enso/issues/8442
 // This does not take into account `displayedExpression`.
-const expressionInfo = computed(() => graph.db.getExpressionInfo(nodeId.value))
+const expressionInfo = computed(() => graph.db.getExpressionInfo(externalId.value))
 const outputPortLabel = computed(() => expressionInfo.value?.typename ?? 'Unknown')
 const executionState = computed(() => expressionInfo.value?.payload.type ?? 'Unknown')
 const suggestionEntry = computed(() => graph.db.nodeMainSuggestion.lookup(nodeId.value))
@@ -369,7 +370,7 @@ function portGroupStyle(port: PortData) {
       :nodePosition="props.node.position"
       :isCircularMenuVisible="menuVisible"
       :currentType="node.vis?.identifier"
-      :dataSource="{ type: 'node', nodeId }"
+      :dataSource="{ type: 'node', nodeId: externalId }"
       :typename="expressionInfo?.typename"
       @update:rect="
         emit('update:visualizationRect', $event),

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -11,15 +11,17 @@ import { usePointer, useResizeObserver } from '@/composables/events'
 import { injectGraphNavigator } from '@/providers/graphNavigator'
 import { injectGraphSelection } from '@/providers/graphSelection'
 import { useGraphStore, type Node } from '@/stores/graph'
+import { asNodeId } from '@/stores/graph/graphDatabase'
 import { useProjectStore } from '@/stores/project'
 import { Ast } from '@/util/ast'
+import type { AstId } from '@/util/ast/abstract'
 import { Prefixes } from '@/util/ast/prefixes'
 import type { Opt } from '@/util/data/opt'
 import { Rect } from '@/util/data/rect'
 import { Vec2 } from '@/util/data/vec2'
 import { displayedIconOf } from '@/util/getIconName'
 import { setIfUndefined } from 'lib0/map'
-import type { ExprId, VisualizationIdentifier } from 'shared/yjsModel'
+import type { VisualizationIdentifier } from 'shared/yjsModel'
 import { computed, onUnmounted, ref, watch, watchEffect } from 'vue'
 
 const MAXIMUM_CLICK_LENGTH_MS = 300
@@ -49,8 +51,8 @@ const emit = defineEmits<{
   draggingCommited: []
   delete: []
   replaceSelection: []
-  outputPortClick: [portId: ExprId]
-  outputPortDoubleClick: [portId: ExprId]
+  outputPortClick: [portId: AstId]
+  outputPortDoubleClick: [portId: AstId]
   doubleClick: []
   'update:edited': [cursorPosition: number]
   'update:rect': [rect: Rect]
@@ -71,7 +73,7 @@ const outputPortsSet = computed(() => {
 })
 
 const widthOverridePx = ref<number>()
-const nodeId = computed(() => props.node.rootSpan.exprId)
+const nodeId = computed(() => asNodeId(props.node.rootSpan.id))
 
 onUnmounted(() => graph.unregisterNodeRect(nodeId.value))
 
@@ -84,13 +86,14 @@ const baseNodeSize = computed(
 const menuVisible = ref(false)
 
 const error = computed(() => {
-  const info = projectStore.computedValueRegistry.db.get(nodeId.value)
+  const externalId = graph.idToExternal(nodeId.value)
+  const info = projectStore.computedValueRegistry.db.get(externalId)
   switch (info?.payload.type) {
     case 'Panic': {
       return info.payload.message
     }
     case 'DataflowError': {
-      return projectStore.dataflowErrors.lookup(nodeId.value)?.value?.message.split(' (at')[0]
+      return projectStore.dataflowErrors.lookup(externalId)?.value?.message.split(' (at')[0]
     }
     default:
       return undefined
@@ -195,7 +198,7 @@ const isOutputContextOverridden = computed({
     const expression = props.node.rootSpan
     const newAst = prefixes.modify(edit, expression, replacements)
     const code = newAst.code()
-    graph.setNodeContent(props.node.rootSpan.exprId, code)
+    graph.setNodeContent(asNodeId(props.node.rootSpan.id), code)
   },
 })
 
@@ -271,8 +274,8 @@ function getRelatedSpanOffset(domNode: globalThis.Node, domOffset: number): numb
 }
 
 const handlePortClick = useDoubleClick(
-  (portId: ExprId) => emit('outputPortClick', portId),
-  (portId: ExprId) => emit('outputPortDoubleClick', portId),
+  (portId: AstId) => emit('outputPortClick', portId),
+  (portId: AstId) => emit('outputPortDoubleClick', portId),
 ).handleClick
 
 const handleNodeClick = useDoubleClick(
@@ -283,7 +286,7 @@ const handleNodeClick = useDoubleClick(
 interface PortData {
   clipRange: [number, number]
   label: string
-  portId: ExprId
+  portId: AstId
 }
 
 const outputPorts = computed((): PortData[] => {
@@ -301,8 +304,8 @@ const outputPorts = computed((): PortData[] => {
   })
 })
 
-const outputHovered = ref<ExprId>()
-const hoverAnimations = new Map<ExprId, ReturnType<typeof useApproach>>()
+const outputHovered = ref<AstId>()
+const hoverAnimations = new Map<AstId, ReturnType<typeof useApproach>>()
 watchEffect(() => {
   const ports = outputPortsSet.value
   for (const key of hoverAnimations.keys()) if (!ports.has(key)) hoverAnimations.delete(key)

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -87,7 +87,7 @@ const baseNodeSize = computed(
 const menuVisible = ref(false)
 
 const error = computed(() => {
-  const externalId = graph.idToExternal(nodeId.value)
+  const externalId = graph.db.idToExternal(nodeId.value)
   const info = projectStore.computedValueRegistry.db.get(externalId)
   switch (info?.payload.type) {
     case 'Panic': {

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -211,7 +211,7 @@ const executionState = computed(() => expressionInfo.value?.payload.type ?? 'Unk
 const suggestionEntry = computed(() => graph.db.nodeMainSuggestion.lookup(nodeId.value))
 const color = computed(() => graph.db.getNodeColorStyle(nodeId.value))
 const icon = computed(() => {
-  const expressionInfo = graph.db.getExpressionInfo(nodeId.value)
+  const expressionInfo = graph.db.getExpressionInfo(externalId.value)
   return displayedIconOf(
     suggestionEntry.value,
     expressionInfo?.methodCall?.methodPointer,

--- a/app/gui2/src/components/GraphEditor/GraphNodes.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNodes.vue
@@ -5,11 +5,11 @@ import { useDragging } from '@/components/GraphEditor/dragging'
 import { injectGraphNavigator } from '@/providers/graphNavigator'
 import { injectGraphSelection } from '@/providers/graphSelection'
 import type { UploadingFile as File, FileName } from '@/stores/awareness'
-import { useGraphStore } from '@/stores/graph'
+import { useGraphStore, type NodeId } from '@/stores/graph'
 import { useProjectStore } from '@/stores/project'
+import type { AstId } from '@/util/ast/abstract.ts'
 import type { Vec2 } from '@/util/data/vec2'
 import { stackItemsEqual } from 'shared/languageServerTypes'
-import type { ExprId } from 'shared/yjsModel'
 import { computed, toRaw } from 'vue'
 
 const projectStore = useProjectStore()
@@ -19,16 +19,16 @@ const selection = injectGraphSelection(true)
 const navigator = injectGraphNavigator(true)
 
 const emit = defineEmits<{
-  nodeOutputPortDoubleClick: [portId: ExprId]
-  nodeDoubleClick: [nodeId: ExprId]
+  nodeOutputPortDoubleClick: [portId: AstId]
+  nodeDoubleClick: [nodeId: NodeId]
 }>()
 
-function nodeIsDragged(movedId: ExprId, offset: Vec2) {
+function nodeIsDragged(movedId: NodeId, offset: Vec2) {
   const scaledOffset = offset.scale(1 / (navigator?.scale ?? 1))
   dragging.startOrUpdate(movedId, scaledOffset)
 }
 
-function hoverNode(id: ExprId | undefined) {
+function hoverNode(id: NodeId | undefined) {
   if (selection != null) selection.hoveredNode = id
 }
 

--- a/app/gui2/src/components/GraphEditor/GraphVisualization.vue
+++ b/app/gui2/src/components/GraphEditor/GraphVisualization.vue
@@ -71,7 +71,7 @@ const configForGettingDefaultVisualization = computed<NodeVisualizationConfigura
     return {
       visualizationModule: 'Standard.Visualization.Helpers',
       expression: 'a -> a.default_visualization.to_js_object.to_json',
-      expressionId: graphStore.idToExternal(props.dataSource.nodeId),
+      expressionId: props.dataSource.nodeId,
     }
   },
 )
@@ -111,7 +111,7 @@ const visualizationData = projectStore.useVisualizationData(() => {
   return props.data == null && props.dataSource?.type === 'node'
     ? {
         ...visPreprocessor.value,
-        expressionId: graphStore.idToExternal(props.dataSource.nodeId),
+        expressionId: props.dataSource.nodeId,
       }
     : null
 })
@@ -125,10 +125,7 @@ const expressionVisualizationData = computedAsync(() => {
   // Tracked in https://github.com/orgs/enso-org/discussions/6832#discussioncomment-7754474.
   const preprocessorCode = `${preprocessor.visualizationModule}.${preprocessor.expression} _ ${argsCode}`
   const expression = `${preprocessorCode} <| ${props.dataSource.expression}`
-  return projectStore.executeExpression(
-    graphStore.idToExternal(props.dataSource.contextId),
-    expression,
-  )
+  return projectStore.executeExpression(props.dataSource.contextId, expression)
 })
 
 const effectiveVisualizationData = computed(() => {

--- a/app/gui2/src/components/GraphEditor/GraphVisualization.vue
+++ b/app/gui2/src/components/GraphEditor/GraphVisualization.vue
@@ -71,7 +71,7 @@ const configForGettingDefaultVisualization = computed<NodeVisualizationConfigura
     return {
       visualizationModule: 'Standard.Visualization.Helpers',
       expression: 'a -> a.default_visualization.to_js_object.to_json',
-      expressionId: props.dataSource.nodeId,
+      expressionId: graphStore.idToExternal(props.dataSource.nodeId),
     }
   },
 )
@@ -111,7 +111,7 @@ const visualizationData = projectStore.useVisualizationData(() => {
   return props.data == null && props.dataSource?.type === 'node'
     ? {
         ...visPreprocessor.value,
-        expressionId: props.dataSource.nodeId,
+        expressionId: graphStore.idToExternal(props.dataSource.nodeId),
       }
     : null
 })
@@ -125,7 +125,10 @@ const expressionVisualizationData = computedAsync(() => {
   // Tracked in https://github.com/orgs/enso-org/discussions/6832#discussioncomment-7754474.
   const preprocessorCode = `${preprocessor.visualizationModule}.${preprocessor.expression} _ ${argsCode}`
   const expression = `${preprocessorCode} <| ${props.dataSource.expression}`
-  return projectStore.executeExpression(props.dataSource.contextId, expression)
+  return projectStore.executeExpression(
+    graphStore.idToExternal(props.dataSource.contextId),
+    expression,
+  )
 })
 
 const effectiveVisualizationData = computed(() => {

--- a/app/gui2/src/components/GraphEditor/NodeWidgetTree.vue
+++ b/app/gui2/src/components/GraphEditor/NodeWidgetTree.vue
@@ -46,7 +46,7 @@ function handleWidgetUpdates(update: WidgetUpdate) {
           ? value
           : value == null
           ? Ast.Wildcard.new(edit)
-          : Ast.RawCode.new(value, edit)
+          : Ast.parse(value, edit)
       edit.replaceValue(origin as Ast.AstId, ast)
     }
   }

--- a/app/gui2/src/components/GraphEditor/NodeWidgetTree.vue
+++ b/app/gui2/src/components/GraphEditor/NodeWidgetTree.vue
@@ -12,7 +12,7 @@ const props = defineProps<{ ast: Ast.Ast }>()
 const graph = useGraphStore()
 const rootPort = computed(() => {
   const input = WidgetInput.FromAst(props.ast)
-  if (props.ast instanceof Ast.Ident && !graph.db.isKnownFunctionCall(props.ast.exprId)) {
+  if (props.ast instanceof Ast.Ident && !graph.db.isKnownFunctionCall(props.ast.id)) {
     input.forcePort = true
   }
   return input

--- a/app/gui2/src/components/GraphEditor/collapsing.ts
+++ b/app/gui2/src/components/GraphEditor/collapsing.ts
@@ -6,6 +6,7 @@ import { nodeFromAst } from '@/util/ast/node'
 import { unwrap } from '@/util/data/result'
 import { tryIdentifier, type Identifier } from '@/util/qualifiedName'
 import * as set from 'lib0/set'
+import { IdMap } from '../../../shared/yjsModel'
 
 // === Types ===
 
@@ -238,7 +239,7 @@ if (import.meta.vitest) {
   const { test, expect } = import.meta.vitest
 
   function setupGraphDb(code: string, graphDb: GraphDb) {
-    const ast = Ast.parseBlock(code)
+    const ast = Ast.parseTransitional(code, new IdMap())
     const expressions = Array.from(ast.statements())
     const func = expressions[0]
     assert(func instanceof Ast.Function)

--- a/app/gui2/src/components/GraphEditor/collapsing.ts
+++ b/app/gui2/src/components/GraphEditor/collapsing.ts
@@ -197,7 +197,7 @@ export function performCollapse(
   edit.replaceRef(functionBlock.id, refactoredBlock)
 
   // Insert a new function.
-  const args: Ast.Owned<Ast.Ast>[] = info.extracted.inputs.map((arg) => Ast.Ident.new(edit, arg))
+  const args: Ast.Owned[] = info.extracted.inputs.map((arg) => Ast.Ident.new(edit, arg))
   const collapsedFunction = Ast.Function.fromExprs(edit, collapsedName, args, collapsed, true)
   topLevel.insert(edit, posToInsert, collapsedFunction)
   return { refactoredNodeId, collapsedNodeIds, outputNodeId }
@@ -208,7 +208,7 @@ function collapsedCallAst(
   info: CollapsedInfo,
   collapsedName: string,
   edit: Ast.MutableModule,
-): { ast: Ast.Owned<Ast.Ast>; nodeId: NodeId } {
+): { ast: Ast.Owned; nodeId: NodeId } {
   const pattern = info.refactored.pattern
   const args = info.refactored.arguments
   const functionName = `${MODULE_NAME}.${collapsedName}`

--- a/app/gui2/src/components/GraphEditor/collapsing.ts
+++ b/app/gui2/src/components/GraphEditor/collapsing.ts
@@ -6,7 +6,6 @@ import { nodeFromAst } from '@/util/ast/node'
 import { unwrap } from '@/util/data/result'
 import { tryIdentifier, type Identifier } from '@/util/qualifiedName'
 import * as set from 'lib0/set'
-import { IdMap } from 'shared/yjsModel'
 
 // === Types ===
 
@@ -239,8 +238,7 @@ if (import.meta.vitest) {
   const { test, expect } = import.meta.vitest
 
   function setupGraphDb(code: string, graphDb: GraphDb) {
-    const ast = Ast.parseTransitional(code, IdMap.Mock())
-    assert(ast instanceof Ast.BodyBlock)
+    const ast = Ast.parseBlock(code)
     const expressions = Array.from(ast.statements())
     const func = expressions[0]
     assert(func instanceof Ast.Function)

--- a/app/gui2/src/components/GraphEditor/collapsing.ts
+++ b/app/gui2/src/components/GraphEditor/collapsing.ts
@@ -1,4 +1,4 @@
-import { GraphDb } from '@/stores/graph/graphDatabase'
+import { asNodeId, GraphDb, type NodeId } from '@/stores/graph/graphDatabase'
 import { assert } from '@/util/assert'
 import { Ast } from '@/util/ast'
 import { moduleMethodNames } from '@/util/ast/abstract'
@@ -6,7 +6,7 @@ import { nodeFromAst } from '@/util/ast/node'
 import { unwrap } from '@/util/data/result'
 import { tryIdentifier, type Identifier } from '@/util/qualifiedName'
 import * as set from 'lib0/set'
-import { IdMap, type ExprId } from 'shared/yjsModel'
+import { IdMap } from 'shared/yjsModel'
 
 // === Types ===
 
@@ -19,7 +19,7 @@ interface CollapsedInfo {
 /** The information about the extracted function. */
 interface ExtractedInfo {
   /** Nodes with these ids should be moved to the function body, in their original order. */
-  ids: Set<ExprId>
+  ids: Set<NodeId>
   /** The output information of the function. */
   output: Output | null
   /** The list of extracted function’s argument names. */
@@ -31,7 +31,7 @@ interface Output {
   /** The id of the node the expression of which should be replaced by the function call.
    * This node is also included into `ids` of the {@link ExtractedInfo} and must be moved into the extracted function.
    */
-  node: ExprId
+  node: NodeId
   /** The identifier of the return value of the extracted function. */
   identifier: Identifier
 }
@@ -39,7 +39,7 @@ interface Output {
 /** The information about the refactored node, the one that needs to be replaced with the function call. */
 interface RefactoredInfo {
   /** The id of the refactored node. */
-  id: ExprId
+  id: NodeId
   /** The pattern of the refactored node. Included for convenience, collapsing does not affect it. */
   pattern: string
   /** The list of necessary arguments for a call of the collapsed function. */
@@ -51,7 +51,7 @@ interface RefactoredInfo {
 /** Prepare the information necessary for collapsing nodes.
  * @throws errors in case of failures, but it should not happen in normal execution.
  */
-export function prepareCollapsedInfo(selected: Set<ExprId>, graphDb: GraphDb): CollapsedInfo {
+export function prepareCollapsedInfo(selected: Set<NodeId>, graphDb: GraphDb): CollapsedInfo {
   if (selected.size == 0) throw new Error('Collapsing requires at least a single selected node.')
   // Leaves are the nodes that have no outgoing connection.
   const leaves = new Set([...selected])
@@ -135,13 +135,13 @@ const COLLAPSED_FUNCTION_NAME = 'collapsed'
 
 interface CollapsingResult {
   /** The ID of the node refactored to the collapsed function call. */
-  refactoredNodeId: ExprId
+  refactoredNodeId: NodeId
   /** IDs of nodes inside the collapsed function, except the output node.
    * The order of these IDs is reversed comparing to the order of nodes in the source code.
    */
-  collapsedNodeIds: ExprId[]
+  collapsedNodeIds: NodeId[]
   /** ID of the output node inside the collapsed function. */
-  outputNodeId?: ExprId | undefined
+  outputNodeId?: NodeId | undefined
 }
 
 /** Perform the actual AST refactoring for collapsing nodes. */
@@ -172,7 +172,7 @@ export function performCollapse(
   )
   const lines = functionBlock.statements()
   for (const line of lines) {
-    const astId = line.exprId
+    const astId = line.id
     const ast = edit.take(astId)?.node
     assert(ast != null)
     if (astIdsToExtract.has(astId)) {
@@ -184,17 +184,17 @@ export function performCollapse(
       refactored.push({ expression: { node: ast } })
     }
   }
-  const collapsedNodeIds = collapsed.map((ast) => nodeFromAst(ast).rootSpan.exprId).reverse()
-  let outputNodeId: ExprId | undefined
+  const collapsedNodeIds = collapsed.map((ast) => asNodeId(nodeFromAst(ast).rootSpan.id)).reverse()
+  let outputNodeId: NodeId | undefined
   const outputIdentifier = info.extracted.output?.identifier
   if (outputIdentifier != null) {
     const ident = Ast.Ident.new(edit, outputIdentifier)
     collapsed.push(ident)
-    outputNodeId = ident.exprId
+    outputNodeId = asNodeId(ident.id)
   }
   // Update the definiton of the refactored function.
   const refactoredBlock = Ast.BodyBlock.new(refactored, edit)
-  edit.replaceRef(functionBlock.exprId, refactoredBlock)
+  edit.replaceRef(functionBlock.id, refactoredBlock)
 
   // Insert a new function.
   const args: Ast.Owned<Ast.Ast>[] = info.extracted.inputs.map((arg) => Ast.Ident.new(edit, arg))
@@ -208,14 +208,14 @@ function collapsedCallAst(
   info: CollapsedInfo,
   collapsedName: string,
   edit: Ast.MutableModule,
-): { ast: Ast.Owned<Ast.Ast>; nodeId: ExprId } {
+): { ast: Ast.Owned<Ast.Ast>; nodeId: NodeId } {
   const pattern = info.refactored.pattern
   const args = info.refactored.arguments
   const functionName = `${MODULE_NAME}.${collapsedName}`
   const expression = functionName + (args.length > 0 ? ' ' : '') + args.join(' ')
   const expressionAst = Ast.parse(expression, edit)
   const ast = Ast.Assignment.new(edit, pattern, expressionAst)
-  return { ast, nodeId: expressionAst.exprId }
+  return { ast, nodeId: asNodeId(expressionAst.id) }
 }
 
 /** Find the position before the current method to insert a collapsed one. */
@@ -226,7 +226,7 @@ function findInsertionPos(
 ): number {
   const currentFuncPosition = topLevel.lines().findIndex((line) => {
     const node = line.expression?.node
-    const expr = node ? module.get(node.exprId)?.innerExpression() : null
+    const expr = node ? module.get(node.id)?.innerExpression() : null
     return expr instanceof Ast.Function && expr.name?.code() === currentMethodName
   })
 
@@ -345,8 +345,8 @@ if (import.meta.vitest) {
     const expectedRefactored = testCase.expected.refactored
     const nodes = Array.from(graphDb.nodeIdToNode.entries())
     expect(nodes.length).toEqual(testCase.initialNodes.length)
-    const nodeCodeToId = new Map<string, ExprId>()
-    const nodePatternToId = new Map<string, ExprId>()
+    const nodeCodeToId = new Map<string, NodeId>()
+    const nodePatternToId = new Map<string, NodeId>()
     for (const code of testCase.initialNodes) {
       const [pattern, expr] = code.split(/\s*=\s*/)
       const [id, _] = nodes.find(([_id, node]) => node.rootSpan.code() == expr)!

--- a/app/gui2/src/components/GraphEditor/dragging.ts
+++ b/app/gui2/src/components/GraphEditor/dragging.ts
@@ -1,13 +1,12 @@
 import { useApproach } from '@/composables/animation'
 import { injectGraphSelection } from '@/providers/graphSelection'
-import { useGraphStore } from '@/stores/graph'
+import { useGraphStore, type NodeId } from '@/stores/graph'
 import { partitionPoint } from '@/util/data/array'
 import type { Opt } from '@/util/data/opt'
 import { Rect } from '@/util/data/rect'
 import { Vec2 } from '@/util/data/vec2'
 import theme from '@/util/theme.json'
 import { iteratorFilter } from 'lib0/iterator'
-import type { ExprId } from 'shared/yjsModel'
 import { computed, markRaw, ref, watchEffect, type ComputedRef, type WatchStopHandle } from 'vue'
 
 const DRAG_SNAP_THRESHOLD = 16
@@ -108,13 +107,13 @@ export function useDragging() {
     currentPos: Vec2
   }
   class CurrentDrag {
-    draggedNodes: Map<ExprId, DraggedNode>
+    draggedNodes: Map<NodeId, DraggedNode>
     grid: SnapGrid
     stopPositionUpdate: WatchStopHandle
 
-    constructor(movedId: ExprId) {
+    constructor(movedId: NodeId) {
       markRaw(this)
-      function* draggedNodes(): Generator<[ExprId, DraggedNode]> {
+      function* draggedNodes(): Generator<[NodeId, DraggedNode]> {
         const ids = selection?.isSelected(movedId) ? selection.selected : [movedId]
         for (const id of ids) {
           const node = graphStore.db.nodeIdToNode.get(id)
@@ -189,7 +188,7 @@ export function useDragging() {
   let currentDrag: CurrentDrag | undefined
 
   return {
-    startOrUpdate(movedId: ExprId, offset: Vec2) {
+    startOrUpdate(movedId: NodeId, offset: Vec2) {
       currentDrag ??= new CurrentDrag(movedId)
       currentDrag.updateOffset(offset)
     },

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetArgumentName.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetArgumentName.vue
@@ -15,7 +15,7 @@ const showArgumentValue = computed(() => {
     !WidgetInput.isAst(props.input) ||
     portInfo == null ||
     !portInfo.connected ||
-    (portInfo.portId as string) !== (props.input.value.exprId as string)
+    (portInfo.portId as string) !== (props.input.value.id as string)
   )
 })
 

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetCheckbox.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetCheckbox.vue
@@ -20,7 +20,7 @@ const value = computed({
       if (node != null) {
         props.onUpdate({
           edit,
-          portUpdate: { value: value ? 'True' : 'False', origin: node.exprId },
+          portUpdate: { value: value ? 'True' : 'False', origin: node.id },
         })
       }
     } else {

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetCheckbox.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetCheckbox.vue
@@ -3,6 +3,8 @@ import CheckboxWidget from '@/components/widgets/CheckboxWidget.vue'
 import { Score, WidgetInput, defineWidget, widgetProps } from '@/providers/widgetRegistry'
 import { useGraphStore } from '@/stores/graph'
 import { Ast } from '@/util/ast'
+import type { TokenId } from '@/util/ast/abstract.ts'
+import { asNot } from '@/util/data/types.ts'
 import { type Identifier, type QualifiedName } from '@/util/qualifiedName.ts'
 import { computed } from 'vue'
 
@@ -35,7 +37,7 @@ const value = computed({
         edit,
         portUpdate: {
           value: value ? 'Boolean.True' : 'Boolean.False',
-          origin: props.input.portId,
+          origin: asNot<TokenId>(props.input.portId),
         },
       })
     }

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetFunction.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetFunction.vue
@@ -16,6 +16,7 @@ import { useGraphStore } from '@/stores/graph'
 import { useProjectStore, type NodeVisualizationConfiguration } from '@/stores/project'
 import { assert, assertUnreachable } from '@/util/assert'
 import { Ast } from '@/util/ast'
+import type { AstId } from '@/util/ast/abstract.ts'
 import {
   ArgumentApplication,
   ArgumentApplicationKey,
@@ -26,7 +27,6 @@ import {
 } from '@/util/callTree'
 import { partitionPoint } from '@/util/data/array'
 import type { Opt } from '@/util/data/opt'
-import type { ExprId } from 'shared/yjsModel'
 import { computed, proxyRefs } from 'vue'
 
 const props = defineProps(widgetProps(widgetDefinition))
@@ -35,12 +35,12 @@ const project = useProjectStore()
 
 provideFunctionInfo(
   proxyRefs({
-    callId: computed(() => props.input.value.exprId),
+    callId: computed(() => props.input.value.id),
   }),
 )
 
 const methodCallInfo = computed(() => {
-  return graph.db.getMethodCallInfo(props.input.value.exprId)
+  return graph.db.getMethodCallInfo(props.input.value.id)
 })
 
 const interpreted = computed(() => {
@@ -52,7 +52,7 @@ const subjectInfo = computed(() => {
   if (analyzed.kind !== 'prefix') return
   const subject = getAccessOprSubject(analyzed.func)
   if (!subject) return
-  return graph.db.getExpressionInfo(subject.exprId)
+  return graph.db.getExpressionInfo(subject.id)
 })
 
 const selfArgumentPreapplied = computed(() => {
@@ -69,7 +69,7 @@ const subjectTypeMatchesMethod = computed(() => {
 const application = computed(() => {
   const call = interpreted.value
   if (!call) return null
-  const noArgsCall = call.kind === 'prefix' ? graph.db.getMethodCall(call.func.exprId) : undefined
+  const noArgsCall = call.kind === 'prefix' ? graph.db.getMethodCall(call.func.id) : undefined
 
   return ArgumentApplication.FromInterpretedWithInfo(call, {
     suggestion: methodCallInfo.value?.suggestion,
@@ -97,10 +97,10 @@ const escapeString = (str: string): string => {
 }
 const makeArgsList = (args: string[]) => '[' + args.map(escapeString).join(', ') + ']'
 
-const selfArgumentAstId = computed<Opt<ExprId>>(() => {
+const selfArgumentAstId = computed<Opt<AstId>>(() => {
   const analyzed = interpretCall(props.input.value, true)
   if (analyzed.kind === 'infix') {
-    return analyzed.lhs?.exprId
+    return analyzed.lhs?.id
   } else {
     const knownArguments = methodCallInfo.value?.suggestion?.arguments
     const hasSelfArgument = knownArguments?.[0]?.name === 'self'
@@ -109,7 +109,7 @@ const selfArgumentAstId = computed<Opt<ExprId>>(() => {
         ? analyzed.args.find((a) => a.argName === 'self' || a.argName == null)?.argument
         : getAccessOprSubject(analyzed.func) ?? analyzed.args[0]?.argument
 
-    return selfArgument?.exprId
+    return selfArgument?.id
   }
 })
 
@@ -117,8 +117,8 @@ const visualizationConfig = computed<Opt<NodeVisualizationConfiguration>>(() => 
   // If we inherit dynamic config, there is no point in attaching visualization.
   if (props.input.dynamicConfig) return null
 
-  const expressionId = selfArgumentAstId.value
-  const astId = props.input.value.exprId
+  const expressionId = selfArgumentAstId.value && graph.idToExternal(selfArgumentAstId.value)
+  const astId = props.input.value.id
   if (astId == null || expressionId == null) return null
   const info = graph.db.getMethodCallInfo(astId)
   if (!info) return null
@@ -182,7 +182,7 @@ function handleArgUpdate(update: WidgetUpdate): boolean {
         newArg = Ast.parse(value, edit)
       }
       const name = argApp.argument.insertAsNamed ? argApp.argument.argInfo.name : null
-      edit.takeAndReplaceValue(argApp.appTree.exprId, (oldAppTree) =>
+      edit.takeAndReplaceValue(argApp.appTree.id, (oldAppTree) =>
         Ast.App.new(oldAppTree, name, newArg, edit),
       )
       props.onUpdate({ edit })
@@ -214,13 +214,13 @@ function handleArgUpdate(update: WidgetUpdate): boolean {
 
         // Named argument can always be removed immediately. Replace the whole application with its
         // target, effectively removing the argument from the call.
-        const func = edit.take(argApp.appTree.function.exprId)
+        const func = edit.take(argApp.appTree.function.id)
         assert(func != null)
         props.onUpdate({
           edit,
           portUpdate: {
             value: func.node,
-            origin: argApp.appTree.exprId,
+            origin: argApp.appTree.id,
           },
         })
         return true
@@ -229,13 +229,13 @@ function handleArgUpdate(update: WidgetUpdate): boolean {
 
         // Infix application is removed as a whole. Only the target is kept.
         if (argApp.appTree.lhs) {
-          const lhs = edit.take(argApp.appTree.lhs.exprId)
+          const lhs = edit.take(argApp.appTree.lhs.id)
           assert(lhs != null)
           props.onUpdate({
             edit,
             portUpdate: {
               value: lhs.node,
-              origin: argApp.appTree.exprId,
+              origin: argApp.appTree.id,
             },
           })
         }
@@ -249,12 +249,12 @@ function handleArgUpdate(update: WidgetUpdate): boolean {
         // Traverse the application chain, starting from the outermost application and going
         // towards the innermost target.
         for (let innerApp of [...app.iterApplications()]) {
-          if (innerApp.appTree.exprId === argApp.appTree.exprId) {
+          if (innerApp.appTree.id === argApp.appTree.id) {
             // Found the application with the argument to remove. Skip the argument and use the
             // application target's code. This is the final iteration of the loop.
-            const newFunction = edit.take(argApp.appTree.function.exprId)?.node
+            const newFunction = edit.take(argApp.appTree.function.id)?.node
             assert(newFunction != undefined)
-            edit.replaceRef(argApp.appTree.exprId, newFunction)
+            edit.replaceRef(argApp.appTree.id, newFunction)
             props.onUpdate({ edit })
             return true
           } else {
@@ -263,11 +263,11 @@ function handleArgUpdate(update: WidgetUpdate): boolean {
             const infoName = innerApp.argument.argInfo?.name ?? null
             // Positional arguments following the deleted argument must all be rewritten to named.
             if (infoName && !innerApp.appTree.argumentName) {
-              const func = edit.take(innerApp.appTree.function.exprId)?.node
-              const arg = edit.take(innerApp.appTree.argument.exprId)?.node
+              const func = edit.take(innerApp.appTree.function.id)?.node
+              const arg = edit.take(innerApp.appTree.argument.id)?.node
               assert(!!func)
               assert(!!arg)
-              edit.replaceValue(innerApp.appTree.exprId, Ast.App.new(func, infoName, arg, edit))
+              edit.replaceValue(innerApp.appTree.id, Ast.App.new(func, infoName, arg, edit))
             }
           }
         }
@@ -292,18 +292,18 @@ export const widgetDefinition = defineWidget(WidgetInput.isFunctionCall, {
     // If ArgumentApplicationKey is stored, we already are handled by some WidgetFunction.
     if (props.input[ArgumentApplicationKey]) return Score.Mismatch
     const ast = props.input.value
-    if (ast.exprId == null) return Score.Mismatch
+    if (ast.id == null) return Score.Mismatch
     const prevFunctionState = injectFunctionInfo(true)
 
     // It is possible to try to render the same function application twice, e.g. when detected an
     // application with no arguments applied yet, but the application target is also an infix call.
     // In that case, the reentrant call method info must be ignored to not create an infinite loop,
     // and to resolve the infix call as its own application.
-    if (prevFunctionState?.callId === ast.exprId) return Score.Mismatch
+    if (prevFunctionState?.callId === ast.id) return Score.Mismatch
 
     if (ast instanceof Ast.App || ast instanceof Ast.OprApp) return Score.Perfect
 
-    const info = db.getMethodCallInfo(ast.exprId)
+    const info = db.getMethodCallInfo(ast.id)
     if (prevFunctionState != null && info?.partiallyApplied === true && ast instanceof Ast.Ident) {
       return Score.Mismatch
     }

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetFunction.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetFunction.vue
@@ -175,7 +175,7 @@ function handleArgUpdate(update: WidgetUpdate): boolean {
     // Perform appropriate AST update, either insertion or deletion.
     if (value != null && argApp?.argument instanceof ArgumentPlaceholder) {
       /* Case: Inserting value to a placeholder. */
-      let newArg: Ast.Owned<Ast.Ast>
+      let newArg: Ast.Owned
       if (value instanceof Ast.Ast) {
         newArg = value
       } else {

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetFunction.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetFunction.vue
@@ -27,6 +27,7 @@ import {
 } from '@/util/callTree'
 import { partitionPoint } from '@/util/data/array'
 import type { Opt } from '@/util/data/opt'
+import type { ExternalId } from 'shared/yjsModel.ts'
 import { computed, proxyRefs } from 'vue'
 
 const props = defineProps(widgetProps(widgetDefinition))
@@ -97,10 +98,10 @@ const escapeString = (str: string): string => {
 }
 const makeArgsList = (args: string[]) => '[' + args.map(escapeString).join(', ') + ']'
 
-const selfArgumentAstId = computed<Opt<AstId>>(() => {
+const selfArgumentExternalId = computed<Opt<ExternalId>>(() => {
   const analyzed = interpretCall(props.input.value, true)
   if (analyzed.kind === 'infix') {
-    return analyzed.lhs?.id
+    return analyzed.lhs?.externalId
   } else {
     const knownArguments = methodCallInfo.value?.suggestion?.arguments
     const hasSelfArgument = knownArguments?.[0]?.name === 'self'
@@ -109,7 +110,7 @@ const selfArgumentAstId = computed<Opt<AstId>>(() => {
         ? analyzed.args.find((a) => a.argName === 'self' || a.argName == null)?.argument
         : getAccessOprSubject(analyzed.func) ?? analyzed.args[0]?.argument
 
-    return selfArgument?.id
+    return selfArgument?.externalId
   }
 })
 
@@ -117,7 +118,7 @@ const visualizationConfig = computed<Opt<NodeVisualizationConfiguration>>(() => 
   // If we inherit dynamic config, there is no point in attaching visualization.
   if (props.input.dynamicConfig) return null
 
-  const expressionId = selfArgumentAstId.value && graph.idToExternal(selfArgumentAstId.value)
+  const expressionId = selfArgumentExternalId.value
   const astId = props.input.value.id
   if (astId == null || expressionId == null) return null
   const info = graph.db.getMethodCallInfo(astId)

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetHierarchy.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetHierarchy.vue
@@ -35,7 +35,7 @@ export const widgetDefinition = defineWidget(WidgetInput.isAst, {
   <div class="WidgetHierarchy" :class="spanClass">
     <NodeWidget
       v-for="(child, index) in children"
-      :key="child.exprId ?? index"
+      :key="child.id ?? index"
       :input="transformChild(child)"
     />
   </div>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetNumber.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetNumber.vue
@@ -3,6 +3,8 @@ import SliderWidget from '@/components/widgets/SliderWidget.vue'
 import { Score, WidgetInput, defineWidget, widgetProps } from '@/providers/widgetRegistry'
 import { useGraphStore } from '@/stores/graph'
 import { Ast } from '@/util/ast'
+import type { TokenId } from '@/util/ast/abstract.ts'
+import { asNot } from '@/util/data/types.ts'
 import { computed } from 'vue'
 
 const props = defineProps(widgetProps(widgetDefinition))
@@ -15,7 +17,7 @@ const value = computed({
   set(value) {
     props.onUpdate({
       edit: graph.astModule.edit(),
-      portUpdate: { value: value.toString(), origin: props.input.portId },
+      portUpdate: { value: value.toString(), origin: asNot<TokenId>(props.input.portId) },
     })
   },
 })

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetPort.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetPort.vue
@@ -9,9 +9,10 @@ import { Score, WidgetInput, defineWidget, widgetProps } from '@/providers/widge
 import { injectWidgetTree } from '@/providers/widgetTree'
 import { PortViewInstance, useGraphStore } from '@/stores/graph'
 import { Ast } from '@/util/ast'
-import type { AstId } from '@/util/ast/abstract'
+import type { AstId, TokenId } from '@/util/ast/abstract'
 import { ArgumentInfoKey } from '@/util/callTree'
 import { Rect } from '@/util/data/rect'
+import { asNot } from '@/util/data/types.ts'
 import { cachedGetter } from '@/util/reactivity'
 import { uuidv4 } from 'lib0/random'
 import {
@@ -60,7 +61,7 @@ const randomUuid = uuidv4() as PortId
 // its result in an intermediate ref, and update it only when the value actually changes. That way
 // effects depending on the port ID value will not be re-triggered unnecessarily.
 const portId = cachedGetter<PortId>(() => {
-  return props.input.portId
+  return asNot<TokenId>(props.input.portId)
 })
 
 const innerWidget = computed(() => {

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetPort.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetPort.vue
@@ -9,11 +9,11 @@ import { Score, WidgetInput, defineWidget, widgetProps } from '@/providers/widge
 import { injectWidgetTree } from '@/providers/widgetTree'
 import { PortViewInstance, useGraphStore } from '@/stores/graph'
 import { Ast } from '@/util/ast'
+import type { AstId } from '@/util/ast/abstract'
 import { ArgumentInfoKey } from '@/util/callTree'
 import { Rect } from '@/util/data/rect'
 import { cachedGetter } from '@/util/reactivity'
 import { uuidv4 } from 'lib0/random'
-import type { ExprId } from 'shared/yjsModel'
 import {
   computed,
   markRaw,
@@ -37,7 +37,7 @@ const selection = injectGraphSelection(true)
 const isHovered = computed(() => selection?.hoveredPort === props.input.portId)
 
 const hasConnection = computed(
-  () => graph.db.connections.reverseLookup(portId.value as ExprId).size > 0,
+  () => graph.db.connections.reverseLookup(portId.value as AstId).size > 0,
 )
 const isCurrentEdgeHoverTarget = computed(
   () => isHovered.value && graph.unconnectedEdge != null && selection?.hoveredPort === portId.value,
@@ -106,7 +106,7 @@ export const widgetDefinition = defineWidget(WidgetInput.isAstOrPlaceholder, {
   score: (props, _db) => {
     const portInfo = injectPortInfo(true)
     const value = props.input.value
-    if (portInfo != null && value instanceof Ast.Ast && portInfo.portId === value.exprId) {
+    if (portInfo != null && value instanceof Ast.Ast && portInfo.portId === value.id) {
       return Score.Mismatch
     }
 

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
@@ -10,7 +10,9 @@ import { useGraphStore } from '@/stores/graph'
 import { requiredImports, type RequiredImport } from '@/stores/graph/imports.ts'
 import { useSuggestionDbStore } from '@/stores/suggestionDatabase'
 import { type SuggestionEntry } from '@/stores/suggestionDatabase/entry.ts'
+import type { TokenId } from '@/util/ast/abstract.ts'
 import { ArgumentInfoKey } from '@/util/callTree'
+import { asNot } from '@/util/data/types.ts'
 import { qnLastSegment, tryQualifiedName, type Identifier } from '@/util/qualifiedName'
 import { computed, ref, watch } from 'vue'
 
@@ -103,7 +105,7 @@ watch(selectedIndex, (_index) => {
     edit,
     portUpdate: {
       value: selectedExpression.value,
-      origin: props.input.portId,
+      origin: asNot<TokenId>(props.input.portId),
     },
   })
   showDropdownWidget.value = false

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetVector.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetVector.vue
@@ -5,6 +5,8 @@ import { injectGraphNavigator } from '@/providers/graphNavigator'
 import { Score, WidgetInput, defineWidget, widgetProps } from '@/providers/widgetRegistry'
 import { useGraphStore } from '@/stores/graph'
 import { Ast, RawAst } from '@/util/ast'
+import type { TokenId } from '@/util/ast/abstract.ts'
+import { asNot } from '@/util/data/types.ts'
 import { computed } from 'vue'
 
 const props = defineProps(widgetProps(widgetDefinition))
@@ -35,7 +37,10 @@ const value = computed({
     // TODO[ao]: here we re-create AST. It would be better to reuse existing AST nodes.
     const newCode = `[${value.map((item) => item.code()).join(', ')}]`
     const edit = graph.astModule.edit()
-    props.onUpdate({ edit, portUpdate: { value: newCode, origin: props.input.portId } })
+    props.onUpdate({
+      edit,
+      portUpdate: { value: newCode, origin: asNot<TokenId>(props.input.portId) },
+    })
   },
 })
 

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetVector.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetVector.vue
@@ -60,7 +60,7 @@ export const widgetDefinition = defineWidget(WidgetInput.isAstOrPlaceholder, {
   <ListWidget
     v-model="value"
     :default="() => defaultItem"
-    :getKey="(ast: Ast.Ast) => ast.exprId"
+    :getKey="(ast: Ast.Ast) => ast.id"
     dragMimeType="application/x-enso-ast-node"
     :toPlainText="(ast: Ast.Ast) => ast.code()"
     :toDragPayload="(ast: Ast.Ast) => ast.serialize()"

--- a/app/gui2/src/composables/selection.ts
+++ b/app/gui2/src/composables/selection.ts
@@ -4,9 +4,9 @@ import { selectionMouseBindings } from '@/bindings'
 import { useEvent, usePointer } from '@/composables/events'
 import type { NavigatorComposable } from '@/composables/navigator'
 import type { PortId } from '@/providers/portInfo.ts'
+import { type NodeId } from '@/stores/graph'
 import type { Rect } from '@/util/data/rect'
 import type { Vec2 } from '@/util/data/vec2'
-import { type ExprId } from 'shared/yjsModel'
 import { computed, proxyRefs, reactive, ref, shallowRef } from 'vue'
 
 export type SelectionComposable<T> = ReturnType<typeof useSelection<T>>
@@ -22,7 +22,7 @@ export function useSelection<T>(
   const anchor = shallowRef<Vec2>()
   const initiallySelected = new Set<T>()
   const selected = reactive(new Set<T>())
-  const hoveredNode = ref<ExprId>()
+  const hoveredNode = ref<NodeId>()
   const hoveredPort = ref<PortId>()
 
   useEvent(document, 'pointerover', (event) => {

--- a/app/gui2/src/composables/stackNavigator.ts
+++ b/app/gui2/src/composables/stackNavigator.ts
@@ -1,9 +1,9 @@
 import type { BreadcrumbItem } from '@/components/NavBreadcrumbs.vue'
 import { useGraphStore } from '@/stores/graph'
 import { useProjectStore } from '@/stores/project'
+import type { AstId } from '@/util/ast/abstract.ts'
 import { qnLastSegment, tryQualifiedName } from '@/util/qualifiedName'
 import type { StackItem } from 'shared/languageServerTypes.ts'
-import type { ExprId } from 'shared/yjsModel.ts'
 import { computed, onMounted, ref } from 'vue'
 
 export function useStackNavigator() {
@@ -55,7 +55,7 @@ export function useStackNavigator() {
     graphStore.updateState()
   }
 
-  function enterNode(id: ExprId) {
+  function enterNode(id: AstId) {
     const expressionInfo = graphStore.db.getExpressionInfo(id)
     if (expressionInfo == null || expressionInfo.methodCall == null) {
       console.debug('Cannot enter node that has no method call.')
@@ -71,7 +71,7 @@ export function useStackNavigator() {
       console.debug('Cannot enter node that is not defined on current module.')
       return
     }
-    projectStore.executionContext.push(id)
+    projectStore.executionContext.push(graphStore.idToExternal(id))
     graphStore.updateState()
     breadcrumbs.value = projectStore.executionContext.desiredStack.slice()
   }

--- a/app/gui2/src/composables/stackNavigator.ts
+++ b/app/gui2/src/composables/stackNavigator.ts
@@ -56,6 +56,7 @@ export function useStackNavigator() {
   }
 
   function enterNode(id: AstId) {
+    const node = graphStore.astModule.get(id)!
     const expressionInfo = graphStore.db.getExpressionInfo(id)
     if (expressionInfo == null || expressionInfo.methodCall == null) {
       console.debug('Cannot enter node that has no method call.')
@@ -71,7 +72,7 @@ export function useStackNavigator() {
       console.debug('Cannot enter node that is not defined on current module.')
       return
     }
-    projectStore.executionContext.push(graphStore.idToExternal(id))
+    projectStore.executionContext.push(node.externalId)
     graphStore.updateState()
     breadcrumbs.value = projectStore.executionContext.desiredStack.slice()
   }

--- a/app/gui2/src/providers/functionInfo.ts
+++ b/app/gui2/src/providers/functionInfo.ts
@@ -1,9 +1,9 @@
 import { createContextStore } from '@/providers'
+import type { AstId } from '@/util/ast/abstract.ts'
 import { identity } from '@vueuse/core'
-import type { ExprId } from 'shared/yjsModel'
 
 interface FunctionInfo {
-  callId: ExprId | undefined
+  callId: AstId | undefined
 }
 
 export { injectFn as injectFunctionInfo, provideFn as provideFunctionInfo }

--- a/app/gui2/src/providers/graphSelection.ts
+++ b/app/gui2/src/providers/graphSelection.ts
@@ -1,8 +1,8 @@
 import type { NavigatorComposable } from '@/composables/navigator'
 import { useSelection } from '@/composables/selection'
 import { createContextStore } from '@/providers'
+import { type NodeId } from '@/stores/graph'
 import type { Rect } from '@/util/data/rect'
-import type { ExprId } from 'shared/yjsModel'
 
 const SELECTION_BRUSH_MARGIN_PX = 6
 
@@ -12,10 +12,10 @@ const { provideFn, injectFn } = createContextStore(
   'graph selection',
   (
     navigator: NavigatorComposable,
-    nodeRects: Map<ExprId, Rect>,
+    nodeRects: Map<NodeId, Rect>,
     callbacks: {
-      onSelected?: (id: ExprId) => void
-      onDeselected?: (id: ExprId) => void
+      onSelected?: (id: NodeId) => void
+      onDeselected?: (id: NodeId) => void
     } = {},
   ) => {
     return useSelection(navigator, nodeRects, SELECTION_BRUSH_MARGIN_PX, callbacks)

--- a/app/gui2/src/providers/portInfo.ts
+++ b/app/gui2/src/providers/portInfo.ts
@@ -1,13 +1,13 @@
 import { createContextStore } from '@/providers'
+import type { AstId, TokenId } from '@/util/ast/abstract'
 import { identity } from '@vueuse/core'
-import type { ExprId } from 'shared/yjsModel'
 
 declare const portIdBrand: unique symbol
 /**
  * Port identification. A port represents a fragment of code displayed/modified by the widget;
  * usually Ast nodes, but other ids are also possible (like argument placeholders).
  */
-export type PortId = ExprId | (string & { [portIdBrand]: never })
+export type PortId = AstId | TokenId | (string & { [portIdBrand]: never })
 
 interface PortInfo {
   portId: PortId

--- a/app/gui2/src/providers/portInfo.ts
+++ b/app/gui2/src/providers/portInfo.ts
@@ -7,7 +7,7 @@ declare const portIdBrand: unique symbol
  * Port identification. A port represents a fragment of code displayed/modified by the widget;
  * usually Ast nodes, but other ids are also possible (like argument placeholders).
  */
-export type PortId = AstId | TokenId | (string & { [portIdBrand]: never })
+export type PortId = AstId | (string & { [portIdBrand]: never })
 
 interface PortInfo {
   portId: PortId

--- a/app/gui2/src/providers/widgetRegistry.ts
+++ b/app/gui2/src/providers/widgetRegistry.ts
@@ -4,7 +4,7 @@ import type { WidgetConfiguration } from '@/providers/widgetRegistry/configurati
 import type { GraphDb } from '@/stores/graph/graphDatabase'
 import type { Typename } from '@/stores/suggestionDatabase/entry'
 import { Ast } from '@/util/ast'
-import { MutableModule } from '@/util/ast/abstract.ts'
+import { MutableModule, type TokenId } from '@/util/ast/abstract.ts'
 import { computed, shallowReactive, type Component, type PropType } from 'vue'
 
 export type WidgetComponent<T extends WidgetInput> = Component<WidgetProps<T>>
@@ -91,7 +91,7 @@ export interface WidgetInput {
    *
    * Also, used as usage key (see {@link usageKeyForInput})
    */
-  portId: PortId
+  portId: PortId | TokenId
   /**
    * An expected widget value. If Ast.Ast or Ast.Token, the widget represents an existing part of
    * code. If string, it may be e.g. a default value of an argument.

--- a/app/gui2/src/providers/widgetRegistry.ts
+++ b/app/gui2/src/providers/widgetRegistry.ts
@@ -12,7 +12,7 @@ export type WidgetComponent<T extends WidgetInput> = Component<WidgetProps<T>>
 export namespace WidgetInput {
   export function FromAst(ast: Ast.Ast | Ast.Token): WidgetInput {
     return {
-      portId: ast.exprId,
+      portId: ast.id,
       value: ast,
     }
   }

--- a/app/gui2/src/providers/widgetRegistry.ts
+++ b/app/gui2/src/providers/widgetRegistry.ts
@@ -4,7 +4,7 @@ import type { WidgetConfiguration } from '@/providers/widgetRegistry/configurati
 import type { GraphDb } from '@/stores/graph/graphDatabase'
 import type { Typename } from '@/stores/suggestionDatabase/entry'
 import { Ast } from '@/util/ast'
-import { MutableModule, type Owned } from '@/util/ast/abstract.ts'
+import { MutableModule } from '@/util/ast/abstract.ts'
 import { computed, shallowReactive, type Component, type PropType } from 'vue'
 
 export type WidgetComponent<T extends WidgetInput> = Component<WidgetProps<T>>
@@ -142,7 +142,7 @@ export interface WidgetProps<T> {
 export interface WidgetUpdate {
   edit: MutableModule
   portUpdate?: {
-    value: Owned<Ast.Ast> | string | undefined
+    value: Ast.Owned | string | undefined
     origin: PortId
   }
 }

--- a/app/gui2/src/providers/widgetTree.ts
+++ b/app/gui2/src/providers/widgetTree.ts
@@ -1,4 +1,5 @@
 import { createContextStore } from '@/providers'
+import { asNodeId } from '@/stores/graph/graphDatabase'
 import { Ast } from '@/util/ast'
 import { computed, proxyRefs, type Ref } from 'vue'
 
@@ -6,7 +7,7 @@ export { injectFn as injectWidgetTree, provideFn as provideWidgetTree }
 const { provideFn, injectFn } = createContextStore(
   'Widget tree',
   (astRoot: Ref<Ast.Ast>, hasActiveAnimations: Ref<boolean>) => {
-    const nodeId = computed(() => astRoot.value.exprId)
+    const nodeId = computed(() => asNodeId(astRoot.value.id))
     const nodeSpanStart = computed(() => astRoot.value.span![0])
     return proxyRefs({ astRoot, nodeId, nodeSpanStart, hasActiveAnimations })
   },

--- a/app/gui2/src/stores/graph/__tests__/graphDatabase.test.ts
+++ b/app/gui2/src/stores/graph/__tests__/graphDatabase.test.ts
@@ -1,7 +1,8 @@
-import { GraphDb } from '@/stores/graph/graphDatabase'
+import { asNodeId, GraphDb } from '@/stores/graph/graphDatabase'
 import { Ast } from '@/util/ast'
+import type { AstId } from '@/util/ast/abstract'
 import assert from 'assert'
-import { IdMap, type ExprId } from 'shared/yjsModel'
+import { IdMap, type ExternalId } from 'shared/yjsModel'
 import { expect, test } from 'vitest'
 
 /**
@@ -9,9 +10,10 @@ import { expect, test } from 'vitest'
  * @param x sequential value, e.g. 15
  * @returns fake uuid, e.g. 00000000-0000-0000-0000-000000000015
  */
-function id(x: number): ExprId {
+function id(x: number): AstId & ExternalId {
   const xStr = `${x}`
-  return ('00000000-0000-0000-0000-000000000000'.slice(0, -xStr.length) + xStr) as ExprId
+  return ('00000000-0000-0000-0000-000000000000'.slice(0, -xStr.length) + xStr) as AstId &
+    ExternalId
 }
 
 test('Reading graph from definition', () => {
@@ -56,9 +58,9 @@ test('Reading graph from definition', () => {
   expect(db.getIdentDefiningNode('node1')).toBe(id(4))
   expect(db.getIdentDefiningNode('node2')).toBe(id(8))
   expect(db.getIdentDefiningNode('function')).toBeUndefined()
-  expect(db.getOutputPortIdentifier(db.getNodeFirstOutputPort(id(4)))).toBe('node1')
-  expect(db.getOutputPortIdentifier(db.getNodeFirstOutputPort(id(8)))).toBe('node2')
-  expect(db.getOutputPortIdentifier(db.getNodeFirstOutputPort(id(3)))).toBe('node1')
+  expect(db.getOutputPortIdentifier(db.getNodeFirstOutputPort(asNodeId(id(4))))).toBe('node1')
+  expect(db.getOutputPortIdentifier(db.getNodeFirstOutputPort(asNodeId(id(8))))).toBe('node2')
+  expect(db.getOutputPortIdentifier(db.getNodeFirstOutputPort(asNodeId(id(3))))).toBe('node1')
 
   // Commented the connection from input node, as we don't support them yet.
   expect(Array.from(db.connections.allForward(), ([key]) => key)).toEqual([id(3), id(7)])
@@ -66,7 +68,7 @@ test('Reading graph from definition', () => {
   expect(Array.from(db.connections.lookup(id(3)))).toEqual([id(9)])
   // expect(db.getOutputPortIdentifier(id(2))).toBe('a')
   expect(db.getOutputPortIdentifier(id(3))).toBe('node1')
-  expect(Array.from(db.dependantNodes(id(4)))).toEqual([id(8), id(12)])
-  expect(Array.from(db.dependantNodes(id(8)))).toEqual([id(12)])
-  expect(Array.from(db.dependantNodes(id(12)))).toEqual([])
+  expect(Array.from(db.dependantNodes(asNodeId(id(4))))).toEqual([id(8), id(12)])
+  expect(Array.from(db.dependantNodes(asNodeId(id(8))))).toEqual([id(12)])
+  expect(Array.from(db.dependantNodes(asNodeId(id(12))))).toEqual([])
 })

--- a/app/gui2/src/stores/graph/graphDatabase.ts
+++ b/app/gui2/src/stores/graph/graphDatabase.ts
@@ -23,6 +23,7 @@ import {
   type Uuid,
 } from 'shared/languageServerTypes'
 import {
+  isUuid,
   sourceRangeKey,
   visMetadataEquals,
   type ExternalId,
@@ -231,8 +232,9 @@ export class GraphDb {
     return this.getPatternExpressionNodeId(binding)
   }
 
-  getExpressionInfo(id: AstId): ExpressionInfo | undefined {
-    return this.valuesRegistry.getExpressionInfo(idToExternal(id))
+  getExpressionInfo(id: AstId | ExternalId): ExpressionInfo | undefined {
+    const externalId = isUuid(id) ? (id as ExternalId) : idToExternal(id)
+    return this.valuesRegistry.getExpressionInfo(externalId)
   }
 
   getOutputPortIdentifier(source: AstId): string | undefined {

--- a/app/gui2/src/stores/graph/graphDatabase.ts
+++ b/app/gui2/src/stores/graph/graphDatabase.ts
@@ -23,7 +23,7 @@ import {
   type Uuid,
 } from 'shared/languageServerTypes'
 import {
-  IdMap,
+  sourceRangeKey,
   visMetadataEquals,
   type ExternalId,
   type NodeMetadata,
@@ -110,9 +110,9 @@ export class BindingsDb {
     ast: RawAstExtended,
     analyzer: AliasAnalyzer,
   ): [MappedKeyMap<SourceRange, RawAstExtended>, Map<AstId, SourceRange>] {
-    const bindingRangeToTree = new MappedKeyMap<SourceRange, RawAstExtended>(IdMap.keyForRange)
+    const bindingRangeToTree = new MappedKeyMap<SourceRange, RawAstExtended>(sourceRangeKey)
     const bindingIdToRange = new Map<AstId, SourceRange>()
-    const bindingRanges = new MappedSet(IdMap.keyForRange)
+    const bindingRanges = new MappedSet(sourceRangeKey)
     for (const [binding, usages] of analyzer.aliases) {
       bindingRanges.add(binding)
       for (const usage of usages) bindingRanges.add(usage)

--- a/app/gui2/src/stores/graph/graphDatabase.ts
+++ b/app/gui2/src/stores/graph/graphDatabase.ts
@@ -3,6 +3,8 @@ import { SuggestionDb, groupColorStyle, type Group } from '@/stores/suggestionDa
 import type { SuggestionEntry } from '@/stores/suggestionDatabase/entry'
 import { bail } from '@/util/assert'
 import { Ast, RawAst, RawAstExtended } from '@/util/ast'
+import type { AstId } from '@/util/ast/abstract'
+import { asAstId } from '@/util/ast/abstract'
 import { AliasAnalyzer } from '@/util/ast/aliasAnalysis'
 import { nodeFromAst } from '@/util/ast/node'
 import { colorFromString } from '@/util/colors'
@@ -18,11 +20,12 @@ import {
   type ExpressionUpdate,
   type MethodCall,
   type StackItem,
+  type Uuid,
 } from 'shared/languageServerTypes'
 import {
   IdMap,
   visMetadataEquals,
-  type ExprId,
+  type ExternalId,
   type NodeMetadata,
   type SourceRange,
   type VisualizationMetadata,
@@ -31,11 +34,18 @@ import { ref, type Ref } from 'vue'
 
 export interface BindingInfo {
   identifier: string
-  usages: Set<ExprId>
+  usages: Set<AstId>
+}
+
+function idFromExternal(id: ExternalId): AstId {
+  return id as Uuid as AstId
+}
+function idToExternal(id: AstId): ExternalId {
+  return id as Uuid as ExternalId
 }
 
 export class BindingsDb {
-  bindings = new ReactiveDb<ExprId, BindingInfo>()
+  bindings = new ReactiveDb<AstId, BindingInfo>()
   identifierToBindingId = new ReactiveIndex(this.bindings, (id, info) => [[info.identifier, id]])
 
   readFunctionAst(ast: RawAstExtended<RawAst.Tree.Function>) {
@@ -57,15 +67,16 @@ export class BindingsDb {
     for (const [bindingRange, usagesRanges] of analyzer.aliases) {
       const aliasAst = bindingRangeToTree.get(bindingRange)
       if (aliasAst == null) continue
-      const info = this.bindings.get(aliasAst.astId)
+      const aliasAstId = idFromExternal(aliasAst.astId)
+      const info = this.bindings.get(aliasAstId)
       if (info == null) {
         function* usageIds() {
           for (const usageRange of usagesRanges) {
             const usageAst = bindingRangeToTree.get(usageRange)
-            if (usageAst != null) yield usageAst.astId
+            if (usageAst != null) yield idFromExternal(usageAst.astId)
           }
         }
-        this.bindings.set(aliasAst.astId, {
+        this.bindings.set(aliasAstId, {
           identifier: aliasAst.repr(),
           usages: new Set(usageIds()),
         })
@@ -80,7 +91,10 @@ export class BindingsDb {
         // Add or update usages.
         for (const usageRange of usagesRanges) {
           const usageAst = bindingRangeToTree.get(usageRange)
-          if (usageAst != null && !info.usages.has(usageAst.astId)) info.usages.add(usageAst.astId)
+          if (usageAst != null) {
+            const usageAstId = idFromExternal(usageAst.astId)
+            if (!info.usages.has(usageAstId)) info.usages.add(usageAstId)
+          }
         }
       }
     }
@@ -95,9 +109,9 @@ export class BindingsDb {
   private static rangeMappings(
     ast: RawAstExtended,
     analyzer: AliasAnalyzer,
-  ): [MappedKeyMap<SourceRange, RawAstExtended>, Map<ExprId, SourceRange>] {
+  ): [MappedKeyMap<SourceRange, RawAstExtended>, Map<AstId, SourceRange>] {
     const bindingRangeToTree = new MappedKeyMap<SourceRange, RawAstExtended>(IdMap.keyForRange)
-    const bindingIdToRange = new Map<ExprId, SourceRange>()
+    const bindingIdToRange = new Map<AstId, SourceRange>()
     const bindingRanges = new MappedSet(IdMap.keyForRange)
     for (const [binding, usages] of analyzer.aliases) {
       bindingRanges.add(binding)
@@ -106,7 +120,7 @@ export class BindingsDb {
     ast.visitRecursive((ast) => {
       if (bindingRanges.has(ast.span())) {
         bindingRangeToTree.set(ast.span(), ast)
-        bindingIdToRange.set(ast.astId, ast.span())
+        bindingIdToRange.set(idFromExternal(ast.astId), ast.span())
         return false
       }
       return true
@@ -116,7 +130,7 @@ export class BindingsDb {
 }
 
 export class GraphDb {
-  nodeIdToNode = new ReactiveDb<ExprId, Node>()
+  nodeIdToNode = new ReactiveDb<NodeId, Node>()
   private bindings = new BindingsDb()
 
   constructor(
@@ -127,14 +141,14 @@ export class GraphDb {
 
   private nodeIdToPatternExprIds = new ReactiveIndex(this.nodeIdToNode, (id, entry) => {
     if (entry.pattern == null) return []
-    const exprs = new Set<ExprId>()
-    entry.pattern.visitRecursive((astOrToken) => exprs.add(astOrToken.exprId))
+    const exprs = new Set<AstId>()
+    entry.pattern.visitRecursive((astOrToken) => exprs.add(asAstId(astOrToken.id)))
     return Array.from(exprs, (expr) => [id, expr])
   })
 
   private nodeIdToExprIds = new ReactiveIndex(this.nodeIdToNode, (id, entry) => {
-    const exprs = new Set<ExprId>()
-    entry.rootSpan.visitRecursive((astOrToken) => exprs.add(astOrToken.exprId))
+    const exprs = new Set<AstId>()
+    entry.rootSpan.visitRecursive((astOrToken) => exprs.add(asAstId(astOrToken.id)))
     return Array.from(exprs, (expr) => [id, expr])
   })
 
@@ -156,9 +170,9 @@ export class GraphDb {
 
   private *connectionsFromBindings(
     info: BindingInfo,
-    alias: ExprId,
-    srcNode: ExprId | undefined,
-  ): Generator<[ExprId, ExprId]> {
+    alias: AstId,
+    srcNode: AstId | undefined,
+  ): Generator<[AstId, AstId]> {
     for (const usage of info.usages) {
       const targetNode = this.getExpressionNodeId(usage)
       // Display only connections to existing targets and different than source node.
@@ -170,10 +184,10 @@ export class GraphDb {
   /** Output port bindings of the node. Lists all bindings that can be dragged out from a node. */
   nodeOutputPorts = new ReactiveIndex(this.nodeIdToNode, (id, entry) => {
     if (entry.pattern == null) return []
-    const ports = new Set<ExprId>()
+    const ports = new Set<AstId>()
     entry.pattern.visitRecursive((ast) => {
-      if (this.bindings.bindings.has(ast.exprId)) {
-        ports.add(ast.exprId)
+      if (this.bindings.bindings.has(asAstId(ast.id))) {
+        ports.add(asAstId(ast.id))
         return false
       }
       return true
@@ -200,28 +214,28 @@ export class GraphDb {
     return groupColorStyle(group)
   })
 
-  getNodeFirstOutputPort(id: ExprId): ExprId {
+  getNodeFirstOutputPort(id: NodeId): AstId {
     return set.first(this.nodeOutputPorts.lookup(id)) ?? id
   }
 
-  getExpressionNodeId(exprId: ExprId | undefined): ExprId | undefined {
+  getExpressionNodeId(exprId: AstId | undefined): NodeId | undefined {
     return exprId && set.first(this.nodeIdToExprIds.reverseLookup(exprId))
   }
 
-  getPatternExpressionNodeId(exprId: ExprId | undefined): ExprId | undefined {
+  getPatternExpressionNodeId(exprId: AstId | undefined): NodeId | undefined {
     return exprId && set.first(this.nodeIdToPatternExprIds.reverseLookup(exprId))
   }
 
-  getIdentDefiningNode(ident: string): ExprId | undefined {
+  getIdentDefiningNode(ident: string): NodeId | undefined {
     const binding = set.first(this.bindings.identifierToBindingId.lookup(ident))
     return this.getPatternExpressionNodeId(binding)
   }
 
-  getExpressionInfo(id: ExprId): ExpressionInfo | undefined {
-    return this.valuesRegistry.getExpressionInfo(id)
+  getExpressionInfo(id: AstId): ExpressionInfo | undefined {
+    return this.valuesRegistry.getExpressionInfo(idToExternal(id))
   }
 
-  getOutputPortIdentifier(source: ExprId): string | undefined {
+  getOutputPortIdentifier(source: AstId): string | undefined {
     return this.bindings.bindings.get(source)?.identifier
   }
 
@@ -233,11 +247,11 @@ export class GraphDb {
     return this.bindings.identifierToBindingId.hasKey(ident)
   }
 
-  isKnownFunctionCall(id: ExprId): boolean {
+  isKnownFunctionCall(id: AstId): boolean {
     return this.getMethodCallInfo(id) != null
   }
 
-  getMethodCall(id: ExprId): MethodCall | undefined {
+  getMethodCall(id: AstId): MethodCall | undefined {
     const info = this.getExpressionInfo(id)
     if (info == null) return
     return (
@@ -248,11 +262,11 @@ export class GraphDb {
   /**
    * Get a list of all nodes that depend on given node. Includes transitive dependencies.
    */
-  dependantNodes(id: ExprId): Set<ExprId> {
+  dependantNodes(id: NodeId): Set<NodeId> {
     const toVisit = [id]
-    const result = new Set<ExprId>()
+    const result = new Set<NodeId>()
 
-    let currentNode: ExprId | undefined
+    let currentNode: NodeId | undefined
     while ((currentNode = toVisit.pop())) {
       const outputPorts = this.nodeOutputPorts.lookup(currentNode)
       for (const outputPort of outputPorts) {
@@ -272,7 +286,7 @@ export class GraphDb {
   }
 
   getMethodCallInfo(
-    id: ExprId,
+    id: AstId,
   ):
     | { methodCall: MethodCall; suggestion: SuggestionEntry; partiallyApplied: boolean }
     | undefined {
@@ -290,11 +304,11 @@ export class GraphDb {
     return { methodCall, suggestion, partiallyApplied }
   }
 
-  getNodeColorStyle(id: ExprId): string {
+  getNodeColorStyle(id: NodeId): string {
     return this.nodeColor.lookup(id) ?? 'var(--node-color-no-type)'
   }
 
-  moveNodeToTop(id: ExprId) {
+  moveNodeToTop(id: NodeId) {
     this.nodeIdToNode.moveToLast(id)
   }
 
@@ -306,17 +320,17 @@ export class GraphDb {
       }
       case 'LocalCall': {
         const exprId = item.expressionId
-        const info = this.getExpressionInfo(exprId)
+        const info = this.valuesRegistry.getExpressionInfo(exprId)
         return info?.methodCall?.methodPointer.name
       }
     }
   }
 
-  readFunctionAst(functionAst_: Ast.Function, getMeta: (id: ExprId) => NodeMetadata | undefined) {
-    const currentNodeIds = new Set<ExprId>()
+  readFunctionAst(functionAst_: Ast.Function, getMeta: (id: AstId) => NodeMetadata | undefined) {
+    const currentNodeIds = new Set<NodeId>()
     for (const nodeAst of functionAst_.bodyExpressions()) {
       const newNode = nodeFromAst(nodeAst)
-      const nodeId = newNode.rootSpan.exprId
+      const nodeId = asNodeId(newNode.rootSpan.id)
       const node = this.nodeIdToNode.get(nodeId)
       const nodeMeta = getMeta(nodeId)
       currentNodeIds.add(nodeId)
@@ -384,8 +398,8 @@ export class GraphDb {
       position: Vec2.Zero,
       vis: undefined,
     }
-    const bindingId = pattern.exprId
-    this.nodeIdToNode.set(id, node)
+    const bindingId = pattern.id
+    this.nodeIdToNode.set(asNodeId(id), node)
     this.bindings.bindings.set(bindingId, { identifier: binding, usages: new Set() })
     return node
   }
@@ -394,7 +408,7 @@ export class GraphDb {
     const nodeId = this.getIdentDefiningNode(binding)
     if (nodeId == null) bail(`The node with identifier '${binding}' was not found.`)
     const update_: ExpressionUpdate = {
-      expressionId: nodeId,
+      expressionId: idToExternal(nodeId),
       profilingInfo: update.profilingInfo ?? [],
       fromCache: update.fromCache ?? false,
       payload: update.payload ?? { type: 'Value' },
@@ -403,6 +417,12 @@ export class GraphDb {
     }
     this.valuesRegistry.processUpdates([update_])
   }
+}
+
+declare const brandNodeId: unique symbol
+export type NodeId = AstId & { [brandNodeId]: never }
+export function asNodeId(id: Ast.AstId): NodeId {
+  return id as NodeId
 }
 
 export interface Node {

--- a/app/gui2/src/stores/graph/graphDatabase.ts
+++ b/app/gui2/src/stores/graph/graphDatabase.ts
@@ -388,9 +388,24 @@ export class GraphDb {
     }
   }
 
+  /** Get the ID of the `Ast` corresponding to the given `ExternalId` as of the last synchronization. */
   idFromExternal(id: ExternalId): AstId {
     return id as Uuid as AstId
   }
+  /** Get the external ID corresponding to the given `AstId` as of the last synchronization.
+   *
+   *  Note that if there is an edit in progress (i.e. a `MutableModule` containing changes that haven't been committed
+   *  and observed), this may be different from the value return by calling `toExternal` on the edited `Ast` object.
+   *
+   *  When performing an edit and obtaining an ID to be sent to the engine, always use `Ast.toExternal`, which gives the
+   *  ID the node will have once it is committed.
+   *
+   *  When looking up a node in data previously obtained from the engine, the choice depends on the situation:
+   *  - If the data being looked up should be inherited from the previous holder of the `ExternalId`, use the current
+   *    `toExternal`.
+   *  - If the data should be associated with the `Ast` that the engine was referring to, use `idToExternal`.
+   *  Either choice is an approximation that will be used until the engine provides an update after processing the edit.
+   */
   idToExternal(id: AstId): ExternalId {
     return id as Uuid as ExternalId
   }

--- a/app/gui2/src/stores/graph/imports.ts
+++ b/app/gui2/src/stores/graph/imports.ts
@@ -177,7 +177,7 @@ function newImportsLocation(module: Ast.Module, scope: Ast.BodyBlock): number {
 }
 
 /** Create an AST representing the required import statement. */
-function requiredImportToAst(value: RequiredImport, module?: MutableModule): Ast.Import {
+function requiredImportToAst(value: RequiredImport, module?: MutableModule): Ast.Owned<Ast.Import> {
   const module_ = module ?? MutableModule.Transient()
   switch (value.kind) {
     case 'Qualified':

--- a/app/gui2/src/stores/graph/index.ts
+++ b/app/gui2/src/stores/graph/index.ts
@@ -296,7 +296,7 @@ export const useGraphStore = defineStore('graph', () => {
   }
 
   function setNodePosition(nodeId: NodeId, position: Vec2) {
-    proj.module?.updateNodeMetadata(idToExternal(nodeId), { x: position.x, y: -position.y })
+    proj.module?.updateNodeMetadata(db.idToExternal(nodeId), { x: position.x, y: -position.y })
   }
 
   function normalizeVisMetadata(
@@ -311,7 +311,7 @@ export const useGraphStore = defineStore('graph', () => {
   function setNodeVisualizationId(nodeId: NodeId, vis: Opt<VisualizationIdentifier>) {
     const node = db.nodeIdToNode.get(nodeId)
     if (!node) return
-    proj.module?.updateNodeMetadata(idToExternal(nodeId), {
+    proj.module?.updateNodeMetadata(db.idToExternal(nodeId), {
       vis: normalizeVisMetadata(vis, node.vis?.visible),
     })
   }
@@ -319,7 +319,7 @@ export const useGraphStore = defineStore('graph', () => {
   function setNodeVisualizationVisible(nodeId: NodeId, visible: boolean) {
     const node = db.nodeIdToNode.get(nodeId)
     if (!node) return
-    proj.module?.updateNodeMetadata(idToExternal(nodeId), {
+    proj.module?.updateNodeMetadata(db.idToExternal(nodeId), {
       vis: normalizeVisMetadata(node.vis?.identifier, visible),
     })
   }
@@ -436,7 +436,7 @@ export const useGraphStore = defineStore('graph', () => {
       module_.doc.setCode(printed.code)
       if (metadataUpdates) {
         for (const [id, meta] of metadataUpdates) {
-          module_.updateNodeMetadata(idToExternal(id), meta)
+          module_.updateNodeMetadata(db.idToExternal(id), meta)
         }
       }
     })
@@ -511,13 +511,6 @@ export const useGraphStore = defineStore('graph', () => {
     }
   }
 
-  function idFromExternal(id: ExternalId): AstId {
-    return id as Uuid as AstId
-  }
-  function idToExternal(id: AstId): ExternalId {
-    return id as Uuid as ExternalId
-  }
-
   return {
     transact,
     db: markRaw(db),
@@ -559,8 +552,6 @@ export const useGraphStore = defineStore('graph', () => {
     commitEdit,
     editScope,
     addMissingImports,
-    idFromExternal,
-    idToExternal,
   }
 })
 

--- a/app/gui2/src/stores/graph/index.ts
+++ b/app/gui2/src/stores/graph/index.ts
@@ -478,7 +478,7 @@ export const useGraphStore = defineStore('graph', () => {
     assert(targetExpr != null)
     assert(body instanceof Ast.BodyBlock, 'Current function body must be a BodyBlock')
 
-    const lines = body.lines()
+    const lines = body.takeLines(edit)
     const sourceIdx = lines.findIndex((line) => line.expression?.node.exprId === sourceExpr)
     const targetIdx = lines.findIndex((line) => line.expression?.node.exprId === targetExpr)
 

--- a/app/gui2/src/stores/graph/index.ts
+++ b/app/gui2/src/stores/graph/index.ts
@@ -282,12 +282,8 @@ export const useGraphStore = defineStore('graph', () => {
   function setNodeContent(id: NodeId, content: string) {
     const node = db.nodeIdToNode.get(id)
     if (!node) return
-    setExpression(node.rootSpan.id, Ast.RawCode.new(content))
-  }
-
-  function setExpression(id: Ast.AstId, content: Ast.Owned) {
     const edit = astModule.edit()
-    edit.replaceValue(id, content)
+    edit.replaceValue(node.rootSpan.id, Ast.parse(content, edit))
     commitEdit(edit)
   }
 

--- a/app/gui2/src/stores/graph/index.ts
+++ b/app/gui2/src/stores/graph/index.ts
@@ -586,7 +586,7 @@ function getExecutedMethodAst(
     }
     case 'LocalCall': {
       const exprId = executionStackTop.expressionId
-      const info = db.getExpressionInfo(exprId as Uuid as AstId)
+      const info = db.getExpressionInfo(exprId)
       if (!info) return undefined
       const ptr = info.methodCall?.methodPointer
       if (!ptr) return undefined

--- a/app/gui2/src/stores/graph/index.ts
+++ b/app/gui2/src/stores/graph/index.ts
@@ -13,7 +13,7 @@ import { useProjectStore } from '@/stores/project'
 import { useSuggestionDbStore } from '@/stores/suggestionDatabase'
 import { assert } from '@/util/assert'
 import { Ast } from '@/util/ast'
-import type { AstId, Module, Owned } from '@/util/ast/abstract'
+import type { AstId, Module } from '@/util/ast/abstract'
 import { MutableModule } from '@/util/ast/abstract'
 import { useObserveYjs } from '@/util/crdt'
 import { partition } from '@/util/data/array'
@@ -285,7 +285,7 @@ export const useGraphStore = defineStore('graph', () => {
     setExpression(node.rootSpan.id, Ast.RawCode.new(content))
   }
 
-  function setExpression(id: Ast.AstId, content: Ast.Owned<Ast.Ast>) {
+  function setExpression(id: Ast.AstId, content: Ast.Owned) {
     const edit = astModule.edit()
     edit.replaceValue(id, content)
     commitEdit(edit)
@@ -404,11 +404,7 @@ export const useGraphStore = defineStore('graph', () => {
    * NOTE: If this returns `true,` The update handlers called `graph.commitEdit` on their own.
    * Therefore the passed in `edit` should not be modified afterwards, as it is already committed.
    */
-  function updatePortValue(
-    edit: MutableModule,
-    id: PortId,
-    value: Owned<Ast.Ast> | undefined,
-  ): boolean {
+  function updatePortValue(edit: MutableModule, id: PortId, value: Ast.Owned | undefined): boolean {
     const update = getPortPrimaryInstance(id)?.onUpdate
     if (!update) return false
     update({ edit, portUpdate: { value, origin: id } })

--- a/app/gui2/src/stores/graph/index.ts
+++ b/app/gui2/src/stores/graph/index.ts
@@ -1,7 +1,7 @@
 import { nonDictatedPlacement } from '@/components/ComponentBrowser/placement'
 import type { PortId } from '@/providers/portInfo'
 import type { WidgetUpdate } from '@/providers/widgetRegistry'
-import { GraphDb } from '@/stores/graph/graphDatabase'
+import { GraphDb, type NodeId } from '@/stores/graph/graphDatabase'
 import {
   addImports,
   filterOutRedundantImports,
@@ -22,11 +22,11 @@ import { Rect } from '@/util/data/rect'
 import { Vec2 } from '@/util/data/vec2'
 import { map, set } from 'lib0'
 import { defineStore } from 'pinia'
-import type { ExpressionUpdate, StackItem } from 'shared/languageServerTypes'
+import type { ExpressionUpdate, StackItem, Uuid } from 'shared/languageServerTypes'
 import {
   IdMap,
   visMetadataEquals,
-  type ExprId,
+  type ExternalId,
   type NodeMetadata,
   type SourceRange,
   type VisualizationIdentifier,
@@ -34,17 +34,17 @@ import {
 } from 'shared/yjsModel'
 import { computed, markRaw, reactive, ref, toRef, watch, type Ref, type ShallowRef } from 'vue'
 
-export { type Node } from '@/stores/graph/graphDatabase'
+export { type Node, type NodeId } from '@/stores/graph/graphDatabase'
 
 export interface NodeEditInfo {
-  id: ExprId
+  id: NodeId
   initialCursorPos: number
 }
 
 export class PortViewInstance {
   constructor(
     public rect: ShallowRef<Rect | undefined>,
-    public nodeId: ExprId,
+    public nodeId: NodeId,
     public onUpdate: (update: WidgetUpdate) => void,
   ) {}
 }
@@ -65,8 +65,8 @@ export const useGraphStore = defineStore('graph', () => {
   const astModule: Module = MutableModule.Observable()
   const moduleRoot = ref<AstId>()
   let moduleDirty = false
-  const nodeRects = reactive(new Map<ExprId, Rect>())
-  const vizRects = reactive(new Map<ExprId, Rect>())
+  const nodeRects = reactive(new Map<NodeId, Rect>())
+  const vizRects = reactive(new Map<NodeId, Rect>())
 
   const topLevel = computed(() => {
     // The top level of the module is always a block.
@@ -97,7 +97,7 @@ export const useGraphStore = defineStore('graph', () => {
   const editedNodeInfo = ref<NodeEditInfo>()
   const imports = ref<{ import: Import; span: SourceRange }[]>([])
   const methodAst = ref<Ast.Function>()
-  const currentNodeIds = ref(new Set<ExprId>())
+  const currentNodeIds = ref(new Set<NodeId>())
 
   const unconnectedEdge = ref<UnconnectedEdge>()
 
@@ -123,7 +123,7 @@ export const useGraphStore = defineStore('graph', () => {
 
       const newRoot = Ast.parseTransitional(textContentLocal, idMap_)
       astModule.replace(newRoot.module)
-      moduleRoot.value = newRoot.exprId
+      moduleRoot.value = newRoot.id
       module.doc.setIdMap(idMap_)
 
       imports.value = []
@@ -154,7 +154,7 @@ export const useGraphStore = defineStore('graph', () => {
     for (const [id, op] of event.changes.keys) {
       if (op.action === 'update' || op.action === 'add') {
         const data = meta.get(id)
-        const node = db.nodeIdToNode.get(id as ExprId)
+        const node = db.nodeIdToNode.get(id as NodeId)
         if (data && node) db.assignUpdatedMetadata(node, data)
       }
     }
@@ -185,7 +185,7 @@ export const useGraphStore = defineStore('graph', () => {
     return edges
   })
 
-  function createEdgeFromOutput(source: ExprId) {
+  function createEdgeFromOutput(source: Ast.AstId) {
     unconnectedEdge.value = { source }
   }
 
@@ -208,7 +208,7 @@ export const useGraphStore = defineStore('graph', () => {
     expression: string,
     metadata: NodeMetadata | undefined = undefined,
     withImports: RequiredImport[] | undefined = undefined,
-  ): Opt<ExprId> {
+  ): Opt<NodeId> {
     const mod = proj.module
     if (!mod) return
     const meta = metadata ?? {
@@ -233,14 +233,14 @@ export const useGraphStore = defineStore('graph', () => {
     if (method.body instanceof Ast.BodyBlock) {
       functionBlock = method.body
     } else if (method.body != null) {
-      functionBlock = edit.takeAndReplaceRef(method.body.exprId, (node) => {
+      functionBlock = edit.takeAndReplaceRef(method.body.id, (node) => {
         return Ast.BodyBlock.new([{ expression: { node } }], edit)
       })
     } else {
-      const newMethod: Ast.Function = edit.takeAndReplaceValue(method.exprId, (func) => {
+      const newMethod: Ast.Function = edit.takeAndReplaceValue(method.id, (func) => {
         assert(func instanceof Ast.Function)
         assert(func.name != null)
-        const name = edit.take(func.name.exprId)?.node
+        const name = edit.take(func.name.id)?.node
         assert(name != null)
         const body = Ast.BodyBlock.new([], edit)
         return Ast.Function.new(edit, name, func.argNodes(), body)
@@ -252,7 +252,7 @@ export const useGraphStore = defineStore('graph', () => {
     const rhs = Ast.parse(expression, edit)
     const assignment = Ast.Assignment.new(edit, ident, rhs)
     functionBlock.push(edit, assignment)
-    commitEdit(edit, new Map([[rhs.exprId, meta]]))
+    commitEdit(edit, new Map([[rhs.id, meta]]))
   }
 
   function addMissingImports(edit: MutableModule, newImports: RequiredImport[]) {
@@ -267,7 +267,7 @@ export const useGraphStore = defineStore('graph', () => {
     addImports(edit, topLevel_, importsToAdd)
   }
 
-  function deleteNodes(ids: ExprId[]) {
+  function deleteNodes(ids: NodeId[]) {
     const edit = astModule.edit()
     for (const id of ids) {
       const node = db.nodeIdToNode.get(id)
@@ -279,20 +279,16 @@ export const useGraphStore = defineStore('graph', () => {
     commitEdit(edit)
   }
 
-  function setNodeContent(id: ExprId, content: string) {
+  function setNodeContent(id: NodeId, content: string) {
     const node = db.nodeIdToNode.get(id)
     if (!node) return
-    setExpressionContent(node.rootSpan.exprId, content)
+    setExpression(node.rootSpan.id, Ast.RawCode.new(content))
   }
 
-  function setExpression(id: ExprId, content: Ast.Owned<Ast.Ast>) {
+  function setExpression(id: Ast.AstId, content: Ast.Owned<Ast.Ast>) {
     const edit = astModule.edit()
-    edit.replaceValue(Ast.asNodeId(id), content)
+    edit.replaceValue(id, content)
     commitEdit(edit)
-  }
-
-  function setExpressionContent(id: ExprId, content: string) {
-    setExpression(id, Ast.RawCode.new(content))
   }
 
   function transact(fn: () => void) {
@@ -303,8 +299,8 @@ export const useGraphStore = defineStore('graph', () => {
     proj.stopCapturingUndo()
   }
 
-  function setNodePosition(nodeId: ExprId, position: Vec2) {
-    proj.module?.updateNodeMetadata(nodeId, { x: position.x, y: -position.y })
+  function setNodePosition(nodeId: NodeId, position: Vec2) {
+    proj.module?.updateNodeMetadata(idToExternal(nodeId), { x: position.x, y: -position.y })
   }
 
   function normalizeVisMetadata(
@@ -316,21 +312,23 @@ export const useGraphStore = defineStore('graph', () => {
     else return vis
   }
 
-  function setNodeVisualizationId(nodeId: ExprId, vis: Opt<VisualizationIdentifier>) {
+  function setNodeVisualizationId(nodeId: NodeId, vis: Opt<VisualizationIdentifier>) {
     const node = db.nodeIdToNode.get(nodeId)
     if (!node) return
-    proj.module?.updateNodeMetadata(nodeId, { vis: normalizeVisMetadata(vis, node.vis?.visible) })
+    proj.module?.updateNodeMetadata(idToExternal(nodeId), {
+      vis: normalizeVisMetadata(vis, node.vis?.visible),
+    })
   }
 
-  function setNodeVisualizationVisible(nodeId: ExprId, visible: boolean) {
+  function setNodeVisualizationVisible(nodeId: NodeId, visible: boolean) {
     const node = db.nodeIdToNode.get(nodeId)
     if (!node) return
-    proj.module?.updateNodeMetadata(nodeId, {
+    proj.module?.updateNodeMetadata(idToExternal(nodeId), {
       vis: normalizeVisMetadata(node.vis?.identifier, visible),
     })
   }
 
-  function updateNodeRect(nodeId: ExprId, rect: Rect) {
+  function updateNodeRect(nodeId: NodeId, rect: Rect) {
     if (rect.pos.equals(Vec2.Zero) && !metadata.value?.has(nodeId)) {
       const { position } = nonDictatedPlacement(rect.size, {
         nodeRects: [...nodeRects.entries()]
@@ -349,12 +347,12 @@ export const useGraphStore = defineStore('graph', () => {
     }
   }
 
-  function updateVizRect(id: ExprId, rect: Rect | undefined) {
+  function updateVizRect(id: NodeId, rect: Rect | undefined) {
     if (rect) vizRects.set(id, rect)
     else vizRects.delete(id)
   }
 
-  function unregisterNodeRect(id: ExprId) {
+  function unregisterNodeRect(id: NodeId) {
     nodeRects.delete(id)
     vizRects.delete(id)
   }
@@ -370,7 +368,7 @@ export const useGraphStore = defineStore('graph', () => {
     if (instances.size === 0) portInstances.delete(id)
   }
 
-  function setEditedNode(id: ExprId | null, cursorPosition: number | null) {
+  function setEditedNode(id: NodeId | null, cursorPosition: number | null) {
     if (!id) {
       editedNodeInfo.value = undefined
       return
@@ -395,8 +393,8 @@ export const useGraphStore = defineStore('graph', () => {
     return getPortPrimaryInstance(id)?.rect.value
   }
 
-  function getPortNodeId(id: PortId): ExprId | undefined {
-    return getPortPrimaryInstance(id)?.nodeId ?? db.getExpressionNodeId(id as string as ExprId)
+  function getPortNodeId(id: PortId): NodeId | undefined {
+    return getPortPrimaryInstance(id)?.nodeId ?? db.getExpressionNodeId(id as string as Ast.AstId)
   }
 
   /**
@@ -435,18 +433,18 @@ export const useGraphStore = defineStore('graph', () => {
     const idMap = new IdMap()
     for (const [tokenKey, id] of printed.info.tokens) {
       const range = Ast.keyToRange(tokenKey)
-      idMap.insertKnownId([range.start, range.end], id)
+      idMap.insertKnownId([range.start, range.end], id as Uuid as ExternalId)
     }
     for (const [nodeKey, ids] of printed.info.nodes) {
       const range = Ast.keyToRange(nodeKey)
-      idMap.insertKnownId([range.start, range.end], ids[0]!)
+      idMap.insertKnownId([range.start, range.end], ids[0]! as Uuid as ExternalId)
     }
     module_.transact(() => {
       module_.doc.setIdMap(idMap)
       module_.doc.setCode(printed.code)
       if (metadataUpdates) {
         for (const [id, meta] of metadataUpdates) {
-          module_.updateNodeMetadata(id, meta)
+          module_.updateNodeMetadata(idToExternal(id), meta)
         }
       }
     })
@@ -469,7 +467,7 @@ export const useGraphStore = defineStore('graph', () => {
    * Additionally all nodes dependent on the `targetNodeId` that end up being before its new line
    * are also moved after it, keeping their relative order.
    */
-  function ensureCorrectNodeOrder(edit: MutableModule, sourceNodeId: ExprId, targetNodeId: ExprId) {
+  function ensureCorrectNodeOrder(edit: MutableModule, sourceNodeId: NodeId, targetNodeId: NodeId) {
     const sourceExpr = db.nodeIdToNode.get(sourceNodeId)?.outerExprId
     const targetExpr = db.nodeIdToNode.get(targetNodeId)?.outerExprId
     const body = methodAstInModule(edit)?.body
@@ -479,8 +477,8 @@ export const useGraphStore = defineStore('graph', () => {
     assert(body instanceof Ast.BodyBlock, 'Current function body must be a BodyBlock')
 
     const lines = body.takeLines(edit)
-    const sourceIdx = lines.findIndex((line) => line.expression?.node.exprId === sourceExpr)
-    const targetIdx = lines.findIndex((line) => line.expression?.node.exprId === targetExpr)
+    const sourceIdx = lines.findIndex((line) => line.expression?.node.id === sourceExpr)
+    const targetIdx = lines.findIndex((line) => line.expression?.node.id === targetExpr)
 
     assert(sourceIdx != null)
     assert(targetIdx != null)
@@ -505,20 +503,27 @@ export const useGraphStore = defineStore('graph', () => {
 
       // Split those lines into two buckets, whether or not they depend on the target.
       const [linesAfter, linesBefore] = partition(linesToSort, (line) =>
-        dependantLines.has(line.expression?.node.exprId),
+        dependantLines.has(line.expression?.node.id),
       )
 
       // Recombine all lines after splitting, keeping existing dependants below the target.
       lines.splice(targetIdx, 0, ...linesBefore, ...linesAfter)
 
       // Finally apply the reordered lines into the body block as AST edit.
-      const ownedBody = edit.take(body.exprId)
+      const ownedBody = edit.take(body.id)
       assert(ownedBody != null)
-      edit.replaceValue(ownedBody.placeholder.exprId, Ast.BodyBlock.new(lines, edit))
+      edit.replaceValue(ownedBody.placeholder.id, Ast.BodyBlock.new(lines, edit))
       return true
     } else {
       return false
     }
+  }
+
+  function idFromExternal(id: ExternalId): AstId {
+    return id as Uuid as AstId
+  }
+  function idToExternal(id: AstId): ExternalId {
+    return id as Uuid as ExternalId
   }
 
   return {
@@ -545,7 +550,6 @@ export const useGraphStore = defineStore('graph', () => {
     deleteNodes,
     ensureCorrectNodeOrder,
     setNodeContent,
-    setExpressionContent,
     setNodePosition,
     setNodeVisualizationId,
     setNodeVisualizationVisible,
@@ -563,6 +567,8 @@ export const useGraphStore = defineStore('graph', () => {
     commitEdit,
     editScope,
     addMissingImports,
+    idFromExternal,
+    idToExternal,
   }
 })
 
@@ -572,12 +578,12 @@ function randomIdent() {
 
 /** An edge, which may be connected or unconnected. */
 export type Edge = {
-  source: ExprId | undefined
+  source: AstId | undefined
   target: PortId | undefined
 }
 
 export type UnconnectedEdge = {
-  source?: ExprId
+  source?: AstId
   target?: PortId
   /** If this edge represents an in-progress edit of a connected edge, it is identified by its target expression. */
   disconnectedEdgeTarget?: PortId
@@ -597,7 +603,7 @@ function getExecutedMethodAst(
     }
     case 'LocalCall': {
       const exprId = executionStackTop.expressionId
-      const info = db.getExpressionInfo(exprId)
+      const info = db.getExpressionInfo(exprId as Uuid as AstId)
       if (!info) return undefined
       const ptr = info.methodCall?.methodPointer
       if (!ptr) return undefined

--- a/app/gui2/src/stores/project/index.ts
+++ b/app/gui2/src/stores/project/index.ts
@@ -35,7 +35,7 @@ import type {
   StackItem,
   VisualizationConfiguration,
 } from 'shared/languageServerTypes'
-import { DistributedProject, type ExprId, type Uuid } from 'shared/yjsModel'
+import { DistributedProject, type ExternalId, type Uuid } from 'shared/yjsModel'
 import {
   computed,
   markRaw,
@@ -107,7 +107,7 @@ export type NodeVisualizationConfiguration = Omit<
   VisualizationConfiguration,
   'executionContextId'
 > & {
-  expressionId: ExprId
+  expressionId: ExternalId
 }
 
 interface ExecutionContextState {
@@ -399,7 +399,10 @@ export class ExecutionContext extends ObservableV2<ExecutionContextNotification>
     })
   }
 
-  recompute(expressionIds: 'all' | ExprId[] = 'all', executionEnvironment?: ExecutionEnvironment) {
+  recompute(
+    expressionIds: 'all' | ExternalId[] = 'all',
+    executionEnvironment?: ExecutionEnvironment,
+  ) {
     this.queue.pushTask(async (state) => {
       if (!state.created) return state
       await state.lsRpc.recomputeExecutionContext(this.id, expressionIds, executionEnvironment)
@@ -637,7 +640,7 @@ export const useProjectStore = defineStore('project', () => {
   }
 
   function executeExpression(
-    expressionId: ExprId,
+    expressionId: ExternalId,
     expression: string,
   ): Promise<Result<string> | null> {
     return new Promise((resolve) => {

--- a/app/gui2/src/stores/visualization/index.ts
+++ b/app/gui2/src/stores/visualization/index.ts
@@ -7,6 +7,7 @@ import * as scatterplotVisualization from '@/components/visualizations/Scatterpl
 import * as sqlVisualization from '@/components/visualizations/SQLVisualization.vue'
 import * as tableVisualization from '@/components/visualizations/TableVisualization.vue'
 import * as warningsVisualization from '@/components/visualizations/WarningsVisualization.vue'
+import type { NodeId } from '@/stores/graph'
 import { useProjectStore } from '@/stores/project'
 import {
   compile,
@@ -21,6 +22,7 @@ import {
   type VisualizationId,
 } from '@/stores/visualization/metadata'
 import type { VisualizationModule } from '@/stores/visualization/runtimeTypes'
+import type { AstId } from '@/util/ast/abstract'
 import type { Opt } from '@/util/data/opt'
 import { isUrlString } from '@/util/data/urlString'
 import { isIconName } from '@/util/iconName'
@@ -28,7 +30,7 @@ import { rpcWithRetries } from '@/util/net'
 import { defineStore } from 'pinia'
 import { ErrorCode, LsRpcError, RemoteRpcError } from 'shared/languageServer'
 import type { Event as LSEvent, VisualizationConfiguration } from 'shared/languageServerTypes'
-import type { ExprId, VisualizationIdentifier } from 'shared/yjsModel'
+import type { VisualizationIdentifier } from 'shared/yjsModel'
 import { computed, reactive } from 'vue'
 
 /** The directory in the project under which custom visualizations can be found. */
@@ -55,12 +57,12 @@ export const DEFAULT_VISUALIZATION_IDENTIFIER: VisualizationIdentifier = {
 export type VisualizationDataSource =
   | {
       type: 'node'
-      nodeId: ExprId
+      nodeId: NodeId
     }
   | {
       type: 'expression'
       expression: string
-      contextId: ExprId
+      contextId: AstId
     }
 
 const builtinVisualizations: VisualizationModule[] = [

--- a/app/gui2/src/stores/visualization/index.ts
+++ b/app/gui2/src/stores/visualization/index.ts
@@ -7,7 +7,6 @@ import * as scatterplotVisualization from '@/components/visualizations/Scatterpl
 import * as sqlVisualization from '@/components/visualizations/SQLVisualization.vue'
 import * as tableVisualization from '@/components/visualizations/TableVisualization.vue'
 import * as warningsVisualization from '@/components/visualizations/WarningsVisualization.vue'
-import type { NodeId } from '@/stores/graph'
 import { useProjectStore } from '@/stores/project'
 import {
   compile,
@@ -22,7 +21,6 @@ import {
   type VisualizationId,
 } from '@/stores/visualization/metadata'
 import type { VisualizationModule } from '@/stores/visualization/runtimeTypes'
-import type { AstId } from '@/util/ast/abstract'
 import type { Opt } from '@/util/data/opt'
 import { isUrlString } from '@/util/data/urlString'
 import { isIconName } from '@/util/iconName'
@@ -30,7 +28,7 @@ import { rpcWithRetries } from '@/util/net'
 import { defineStore } from 'pinia'
 import { ErrorCode, LsRpcError, RemoteRpcError } from 'shared/languageServer'
 import type { Event as LSEvent, VisualizationConfiguration } from 'shared/languageServerTypes'
-import type { VisualizationIdentifier } from 'shared/yjsModel'
+import type { ExternalId, VisualizationIdentifier } from 'shared/yjsModel'
 import { computed, reactive } from 'vue'
 
 /** The directory in the project under which custom visualizations can be found. */
@@ -57,12 +55,12 @@ export const DEFAULT_VISUALIZATION_IDENTIFIER: VisualizationIdentifier = {
 export type VisualizationDataSource =
   | {
       type: 'node'
-      nodeId: NodeId
+      nodeId: ExternalId
     }
   | {
       type: 'expression'
       expression: string
-      contextId: AstId
+      contextId: ExternalId
     }
 
 const builtinVisualizations: VisualizationModule[] = [

--- a/app/gui2/src/util/ast/__tests__/abstract.test.ts
+++ b/app/gui2/src/util/ast/__tests__/abstract.test.ts
@@ -349,14 +349,14 @@ test.each(cases)('parse/print round trip: %s', (code) => {
   // Get an AST.
   const root = Ast.parseBlock(code)
   // Print AST back to source.
-  const printed = Ast.print(root.exprId, root.module)
+  const printed = Ast.print(root.id, root.module)
   const info1 = printed.info
   expect(printed.code).toEqual(code)
 
   // Re-parse.
   const root1 = Ast.parseBlock(printed)
   // Check that Identities match original AST.
-  const reprinted = Ast.print(root1.exprId, root1.module)
+  const reprinted = Ast.print(root1.id, root1.module)
   expect(reprinted.info.nodes).toEqual(info1.nodes)
   expect(reprinted.info.tokens).toEqual(info1.tokens)
 })
@@ -403,10 +403,10 @@ test('Modify subexpression', () => {
   const edit = root.module.edit()
   const newValue = Ast.TextLiteral.new('bar', edit)
   expect(newValue.code()).toBe("'bar'")
-  const oldExprId = assignment.expression!.exprId
-  edit.replaceValue(assignment.expression!.exprId, newValue)
-  expect(assignment.expression!.exprId).toBe(oldExprId)
-  expect(edit.get(assignment.expression!.exprId)?.code()).toBe("'bar'")
+  const oldExprId = assignment.expression!.id
+  edit.replaceValue(assignment.expression!.id, newValue)
+  expect(assignment.expression!.id).toBe(oldExprId)
+  expect(edit.get(assignment.expression!.id)?.code()).toBe("'bar'")
   const printed = root.code(edit)
   expect(printed).toEqual("main =\n    text1 = 'bar'\n")
 })
@@ -417,11 +417,11 @@ test('Replace subexpression', () => {
   const edit = root.module.edit()
   const newValue = Ast.TextLiteral.new('bar', edit)
   expect(newValue.code()).toBe("'bar'")
-  edit.replaceRef(assignment.expression!.exprId, newValue)
-  const assignment_ = edit.get(assignment.exprId)!
+  edit.replaceRef(assignment.expression!.id, newValue)
+  const assignment_ = edit.get(assignment.id)!
   assert(assignment_ instanceof Ast.Assignment)
-  expect(assignment_.expression!.exprId).toBe(newValue.exprId)
-  expect(edit.get(assignment_.expression!.exprId)?.code()).toBe("'bar'")
+  expect(assignment_.expression!.id).toBe(newValue.id)
+  expect(edit.get(assignment_.expression!.id)?.code()).toBe("'bar'")
   const printed = root.code(edit)
   expect(printed).toEqual("main =\n    text1 = 'bar'\n")
 })
@@ -430,13 +430,13 @@ test('Change ID of node', () => {
   const { root, assignment } = simpleModule()
   expect(assignment.expression).not.toBeNull()
   const edit = root.module.edit()
-  const expression = edit.takeValue(assignment.expression!.exprId)!
+  const expression = edit.takeValue(assignment.expression!.id)!
   expect(expression.code()).toBe('"foo"')
-  edit.replaceRef(assignment.expression!.exprId, expression)
-  const assignment_ = edit.get(assignment.exprId)!
+  edit.replaceRef(assignment.expression!.id, expression)
+  const assignment_ = edit.get(assignment.id)!
   assert(assignment_ instanceof Ast.Assignment)
-  expect(assignment_.expression!.exprId).not.toBe(assignment.expression!.exprId)
-  expect(edit.get(assignment_.expression!.exprId)?.code()).toBe('"foo"')
+  expect(assignment_.expression!.id).not.toBe(assignment.expression!.id)
+  expect(edit.get(assignment_.expression!.id)?.code()).toBe('"foo"')
   const printed = root.code(edit)
   expect(printed).toEqual('main =\n    text1 = "foo"\n')
 })
@@ -450,7 +450,7 @@ test('Delete expression', () => {
   const _assignment1 = iter.next()
   const assignment2: Ast.Assignment = iter.next().value
   const edit = root.module.edit()
-  edit.delete(assignment2.exprId)
+  edit.delete(assignment2.id)
   const printed = root.code(edit)
   expect(printed).toEqual('main =\n    text1 = "foo"\n')
 })

--- a/app/gui2/src/util/ast/__tests__/aliasAnalysis.test.ts
+++ b/app/gui2/src/util/ast/__tests__/aliasAnalysis.test.ts
@@ -28,7 +28,7 @@
 import { assertDefined } from '@/util/assert'
 import { AliasAnalyzer } from '@/util/ast/aliasAnalysis'
 import { MappedKeyMap, MappedSet } from '@/util/containers'
-import { IdMap, type SourceRange } from 'shared/yjsModel'
+import { sourceRangeKey, type SourceRange } from 'shared/yjsModel'
 import { expect, test } from 'vitest'
 
 /** The type of annotation. */
@@ -56,7 +56,7 @@ function parseAnnotations(annotatedCode: string): {
   unannotatedCode: string
   annotations: MappedKeyMap<SourceRange, Annotation>
 } {
-  const annotations = new MappedKeyMap<SourceRange, Annotation>(IdMap.keyForRange)
+  const annotations = new MappedKeyMap<SourceRange, Annotation>(sourceRangeKey)
 
   // Iterate over all annotations (either bindings or usages).
   // I.e. we want to cover both `«1,x»` and `»1,x«` cases, while keeping the track of the annotation type.
@@ -113,10 +113,10 @@ function parseAnnotations(annotatedCode: string): {
 /** Alias analysis test case, typically parsed from an annotated code. */
 class TestCase {
   /** The expected aliases. */
-  readonly expectedAliases = new MappedKeyMap<SourceRange, SourceRange[]>(IdMap.keyForRange)
+  readonly expectedAliases = new MappedKeyMap<SourceRange, SourceRange[]>(sourceRangeKey)
 
   /** The expected unresolved symbols. */
-  readonly expectedUnresolvedSymbols = new MappedSet<SourceRange>(IdMap.keyForRange)
+  readonly expectedUnresolvedSymbols = new MappedSet<SourceRange>(sourceRangeKey)
 
   /**
    * @param code The code of the program to be tested, without annotations.

--- a/app/gui2/src/util/ast/__tests__/match.test.ts
+++ b/app/gui2/src/util/ast/__tests__/match.test.ts
@@ -104,13 +104,13 @@ test.each([
   const pattern = Pattern.parse(template)
   const edit = MutableModule.Transient()
   const intron = Ast.parse(source, edit)
-  const instantiated = pattern.instantiate(edit, [intron.exprId])
+  const instantiated = pattern.instantiate(edit, [intron.id])
   expect(instantiated.code(edit)).toBe(result)
 
   // Check that `instantiate` has not affected the base module.
   const intron2 = Ast.parse(source, edit)
   const originalParent = intron2.parent
   const edit2 = edit.edit()
-  pattern.instantiate(edit2, [intron2.exprId])
-  expect(edit.get(intron2.exprId)!.parent).toBe(originalParent)
+  pattern.instantiate(edit2, [intron2.id])
+  expect(edit.get(intron2.id)!.parent).toBe(originalParent)
 })

--- a/app/gui2/src/util/ast/abstract.ts
+++ b/app/gui2/src/util/ast/abstract.ts
@@ -1375,25 +1375,6 @@ export class Wildcard extends Ast {
   }
 }
 
-export class RawCode extends Ast {
-  private readonly code_: NodeChild
-
-  constructor(module: MutableModule, id: AstId | undefined, code: NodeChild) {
-    super(module, id)
-    this.code_ = code
-  }
-
-  static new(code: string, moduleIn?: MutableModule, id?: AstId | undefined) {
-    const token = new Token(code, newTokenId(), RawAst.Token.Type.Ident)
-    const module = moduleIn ?? MutableModule.Transient()
-    return asOwned(new RawCode(module, id, unspaced(token)))
-  }
-
-  *concreteChildren(): IterableIterator<NodeChild> {
-    yield this.code_
-  }
-}
-
 function abstract(
   module: MutableModule,
   tree: RawAst.Tree,

--- a/app/gui2/src/util/ast/abstract.ts
+++ b/app/gui2/src/util/ast/abstract.ts
@@ -1723,7 +1723,7 @@ export function functionBlock(module: Module, name: string): BodyBlock | null {
   return method.body
 }
 
-export function parseTransitional(code: string, idMap: IdMap): Ast {
+export function parseTransitional(code: string, idMap: IdMap): Owned<BodyBlock> {
   const rawAst = RawAstExtended.parse(code, idMap.clone())
   const nodes = new Map<NodeKey, AstId[]>()
   const tokens = new Map<TokenKey, TokenId>()

--- a/app/gui2/src/util/ast/abstract.ts
+++ b/app/gui2/src/util/ast/abstract.ts
@@ -355,6 +355,10 @@ export abstract class Ast {
   readonly module: Module
   parent: AstId | undefined
 
+  get externalId(): ExternalId {
+    return this.id as Uuid as ExternalId
+  }
+
   // Deprecated interface for incremental integration of Ast API. Eliminate usages for #8367.
   get astExtended(): RawAstExtended | undefined {
     return this.module.getExtended(this.id)

--- a/app/gui2/src/util/ast/aliasAnalysis.ts
+++ b/app/gui2/src/util/ast/aliasAnalysis.ts
@@ -9,7 +9,7 @@ import {
 } from '@/util/ast'
 import { MappedKeyMap, MappedSet, NonEmptyStack } from '@/util/containers'
 import type { LazyObject } from '@/util/parserSupport'
-import { IdMap, rangeIsBefore, type SourceRange } from 'shared/yjsModel'
+import { rangeIsBefore, sourceRangeKey, type SourceRange } from 'shared/yjsModel'
 
 const ACCESSOR_OPERATOR = '.'
 
@@ -88,7 +88,7 @@ export function identifierKind(token: RawAst.Token.Ident): IdentifierType {
 
 export class AliasAnalyzer {
   /** All symbols that are not yet resolved (i.e. that were not bound in the analyzed tree). */
-  readonly unresolvedSymbols = new MappedSet<SourceRange>(IdMap.keyForRange)
+  readonly unresolvedSymbols = new MappedSet<SourceRange>(sourceRangeKey)
 
   /** The AST representation of the code. */
   readonly ast: RawAst.Tree
@@ -102,7 +102,7 @@ export class AliasAnalyzer {
   /** The stack for keeping track whether we are in a pattern or expression context. */
   private readonly contexts: NonEmptyStack<Context> = new NonEmptyStack(Context.Expression)
 
-  public readonly aliases = new MappedKeyMap<SourceRange, MappedSet<SourceRange>>(IdMap.keyForRange)
+  public readonly aliases = new MappedKeyMap<SourceRange, MappedSet<SourceRange>>(sourceRangeKey)
 
   /**
    * @param code text representation of the code.
@@ -137,7 +137,7 @@ export class AliasAnalyzer {
     log(() => `Binding ${identifier}@[${range}]`)
     scope.bindings.set(identifier, token)
     assert(!this.aliases.has(range), `Token at ${range} is already bound.`)
-    this.aliases.set(range, new MappedSet<SourceRange>(IdMap.keyForRange))
+    this.aliases.set(range, new MappedSet<SourceRange>(sourceRangeKey))
   }
 
   addConnection(source: RawAst.Token, target: RawAst.Token) {

--- a/app/gui2/src/util/ast/extended.ts
+++ b/app/gui2/src/util/ast/extended.ts
@@ -14,7 +14,7 @@ import type { Opt } from '@/util/data/opt'
 import * as encoding from 'lib0/encoding'
 import * as sha256 from 'lib0/hash/sha256'
 import * as map from 'lib0/map'
-import type { ExprId, IdMap, SourceRange } from 'shared/yjsModel'
+import type { ExternalId, IdMap, SourceRange } from 'shared/yjsModel'
 import { markRaw } from 'vue'
 
 type ExtractType<V, T> = T extends ReadonlyArray<infer Ts>
@@ -94,13 +94,13 @@ export class AstExtended<T extends Tree | Token = Tree | Token, HasIdMap extends
     this.ctx = ctx
   }
 
-  get astId(): CondType<ExprId, HasIdMap> {
+  get astId(): CondType<ExternalId, HasIdMap> {
     if (this.ctx.idMap != null) {
       const id = this.ctx.idMap.getIfExist(parsedTreeOrTokenRange(this.inner))
       assert(id != null, 'All AST nodes should have an assigned ID')
-      return id as CondType<ExprId, HasIdMap>
+      return id as CondType<ExternalId, HasIdMap>
     } else {
-      return undefined as CondType<ExprId, HasIdMap>
+      return undefined as CondType<ExternalId, HasIdMap>
     }
   }
 

--- a/app/gui2/src/util/ast/match.ts
+++ b/app/gui2/src/util/ast/match.ts
@@ -22,7 +22,7 @@ export class Pattern {
   match(target: Ast.Ast): Ast.AstId[] | undefined {
     const extracted: Ast.AstId[] = []
     if (this.tokenTree.length === 1 && this.tokenTree[0] === this.placeholder) {
-      return [target.exprId]
+      return [target.id]
     }
     if (
       isMatch_(
@@ -101,7 +101,7 @@ function placeholders(ast: Ast.Ast, placeholder: string, outIn?: PlaceholderRef[
       const nodeChild = child as Ast.NodeChild<Ast.AstId>
       const subtree = ast.module.get(child.node)!
       if (subtree instanceof Ast.Ident && subtree.code() === placeholder) {
-        out.push({ ref: nodeChild, parent: ast.exprId })
+        out.push({ ref: nodeChild, parent: ast.id })
       } else {
         placeholders(subtree, placeholder, out)
       }

--- a/app/gui2/src/util/ast/node.ts
+++ b/app/gui2/src/util/ast/node.ts
@@ -5,7 +5,7 @@ import { Vec2 } from '@/util/data/vec2'
 export function nodeFromAst(ast: Ast.Ast): Node {
   if (ast instanceof Ast.Assignment) {
     return {
-      outerExprId: ast.exprId,
+      outerExprId: ast.id,
       pattern: ast.pattern ?? undefined,
       rootSpan: ast.expression ?? ast,
       position: Vec2.Zero,
@@ -13,7 +13,7 @@ export function nodeFromAst(ast: Ast.Ast): Node {
     }
   } else {
     return {
-      outerExprId: ast.exprId,
+      outerExprId: ast.id,
       pattern: undefined,
       rootSpan: ast,
       position: Vec2.Zero,

--- a/app/gui2/src/util/ast/prefixes.ts
+++ b/app/gui2/src/util/ast/prefixes.ts
@@ -52,7 +52,7 @@ export class Prefixes<T extends Record<keyof T, Pattern>> {
       if (!replacement) continue
       const pattern = this.prefixes[key]
       const parts = [...replacement, result]
-      const partsIds = Array.from(parts, (ast) => ast.exprId)
+      const partsIds = Array.from(parts, (ast) => ast.id)
       result = pattern.instantiate(edit, partsIds)
     }
     return result

--- a/app/gui2/src/util/callTree.ts
+++ b/app/gui2/src/util/callTree.ts
@@ -86,7 +86,7 @@ export class ArgumentAst {
   }
 
   get portId(): PortId {
-    return this.ast.exprId
+    return this.ast.id
   }
 }
 
@@ -166,7 +166,7 @@ export class ArgumentApplication {
     const { suggestion, widgetCfg } = callInfo
 
     const kind = ApplicationKind.Infix
-    const callId = interpreted.appTree.exprId
+    const callId = interpreted.appTree.id
 
     const argFor = (key: 'lhs' | 'rhs', index: number) => {
       const tree = interpreted[key]
@@ -185,7 +185,7 @@ export class ArgumentApplication {
 
   private static FromInterpretedPrefix(interpreted: InterpretedPrefix, callInfo: CallInfo) {
     const { notAppliedArguments, suggestion, widgetCfg, subjectAsSelf } = callInfo
-    const callId = interpreted.func.exprId
+    const callId = interpreted.func.id
 
     const knownArguments = suggestion?.arguments
     const allPossiblePrefixArguments = Array.from(knownArguments ?? [], (_, i) => i)
@@ -369,7 +369,7 @@ export class ArgumentApplication {
     return {
       portId:
         this.argument instanceof ArgumentAst
-          ? this.appTree.exprId
+          ? this.appTree.id
           : (`app:${this.argument.portId}` as PortId),
       value: this.appTree,
       [ArgumentApplicationKey]: this,

--- a/app/gui2/src/util/data/types.ts
+++ b/app/gui2/src/util/data/types.ts
@@ -1,0 +1,5 @@
+export function asNot<Not>(value: any): Excluding<Not, typeof value> {
+  return value as any
+}
+
+type Excluding<Not, Value> = Value extends Not ? never : Value

--- a/app/gui2/stories/GraphNode.story.vue
+++ b/app/gui2/stories/GraphNode.story.vue
@@ -47,7 +47,7 @@ const node = computed((): Node => {
 const mockRects = reactive(new Map())
 
 watchEffect((onCleanup) => {
-  const id = node.value.rootSpan.exprId
+  const id = node.value.rootSpan.id
   mockRects.set(id, Rect.Zero)
   onCleanup(() => {
     mockRects.delete(id)

--- a/app/gui2/ydoc-server/serialization.ts
+++ b/app/gui2/ydoc-server/serialization.ts
@@ -1,7 +1,7 @@
 /** Translation of `yjsModel` types to and from the `fileFormat` representation. */
 
 import * as json from 'lib0/json'
-import { ExternalId, IdMap } from '../shared/yjsModel'
+import { ExternalId, IdMap, sourceRangeFromKey } from '../shared/yjsModel'
 import * as fileFormat from './fileFormat'
 
 export function deserializeIdMap(idMapJson: string) {
@@ -26,7 +26,7 @@ export function serializeIdMap(map: IdMap): string {
 function idMapToArray(map: IdMap): fileFormat.IdMapEntry[] {
   const entries: fileFormat.IdMapEntry[] = []
   map.entries().forEach(([rangeBuffer, id]) => {
-    const decoded = IdMap.rangeForKey(rangeBuffer)
+    const decoded = sourceRangeFromKey(rangeBuffer)
     const index = decoded[0]
     const endIndex = decoded[1]
     if (index == null || endIndex == null) return

--- a/app/gui2/ydoc-server/serialization.ts
+++ b/app/gui2/ydoc-server/serialization.ts
@@ -1,7 +1,7 @@
 /** Translation of `yjsModel` types to and from the `fileFormat` representation. */
 
 import * as json from 'lib0/json'
-import { ExprId, IdMap } from '../shared/yjsModel'
+import { ExternalId, IdMap } from '../shared/yjsModel'
 import * as fileFormat from './fileFormat'
 
 export function deserializeIdMap(idMapJson: string) {
@@ -13,7 +13,7 @@ export function deserializeIdMap(idMapJson: string) {
       console.error(`Invalid range for id ${id}:`, range)
       continue
     }
-    idMap.insertKnownId([index.value, index.value + size.value], id as ExprId)
+    idMap.insertKnownId([index.value, index.value + size.value], id as ExternalId)
   }
   return idMap
 }


### PR DESCRIPTION
### Pull Request Description

Some refactoring separated from #8825 for easier review.

### Important Notes

**ID types**

The new *synchronization IDs* will replace `ExprId` for `Ast` references in frontend logic. `ExprId` (now called `ExternalId`) is now used only for module serialization and engine communication. The graph database will maintain an index that is used to translate at the boundaries. For now, this translation is implemented as a type cast, as the IDs have the same values until the next PR.

- `AstId`: Identifies an `Ast` node.
- `NodeId`: A subtype of `AstId`.
- `ExternalId`: UUID used for serialization and engine communication.

**Other changes**:

- Immediate validation of `Owned` usage.
- Eliminate `Ast.RawCode`.
- Prepare to remove `IdMap` from yjsModel.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
