### PR TITLE
CI: Use GH Actions concurrency setting to manage cancelling.

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -181,17 +181,6 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  enso-build-ci-gen-job-cancel-workflow-linux:
-    name: Cancel Previous Runs
-    runs-on:
-      - ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.0
-        with:
-          access_token: ${{ github.token }}
-    permissions:
-      actions: write
   enso-build-ci-gen-job-lint-linux:
     name: Lint (linux)
     runs-on:
@@ -791,3 +780,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 env:
   ENSO_BUILD_SKIP_VERSION_CHECK: "true"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel_in_progress: ${{ github.ref != 'refs/heads/develop' }}

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -181,6 +181,18 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  enso-build-ci-gen-job-cancel-workflow-linux:
+    name: Cancel Previous Runs
+    if: github.ref != 'refs/heads/develop'
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+        with:
+          access_token: ${{ github.token }}
+    permissions:
+      actions: write
   enso-build-ci-gen-job-lint-linux:
     name: Lint (linux)
     runs-on:
@@ -780,6 +792,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 env:
   ENSO_BUILD_SKIP_VERSION_CHECK: "true"
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -782,4 +782,4 @@ env:
   ENSO_BUILD_SKIP_VERSION_CHECK: "true"
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel_in_progress: ${{ github.ref != 'refs/heads/develop' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}

--- a/.github/workflows/scala-new.yml
+++ b/.github/workflows/scala-new.yml
@@ -9,17 +9,6 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 jobs:
-  enso-build-ci-gen-job-cancel-workflow-linux:
-    name: Cancel Previous Runs
-    runs-on:
-      - ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.0
-        with:
-          access_token: ${{ github.token }}
-    permissions:
-      actions: write
   enso-build-ci-gen-job-ci-check-backend-linux:
     name: Engine (linux)
     runs-on:
@@ -263,3 +252,6 @@ jobs:
       checks: write
 env:
   ENSO_BUILD_SKIP_VERSION_CHECK: "true"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel_in_progress: ${{ github.ref != 'refs/heads/develop' }}

--- a/.github/workflows/scala-new.yml
+++ b/.github/workflows/scala-new.yml
@@ -254,4 +254,4 @@ env:
   ENSO_BUILD_SKIP_VERSION_CHECK: "true"
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel_in_progress: ${{ github.ref != 'refs/heads/develop' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}

--- a/.github/workflows/scala-new.yml
+++ b/.github/workflows/scala-new.yml
@@ -9,6 +9,18 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 jobs:
+  enso-build-ci-gen-job-cancel-workflow-linux:
+    name: Cancel Previous Runs
+    if: github.ref != 'refs/heads/develop'
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.0
+        with:
+          access_token: ${{ github.token }}
+    permissions:
+      actions: write
   enso-build-ci-gen-job-ci-check-backend-linux:
     name: Engine (linux)
     runs-on:
@@ -252,6 +264,3 @@ jobs:
       checks: write
 env:
   ENSO_BUILD_SKIP_VERSION_CHECK: "true"
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/develop' }}

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -5,7 +5,6 @@ use crate::ci_gen::secret;
 use crate::ci_gen::step;
 use crate::ci_gen::RunStepsBuilder;
 
-use ide_ci::actions::workflow::definition::cancel_workflow_action;
 use ide_ci::actions::workflow::definition::Access;
 use ide_ci::actions::workflow::definition::Job;
 use ide_ci::actions::workflow::definition::JobArchetype;
@@ -94,26 +93,6 @@ pub fn plain_job(
     command_line: impl Into<String>,
 ) -> Job {
     RunStepsBuilder::new(command_line).build_job(name, runs_on)
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct CancelWorkflow;
-impl JobArchetype for CancelWorkflow {
-    fn job(&self, _os: OS) -> Job {
-        Job {
-            name: "Cancel Previous Runs".into(),
-            // It is important that this particular job runs pretty much everywhere (we use x64,
-            // as all currently available GH runners have this label). If we limited it only to
-            // our self-hosted machines (as we usually do), it'd be enqueued after other jobs
-            // and wouldn't be able to cancel them.
-            runs_on: vec![RunnerLabel::LinuxLatest],
-            steps: vec![cancel_workflow_action()],
-            ..default()
-        }
-        // Necessary permission to cancel a run, as per:
-        // https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#cancel-a-workflow-run
-        .with_permission(Permission::Actions, Access::Write)
-    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/build/ci_utils/src/actions/workflow/definition.rs
+++ b/build/ci_utils/src/actions/workflow/definition.rs
@@ -126,7 +126,11 @@ pub struct JobId(String);
 #[serde(rename_all = "kebab-case", untagged)]
 pub enum Concurrency {
     Plain(String),
-    Map { group: String, cancel_in_progress: String },
+    #[serde(rename_all = "kebab-case")]
+    Map {
+        group:              String,
+        cancel_in_progress: String,
+    },
 }
 
 impl Concurrency {

--- a/build/ci_utils/src/actions/workflow/definition.rs
+++ b/build/ci_utils/src/actions/workflow/definition.rs
@@ -119,18 +119,6 @@ pub fn run(run_args: impl AsRef<str>) -> Step {
     shell(format!("./run {}", run_args.as_ref()))
 }
 
-pub fn cancel_workflow_action() -> Step {
-    Step {
-        name: Some("Cancel Previous Runs".into()),
-        uses: Some("styfle/cancel-workflow-action@0.12.0".into()),
-        with: Some(step::Argument::Other(BTreeMap::from_iter([(
-            "access_token".into(),
-            "${{ github.token }}".into(),
-        )]))),
-        ..default()
-    }
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct JobId(String);
 
@@ -138,7 +126,7 @@ pub struct JobId(String);
 #[serde(rename_all = "kebab-case", untagged)]
 pub enum Concurrency {
     Plain(String),
-    Map { group: String, cancel_in_progress: bool },
+    Map { group: String, cancel_in_progress: String },
 }
 
 impl Concurrency {

--- a/build/ci_utils/src/actions/workflow/definition.rs
+++ b/build/ci_utils/src/actions/workflow/definition.rs
@@ -119,6 +119,18 @@ pub fn run(run_args: impl AsRef<str>) -> Step {
     shell(format!("./run {}", run_args.as_ref()))
 }
 
+pub fn cancel_workflow_action() -> Step {
+    Step {
+        name: Some("Cancel Previous Runs".into()),
+        uses: Some("styfle/cancel-workflow-action@0.12.0".into()),
+        with: Some(step::Argument::Other(BTreeMap::from_iter([(
+            "access_token".into(),
+            "${{ github.token }}".into(),
+        )]))),
+        ..default()
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct JobId(String);
 


### PR DESCRIPTION
### Pull Request Description
Disable cancelling CI checks on develop commits. 

This is to learn more about CI stability and easier catch regressions.
If this proves to time-consuming for our runners, I'll revert this.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
