### PR TITLE
Reduced resources for various Akka dispatchers

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/LibraryPreinstallHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/libraries/handler/LibraryPreinstallHandler.scala
@@ -38,7 +38,7 @@ import org.enso.librarymanager.{
   ResolvingLibraryProvider
 }
 
-import java.util.concurrent.Executors
+import java.util.concurrent.{ExecutorService, Executors}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Success, Try}
 
@@ -59,8 +59,9 @@ class LibraryPreinstallHandler(
     with LazyLogging
     with UnhandledLogging {
 
+  private val threadPool: ExecutorService = Executors.newCachedThreadPool()
   implicit private val ec: ExecutionContext =
-    ExecutionContext.fromExecutor(Executors.newCachedThreadPool())
+    ExecutionContext.fromExecutor(threadPool)
 
   override def receive: Receive = requestStage
 
@@ -186,6 +187,7 @@ class LibraryPreinstallHandler(
           replyTo ! ResponseResult(LibraryPreinstall, requestId, Unused)
       }
 
+      threadPool.shutdown()
       context.stop(self)
 
     case Status.Failure(throwable) =>

--- a/engine/language-server/src/test/resources/application-test.conf
+++ b/engine/language-server/src/test/resources/application-test.conf
@@ -4,6 +4,63 @@ akka.http.server.websocket.periodic-keep-alive-max-idle = 1 second
 akka.loglevel = "ERROR"
 akka.test.timefactor = ${?CI_TEST_TIMEFACTOR}
 akka.test.single-expect-default = 5s
+akka.actor.default-dispatcher = {
+  # Dispatcher is the name of the event-based dispatcher
+  type = Dispatcher
+  # What kind of ExecutionService to use
+  executor = "thread-pool-executor"
+  # Configuration for the thread pool
+  thread-pool-executor {
+    fixed-pool-size = 2
+    # Keep alive time for threads
+    keep-alive-time = 10s
+    # Allow core threads to time out
+    allow-core-timeout = off
+  }
+  # Throughput defines the maximum number of messages to be
+  # processed per actor before the thread jumps to the next actor.
+  # Set to 1 for as fair as possible.
+  throughput = 20
+}
+
+akka.actor.internal-dispatcher = {
+  # Dispatcher is the name of the event-based dispatcher
+  type = Dispatcher
+  # What kind of ExecutionService to use
+  executor = "thread-pool-executor"
+  # Configuration for the thread pool
+  thread-pool-executor {
+    fixed-pool-size = 2
+    # Keep alive time for threads
+    keep-alive-time = 10s
+    # Allow core threads to time out
+    allow-core-timeout = off
+  }
+  # Throughput defines the maximum number of messages to be
+  # processed per actor before the thread jumps to the next actor.
+  # Set to 1 for as fair as possible.
+  throughput = 20
+}
+
+akka.actor.default-blocking-io-dispatcher = {
+  # Dispatcher is the name of the event-based dispatcher
+  type = Dispatcher
+  # What kind of ExecutionService to use
+  executor = "thread-pool-executor"
+  # Configuration for the thread pool
+  thread-pool-executor {
+    fixed-pool-size = 2
+    # Keep alive time for threads
+    keep-alive-time = 10s
+    # Allow core threads to time out
+    allow-core-timeout = off
+  }
+  # Throughput defines the maximum number of messages to be
+  # processed per actor before the thread jumps to the next actor.
+  # Set to 1 for as fair as possible.
+  throughput = 20
+}
+
 
 
 searcher.db.numThreads = 1

--- a/engine/language-server/src/test/scala/org/enso/languageserver/boot/resource/RepoInitializationSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/boot/resource/RepoInitializationSpec.scala
@@ -35,7 +35,8 @@ class RepoInitializationSpec
   val Timeout: FiniteDuration = 10.seconds.dilated
 
   override def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
+    TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+    super.afterAll()
   }
 
   "RepoInitialization" should {

--- a/engine/language-server/src/test/scala/org/enso/languageserver/filemanager/ContentRootManagerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/filemanager/ContentRootManagerSpec.scala
@@ -5,10 +5,7 @@ import akka.testkit.{TestDuration, TestKit, TestProbe}
 import org.apache.commons.lang3.SystemUtils
 import org.enso.languageserver.boot.{ProfilingConfig, StartupConfig}
 import org.enso.languageserver.data._
-import org.enso.languageserver.filemanager.ContentRootManagerProtocol.{
-  ContentRootsAddedNotification,
-  SubscribeToNotifications
-}
+import org.enso.languageserver.filemanager.ContentRootManagerProtocol.{ContentRootsAddedNotification, SubscribeToNotifications}
 import org.enso.logger.ReportLogsOnFailure
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.testkit.{EitherValue, WithTemporaryDirectory}
@@ -16,7 +13,7 @@ import org.scalatest.concurrent.Futures
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
-import org.scalatest.{Inside, OptionValues}
+import org.scalatest.{BeforeAndAfterAll, Inside, OptionValues}
 
 import java.io.File
 import java.nio.file.{Path => JPath}
@@ -32,10 +29,17 @@ class ContentRootManagerSpec
     with EitherValue
     with OptionValues
     with WithTemporaryDirectory
+    with BeforeAndAfterAll
     with ReportLogsOnFailure {
 
   var rootManager: ContentRootManagerWrapper = _
   var rootActor: ActorRef                    = _
+
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+    super.afterAll()
+  }
 
   override def beforeEach(): Unit = {
     super.beforeEach()

--- a/engine/language-server/src/test/scala/org/enso/languageserver/filemanager/ContentRootManagerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/filemanager/ContentRootManagerSpec.scala
@@ -5,7 +5,10 @@ import akka.testkit.{TestDuration, TestKit, TestProbe}
 import org.apache.commons.lang3.SystemUtils
 import org.enso.languageserver.boot.{ProfilingConfig, StartupConfig}
 import org.enso.languageserver.data._
-import org.enso.languageserver.filemanager.ContentRootManagerProtocol.{ContentRootsAddedNotification, SubscribeToNotifications}
+import org.enso.languageserver.filemanager.ContentRootManagerProtocol.{
+  ContentRootsAddedNotification,
+  SubscribeToNotifications
+}
 import org.enso.logger.ReportLogsOnFailure
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.testkit.{EitherValue, WithTemporaryDirectory}
@@ -34,7 +37,6 @@ class ContentRootManagerSpec
 
   var rootManager: ContentRootManagerWrapper = _
   var rootActor: ActorRef                    = _
-
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system, verifySystemShutdown = true)

--- a/engine/language-server/src/test/scala/org/enso/languageserver/libraries/LocalLibraryManagerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/libraries/LocalLibraryManagerSpec.scala
@@ -27,7 +27,8 @@ class LocalLibraryManagerSpec
   val Timeout: FiniteDuration = 10.seconds
 
   override def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
+    TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+    super.afterAll()
   }
 
   "LocalLibraryManager" should {

--- a/engine/language-server/src/test/scala/org/enso/languageserver/requesthandler/monitoring/PingHandlerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/requesthandler/monitoring/PingHandlerSpec.scala
@@ -8,6 +8,7 @@ import org.enso.languageserver.monitoring.MonitoringApi
 import org.enso.languageserver.monitoring.MonitoringProtocol.{Ping, Pong}
 import org.enso.logger.ReportLogsOnFailure
 import org.enso.testkit.FlakySpec
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.must.Matchers
 
@@ -19,7 +20,12 @@ class PingHandlerSpec
     with AnyFlatSpecLike
     with Matchers
     with FlakySpec
+    with BeforeAndAfterAll
     with ReportLogsOnFailure {
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+  }
 
   "A PingHandler" must "scatter pings to all subsystems" in {
     //given

--- a/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/runtime/ContextEventsListenerSpec.scala
@@ -40,7 +40,8 @@ class ContextEventsListenerSpec
     with ReportLogsOnFailure {
 
   override def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
+    TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+    super.afterAll()
   }
 
   "ContextEventsListener" should {

--- a/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/search/SuggestionsHandlerSpec.scala
@@ -46,7 +46,8 @@ class SuggestionsHandlerSpec
   val Timeout: FiniteDuration = 10.seconds
 
   override def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
+    TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+    super.afterAll()
   }
 
   "SuggestionsHandler" should {

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/binary/BaseBinaryServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/binary/BaseBinaryServerTest.scala
@@ -35,7 +35,7 @@ import org.enso.languageserver.websocket.binary.factory.{
 
 import scala.concurrent.duration._
 
-class BaseBinaryServerTest extends BinaryServerTestKit {
+abstract class BaseBinaryServerTest extends BinaryServerTestKit {
 
   val testContentRootId = UUID.randomUUID()
   val testContentRoot = ContentRootWithFile(

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/binary/BinaryServerTestKit.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/binary/BinaryServerTestKit.scala
@@ -36,7 +36,8 @@ abstract class BinaryServerTestKit
     with BeforeAndAfterEach {
 
   override def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
+    TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+    super.afterAll()
   }
 
   val interface       = "127.0.0.1"
@@ -59,6 +60,7 @@ abstract class BinaryServerTestKit
 
   override def afterEach(): Unit = {
     val _ = binding.unbind()
+    super.afterEach()
   }
 
   protected def newWsClient(): WsTestClient = new WsTestClient(address)

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
@@ -13,8 +13,17 @@ import org.enso.filewatcher.{NoopWatcherFactory, WatcherAdapterFactory}
 import org.enso.jsonrpc.test.JsonRpcServerTestKit
 import org.enso.jsonrpc.{ClientControllerFactory, ProtocolFactory}
 import org.enso.languageserver.TestClock
-import org.enso.languageserver.boot.{ProfilingConfig, StartupConfig, TimingsConfig}
-import org.enso.languageserver.boot.resource.{DirectoriesInitialization, RepoInitialization, SequentialResourcesInitialization, ZioRuntimeInitialization}
+import org.enso.languageserver.boot.{
+  ProfilingConfig,
+  StartupConfig,
+  TimingsConfig
+}
+import org.enso.languageserver.boot.resource.{
+  DirectoriesInitialization,
+  RepoInitialization,
+  SequentialResourcesInitialization,
+  ZioRuntimeInitialization
+}
 import org.enso.languageserver.capability.CapabilityRouter
 import org.enso.languageserver.data._
 import org.enso.languageserver.effect.{TestRuntime, ZioExec}
@@ -23,8 +32,14 @@ import org.enso.languageserver.filemanager._
 import org.enso.languageserver.io._
 import org.enso.languageserver.libraries._
 import org.enso.languageserver.monitoring.IdlenessMonitor
-import org.enso.languageserver.profiling.{ProfilingManager, TestProfilingSnapshot}
-import org.enso.languageserver.protocol.json.{JsonConnectionControllerFactory, JsonRpcProtocolFactory}
+import org.enso.languageserver.profiling.{
+  ProfilingManager,
+  TestProfilingSnapshot
+}
+import org.enso.languageserver.protocol.json.{
+  JsonConnectionControllerFactory,
+  JsonRpcProtocolFactory
+}
 import org.enso.languageserver.runtime.{ContextRegistry, RuntimeFailureMapper}
 import org.enso.languageserver.search.SuggestionsHandler
 import org.enso.languageserver.search.SuggestionsHandler.ProjectNameUpdated
@@ -37,7 +52,10 @@ import org.enso.librarymanager.published.PublishedLibraryCache
 import org.enso.pkg.PackageManager
 import org.enso.polyglot.data.TypeGraph
 import org.enso.polyglot.runtime.Runtime.Api
-import org.enso.runtimeversionmanager.test.{FakeEnvironment, TestableThreadSafeFileLockManager}
+import org.enso.runtimeversionmanager.test.{
+  FakeEnvironment,
+  TestableThreadSafeFileLockManager
+}
 import org.enso.searcher.sql.{SqlDatabase, SqlSuggestionsRepo}
 import org.enso.testkit.{EitherValue, WithTemporaryDirectory}
 import org.enso.text.Sha3_224VersionCalculator
@@ -51,7 +69,7 @@ import java.nio.file.{Files, Path}
 import java.util.UUID
 import scala.concurrent.duration._
 
-class BaseServerTest
+abstract class BaseServerTest
     extends JsonRpcServerTestKit
     with EitherValue
     with OptionValues

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
@@ -179,6 +179,11 @@ class BaseServerTest
     super.afterEach()
   }
 
+  override def afterAll(): Unit = {
+    sqlDatabase.close()
+    super.afterAll()
+  }
+
   /** Locates the root of the Enso repository. Heuristic: we just keep going up the directory tree
     * until we are in a directory containing ".git" subdirectory. Note that we cannot use the "enso"
     * name, as users are free to name their cloned directories however they like.

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
@@ -13,17 +13,8 @@ import org.enso.filewatcher.{NoopWatcherFactory, WatcherAdapterFactory}
 import org.enso.jsonrpc.test.JsonRpcServerTestKit
 import org.enso.jsonrpc.{ClientControllerFactory, ProtocolFactory}
 import org.enso.languageserver.TestClock
-import org.enso.languageserver.boot.{
-  ProfilingConfig,
-  StartupConfig,
-  TimingsConfig
-}
-import org.enso.languageserver.boot.resource.{
-  DirectoriesInitialization,
-  RepoInitialization,
-  SequentialResourcesInitialization,
-  ZioRuntimeInitialization
-}
+import org.enso.languageserver.boot.{ProfilingConfig, StartupConfig, TimingsConfig}
+import org.enso.languageserver.boot.resource.{DirectoriesInitialization, RepoInitialization, SequentialResourcesInitialization, ZioRuntimeInitialization}
 import org.enso.languageserver.capability.CapabilityRouter
 import org.enso.languageserver.data._
 import org.enso.languageserver.effect.{TestRuntime, ZioExec}
@@ -32,14 +23,8 @@ import org.enso.languageserver.filemanager._
 import org.enso.languageserver.io._
 import org.enso.languageserver.libraries._
 import org.enso.languageserver.monitoring.IdlenessMonitor
-import org.enso.languageserver.profiling.{
-  ProfilingManager,
-  TestProfilingSnapshot
-}
-import org.enso.languageserver.protocol.json.{
-  JsonConnectionControllerFactory,
-  JsonRpcProtocolFactory
-}
+import org.enso.languageserver.profiling.{ProfilingManager, TestProfilingSnapshot}
+import org.enso.languageserver.protocol.json.{JsonConnectionControllerFactory, JsonRpcProtocolFactory}
 import org.enso.languageserver.runtime.{ContextRegistry, RuntimeFailureMapper}
 import org.enso.languageserver.search.SuggestionsHandler
 import org.enso.languageserver.search.SuggestionsHandler.ProjectNameUpdated
@@ -52,10 +37,7 @@ import org.enso.librarymanager.published.PublishedLibraryCache
 import org.enso.pkg.PackageManager
 import org.enso.polyglot.data.TypeGraph
 import org.enso.polyglot.runtime.Runtime.Api
-import org.enso.runtimeversionmanager.test.{
-  FakeEnvironment,
-  TestableThreadSafeFileLockManager
-}
+import org.enso.runtimeversionmanager.test.{FakeEnvironment, TestableThreadSafeFileLockManager}
 import org.enso.searcher.sql.{SqlDatabase, SqlSuggestionsRepo}
 import org.enso.testkit.{EitherValue, WithTemporaryDirectory}
 import org.enso.text.Sha3_224VersionCalculator
@@ -67,7 +49,6 @@ import java.io.File
 import java.net.URISyntaxException
 import java.nio.file.{Files, Path}
 import java.util.UUID
-
 import scala.concurrent.duration._
 
 class BaseServerTest

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/LibrariesTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/LibrariesTest.scala
@@ -59,7 +59,7 @@ class LibrariesTest
   )
 
   "LocalLibraryManager" should {
-    "create a library project and include it on the list of local projects" taggedAs SkipOnFailure in {
+    "create a library project and include it on the list of local projects" taggedAs Flaky in {
       val client          = getInitialisedWsClient()
       val testLibraryName = LibraryName("user", "My_Local_Lib")
 

--- a/lib/scala/connected-lock-manager/src/test/scala/org/enso/lockmanager/ConnectedLockManagerTest.scala
+++ b/lib/scala/connected-lock-manager/src/test/scala/org/enso/lockmanager/ConnectedLockManagerTest.scala
@@ -2,9 +2,16 @@ package org.enso.lockmanager
 
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
-import org.enso.distribution.locking.{LockManager, LockType, ThreadSafeFileLockManager}
+import org.enso.distribution.locking.{
+  LockManager,
+  LockType,
+  ThreadSafeFileLockManager
+}
 import org.enso.lockmanager.ActorToHandlerConnector.SetRequestHandler
-import org.enso.lockmanager.client.{ConnectedLockManager, RuntimeServerRequestHandler}
+import org.enso.lockmanager.client.{
+  ConnectedLockManager,
+  RuntimeServerRequestHandler
+}
 import org.enso.lockmanager.server.LockManagerService
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.testkit.{TestSynchronizer, WithTemporaryDirectory}

--- a/lib/scala/connected-lock-manager/src/test/scala/org/enso/lockmanager/ConnectedLockManagerTest.scala
+++ b/lib/scala/connected-lock-manager/src/test/scala/org/enso/lockmanager/ConnectedLockManagerTest.scala
@@ -2,19 +2,13 @@ package org.enso.lockmanager
 
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
-import org.enso.distribution.locking.{
-  LockManager,
-  LockType,
-  ThreadSafeFileLockManager
-}
+import org.enso.distribution.locking.{LockManager, LockType, ThreadSafeFileLockManager}
 import org.enso.lockmanager.ActorToHandlerConnector.SetRequestHandler
-import org.enso.lockmanager.client.{
-  ConnectedLockManager,
-  RuntimeServerRequestHandler
-}
+import org.enso.lockmanager.client.{ConnectedLockManager, RuntimeServerRequestHandler}
 import org.enso.lockmanager.server.LockManagerService
 import org.enso.polyglot.runtime.Runtime.Api
 import org.enso.testkit.{TestSynchronizer, WithTemporaryDirectory}
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
@@ -24,7 +18,13 @@ class ConnectedLockManagerTest
     extends TestKit(ActorSystem("TestSystem"))
     with AnyWordSpecLike
     with Matchers
+    with BeforeAndAfterAll
     with WithTemporaryDirectory {
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+    super.afterAll()
+  }
 
   private def lockRoot = getTestDirectory.resolve("locks")
 

--- a/lib/scala/json-rpc-server-test/src/main/scala/org/enso/jsonrpc/test/JsonRpcServerTestKit.scala
+++ b/lib/scala/json-rpc-server-test/src/main/scala/org/enso/jsonrpc/test/JsonRpcServerTestKit.scala
@@ -45,7 +45,8 @@ abstract class JsonRpcServerTestKit
   }
 
   override def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
+    TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+    super.afterAll()
   }
 
   val interface       = "127.0.0.1"
@@ -137,7 +138,7 @@ abstract class JsonRpcServerTestKit
                   .append(")\n")
               }
             }
-            println(sb.toString())
+            //println(sb.toString())
             throw e
         }
       if (debugMessages) println(message)

--- a/lib/scala/json-rpc-server/src/test/scala/org/enso/jsonrpc/MessageHandlerSpec.scala
+++ b/lib/scala/json-rpc-server/src/test/scala/org/enso/jsonrpc/MessageHandlerSpec.scala
@@ -21,7 +21,7 @@ class MessageHandlerSpec
     with BeforeAndAfterEach {
 
   override def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
+    TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
   }
 
   case object MyRequest extends Method("RequestMethod") {

--- a/lib/scala/json-rpc-server/src/test/scala/org/enso/jsonrpc/MessageHandlerSpec.scala
+++ b/lib/scala/json-rpc-server/src/test/scala/org/enso/jsonrpc/MessageHandlerSpec.scala
@@ -22,6 +22,7 @@ class MessageHandlerSpec
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
+    super.afterAll()
   }
 
   case object MyRequest extends Method("RequestMethod") {

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerSupervisorSpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/infrastructure/languageserver/LanguageServerSupervisorSpec.scala
@@ -103,7 +103,7 @@ class LanguageServerSupervisorSpec
   }
 
   override def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
+    TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
   }
 
   trait TestCtx {

--- a/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/infrastructure/languageserver/ProjectRenameActionSpec.scala
+++ b/lib/scala/project-manager/src/test/scala/org/enso/projectmanager/infrastructure/languageserver/ProjectRenameActionSpec.scala
@@ -128,7 +128,7 @@ class ProjectRenameActionSpec
   }
 
   override def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
+    TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
   }
 
   trait TestCtx {


### PR DESCRIPTION
### Pull Request Description

The defaults picked up by Akka tend to make us of all resources which is unnecessary and overwhelming for tests.

Improves #8806, potentially.

Before
![Screenshot from 2024-01-28 22-34-42](https://github.com/enso-org/enso/assets/292128/f80eb66a-2f37-44d5-bcdb-f00a78fe72fd)
After
![Screenshot from 2024-01-31 00-12-10](https://github.com/enso-org/enso/assets/292128/c5223912-5f6e-413c-a0a4-050afa3ed463)

when running the problematic `LibrariesTest`.

Full `language-server` test suite.
Before
![Screenshot from 2024-01-31 00-20-50](https://github.com/enso-org/enso/assets/292128/f1c94a66-6905-4f57-8a7d-7df049714353)
After
![Screenshot from 2024-01-31 00-18-40](https://github.com/enso-org/enso/assets/292128/3a11125e-d593-43df-8d35-1a8915812b2b)


### Important Notes

Note that Executors assigned to Zio and initializers should also be improved. Unfortunately due to various blocking threadpools  it is easy to get timeouts when running the whole suite.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
