### PR TITLE
Enable the Code Editor

### DIFF
--- a/app/gui2/shared/ast/debug.ts
+++ b/app/gui2/shared/ast/debug.ts
@@ -1,0 +1,15 @@
+import { Ast } from './tree'
+
+/// Returns a GraphViz graph illustrating parent/child relationships in the given subtree.
+export function graphParentPointers(ast: Ast) {
+  const sanitize = (id: string) => id.replace('ast:', '').replace(/[^A-Za-z0-9]/g, '')
+  const graph = new Array<{ parent: string; child: string }>()
+  ast.visitRecursiveAst((ast) => {
+    const parent = ast.parentId
+    if (parent) graph.push({ child: sanitize(ast.id), parent: sanitize(parent) })
+  })
+  let result = 'digraph parentPointers {\n'
+  for (const { parent, child } of graph) result += `${parent} -> ${child};\n`
+  result += '}\n'
+  return result
+}

--- a/app/gui2/shared/ast/mutableModule.ts
+++ b/app/gui2/shared/ast/mutableModule.ts
@@ -57,6 +57,22 @@ export class MutableModule implements Module {
     return instance as Mutable<T>
   }
 
+  checkedGetVersions<T extends { [name: string]: Ast }>(
+    asts: T,
+  ): { [K in keyof T]: Mutable<T[K]> } {
+    return Object.fromEntries(
+      Object.entries(asts).map(([key, value]) => [key, this.getVersion(value)]),
+    ) as any
+  }
+
+  getVersions<T extends { [name: string]: Ast }>(
+    asts: T,
+  ): { [K in keyof T]: Mutable<T[K]> | undefined } {
+    return Object.fromEntries(
+      Object.entries(asts).map(([key, value]) => [key, this.get(value.id)]),
+    ) as any
+  }
+
   edit(): MutableModule {
     const doc = new Y.Doc()
     Y.applyUpdateV2(doc, Y.encodeStateAsUpdateV2(this.ydoc))
@@ -91,6 +107,15 @@ export class MutableModule implements Module {
   syncRoot(root: Owned) {
     this.replaceRoot(root)
     this.gc()
+  }
+
+  syncToCode(code: string) {
+    const root = this.root()
+    if (root) {
+      root.syncToCode(code)
+    } else {
+      this.replaceRoot(Ast.parse(code, this))
+    }
   }
 
   private gc() {

--- a/app/gui2/shared/ast/parse.ts
+++ b/app/gui2/shared/ast/parse.ts
@@ -480,7 +480,7 @@ export function parseExtended(code: string, idMap?: IdMap | undefined, inModule?
 export function setExternalIds(edit: MutableModule, spans: SpanMap, ids: IdMap) {
   let astsMatched = 0
   let asts = 0
-  edit.root()?.visitRecursiveAst((_ast) => (asts += 1))
+  edit.root()?.visitRecursiveAst((_ast) => void (asts += 1))
   for (const [key, externalId] of ids.entries()) {
     const asts = spans.nodes.get(key as NodeKey)
     if (asts) {

--- a/app/gui2/shared/ast/parse.ts
+++ b/app/gui2/shared/ast/parse.ts
@@ -424,8 +424,9 @@ export function parseBlock(code: string, inModule?: MutableModule) {
 export function parse(code: string, module?: MutableModule): Owned {
   const module_ = module ?? MutableModule.Transient()
   const ast = parseBlock(code, module_)
-  const [expr] = ast.statements()
-  if (!expr) return ast
+  const statements = Array.from(ast.statements())
+  const [expr] = statements
+  if (!expr || statements.length !== 1) return ast
   const parent = parentId(expr)
   if (parent) module_.delete(parent)
   expr.fields.set('parent', undefined)

--- a/app/gui2/shared/ast/tree.ts
+++ b/app/gui2/shared/ast/tree.ts
@@ -11,6 +11,7 @@ import type {
 } from '.'
 import {
   MutableModule,
+  ROOT_ID,
   Token,
   asOwned,
   isIdentifier,
@@ -134,7 +135,7 @@ export abstract class Ast {
 
   get parentId(): AstId | undefined {
     const parentId = this.fields.get('parent')
-    if (parentId !== 'ROOT_ID') return parentId
+    if (parentId !== ROOT_ID) return parentId
   }
 
   parent(): Ast | undefined {

--- a/app/gui2/shared/ast/tree.ts
+++ b/app/gui2/shared/ast/tree.ts
@@ -24,6 +24,7 @@ import {
   print,
   printAst,
   printBlock,
+  syncToCode,
 } from '.'
 import { assert, assertDefined, assertEqual, bail } from '../util/assert'
 import type { Result } from '../util/data/result'
@@ -54,6 +55,15 @@ export interface AstFields {
   parent: AstId | undefined
   metadata: FixedMap<MetadataFields>
 }
+function allKeys<T>(keys: Record<keyof T, any>): (keyof T)[] {
+  return Object.keys(keys) as any
+}
+const astFieldKeys = allKeys<AstFields>({
+  id: null,
+  type: null,
+  parent: null,
+  metadata: null,
+})
 export abstract class Ast {
   readonly module: Module
   /** @internal */
@@ -281,6 +291,11 @@ export abstract class MutableAst extends Ast {
     return this.module.checkedGet(parentId)
   }
 
+  /** Modify this tree to represent the given code, while minimizing changes from the current set of `Ast`s. */
+  syncToCode(code: string) {
+    syncToCode(this, code)
+  }
+
   ///////////////////
 
   /** @internal */
@@ -448,6 +463,8 @@ export class MutableApp extends App implements MutableAst {
       this.setFunction(replacement)
     } else if (this.fields.get('argument').node === target) {
       this.setArgument(replacement)
+    } else {
+      bail(`Child not found: this.id=${this.id} target=${target}`)
     }
   }
 }

--- a/app/gui2/shared/ast/tree.ts
+++ b/app/gui2/shared/ast/tree.ts
@@ -115,8 +115,8 @@ export abstract class Ast {
     }
   }
 
-  visitRecursiveAst(visit: (ast: Ast) => void): void {
-    visit(this)
+  visitRecursiveAst(visit: (ast: Ast) => void | boolean): void {
+    if (visit(this) === false) return
     for (const child of this.children()) {
       if (!isToken(child)) child.visitRecursiveAst(visit)
     }

--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -163,7 +163,8 @@ function sourcePortForSelection() {
 }
 
 useEvent(window, 'keydown', (event) => {
-  interactionBindingsHandler(event) || graphBindingsHandler(event) || codeEditorHandler(event)
+  ;(!keyboardBusy() && (interactionBindingsHandler(event) || graphBindingsHandler(event))) ||
+    (!keyboardBusyExceptIn(codeEditorArea.value) && codeEditorHandler(event))
 })
 useEvent(window, 'pointerdown', interactionBindingsHandler, { capture: true })
 
@@ -325,7 +326,6 @@ const codeEditorArea = ref<HTMLElement>()
 const showCodeEditor = ref(false)
 const codeEditorHandler = codeEditorBindings.handler({
   toggle() {
-    if (keyboardBusyExceptIn(codeEditorArea.value)) return false
     showCodeEditor.value = !showCodeEditor.value
   },
 })

--- a/app/gui2/src/components/GraphEditor/NodeWidgetTree.vue
+++ b/app/gui2/src/components/GraphEditor/NodeWidgetTree.vue
@@ -36,12 +36,12 @@ function handleWidgetUpdates(update: WidgetUpdate) {
     const { value, origin } = update.portUpdate
     if (Ast.isAstId(origin)) {
       const ast =
-        value instanceof Ast.Ast
-          ? value
-          : value == null
-          ? Ast.Wildcard.new(edit)
-          : Ast.parse(value, edit)
-      edit.replaceValue(origin as Ast.AstId, ast)
+        value instanceof Ast.Ast ? value : value == null ? Ast.Wildcard.new(edit) : undefined
+      if (ast) {
+        edit.replaceValue(origin as Ast.AstId, ast)
+      } else if (typeof value === 'string') {
+        edit.get(origin)?.syncToCode(value)
+      }
     } else {
       console.error(`[UPDATE ${origin}] Invalid top-level origin. Expected expression ID.`)
     }

--- a/app/gui2/src/stores/graph/graphDatabase.ts
+++ b/app/gui2/src/stores/graph/graphDatabase.ts
@@ -140,13 +140,13 @@ export class GraphDb {
 
   private nodeIdToPatternExprIds = new ReactiveIndex(this.nodeIdToNode, (id, entry) => {
     const exprs: AstId[] = []
-    if (entry.pattern) entry.pattern.visitRecursiveAst((ast) => exprs.push(ast.id))
+    if (entry.pattern) entry.pattern.visitRecursiveAst((ast) => void exprs.push(ast.id))
     return Array.from(exprs, (expr) => [id, expr])
   })
 
   private nodeIdToExprIds = new ReactiveIndex(this.nodeIdToNode, (id, entry) => {
     const exprs: AstId[] = []
-    entry.rootSpan.visitRecursiveAst((ast) => exprs.push(ast.id))
+    entry.rootSpan.visitRecursiveAst((ast) => void exprs.push(ast.id))
     return Array.from(exprs, (expr) => [id, expr])
   })
 

--- a/app/gui2/src/stores/graph/index.ts
+++ b/app/gui2/src/stores/graph/index.ts
@@ -263,7 +263,7 @@ export const useGraphStore = defineStore('graph', () => {
     const node = db.nodeIdToNode.get(id)
     if (!node) return
     edit((edit) => {
-      edit.getVersion(node.rootSpan).replaceValue(Ast.parse(content, edit))
+      edit.getVersion(node.rootSpan).syncToCode(content)
     })
   }
 

--- a/app/gui2/src/stores/project/index.ts
+++ b/app/gui2/src/stores/project/index.ts
@@ -573,7 +573,7 @@ export const useProjectStore = defineStore('project', () => {
   const visualizationDataRegistry = new VisualizationDataRegistry(executionContext, dataConnection)
   const computedValueRegistry = ComputedValueRegistry.WithExecutionContext(executionContext)
 
-  const diagnostics = ref<Diagnostic[]>([])
+  const diagnostics = shallowRef<Diagnostic[]>([])
   executionContext.on('executionStatus', (newDiagnostics) => {
     diagnostics.value = newDiagnostics
   })

--- a/app/gui2/src/util/ast/__tests__/testCase.ts
+++ b/app/gui2/src/util/ast/__tests__/testCase.ts
@@ -1,0 +1,74 @@
+import { assert, assertDefined } from 'shared/util/assert'
+import { Ast } from '..'
+
+export type StringsWithTypeValues = Record<string, any>
+export type WithValuesInstantiated<Spec extends StringsWithTypeValues> = {
+  [Name in keyof Spec]: InstanceType<Spec[Name]>
+}
+export type TestCase<T extends StringsWithTypeValues> = {
+  statements: WithValuesInstantiated<T>
+  module: Ast.Module
+}
+
+export function testCase<T extends StringsWithTypeValues>(spec: T): TestCase<T> {
+  let code = ''
+  for (const lineCode of Object.keys(spec)) {
+    code += lineCode
+    code += '\n'
+  }
+
+  const statementIndex = new Map<string, Ast.Ast>()
+  const parsed = Ast.parseBlock(code)
+  parsed.module.replaceRoot(parsed)
+  const statements = new Array<Ast.Ast>()
+  parsed.visitRecursiveAst((ast) => {
+    if (ast instanceof Ast.BodyBlock) statements.push(...ast.statements())
+  })
+  for (const statement of statements) {
+    const code = statement.code()
+    const trimmedFirstLine = code.split('\n', 1)[0]!.trim()
+    assert(
+      !statementIndex.has(trimmedFirstLine),
+      'Not implemented: Disambiguating duplicate statements.',
+    )
+    statementIndex.set(trimmedFirstLine, statement)
+  }
+
+  const result: Partial<WithValuesInstantiated<T>> = {}
+  for (const [lineCode, lineType] of Object.entries(spec)) {
+    const trimmed = lineCode.trim()
+    const statement = statementIndex.get(trimmed)
+    assertDefined(statement)
+    assert(statement instanceof lineType)
+    const key: keyof WithValuesInstantiated<T> = lineCode
+    result[key] = statement as any
+  }
+  return { statements: result as any, module: parsed.module }
+}
+
+export function tryFindExpressions<T extends StringsWithTypeValues>(
+  root: Ast.Ast,
+  expressions: T,
+): Partial<WithValuesInstantiated<T>> {
+  const result: Partial<WithValuesInstantiated<T>> = {}
+  const expressionsSought = new Set(Object.keys(expressions))
+  root.visitRecursiveAst((ast) => {
+    const code = ast.code()
+    const trimmedFirstLine = code.split('\n', 1)[0]!.trim()
+    if (!expressionsSought.has(trimmedFirstLine)) return
+    const key: keyof WithValuesInstantiated<T> = trimmedFirstLine
+    if (!(ast instanceof expressions[trimmedFirstLine])) return
+    assert(!(key in result))
+    result[key] = ast as any
+  })
+  return result
+}
+
+export function findExpressions<T extends StringsWithTypeValues>(
+  root: Ast.Ast,
+  expressions: T,
+): WithValuesInstantiated<T> {
+  const result = tryFindExpressions(root, expressions)
+  for (const key of Object.keys(expressions)) assert(key in result)
+  return result as any
+}

--- a/app/gui2/ydoc-server/languageServerSession.ts
+++ b/app/gui2/ydoc-server/languageServerSession.ts
@@ -4,14 +4,7 @@ import * as map from 'lib0/map'
 import { ObservableV2 } from 'lib0/observable'
 import * as random from 'lib0/random'
 import * as Y from 'yjs'
-import {
-  Ast,
-  MutableModule,
-  parseBlockWithSpans,
-  setExternalIds,
-  spanMapToIdMap,
-} from '../shared/ast'
-import { print } from '../shared/ast/parse'
+import * as Ast from '../shared/ast'
 import { EnsoFileParts, combineFileParts, splitFileContents } from '../shared/ensoFile'
 import { LanguageServer, computeTextChecksum } from '../shared/languageServer'
 import { Checksum, FileEdit, Path, TextEdit, response } from '../shared/languageServerTypes'
@@ -416,7 +409,7 @@ class ModulePersistence extends ObservableV2<{ removed: () => void }> {
     const update = this.updateToApply
     this.updateToApply = null
 
-    const syncModule = new MutableModule(this.doc.ydoc)
+    const syncModule = new Ast.MutableModule(this.doc.ydoc)
     const moduleUpdate = syncModule.applyUpdate(update, 'remote')
     if (moduleUpdate && this.syncedContent) {
       const synced = splitFileContents(this.syncedContent)
@@ -511,21 +504,30 @@ class ModulePersistence extends ObservableV2<{ removed: () => void }> {
       const nodeMeta = Object.entries(metadata.ide.node)
 
       let parsedSpans
-      const syncModule = new MutableModule(this.doc.ydoc)
+      const syncModule = new Ast.MutableModule(this.doc.ydoc)
       if (code !== this.syncedCode) {
-        const { root, spans } = parseBlockWithSpans(code, syncModule)
-        syncModule.syncRoot(root)
-        parsedSpans = spans
+        const syncRoot = syncModule.root()
+        if (syncRoot) {
+          const edit = syncModule.edit()
+          edit.getVersion(syncRoot).syncToCode(code)
+          const editedRoot = edit.root()
+          if (editedRoot instanceof Ast.BodyBlock) Ast.repair(editedRoot, edit)
+          Y.applyUpdateV2(this.doc.ydoc, Y.encodeStateAsUpdateV2(edit.ydoc))
+        } else {
+          const { root, spans } = Ast.parseBlockWithSpans(code, syncModule)
+          syncModule.syncRoot(root)
+          parsedSpans = spans
+        }
       }
       const astRoot = syncModule.root()
       if (!astRoot) return
       if ((code !== this.syncedCode || idMapJson !== this.syncedIdMap) && idMapJson) {
         const idMap = deserializeIdMap(idMapJson)
-        const spans = parsedSpans ?? print(astRoot).info
-        const newExternalIds = setExternalIds(syncModule, spans, idMap)
+        const spans = parsedSpans ?? Ast.print(astRoot).info
+        const newExternalIds = Ast.setExternalIds(syncModule, spans, idMap)
         if (newExternalIds !== 0) {
           if (code !== this.syncedCode) {
-            unsyncedIdMap = spanMapToIdMap(spans)
+            unsyncedIdMap = Ast.spanMapToIdMap(spans)
           } else {
             console.warn(
               `The LS sent an IdMap-only edit that is missing ${newExternalIds} of our expected ASTs.`,
@@ -539,7 +541,7 @@ class ModulePersistence extends ObservableV2<{ removed: () => void }> {
           metadataJson !== this.syncedMetaJson) &&
         nodeMeta.length !== 0
       ) {
-        const externalIdToAst = new Map<ExternalId, Ast>()
+        const externalIdToAst = new Map<ExternalId, Ast.Ast>()
         astRoot.visitRecursiveAst((ast) => {
           if (!externalIdToAst.has(ast.externalId)) externalIdToAst.set(ast.externalId, ast)
         })

--- a/app/ide-desktop/lib/dashboard/src/layouts/dashboard/Chat.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/dashboard/Chat.tsx
@@ -748,7 +748,6 @@ export default function Chat(props: ChatProps) {
           <textarea
             ref={messageInputRef}
             rows={1}
-            autoFocus
             required
             placeholder="Type your message ..."
             className="w-full rounded-lg bg-transparent resize-none p-1"


### PR DESCRIPTION
### Pull Request Description

Part 3/4 of #8238.

- Fix most of the UI problems with our CodeMirror integration (Fixed view stability; Fixed a focus bug; Fixed errors caused by diagnostics range exceptions; Fixed linter invalidation--see https://discuss.codemirror.net/t/problem-trying-to-force-linting/5823; Implemented edit-coalescing for performance); Enable code edits.
- Implement some functionality that will be the foundation of the new apply-text-edits algorithm (next PR).
- For now, a simplistic apply-text-edits implementation is used. It loses the metadata of the edited node, but shouldn't disturb anything else.

### Important Notes

- The `syncToCode` implementation will be replaced in the next PR, but the analysis it is based on will be part of the full algorithm.
- Sometimes the Code Editor doesn't respond to inputs. I'm still debugging this and will fix it in the next PR. Moving the cursor with the arrow keys works around it for now.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
