### PR TITLE
Refactoring before text edits

### DIFF
--- a/app/gui2/shared/ast/parse.ts
+++ b/app/gui2/shared/ast/parse.ts
@@ -60,32 +60,212 @@ export function abstract(
   tree: RawAst.Tree,
   code: string,
 ): { root: Owned; spans: SpanMap; toRaw: Map<AstId, RawAst.Tree> } {
-  const tokens = new Map()
-  const nodes = new Map()
-  const toRaw = new Map()
-  const root = abstractTree(module, tree, code, nodes, tokens, toRaw).node
-  const spans = { tokens, nodes }
-  return { root, spans, toRaw }
+  const abstractor = new Abstractor(module, code)
+  const root = abstractor.abstractTree(tree).node
+  const spans = { tokens: abstractor.tokens, nodes: abstractor.nodes }
+  return { root, spans, toRaw: abstractor.toRaw }
 }
 
-function abstractTree(
-  module: MutableModule,
-  tree: RawAst.Tree,
-  code: string,
-  nodesOut: NodeSpanMap,
-  tokensOut: TokenSpanMap,
-  toRaw: Map<AstId, RawAst.Tree>,
-): { whitespace: string | undefined; node: Owned } {
-  const recurseTree = (tree: RawAst.Tree) =>
-    abstractTree(module, tree, code, nodesOut, tokensOut, toRaw)
-  const recurseToken = (token: RawAst.Token.Token) => abstractToken(token, code, tokensOut)
-  const visitChildren = (tree: LazyObject) => {
+class Abstractor {
+  private readonly module: MutableModule
+  private readonly code: string
+  readonly nodes: NodeSpanMap
+  readonly tokens: TokenSpanMap
+  readonly toRaw: Map<AstId, RawAst.Tree>
+
+  constructor(module: MutableModule, code: string) {
+    this.module = module
+    this.code = code
+    this.nodes = new Map()
+    this.tokens = new Map()
+    this.toRaw = new Map()
+  }
+
+  abstractTree(tree: RawAst.Tree): { whitespace: string | undefined; node: Owned } {
+    const whitespaceStart = tree.whitespaceStartInCodeParsed
+    const whitespaceEnd = whitespaceStart + tree.whitespaceLengthInCodeParsed
+    const whitespace = this.code.substring(whitespaceStart, whitespaceEnd)
+    const codeStart = whitespaceEnd
+    const codeEnd = codeStart + tree.childrenLengthInCodeParsed
+    const spanKey = nodeKey(codeStart, codeEnd - codeStart)
+    let node: Owned
+    switch (tree.type) {
+      case RawAst.Tree.Type.BodyBlock: {
+        const lines = Array.from(tree.statements, (line) => {
+          const newline = this.abstractToken(line.newline)
+          const expression = line.expression ? this.abstractTree(line.expression) : undefined
+          return { newline, expression }
+        })
+        node = BodyBlock.concrete(this.module, lines)
+        break
+      }
+      case RawAst.Tree.Type.Function: {
+        const name = this.abstractTree(tree.name)
+        const argumentDefinitions = Array.from(tree.args, (arg) => this.abstractChildren(arg))
+        const equals = this.abstractToken(tree.equals)
+        const body = tree.body !== undefined ? this.abstractTree(tree.body) : undefined
+        node = Function.concrete(this.module, name, argumentDefinitions, equals, body)
+        break
+      }
+      case RawAst.Tree.Type.Ident: {
+        const token = this.abstractToken(tree.token)
+        node = Ident.concrete(this.module, token)
+        break
+      }
+      case RawAst.Tree.Type.Assignment: {
+        const pattern = this.abstractTree(tree.pattern)
+        const equals = this.abstractToken(tree.equals)
+        const value = this.abstractTree(tree.expr)
+        node = Assignment.concrete(this.module, pattern, equals, value)
+        break
+      }
+      case RawAst.Tree.Type.App: {
+        const func = this.abstractTree(tree.func)
+        const arg = this.abstractTree(tree.arg)
+        node = App.concrete(this.module, func, undefined, undefined, arg)
+        break
+      }
+      case RawAst.Tree.Type.NamedApp: {
+        const func = this.abstractTree(tree.func)
+        const open = tree.open ? this.abstractToken(tree.open) : undefined
+        const name = this.abstractToken(tree.name)
+        const equals = this.abstractToken(tree.equals)
+        const arg = this.abstractTree(tree.arg)
+        const close = tree.close ? this.abstractToken(tree.close) : undefined
+        const parens = open && close ? { open, close } : undefined
+        const nameSpecification = { name, equals }
+        node = App.concrete(this.module, func, parens, nameSpecification, arg)
+        break
+      }
+      case RawAst.Tree.Type.UnaryOprApp: {
+        const opr = this.abstractToken(tree.opr)
+        const arg = tree.rhs ? this.abstractTree(tree.rhs) : undefined
+        if (arg && opr.node.code() === '-') {
+          node = NegationApp.concrete(this.module, opr, arg)
+        } else {
+          node = UnaryOprApp.concrete(this.module, opr, arg)
+        }
+        break
+      }
+      case RawAst.Tree.Type.OprApp: {
+        const lhs = tree.lhs ? this.abstractTree(tree.lhs) : undefined
+        const opr = tree.opr.ok
+          ? [this.abstractToken(tree.opr.value)]
+          : Array.from(tree.opr.error.payload.operators, this.abstractToken.bind(this))
+        const rhs = tree.rhs ? this.abstractTree(tree.rhs) : undefined
+        if (opr.length === 1 && opr[0]?.node.code() === '.' && rhs?.node instanceof MutableIdent) {
+          // Propagate type.
+          const rhs_ = { ...rhs, node: rhs.node }
+          node = PropertyAccess.concrete(this.module, lhs, opr[0], rhs_)
+        } else {
+          node = OprApp.concrete(this.module, lhs, opr, rhs)
+        }
+        break
+      }
+      case RawAst.Tree.Type.Number: {
+        const tokens = []
+        if (tree.base) tokens.push(this.abstractToken(tree.base))
+        if (tree.integer) tokens.push(this.abstractToken(tree.integer))
+        if (tree.fractionalDigits) {
+          tokens.push(this.abstractToken(tree.fractionalDigits.dot))
+          tokens.push(this.abstractToken(tree.fractionalDigits.digits))
+        }
+        node = NumericLiteral.concrete(this.module, tokens)
+        break
+      }
+      case RawAst.Tree.Type.Wildcard: {
+        const token = this.abstractToken(tree.token)
+        node = Wildcard.concrete(this.module, token)
+        break
+      }
+      // These expression types are (or will be) used for backend analysis.
+      // The frontend can ignore them, avoiding some problems with expressions sharing spans
+      // (which makes it impossible to give them unique IDs in the current IdMap format).
+      case RawAst.Tree.Type.OprSectionBoundary:
+      case RawAst.Tree.Type.TemplateFunction:
+        return { whitespace, node: this.abstractTree(tree.ast).node }
+      case RawAst.Tree.Type.Invalid: {
+        const expression = this.abstractTree(tree.ast)
+        node = Invalid.concrete(this.module, expression)
+        break
+      }
+      case RawAst.Tree.Type.Group: {
+        const open = tree.open ? this.abstractToken(tree.open) : undefined
+        const expression = tree.body ? this.abstractTree(tree.body) : undefined
+        const close = tree.close ? this.abstractToken(tree.close) : undefined
+        node = Group.concrete(this.module, open, expression, close)
+        break
+      }
+      case RawAst.Tree.Type.TextLiteral: {
+        const open = tree.open ? this.abstractToken(tree.open) : undefined
+        const newline = tree.newline ? this.abstractToken(tree.newline) : undefined
+        const elements = []
+        for (const e of tree.elements) {
+          elements.push(...this.abstractChildren(e))
+        }
+        const close = tree.close ? this.abstractToken(tree.close) : undefined
+        node = TextLiteral.concrete(this.module, open, newline, elements, close)
+        break
+      }
+      case RawAst.Tree.Type.Documented: {
+        const open = this.abstractToken(tree.documentation.open)
+        const elements = []
+        for (const e of tree.documentation.elements) {
+          elements.push(...this.abstractChildren(e))
+        }
+        const newlines = Array.from(tree.documentation.newlines, this.abstractToken.bind(this))
+        const expression = tree.expression ? this.abstractTree(tree.expression) : undefined
+        node = Documented.concrete(this.module, open, elements, newlines, expression)
+        break
+      }
+      case RawAst.Tree.Type.Import: {
+        const recurseBody = (tree: RawAst.Tree) => {
+          const body = this.abstractTree(tree)
+          if (body.node instanceof Invalid && body.node.code() === '') return undefined
+          return body
+        }
+        const recurseSegment = (segment: RawAst.MultiSegmentAppSegment) => ({
+          header: this.abstractToken(segment.header),
+          body: segment.body ? recurseBody(segment.body) : undefined,
+        })
+        const polyglot = tree.polyglot ? recurseSegment(tree.polyglot) : undefined
+        const from = tree.from ? recurseSegment(tree.from) : undefined
+        const import_ = recurseSegment(tree.import)
+        const all = tree.all ? this.abstractToken(tree.all) : undefined
+        const as = tree.as ? recurseSegment(tree.as) : undefined
+        const hiding = tree.hiding ? recurseSegment(tree.hiding) : undefined
+        node = Import.concrete(this.module, polyglot, from, import_, all, as, hiding)
+        break
+      }
+      default: {
+        node = Generic.concrete(this.module, this.abstractChildren(tree))
+      }
+    }
+    this.toRaw.set(node.id, tree)
+    map.setIfUndefined(this.nodes, spanKey, (): Ast[] => []).unshift(node)
+    return { node, whitespace }
+  }
+
+  private abstractToken(token: RawAst.Token): { whitespace: string; node: Token } {
+    const whitespaceStart = token.whitespaceStartInCodeBuffer
+    const whitespaceEnd = whitespaceStart + token.whitespaceLengthInCodeBuffer
+    const whitespace = this.code.substring(whitespaceStart, whitespaceEnd)
+    const codeStart = token.startInCodeBuffer
+    const codeEnd = codeStart + token.lengthInCodeBuffer
+    const tokenCode = this.code.substring(codeStart, codeEnd)
+    const key = tokenKey(codeStart, codeEnd - codeStart)
+    const node = Token.new(tokenCode, token.type)
+    this.tokens.set(key, node)
+    return { whitespace, node }
+  }
+
+  private abstractChildren(tree: LazyObject) {
     const children: NodeChild<Owned | Token>[] = []
     const visitor = (child: LazyObject) => {
       if (RawAst.Tree.isInstance(child)) {
-        children.push(recurseTree(child))
+        children.push(this.abstractTree(child))
       } else if (RawAst.Token.isInstance(child)) {
-        children.push(recurseToken(child))
+        children.push(this.abstractToken(child))
       } else {
         child.visitChildren(visitor)
       }
@@ -93,185 +273,6 @@ function abstractTree(
     tree.visitChildren(visitor)
     return children
   }
-  const whitespaceStart = tree.whitespaceStartInCodeParsed
-  const whitespaceEnd = whitespaceStart + tree.whitespaceLengthInCodeParsed
-  const whitespace = code.substring(whitespaceStart, whitespaceEnd)
-  const codeStart = whitespaceEnd
-  const codeEnd = codeStart + tree.childrenLengthInCodeParsed
-  const spanKey = nodeKey(codeStart, codeEnd - codeStart)
-  let node: Owned
-  switch (tree.type) {
-    case RawAst.Tree.Type.BodyBlock: {
-      const lines = Array.from(tree.statements, (line) => {
-        const newline = recurseToken(line.newline)
-        const expression = line.expression ? recurseTree(line.expression) : undefined
-        return { newline, expression }
-      })
-      node = BodyBlock.concrete(module, lines)
-      break
-    }
-    case RawAst.Tree.Type.Function: {
-      const name = recurseTree(tree.name)
-      const argumentDefinitions = Array.from(tree.args, (arg) => visitChildren(arg))
-      const equals = recurseToken(tree.equals)
-      const body = tree.body !== undefined ? recurseTree(tree.body) : undefined
-      node = Function.concrete(module, name, argumentDefinitions, equals, body)
-      break
-    }
-    case RawAst.Tree.Type.Ident: {
-      const token = recurseToken(tree.token)
-      node = Ident.concrete(module, token)
-      break
-    }
-    case RawAst.Tree.Type.Assignment: {
-      const pattern = recurseTree(tree.pattern)
-      const equals = recurseToken(tree.equals)
-      const value = recurseTree(tree.expr)
-      node = Assignment.concrete(module, pattern, equals, value)
-      break
-    }
-    case RawAst.Tree.Type.App: {
-      const func = recurseTree(tree.func)
-      const arg = recurseTree(tree.arg)
-      node = App.concrete(module, func, undefined, undefined, arg)
-      break
-    }
-    case RawAst.Tree.Type.NamedApp: {
-      const func = recurseTree(tree.func)
-      const open = tree.open ? recurseToken(tree.open) : undefined
-      const name = recurseToken(tree.name)
-      const equals = recurseToken(tree.equals)
-      const arg = recurseTree(tree.arg)
-      const close = tree.close ? recurseToken(tree.close) : undefined
-      const parens = open && close ? { open, close } : undefined
-      const nameSpecification = { name, equals }
-      node = App.concrete(module, func, parens, nameSpecification, arg)
-      break
-    }
-    case RawAst.Tree.Type.UnaryOprApp: {
-      const opr = recurseToken(tree.opr)
-      const arg = tree.rhs ? recurseTree(tree.rhs) : undefined
-      if (arg && opr.node.code() === '-') {
-        node = NegationApp.concrete(module, opr, arg)
-      } else {
-        node = UnaryOprApp.concrete(module, opr, arg)
-      }
-      break
-    }
-    case RawAst.Tree.Type.OprApp: {
-      const lhs = tree.lhs ? recurseTree(tree.lhs) : undefined
-      const opr = tree.opr.ok
-        ? [recurseToken(tree.opr.value)]
-        : Array.from(tree.opr.error.payload.operators, recurseToken)
-      const rhs = tree.rhs ? recurseTree(tree.rhs) : undefined
-      if (opr.length === 1 && opr[0]?.node.code() === '.' && rhs?.node instanceof MutableIdent) {
-        // Propagate type.
-        const rhs_ = { ...rhs, node: rhs.node }
-        node = PropertyAccess.concrete(module, lhs, opr[0], rhs_)
-      } else {
-        node = OprApp.concrete(module, lhs, opr, rhs)
-      }
-      break
-    }
-    case RawAst.Tree.Type.Number: {
-      const tokens = []
-      if (tree.base) tokens.push(recurseToken(tree.base))
-      if (tree.integer) tokens.push(recurseToken(tree.integer))
-      if (tree.fractionalDigits) {
-        tokens.push(recurseToken(tree.fractionalDigits.dot))
-        tokens.push(recurseToken(tree.fractionalDigits.digits))
-      }
-      node = NumericLiteral.concrete(module, tokens)
-      break
-    }
-    case RawAst.Tree.Type.Wildcard: {
-      const token = recurseToken(tree.token)
-      node = Wildcard.concrete(module, token)
-      break
-    }
-    // These expression types are (or will be) used for backend analysis.
-    // The frontend can ignore them, avoiding some problems with expressions sharing spans
-    // (which makes it impossible to give them unique IDs in the current IdMap format).
-    case RawAst.Tree.Type.OprSectionBoundary:
-    case RawAst.Tree.Type.TemplateFunction:
-      return { whitespace, node: recurseTree(tree.ast).node }
-    case RawAst.Tree.Type.Invalid: {
-      const expression = recurseTree(tree.ast)
-      node = Invalid.concrete(module, expression)
-      break
-    }
-    case RawAst.Tree.Type.Group: {
-      const open = tree.open ? recurseToken(tree.open) : undefined
-      const expression = tree.body ? recurseTree(tree.body) : undefined
-      const close = tree.close ? recurseToken(tree.close) : undefined
-      node = Group.concrete(module, open, expression, close)
-      break
-    }
-    case RawAst.Tree.Type.TextLiteral: {
-      const open = tree.open ? recurseToken(tree.open) : undefined
-      const newline = tree.newline ? recurseToken(tree.newline) : undefined
-      const elements = []
-      for (const e of tree.elements) {
-        elements.push(...visitChildren(e))
-      }
-      const close = tree.close ? recurseToken(tree.close) : undefined
-      node = TextLiteral.concrete(module, open, newline, elements, close)
-      break
-    }
-    case RawAst.Tree.Type.Documented: {
-      const open = recurseToken(tree.documentation.open)
-      const elements = []
-      for (const e of tree.documentation.elements) {
-        elements.push(...visitChildren(e))
-      }
-      const newlines = Array.from(tree.documentation.newlines, recurseToken)
-      const expression = tree.expression ? recurseTree(tree.expression) : undefined
-      node = Documented.concrete(module, open, elements, newlines, expression)
-      break
-    }
-    case RawAst.Tree.Type.Import: {
-      const recurseBody = (tree: RawAst.Tree) => {
-        const body = recurseTree(tree)
-        if (body.node instanceof Invalid && body.node.code() === '') return undefined
-        return body
-      }
-      const recurseSegment = (segment: RawAst.MultiSegmentAppSegment) => ({
-        header: recurseToken(segment.header),
-        body: segment.body ? recurseBody(segment.body) : undefined,
-      })
-      const polyglot = tree.polyglot ? recurseSegment(tree.polyglot) : undefined
-      const from = tree.from ? recurseSegment(tree.from) : undefined
-      const import_ = recurseSegment(tree.import)
-      const all = tree.all ? recurseToken(tree.all) : undefined
-      const as = tree.as ? recurseSegment(tree.as) : undefined
-      const hiding = tree.hiding ? recurseSegment(tree.hiding) : undefined
-      node = Import.concrete(module, polyglot, from, import_, all, as, hiding)
-      break
-    }
-    default: {
-      node = Generic.concrete(module, visitChildren(tree))
-    }
-  }
-  toRaw.set(node.id, tree)
-  map.setIfUndefined(nodesOut, spanKey, (): Ast[] => []).unshift(node)
-  return { node, whitespace }
-}
-
-function abstractToken(
-  token: RawAst.Token,
-  code: string,
-  tokensOut: TokenSpanMap,
-): { whitespace: string; node: Token } {
-  const whitespaceStart = token.whitespaceStartInCodeBuffer
-  const whitespaceEnd = whitespaceStart + token.whitespaceLengthInCodeBuffer
-  const whitespace = code.substring(whitespaceStart, whitespaceEnd)
-  const codeStart = token.startInCodeBuffer
-  const codeEnd = codeStart + token.lengthInCodeBuffer
-  const tokenCode = code.substring(codeStart, codeEnd)
-  const key = tokenKey(codeStart, codeEnd - codeStart)
-  const node = Token.new(tokenCode, token.type)
-  tokensOut.set(key, node)
-  return { whitespace, node }
 }
 
 declare const nodeKeyBrand: unique symbol

--- a/app/gui2/shared/ast/tree.ts
+++ b/app/gui2/shared/ast/tree.ts
@@ -993,17 +993,17 @@ export class MutableImport extends Import implements MutableAst {
 
   replaceChild<T extends MutableAst>(target: AstId, replacement: Owned<T>) {
     const { polyglot, from, import: import_, as, hiding } = getAll(this.fields)
-    ;(polyglot?.body?.node === target
-      ? this.setPolyglot
+    polyglot?.body?.node === target
+      ? this.setPolyglot(replacement)
       : from?.body?.node === target
-      ? this.setFrom
+      ? this.setFrom(replacement)
       : import_.body?.node === target
-      ? this.setImport
+      ? this.setImport(replacement)
       : as?.body?.node === target
-      ? this.setAs
+      ? this.setAs(replacement)
       : hiding?.body?.node === target
-      ? this.setHiding
-      : bail(`Failed to find child ${target} in node ${this.externalId}.`))(replacement)
+      ? this.setHiding(replacement)
+      : bail(`Failed to find child ${target} in node ${this.externalId}.`)
   }
 }
 export interface MutableImport extends Import, MutableAst {

--- a/app/gui2/shared/ast/tree.ts
+++ b/app/gui2/shared/ast/tree.ts
@@ -208,6 +208,12 @@ export abstract class MutableAst extends Ast {
     return old
   }
 
+  replaceValueChecked<T extends MutableAst>(replacement: Owned<T>): Owned<typeof this> {
+    const parentId = this.fields.get('parent')
+    assertDefined(parentId)
+    return this.replaceValue(replacement)
+  }
+
   /** Replace the parent of this object with a reference to a new placeholder object.
    *  Returns the object, now parentless, and the placeholder. */
   takeToReplace(): Removed<this> {
@@ -325,9 +331,13 @@ interface AppFields {
 }
 export class App extends Ast {
   declare fields: FixedMap<AstFields & AppFields>
-
   constructor(module: Module, fields: FixedMapView<AstFields & AppFields>) {
     super(module, fields)
+  }
+
+  static tryParse(source: string, module?: MutableModule): Owned<MutableApp> | undefined {
+    const parsed = parse(source, module)
+    if (parsed instanceof MutableApp) return parsed
   }
 
   static concrete(
@@ -457,6 +467,11 @@ export class UnaryOprApp extends Ast {
     super(module, fields)
   }
 
+  static tryParse(source: string, module?: MutableModule): Owned<MutableUnaryOprApp> | undefined {
+    const parsed = parse(source, module)
+    if (parsed instanceof MutableUnaryOprApp) return parsed
+  }
+
   static concrete(
     module: MutableModule,
     operator: NodeChild<Token>,
@@ -520,6 +535,11 @@ export class NegationApp extends Ast {
     super(module, fields)
   }
 
+  static tryParse(source: string, module?: MutableModule): Owned<MutableNegationApp> | undefined {
+    const parsed = parse(source, module)
+    if (parsed instanceof MutableNegationApp) return parsed
+  }
+
   static concrete(module: MutableModule, operator: NodeChild<Token>, argument: NodeChild<Owned>) {
     const base = module.baseObject('NegationApp')
     const id_ = base.get('id')
@@ -575,6 +595,11 @@ export class OprApp extends Ast {
   declare fields: FixedMapView<AstFields & OprAppFields>
   constructor(module: Module, fields: FixedMapView<AstFields & OprAppFields>) {
     super(module, fields)
+  }
+
+  static tryParse(source: string, module?: MutableModule): Owned<MutableOprApp> | undefined {
+    const parsed = parse(source, module)
+    if (parsed instanceof MutableOprApp) return parsed
   }
 
   static concrete(
@@ -662,6 +687,14 @@ export class PropertyAccess extends Ast {
   declare fields: FixedMapView<AstFields & PropertyAccessFields>
   constructor(module: Module, fields: FixedMapView<AstFields & PropertyAccessFields>) {
     super(module, fields)
+  }
+
+  static tryParse(
+    source: string,
+    module?: MutableModule,
+  ): Owned<MutablePropertyAccess> | undefined {
+    const parsed = parse(source, module)
+    if (parsed instanceof MutablePropertyAccess) return parsed
   }
 
   static new(module: MutableModule, lhs: Owned, rhs: IdentLike) {
@@ -865,6 +898,11 @@ export class Import extends Ast {
     super(module, fields)
   }
 
+  static tryParse(source: string, module?: MutableModule): Owned<MutableImport> | undefined {
+    const parsed = parse(source, module)
+    if (parsed instanceof MutableImport) return parsed
+  }
+
   get polyglot(): Ast | undefined {
     return this.module.checkedGet(this.fields.get('polyglot')?.body?.node)
   }
@@ -1045,6 +1083,11 @@ export class TextLiteral extends Ast {
     super(module, fields)
   }
 
+  static tryParse(source: string, module?: MutableModule): Owned<MutableTextLiteral> | undefined {
+    const parsed = parse(source, module)
+    if (parsed instanceof MutableTextLiteral) return parsed
+  }
+
   static concrete(
     module: MutableModule,
     open: NodeChild<Token> | undefined,
@@ -1103,6 +1146,11 @@ export class Documented extends Ast {
   declare fields: FixedMapView<AstFields & DocumentedFields>
   constructor(module: Module, fields: FixedMapView<AstFields & DocumentedFields>) {
     super(module, fields)
+  }
+
+  static tryParse(source: string, module?: MutableModule): Owned<MutableDocumented> | undefined {
+    const parsed = parse(source, module)
+    if (parsed instanceof MutableDocumented) return parsed
   }
 
   static concrete(
@@ -1230,6 +1278,11 @@ export class Group extends Ast {
     super(module, fields)
   }
 
+  static tryParse(source: string, module?: MutableModule): Owned<MutableGroup> | undefined {
+    const parsed = parse(source, module)
+    if (parsed instanceof MutableGroup) return parsed
+  }
+
   static concrete(
     module: MutableModule,
     open: NodeChild<Token> | undefined,
@@ -1286,6 +1339,14 @@ export class NumericLiteral extends Ast {
     super(module, fields)
   }
 
+  static tryParse(
+    source: string,
+    module?: MutableModule,
+  ): Owned<MutableNumericLiteral> | undefined {
+    const parsed = parse(source, module)
+    if (parsed instanceof MutableNumericLiteral) return parsed
+  }
+
   static concrete(module: MutableModule, tokens: NodeChild<Token>[]) {
     const base = module.baseObject('NumericLiteral')
     const fields = setAll(base, { tokens })
@@ -1334,6 +1395,11 @@ export class Function extends Ast {
   declare fields: FixedMapView<AstFields & FunctionFields>
   constructor(module: Module, fields: FixedMapView<AstFields & FunctionFields>) {
     super(module, fields)
+  }
+
+  static tryParse(source: string, module?: MutableModule): Owned<MutableFunction> | undefined {
+    const parsed = parse(source, module)
+    if (parsed instanceof MutableFunction) return parsed
   }
 
   get name(): Ast {
@@ -1477,6 +1543,11 @@ export class Assignment extends Ast {
     super(module, fields)
   }
 
+  static tryParse(source: string, module?: MutableModule): Owned<MutableAssignment> | undefined {
+    const parsed = parse(source, module)
+    if (parsed instanceof MutableAssignment) return parsed
+  }
+
   static concrete(
     module: MutableModule,
     pattern: NodeChild<Owned>,
@@ -1549,6 +1620,11 @@ export class BodyBlock extends Ast {
   declare fields: FixedMapView<AstFields & BodyBlockFields>
   constructor(module: Module, fields: FixedMapView<AstFields & BodyBlockFields>) {
     super(module, fields)
+  }
+
+  static tryParse(source: string, module?: MutableModule): Owned<MutableBodyBlock> | undefined {
+    const parsed = parse(source, module)
+    if (parsed instanceof MutableBodyBlock) return parsed
   }
 
   static concrete(module: MutableModule, lines: OwnedBlockLine[]) {
@@ -1712,6 +1788,11 @@ export class Ident extends Ast {
     super(module, fields)
   }
 
+  static tryParse(source: string, module?: MutableModule): Owned<MutableIdent> | undefined {
+    const parsed = parse(source, module)
+    if (parsed instanceof MutableIdent) return parsed
+  }
+
   get token(): IdentifierToken {
     return this.module.getToken(this.fields.get('token').node) as IdentifierToken
   }
@@ -1763,6 +1844,11 @@ export class Wildcard extends Ast {
   declare fields: FixedMapView<AstFields & WildcardFields>
   constructor(module: Module, fields: FixedMapView<AstFields & WildcardFields>) {
     super(module, fields)
+  }
+
+  static tryParse(source: string, module?: MutableModule): Owned<MutableWildcard> | undefined {
+    const parsed = parse(source, module)
+    if (parsed instanceof MutableWildcard) return parsed
   }
 
   get token(): Token {

--- a/app/gui2/src/components/GraphEditor/GraphEdges.vue
+++ b/app/gui2/src/components/GraphEditor/GraphEdges.vue
@@ -56,7 +56,7 @@ const editingEdge: Interaction = {
 interaction.setWhen(() => graph.unconnectedEdge != null, editingEdge)
 
 function disconnectEdge(target: PortId) {
-  graph.commitDirect((edit) => {
+  graph.edit((edit) => {
     if (!graph.updatePortValue(edit, target, undefined)) {
       if (isAstId(target)) {
         console.warn(`Failed to disconnect edge from port ${target}, falling back to direct edit.`)
@@ -79,7 +79,7 @@ function createEdge(source: AstId, target: PortId) {
     return console.error(`Failed to connect edge, source or target node not found.`)
   }
 
-  const edit = graph.astModule.edit()
+  const edit = graph.startEdit()
   const reorderResult = graph.ensureCorrectNodeOrder(edit, sourceNode, targetNode)
   if (reorderResult === 'circular') {
     // Creating this edge would create a circular dependency. Prevent that and display error.

--- a/app/gui2/src/components/GraphEditor/NodeWidgetTree.vue
+++ b/app/gui2/src/components/GraphEditor/NodeWidgetTree.vue
@@ -31,11 +31,9 @@ const observedLayoutTransitions = new Set([
 ])
 
 function handleWidgetUpdates(update: WidgetUpdate) {
+  const edit = update.edit ?? graph.startEdit()
   if (update.portUpdate) {
-    const {
-      edit,
-      portUpdate: { value, origin },
-    } = update
+    const { value, origin } = update.portUpdate
     if (Ast.isAstId(origin)) {
       const ast =
         value instanceof Ast.Ast
@@ -48,7 +46,7 @@ function handleWidgetUpdates(update: WidgetUpdate) {
       console.error(`[UPDATE ${origin}] Invalid top-level origin. Expected expression ID.`)
     }
   }
-  graph.commitEdit(update.edit)
+  graph.commitEdit(edit)
   // This handler is guaranteed to be the last handler in the chain.
   return true
 }

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetCheckbox.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetCheckbox.vue
@@ -17,7 +17,7 @@ const value = computed({
     return WidgetInput.valueRepr(props.input)?.endsWith('True') ?? false
   },
   set(value) {
-    const edit = graph.astModule.edit()
+    const edit = graph.startEdit()
     if (props.input.value instanceof Ast.Ast) {
       setBoolNode(
         edit.getVersion(props.input.value),

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetFunction.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetFunction.vue
@@ -162,10 +162,8 @@ const widgetConfiguration = computed(() => {
 function handleArgUpdate(update: WidgetUpdate): boolean {
   const app = application.value
   if (update.portUpdate && app instanceof ArgumentApplication) {
-    const {
-      edit,
-      portUpdate: { value, origin },
-    } = update
+    const { value, origin } = update.portUpdate
+    const edit = update.edit ?? graph.startEdit()
     // Find the updated argument by matching origin port/expression with the appropriate argument.
     // We are interested only in updates at the top level of the argument AST. Updates from nested
     // widgets do not need to be processed at the function application level.

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetNumber.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetNumber.vue
@@ -16,7 +16,6 @@ const value = computed({
   },
   set(value) {
     props.onUpdate({
-      edit: graph.astModule.edit(),
       portUpdate: { value: value.toString(), origin: asNot<TokenId>(props.input.portId) },
     })
   },

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
@@ -10,6 +10,7 @@ import { useGraphStore } from '@/stores/graph'
 import { requiredImports, type RequiredImport } from '@/stores/graph/imports.ts'
 import { useSuggestionDbStore } from '@/stores/suggestionDatabase'
 import { type SuggestionEntry } from '@/stores/suggestionDatabase/entry.ts'
+import { Ast } from '@/util/ast'
 import type { TokenId } from '@/util/ast/abstract.ts'
 import { ArgumentInfoKey } from '@/util/callTree'
 import { asNot } from '@/util/data/types.ts'
@@ -117,9 +118,11 @@ function toggleDropdownWidget() {
 
 // When the selected index changes, we update the expression content.
 watch(selectedIndex, (_index) => {
-  const edit = graph.astModule.edit()
-  if (selectedTag.value?.requiredImports)
+  let edit: Ast.MutableModule | undefined
+  if (selectedTag.value?.requiredImports) {
+    edit = graph.startEdit()
     graph.addMissingImports(edit, selectedTag.value.requiredImports)
+  }
   props.onUpdate({
     edit,
     portUpdate: {

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
@@ -16,7 +16,6 @@ const value = computed({
   },
   set(value) {
     props.onUpdate({
-      edit: graph.astModule.edit(),
       portUpdate: { value: value.toString(), origin: asNot<TokenId>(props.input.portId) },
     })
   },

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetVector.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetVector.vue
@@ -36,9 +36,7 @@ const value = computed({
   set(value) {
     // TODO[ao]: here we re-create AST. It would be better to reuse existing AST nodes.
     const newCode = `[${value.map((item) => item.code()).join(', ')}]`
-    const edit = graph.astModule.edit()
     props.onUpdate({
-      edit,
       portUpdate: { value: newCode, origin: asNot<TokenId>(props.input.portId) },
     })
   },

--- a/app/gui2/src/composables/stackNavigator.ts
+++ b/app/gui2/src/composables/stackNavigator.ts
@@ -55,8 +55,12 @@ export function useStackNavigator() {
   }
 
   function enterNode(id: AstId) {
-    const node = graphStore.astModule.get(id)!
-    const expressionInfo = graphStore.db.getExpressionInfo(id)
+    const externalId = graphStore.db.idToExternal(id)
+    if (externalId == null) {
+      console.debug("Cannot enter node that hasn't been committed yet.")
+      return
+    }
+    const expressionInfo = graphStore.db.getExpressionInfo(externalId)
     if (expressionInfo == null || expressionInfo.methodCall == null) {
       console.debug('Cannot enter node that has no method call.')
       return
@@ -71,7 +75,7 @@ export function useStackNavigator() {
       console.debug('Cannot enter node that is not defined on current module.')
       return
     }
-    projectStore.executionContext.push(node.externalId)
+    projectStore.executionContext.push(externalId)
     graphStore.updateState()
     breadcrumbs.value = projectStore.executionContext.desiredStack.slice()
   }

--- a/app/gui2/src/providers/widgetRegistry.ts
+++ b/app/gui2/src/providers/widgetRegistry.ts
@@ -141,7 +141,7 @@ export interface WidgetProps<T> {
  * is committed in {@link NodeWidgetTree}.
  */
 export interface WidgetUpdate {
-  edit: MutableModule
+  edit?: MutableModule | undefined
   portUpdate?: {
     value: Ast.Owned | string | undefined
     origin: PortId

--- a/app/gui2/src/stores/graph/imports.ts
+++ b/app/gui2/src/stores/graph/imports.ts
@@ -537,8 +537,8 @@ if (import.meta.vitest) {
   })
 
   const parseImport = (code: string): Import | null => {
-    const ast: Ast.Ast = Ast.parse(code)
-    return ast instanceof Ast.Import ? recognizeImport(ast) : null
+    const ast = Ast.Import.tryParse(code)
+    return ast ? recognizeImport(ast) : null
   }
 
   test.each([

--- a/app/gui2/src/stores/graph/index.ts
+++ b/app/gui2/src/stores/graph/index.ts
@@ -442,6 +442,8 @@ export const useGraphStore = defineStore('graph', () => {
         Ast.repair(root, edit)
       }
     }, 'local')
+    if (!direct)
+      Y.applyUpdateV2(syncModule.value!.ydoc, Y.encodeStateAsUpdateV2(edit.ydoc), 'local')
     return result!
   }
 


### PR DESCRIPTION
### Pull Request Description

Changes in preparation for #8238 features.

### Important Notes

Changed edit APIs:
- **`graph.astModule` is deprecated.** It will be removed in my next PR.
- Prefer `graph.edit` to start and commit an edit.
- Use `graph.startEdit` / `graph.commitEdit` if the edit can't be confined to one scope.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
