### PR TITLE
Dispose ydocs provider when closing app

### DIFF
--- a/app/gui2/src/App.vue
+++ b/app/gui2/src/App.vue
@@ -6,7 +6,8 @@ import { useSuggestionDbStore } from '@/stores/suggestionDatabase'
 import { configValue, type ApplicationConfig, type ApplicationConfigValue } from '@/util/config'
 import ProjectView from '@/views/ProjectView.vue'
 import { isDevMode } from 'shared/util/detect'
-import { computed, onMounted, toRaw } from 'vue'
+import { computed, onMounted, onUnmounted, toRaw } from 'vue'
+import { useProjectStore } from './stores/project'
 
 const props = defineProps<{
   config: ApplicationConfig
@@ -25,6 +26,9 @@ onMounted(() => {
   if (isDevMode) {
     ;(window as any).suggestionDb = toRaw(suggestionDb.entries)
   }
+})
+onUnmounted(() => {
+  useProjectStore().disposeYDocsProvider()
 })
 </script>
 

--- a/app/gui2/src/stores/project/index.ts
+++ b/app/gui2/src/stores/project/index.ts
@@ -499,6 +499,7 @@ export const useProjectStore = defineStore('project', () => {
     return tryQualifiedName(`${fullName.value}.${withDotSeparators}`)
   })
 
+  let yDocsProvider: ReturnType<typeof attachProvider> | undefined
   watchEffect((onCleanup) => {
     if (lsUrls.rpcUrl.startsWith('mock://')) {
       doc.load()
@@ -510,16 +511,14 @@ export const useProjectStore = defineStore('project', () => {
     const socketUrl = new URL(location.origin)
     socketUrl.protocol = location.protocol.replace(/^http/, 'ws')
     socketUrl.pathname = '/project'
-    const provider = attachProvider(
+    yDocsProvider = attachProvider(
       socketUrl.href,
       'index',
       { ls: lsUrls.rpcUrl },
       doc,
       awareness.internal,
     )
-    onCleanup(() => {
-      provider.dispose()
-    })
+    onCleanup(disposeYDocsProvider)
   })
 
   const projectModel = new DistributedProject(doc)
@@ -675,6 +674,11 @@ export const useProjectStore = defineStore('project', () => {
 
   const { executionMode } = setupSettings(projectModel)
 
+  function disposeYDocsProvider() {
+    yDocsProvider?.dispose()
+    yDocsProvider = undefined
+  }
+
   return {
     setObservedFileName(name: string) {
       observedFileName.value = name
@@ -699,6 +703,7 @@ export const useProjectStore = defineStore('project', () => {
     executionMode,
     dataflowErrors,
     executeExpression,
+    disposeYDocsProvider,
   }
 })
 


### PR DESCRIPTION
### Pull Request Description

This fixes an effect of an old project's node being displayed when opening another one. I discovered those old nodes were read from YDocs server. I suppose this is some process from old project still interfering with ydocs (but I don't know how exactly - we're supposed to have different docs for each language server, aren't we?). Anyway, disposing ydocs provider on app unmount looks like good idea, and it fixed the issue.

It _does not_ resolve problem with connection retries after closing project (#8964)

[Screencast from 2024-02-07 14-53-00.webm](https://github.com/enso-org/enso/assets/3919101/2a58bf11-05ef-4049-9d4d-2cd2d3ed469f)


### Important Notes

Perhaps the better way would be to assume the pinia (or maybe entire gui2's `App`) persists between projects and just have configuration updated (and on update reconnect with different LS + change used ydocs server endpoint). But this is a harder task. Any discussions here are welcome.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- ~~[ ] The documentation has been updated, if necessary.~~
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - ~~[ ] Unit tests have been written where possible.~~
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
