### PR TITLE
Fix loading wasm for ydocs server

### DIFF
--- a/app/ide-desktop/lib/client/src/bin/server.ts
+++ b/app/ide-desktop/lib/client/src/bin/server.ts
@@ -102,14 +102,21 @@ export class Server {
                             reject(err)
                         }
                         // Prepare the YDoc server access point for the new Vue-based GUI.
-                        if (httpServer) {
+                        // TODO[ao]: This is very ugly quickfix to make our rust-ffi WASM
+                        // working both in browser and in ydocs server. Doing it properly
+                        // is tracked in https://github.com/enso-org/enso/issues/8931
+                        const assets = path.join(paths.ASSETS_PATH, 'assets')
+                        const bundledFiles = fs.existsSync(assets) ? fs.readdirSync(assets) : []
+                        const rust_ffi_wasm = bundledFiles.find(name =>
+                            /rust_ffi_bg-.*\.wasm/.test(name)
+                        )
+                        if (httpServer && rust_ffi_wasm) {
                             await ydocServer.createGatewayServer(
                                 httpServer,
-                                // TODO[ao]: This is very ugly quickfix to make our rust-ffi WASM
-                                // working both in browser and in ydocs server. Doing it properly
-                                // is tracked in https://github.com/enso-org/enso/issues/8931
-                                path.join(paths.ASSETS_PATH, 'assets', 'rust_ffi_bg-c353f976.wasm')
+                                path.join(assets, rust_ffi_wasm)
                             )
+                        } else {
+                            logger.warn('YDocs server is not run, new GUI may not work properly!')
                         }
                         logger.log(`Server started on port ${this.config.port}.`)
                         logger.log(

--- a/app/ide-desktop/lib/client/src/bin/server.ts
+++ b/app/ide-desktop/lib/client/src/bin/server.ts
@@ -107,13 +107,13 @@ export class Server {
                         // is tracked in https://github.com/enso-org/enso/issues/8931
                         const assets = path.join(paths.ASSETS_PATH, 'assets')
                         const bundledFiles = fs.existsSync(assets) ? fs.readdirSync(assets) : []
-                        const rust_ffi_wasm = bundledFiles.find(name =>
+                        const rustFFIWasm = bundledFiles.find(name =>
                             /rust_ffi_bg-.*\.wasm/.test(name)
                         )
-                        if (httpServer && rust_ffi_wasm) {
+                        if (httpServer && rustFFIWasm != null) {
                             await ydocServer.createGatewayServer(
                                 httpServer,
-                                path.join(assets, rust_ffi_wasm)
+                                path.join(assets, rustFFIWasm)
                             )
                         } else {
                             logger.warn('YDocs server is not run, new GUI may not work properly!')


### PR DESCRIPTION
### Pull Request Description

#8893 introduced a fatal regression for old IDE + new IDE also does not work on every system.

The fix:
1. Don't assume that WASM needed by ydocs server is bundled
2. Don't assume we know its exact name.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
