### PR TITLE
Fix Code Editor click

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/App.tsx
+++ b/app/ide-desktop/lib/dashboard/src/App.tsx
@@ -192,7 +192,7 @@ function AppRouter(props: AppProps) {
         isClick &&
         !(event.target instanceof HTMLInputElement) &&
         !(event.target instanceof HTMLTextAreaElement) &&
-        (!(event.target instanceof HTMLElement && event.target.isContentEditable))
+        !(event.target instanceof HTMLElement && event.target.isContentEditable)
       ) {
         document.getSelection()?.removeAllRanges()
       }

--- a/app/ide-desktop/lib/dashboard/src/App.tsx
+++ b/app/ide-desktop/lib/dashboard/src/App.tsx
@@ -191,7 +191,8 @@ function AppRouter(props: AppProps) {
       if (
         isClick &&
         !(event.target instanceof HTMLInputElement) &&
-        !(event.target instanceof HTMLTextAreaElement)
+        !(event.target instanceof HTMLTextAreaElement) &&
+        (!(event.target instanceof HTMLElement && event.target.isContentEditable))
       ) {
         document.getSelection()?.removeAllRanges()
       }


### PR DESCRIPTION
### Pull Request Description

Clearing the selection on mouseup breaks the CodeMirror integration. Adding this exception for contenteditable elements would fix it. Is this compatible with whatever this event handler is needed for?

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
