### PR TITLE
Always runEngineDistribution with -ea

### DIFF
--- a/project/DistributionPackage.scala
+++ b/project/DistributionPackage.scala
@@ -278,7 +278,9 @@ object DistributionPackage {
     pb.command(all)
     if (args.contains("--debug")) {
       all.remove("--debug")
-      pb.environment().put("JAVA_OPTS", WithDebugCommand.DEBUG_OPTION)
+      pb.environment().put("JAVA_OPTS", "-ea " + WithDebugCommand.DEBUG_OPTION)
+    } else {
+      pb.environment().put("JAVA_OPTS", "-ea")
     }
     pb.inheritIO()
     val p        = pb.start()


### PR DESCRIPTION
### Pull Request Description

When I execute `sbt> runEngineDistribution test/Base_Tests` I always get one failure - as the tests are supposed to be run with `-ea` enabled. That's annoying - let's fix the problem by always running with `-ea` when `runEngineDistribution` `sbt` command is used.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      style guides. 
- All code has been tested:
  - [x] Unit tests have been written where possible.
