### PR TITLE
CI: force sbt server to start

### DIFF
--- a/build/build/src/engine/sbt.rs
+++ b/build/build/src/engine/sbt.rs
@@ -43,6 +43,8 @@ impl CommandProvider for Context {
         cmd.env(ide_ci::env::known::LC_ALL, ide_ci::env::known::C_UTF8);
         // This prevents https://github.com/sbt/sbt/issues/6777#issuecomment-1613316167
         cmd.set_env(ide_ci::programs::sbt::SBT_SERVER_FORCESTART, &true)?;
+        // Again. Preferably there should be no sbt server spawned at all.
+        cmd.apply(&sbt::ServerAutostart(false));
         Ok(cmd)
     }
 }

--- a/build/build/src/engine/sbt.rs
+++ b/build/build/src/engine/sbt.rs
@@ -41,6 +41,8 @@ impl CommandProvider for Context {
         }
         // This prevents https://github.com/sbt/sbt-assembly/issues/496
         cmd.env(ide_ci::env::known::LC_ALL, ide_ci::env::known::C_UTF8);
+        // This prevents https://github.com/sbt/sbt/issues/6777#issuecomment-1613316167
+        cmd.set_env(ide_ci::programs::sbt::SBT_SERVER_FORCESTART, &true)?;
         Ok(cmd)
     }
 }

--- a/build/ci_utils/src/programs/sbt.rs
+++ b/build/ci_utils/src/programs/sbt.rs
@@ -11,6 +11,7 @@ define_env_var! {
     SBT_SERVER_FORCESTART, bool;
 }
 
+#[derive(Clone, Copy, Debug)]
 pub struct ServerAutostart(pub bool);
 impl Manipulator for ServerAutostart {
     fn apply<C: IsCommandWrapper + ?Sized>(&self, command: &mut C) {

--- a/build/ci_utils/src/programs/sbt.rs
+++ b/build/ci_utils/src/programs/sbt.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 
 use crate::define_env_var;
+use crate::program::command::Manipulator;
 
 
 
@@ -10,6 +11,14 @@ define_env_var! {
     SBT_SERVER_FORCESTART, bool;
 }
 
+pub struct ServerAutostart(pub bool);
+impl Manipulator for ServerAutostart {
+    fn apply<C: IsCommandWrapper + ?Sized>(&self, command: &mut C) {
+        let arg = "sbt.server.autostart";
+        let arg = format!("-D{arg}={}", self.0);
+        command.arg(arg);
+    }
+}
 
 macro_rules! strong_string {
     ($name:ident($inner_ty:ty)) => {

--- a/build/ci_utils/src/programs/sbt.rs
+++ b/build/ci_utils/src/programs/sbt.rs
@@ -1,5 +1,14 @@
 use crate::prelude::*;
 
+use crate::define_env_var;
+
+
+
+define_env_var! {
+    /// Force the SBT server to start, avoiding `ServerAlreadyBootingException`.
+    /// See: https://github.com/sbt/sbt/issues/6777#issuecomment-1613316167
+    SBT_SERVER_FORCESTART, bool;
+}
 
 
 macro_rules! strong_string {


### PR DESCRIPTION
### Pull Request Description
On Windows, Engine checks were failing from time to time with an error like:
```
sbt thinks that server is already booting because of this exception:
sbt.internal.ServerAlreadyBootingException: java.io.IOException: Could not create lock for \\.\pipe\sbt-load-802998070017202719_lock, error 1336
	at sbt.internal.BootServerSocket.newSocket(BootServerSocket.java:357)
	at sbt.internal.BootServerSocket.<init>(BootServerSocket.java:296)
	at sbt.xMain$.getSocketOrExit(Main.scala:152)
	at sbt.xMain$.bootServerSocket$lzycompute$1(Main.scala:78)
	at sbt.xMain$.bootServerSocket$1(Main.scala:78)
	at sbt.xMain$.withStreams$1(Main.scala:86)
	at sbt.xMain$.run(Main.scala:123)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at sbt.internal.XMainConfiguration.run(XMainConfiguration.java:59)
	at sbt.xMain.run(Main.scala:47)
	at xsbt.boot.Launch$.$anonfun$run$1(Launch.scala:149)
	at xsbt.boot.Launch$.withContextLoader(Launch.scala:176)
	at xsbt.boot.Launch$.run(Launch.scala:149)
	at xsbt.boot.Launch$.$anonfun$apply$1(Launch.scala:44)
	at xsbt.boot.Launch$.launch(Launch.scala:159)
	at xsbt.boot.Launch$.apply(Launch.scala:44)
	at xsbt.boot.Launch$.apply(Launch.scala:21)
	at xsbt.boot.Boot$.runImpl(Boot.scala:78)
	at xsbt.boot.Boot$.run(Boot.scala:73)
	at xsbt.boot.Boot$.main(Boot.scala:21)
	at xsbt.boot.Boot.main(Boot.scala)
Caused by: java.io.IOException: Could not create lock for \\.\pipe\sbt-load-802998070017202719_lock, error 1336
	at org.scalasbt.ipcsocket.Win32NamedPipeServerSocket.<init>(Win32NamedPipeServerSocket.java:129)
	at org.scalasbt.ipcsocket.Win32NamedPipeServerSocket.<init>(Win32NamedPipeServerSocket.java:48)
	at sbt.internal.BootServerSocket.newSocket(BootServerSocket.java:351)
	... 21 more
```

[It has been suggested](https://github.com/sbt/sbt/issues/6777#issuecomment-1613316167) that `SBT_SERVER_FORCESTART` should be set to avoid this issue.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
