### PR TITLE
Fix bug in map visualization

### DIFF
--- a/app/gui2/src/components/visualizations/GeoMapVisualization.vue
+++ b/app/gui2/src/components/visualizations/GeoMapVisualization.vue
@@ -336,7 +336,7 @@ function extractVisualizationDataFromFullConfig(parsedData: RegularData | Layer)
 function extractVisualizationDataFromDataFrame(parsedData: DataFrame) {
   const newPoints: Location[] = []
   for (let i = 0; i < parsedData.df_latitude.length; i += 1) {
-    const latitude = parsedData.df_longitude[i]!
+    const latitude = parsedData.df_latitude[i]!
     const longitude = parsedData.df_longitude[i]!
     const label = parsedData.df_label?.[i]
     const color = parsedData.df_color?.[i]


### PR DESCRIPTION
### Pull Request Description
- Fix a bug where longitude was used as both latitude and longitude, due to a typo....

### Important Notes
- As our Mapbox token is no longer valid, the map visualization no longer works, even with this fix. As a result, this cannot be tested properly.
- However, this can still be tested somewhat, by seeing that the error is no longer present in the repro:
  - Open the `Colorado COVID` template
  - Open the viz on this node (at the bottom right of graph. it may help to zoom out using Ctrl+Shift+A.):
![image](https://github.com/enso-org/enso/assets/4046547/54849e5f-8a53-4f5b-8bdf-f08fe8ca51f0)
  - Compare the errors logged in the console between `develop`, and this branch. This branch should not have the error about `lat` (latitude) being out of range.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
