### PR TITLE
Using latest GraalVM bits in Enso

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1566,6 +1566,7 @@ lazy val `runtime-test-instruments` =
       libraryDependencies ++= GraalVM.modules,
       libraryDependencies ++= Seq(
         "org.graalvm.sdk"     % "polyglot-tck"            % graalMavenPackagesVersion,
+        "org.graalvm.truffle" % "truffle-dsl-processor"   % graalMavenPackagesVersion,
         "org.graalvm.truffle" % "truffle-tck"             % graalMavenPackagesVersion,
         "org.graalvm.truffle" % "truffle-tck-common"      % graalMavenPackagesVersion,
         "org.graalvm.truffle" % "truffle-tck-tests"       % graalMavenPackagesVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ val graalVersion = "21.0.1"
 // Version used for the Graal/Truffle related Maven packages
 // Keep in sync with GraalVM.version. Do not change the name of this variable,
 // it is used by the Rust build script via regex matching.
-val graalMavenPackagesVersion = "23.1.0"
+val graalMavenPackagesVersion = "24.1.0-SNAPSHOT"
 val targetJavaVersion         = "17"
 val defaultDevEnsoVersion     = "0.0.0-dev"
 val ensoVersion = sys.env.getOrElse(
@@ -1228,6 +1228,7 @@ lazy val `polyglot-api` = project
         "runtime-fat-jar"
       ) / Compile / fullClasspath).value,
     libraryDependencies ++= Seq(
+      "org.graalvm.polyglot"   % "polyglot"         % graalMavenPackagesVersion % "provided",
       "org.graalvm.sdk"        % "polyglot-tck"     % graalMavenPackagesVersion % "provided",
       "org.graalvm.truffle"    % "truffle-api"      % graalMavenPackagesVersion % "provided",
       "com.google.flatbuffers" % "flatbuffers-java" % flatbuffersVersion,
@@ -1261,6 +1262,7 @@ lazy val `language-server` = (project in file("engine/language-server"))
       "com.typesafe.akka"          %% "akka-http-testkit"    % akkaHTTPVersion           % Test,
       "org.scalatest"              %% "scalatest"            % scalatestVersion          % Test,
       "org.scalacheck"             %% "scalacheck"           % scalacheckVersion         % Test,
+      "org.graalvm.polyglot"        % "polyglot"             % graalMavenPackagesVersion % "provided",
       "org.graalvm.sdk"             % "polyglot-tck"         % graalMavenPackagesVersion % "provided",
       "org.eclipse.jgit"            % "org.eclipse.jgit"     % jgitVersion,
       "org.bouncycastle"            % "bcutil-jdk18on"       % "1.76"                    % Test,
@@ -1432,6 +1434,7 @@ lazy val frgaalJavaCompilerSetting =
   customFrgaalJavaCompilerSettings(targetJavaVersion)
 
 def customFrgaalJavaCompilerSettings(targetJdk: String) = Seq(
+  resolvers += Resolver.mavenLocal,
   Compile / compile / compilers := FrgaalJavaCompiler.compilers(
     (Compile / dependencyClasspath).value,
     compilers.value,
@@ -1482,10 +1485,11 @@ lazy val `runtime-language-epb` =
       Test / javaOptions ++= Seq(),
       instrumentationSettings,
       libraryDependencies ++= Seq(
-        "junit"               % "junit"                 % junitVersion              % Test,
-        "com.github.sbt"      % "junit-interface"       % junitIfVersion            % Test,
-        "org.graalvm.truffle" % "truffle-api"           % graalMavenPackagesVersion % "provided",
-        "org.graalvm.truffle" % "truffle-dsl-processor" % graalMavenPackagesVersion % "provided"
+        "junit"                % "junit"                 % junitVersion              % Test,
+        "com.github.sbt"       % "junit-interface"       % junitIfVersion            % Test,
+        "org.graalvm.polyglot" % "polyglot"              % graalMavenPackagesVersion % "provided",
+        "org.graalvm.truffle"  % "truffle-api"           % graalMavenPackagesVersion % "provided",
+        "org.graalvm.truffle"  % "truffle-dsl-processor" % graalMavenPackagesVersion % "provided"
       )
     )
 
@@ -1620,6 +1624,7 @@ lazy val runtime = (project in file("engine/runtime"))
       "org.apache.tika"      % "tika-core"               % tikaVersion,
       "org.graalvm.polyglot" % "polyglot"                % graalMavenPackagesVersion % "provided",
       "org.graalvm.sdk"      % "polyglot-tck"            % graalMavenPackagesVersion % "provided",
+      "org.graalvm.sdk"      % "collections"             % graalMavenPackagesVersion % "provided",
       "org.graalvm.truffle"  % "truffle-api"             % graalMavenPackagesVersion % "provided",
       "org.graalvm.truffle"  % "truffle-dsl-processor"   % graalMavenPackagesVersion % "provided",
       "org.graalvm.truffle"  % "truffle-tck"             % graalMavenPackagesVersion % Test,
@@ -1866,11 +1871,12 @@ lazy val `runtime-compiler` =
       frgaalJavaCompilerSetting,
       instrumentationSettings,
       libraryDependencies ++= Seq(
-        "junit"            % "junit"                   % junitVersion       % Test,
-        "com.github.sbt"   % "junit-interface"         % junitIfVersion     % Test,
-        "org.scalatest"   %% "scalatest"               % scalatestVersion   % Test,
-        "org.netbeans.api" % "org-openide-util-lookup" % netbeansApiVersion % "provided",
-        "com.lihaoyi"     %% "fansi"                   % fansiVersion
+        "junit"                % "junit"                   % junitVersion              % Test,
+        "com.github.sbt"       % "junit-interface"         % junitIfVersion            % Test,
+        "org.scalatest"       %% "scalatest"               % scalatestVersion          % Test,
+        "org.graalvm.polyglot" % "polyglot"                % graalMavenPackagesVersion % "provided",
+        "org.netbeans.api"     % "org-openide-util-lookup" % netbeansApiVersion        % "provided",
+        "com.lihaoyi"         %% "fansi"                   % fansiVersion
       )
     )
     .dependsOn(`runtime-parser`)
@@ -2085,14 +2091,15 @@ lazy val `engine-runner` = project
     commands += WithDebugCommand.withDebug,
     inConfig(Compile)(truffleRunOptionsSettings),
     libraryDependencies ++= Seq(
-      "org.graalvm.sdk"     % "polyglot-tck"    % graalMavenPackagesVersion % Provided,
-      "org.graalvm.truffle" % "truffle-api"     % graalMavenPackagesVersion % Provided,
-      "commons-cli"         % "commons-cli"     % commonsCliVersion,
-      "com.monovore"       %% "decline"         % declineVersion,
-      "org.jline"           % "jline"           % jlineVersion,
-      "org.typelevel"      %% "cats-core"       % catsVersion,
-      "junit"               % "junit"           % junitVersion              % Test,
-      "com.github.sbt"      % "junit-interface" % junitIfVersion            % Test
+      "org.graalvm.polyglot" % "polyglot"        % graalMavenPackagesVersion % "provided",
+      "org.graalvm.sdk"      % "polyglot-tck"    % graalMavenPackagesVersion % Provided,
+      "org.graalvm.truffle"  % "truffle-api"     % graalMavenPackagesVersion % Provided,
+      "commons-cli"          % "commons-cli"     % commonsCliVersion,
+      "com.monovore"        %% "decline"         % declineVersion,
+      "org.jline"            % "jline"           % jlineVersion,
+      "org.typelevel"       %% "cats-core"       % catsVersion,
+      "junit"                % "junit"           % junitVersion              % Test,
+      "com.github.sbt"       % "junit-interface" % junitIfVersion            % Test
     ),
     run / connectInput := true
   )
@@ -2592,6 +2599,7 @@ lazy val `std-base` = project
       `base-polyglot-root` / "std-base.jar",
     libraryDependencies ++= Seq(
       "org.graalvm.polyglot" % "polyglot"                % graalMavenPackagesVersion,
+      "org.graalvm.sdk"      % "collections"             % graalMavenPackagesVersion,
       "org.netbeans.api"     % "org-openide-util-lookup" % netbeansApiVersion % "provided"
     ),
     Compile / packageBin := Def.task {
@@ -2708,6 +2716,7 @@ lazy val `std-table` = project
     },
     libraryDependencies ++= Seq(
       "org.graalvm.polyglot"     % "polyglot"                % graalMavenPackagesVersion % "provided",
+      "org.graalvm.sdk"          % "collections"             % graalMavenPackagesVersion,
       "org.netbeans.api"         % "org-openide-util-lookup" % netbeansApiVersion        % "provided",
       "com.univocity"            % "univocity-parsers"       % univocityParsersVersion,
       "org.apache.poi"           % "poi-ooxml"               % poiOoxmlVersion,
@@ -2797,6 +2806,7 @@ lazy val `std-database` = project
       `database-polyglot-root` / "std-database.jar",
     libraryDependencies ++= Seq(
       "org.graalvm.polyglot" % "polyglot"                % graalMavenPackagesVersion % "provided",
+      "org.graalvm.sdk"      % "collections"             % graalMavenPackagesVersion % "provided",
       "org.netbeans.api"     % "org-openide-util-lookup" % netbeansApiVersion        % "provided",
       "org.xerial"           % "sqlite-jdbc"             % sqliteVersion,
       "org.postgresql"       % "postgresql"              % "42.4.0"

--- a/engine/runtime/src/test/java/org/enso/interpreter/test/ForeignMethodInvokeTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/test/ForeignMethodInvokeTest.java
@@ -3,12 +3,12 @@ package org.enso.interpreter.test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Random;
 import java.util.concurrent.Executors;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class ForeignMethodInvokeTest extends TestBase {
@@ -16,7 +16,19 @@ public class ForeignMethodInvokeTest extends TestBase {
 
   @BeforeClass
   public static void prepareCtx() {
-    ctx = defaultContextBuilder("enso", "js").build();
+    var r = new Random();
+    var b =
+        defaultContextBuilder("enso", "js")
+            .onDeniedThreadAccess(
+                (ex) -> {
+                  ex.printStackTrace();
+                  try {
+                    Thread.sleep(r.nextInt(100));
+                  } catch (InterruptedException ignore) {
+                  }
+                  System.err.println("Trying again");
+                });
+    ctx = b.build();
   }
 
   @AfterClass
@@ -85,7 +97,6 @@ public class ForeignMethodInvokeTest extends TestBase {
     assertEquals(12, res2.getArrayElement(2).asInt());
   }
 
-  @Ignore
   @Test
   public void testParallelInteropWithJavaScript() throws Exception {
     var source =

--- a/project/GraalVM.scala
+++ b/project/GraalVM.scala
@@ -10,7 +10,12 @@ import scala.collection.immutable.Seq
   */
 object GraalVM {
   // Keep in sync with graalMavenPackagesVersion in build.sbt
-  val version: String = "23.1.0"
+  val version: String       = "24.1.0-SNAPSHOT"
+  private val pythonVersion = "23.1.0"
+  private val jsVersion     = "23.1.0"
+  private val llvmVersion   = "23.1.0"
+  private val regexVersion  = "23.1.0"
+  private val toolVersion   = "23.1.0"
 
   /** The list of modules that are included in the `component` directory in engine distribution.
     * When invoking the `java` command, these modules need to be put on the module-path.
@@ -52,39 +57,39 @@ object GraalVM {
     */
 
   val pythonPkgs = Seq(
-    "org.graalvm.python"   % "python-language"    % version,
-    "org.graalvm.python"   % "python-resources"   % version,
+    "org.graalvm.python"   % "python-language"    % pythonVersion,
+    "org.graalvm.python"   % "python-resources"   % pythonVersion,
     "org.bouncycastle"     % "bcutil-jdk18on"     % "1.76",
     "org.bouncycastle"     % "bcpkix-jdk18on"     % "1.76",
     "org.bouncycastle"     % "bcprov-jdk18on"     % "1.76",
-    "org.graalvm.llvm"     % "llvm-api"           % version,
+    "org.graalvm.llvm"     % "llvm-api"           % llvmVersion,
     "org.graalvm.truffle"  % "truffle-nfi"        % version,
     "org.graalvm.truffle"  % "truffle-nfi-libffi" % version,
-    "org.graalvm.regex"    % "regex"              % version,
-    "org.graalvm.tools"    % "profiler-tool"      % version,
+    "org.graalvm.regex"    % "regex"              % regexVersion,
+    "org.graalvm.tools"    % "profiler-tool"      % toolVersion,
     "org.graalvm.shadowed" % "json"               % version,
     "org.graalvm.shadowed" % "icu4j"              % version,
     "org.tukaani"          % "xz"                 % "1.9"
   )
 
   val jsPkgs = Seq(
-    "org.graalvm.js"       % "js-language" % version,
-    "org.graalvm.regex"    % "regex"       % version,
-    "org.graalvm.shadowed" % "icu4j"       % version
+    "org.graalvm.js"       % "js-language" % jsVersion,
+    "org.graalvm.regex"    % "regex"       % regexVersion,
+    "org.graalvm.shadowed" % "icu4j"       % jsVersion
   )
 
   val chromeInspectorPkgs = Seq(
-    "org.graalvm.tools"    % "chromeinspector-tool" % version,
+    "org.graalvm.tools"    % "chromeinspector-tool" % toolVersion,
     "org.graalvm.shadowed" % "json"                 % version,
-    "org.graalvm.tools"    % "profiler-tool"        % version
+    "org.graalvm.tools"    % "profiler-tool"        % toolVersion
   )
 
   val debugAdapterProtocolPkgs = Seq(
-    "org.graalvm.tools" % "dap-tool" % version
+    "org.graalvm.tools" % "dap-tool" % toolVersion
   )
 
   val insightPkgs = Seq(
-    "org.graalvm.tools" % "insight-tool" % version
+    "org.graalvm.tools" % "insight-tool" % toolVersion
   )
 
   val espressoPkgs = if ("espresso".equals(System.getenv("ENSO_JAVA"))) {

--- a/project/JPMSUtils.scala
+++ b/project/JPMSUtils.scala
@@ -64,15 +64,24 @@ object JPMSUtils {
       )
     }
 
+    val found = mutable.Seq()
     val ret = cp.filter(dep => {
       val moduleID = dep.metadata.get(AttributeKey[ModuleID]("moduleID")).get
-      shouldFilterModule(moduleID)
+      if (shouldFilterModule(moduleID)) {
+        found :+ moduleID
+        true
+      } else {
+        false
+      }
     })
     if (shouldContainAll) {
       if (ret.size < distinctModules.size) {
         log.error("Not all modules from classpath were found")
         log.error(s"Returned (${ret.size}): $ret")
         log.error(s"Expected: (${distinctModules.size}): $distinctModules")
+
+        val missing = distinctModules.diff(found)
+        log.error(s"Missing IDs: $missing")
       }
     }
     ret


### PR DESCRIPTION
### Pull Request Description

Using https://github.com/oracle/graal/pull/8266 in Enso. This is an exploratory work using manually built SNAPSHOT bits of GraalVM that will be released as version `24.1` in middle of the year.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
