### PR TITLE
Remove vite-plugin-top-level-await plugin

### DIFF
--- a/app/gui2/e2e/main.ts
+++ b/app/gui2/e2e/main.ts
@@ -1,5 +1,6 @@
 import 'enso-dashboard/src/tailwind.css'
 import { createPinia } from 'pinia'
+import { initializeFFI } from 'shared/ast/ffi'
 import { createApp, ref } from 'vue'
 import { mockDataHandler, mockLSHandler } from '../mock/engine'
 import '../src/assets/base.css'
@@ -8,6 +9,8 @@ import { provideVisualizationConfig } from '../src/providers/visualizationConfig
 import { Vec2 } from '../src/util/data/vec2'
 import { MockTransport, MockWebSocket } from '../src/util/net'
 import MockApp from './MockApp.vue'
+
+await initializeFFI()
 
 MockTransport.addMock('engine', mockLSHandler)
 MockWebSocket.addMock('data', mockDataHandler)

--- a/app/gui2/e2e/main.ts
+++ b/app/gui2/e2e/main.ts
@@ -10,8 +10,6 @@ import { Vec2 } from '../src/util/data/vec2'
 import { MockTransport, MockWebSocket } from '../src/util/net'
 import MockApp from './MockApp.vue'
 
-await initializeFFI()
-
 MockTransport.addMock('engine', mockLSHandler)
 MockWebSocket.addMock('data', mockDataHandler)
 
@@ -58,4 +56,4 @@ provideVisualizationConfig._mock(
   },
   app,
 )
-app.mount('#app')
+initializeFFI().then(() => app.mount('#app'))

--- a/app/gui2/package.json
+++ b/app/gui2/package.json
@@ -129,7 +129,6 @@
     "unbzip2-stream": "^1.4.3",
     "vite": "^4.4.9",
     "vite-plugin-inspect": "^0.7.38",
-    "vite-plugin-top-level-await": "^1.3.1",
     "vitest": "^0.34.2",
     "vue-react-wrapper": "^0.3.1",
     "vue-tsc": "^1.8.8"

--- a/app/gui2/src/components/ComponentBrowser/__tests__/input.test.ts
+++ b/app/gui2/src/components/ComponentBrowser/__tests__/input.test.ts
@@ -17,8 +17,11 @@ import {
 import type { AstId } from '@/util/ast/abstract'
 import { unwrap } from '@/util/data/result'
 import { tryIdentifier, tryQualifiedName } from '@/util/qualifiedName'
+import { initializeFFI } from 'shared/ast/ffi'
 import type { ExternalId, Uuid } from 'shared/yjsModel'
 import { expect, test } from 'vitest'
+
+await initializeFFI()
 
 test.each([
   ['', 0, { type: 'insert', position: 0 }, {}],

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script setup lang="ts">
 import { nodeEditBindings } from '@/bindings'
 import CircularMenu from '@/components/CircularMenu.vue'
 import GraphNodeError from '@/components/GraphEditor/GraphNodeError.vue'
@@ -38,9 +38,7 @@ const prefixes = Prefixes.FromLines({
   skip: 'SKIP __',
   freeze: 'FREEZE __',
 })
-</script>
 
-<script setup lang="ts">
 const props = defineProps<{
   node: Node
   edited: boolean

--- a/app/gui2/src/providers/__tests__/widgetRegistry.test.ts
+++ b/app/gui2/src/providers/__tests__/widgetRegistry.test.ts
@@ -9,10 +9,13 @@ import {
 import { GraphDb } from '@/stores/graph/graphDatabase'
 import { Ast } from '@/util/ast'
 import { ApplicationKind, ArgumentInfoKey } from '@/util/callTree'
+import { initializeFFI } from 'shared/ast/ffi'
 import { describe, expect, test } from 'vitest'
 import { defineComponent } from 'vue'
 import type { PortId } from '../portInfo'
 import { DisplayMode, argsWidgetConfigurationSchema } from '../widgetRegistry/configuration'
+
+await initializeFFI()
 
 describe('WidgetRegistry', () => {
   function makeMockWidget<T extends WidgetInput>(

--- a/app/gui2/src/stores/graph/__tests__/graphDatabase.test.ts
+++ b/app/gui2/src/stores/graph/__tests__/graphDatabase.test.ts
@@ -1,8 +1,11 @@
 import { asNodeId, GraphDb } from '@/stores/graph/graphDatabase'
 import { Ast, RawAst } from '@/util/ast'
 import assert from 'assert'
+import { initializeFFI } from 'shared/ast/ffi'
 import { IdMap, type ExternalId } from 'shared/yjsModel'
 import { expect, test } from 'vitest'
+
+await initializeFFI()
 
 /**
  * Create a predictable fake UUID which contains given number in decimal at the end.

--- a/app/gui2/src/util/ast/__tests__/aliasAnalysis.test.ts
+++ b/app/gui2/src/util/ast/__tests__/aliasAnalysis.test.ts
@@ -28,8 +28,11 @@
 import { assertDefined } from '@/util/assert'
 import { AliasAnalyzer } from '@/util/ast/aliasAnalysis'
 import { MappedKeyMap, MappedSet } from '@/util/containers'
+import { initializeFFI } from 'shared/ast/ffi'
 import { sourceRangeKey, type SourceRange } from 'shared/yjsModel'
 import { expect, test } from 'vitest'
+
+await initializeFFI()
 
 /** The type of annotation. */
 enum AnnotationType {

--- a/app/gui2/src/util/ast/aliasAnalysis.ts
+++ b/app/gui2/src/util/ast/aliasAnalysis.ts
@@ -8,11 +8,8 @@ import {
   readTokenSpan,
 } from '@/util/ast'
 import { MappedKeyMap, MappedSet, NonEmptyStack } from '@/util/containers'
-import { initializeFFI } from 'shared/ast/ffi'
 import type { LazyObject } from 'shared/ast/parserSupport'
 import { rangeIsBefore, sourceRangeKey, type SourceRange } from 'shared/yjsModel'
-
-await initializeFFI()
 
 const ACCESSOR_OPERATOR = '.'
 

--- a/app/gui2/vite.config.ts
+++ b/app/gui2/vite.config.ts
@@ -6,7 +6,6 @@ import postcssNesting from 'postcss-nesting'
 import tailwindcss from 'tailwindcss'
 import tailwindcssNesting from 'tailwindcss/nesting'
 import { defineConfig, type Plugin } from 'vite'
-import topLevelAwait from 'vite-plugin-top-level-await'
 // @ts-expect-error
 import * as tailwindConfig from '../ide-desktop/lib/dashboard/tailwind.config'
 import { createGatewayServer } from './ydoc-server'
@@ -18,7 +17,7 @@ const IS_CLOUD_BUILD = process.env.CLOUD_BUILD === 'true'
 // https://vitejs.dev/config/
 export default defineConfig({
   cacheDir: '../../node_modules/.cache/vite',
-  plugins: [vue(), gatewayServer(), topLevelAwait()],
+  plugins: [vue(), gatewayServer()],
   optimizeDeps: {
     entries: 'index.html',
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,7 +118,6 @@
         "unbzip2-stream": "^1.4.3",
         "vite": "^4.4.9",
         "vite-plugin-inspect": "^0.7.38",
-        "vite-plugin-top-level-await": "^1.3.1",
         "vitest": "^0.34.2",
         "vue-react-wrapper": "^0.3.1",
         "vue-tsc": "^1.8.8"
@@ -3763,22 +3762,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@rollup/plugin-virtual": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.0.2",
       "dev": true,
@@ -3934,107 +3917,6 @@
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
-    },
-    "node_modules/@swc/core": {
-      "version": "1.3.85",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/types": "^0.1.4"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/swc"
-      },
-      "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.85",
-        "@swc/core-darwin-x64": "1.3.85",
-        "@swc/core-linux-arm-gnueabihf": "1.3.85",
-        "@swc/core-linux-arm64-gnu": "1.3.85",
-        "@swc/core-linux-arm64-musl": "1.3.85",
-        "@swc/core-linux-x64-gnu": "1.3.85",
-        "@swc/core-linux-x64-musl": "1.3.85",
-        "@swc/core-win32-arm64-msvc": "1.3.85",
-        "@swc/core-win32-ia32-msvc": "1.3.85",
-        "@swc/core-win32-x64-msvc": "1.3.85"
-      },
-      "peerDependencies": {
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependenciesMeta": {
-        "@swc/helpers": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.3.85",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.85",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.3.85",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.3.85",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/types": {
-      "version": "0.1.4",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -17367,18 +17249,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.3",
       "dev": true,
@@ -17550,19 +17420,6 @@
       },
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/vite-plugin-top-level-await": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/plugin-virtual": "^3.0.1",
-        "@swc/core": "^1.3.10",
-        "uuid": "^9.0.0"
-      },
-      "peerDependencies": {
-        "vite": ">=2.8"
       }
     },
     "node_modules/vite/node_modules/@esbuild/android-arm": {


### PR DESCRIPTION
### Pull Request Description

We've used the vite-plugin-top-level-await to support top level await. But most of them were removed anyway, because the ide-desktop/lib/client is bundled as CJS and use some of gui2 code. And the plugin [is causing problems](https://github.com/Menci/vite-plugin-top-level-await/issues/25), [also in our CI](https://github.com/enso-org/enso/actions/runs/7842841953/job/21402194728?pr=9013#step:8:458) 

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- ~~[ ] The documentation has been updated, if necessary.~~
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - ~~[ ] Unit tests have been written where possible.~~
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
