### PR TITLE
CI: Remove Manual Stdlib Compilation

### DIFF
--- a/build/build/src/engine/context.rs
+++ b/build/build/src/engine/context.rs
@@ -517,20 +517,6 @@ impl RunContext {
 
         // === Build Distribution ===
         debug!("Building distribution");
-        if self.config.build_engine_package() {
-            let std_libs =
-                &self.repo_root.built_distribution.enso_engine_triple.engine_package.lib.standard;
-            // let std_libs = self.paths.engine.dir.join("lib").join("Standard");
-            // Compile the Standard Libraries (Unix)
-            debug!("Compiling standard libraries under {}", std_libs.display());
-            for entry in ide_ci::fs::read_dir(std_libs)? {
-                let entry = entry?;
-                let target = entry.path().join(self.paths.version().to_string());
-                enso.compile_lib(target)?.run_ok().await?;
-            }
-        }
-
-
         if self.config.build_native_runner {
             debug!("Building and testing native engine runners");
             runner_sanity_test(&self.repo_root, None).await?;

--- a/build/build/src/enso.rs
+++ b/build/build/src/enso.rs
@@ -98,16 +98,6 @@ impl BuiltEnso {
         Ok(command)
     }
 
-    pub fn compile_lib(&self, target: impl AsRef<Path>) -> Result<Command> {
-        ide_ci::fs::require_exist(&target)?;
-        let mut command = self.cmd()?;
-        command
-            .arg(IrCaches::Yes)
-            .args(["--no-compile-dependencies", "--no-global-cache", "--compile"])
-            .arg(target.as_ref());
-        Ok(command)
-    }
-
     pub async fn run_tests(
         &self,
         ir_caches: IrCaches,


### PR DESCRIPTION
### Pull Request Description
CI currently manually compiles standard library. However, this became redundant since the `buildEngineDistribution` included the very same behavior.
Because of that, we ended up compiling the libraries twice.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
