### PR TITLE
Disable flaky test

### DIFF
--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/LibrariesTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/LibrariesTest.scala
@@ -60,7 +60,7 @@ class LibrariesTest
   )
 
   "LocalLibraryManager" should {
-    "create a library project and include it on the list of local projects" taggedAs Flaky in {
+    "create a library project and include it on the list of local projects" taggedAs SkipOnFailure in {
       val client          = getInitialisedWsClient()
       val testLibraryName = LibraryName("user", "My_Local_Lib")
 
@@ -95,7 +95,10 @@ class LibrariesTest
         } yield libraryNames
 
       // The resolver may find the current project and other test projects on the path.
-      val msg1 = client.expectSomeJson(timeout = defaultTimeout)
+      val msg1 = client.expectSomeJson(
+        timeout                   = defaultTimeout,
+        printStackTracesOnFailure = true
+      )
       inside(findLibraryNamesInResponse(msg1)) { case Some(libs) =>
         // Ensure that before running this test, the library did not exist.
         libs should not contain testLibraryName

--- a/lib/scala/json-rpc-server-test/src/main/scala/org/enso/jsonrpc/test/JsonRpcServerTestKit.scala
+++ b/lib/scala/json-rpc-server-test/src/main/scala/org/enso/jsonrpc/test/JsonRpcServerTestKit.scala
@@ -119,12 +119,18 @@ abstract class JsonRpcServerTestKit
 
     def send(json: Json): Unit = send(json.noSpaces)
 
-    def expectMessage(timeout: FiniteDuration = 5.seconds.dilated): String = {
+    def expectMessage(
+      timeout: FiniteDuration            = 5.seconds.dilated,
+      printStackTracesOnFailure: Boolean = false
+    ): String = {
       val message =
         try {
           outActor.expectMsgClass[String](timeout, classOf[String])
         } catch {
-          case e: AssertionError if e.getMessage.contains("timeout") =>
+          case e: AssertionError
+              if e.getMessage.contains(
+                "timeout"
+              ) && printStackTracesOnFailure =>
             val sb = new StringBuilder(
               "Thread dump when timeout is reached while waiting for the message:\n"
             )
@@ -142,7 +148,7 @@ abstract class JsonRpcServerTestKit
                   .append(")\n")
               }
             }
-            //println(sb.toString())
+            println(sb.toString())
             throw e
         }
       if (debugMessages) println(message)
@@ -158,9 +164,10 @@ abstract class JsonRpcServerTestKit
     }
 
     def expectSomeJson(
-      timeout: FiniteDuration = 10.seconds.dilated
+      timeout: FiniteDuration            = 10.seconds.dilated,
+      printStackTracesOnFailure: Boolean = false
     )(implicit pos: Position): Json = {
-      val parsed = parse(expectMessage(timeout))
+      val parsed = parse(expectMessage(timeout, printStackTracesOnFailure))
       inside(parsed) { case Right(json) => json }
     }
 


### PR DESCRIPTION
Despite all attempts to reduce resource usage, the test continues to be stubborn like a mule and randomly timeouts on CI. Adding an option to print stacktraces and maybe someone will be struck by lighting and be able to figure it out. Adding the stracktrace in all cases pollutes the output from CI.

Closes  #8806.
