### PR TITLE
Reduce test flakiness 

### DIFF
--- a/app/gui2/e2e/actions.ts
+++ b/app/gui2/e2e/actions.ts
@@ -9,7 +9,7 @@ import * as locate from './locate'
 /** Perform a successful login. */
 export async function goToGraph(page: Page) {
   await page.goto('/')
-  expect(page.locator('.App')).toBeVisible()
+  await expect(page.locator('.App')).toBeVisible()
   // Wait until nodes are loaded.
-  customExpect.toExist(locate.graphNode(page))
+  await customExpect.toExist(locate.graphNode(page))
 }

--- a/app/gui2/e2e/actions.ts
+++ b/app/gui2/e2e/actions.ts
@@ -1,4 +1,6 @@
-import { type Page } from '@playwright/test'
+import { expect, type Page } from '@playwright/test'
+import * as customExpect from './customExpect'
+import * as locate from './locate'
 
 // =================
 // === goToGraph ===
@@ -7,5 +9,7 @@ import { type Page } from '@playwright/test'
 /** Perform a successful login. */
 export async function goToGraph(page: Page) {
   await page.goto('/')
-  // Originally this clicked the play button but for now that is out of scope.
+  expect(page.locator('.App')).toBeVisible()
+  // Wait until nodes are loaded.
+  customExpect.toExist(locate.graphNode(page))
 }

--- a/app/gui2/e2e/typesOnNodeHover.spec.ts
+++ b/app/gui2/e2e/typesOnNodeHover.spec.ts
@@ -1,4 +1,4 @@
-import { expect, Locator, Page, test } from '@playwright/test'
+import { expect, test, type Locator, type Page } from '@playwright/test'
 import assert from 'assert'
 import * as actions from './actions'
 import { mockExpressionUpdate } from './expressionUpdates'

--- a/app/gui2/package.json
+++ b/app/gui2/package.json
@@ -12,7 +12,7 @@
     "build": "npm --workspace enso-dashboard run compile && run-p typecheck build-only",
     "build:cloud": "cross-env CLOUD_BUILD=true npm run build",
     "preview": "vite preview",
-    "test": "vitest run && playwright test --reporter=html",
+    "test": "vitest run && playwright test",
     "test:unit": "vitest",
     "test:e2e": "playwright test",
     "story:dev": "histoire dev",

--- a/app/gui2/playwright.config.ts
+++ b/app/gui2/playwright.config.ts
@@ -39,7 +39,6 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   ...(process.env.CI ? { workers: 1 } : {}),
-  reporter: 'line',
   expect: {
     timeout: 5000,
     toHaveScreenshot: { threshold: 0 },

--- a/app/gui2/playwright.config.ts
+++ b/app/gui2/playwright.config.ts
@@ -109,7 +109,10 @@ export default defineConfig({
     env: {
       E2E: 'true',
     },
-    command: `npx vite build && npx vite preview --port ${PORT} --strictPort`,
+    command:
+      process.env.CI || process.env.PROD
+        ? `npx vite build && npx vite preview --port ${PORT} --strictPort`
+        : `npx vite dev --port ${PORT}`,
     // Build from scratch apparently can take a while on CI machines.
     timeout: 120 * 1000,
     port: PORT,


### PR DESCRIPTION
### Pull Request Description

Probably fixes the first point in #8942 

My guess is that the mockExpressionUpdate may be not set in cases when the test runs before App mounting. To make sure all the setup is done, we wait for `App` widget to being mounted before proceeding.

### Important Notes

This PR also change the way we run test's server. Before it was always a production build, but this makes development iteration long. Now we test production build only on CI or when `PROD=true` env variable is set.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
