### PR TITLE
Fix interfering click handlers

### DIFF
--- a/app/gui2/e2e/collapsingAndEntering.spec.ts
+++ b/app/gui2/e2e/collapsingAndEntering.spec.ts
@@ -27,8 +27,6 @@ test('Leaving entered nodes', async ({ page }) => {
   await actions.goToGraph(page)
   await enterToFunc2(page)
 
-  await page.waitForTimeout(600)
-
   await page.mouse.dblclick(100, 100)
   await expectInsideFunc1(page)
 

--- a/app/gui2/e2e/collapsingAndEntering.spec.ts
+++ b/app/gui2/e2e/collapsingAndEntering.spec.ts
@@ -27,18 +27,22 @@ test('Leaving entered nodes', async ({ page }) => {
   await actions.goToGraph(page)
   await enterToFunc2(page)
 
-  await locate.graphEditor(page).dblclick()
+  await page.waitForTimeout(600)
+
+  await page.mouse.dblclick(100, 100)
   await expectInsideFunc1(page)
 
-  await locate.graphEditor(page).dblclick()
+  await page.mouse.dblclick(100, 100)
   await expectInsideMain(page)
 })
 
 test('Using breadcrumbs to navigate', async ({ page }) => {
   await actions.goToGraph(page)
   await enterToFunc2(page)
-  await locate.graphEditor(page).dblclick()
-  await locate.graphEditor(page).dblclick()
+  await page.mouse.dblclick(100, 100)
+  await expectInsideFunc1(page)
+  await page.mouse.dblclick(100, 100)
+  await expectInsideMain(page)
   // Breadcrumbs still have all the crumbs, but the last two are dimmed.
   await expect(locate.navBreadcrumb(page)).toHaveText(['main', 'func1', 'func2'])
   await expect(locate.navBreadcrumb(page, (f) => f.class('inactive'))).toHaveText([
@@ -118,6 +122,8 @@ async function expectInsideFunc2(page: Page) {
 async function enterToFunc2(page: Page) {
   await mockCollapsedFunctionInfo(page, 'final', 'func1')
   await locate.graphNodeByBinding(page, 'final').dblclick()
+  await expectInsideFunc1(page)
   await mockCollapsedFunctionInfo(page, 'f2', 'func2')
   await locate.graphNodeByBinding(page, 'f2').dblclick()
+  await expectInsideFunc2(page)
 }

--- a/app/gui2/e2e/collapsingAndEntering.spec.ts
+++ b/app/gui2/e2e/collapsingAndEntering.spec.ts
@@ -63,9 +63,19 @@ test('Collapsing nodes', async ({ page }) => {
   const initialNodesCount = await locate.graphNode(page).count()
   await mockCollapsedFunctionInfo(page, 'final', 'func1')
 
-  await locate.graphNodeByBinding(page, 'ten').click({ modifiers: ['Shift'] })
-  await locate.graphNodeByBinding(page, 'sum').click({ modifiers: ['Shift'] })
-  await locate.graphNodeByBinding(page, 'prod').click({ modifiers: ['Shift'] })
+  // Widgets may "steal" clicks, so we always click at icon.
+  await locate
+    .graphNodeByBinding(page, 'ten')
+    .locator('.icon')
+    .click({ modifiers: ['Shift'] })
+  await locate
+    .graphNodeByBinding(page, 'sum')
+    .locator('.icon')
+    .click({ modifiers: ['Shift'] })
+  await locate
+    .graphNodeByBinding(page, 'prod')
+    .locator('.icon')
+    .click({ modifiers: ['Shift'] })
 
   await page.keyboard.press(COLLAPSE_SHORTCUT)
   await expect(locate.graphNode(page)).toHaveCount(initialNodesCount - 2)
@@ -79,7 +89,10 @@ test('Collapsing nodes', async ({ page }) => {
   await customExpect.toExist(locate.graphNodeByBinding(page, 'sum'))
   await customExpect.toExist(locate.graphNodeByBinding(page, 'prod'))
 
-  locate.graphNodeByBinding(page, 'ten').click({ modifiers: ['Shift'] })
+  locate
+    .graphNodeByBinding(page, 'ten')
+    .locator('.icon')
+    .click({ modifiers: ['Shift'] })
   // Wait till node is selected.
   await expect(locate.graphNodeByBinding(page, 'ten').and(page.locator('.selected'))).toHaveCount(1)
   await page.keyboard.press(COLLAPSE_SHORTCUT)

--- a/app/gui2/src/bindings.ts
+++ b/app/gui2/src/bindings.ts
@@ -28,7 +28,7 @@ export const graphBindings = defineKeybinds('graph-editor', {
   deleteSelected: ['OsDelete'],
   zoomToSelected: ['Mod+Shift+A'],
   selectAll: ['Mod+A'],
-  deselectAll: ['Escape', 'PointerMain'],
+  deselectAll: ['Escape'],
   copyNode: ['Mod+C'],
   pasteNode: ['Mod+V'],
   collapse: ['Mod+G'],

--- a/app/gui2/src/components/CircularMenu.vue
+++ b/app/gui2/src/components/CircularMenu.vue
@@ -18,7 +18,12 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div :class="`${props.isFullMenuVisible ? 'CircularMenu full' : 'CircularMenu partial'}`">
+  <div
+    :class="`${props.isFullMenuVisible ? 'CircularMenu full' : 'CircularMenu partial'}`"
+    pointerdown.stop
+    pointerup.stop
+    click.stop
+  >
     <ToggleIcon
       icon="eye"
       class="icon-container button slot5"
@@ -26,7 +31,7 @@ const emit = defineEmits<{
       :modelValue="props.isVisualizationVisible"
       @update:modelValue="emit('update:isVisualizationVisible', $event)"
     />
-    <SvgIcon name="edit" class="icon-container button slot6" @pointerdown="emit('startEditing')" />
+    <SvgIcon name="edit" class="icon-container button slot6" @click="emit('startEditing')" />
     <ToggleIcon
       :icon="props.isOutputContextEnabledGlobally ? 'no_auto_replay' : 'auto_replay'"
       class="icon-container button slot7"

--- a/app/gui2/src/components/CircularMenu.vue
+++ b/app/gui2/src/components/CircularMenu.vue
@@ -20,9 +20,9 @@ const emit = defineEmits<{
 <template>
   <div
     :class="`${props.isFullMenuVisible ? 'CircularMenu full' : 'CircularMenu partial'}`"
-    pointerdown.stop
-    pointerup.stop
-    click.stop
+    @pointerdown.stop
+    @pointerup.stop
+    @click.stop
   >
     <ToggleIcon
       icon="eye"

--- a/app/gui2/src/components/CircularMenu.vue
+++ b/app/gui2/src/components/CircularMenu.vue
@@ -31,7 +31,7 @@ const emit = defineEmits<{
       :modelValue="props.isVisualizationVisible"
       @update:modelValue="emit('update:isVisualizationVisible', $event)"
     />
-    <SvgIcon name="edit" class="icon-container button slot6" @click="emit('startEditing')" />
+    <SvgIcon name="edit" class="icon-container button slot6" @click.stop="emit('startEditing')" />
     <ToggleIcon
       :icon="props.isOutputContextEnabledGlobally ? 'no_auto_replay' : 'auto_replay'"
       class="icon-container button slot7"

--- a/app/gui2/src/components/CodeEditor.vue
+++ b/app/gui2/src/components/CodeEditor.vue
@@ -333,6 +333,8 @@ const editorStyle = computed(() => {
     @keydown.delete.stop
     @wheel.stop.passive
     @pointerdown.stop
+    @pointerup.stop
+    @click.stop
     @contextmenu.stop
   >
     <div class="resize-handle" v-on="resize.events" @dblclick="resetSize">

--- a/app/gui2/src/components/ComponentBrowser.vue
+++ b/app/gui2/src/components/ComponentBrowser.vue
@@ -43,11 +43,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   accepted: [searcherExpression: string, requiredImports: RequiredImport[]]
-  closed: [
-    searcherExpression: string,
-    requiredImports: RequiredImport[],
-    anyUserInputChange: boolean,
-  ]
+  closed: [searcherExpression: string, requiredImports: RequiredImport[], anyInputChange: boolean]
   canceled: []
 }>()
 
@@ -141,13 +137,6 @@ watch(
 )
 
 function handleDefocus(e: FocusEvent) {
-  console.log(
-    'focusout',
-    e.relatedTarget,
-    cbRoot.value != null,
-    e.relatedTarget instanceof Node,
-    cbRoot.value?.contains(e.relatedTarget),
-  )
   const stillInside =
     cbRoot.value != null &&
     e.relatedTarget instanceof Node &&
@@ -159,8 +148,12 @@ function handleDefocus(e: FocusEvent) {
   }
 }
 
+/** Prevent default on an event if input is not its target.
+ *
+ * The mouse events emitted on other elements may make input selection disappear, what we want to
+ * avoid.
+ */
 function preventNonInputDefault(e: Event) {
-  console.log('check', e, inputField.value, e.target !== inputField.value)
   if (inputField.value != null && e.target !== inputField.value) {
     e.preventDefault()
   }

--- a/app/gui2/src/components/ComponentBrowser.vue
+++ b/app/gui2/src/components/ComponentBrowser.vue
@@ -43,7 +43,6 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   accepted: [searcherExpression: string, requiredImports: RequiredImport[]]
-  closed: [searcherExpression: string, requiredImports: RequiredImport[], anyInputChange: boolean]
   canceled: []
 }>()
 
@@ -166,7 +165,11 @@ useEvent(
     if (event.button !== 0) return
     if (!(event.target instanceof Element)) return
     if (!cbRoot.value?.contains(event.target)) {
-      emit('closed', input.code.value, input.importsToAdd(), input.anyChange.value)
+      if (input.anyChange.value) {
+        emit('accepted', input.code.value, input.importsToAdd())
+      } else {
+        emit('canceled')
+      }
     }
   },
   { capture: true },

--- a/app/gui2/src/components/ComponentBrowser.vue
+++ b/app/gui2/src/components/ComponentBrowser.vue
@@ -111,8 +111,10 @@ function readInputFieldSelection() {
     inputField.value.selectionStart != null &&
     inputField.value.selectionEnd != null
   ) {
-    input.selection.value.start = inputField.value.selectionStart
-    input.selection.value.end = inputField.value.selectionEnd
+    input.selection.value = {
+      start: inputField.value.selectionStart,
+      end: inputField.value.selectionEnd,
+    }
   }
 }
 // HTMLInputElement's same event is not supported in chrome yet. We just react for any

--- a/app/gui2/src/components/ComponentBrowser/__tests__/input.test.ts
+++ b/app/gui2/src/components/ComponentBrowser/__tests__/input.test.ts
@@ -1,5 +1,5 @@
 import { useComponentBrowserInput } from '@/components/ComponentBrowser/input'
-import { GraphDb } from '@/stores/graph/graphDatabase'
+import { asNodeId, GraphDb } from '@/stores/graph/graphDatabase'
 import type { RequiredImport } from '@/stores/graph/imports'
 import { ComputedValueRegistry } from '@/stores/project/computedValueRegistry'
 import { SuggestionDb } from '@/stores/suggestionDatabase'
@@ -22,6 +22,24 @@ import type { ExternalId, Uuid } from 'shared/yjsModel'
 import { expect, test } from 'vitest'
 
 await initializeFFI()
+
+const operator1Id = '3d0e9b96-3ca0-4c35-a820-7d3a1649de55' as AstId
+const operator1ExternalId = operator1Id as Uuid as ExternalId
+const operator2Id = '5eb16101-dd2b-4034-a6e2-476e8bfa1f2b' as AstId
+
+function mockGraphDb() {
+  const computedValueRegistryMock = ComputedValueRegistry.Mock()
+  computedValueRegistryMock.db.set(operator1ExternalId, {
+    typename: 'Standard.Base.Number',
+    methodCall: undefined,
+    payload: { type: 'Value' },
+    profilingInfo: [],
+  })
+  const db = GraphDb.Mock(computedValueRegistryMock)
+  db.mockNode('operator1', operator1Id, 'Data.read')
+  db.mockNode('operator2', operator2Id)
+  return db
+}
 
 test.each([
   ['', 0, { type: 'insert', position: 0 }, {}],
@@ -101,21 +119,7 @@ test.each([
       selfArg?: { type: string; typename?: string }
     },
   ) => {
-    const operator1Id = '3d0e9b96-3ca0-4c35-a820-7d3a1649de55' as AstId
-    const operator1ExternalId = operator1Id as Uuid as ExternalId
-    const operator2Id = '5eb16101-dd2b-4034-a6e2-476e8bfa1f2b' as AstId
-    const computedValueRegistryMock = ComputedValueRegistry.Mock()
-    computedValueRegistryMock.db.set(operator1ExternalId, {
-      typename: 'Standard.Base.Number',
-      methodCall: undefined,
-      payload: { type: 'Value' },
-      profilingInfo: [],
-    })
-    const mockGraphDb = GraphDb.Mock(computedValueRegistryMock)
-    mockGraphDb.mockNode('operator1', operator1Id)
-    mockGraphDb.mockNode('operator2', operator2Id)
-
-    const input = useComponentBrowserInput(mockGraphDb, new SuggestionDb())
+    const input = useComponentBrowserInput(mockGraphDb(), new SuggestionDb())
     input.code.value = code
     input.selection.value = { start: cursorPos, end: cursorPos }
     const context = input.context.value
@@ -359,3 +363,55 @@ test.each([
     expect(input.importsToAdd()).toEqual(expectedImports)
   },
 )
+
+test.each`
+  typed    | finalCodeWithSourceNode
+  ${'foo'} | ${'operator1.foo'}
+  ${' '}   | ${'operator1. '}
+  ${'+'}   | ${'operator1 + '}
+  ${'>='}  | ${'operator1 >= '}
+`('Initialize input for new node and type $typed', ({ typed, finalCodeWithSourceNode }) => {
+  const mockDb = mockGraphDb()
+  const sourceNode = operator1Id
+  const sourcePort = mockDb.getNodeFirstOutputPort(asNodeId(sourceNode))
+  const input = useComponentBrowserInput(mockDb, new SuggestionDb())
+
+  // Without source node
+  input.reset({ type: 'newNode' })
+  expect(input.code.value).toBe('')
+  expect(input.selection.value).toEqual({ start: 0, end: 0 })
+  expect(input.anyChange.value).toBeFalsy()
+  input.code.value = typed
+  input.selection.value.start = input.selection.value.end = typed.length
+  expect(input.code.value).toBe(typed)
+  expect(input.selection.value).toEqual({ start: typed.length, end: typed.length })
+  expect(input.anyChange.value).toBeTruthy()
+
+  // With source node
+  input.reset({ type: 'newNode', sourcePort })
+  expect(input.code.value).toBe('operator1.')
+  expect(input.selection.value).toEqual({ start: 10, end: 10 })
+  expect(input.anyChange.value).toBeFalsy()
+  input.code.value = `operator1.${typed}`
+  input.selection.value.start = input.selection.value.end = typed.length + 10
+  expect(input.code.value).toBe(finalCodeWithSourceNode)
+  expect(input.selection.value).toEqual({
+    start: finalCodeWithSourceNode.length,
+    end: finalCodeWithSourceNode.length,
+  })
+  expect(input.anyChange.value).toBeTruthy()
+})
+
+test('Initialize input for edited node', () => {
+  const input = useComponentBrowserInput(mockGraphDb(), new SuggestionDb())
+  input.reset({ type: 'editNode', node: asNodeId(operator1Id), cursorPos: 4 })
+  expect(input.code.value).toBe('Data.read')
+  expect(input.selection.value).toEqual({ start: 4, end: 4 })
+  expect(input.anyChange.value).toBeFalsy()
+  // Typing anything should not affected existing code (in contrary to new node creation)
+  input.code.value = `Data.+.read`
+  input.selection.value.start = input.selection.value.end = 5
+  expect(input.code.value).toEqual('Data.+.read')
+  expect(input.selection.value).toEqual({ start: 5, end: 5 })
+  expect(input.anyChange.value).toBeTruthy()
+})

--- a/app/gui2/src/components/ComponentBrowser/filtering.ts
+++ b/app/gui2/src/components/ComponentBrowser/filtering.ts
@@ -6,6 +6,7 @@ import {
 import type { Opt } from '@/util/data/opt'
 import { Range } from '@/util/data/range'
 import { qnIsTopElement, qnParent, type QualifiedName } from '@/util/qualifiedName'
+import escapeStringRegexp from '@/util/regexp'
 
 export type SelfArg =
   | {
@@ -58,7 +59,7 @@ class FilteringWithPattern {
     // - The unmatched rest of the word, up to, but excluding, the next underscore
     // - The unmatched words before the next matched word, including any underscores
     this.wordMatchRegex = new RegExp(
-      '(^|.*?_)(' + pattern.replace(/_/g, ')([^_]*)(.*?)(_') + ')([^_]*)(.*)',
+      '(^|.*?_)(' + escapeStringRegexp(pattern).replace(/_/g, ')([^_]*)(.*?)(_') + ')([^_]*)(.*)',
       'i',
     )
     if (pattern.length > 1 && !/_/.test(pattern)) {
@@ -302,10 +303,11 @@ export class Filtering {
       let prefix = ''
       let suffix = ''
       for (const [, text, separator] of this.fullPattern.matchAll(/(.+?)([._]|$)/g)) {
+        const escaped = escapeStringRegexp(text ?? '')
         const segment =
           separator === '_'
-            ? `()(${text})([^_.]*)(_)`
-            : `([^.]*_)?(${text})([^.]*)(${separator === '.' ? '\\.' : ''})`
+            ? `()(${escaped})([^_.]*)(_)`
+            : `([^.]*_)?(${escaped})([^.]*)(${separator === '.' ? '\\.' : ''})`
         prefix = '(?:' + prefix
         suffix += segment + ')?'
       }

--- a/app/gui2/src/components/ComponentBrowser/input.ts
+++ b/app/gui2/src/components/ComponentBrowser/input.ts
@@ -465,8 +465,6 @@ export function useComponentBrowserInput(
   function setSourceNode(sourcePort: AstId, operator: string = '.') {
     const sourceNodeName = graphDb.getOutputPortIdentifier(sourcePort)
     code.value = sourceNodeName ? `${sourceNodeName}${operator}` : ''
-    console.error(JSON.stringify(code.value))
-    console.error(code.value.length)
     selection.value = { start: code.value.length, end: code.value.length }
   }
 

--- a/app/gui2/src/components/ComponentBrowser/input.ts
+++ b/app/gui2/src/components/ComponentBrowser/input.ts
@@ -460,8 +460,12 @@ export function useComponentBrowserInput(
   function setSourceNode(sourcePort: AstId, operator: string = '.') {
     const sourceNodeName = graphDb.getOutputPortIdentifier(sourcePort)
     code.value = sourceNodeName ? `${sourceNodeName}${operator}` : ''
+    console.log(code.value)
+    console.log(code.value.length)
     selection.value = { start: code.value.length, end: code.value.length }
   }
+
+  watch(selection, console.log, { flush: 'sync' })
 
   return {
     /** The current input's text (code). */

--- a/app/gui2/src/components/DocumentationPanel/DocsBreadcrumb.vue
+++ b/app/gui2/src/components/DocumentationPanel/DocsBreadcrumb.vue
@@ -9,7 +9,7 @@ const emit = defineEmits<{ click: [] }>()
 <template>
   <div class="Breadcrumb">
     <SvgIcon v-if="props.icon" :name="props.icon || ''" />
-    <span @click="emit('click')" v-text="props.text"></span>
+    <span @click.stop="emit('click')" v-text="props.text"></span>
   </div>
 </template>
 

--- a/app/gui2/src/components/DocumentationPanel/DocsBreadcrumb.vue
+++ b/app/gui2/src/components/DocumentationPanel/DocsBreadcrumb.vue
@@ -9,7 +9,7 @@ const emit = defineEmits<{ click: [] }>()
 <template>
   <div class="Breadcrumb">
     <SvgIcon v-if="props.icon" :name="props.icon || ''" />
-    <span @pointerdown="emit('click')" v-text="props.text"></span>
+    <span @click="emit('click')" v-text="props.text"></span>
   </div>
 </template>
 

--- a/app/gui2/src/components/DocumentationPanel/DocsBreadcrumbs.vue
+++ b/app/gui2/src/components/DocumentationPanel/DocsBreadcrumbs.vue
@@ -33,13 +33,13 @@ function shrinkFactor(index: number): number {
         name="arrow_left"
         draggable="false"
         :class="['icon', 'button', 'arrow', { inactive: !props.canGoBackward }]"
-        @click="emit('backward')"
+        @click.stop="emit('backward')"
       />
       <SvgIcon
         name="arrow_right"
         draggable="false"
         :class="['icon', 'button', 'arrow', { inactive: !props.canGoForward }]"
-        @click="emit('forward')"
+        @click.stop="emit('forward')"
       />
     </div>
     <TransitionGroup name="breadcrumbs">

--- a/app/gui2/src/components/DocumentationPanel/DocsBreadcrumbs.vue
+++ b/app/gui2/src/components/DocumentationPanel/DocsBreadcrumbs.vue
@@ -33,13 +33,13 @@ function shrinkFactor(index: number): number {
         name="arrow_left"
         draggable="false"
         :class="['icon', 'button', 'arrow', { inactive: !props.canGoBackward }]"
-        @pointerdown="emit('backward')"
+        @click="emit('backward')"
       />
       <SvgIcon
         name="arrow_right"
         draggable="false"
         :class="['icon', 'button', 'arrow', { inactive: !props.canGoForward }]"
-        @pointerdown="emit('forward')"
+        @click="emit('forward')"
       />
     </div>
     <TransitionGroup name="breadcrumbs">

--- a/app/gui2/src/components/DocumentationPanel/DocsList.vue
+++ b/app/gui2/src/components/DocumentationPanel/DocsList.vue
@@ -48,10 +48,7 @@ const annotations = computed<Array<string | undefined>>(() => {
 <template>
   <ul v-if="props.items.items.length > 0">
     <li v-for="(item, index) in props.items.items" :key="index" :class="props.items.kind">
-      <a
-        :class="['link', props.items.kind]"
-        @pointerdown.stop.prevent="emit('linkClicked', item.id)"
-      >
+      <a :class="['link', props.items.kind]" @click.prevent="emit('linkClicked', item.id)">
         <span class="entryName">{{ qnSplit(item.name)[1] }}</span>
         <span class="arguments">{{ ' ' + argumentsList(item.arguments) }}</span>
       </a>

--- a/app/gui2/src/components/DocumentationPanel/DocsList.vue
+++ b/app/gui2/src/components/DocumentationPanel/DocsList.vue
@@ -48,7 +48,7 @@ const annotations = computed<Array<string | undefined>>(() => {
 <template>
   <ul v-if="props.items.items.length > 0">
     <li v-for="(item, index) in props.items.items" :key="index" :class="props.items.kind">
-      <a :class="['link', props.items.kind]" @click.prevent="emit('linkClicked', item.id)">
+      <a :class="['link', props.items.kind]" @click.stop="emit('linkClicked', item.id)">
         <span class="entryName">{{ qnSplit(item.name)[1] }}</span>
         <span class="arguments">{{ ' ' + argumentsList(item.arguments) }}</span>
       </a>

--- a/app/gui2/src/components/ExecutionModeSelector.vue
+++ b/app/gui2/src/components/ExecutionModeSelector.vue
@@ -25,7 +25,7 @@ useEvent(document, 'pointerdown', onDocumentClick)
 <template>
   <div ref="executionModeSelectorNode" class="ExecutionModeSelector">
     <div class="execution-mode-button">
-      <div class="execution-mode button" @pointerdown.stop="isDropdownOpen = !isDropdownOpen">
+      <div class="execution-mode button" @click="isDropdownOpen = !isDropdownOpen">
         <span v-text="props.modelValue"></span>
       </div>
       <div class="divider"></div>
@@ -33,7 +33,7 @@ useEvent(document, 'pointerdown', onDocumentClick)
         name="workflow_play"
         class="play button"
         draggable="false"
-        @pointerdown="
+        @click="
           () => {
             isDropdownOpen = false
             emit('execute')
@@ -47,7 +47,7 @@ useEvent(document, 'pointerdown', onDocumentClick)
           <span
             v-if="modelValue !== otherMode"
             class="button"
-            @pointerdown="emit('update:modelValue', otherMode), (isDropdownOpen = false)"
+            @click="emit('update:modelValue', otherMode), (isDropdownOpen = false)"
             v-text="otherMode"
           ></span>
         </template>

--- a/app/gui2/src/components/ExecutionModeSelector.vue
+++ b/app/gui2/src/components/ExecutionModeSelector.vue
@@ -25,7 +25,7 @@ useEvent(document, 'pointerdown', onDocumentClick)
 <template>
   <div ref="executionModeSelectorNode" class="ExecutionModeSelector">
     <div class="execution-mode-button">
-      <div class="execution-mode button" @click="isDropdownOpen = !isDropdownOpen">
+      <div class="execution-mode button" @click.stop="isDropdownOpen = !isDropdownOpen">
         <span v-text="props.modelValue"></span>
       </div>
       <div class="divider"></div>
@@ -33,7 +33,7 @@ useEvent(document, 'pointerdown', onDocumentClick)
         name="workflow_play"
         class="play button"
         draggable="false"
-        @click="
+        @click.stop="
           () => {
             isDropdownOpen = false
             emit('execute')
@@ -47,7 +47,7 @@ useEvent(document, 'pointerdown', onDocumentClick)
           <span
             v-if="modelValue !== otherMode"
             class="button"
-            @click="emit('update:modelValue', otherMode), (isDropdownOpen = false)"
+            @click.stop="emit('update:modelValue', otherMode), (isDropdownOpen = false)"
             v-text="otherMode"
           ></span>
         </template>

--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -416,18 +416,6 @@ function hideComponentBrowser() {
   componentBrowserVisible.value = false
 }
 
-function onComponentBrowserClose(
-  content: string,
-  requiredImports: RequiredImport[],
-  anyInputChange: boolean,
-) {
-  if (anyInputChange) {
-    onComponentBrowserCommit(content, requiredImports)
-  } else {
-    onComponentBrowserCancel()
-  }
-}
-
 function onComponentBrowserCommit(content: string, requiredImports: RequiredImport[]) {
   if (content != null) {
     if (graphStore.editedNodeInfo) {
@@ -666,7 +654,6 @@ function handleEdgeDrop(source: AstId, position: Vec2) {
       :nodePosition="componentBrowserNodePosition"
       :usage="componentBrowserUsage"
       @accepted="onComponentBrowserCommit"
-      @closed="onComponentBrowserClose"
       @canceled="onComponentBrowserCancel"
     />
     <TopBar

--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -418,6 +418,18 @@ function hideComponentBrowser() {
   componentBrowserVisible.value = false
 }
 
+function onComponentBrowserClose(
+  content: string,
+  requiredImports: RequiredImport[],
+  anyUserInputChange: boolean,
+) {
+  if (anyUserInputChange) {
+    onComponentBrowserCommit(content, requiredImports)
+  } else {
+    onComponentBrowserCancel()
+  }
+}
+
 function onComponentBrowserCommit(content: string, requiredImports: RequiredImport[]) {
   if (content != null) {
     if (graphStore.editedNodeInfo) {
@@ -656,7 +668,7 @@ function handleEdgeDrop(source: AstId, position: Vec2) {
       :nodePosition="componentBrowserNodePosition"
       :usage="componentBrowserUsage"
       @accepted="onComponentBrowserCommit"
-      @closed="onComponentBrowserCommit"
+      @closed="onComponentBrowserClose"
       @canceled="onComponentBrowserCancel"
     />
     <TopBar

--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -317,15 +317,17 @@ const graphBindingsHandler = graphBindings.handler({
   },
 })
 
-const handleClick = useDoubleClick(
+const { handleClick } = useDoubleClick(
   (e: MouseEvent) => {
+    console.log('111')
     graphBindingsHandler(e)
   },
   () => {
+    console.log('222')
     if (keyboardBusy()) return false
     stackNavigator.exitNode()
   },
-).handleClick
+)
 const codeEditorArea = ref<HTMLElement>()
 const showCodeEditor = ref(false)
 const codeEditorHandler = codeEditorBindings.handler({
@@ -673,7 +675,11 @@ function handleEdgeDrop(source: AstId, position: Vec2) {
       @zoomIn="graphNavigator.scale *= 1.1"
       @zoomOut="graphNavigator.scale *= 0.9"
     />
-    <PlusButton @pointerdown="interaction.setCurrent(creatingNodeFromButton)" />
+    <PlusButton
+      @click.stop="interaction.setCurrent(creatingNodeFromButton)"
+      @pointerdown.stop
+      @pointerup.stop
+    />
     <Transition>
       <Suspense ref="codeEditorArea">
         <CodeEditor v-if="showCodeEditor" />

--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -319,11 +319,9 @@ const graphBindingsHandler = graphBindings.handler({
 
 const { handleClick } = useDoubleClick(
   (e: MouseEvent) => {
-    console.log('111')
     graphBindingsHandler(e)
   },
   () => {
-    console.log('222')
     if (keyboardBusy()) return false
     stackNavigator.exitNode()
   },
@@ -421,9 +419,9 @@ function hideComponentBrowser() {
 function onComponentBrowserClose(
   content: string,
   requiredImports: RequiredImport[],
-  anyUserInputChange: boolean,
+  anyInputChange: boolean,
 ) {
-  if (anyUserInputChange) {
+  if (anyInputChange) {
     onComponentBrowserCommit(content, requiredImports)
   } else {
     onComponentBrowserCancel()

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -424,7 +424,9 @@ function openFullMenu() {
         :name="icon"
         @click.right.stop.prevent="openFullMenu"
       ></SvgIcon>
-      <div ref="contentNode" class="widget-tree">
+      <!-- We stop pointerdown and pointerup, because the dragPointer handlers are supressing 
+        "click" event on widgets-->
+      <div ref="contentNode" class="widget-tree" @pointerdown.stop @pointerup.stop>
         <NodeWidgetTree :ast="displayedExpression" :nodeId="nodeId" />
       </div>
     </div>

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -412,12 +412,15 @@ function openFullMenu() {
       @update:id="emit('update:visualizationId', $event)"
       @update:visible="emit('update:visualizationVisible', $event)"
     />
-    <div class="node" @pointerdown="handleNodeClick" v-on="dragPointer.events">
-      <SvgIcon
-        class="icon grab-handle"
-        :name="icon"
-        @pointerdown.right.stop="openFullMenu"
-      ></SvgIcon>
+    <div
+      class="node"
+      @click="handleNodeClick"
+      v-on="dragPointer.events"
+      @pointerdown.stop
+      @pointerup.stop
+      @click.stop
+    >
+      <SvgIcon class="icon grab-handle" :name="icon" @click.right.stop="openFullMenu"></SvgIcon>
       <div ref="contentNode" class="widget-tree">
         <NodeWidgetTree :ast="displayedExpression" :nodeId="nodeId" />
       </div>

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -150,6 +150,9 @@ const startEpochMs = ref(0)
 let startEvent: PointerEvent | null = null
 let startPos = Vec2.Zero
 
+// TODO[ao]: Now, the dragPointer.events are preventing `click` events on widgets if they don't
+// stop pointerup and pointerdown. Now we ensure that any widget handling click does that, but
+// instead `usePointer` should be smarter.
 const dragPointer = usePointer((pos, event, type) => {
   if (type !== 'start') {
     const fullOffset = pos.absolute.sub(startPos)

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -419,7 +419,11 @@ function openFullMenu() {
       @pointerdown.stop
       @pointerup.stop
     >
-      <SvgIcon class="icon grab-handle" :name="icon" @click.right.stop="openFullMenu"></SvgIcon>
+      <SvgIcon
+        class="icon grab-handle"
+        :name="icon"
+        @click.right.stop.prevent="openFullMenu"
+      ></SvgIcon>
       <div ref="contentNode" class="widget-tree">
         <NodeWidgetTree :ast="displayedExpression" :nodeId="nodeId" />
       </div>

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -414,11 +414,10 @@ function openFullMenu() {
     />
     <div
       class="node"
-      @click="handleNodeClick"
+      @click.stop="handleNodeClick"
       v-on="dragPointer.events"
       @pointerdown.stop
       @pointerup.stop
-      @click.stop
     >
       <SvgIcon class="icon grab-handle" :name="icon" @click.right.stop="openFullMenu"></SvgIcon>
       <div ref="contentNode" class="widget-tree">

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -173,6 +173,7 @@ const dragPointer = usePointer((pos, event, type) => {
         pos.absolute.distanceSquared(startPos) <= MAXIMUM_CLICK_DISTANCE_SQ
       ) {
         nodeSelection?.handleSelectionOf(startEvent, new Set([nodeId.value]))
+        handleNodeClick(event)
         menuVisible.value = MenuState.Partial
       }
       startEvent = null
@@ -419,8 +420,8 @@ function openFullMenu() {
     <div
       ref="contentNode"
       class="node"
-      @click.stop="handleNodeClick"
       v-on="dragPointer.events"
+      @click.stop
       @pointerdown.stop
       @pointerup.stop
     >

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetCheckbox.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetCheckbox.vue
@@ -90,10 +90,13 @@ export const widgetDefinition = defineWidget(WidgetInput.isAstOrPlaceholder, {
 </script>
 
 <template>
+  <!-- See comment in GraphNode next to dragPointer definition about stopping pointerdown and pointerup -->
   <CheckboxWidget
     v-model="value"
     class="WidgetCheckbox"
     contenteditable="false"
     @beforeinput.stop
+    @pointerdown.stop
+    @pointerup.stop
   />
 </template>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetNumber.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetNumber.vue
@@ -52,7 +52,14 @@ export const widgetDefinition = defineWidget(WidgetInput.isAstOrPlaceholder, {
 </script>
 
 <template>
-  <NumericInputWidget v-model="value" class="WidgetNumber r-24" :limits="limits" />
+  <!-- See comment in GraphNode next to dragPointer definition about stopping pointerdown and pointerup -->
+  <NumericInputWidget
+    v-model="value"
+    class="WidgetNumber r-24"
+    :limits="limits"
+    @pointerdown.stop
+    @pointerup.stop
+  />
 </template>
 
 <style scoped>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
@@ -171,7 +171,7 @@ export const widgetDefinition = defineWidget(WidgetInput.isAstOrPlaceholder, {
 </script>
 
 <template>
-  <div class="WidgetSelection" @pointerdown.stop="toggleDropdownWidget">
+  <div class="WidgetSelection" @click.stop="toggleDropdownWidget">
     <NodeWidget ref="childWidgetRef" :input="innerWidgetInput" />
     <SvgIcon name="arrow_right_head_only" class="arrow" />
     <DropdownWidget
@@ -180,7 +180,6 @@ export const widgetDefinition = defineWidget(WidgetInput.isAstOrPlaceholder, {
       :color="'var(--node-color-primary)'"
       :values="tagLabels"
       :selectedValue="selectedLabel"
-      @pointerdown.stop
       @click="onClick($event)"
     />
   </div>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
@@ -171,7 +171,8 @@ export const widgetDefinition = defineWidget(WidgetInput.isAstOrPlaceholder, {
 </script>
 
 <template>
-  <div class="WidgetSelection" @click.stop="toggleDropdownWidget">
+  <!-- See comment in GraphNode next to dragPointer definition about stopping pointerdown and pointerup -->
+  <div class="WidgetSelection" @pointerdown.stop @pointerup.stop @click.stop="toggleDropdownWidget">
     <NodeWidget ref="childWidgetRef" :input="innerWidgetInput" />
     <SvgIcon name="arrow_right_head_only" class="arrow" />
     <DropdownWidget

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
@@ -36,7 +36,8 @@ export const widgetDefinition = defineWidget(WidgetInput.isAstOrPlaceholder, {
 </script>
 
 <template>
-  <EnsoTextInputWidget v-model="value" class="WidgetText r-24" />
+  <!-- See comment in GraphNode next to dragPointer definition about stopping pointerdown -->
+  <EnsoTextInputWidget v-model="value" class="WidgetText r-24" @pointerdown.stop />
 </template>
 
 <style scoped>

--- a/app/gui2/src/components/NavBar.vue
+++ b/app/gui2/src/components/NavBar.vue
@@ -11,7 +11,7 @@ const emit = defineEmits<{ back: []; forward: []; breadcrumbClick: [index: numbe
 </script>
 
 <template>
-  <div class="NavBar">
+  <div class="NavBar" @pointerdown.stop @pointerup.stop @click.stop>
     <SvgIcon name="graph_editor" draggable="false" class="icon" />
     <div class="breadcrumbs-controls">
       <SvgIcon
@@ -19,14 +19,14 @@ const emit = defineEmits<{ back: []; forward: []; breadcrumbClick: [index: numbe
         draggable="false"
         class="icon button"
         :class="{ inactive: !props.allowNavigationLeft }"
-        @pointerdown="emit('back')"
+        @click.stop="emit('back')"
       />
       <SvgIcon
         name="arrow_right"
         draggable="false"
         class="icon button"
         :class="{ inactive: !props.allowNavigationRight }"
-        @pointerdown="emit('forward')"
+        @click.stop="emit('forward')"
       />
     </div>
     <NavBreadcrumbs :breadcrumbs="props.breadcrumbs" @selected="emit('breadcrumbClick', $event)" />

--- a/app/gui2/src/components/NavBreadcrumb.vue
+++ b/app/gui2/src/components/NavBreadcrumb.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
 const props = defineProps<{ text: string; active: boolean }>()
-const emit = defineEmits<{ click: [] }>()
 </script>
 
 <template>
   <div :class="['NavBreadcrumb', { inactive: !props.active }]">
-    <span @click="emit('click')" v-text="props.text"></span>
+    <span v-text="props.text"></span>
   </div>
 </template>
 

--- a/app/gui2/src/components/NavBreadcrumbs.vue
+++ b/app/gui2/src/components/NavBreadcrumbs.vue
@@ -23,7 +23,7 @@ const emit = defineEmits<{ selected: [index: number] }>()
       <NavBreadcrumb
         :text="breadcrumb.label"
         :active="breadcrumb.active"
-        @pointerdown="emit('selected', index)"
+        @click.stop="emit('selected', index)"
       />
     </template>
   </div>

--- a/app/gui2/src/components/ProjectTitle.vue
+++ b/app/gui2/src/components/ProjectTitle.vue
@@ -6,7 +6,7 @@ const emit = defineEmits<{ execute: []; 'update:mode': [mode: string] }>()
 </script>
 
 <template>
-  <div class="ProjectTitle">
+  <div class="ProjectTitle" @pointerdown.stop @pointerup.stop @click.stop>
     <span class="title" v-text="props.title"></span>
     <ExecutionModeSelector
       :modes="props.modes"

--- a/app/gui2/src/components/ToggleIcon.vue
+++ b/app/gui2/src/components/ToggleIcon.vue
@@ -22,6 +22,8 @@ const emit = defineEmits<{
   <SvgIcon
     :name="props.icon"
     :class="{ toggledOn: modelValue }"
-    @pointerdown.stop="emit('update:modelValue', !modelValue)"
+    @pointerdown.stop
+    @pointerup.stop
+    @click.stop="emit('update:modelValue', !modelValue)"
   />
 </template>

--- a/app/gui2/src/components/ToggleIcon.vue
+++ b/app/gui2/src/components/ToggleIcon.vue
@@ -22,8 +22,6 @@ const emit = defineEmits<{
   <SvgIcon
     :name="props.icon"
     :class="{ toggledOn: modelValue }"
-    @pointerdown.stop
-    @pointerup.stop
     @click.stop="emit('update:modelValue', !modelValue)"
   />
 </template>

--- a/app/gui2/src/components/VisualizationContainer.vue
+++ b/app/gui2/src/components/VisualizationContainer.vue
@@ -105,6 +105,9 @@ const resizeBottomRight = usePointer((pos, _, type) => {
         '--color-visualization-bg': config.background,
         '--node-height': `${config.nodeSize.y}px`,
       }"
+      @pointerdown.stop
+      @pointerup.stop
+      @click.stop
     >
       <div class="resizer-right" v-on="resizeRight.stop.events"></div>
       <div class="resizer-bottom" v-on="resizeBottom.stop.events"></div>
@@ -132,22 +135,18 @@ const resizeBottomRight = usePointer((pos, _, type) => {
             invisible: config.isCircularMenuVisible,
             hidden: config.fullscreen,
           }"
+          @pointerdown.stop
+          @pointerup.stop
+          @click.stop
         >
-          <button
-            class="image-button active"
-            @pointerdown.stop="config.hide()"
-            @click="config.hide()"
-          >
+          <button class="image-button active" @click.stop="config.hide()">
             <SvgIcon class="icon" name="eye" alt="Hide visualization" />
           </button>
         </div>
         <div class="toolbar">
           <button
             class="image-button active"
-            @pointerdown.stop="(config.fullscreen = !config.fullscreen), blur($event)"
-            @click.prevent="
-              isTriggeredByKeyboard($event) && (config.fullscreen = !config.fullscreen)
-            "
+            @click.stop.prevent="(config.fullscreen = !config.fullscreen), blur($event)"
           >
             <SvgIcon
               class="icon"
@@ -158,9 +157,9 @@ const resizeBottomRight = usePointer((pos, _, type) => {
           <div class="icon-container">
             <button
               class="image-button active"
-              @pointerdown.stop="!isSelectorVisible && (isSelectorVisible = !isSelectorVisible)"
-              @click.prevent="
-                isTriggeredByKeyboard($event) && (isSelectorVisible = !isSelectorVisible)
+              @click.stop.prevent="
+                (!isSelectorVisible || isTriggeredByKeyboard($event)) &&
+                  (isSelectorVisible = !isSelectorVisible)
               "
             >
               <SvgIcon

--- a/app/gui2/src/components/VisualizationSelector.vue
+++ b/app/gui2/src/components/VisualizationSelector.vue
@@ -40,6 +40,9 @@ onMounted(() => setTimeout(() => rootNode.value?.querySelector('button')?.focus(
     ref="rootNode"
     class="VisualizationSelector"
     @focusout="$event.relatedTarget == null && emit('hide')"
+    @pointerdown.stop
+    @pointerup.stop
+    @click.stop
   >
     <div class="background"></div>
     <ul>
@@ -47,7 +50,7 @@ onMounted(() => setTimeout(() => rootNode.value?.querySelector('button')?.focus(
         v-for="type_ in props.types"
         :key="visIdKey(type_)"
         :class="{ selected: visIdentifierEquals(props.modelValue, type_) }"
-        @pointerdown.stop="emit('update:modelValue', type_)"
+        @click.stop="emit('update:modelValue', type_)"
       >
         <button>
           <SvgIcon class="icon" :name="visualizationStore.icon(type_) ?? 'columns_increasing'" />

--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -535,10 +535,10 @@ useEvent(document, 'keydown', bindings.handler({ zoomToSelected: () => zoomToSel
   <VisualizationContainer :belowToolbar="true">
     <template #toolbar>
       <button class="image-button active">
-        <SvgIcon name="show_all" alt="Fit all" @pointerdown="zoomToSelected(false)" />
+        <SvgIcon name="show_all" alt="Fit all" @click.stop="zoomToSelected(false)" />
       </button>
       <button class="image-button" :class="{ active: brushExtent != null }">
-        <SvgIcon name="find" alt="Zoom to selected" @pointerdown="zoomToSelected" />
+        <SvgIcon name="find" alt="Zoom to selected" @click.stop="zoomToSelected" />
       </button>
     </template>
     <div ref="containerNode" class="ScatterplotVisualization" @pointerdown.stop>

--- a/app/gui2/src/components/widgets/CheckboxWidget.vue
+++ b/app/gui2/src/components/widgets/CheckboxWidget.vue
@@ -4,17 +4,7 @@ const emit = defineEmits<{ 'update:modelValue': [modelValue: boolean] }>()
 </script>
 
 <template>
-  <div
-    class="Checkbox r-24"
-    @pointerdown="
-      !$event.ctrlKey &&
-        !$event.shiftKey &&
-        !$event.altKey &&
-        !$event.metaKey &&
-        $event.stopImmediatePropagation()
-    "
-    @click="emit('update:modelValue', !props.modelValue)"
-  >
+  <div class="Checkbox r-24" @click.stop="emit('update:modelValue', !props.modelValue)">
     <div :class="{ hidden: !props.modelValue }"></div>
   </div>
 </template>

--- a/app/gui2/src/components/widgets/DropdownWidget.vue
+++ b/app/gui2/src/components/widgets/DropdownWidget.vue
@@ -47,15 +47,15 @@ const NEXT_SORT_DIRECTION: Record<SortDirection, SortDirection> = {
 </script>
 
 <template>
-  <div class="Dropdown">
+  <div class="Dropdown" @pointerdown.stop @pointerup.stop @click.stop>
     <ul class="list" :style="{ background: color }" @wheel.stop>
       <template v-for="[value, index] in sortedValuesAndIndices" :key="value">
         <li v-if="value === selectedValue">
-          <div class="selected-item button" @pointerdown="emit('click', index)">
+          <div class="selected-item button" @click.stop="emit('click', index)">
             <span v-text="value"></span>
           </div>
         </li>
-        <li v-else class="selectable-item button" @pointerdown="emit('click', index)">
+        <li v-else class="selectable-item button" @click.stop="emit('click', index)">
           <span v-text="value"></span>
         </li>
       </template>

--- a/app/gui2/src/components/widgets/EnsoTextInputWidget.vue
+++ b/app/gui2/src/components/widgets/EnsoTextInputWidget.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useResizeObserver } from '@/composables/events'
-import { escape, unescape } from '@/util/ast/abstract'
+import { escape, unescape } from '@/util/ast/text'
 import { blurIfNecessary } from '@/util/autoBlur'
 import { getTextWidthByFont } from '@/util/measurement'
 import { computed, ref, watch, type StyleValue } from 'vue'

--- a/app/gui2/src/components/widgets/ListWidget.vue
+++ b/app/gui2/src/components/widgets/ListWidget.vue
@@ -404,14 +404,7 @@ watchPostEffect(() => {
       <SvgIcon
         class="add-item"
         name="vector_add"
-        @pointerdown="
-          !$event.ctrlKey &&
-            !$event.shiftKey &&
-            !$event.altKey &&
-            !$event.metaKey &&
-            $event.stopImmediatePropagation()
-        "
-        @click="emit('update:modelValue', [...props.modelValue, props.default()])"
+        @click.stop="emit('update:modelValue', [...props.modelValue, props.default()])"
       />
       <span class="token">]</span>
     </div>

--- a/app/gui2/src/composables/doubleClick.ts
+++ b/app/gui2/src/composables/doubleClick.ts
@@ -13,7 +13,6 @@ export function useDoubleClick<Args extends any[]>(
   let singleClickTimer: ReturnType<typeof setTimeout>
 
   const handleClick = (...args: Args) => {
-    console.log('clickCount', clickCount)
     clickCount++
     if (clickCount === 1) {
       onClick(...args)

--- a/app/gui2/src/composables/doubleClick.ts
+++ b/app/gui2/src/composables/doubleClick.ts
@@ -13,6 +13,7 @@ export function useDoubleClick<Args extends any[]>(
   let singleClickTimer: ReturnType<typeof setTimeout>
 
   const handleClick = (...args: Args) => {
+    console.log('clickCount', clickCount)
     clickCount++
     if (clickCount === 1) {
       onClick(...args)

--- a/app/gui2/src/composables/stackNavigator.ts
+++ b/app/gui2/src/composables/stackNavigator.ts
@@ -35,13 +35,16 @@ export function useStackNavigator() {
 
   function handleBreadcrumbClick(index: number) {
     const activeStack = projectStore.executionContext.desiredStack
+    console.log('DEBŁUG:', activeStack.length, index)
     // Number of items in desired stack should be index + 1
     if (index + 1 < activeStack.length) {
       for (let i = activeStack.length; i > index + 1; i--) {
+        console.log('POP', i)
         projectStore.executionContext.pop()
       }
     } else if (index + 1 > activeStack.length) {
       for (let i = activeStack.length; i <= index; i++) {
+        console.log('PUSH', i)
         const stackItem = breadcrumbs.value[i]
         if (stackItem?.type === 'LocalCall') {
           const exprId = stackItem.expressionId
@@ -81,6 +84,7 @@ export function useStackNavigator() {
   }
 
   function exitNode() {
+    console.log('Exiting node')
     projectStore.executionContext.pop()
     graphStore.updateState()
   }

--- a/app/gui2/src/composables/stackNavigator.ts
+++ b/app/gui2/src/composables/stackNavigator.ts
@@ -35,16 +35,13 @@ export function useStackNavigator() {
 
   function handleBreadcrumbClick(index: number) {
     const activeStack = projectStore.executionContext.desiredStack
-    console.log('DEBŁUG:', activeStack.length, index)
     // Number of items in desired stack should be index + 1
     if (index + 1 < activeStack.length) {
       for (let i = activeStack.length; i > index + 1; i--) {
-        console.log('POP', i)
         projectStore.executionContext.pop()
       }
     } else if (index + 1 > activeStack.length) {
       for (let i = activeStack.length; i <= index; i++) {
-        console.log('PUSH', i)
         const stackItem = breadcrumbs.value[i]
         if (stackItem?.type === 'LocalCall') {
           const exprId = stackItem.expressionId
@@ -84,7 +81,6 @@ export function useStackNavigator() {
   }
 
   function exitNode() {
-    console.log('Exiting node')
     projectStore.executionContext.pop()
     graphStore.updateState()
   }

--- a/app/gui2/src/stores/project/index.ts
+++ b/app/gui2/src/stores/project/index.ts
@@ -310,6 +310,7 @@ export class ExecutionContext extends ObservableV2<ExecutionContextNotification>
   }
 
   pop() {
+    console.trace('POPPING', this.desiredStack.length)
     if (this.desiredStack.length === 1) {
       console.debug('Cannot pop last item from execution context stack')
       return
@@ -317,6 +318,7 @@ export class ExecutionContext extends ObservableV2<ExecutionContextNotification>
     this.desiredStack.pop()
     this.queue.pushTask(async (state) => {
       if (!state.created) return state
+      console.log('POPPING2', state.stack.length)
       if (state.stack.length === 1) {
         console.debug('Cannot pop last item from execution context stack')
         return state

--- a/app/gui2/src/stores/project/index.ts
+++ b/app/gui2/src/stores/project/index.ts
@@ -310,7 +310,6 @@ export class ExecutionContext extends ObservableV2<ExecutionContextNotification>
   }
 
   pop() {
-    console.trace('POPPING', this.desiredStack.length)
     if (this.desiredStack.length === 1) {
       console.debug('Cannot pop last item from execution context stack')
       return
@@ -318,7 +317,6 @@ export class ExecutionContext extends ObservableV2<ExecutionContextNotification>
     this.desiredStack.pop()
     this.queue.pushTask(async (state) => {
       if (!state.created) return state
-      console.log('POPPING2', state.stack.length)
       if (state.stack.length === 1) {
         console.debug('Cannot pop last item from execution context stack')
         return state

--- a/app/gui2/src/util/ast/__tests__/abstract.test.ts
+++ b/app/gui2/src/util/ast/__tests__/abstract.test.ts
@@ -2,7 +2,8 @@ import { assert } from '@/util/assert'
 import { Ast } from '@/util/ast'
 import { initializeFFI } from 'shared/ast/ffi'
 import { expect, test } from 'vitest'
-import { MutableModule, escape, unescape, type Identifier } from '../abstract'
+import { MutableModule, type Identifier } from '../abstract'
+import { escape, unescape } from '../text'
 import { findExpressions, testCase, tryFindExpressions } from './testCase'
 
 await initializeFFI()

--- a/app/gui2/src/util/ast/abstract.ts
+++ b/app/gui2/src/util/ast/abstract.ts
@@ -1,5 +1,4 @@
 import { parseEnso } from '@/util/ast'
-import { swapKeysAndValues } from '@/util/record'
 import type { AstId, MutableAst, NodeKey, Owned, TokenId, TokenKey } from 'shared/ast'
 import {
   Ast,
@@ -13,31 +12,6 @@ import {
   print,
 } from 'shared/ast'
 export * from 'shared/ast'
-
-const mapping: Record<string, string> = {
-  '\b': '\\b',
-  '\f': '\\f',
-  '\n': '\\n',
-  '\r': '\\r',
-  '\t': '\\t',
-  '\v': '\\v',
-  '"': '\\"',
-  "'": "\\'",
-  '`': '``',
-}
-
-const reverseMapping = swapKeysAndValues(mapping)
-
-/** Escape a string so it can be safely spliced into an interpolated (`''`) Enso string.
- * NOT USABLE to insert into raw strings. Does not include quotes. */
-export function escape(string: string) {
-  return string.replace(/[\0\b\f\n\r\t\v"'`]/g, (match) => mapping[match]!)
-}
-
-/** The reverse of `escape`: transform the string into human-readable form, not suitable for interpolation. */
-export function unescape(string: string) {
-  return string.replace(/\\[0bfnrtv"']|``/g, (match) => reverseMapping[match]!)
-}
 
 export function deserialize(serialized: string): Owned {
   const parsed: SerializedPrintedSource = JSON.parse(serialized)

--- a/app/gui2/src/util/ast/text.ts
+++ b/app/gui2/src/util/ast/text.ts
@@ -1,3 +1,5 @@
+import { swapKeysAndValues } from '@/util/record'
+
 const mapping: Record<string, string> = {
   '\b': '\\b',
   '\f': '\\f',
@@ -5,14 +7,20 @@ const mapping: Record<string, string> = {
   '\r': '\\r',
   '\t': '\\t',
   '\v': '\\v',
-  '\\': '\\\\',
   '"': '\\"',
   "'": "\\'",
   '`': '``',
 }
 
+const reverseMapping = swapKeysAndValues(mapping)
+
 /** Escape a string so it can be safely spliced into an interpolated (`''`) Enso string.
  * NOT USABLE to insert into raw strings. Does not include quotes. */
 export function escape(string: string) {
-  return string.replace(/[\0\b\f\n\r\t\v\\"'`]/g, (match) => mapping[match]!)
+  return string.replace(/[\0\b\f\n\r\t\v"'`]/g, (match) => mapping[match]!)
+}
+
+/** The reverse of `escape`: transform the string into human-readable form, not suitable for interpolation. */
+export function unescape(string: string) {
+  return string.replace(/\\[0bfnrtv"']|``/g, (match) => reverseMapping[match]!)
 }

--- a/app/gui2/src/util/regexp.ts
+++ b/app/gui2/src/util/regexp.ts
@@ -1,0 +1,3 @@
+export default function escapeStringRegexp(s: string) {
+  return s.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
+}

--- a/app/gui2/src/util/shortcuts.ts
+++ b/app/gui2/src/util/shortcuts.ts
@@ -333,7 +333,11 @@ export function defineKeybinds<
       const keybinds =
         event instanceof KeyboardEvent
           ? keyboardShortcuts[event.key.toLowerCase() as Key_]?.[eventModifierFlags]
-          : mouseShortcuts[event.buttons as PointerButtonFlags]?.[eventModifierFlags]
+          : mouseShortcuts[
+              (event.type === 'click' // `click` events don't have 'buttons' field initialized.
+                ? POINTER_BUTTON_FLAG.PointerMain
+                : event.buttons) as PointerButtonFlags
+            ]?.[eventModifierFlags]
       let handle = handlers[DefaultHandler]
       if (keybinds != null) {
         for (const bindingName in handlers) {


### PR DESCRIPTION
### Pull Request Description

Fixes one failure in #8942 which caught a real issue: clicks at various panels were triggering many handlers at once, often unexpectedly - for example quick clicking at breadcrumbs (and automatic tests always click fast) we could also trigger getting out the current node.

Therefore, I added `stopPropagation` for all mouse events on "panel" level + where I think the event should be considered "handled" and no longer bother anyone. Also, to unify things, most actions are for `click` event.

Additionally I spotted and fixed some issues:
* When "clicking-off" Component Browser, it creates new node only if anything was actually typed in (no more dangling `operatorX.` nodes)
* Filtering now works for operators
* When, after opening CB with source node, user starts typing operator, we replace dot with space
* Fixed our shortcut handler, so it works properly with `click` event.
* Fixed problems with defocusing input in CB when clicking at links.

### Important Notes

I removed `PointerMain` binding for deselectAll, because it was triggered every time did the area selection.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
