### PR TITLE
Synchronize suggestions loading after the reconnect

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/search/SearchProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/search/SearchProtocol.scala
@@ -493,6 +493,9 @@ object SearchProtocol {
     updates: Seq[SuggestionsDatabaseUpdate]
   )
 
+  /** A request to clean the suggestions database. */
+  case object CleanSuggestionsDatabase
+
   /** The request to receive contents of the suggestions database. */
   case object GetSuggestionsDatabase
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/search/SuggestionsHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/search/SuggestionsHandler.scala
@@ -110,6 +110,8 @@ final class SuggestionsHandler(
     )
     context.system.eventStream
       .subscribe(self, classOf[Api.LibraryLoaded])
+    context.system.eventStream
+      .subscribe(self, classOf[Api.BackgroundJobsStartedNotification])
     context.system.eventStream.subscribe(self, classOf[FileDeletedEvent])
     context.system.eventStream
       .subscribe(self, InitializedEvent.SuggestionsRepoInitialized.getClass)
@@ -186,12 +188,28 @@ final class SuggestionsHandler(
 
     case msg: Api.SuggestionsDatabaseSuggestionsLoadedNotification
         if state.isSuggestionLoadingRunning =>
-      state.suggestionLoadingQueue.enqueue(msg)
+      logger.trace(
+        "SuggestionsDatabaseSuggestionsLoadedNotification [shouldStartBackgroundProcessing={}].",
+        state.shouldStartBackgroundProcessing
+      )
+      if (state.shouldStartBackgroundProcessing) {
+        state.suggestionLoadingQueue.clear()
+      } else {
+        state.suggestionLoadingQueue.enqueue(msg)
+      }
 
     case msg: Api.SuggestionsDatabaseSuggestionsLoadedNotification =>
       logger.debug(
         "Starting loading suggestions for library [{}].",
         msg.libraryName
+      )
+      context.become(
+        initialized(
+          projectName,
+          graph,
+          clients,
+          state.suggestionLoadingRunning()
+        )
       )
       applyLoadedSuggestions(msg.suggestions)
         .onComplete {
@@ -214,14 +232,6 @@ final class SuggestionsHandler(
             )
             self ! SuggestionsHandler.SuggestionLoadingCompleted
         }
-      context.become(
-        initialized(
-          projectName,
-          graph,
-          clients,
-          state.suggestionLoadingRunning()
-        )
-      )
 
     case msg: Api.SuggestionsDatabaseModuleUpdateNotification
         if state.isSuggestionUpdatesRunning =>
@@ -304,14 +314,46 @@ final class SuggestionsHandler(
         )
       )
 
+    case Api.BackgroundJobsStartedNotification() =>
+      context.become(
+        initialized(
+          projectName,
+          graph,
+          clients,
+          state.backgroundProcessingStarted()
+        )
+      )
+
     case GetSuggestionsDatabaseVersion =>
       suggestionsRepo.currentVersion
         .map(GetSuggestionsDatabaseVersionResult)
         .pipeTo(sender())
 
+    case CleanSuggestionsDatabase =>
+      if (state.isSuggestionLoadingRunning) stash()
+      else {
+        context.become(
+          initialized(
+            projectName,
+            graph,
+            clients,
+            state.suggestionLoadingRunning()
+          )
+        )
+        for {
+          _ <- suggestionsRepo.clean
+        } yield {
+          logger.trace(
+            "CleanSuggestionsDatabase [{}].",
+            state.suggestionLoadingQueue
+          )
+          state.suggestionLoadingQueue.clear()
+          runtimeConnector ! Api.Request(Api.StartBackgroundProcessing())
+        }
+      }
+
     case GetSuggestionsDatabase =>
       val responseAction = for {
-        _       <- suggestionsRepo.clean
         version <- suggestionsRepo.currentVersion
       } yield GetSuggestionsDatabaseResult(version, Seq())
 
@@ -325,7 +367,8 @@ final class SuggestionsHandler(
         InvalidateModulesIndexHandler.props(
           RuntimeFailureMapper(contentRootManager),
           timeout,
-          runtimeConnector
+          runtimeConnector,
+          self
         )
       )
 
@@ -336,7 +379,7 @@ final class SuggestionsHandler(
           projectName,
           graph,
           clients,
-          state.backgroundProcessingStarted()
+          state.backgroundProcessingStopped()
         )
       )
 
@@ -419,7 +462,8 @@ final class SuggestionsHandler(
         InvalidateModulesIndexHandler.props(
           runtimeFailureMapper,
           timeout,
-          runtimeConnector
+          runtimeConnector,
+          self
         )
       )
       action.pipeTo(handler)(sender())
@@ -450,6 +494,7 @@ final class SuggestionsHandler(
       )
 
     case SuggestionLoadingCompleted =>
+      unstashAll()
       if (state.suggestionLoadingQueue.nonEmpty) {
         self ! state.suggestionLoadingQueue.dequeue()
       }

--- a/engine/language-server/src/main/scala/org/enso/languageserver/search/handler/InvalidateModulesIndexHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/search/handler/InvalidateModulesIndexHandler.scala
@@ -17,11 +17,13 @@ import scala.concurrent.duration.FiniteDuration
   * @param runtimeFailureMapper mapper for runtime failures
   * @param timeout request timeout
   * @param runtime reference to the runtime connector
+  * @param suggestionsHandler reference to the suggestions handler
   */
 final class InvalidateModulesIndexHandler(
   runtimeFailureMapper: RuntimeFailureMapper,
   timeout: FiniteDuration,
-  runtime: ActorRef
+  runtime: ActorRef,
+  suggestionsHandler: ActorRef
 ) extends Actor
     with LazyLogging
     with UnhandledLogging {
@@ -50,6 +52,7 @@ final class InvalidateModulesIndexHandler(
       context.stop(self)
 
     case Api.Response(_, Api.InvalidateModulesIndexResponse()) =>
+      suggestionsHandler ! SearchProtocol.CleanSuggestionsDatabase
       replyTo ! SearchProtocol.InvalidateSuggestionsDatabaseResult
       cancellable.cancel()
       context.stop(self)
@@ -67,14 +70,21 @@ object InvalidateModulesIndexHandler {
     *
     * @param runtimeFailureMapper mapper for runtime failures
     * @param timeout request timeout
-    * @param runtime reference to the runtime conector
+    * @param runtime reference to the runtime connector
+    * @param suggestionsHandler reference to the suggestions handler
     */
   def props(
     runtimeFailureMapper: RuntimeFailureMapper,
     timeout: FiniteDuration,
-    runtime: ActorRef
+    runtime: ActorRef,
+    suggestionsHandler: ActorRef
   ): Props =
     Props(
-      new InvalidateModulesIndexHandler(runtimeFailureMapper, timeout, runtime)
+      new InvalidateModulesIndexHandler(
+        runtimeFailureMapper,
+        timeout,
+        runtime,
+        suggestionsHandler
+      )
     )
 }

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/InvalidateModulesIndexCommand.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/InvalidateModulesIndexCommand.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 import java.util.logging.Level;
 import org.enso.interpreter.instrument.execution.RuntimeContext;
 import org.enso.interpreter.instrument.job.DeserializeLibrarySuggestionsJob;
-import org.enso.interpreter.instrument.job.StartBackgroundProcessingJob;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.polyglot.runtime.Runtime$Api$InvalidateModulesIndexResponse;
 import scala.Option;
@@ -33,6 +32,7 @@ public final class InvalidateModulesIndexCommand extends AsynchronousCommand {
           TruffleLogger logger = ctx.executionService().getLogger();
           long writeCompilationLockTimestamp = ctx.locking().acquireWriteCompilationLock();
           try {
+            ctx.jobControlPlane().stopBackgroundJobs();
             ctx.jobControlPlane().abortBackgroundJobs(DeserializeLibrarySuggestionsJob.class);
 
             EnsoContext context = ctx.executionService().getContext();
@@ -48,7 +48,6 @@ public final class InvalidateModulesIndexCommand extends AsynchronousCommand {
                       return BoxedUnit.UNIT;
                     });
 
-            StartBackgroundProcessingJob.startBackgroundJobs(ctx);
             reply(new Runtime$Api$InvalidateModulesIndexResponse(), ctx);
           } finally {
             ctx.locking().releaseWriteCompilationLock();

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/BackgroundJob.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/BackgroundJob.java
@@ -23,6 +23,17 @@ public abstract class BackgroundJob<A> extends Job<A> {
   }
 
   /**
+   * Create a background job with priority.
+   *
+   * @param priority the job priority. Lower number indicates higher priority.
+   * @param mayInterruptIfRunning the flag indicating if the running job may be interrupted.
+   */
+  public BackgroundJob(int priority, boolean mayInterruptIfRunning) {
+    super(List$.MODULE$.empty(), true, mayInterruptIfRunning);
+    this.priority = priority;
+  }
+
+  /**
    * @return the job priority.
    */
   public int getPriority() {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/StartBackgroundProcessingCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/StartBackgroundProcessingCmd.scala
@@ -19,8 +19,7 @@ final class StartBackgroundProcessingCmd(
     ctx: RuntimeContext,
     ec: ExecutionContext
   ): Future[Unit] = {
-    StartBackgroundProcessingJob.startBackgroundJobs()
-    Future.successful(())
+    Future(StartBackgroundProcessingJob.startBackgroundJobs())
   }
 
 }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/DeserializeLibrarySuggestionsJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/DeserializeLibrarySuggestionsJob.scala
@@ -14,7 +14,7 @@ import scala.jdk.CollectionConverters._
   */
 final class DeserializeLibrarySuggestionsJob(
   val libraryName: LibraryName
-) extends BackgroundJob[Unit](DeserializeLibrarySuggestionsJob.Priority)
+) extends BackgroundJob[Unit](DeserializeLibrarySuggestionsJob.Priority, true)
     with UniqueJob[Unit] {
 
   /** @inheritdoc */

--- a/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlSuggestionsRepo.scala
+++ b/lib/scala/searcher/src/main/scala/org/enso/searcher/sql/SqlSuggestionsRepo.scala
@@ -175,10 +175,7 @@ final class SqlSuggestionsRepo(val db: SqlDatabase)(implicit
 
   /** The query to clean the repo. */
   private def cleanQuery: DBIO[Unit] = {
-    for {
-      _ <- Suggestions.delete
-      _ <- SuggestionsVersion.delete
-    } yield ()
+    DBIO.seq(Suggestions.delete, SuggestionsVersion.delete)
   }
 
   /** The query to get all suggestions.


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

related #8689 

Fixes a race between the language server SQL updating logic and the engine `DeserializeLibrarySuggestionsJob`s when the library suggestions may start loading before the database is properly cleaned up after the reconnect.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
