### PR TITLE
Text Editor shows up for Text only parameters.

### DIFF
--- a/app/gui2/e2e/widgets.spec.ts
+++ b/app/gui2/e2e/widgets.spec.ts
@@ -187,7 +187,7 @@ test('Managing aggregates in `aggregate` node', async ({ page }) => {
     '.',
     'Count_Distinct',
   ])
-  await expect(columnsArg.locator('.EnsoTextInputWidget > input')).toHaveValue('"column 1"')
+  await expect(columnsArg.locator('.EnsoTextInputWidget > input').first()).toHaveValue('"column 1"')
 
   // Add another aggregate
   await columnsArg.locator('.add-item').click()
@@ -222,7 +222,7 @@ test('Managing aggregates in `aggregate` node', async ({ page }) => {
   await dropDown.expectVisibleWithOptions(page, ['column 1', 'column 2'])
   await dropDown.clickOption(page, 'column 2')
   await expect(secondItem.locator('.WidgetToken')).toHaveText(['Aggregate_Column', '.', 'Group_By'])
-  await expect(secondItem.locator('.EnsoTextInputWidget > input')).toHaveValue('"column 2"')
+  await expect(secondItem.locator('.EnsoTextInputWidget > input').first()).toHaveValue('"column 2"')
 
   // Switch aggregates
   //TODO[ao] I have no idea how to emulate drag. Simple dragTo does not work (some element seem to capture event).

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import EnsoTextInputWidget from '@/components/widgets/EnsoTextInputWidget.vue'
-import { WidgetInput, widgetProps } from '@/providers/widgetRegistry'
+import { Score, WidgetInput, defineWidget, widgetProps } from '@/providers/widgetRegistry'
 import { useGraphStore } from '@/stores/graph'
 import { Ast } from '@/util/ast'
 import type { TokenId } from '@/util/ast/abstract'

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
@@ -12,7 +12,7 @@ const graph = useGraphStore()
 const value = computed({
   get() {
     const valueStr = WidgetInput.valueRepr(props.input)
-    return (typeof valueStr === 'string' && Ast.parse(valueStr) instanceof Ast.TextLiteral)
+    return typeof valueStr === 'string' && Ast.parse(valueStr) instanceof Ast.TextLiteral
       ? valueStr
       : ''
   },

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import EnsoTextInputWidget from '@/components/widgets/EnsoTextInputWidget.vue'
-import { Score, WidgetInput, defineWidget, widgetProps } from '@/providers/widgetRegistry'
+import { WidgetInput, widgetProps } from '@/providers/widgetRegistry'
 import { useGraphStore } from '@/stores/graph'
 import { Ast } from '@/util/ast'
 import type { TokenId } from '@/util/ast/abstract'
@@ -12,7 +12,9 @@ const graph = useGraphStore()
 const value = computed({
   get() {
     const valueStr = WidgetInput.valueRepr(props.input)
-    return valueStr ?? ''
+    return (typeof valueStr === 'string' && Ast.parse(valueStr) instanceof Ast.TextLiteral)
+      ? valueStr
+      : ''
   },
   set(value) {
     props.onUpdate({
@@ -29,7 +31,7 @@ export const widgetDefinition = defineWidget(WidgetInput.isAstOrPlaceholder, {
     if (props.input.value instanceof Ast.TextLiteral) return Score.Perfect
     if (props.input.dynamicConfig?.kind === 'Text_Input') return Score.Perfect
     const type = props.input.expectedType
-    if (type === 'Standard.Base.Data.Text') return Score.Good
+    if (type === 'Standard.Base.Data.Text.Text') return Score.Good
     return Score.Mismatch
   },
 })


### PR DESCRIPTION
### Pull Request Description

- Fix type name so that Text Editor shows for parameters.
- Following on from #9010, now show the default text values.
![image](https://github.com/enso-org/enso/assets/4699705/da68fec4-25b9-4e04-ba13-a2d112cf67c9)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
