### PR TITLE
Fix vector widget in non-argument literal

### DIFF
--- a/app/gui2/e2e/collapsingAndEntering.spec.ts
+++ b/app/gui2/e2e/collapsingAndEntering.spec.ts
@@ -92,7 +92,7 @@ test('Collapsing nodes', async ({ page }) => {
 })
 
 async function expectInsideMain(page: Page) {
-  await expect(locate.graphNode(page)).toHaveCount(9)
+  await expect(locate.graphNode(page)).toHaveCount(10)
   await customExpect.toExist(locate.graphNodeByBinding(page, 'five'))
   await customExpect.toExist(locate.graphNodeByBinding(page, 'ten'))
   await customExpect.toExist(locate.graphNodeByBinding(page, 'sum'))

--- a/app/gui2/e2e/collapsingAndEntering.spec.ts
+++ b/app/gui2/e2e/collapsingAndEntering.spec.ts
@@ -86,7 +86,7 @@ test('Collapsing nodes', async ({ page }) => {
   const secondCollapsedNode = locate.graphNodeByBinding(page, 'ten')
   await expect(secondCollapsedNode.locator('.WidgetToken')).toHaveText(['Main', '.', 'collapsed1'])
   await mockCollapsedFunctionInfo(page, 'ten', 'collapsed1')
-  secondCollapsedNode.dblclick()
+  await secondCollapsedNode.dblclick()
   await expect(locate.graphNode(page)).toHaveCount(2)
   await customExpect.toExist(locate.graphNodeByBinding(page, 'ten'))
 })

--- a/app/gui2/e2e/widgets.spec.ts
+++ b/app/gui2/e2e/widgets.spec.ts
@@ -27,6 +27,23 @@ class DropDownLocator {
   }
 }
 
+test('Widget in plain AST', async ({ page }) => {
+  await actions.goToGraph(page)
+  const numberNode = locate.graphNodeByBinding(page, 'five')
+  const numberWidget = numberNode.locator('.WidgetNumber')
+  await expect(numberWidget).toBeVisible()
+  await expect(numberWidget.locator('.value')).toHaveValue('5')
+
+  const listNode = locate.graphNodeByBinding(page, 'list')
+  const listWidget = listNode.locator('.WidgetVector')
+  await expect(listWidget).toBeVisible()
+
+  const textNode = locate.graphNodeByBinding(page, 'text')
+  const textWidget = textNode.locator('.WidgetText')
+  await expect(textWidget).toBeVisible()
+  await expect(textWidget.locator('.value')).toHaveValue("'test'")
+})
+
 test('Selection widgets in Data.read node', async ({ page }) => {
   await actions.goToGraph(page)
   await mockMethodCallInfo(page, 'data', {

--- a/app/gui2/mock/engine.ts
+++ b/app/gui2/mock/engine.ts
@@ -58,6 +58,7 @@ main =
     prod = sum * 3
     final = Main.func1 prod
     list = []
+    text = 'test'
     
     # Widget tests
     data = Data.read

--- a/app/gui2/playwright.config.ts
+++ b/app/gui2/playwright.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
   use: {
     headless: !DEBUG,
     trace: 'on-first-retry',
-    viewport: { width: 1920, height: 1200 },
+    viewport: { width: 1920, height: 1600 },
     ...(DEBUG
       ? {}
       : {

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetVector.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetVector.vue
@@ -54,9 +54,11 @@ export const widgetDefinition = defineWidget(WidgetInput.isAstOrPlaceholder, {
     if (props.input.dynamicConfig?.kind === 'Vector_Editor') return Score.Perfect
     else if (props.input.expectedType?.startsWith('Standard.Base.Data.Vector.Vector'))
       return Score.Good
-    else if (props.input.value instanceof Ast.Ast)
-      return props.input.value.children().next().value.code === '[' ? Score.Perfect : Score.Mismatch
-    else return Score.Mismatch
+    else if (props.input.value instanceof Ast.Ast) {
+      return props.input.value.children().next().value.code() === '['
+        ? Score.Perfect
+        : Score.Mismatch
+    } else return Score.Mismatch
   },
 })
 </script>


### PR DESCRIPTION
### Pull Request Description

Fix vector widget not appearing in non-argument list literals. Added tests for showing widgets for various literals.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
