### PR TITLE
Keep only module-info.class in the root of runtime-fat-jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2018,8 +2018,10 @@ lazy val `runtime-fat-jar` =
           MergeStrategy.discard
         case PathList("META-INF", "services", xs @ _*) =>
           MergeStrategy.concat
-        case PathList(xs @ _*) if xs.last.contains("module-info") =>
+        case PathList("module-info.class") =>
           MergeStrategy.preferProject
+        case PathList(xs @ _*) if xs.last.contains("module-info.class") =>
+          MergeStrategy.discard
         case _ => MergeStrategy.first
       }
     )


### PR DESCRIPTION
### Pull Request Description

Additional fix to #8940. After this change there is only a single module info:
```
enso$ unzip runtime.jar module-info.class
enso$ javap module-info.class 
Compiled from "module-info.java"
open module org.enso.runtime {
  requires java.base;
  requires java.compiler;
  requires java.desktop;
  requires java.se;
  requires jdk.unsupported;
  requires org.graalvm.polyglot;
  requires org.graalvm.truffle;
  requires static org.slf4j;
  uses org.slf4j.spi.SLF4JServiceProvider;
  uses org.enso.interpreter.instrument.HandlerFactory;
  provides  com.oracle.truffle.api.provider.TruffleLanguageProvider with
    org.enso.interpreter.EnsoLanguageProvider,
    org.enso.interpreter.epb.EpbLanguageProvider;
  provides  com.oracle.truffle.api.instrumentation.provider.TruffleInstrumentProvider with
    org.enso.interpreter.instrument.ReplDebuggerInstrumentProvider,
    org.enso.interpreter.instrument.RuntimeServerInstrumentProvider,
    org.enso.interpreter.instrument.IdExecutionInstrumentProvider;
}
```
all other `META-INF/versions/*/module-info.class` files are dropped.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      style guides. 
- All code has been tested:
  - [x] Unit tests continue to pass
