### PR TITLE
Use backend errors in toast notifications

### DIFF
--- a/app/ide-desktop/README.md
+++ b/app/ide-desktop/README.md
@@ -1,0 +1,26 @@
+# Desktop app
+
+This folder contains projects related to the desktop app.
+
+## Folder structure
+
+Refer to the `README.md` in each individual module (if it exists) for the
+internal folder structure of the module.
+
+- `assets/`: Icons and images used by other modules. Currently these are only
+  used by `dashboard/`.
+- `client/`: The code for the Electron desktop app.
+- `common/`: Utility functions required by multiple other modules.
+- `content/`: The entry point for the GUI1 web app. This is the main page for
+  the desktop app.
+- `content-config/`: The statically-typed configuration object for `content/`.
+- [`dashboard/`](./lib/dashboard/README.md): The dashboard, used to manage
+  projects. It launches the GUI (located in `content/` for GUI1, or `/app/gui2/`
+  for GUI2) when a project is opened.
+- `esbuild-plugin-copy-directories/`: An ESBuild plugin for continuously copying
+  directories from the a given location to a given subdirectory of the build
+  output directory.
+- `icons/`: Generates the logo for the app.
+- `ts-plugin-namespace-auto-import/`: (WIP) A TypeScript plugin to change
+  auto-import to use `import * as moduleName` rather than `import {}`.
+- `types/`: Miscellaneous types used by multiple modules.

--- a/app/ide-desktop/eslint.config.js
+++ b/app/ide-desktop/eslint.config.js
@@ -228,6 +228,11 @@ const RESTRICTED_SYNTAXES = [
         selector: 'CallExpression[callee.name=toastAndLog][arguments.0.value=/\\.$/]',
         message: '`toastAndLog` already includes a trailing `.`',
     },
+    {
+        selector:
+            'JSXElement[closingElement!=null]:not(:has(.children:matches(JSXText[raw=/\\S/], :not(JSXText))))',
+        message: 'Use self-closing tags (`<tag />`) for tags without children.',
+    },
 ]
 
 // ============================

--- a/app/ide-desktop/lib/dashboard/README.md
+++ b/app/ide-desktop/lib/dashboard/README.md
@@ -6,10 +6,9 @@ management, project sharing, and user accounts and authentication.
 ## Folder structure
 
 - `mock/`: Overrides for specific files in `src/` when running Playwright tests.
-- `test-component/`: Contains component tests.
-- `test-e2e/`: Contains end-to-end tests.
+- `e2e/`: Contains end-to-end tests.
 - `**/__tests__/`: Contains all unit tests. Unit tests MUST be in a `__tests__/`
-  subfolder, not beside the module they are testing.
+  subfolder, not beside (and not inside) the module they are testing.
 - `src/`: The dashboard application.
   - `index.html`: The sole HTML file used by this SPA. It imports the TS entry
     point.
@@ -27,3 +26,8 @@ management, project sharing, and user accounts and authentication.
       - `components/`: Contains all components used by the authentication flow.
       - `providers/`: Contains React `Context`s required for authentication, and
         used by the main app.
+- `index.html`: The entrypoint, in the format required by Vite.
+- `404.html`: A copy of the entrypoint. This is served on unknown routes by
+  certain static hosting providers.
+- `esbuild-config.ts`: Configuration for ESBuild based on the environment
+  variables. This is a dependency of `esbuild-config.ts` in sibling modules.

--- a/app/ide-desktop/lib/dashboard/src/components/ColorPicker.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/ColorPicker.tsx
@@ -30,7 +30,7 @@ export default function ColorPicker(props: ColorPickerProps) {
               backgroundColor: backend.lChColorToCssColor(currentColor),
             }}
           >
-            <div className="hidden peer-checked:group-[]:block bg-frame-selected rounded-full w-2 h-2"></div>
+            <div className="hidden peer-checked:group-[]:block bg-frame-selected rounded-full w-2 h-2" />
           </button>
         </label>
       ))}

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/FileNameColumn.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/FileNameColumn.tsx
@@ -90,11 +90,7 @@ export default function FileNameColumn(props: FileNameColumnProps) {
           rowState.setVisibility(Visibility.faded)
           try {
             const createdFile = await backend.uploadFile(
-              {
-                fileId,
-                fileName: asset.title,
-                parentDirectoryId: asset.parentId,
-              },
+              { fileId, fileName: asset.title, parentDirectoryId: asset.parentId },
               file
             )
             rowState.setVisibility(Visibility.visible)
@@ -102,15 +98,12 @@ export default function FileNameColumn(props: FileNameColumnProps) {
           } catch (error) {
             switch (event.type) {
               case AssetEventType.uploadFiles: {
-                dispatchAssetListEvent({
-                  type: AssetListEventType.delete,
-                  key: item.key,
-                })
-                toastAndLog('Could not upload file', error)
+                dispatchAssetListEvent({ type: AssetListEventType.delete, key: item.key })
+                toastAndLog(null, error)
                 break
               }
               case AssetEventType.updateFiles: {
-                toastAndLog('Could not update file', error)
+                toastAndLog(null, error)
                 break
               }
             }

--- a/app/ide-desktop/lib/dashboard/src/layouts/dashboard/AssetProperties.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/dashboard/AssetProperties.tsx
@@ -164,7 +164,7 @@ export default function AssetProperties(props: AssetPropertiesProps) {
                   setDescription(event.currentTarget.value)
                 }}
                 className="bg-frame resize-none rounded-lg w-full p-2"
-              ></textarea>
+              />
               <button type="submit" className="self-start bg-frame-selected rounded-full px-4 py-1">
                 Update
               </button>

--- a/app/ide-desktop/lib/dashboard/src/layouts/dashboard/AssetSearchBar.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/dashboard/AssetSearchBar.tsx
@@ -236,7 +236,7 @@ export default function AssetSearchBar(props: AssetSearchBarProps) {
         }}
       />
       <div className="absolute flex flex-col top-0 left-0 overflow-hidden w-full before:absolute before:bg-frame before:inset-0 before:backdrop-blur-3xl rounded-2xl pointer-events-none transition-all duration-300">
-        <div className="relative padding h-8"></div>
+        <div className="relative padding h-8" />
         {areSuggestionsVisible && (
           <div className="relative flex flex-col gap-2">
             {/* Tags (`name:`, `modified:`, etc.) */}

--- a/app/ide-desktop/lib/dashboard/src/layouts/dashboard/GlobalContextMenu.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/dashboard/GlobalContextMenu.tsx
@@ -65,7 +65,7 @@ export default function GlobalContextMenu(props: GlobalContextMenuProps) {
               unsetModal()
             }
           }}
-        ></input>
+        />
       )}
       <MenuEntry
         hidden={hidden}

--- a/app/ide-desktop/lib/dashboard/src/services/RemoteBackend.ts
+++ b/app/ide-desktop/lib/dashboard/src/services/RemoteBackend.ts
@@ -11,7 +11,6 @@ import Backend, * as backendModule from '#/services/Backend'
 import * as remoteBackendPaths from '#/services/remoteBackendPaths'
 
 import * as config from '#/utilities/config'
-import * as errorModule from '#/utilities/error'
 import type HttpClient from '#/utilities/HttpClient'
 import * as object from '#/utilities/object'
 
@@ -35,6 +34,18 @@ const ONE_DAY_MS = 86_400_000
 const DEFAULT_OPEN_PROJECT_BODY: backendModule.OpenProjectRequestBody = {
   forceCreate: false,
   executeAsync: false,
+}
+
+// =============
+// === Types ===
+// =============
+
+/** The format of all errors returned by the backend. */
+interface RemoteBackendError {
+  readonly type: string
+  readonly code: string
+  readonly message: string
+  readonly param: string
 }
 
 // ============================
@@ -141,7 +152,9 @@ export default class RemoteBackend extends Backend {
     // All of our API endpoints are authenticated, so we expect the `Authorization` header to be
     // set.
     if (!new Headers(this.client.defaultHeaders).has('Authorization')) {
-      return this.throw('Authorization header not set.')
+      const message = 'Authorization header not set'
+      this.logger.error(message)
+      throw new Error(message)
     } else {
       if (detect.IS_DEV_MODE) {
         // @ts-expect-error This exists only for debugging purposes. It does not have types
@@ -154,7 +167,14 @@ export default class RemoteBackend extends Backend {
 
   /** Log an error message and throws an {@link Error} with the specified message.
    * @throws {Error} Always. */
-  throw(message: string): never {
+  async throw(prefix: string, response: Response | null): Promise<never> {
+    const error =
+      response == null
+        ? { message: 'unknown error' }
+        : // This is SAFE only when the response has been confirmed to have an erroring status code.
+          // eslint-disable-next-line no-restricted-syntax
+          ((await response.json()) as RemoteBackendError)
+    const message = `${prefix}: ${error.message}.`
     this.logger.error(message)
     throw new Error(message)
   }
@@ -164,7 +184,7 @@ export default class RemoteBackend extends Backend {
     const path = remoteBackendPaths.LIST_USERS_PATH
     const response = await this.get<ListUsersResponseBody>(path)
     if (!responseIsSuccessful(response)) {
-      return this.throw(`Could not list users in the organization.`)
+      return this.throw(`Could not list users in the organization`, response)
     } else {
       return (await response.json()).users
     }
@@ -177,7 +197,7 @@ export default class RemoteBackend extends Backend {
     const path = remoteBackendPaths.CREATE_USER_PATH
     const response = await this.post<backendModule.User>(path, body)
     if (!responseIsSuccessful(response)) {
-      return this.throw('Could not create user.')
+      return this.throw('Could not create user', response)
     } else {
       return await response.json()
     }
@@ -189,9 +209,9 @@ export default class RemoteBackend extends Backend {
     const response = await this.put(path, body)
     if (!responseIsSuccessful(response)) {
       if (body.username != null) {
-        return this.throw('Could not change username.')
+        return this.throw('Could not change username', response)
       } else {
-        return this.throw('Could not update user.')
+        return this.throw('Could not update user', response)
       }
     } else {
       return
@@ -202,7 +222,7 @@ export default class RemoteBackend extends Backend {
   override async deleteUser(): Promise<void> {
     const response = await this.delete(remoteBackendPaths.DELETE_USER_PATH)
     if (!responseIsSuccessful(response)) {
-      return this.throw('Could not delete user.')
+      return this.throw('Could not delete user', response)
     } else {
       return
     }
@@ -213,7 +233,7 @@ export default class RemoteBackend extends Backend {
     const path = remoteBackendPaths.INVITE_USER_PATH
     const response = await this.post(path, body)
     if (!responseIsSuccessful(response)) {
-      return this.throw(`Could not invite user '${body.userEmail}'.`)
+      return this.throw(`Could not invite user '${body.userEmail}'`, response)
     } else {
       return
     }
@@ -232,7 +252,7 @@ export default class RemoteBackend extends Backend {
     const path = `${remoteBackendPaths.UPLOAD_USER_PICTURE_PATH}?${paramsString}`
     const response = await this.putBinary<backendModule.User>(path, file)
     if (!responseIsSuccessful(response)) {
-      return this.throw('Could not upload user profile picture.')
+      return this.throw('Could not upload user profile picture', response)
     } else {
       return await response.json()
     }
@@ -247,7 +267,7 @@ export default class RemoteBackend extends Backend {
       // Organization info has not yet been created.
       return null
     } else if (!responseIsSuccessful(response)) {
-      return this.throw('Could not get organization.')
+      return this.throw('Could not get organization', response)
     } else {
       return await response.json()
     }
@@ -264,7 +284,7 @@ export default class RemoteBackend extends Backend {
       // Organization info has not yet been created.
       return null
     } else if (!responseIsSuccessful(response)) {
-      return this.throw('Could not update organization.')
+      return this.throw('Could not update organization', response)
     } else {
       return await response.json()
     }
@@ -283,7 +303,7 @@ export default class RemoteBackend extends Backend {
     const path = `${remoteBackendPaths.UPLOAD_ORGANIZATION_PICTURE_PATH}?${paramsString}`
     const response = await this.putBinary<backendModule.OrganizationInfo>(path, file)
     if (!responseIsSuccessful(response)) {
-      return this.throw('Could not upload user profile picture.')
+      return this.throw('Could not upload user profile picture', response)
     } else {
       return await response.json()
     }
@@ -294,7 +314,7 @@ export default class RemoteBackend extends Backend {
     const path = remoteBackendPaths.CREATE_PERMISSION_PATH
     const response = await this.post<backendModule.User>(path, body)
     if (!responseIsSuccessful(response)) {
-      return this.throw(`Could not set permissions.`)
+      return this.throw('Could not set permissions', response)
     } else {
       return
     }
@@ -338,9 +358,9 @@ export default class RemoteBackend extends Backend {
         return []
       } else if (query.parentId != null) {
         const name = title != null ? `'${title}'` : `with ID '${query.parentId}'`
-        return this.throw(`Could not list folder ${name}.`)
+        return this.throw(`Could not list folder ${name}`, response)
       } else {
-        return this.throw('Could not list root folder.')
+        return this.throw('Could not list root folder', response)
       }
     } else {
       return (await response.json()).assets
@@ -366,7 +386,7 @@ export default class RemoteBackend extends Backend {
     const path = remoteBackendPaths.CREATE_DIRECTORY_PATH
     const response = await this.post<backendModule.CreatedDirectory>(path, body)
     if (!responseIsSuccessful(response)) {
-      return this.throw(`Could not create folder with name '${body.title}'.`)
+      return this.throw(`Could not create folder with name '${body.title}'`, response)
     } else {
       return await response.json()
     }
@@ -383,7 +403,7 @@ export default class RemoteBackend extends Backend {
     const response = await this.put<backendModule.UpdatedDirectory>(path, body)
     if (!responseIsSuccessful(response)) {
       const name = title != null ? `'${title}'` : `with ID '${directoryId}'`
-      return this.throw(`Could not update folder ${name}.`)
+      return this.throw(`Could not update folder ${name}`, response)
     } else {
       return await response.json()
     }
@@ -398,7 +418,7 @@ export default class RemoteBackend extends Backend {
     const response = await this.get<backendModule.AssetVersions>(path)
     if (!responseIsSuccessful(response)) {
       const name = title != null ? `'${title}'` : `with ID '${assetId}'`
-      return this.throw(`Could not list versions for ${name}.`)
+      return this.throw(`Could not list versions for ${name}`, response)
     } else {
       return await response.json()
     }
@@ -415,7 +435,7 @@ export default class RemoteBackend extends Backend {
     const response = await this.patch(path, body)
     if (!responseIsSuccessful(response)) {
       const name = title != null ? `'${title}'` : `asset with ID '${assetId}'`
-      return this.throw(`Could not update ${name}.`)
+      return this.throw(`Could not update ${name}.`, response)
     } else {
       return
     }
@@ -428,7 +448,7 @@ export default class RemoteBackend extends Backend {
     const response = await this.delete(path)
     if (!responseIsSuccessful(response)) {
       const name = title != null ? `'${title}'` : `asset with ID '${assetId}'`
-      return this.throw(`Unable to delete ${name}.`)
+      return this.throw(`Unable to delete ${name}.`, response)
     } else {
       return
     }
@@ -446,7 +466,8 @@ export default class RemoteBackend extends Backend {
       return this.throw(
         `Unable to restore ${
           title != null ? `'${title}'` : `asset with ID '${assetId}'`
-        } from Trash.`
+        } from Trash`,
+        response
       )
     } else {
       return
@@ -471,7 +492,8 @@ export default class RemoteBackend extends Backend {
           parentDirectoryTitle != null
             ? `'${parentDirectoryTitle}'`
             : `directory with ID '${parentDirectoryId}'`
-        }.`
+        }`,
+        response
       )
     } else {
       return await response.json()
@@ -484,7 +506,7 @@ export default class RemoteBackend extends Backend {
     const path = remoteBackendPaths.LIST_PROJECTS_PATH
     const response = await this.get<ListProjectsResponseBody>(path)
     if (!responseIsSuccessful(response)) {
-      return this.throw('Could not list projects.')
+      return this.throw('Could not list projects', response)
     } else {
       return (await response.json()).projects.map(project => ({
         ...project,
@@ -504,7 +526,7 @@ export default class RemoteBackend extends Backend {
     const path = remoteBackendPaths.CREATE_PROJECT_PATH
     const response = await this.post<backendModule.CreatedProject>(path, body)
     if (!responseIsSuccessful(response)) {
-      return this.throw(`Could not create project with name '${body.projectName}'.`)
+      return this.throw(`Could not create project with name '${body.projectName}'`, response)
     } else {
       return await response.json()
     }
@@ -520,7 +542,8 @@ export default class RemoteBackend extends Backend {
     const response = await this.post(path, {})
     if (!responseIsSuccessful(response)) {
       return this.throw(
-        `Could not close project ${title != null ? `'${title}'` : `with ID '${projectId}'`}.`
+        `Could not close project ${title != null ? `'${title}'` : `with ID '${projectId}'`}`,
+        response
       )
     } else {
       return
@@ -539,7 +562,8 @@ export default class RemoteBackend extends Backend {
       return this.throw(
         `Could not get details of project ${
           title != null ? `'${title}'` : `with ID '${projectId}'`
-        }.`
+        }`,
+        response
       )
     } else {
       const project = await response.json()
@@ -568,7 +592,8 @@ export default class RemoteBackend extends Backend {
     const response = await this.post(path, body ?? DEFAULT_OPEN_PROJECT_BODY)
     if (!responseIsSuccessful(response)) {
       return this.throw(
-        `Could not open project ${title != null ? `'${title}'` : `with ID '${projectId}'`}.`
+        `Could not open project ${title != null ? `'${title}'` : `with ID '${projectId}'`}`,
+        response
       )
     } else {
       return
@@ -586,7 +611,8 @@ export default class RemoteBackend extends Backend {
     const response = await this.put<backendModule.UpdatedProject>(path, body)
     if (!responseIsSuccessful(response)) {
       return this.throw(
-        `Could not update project ${title != null ? `'${title}'` : `with ID '${projectId}'`}.`
+        `Could not update project ${title != null ? `'${title}'` : `with ID '${projectId}'`}`,
+        response
       )
     } else {
       return await response.json()
@@ -605,7 +631,8 @@ export default class RemoteBackend extends Backend {
       return this.throw(
         `Could not get resource usage for project ${
           title != null ? `'${title}'` : `with ID '${projectId}'`
-        }.`
+        }`,
+        response
       )
     } else {
       return await response.json()
@@ -618,7 +645,7 @@ export default class RemoteBackend extends Backend {
     const path = remoteBackendPaths.LIST_FILES_PATH
     const response = await this.get<ListFilesResponseBody>(path)
     if (!responseIsSuccessful(response)) {
-      return this.throw('Could not list files.')
+      return this.throw('Could not list files', response)
     } else {
       return (await response.json()).files
     }
@@ -640,19 +667,10 @@ export default class RemoteBackend extends Backend {
     const path = `${remoteBackendPaths.UPLOAD_FILE_PATH}?${paramsString}`
     const response = await this.postBinary<backendModule.FileInfo>(path, file)
     if (!responseIsSuccessful(response)) {
-      let suffix = '.'
-      try {
-        const error = errorModule.tryGetError<unknown>(await response.json())
-        if (error != null) {
-          suffix = `: ${error}`
-        }
-      } catch {
-        // Ignored.
-      }
       if (params.fileId != null) {
-        return this.throw(`Could not upload file with ID '${params.fileId}'${suffix}`)
+        return this.throw(`Could not upload file with ID '${params.fileId}'`, response)
       } else {
-        return this.throw(`Could not upload file${suffix}`)
+        return this.throw('Could not upload file', response)
       }
     } else {
       return await response.json()
@@ -669,7 +687,8 @@ export default class RemoteBackend extends Backend {
     const response = await this.get<backendModule.FileDetails>(path)
     if (!responseIsSuccessful(response)) {
       return this.throw(
-        `Could not get details of project ${title != null ? `'${title}'` : `with ID '${fileId}'`}.`
+        `Could not get details of project ${title != null ? `'${title}'` : `with ID '${fileId}'`}`,
+        response
       )
     } else {
       return await response.json()
@@ -684,7 +703,7 @@ export default class RemoteBackend extends Backend {
     const path = remoteBackendPaths.CREATE_CONNECTOR_PATH
     const response = await this.post<backendModule.ConnectorInfo>(path, body)
     if (!responseIsSuccessful(response)) {
-      return this.throw(`Could not create Data Link with name '${body.name}'.`)
+      return this.throw(`Could not create Data Link with name '${body.name}'`, response)
     } else {
       return await response.json()
     }
@@ -700,7 +719,7 @@ export default class RemoteBackend extends Backend {
     const response = await this.get<backendModule.Connector>(path)
     if (!responseIsSuccessful(response)) {
       const name = title != null ? `'${title}'` : `with ID '${connectorId}'`
-      return this.throw(`Could not get Data Link ${name}.`)
+      return this.throw(`Could not get Data Link ${name}`, response)
     } else {
       return await response.json()
     }
@@ -716,7 +735,7 @@ export default class RemoteBackend extends Backend {
     const response = await this.delete(path)
     if (!responseIsSuccessful(response)) {
       const name = title != null ? `'${title}'` : `with ID '${connectorId}'`
-      return this.throw(`Could not delete Data Link ${name}.`)
+      return this.throw(`Could not delete Data Link ${name}`, response)
     } else {
       return
     }
@@ -730,7 +749,7 @@ export default class RemoteBackend extends Backend {
     const path = remoteBackendPaths.CREATE_SECRET_PATH
     const response = await this.post<backendModule.SecretId>(path, body)
     if (!responseIsSuccessful(response)) {
-      return this.throw(`Could not create secret with name '${body.name}'.`)
+      return this.throw(`Could not create secret with name '${body.name}'`, response)
     } else {
       return await response.json()
     }
@@ -746,7 +765,7 @@ export default class RemoteBackend extends Backend {
     const response = await this.get<backendModule.Secret>(path)
     if (!responseIsSuccessful(response)) {
       const name = title != null ? `'${title}'` : `with ID '${secretId}'`
-      return this.throw(`Could not get secret ${name}.`)
+      return this.throw(`Could not get secret ${name}`, response)
     } else {
       return await response.json()
     }
@@ -763,7 +782,7 @@ export default class RemoteBackend extends Backend {
     const response = await this.put(path, body)
     if (!responseIsSuccessful(response)) {
       const name = title != null ? `'${title}'` : `with ID '${secretId}'`
-      return this.throw(`Could not update secret ${name}.`)
+      return this.throw(`Could not update secret ${name}`, response)
     } else {
       return
     }
@@ -775,7 +794,7 @@ export default class RemoteBackend extends Backend {
     const path = remoteBackendPaths.LIST_SECRETS_PATH
     const response = await this.get<ListSecretsResponseBody>(path)
     if (!responseIsSuccessful(response)) {
-      return this.throw('Could not list secrets.')
+      return this.throw('Could not list secrets', response)
     } else {
       return (await response.json()).secrets
     }
@@ -787,7 +806,7 @@ export default class RemoteBackend extends Backend {
     const path = remoteBackendPaths.CREATE_TAG_PATH
     const response = await this.post<backendModule.Label>(path, body)
     if (!responseIsSuccessful(response)) {
-      return this.throw(`Could not create label '${body.value}'.`)
+      return this.throw(`Could not create label '${body.value}'`, response)
     } else {
       return await response.json()
     }
@@ -799,7 +818,7 @@ export default class RemoteBackend extends Backend {
     const path = remoteBackendPaths.LIST_TAGS_PATH
     const response = await this.get<ListTagsResponseBody>(path)
     if (!responseIsSuccessful(response)) {
-      return this.throw(`Could not list labels.`)
+      return this.throw(`Could not list labels`, response)
     } else {
       return (await response.json()).tags
     }
@@ -816,7 +835,7 @@ export default class RemoteBackend extends Backend {
     const response = await this.patch<ListTagsResponseBody>(path, { labels })
     if (!responseIsSuccessful(response)) {
       const name = title != null ? `'${title}'` : `with ID '${assetId}'`
-      return this.throw(`Could not set labels for asset ${name}.`)
+      return this.throw(`Could not set labels for asset ${name}`, response)
     } else {
       return
     }
@@ -831,7 +850,7 @@ export default class RemoteBackend extends Backend {
     const path = remoteBackendPaths.deleteTagPath(tagId)
     const response = await this.delete(path)
     if (!responseIsSuccessful(response)) {
-      return this.throw(`Could not delete label '${value}'.`)
+      return this.throw(`Could not delete label '${value}'`, response)
     } else {
       return
     }
@@ -850,7 +869,7 @@ export default class RemoteBackend extends Backend {
     const path = remoteBackendPaths.LIST_VERSIONS_PATH + '?' + paramsString
     const response = await this.get<ListVersionsResponseBody>(path)
     if (!responseIsSuccessful(response)) {
-      return this.throw(`Could not list versions of type '${params.versionType}'.`)
+      return this.throw(`Could not list versions of type '${params.versionType}'`, response)
     } else {
       return (await response.json()).versions
     }
@@ -865,7 +884,7 @@ export default class RemoteBackend extends Backend {
     } else {
       const version = (await this.listVersions({ versionType, default: true }))[0]?.number
       if (version == null) {
-        return this.throw(`No default ${versionType} version found.`)
+        return this.throw(`No default ${versionType} version found`, null)
       } else {
         const info: DefaultVersionInfo = { version, lastUpdatedEpochMs: nowEpochMs }
         this.defaultVersions[versionType] = info


### PR DESCRIPTION
### Pull Request Description
Adds the `message` returned by the backend to the toast notification, so that the user gets a more detailed error message.

### Important Notes
- Not sure what's the best way to properly test this, as for a lot of the backend endpoints there is no easy way to (even intentionally) trigger them from the frontend, because the frontend does a decent amount of validation as well.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
