### PR TITLE
Fix NPE when recomputing the context

### DIFF
--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
@@ -73,16 +73,17 @@ class RecomputeContextCmd(
         }
         .getOrElse(Set())
     if (invalidatedExpressions.nonEmpty) {
-      val updates = invalidatedExpressions.map { expressionId =>
-        Api.ExpressionUpdate(
-          expressionId,
-          None,
-          None,
-          Vector.empty,
-          true,
-          false,
-          Api.ExpressionUpdate.Payload.Pending(None, None)
-        )
+      val updates = invalidatedExpressions.collect {
+        case expressionId if expressionId ne null =>
+          Api.ExpressionUpdate(
+            expressionId,
+            None,
+            None,
+            Vector.empty,
+            true,
+            false,
+            Api.ExpressionUpdate.Payload.Pending(None, None)
+          )
       }
       ctx.endpoint.sendToClient(
         Api.Response(Api.ExpressionUpdates(request.contextId, updates))


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

related #8689 

Fixes the NPE during the serialization of update messages.

```
java.lang.NullPointerException: Cannot invoke "java.util.UUID.toString()" because "a" is null
```

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
 