### PR TITLE
CI: Retry Artifact Upload Finalization

### DIFF
--- a/build/ci_utils/src/actions/artifacts/run_session.rs
+++ b/build/ci_utils/src/actions/artifacts/run_session.rs
@@ -57,7 +57,7 @@ impl SessionClient {
     ) -> Result<PatchArtifactSizeResponse> {
         raw::endpoints::patch_artifact_size(
             &self.json_client,
-            self.artifact_url.clone(),
+            &self.artifact_url,
             artifact_name,
             total_size,
         )

--- a/build/ci_utils/src/actions/workflow.rs
+++ b/build/ci_utils/src/actions/workflow.rs
@@ -108,3 +108,7 @@ impl Message {
 pub fn message(level: MessageLevel, text: impl AsRef<str>) {
     Message { level, text: text.as_ref().into() }.send()
 }
+
+pub fn warn(text: impl AsRef<str>) {
+    message(MessageLevel::Warning, text)
+}

--- a/build/ci_utils/src/io.rs
+++ b/build/ci_utils/src/io.rs
@@ -74,15 +74,33 @@ pub async fn download_and_extract(
     client::download_and_extract(&default(), url, output_dir).await
 }
 
-// pub async fn stream_to_file<E: Into<Box<dyn std::error::Error + Send + Sync>>>(
-//     stream: impl Stream<Item = std::result::Result<Bytes, E>> + Unpin,
-//     output_path: impl AsRef<Path>,
-// ) -> Result {
-//     let mut reader = tokio_util::io::StreamReader::new(stream.map_err(std::io::Error::other));
-//     let mut output = crate::fs::tokio::create(output_path).await?;
-//     tokio::io::copy(&mut reader, &mut output).await?;
-//     Ok(())
-// }
+/// Retry a given action until it succeeds or the maximum number of attempts is reached.
+pub async fn retry<Fn, Fut, Ret>(mut action: Fn) -> Result<Ret>
+where
+    Fn: FnMut() -> Fut,
+    Fut: Future<Output = Result<Ret>>, {
+    let growth_factor = 1.5;
+    let mut attempts = 5;
+    let mut delay = std::time::Duration::from_millis(500);
+    let max_delay = std::time::Duration::from_secs(10);
+
+    loop {
+        match action().await {
+            Ok(result) => return Ok(result),
+            Err(err) => {
+                let warning = format!("Failed to execute action: {err:?}");
+                crate::actions::workflow::warn(&warning);
+                warn!("{warning}");
+                if attempts == 0 {
+                    return Err(err);
+                }
+                attempts -= 1;
+                tokio::time::sleep(delay).await;
+                delay = delay.mul_f32(growth_factor).min(max_delay);
+            }
+        }
+    }
+}
 
 
 #[cfg(test)]


### PR DESCRIPTION
### Pull Request Description
This has been observed to be the most random error-prone part of the Rust build scripts.

This adds several retries to the patching of the artifact size (which finalizes the upload).
Additional diagnostics was added, so we observe if the retries are actually helping, so we can better understand the issue if this is not enough to fix it.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
