### PR TITLE
Refactoring `Table.set` for GUI2 and other GUI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -617,6 +617,7 @@
 - [Implemented Write support for `S3_File`.][8921]
 - [Separate `Group_By` from `columns` into new argument on `aggregate`.][9027]
 - [Allow `copy_to` and `move_to` to work between local and S3 files.][9054]
+- [Adjusted expression handling and new `Simple_Expression` type.][9128]
 
 [debug-shortcuts]:
   https://github.com/enso-org/enso/blob/develop/app/gui/docs/product/shortcuts.md#debug
@@ -890,6 +891,7 @@
 [8921]: https://github.com/enso-org/enso/pull/8921
 [9027]: https://github.com/enso-org/enso/pull/9027
 [9054]: https://github.com/enso-org/enso/pull/9054
+[9128]: https://github.com/enso-org/enso/pull/9128
 
 #### Enso Compiler
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Helpers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Helpers.enso
@@ -11,5 +11,5 @@ expect_text : Any -> Any -> Any ! Type_Error
 expect_text text_maybe ~action = case text_maybe of
     _ : Text -> action
     _ ->
-        Error.throw (Type_Error.Error Text (Meta.type_of text_maybe) "text_maybe")
+        Error.throw (Type_Error.Error Text text_maybe "text_maybe")
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
@@ -47,8 +47,8 @@ type Regex
          text before matching on it.
 
        If an empty regex is used, `compile` throws an Illegal_Argument error.
-    compile : Text -> Boolean | Nothing -> Regex ! Regex_Syntax_Error | Illegal_Argument
-    compile expression case_insensitive=False =
+    compile : Text -> Boolean -> Regex ! Regex_Syntax_Error | Illegal_Argument
+    compile expression:Text case_insensitive:Boolean=False =
         if expression == '' then Error.throw (Illegal_Argument.Error "Regex cannot be the empty string") else
             options_string = if case_insensitive == True then "usgi" else "usg"
 
@@ -489,3 +489,17 @@ type Regex_Syntax_Error
        Provides a human-readable representation of the `Regex_Syntax_Error`.
     to_display_text : Text
     to_display_text self = "Regex Syntax Error:" + self.message
+
+## Shorthand to creates a regular expression from a Text value.
+
+   Arguments
+   - expression: The text representing the regular expression that you want to
+     compile. Must be non-empty.
+   - case_insensitive: Enables or disables case-insensitive matching. Case
+     insensitive matching behaves as if it normalises the case of all input
+     text before matching on it.
+
+   If an empty regex is used, `compile` throws an Illegal_Argument error.
+regex : Text -> Boolean -> Regex ! Regex_Syntax_Error | Illegal_Argument
+regex expression:Text case_insensitive:Boolean=False = Regex.compile expression case_insensitive
+

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
@@ -492,14 +492,11 @@ type Regex_Syntax_Error
 
 ## Shorthand to creates a regular expression from a Text value.
 
+   If an empty regex is used, throws an Illegal_Argument error.
+
    Arguments
    - expression: The text representing the regular expression that you want to
      compile. Must be non-empty.
-   - case_insensitive: Enables or disables case-insensitive matching. Case
-     insensitive matching behaves as if it normalises the case of all input
-     text before matching on it.
-
-   If an empty regex is used, `compile` throws an Illegal_Argument error.
-regex : Text -> Boolean -> Regex ! Regex_Syntax_Error | Illegal_Argument
-regex expression:Text case_insensitive:Boolean=False = Regex.compile expression case_insensitive
+regex : Text -> Regex ! Regex_Syntax_Error | Illegal_Argument
+regex expression:Text = Regex.compile expression
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
@@ -490,7 +490,7 @@ type Regex_Syntax_Error
     to_display_text : Text
     to_display_text self = "Regex Syntax Error:" + self.message
 
-## Shorthand to creates a regular expression from a Text value.
+## Shorthand to create a regular expression from a Text value.
 
    If an empty regex is used, throws an Illegal_Argument error.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Common.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Errors/Common.enso
@@ -79,7 +79,7 @@ type Type_Error
                         _ -> ". Try to apply " + (missing_args.join ", ") + " arguments"
                _ -> tpe.to_text
 
-        "Type error: expected "+self.comment+" to be "+self.expected.to_display_text+", but got "+type_of_actual+"."
+        "Type error: expected "+self.comment+" to be "+self.expected.to_display_text+", but got "+(if type_of_actual.is_a Text then type_of_actual else "<ERR>")+"."
 
 @Builtin_Type
 type Compile_Error

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Main.enso
@@ -92,6 +92,7 @@ from project.Data.Index_Sub_Range.Index_Sub_Range import First, Last
 from project.Data.Json.Extensions import all
 from project.Data.Range.Extensions import all
 from project.Data.Text.Extensions import all
+from project.Data.Text.Regex import regex
 from project.Errors.Problem_Behavior.Problem_Behavior import all
 from project.Meta.Enso_Project import enso_project
 from project.Network.Extensions import all
@@ -189,6 +190,7 @@ from project.Data.Numbers export Float, Integer, Number
 from project.Data.Range.Extensions export all
 from project.Data.Statistics export all hiding to_moment_statistic, wrap_java_call, calculate_correlation_statistics, calculate_spearman_rank, calculate_correlation_statistics_matrix, compute_fold, empty_value, is_valid
 from project.Data.Text.Extensions export all
+from project.Data.Text.Regex export regex
 from project.Errors.Problem_Behavior.Problem_Behavior export all
 from project.Function export all
 from project.Meta.Enso_Project export enso_project

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Widget_Helpers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Widget_Helpers.enso
@@ -14,7 +14,7 @@ from project.Metadata.Choice import Option
    Creates a Regex / Text Widget for search and replace.
 make_regex_text_widget : Widget
 make_regex_text_widget =
-    make_single_choice [["Text", '""'], ["Regular Expression", '"^$".to_regex']]
+    make_single_choice [["Text", '""'], ["Regular Expression", '(regex "^$")']]
 
 ## PRIVATE
    Creates a Single_Choice Widget for delimiters.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Widget_Helpers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Widget_Helpers.enso
@@ -14,7 +14,7 @@ from project.Metadata.Choice import Option
    Creates a Regex / Text Widget for search and replace.
 make_regex_text_widget : Widget
 make_regex_text_widget =
-    make_single_choice [["Text", '""'], ["Regular Expression", '(regex "^$")']]
+    make_single_choice [["<Text Value>", '""'], ["<Regular Expression>", '(regex "^$")']]
 
 ## PRIVATE
    Creates a Single_Choice Widget for delimiters.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Column.enso
@@ -1306,7 +1306,7 @@ type DB_Column
         Value_Type.expect_text self <| Value_Type.expect_integer n <|
             n2 = n.max 0
             new_name = self.naming_helper.function_name "text_right" [self, n]
-            self.make_binary_op "RIGHT" n2 new_name           
+            self.make_binary_op "RIGHT" n2 new_name
 
     ## GROUP Standard.Base.Logical
        ICON preparation

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
@@ -633,7 +633,8 @@ type DB_Table
     filter_by_expression : Text -> Problem_Behavior -> DB_Table ! No_Such_Column | Invalid_Value_Type | Expression_Error
     filter_by_expression self expression on_problems=Report_Warning =
         column = self.evaluate_expression expression on_problems
-        self.filter column Filter_Condition.Is_True
+        result = self.filter column Filter_Condition.Is_True
+        Warning.attach (Deprecated.Warning "Standard.Database.Data.DB_Table.DB_Table" "filter_by_expression" "Deprecated: use `filter` with an `Expression` instead.") result
 
     ## ALIAS first, last, sample, slice
        GROUP Standard.Base.Selections
@@ -814,14 +815,14 @@ type DB_Table
         new_ctx = self.context.set_limit max_rows
         self.updated_context new_ctx
 
-    ## ALIAS add column, new column, update column
+    ## ALIAS add column, new column, update column, formula
        GROUP Standard.Base.Values
        ICON dataframe_map_column
        Sets the column value at the given name.
 
        Arguments:
        - column: The new column or expression to create column.
-       - new_name: Optional new name for the column.
+       - as: Optional new name for the column.
        - set_mode: Specifies the expected behaviour in regards to existing
          column with the same name.
        - on_problems: Specifies how to handle problems with expression
@@ -855,11 +856,11 @@ type DB_Table
              example_set =
                  table = Examples.inventory_table
                  double_inventory = table.at "total_stock" * 2
-                 table.set double_inventory new_name="total_stock"
-                 table.set "2 * [total_stock]" new_name="total_stock_expr"
-    @new_name Widget_Helpers.make_column_name_selector
+                 table.set double_inventory as="total_stock"
+                 table.set "2 * [total_stock]" as="total_stock_expr"
+    @column Column_Operation.default_widget
     set : DB_Column | Text | Expression | Array | Vector | Range | Date_Range | Constant_Column | Column_Operation -> Text -> Set_Mode -> Problem_Behavior -> DB_Table ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
-    set self column (new_name : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =
+    set self column (as : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =
         problem_builder = Problem_Builder.new
         unique = self.column_naming_helper.create_unique_name_strategy
         unique.mark_used self.column_names
@@ -871,18 +872,18 @@ type DB_Table
                 if Helpers.check_integrity self column then column else
                     Error.throw (Integrity_Error.Error "Column "+column.name)
             _ : Constant_Column -> self.make_constant_column column
-            _ : Column_Operation -> column.evaluate self (set_mode==Set_Mode.Update && new_name=="") on_problems
+            _ : Column_Operation -> column.evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
             _ : Vector -> Error.throw (Unsupported_Database_Operation.Error "Cannot use `Vector` for `set` in the database.")
             _ : Array -> Error.throw (Unsupported_Database_Operation.Error "Cannot use `Array` for `set` in the database.")
             _ : Range -> Error.throw (Unsupported_Database_Operation.Error "Cannot use `Range` for `set` in the database.")
             _ : Date_Range -> Error.throw (Unsupported_Database_Operation.Error "Cannot use `Date_Range` for `set` in the database.")
             _ -> Error.throw (Illegal_Argument.Error "Unsupported type for `DB_Table.set`.")
 
-        ## If `new_name` was specified, use that. Otherwise, if `column` is a
+        ## If `as` was specified, use that. Otherwise, if `column` is a
            `DB_Column`, use its name. In these two cases, do not make it unique.
            Otherwise, make it unique. If set_mode is Update, however, do not
            make it unique.
-        new_column_name = if new_name != "" then new_name else
+        new_column_name = if as != "" then as else
             if column.is_a DB_Column || set_mode==Set_Mode.Update || set_mode==Set_Mode.Add_Or_Update then resolved.name else unique.make_unique resolved.name
         renamed = resolved.rename new_column_name
         renamed.if_not_error <| self.column_naming_helper.check_ambiguity self.column_names renamed.name <|
@@ -1843,7 +1844,7 @@ type DB_Table
                         if new_columns.is_empty then handle_no_output_columns else
                             result = self.updated_context_and_columns new_ctx new_columns subquery=True
                             if validated.old_style.not then result else
-                                Warning.attach (Deprecated.Warning "Standard.Database.Data.Aggregate_Column.Aggregate_Column" "Group_By" "Deprecated: `Group_By` constructor has been deprecated, use the `group_by` argument instead.") result
+                                Warning.attach (Deprecated.Warning "Standard.Table.Data.Aggregate_Column.Aggregate_Column" "Group_By" "Deprecated: `Group_By` constructor has been deprecated, use the `group_by` argument instead.") result
 
     ## GROUP Standard.Base.Calculations
        ICON dataframe_map_row
@@ -2024,7 +2025,7 @@ type DB_Table
         selected = self.columns_helper.select_columns columns Case_Sensitivity.Default reorder=False error_on_missing_columns=error_on_missing_columns on_problems=on_problems error_on_empty=False . map self.make_column
         selected.fold self table-> column_to_parse->
             new_column = column_to_parse.parse type format on_problems
-            table.set new_column new_name=column_to_parse.name set_mode=Set_Mode.Update
+            table.set new_column as=column_to_parse.name set_mode=Set_Mode.Update
 
     ## GROUP Standard.Base.Conversions
        ICON convert
@@ -2339,7 +2340,7 @@ type DB_Table
         selected = self.columns_helper.select_columns columns Case_Sensitivity.Default reorder=False error_on_missing_columns=error_on_missing_columns on_problems=on_problems error_on_empty=False . map self.make_column
         selected.fold self table-> column_to_cast->
             new_column = column_to_cast.cast value_type on_problems
-            table.set new_column new_name=column_to_cast.name set_mode=Set_Mode.Update
+            table.set new_column as=column_to_cast.name set_mode=Set_Mode.Update
 
     ## GROUP Standard.Base.Conversions
        ICON convert

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
@@ -858,14 +858,15 @@ type DB_Table
                  table.set double_inventory new_name="total_stock"
                  table.set "2 * [total_stock]" new_name="total_stock_expr"
     @new_name Widget_Helpers.make_column_name_selector
-    set : DB_Column | Text | Array | Vector | Range | Date_Range | Constant_Column | Column_Operation -> Text -> Set_Mode -> Problem_Behavior -> DB_Table ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
+    set : DB_Column | Text | Expression | Array | Vector | Range | Date_Range | Constant_Column | Column_Operation -> Text -> Set_Mode -> Problem_Behavior -> DB_Table ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
     set self column (new_name : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =
         problem_builder = Problem_Builder.new
         unique = self.column_naming_helper.create_unique_name_strategy
         unique.mark_used self.column_names
 
         resolved = case column of
-            _ : Text -> self.evaluate_expression column on_problems
+            _ : Text -> self.make_constant_column column
+            _ : Expression -> self.evaluate_expression column on_problems
             _ : DB_Column ->
                 if Helpers.check_integrity self column then column else
                     Error.throw (Integrity_Error.Error "Column "+column.name)
@@ -921,12 +922,12 @@ type DB_Table
              an `Arithmetic_Error`.
            - If more than 10 rows encounter computation issues,
              an `Additional_Warnings`.
-    evaluate_expression : Text -> Problem_Behavior -> DB_Column ! No_Such_Column | Invalid_Value_Type | Expression_Error
-    evaluate_expression self expression on_problems=Report_Warning =
+    evaluate_expression : Expression -> Problem_Behavior -> DB_Column ! No_Such_Column | Invalid_Value_Type | Expression_Error
+    evaluate_expression self expression:Expression on_problems=Report_Warning =
         get_column name = self.at name
         new_column = Expression.evaluate expression get_column self.make_constant_column "Standard.Database.Data.DB_Column" "DB_Column" DB_Column.var_args_functions
         problems = Warning.get_all new_column . map .value
-        result = new_column.rename (self.connection.base_connection.column_naming_helper.sanitize_name expression)
+        result = new_column.rename (self.connection.base_connection.column_naming_helper.sanitize_name expression.expression)
         on_problems.attach_problems_before problems <|
             Warning.set result []
 
@@ -2646,7 +2647,7 @@ type DB_Table
              fill_nothing = table.fill_nothing ["col0", "col1"] 20.5
     @columns Widget_Helpers.make_column_name_vector_selector
     @default (self -> Widget_Helpers.make_fill_default_value_selector column_source=self add_text=True add_number=True add_boolean=True)
-    fill_nothing : Vector (Integer | Text | Regex) | Text | Integer | Regex -> DB_Column | Column_Ref | Previous_Value | Any -> DB_Table
+    fill_nothing : Vector (Integer | Text | Regex) | Text | Integer | Regex -> DB_Column | Column_Ref | Expression | Previous_Value | Any -> DB_Table
     fill_nothing self (columns : Vector | Text | Integer | Regex) default =
         resolved_default = (self:Table_Ref).resolve default
         transformer col = col.fill_nothing resolved_default
@@ -2674,7 +2675,7 @@ type DB_Table
              fill_empty = table.fill_empty ["col0", "col1"] "hello"
     @columns Widget_Helpers.make_column_name_vector_selector
     @default (self -> Widget_Helpers.make_fill_default_value_selector column_source=self add_text=True)
-    fill_empty : Vector (Integer | Text | Regex) | Text | Integer | Regex -> DB_Column | Column_Ref | Previous_Value | Any -> DB_Table
+    fill_empty : Vector (Integer | Text | Regex) | Text | Integer | Regex -> DB_Column | Column_Ref | Expression | Previous_Value | Any -> DB_Table
     fill_empty self (columns : Vector | Text | Integer | Regex) default =
         resolved_default = (self:Table_Ref).resolve default
         transformer col = col.fill_empty resolved_default
@@ -2715,8 +2716,8 @@ type DB_Table
     @columns Widget_Helpers.make_column_name_vector_selector
     @term (Widget_Helpers.make_column_ref_by_name_selector add_regex=True add_text=True)
     @new_text (Widget_Helpers.make_column_ref_by_name_selector add_text=True)
-    text_replace : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Text | DB_Column | Column_Ref | Regex -> Text | DB_Column | Column_Ref -> Case_Sensitivity -> Boolean -> DB_Column
-    text_replace self columns (term : Text | DB_Column | Column_Ref | Regex = "") (new_text : Text | DB_Column | Column_Ref = "") case_sensitivity=Case_Sensitivity.Sensitive only_first=False =
+    text_replace : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Text | DB_Column | Column_Ref | Expression | Regex -> Text | DB_Column | Column_Ref | Expression -> Case_Sensitivity -> Boolean -> DB_Column
+    text_replace self columns (term : Text | DB_Column | Column_Ref | Expression | Regex = "") (new_text : Text | DB_Column | Column_Ref | Expression = "") case_sensitivity=Case_Sensitivity.Sensitive only_first=False =
         table_ref = Table_Ref.from self
         resolved_term = table_ref.resolve term
         resolved_new_text = table_ref.resolve new_text

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
@@ -858,7 +858,7 @@ type DB_Table
                  table = Examples.inventory_table
                  double_inventory = table.at "total_stock" * 2
                  table.set double_inventory as="total_stock"
-                 table.set "2 * [total_stock]" as="total_stock_expr"
+                 table.set (expr "2 * [total_stock]") as="total_stock_expr"
     @column Simple_Expression.default_widget
     set : DB_Column | Text | Expression | Array | Vector | Range | Date_Range | Constant_Column | Simple_Expression | Column_Operation -> Text -> Set_Mode -> Problem_Behavior -> DB_Table ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
     set self column (as : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
@@ -823,7 +823,7 @@ type DB_Table
        Sets the column value at the given name.
 
        Arguments:
-       - column: The new column or expression to create column.
+       - value: The value, expression or column to create column.
        - as: Optional new name for the column.
        - set_mode: Specifies the expected behaviour in regards to existing
          column with the same name.
@@ -860,34 +860,34 @@ type DB_Table
                  double_inventory = table.at "total_stock" * 2
                  table.set double_inventory as="total_stock"
                  table.set (expr "2 * [total_stock]") as="total_stock_expr"
-    @column Simple_Expression.default_widget
+    @value Simple_Expression.default_widget
     set : DB_Column | Text | Expression | Array | Vector | Range | Date_Range | Constant_Column | Simple_Expression | Column_Operation -> Text -> Set_Mode -> Problem_Behavior -> DB_Table ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
-    set self column (as : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =
+    set self value (as : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =
         problem_builder = Problem_Builder.new
         unique = self.column_naming_helper.create_unique_name_strategy
         unique.mark_used self.column_names
 
-        resolved = case column of
-            _ : Text -> self.make_constant_column column
-            _ : Expression -> self.evaluate_expression column on_problems
+        resolved = case value of
+            _ : Text -> self.make_constant_column value
+            _ : Expression -> self.evaluate_expression value on_problems
             _ : DB_Column ->
-                if Helpers.check_integrity self column then column else
-                    Error.throw (Integrity_Error.Error "Column "+column.name)
-            _ : Constant_Column -> self.make_constant_column column
-            _ : Column_Operation -> (column:Simple_Expression).evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
-            _ : Simple_Expression -> column.evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
+                if Helpers.check_integrity self value then value else
+                    Error.throw (Integrity_Error.Error "Column "+value.name)
+            _ : Constant_Column -> self.make_constant_column value
+            _ : Column_Operation -> (value:Simple_Expression).evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
+            _ : Simple_Expression -> value.evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
             _ : Vector -> Error.throw (Unsupported_Database_Operation.Error "Cannot use `Vector` for `set` in the database.")
             _ : Array -> Error.throw (Unsupported_Database_Operation.Error "Cannot use `Array` for `set` in the database.")
             _ : Range -> Error.throw (Unsupported_Database_Operation.Error "Cannot use `Range` for `set` in the database.")
             _ : Date_Range -> Error.throw (Unsupported_Database_Operation.Error "Cannot use `Date_Range` for `set` in the database.")
             _ -> Error.throw (Illegal_Argument.Error "Unsupported type for `DB_Table.set`.")
 
-        ## If `as` was specified, use that. Otherwise, if `column` is a
+        ## If `as` was specified, use that. Otherwise, if `value` is a
            `DB_Column`, use its name. In these two cases, do not make it unique.
            Otherwise, make it unique. If set_mode is Update, however, do not
            make it unique.
         new_column_name = if as != "" then as else
-            if column.is_a DB_Column || set_mode==Set_Mode.Update || set_mode==Set_Mode.Add_Or_Update then resolved.name else unique.make_unique resolved.name
+            if value.is_a DB_Column || set_mode==Set_Mode.Update || set_mode==Set_Mode.Add_Or_Update then resolved.name else unique.make_unique resolved.name
         renamed = resolved.rename new_column_name
         renamed.if_not_error <| self.column_naming_helper.check_ambiguity self.column_names renamed.name <|
             index = self.internal_columns.index_of (c -> c.name == renamed.name)

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
@@ -18,7 +18,6 @@ from Standard.Base.Widget_Helpers import make_delimiter_selector, make_format_ch
 
 import Standard.Table.Data.Blank_Selector.Blank_Selector
 import Standard.Table.Data.Calculations.Column_Operation.Column_Operation
-import Standard.Table.Data.Calculations.Column_Operation.Derived_Column
 import Standard.Table.Data.Column_Ref.Column_Ref
 import Standard.Table.Data.Constants.Previous_Value
 import Standard.Table.Data.Expression.Expression
@@ -29,6 +28,7 @@ import Standard.Table.Data.Join_Kind_Cross.Join_Kind_Cross
 import Standard.Table.Data.Match_Columns as Match_Columns_Helpers
 import Standard.Table.Data.Report_Unmatched.Report_Unmatched
 import Standard.Table.Data.Row.Row
+import Standard.Table.Data.Simple_Expression.Simple_Expression
 import Standard.Table.Data.Table.Table
 import Standard.Table.Data.Type.Value_Type_Helpers
 import Standard.Table.Extensions.Table_Ref.Table_Ref
@@ -859,8 +859,8 @@ type DB_Table
                  double_inventory = table.at "total_stock" * 2
                  table.set double_inventory as="total_stock"
                  table.set "2 * [total_stock]" as="total_stock_expr"
-    @column Derived_Column.default_widget
-    set : DB_Column | Text | Expression | Array | Vector | Range | Date_Range | Constant_Column | Derived_Column | Column_Operation -> Text -> Set_Mode -> Problem_Behavior -> DB_Table ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
+    @column Simple_Expression.default_widget
+    set : DB_Column | Text | Expression | Array | Vector | Range | Date_Range | Constant_Column | Simple_Expression | Column_Operation -> Text -> Set_Mode -> Problem_Behavior -> DB_Table ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
     set self column (as : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =
         problem_builder = Problem_Builder.new
         unique = self.column_naming_helper.create_unique_name_strategy
@@ -873,8 +873,8 @@ type DB_Table
                 if Helpers.check_integrity self column then column else
                     Error.throw (Integrity_Error.Error "Column "+column.name)
             _ : Constant_Column -> self.make_constant_column column
-            _ : Column_Operation -> (column:Derived_Column).evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
-            _ : Derived_Column -> column.evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
+            _ : Column_Operation -> (column:Simple_Expression).evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
+            _ : Simple_Expression -> column.evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
             _ : Vector -> Error.throw (Unsupported_Database_Operation.Error "Cannot use `Vector` for `set` in the database.")
             _ : Array -> Error.throw (Unsupported_Database_Operation.Error "Cannot use `Array` for `set` in the database.")
             _ : Range -> Error.throw (Unsupported_Database_Operation.Error "Cannot use `Range` for `set` in the database.")

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
@@ -573,7 +573,7 @@ type DB_Table
          Select people celebrating a jubilee.
 
              people.filter "age" (age -> (age%10 == 0))
-    @column Widget_Helpers.make_column_name_selector
+    @column (Widget_Helpers.make_column_name_selector add_expression=True)
     @filter Widget_Helpers.make_filter_condition_selector
     filter : (DB_Column | Text | Integer) -> (Filter_Condition | (Any -> Boolean)) -> Problem_Behavior -> DB_Table ! No_Such_Column | Index_Out_Of_Bounds | Invalid_Value_Type
     filter self column (filter : Filter_Condition | (Any -> Boolean) = Filter_Condition.Equal True) on_problems=Report_Warning = case column of
@@ -1957,13 +1957,13 @@ type DB_Table
            ----|---------|---------
             A  | Example | France
     @group_by Widget_Helpers.make_column_name_vector_selector
-    @name_column Widget_Helpers.make_column_name_selector
+    @names Widget_Helpers.make_column_name_selector
     @values Widget_Helpers.make_aggregate_column_selector
     cross_tab : Vector (Integer | Text | Regex | Aggregate_Column) | Text | Integer | Regex -> (Text | Integer) -> Aggregate_Column | Vector Aggregate_Column -> Problem_Behavior -> DB_Table ! Missing_Input_Columns | Invalid_Aggregate_Column | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings | Invalid_Column_Names
-    cross_tab self group_by name_column values=Aggregate_Column.Count (on_problems=Report_Warning) =
+    cross_tab self group_by names values=Aggregate_Column.Count (on_problems=Report_Warning) =
         ## Avoid unused arguments warning. We cannot rename arguments to `_`,
            because we need to keep the API consistent with the in-memory table.
-        _ = [group_by, name_column, values, on_problems]
+        _ = [group_by, names, values, on_problems]
         msg = "Cross tab of database tables is not supported, the table has to be materialized first with `read`."
         Error.throw (Unsupported_Database_Operation.Error msg)
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
@@ -594,6 +594,7 @@ type DB_Table
                   missing arguments and then another error is more appropriate.
                _ : Function -> Filter_Condition_Module.handle_constructor_missing_arguments filter <|
                    Error.throw (Unsupported_Database_Operation.Error "Filtering with a custom predicate is not supported in the database.")
+       _ : Expression -> self.filter (self.evaluate_expression column on_problems) filter on_problems
        _ ->
            table_at = self.at column
            self.filter table_at filter on_problems
@@ -632,8 +633,8 @@ type DB_Table
 
              people.filter_by_expression "[age] % 10 == 0"
     filter_by_expression : Text -> Problem_Behavior -> DB_Table ! No_Such_Column | Invalid_Value_Type | Expression_Error
-    filter_by_expression self expression on_problems=Report_Warning =
-        column = self.evaluate_expression expression on_problems
+    filter_by_expression self expression:Text on_problems=Report_Warning =
+        column = self.evaluate_expression (Expression.Value expression) on_problems
         result = self.filter column Filter_Condition.Is_True
         Warning.attach (Deprecated.Warning "Standard.Database.Data.DB_Table.DB_Table" "filter_by_expression" "Deprecated: use `filter` with an `Expression` instead.") result
 
@@ -925,8 +926,8 @@ type DB_Table
              an `Arithmetic_Error`.
            - If more than 10 rows encounter computation issues,
              an `Additional_Warnings`.
-    evaluate_expression : Expression -> Problem_Behavior -> DB_Column ! No_Such_Column | Invalid_Value_Type | Expression_Error
-    evaluate_expression self expression:Expression on_problems=Report_Warning =
+    evaluate_expression : Text | Expression -> Problem_Behavior -> DB_Column ! No_Such_Column | Invalid_Value_Type | Expression_Error
+    evaluate_expression self (expression:Text|Expression) on_problems=Report_Warning = if expression.is_a Text then self.evaluate_expression (Expression.Value expression) on_problems else
         get_column name = self.at name
         new_column = Expression.evaluate expression get_column self.make_constant_column "Standard.Database.Data.DB_Column" "DB_Column" DB_Column.var_args_functions
         problems = Warning.get_all new_column . map .value

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
@@ -704,7 +704,7 @@ type DB_Table
     ## PRIVATE
        Filter out all rows.
     remove_all_rows : DB_Table
-    remove_all_rows self = self.filter_by_expression "0==1"
+    remove_all_rows self = self.filter (Expression.Value "0==1")
 
     ## ALIAS add index column, rank, record id
        GROUP Standard.Base.Values

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
@@ -18,6 +18,7 @@ from Standard.Base.Widget_Helpers import make_delimiter_selector, make_format_ch
 
 import Standard.Table.Data.Blank_Selector.Blank_Selector
 import Standard.Table.Data.Calculations.Column_Operation.Column_Operation
+import Standard.Table.Data.Calculations.Column_Operation.Derived_Column
 import Standard.Table.Data.Column_Ref.Column_Ref
 import Standard.Table.Data.Constants.Previous_Value
 import Standard.Table.Data.Expression.Expression
@@ -858,8 +859,8 @@ type DB_Table
                  double_inventory = table.at "total_stock" * 2
                  table.set double_inventory as="total_stock"
                  table.set "2 * [total_stock]" as="total_stock_expr"
-    @column Column_Operation.default_widget
-    set : DB_Column | Text | Expression | Array | Vector | Range | Date_Range | Constant_Column | Column_Operation -> Text -> Set_Mode -> Problem_Behavior -> DB_Table ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
+    @column Derived_Column.default_widget
+    set : DB_Column | Text | Expression | Array | Vector | Range | Date_Range | Constant_Column | Derived_Column | Column_Operation -> Text -> Set_Mode -> Problem_Behavior -> DB_Table ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
     set self column (as : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =
         problem_builder = Problem_Builder.new
         unique = self.column_naming_helper.create_unique_name_strategy
@@ -872,7 +873,8 @@ type DB_Table
                 if Helpers.check_integrity self column then column else
                     Error.throw (Integrity_Error.Error "Column "+column.name)
             _ : Constant_Column -> self.make_constant_column column
-            _ : Column_Operation -> column.evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
+            _ : Column_Operation -> (column:Derived_Column).evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
+            _ : Derived_Column -> column.evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
             _ : Vector -> Error.throw (Unsupported_Database_Operation.Error "Cannot use `Vector` for `set` in the database.")
             _ : Array -> Error.throw (Unsupported_Database_Operation.Error "Cannot use `Array` for `set` in the database.")
             _ : Range -> Error.throw (Unsupported_Database_Operation.Error "Cannot use `Range` for `set` in the database.")

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Calculations/Column_Operation.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Calculations/Column_Operation.enso
@@ -5,6 +5,7 @@ from Standard.Base.Metadata.Choice import Option
 from Standard.Base.Metadata.Widget import Single_Choice
 
 import project.Data.Column_Ref.Column_Ref
+import project.Data.Expression.Expression
 import project.Extensions.Table_Ref.Table_Ref
 import project.Internal.Widget_Helpers
 from project.Internal.Filter_Condition_Helpers import make_filter_column
@@ -13,69 +14,69 @@ from project.Internal.Filter_Condition_Helpers import make_filter_column
    column.
 type Column_Operation
     ## Add two values/columns.
-    Add (input : Column_Ref|Number|Text) (rhs : Column_Ref|Number|Text)
+    Add (input : Column_Ref|Expression|Number|Text) (rhs : Column_Ref|Expression|Number|Text)
 
     ## Subtract two values/columns.
-    Subtract (input : Column_Ref|Number) (rhs : Column_Ref|Number)
+    Subtract (input : Column_Ref|Expression|Number) (rhs : Column_Ref|Expression|Number)
 
     ## Multiply two values/columns.
-    Multiply (input : Column_Ref|Number) (rhs : Column_Ref|Number)
+    Multiply (input : Column_Ref|Expression|Number) (rhs : Column_Ref|Expression|Number)
 
     ## Divide a fixed value or column by another value or column.
-    Divide (input : Column_Ref|Number) (rhs : Column_Ref|Number)
+    Divide (input : Column_Ref|Expression|Number) (rhs : Column_Ref|Expression|Number)
 
     ## Compute the remainder of a fixed value or column divided by another
        value or column.
-    Mod (input : Column_Ref|Number) (rhs : Column_Ref|Number)
+    Mod (input : Column_Ref|Expression|Number) (rhs : Column_Ref|Expression|Number)
 
     ## Raise a fixed value or column to the power of another value or column.
-    Power (input : Column_Ref|Number) (rhs : Column_Ref|Number)
+    Power (input : Column_Ref|Expression|Number) (rhs : Column_Ref|Expression|Number)
 
     ## Rounds values in the column to the specified precision.
-    Round (input : Column_Ref|Number) (precision:Integer = 0) (use_bankers:Boolean = False)
+    Round (input : Column_Ref|Expression|Number) (precision:Integer = 0) (use_bankers:Boolean = False)
 
     ## Rounds values in the column up to the nearest integer.
-    Ceil (input : Column_Ref|Number)
+    Ceil (input : Column_Ref|Expression|Number)
 
     ## Rounds values in the column down to the nearest integer.
-    Floor (input : Column_Ref|Number)
+    Floor (input : Column_Ref|Expression|Number)
 
     ## Truncates the fractional part of values in the column.
        If a Date_Time, returns the Date.
-    Truncate (input : Column_Ref|Number|Date_Time)
+    Truncate (input : Column_Ref|Expression|Number|Date_Time)
 
     ## Returns the minimum value of two columns.
-    Min (input : Column_Ref|Any) (rhs : Column_Ref|Any)
+    Min (input : Column_Ref|Expression|Any) (rhs : Column_Ref|Expression|Any)
 
     ## Returns the maximum value of two columns.
-    Max (input : Column_Ref|Any) (rhs : Column_Ref|Any)
+    Max (input : Column_Ref|Expression|Any) (rhs : Column_Ref|Expression|Any)
 
     ## Adds a period to a date/time column.
-    Date_Add (input : Column_Ref|Date_Time|Date|Time_Of_Day) (length : Column_Ref|Integer) (period : Date_Period|Time_Period = Date_Period.Day)
+    Date_Add (input : Column_Ref|Expression|Date_Time|Date|Time_Of_Day) (length : Column_Ref|Expression|Integer) (period : Date_Period|Time_Period = Date_Period.Day)
 
     ## Returns part of a date/time column.
-    Date_Part (input : Column_Ref|Date_Time|Date|Time_Of_Day) (period : Date_Period|Time_Period)
+    Date_Part (input : Column_Ref|Expression|Date_Time|Date|Time_Of_Day) (period : Date_Period|Time_Period)
 
     ## Returns the difference between two date/time columns.
-    Date_Diff (input : Column_Ref|Date_Time|Date|Time_Of_Day) (end : Column_Ref|Date_Time|Date|Time_Of_Day) (period:Date_Period|Time_Period = Date_Period.Day)
+    Date_Diff (input : Column_Ref|Expression|Date_Time|Date|Time_Of_Day) (end : Column_Ref|Expression|Date_Time|Date|Time_Of_Day) (period:Date_Period|Time_Period = Date_Period.Day)
 
     ## Negate a boolean column.
-    Not (input : Column_Ref|Boolean)
+    Not (input : Column_Ref|Expression|Boolean)
 
     ## Boolean AND on two boolean columns.
-    And (input : Column_Ref|Boolean) (rhs : Column_Ref|Boolean)
+    And (input : Column_Ref|Expression|Boolean) (rhs : Column_Ref|Expression|Boolean)
 
     ## Boolean OR on two boolean columns.
-    Or (input : Column_Ref|Boolean) (rhs : Column_Ref|Boolean)
+    Or (input : Column_Ref|Expression|Boolean) (rhs : Column_Ref|Expression|Boolean)
 
     ## If input meets a condition return true value, otherwise false value.
 
        The `true_value` and `false_value` can be either a constant or a column.
-    If (input : Column_Ref|Any) (condition:Filter_Condition) (true_value:Column_Ref|Any = True) (false_value:Column_Ref|Any = False)
+    If (input : Column_Ref|Expression|Any) (condition:Filter_Condition) (true_value:Column_Ref|Expression|Any = True) (false_value:Column_Ref|Expression|Any = False)
 
     ## Removes the specified characters, by default any whitespace, from the
        start, the end, or both ends of the input.
-    Trim (input : Column_Ref|Text) (where:Location = Location.Both) (what:Text|Column_Ref = "")
+    Trim (input : Column_Ref|Expression|Text) (where:Location = Location.Both) (what:Text|Column_Ref = "")
 
     ## PRIVATE
        Interprets the `Column_Operation` as operation on columns of a provided

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Calculations/Column_Operation.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Calculations/Column_Operation.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base.Errors.Deprecated.Deprecated
 import Standard.Base.Metadata.Display
 import Standard.Base.Metadata.Widget
 from Standard.Base.Metadata.Choice import Option
@@ -9,6 +10,156 @@ import project.Data.Expression.Expression
 import project.Extensions.Table_Ref.Table_Ref
 import project.Internal.Widget_Helpers
 from project.Internal.Filter_Condition_Helpers import make_filter_column
+
+## Defines a derived column.
+type Derived_Column
+    From (input : Column_Ref|Expression|Number|Text|Boolean) (operation : Derived_Operation)
+
+    ## PRIVATE
+       Interprets the `Derived_Column` as operation on columns of a provided
+       table, resolving the column references.
+       It creates a new column instance which can be added to the table.
+    evaluate : Table_Ref -> Boolean -> Problem_Behavior -> Any
+    evaluate self table:Table_Ref use_input_name:Boolean on_problems:Problem_Behavior =
+        input_column = table.resolve_as_column self.input
+        derived = case self.operation of
+            Derived_Operation.Add rhs -> input_column + (table.resolve rhs)
+            Derived_Operation.Subtract rhs -> input_column - (table.resolve rhs)
+            Derived_Operation.Multiply rhs -> input_column * (table.resolve rhs)
+            Derived_Operation.Divide rhs -> input_column / (table.resolve rhs)
+            Derived_Operation.Mod rhs -> input_column % (table.resolve rhs)
+            Derived_Operation.Power rhs -> input_column ^ (table.resolve rhs)
+            Derived_Operation.Round precision use_bankers -> input_column.round precision use_bankers
+            Derived_Operation.Ceil -> input_column.ceil
+            Derived_Operation.Floor -> input_column.floor
+            Derived_Operation.Truncate -> input_column.truncate
+            Derived_Operation.Min rhs -> input_column.min (table.resolve rhs)
+            Derived_Operation.Max rhs -> input_column.max (table.resolve rhs)
+            Derived_Operation.Date_Add length period -> input_column.date_add (table.resolve length) period
+            Derived_Operation.Date_Part period -> input_column.date_part period
+            Derived_Operation.Date_Diff end period -> input_column.date_diff (table.resolve end) period
+            Derived_Operation.Not -> input_column.not
+            Derived_Operation.And rhs -> input_column && (table.resolve rhs)
+            Derived_Operation.Or rhs -> input_column || (table.resolve rhs)
+            Derived_Operation.Trim where what -> input_column.trim where (table.resolve what)
+            Derived_Operation.If condition true_value false_value ->
+                condition_column =  make_filter_column input_column (table.resolve_condition condition) on_problems
+                condition_column.iif (table.resolve true_value) (table.resolve false_value)
+        if use_input_name then derived.rename input_column.name else derived
+
+    ## PRIVATE
+       Create a widget for operation
+    default_widget : Table_Ref -> Display -> Widget
+    default_widget table:Table_Ref display=Display.Always =
+        ## Constants
+        text = Option "<Text Value>" "''"
+        number = Option "<Number Value>" "0"
+        boolean = Option "<True/False>" "True"
+        expression = Option "<Expression>" "(expr '["+table.column_names.first+"]')"
+
+        col_names = Widget_Helpers.make_column_ref_by_name_selector table
+        with_all_types = Widget_Helpers.make_column_ref_by_name_selector table add_text=True add_number=True add_boolean=True
+        with_number_text = Widget_Helpers.make_column_ref_by_name_selector table add_text=True add_number=True
+        with_number = Widget_Helpers.make_column_ref_by_name_selector table add_number=True
+        with_boolean = Widget_Helpers.make_column_ref_by_name_selector table add_boolean=True
+        with_text = Widget_Helpers.make_column_ref_by_name_selector table add_text=True
+
+        filter_cond = Widget_Helpers.make_filter_condition_selector table
+
+        builder = Vector.new_builder
+        fqn = Meta.get_qualified_type_name Derived_Operation
+        builder.append (Option "add" fqn+".Add" [["rhs", with_number_text]])
+        builder.append (Option "subtract" fqn+".Subtract" [["rhs", with_number]])
+        builder.append (Option "multiply" fqn+".Multiply" [["rhs", with_number]])
+        builder.append (Option "divide" fqn+".Divide" [["rhs", with_number]])
+        builder.append (Option "mod" fqn+".Mod" [["rhs", with_number]])
+        builder.append (Option "power" fqn+".Power" [["rhs", with_number]])
+        builder.append (Option "round" fqn+".Round")
+        builder.append (Option "ceil" fqn+".Ceil")
+        builder.append (Option "floor" fqn+".Floor")
+        builder.append (Option "truncate" fqn+".Truncate")
+        builder.append (Option "min" fqn+".Min" [["rhs", with_number_text]])
+        builder.append (Option "max" fqn+".Max" [["rhs", with_number_text]])
+        builder.append (Option "date add" fqn+".Date_Add" [["length", col_names]])
+        builder.append (Option "date part" fqn+".Date_Part")
+        builder.append (Option "date diff" fqn+".Date_Diff" [["end", col_names]])
+        builder.append (Option "not" fqn+".Not")
+        builder.append (Option "and" fqn+".And" [["rhs", with_boolean]])
+        builder.append (Option "or" fqn+".Or" [["rhs", with_boolean]])
+        builder.append (Option "if" fqn+".If" [["condition", filter_cond], ["true_value", with_all_types], ["false_value", with_all_types]])
+        builder.append (Option "trim" fqn+".Trim" [["what", with_text]])
+
+        fqn_column = Meta.get_qualified_type_name Derived_Column
+        derived = Option "Derived Operation" fqn_column+".From" [["input", col_names], ["operation", Single_Choice builder.to_vector]]
+
+        Single_Choice [text, number, boolean, expression, derived] display=display
+
+## Defines the operation on a derived column.
+type Derived_Operation
+    ## Add two values/columns.
+    Add (rhs : Column_Ref|Expression|Number|Text)
+
+    ## Subtract two values/columns.
+    Subtract (rhs : Column_Ref|Expression|Number)
+
+    ## Multiply two values/columns.
+    Multiply (rhs : Column_Ref|Expression|Number)
+
+    ## Divide a fixed value or column by another value or column.
+    Divide (rhs : Column_Ref|Expression|Number)
+
+    ## Compute the remainder of a fixed value or column divided by another
+       value or column.
+    Mod (rhs : Column_Ref|Expression|Number)
+
+    ## Raise a fixed value or column to the power of another value or column.
+    Power (rhs : Column_Ref|Expression|Number)
+
+    ## Rounds values in the column to the specified precision.
+    Round (precision:Integer = 0) (use_bankers:Boolean = False)
+
+    ## Rounds values in the column up to the nearest integer.
+    Ceil
+
+    ## Rounds values in the column down to the nearest integer.
+    Floor
+
+    ## Truncates the fractional part of values in the column.
+       If a Date_Time, returns the Date.
+    Truncate
+
+    ## Returns the minimum value of two columns.
+    Min (rhs : Column_Ref|Expression|Any)
+
+    ## Returns the maximum value of two columns.
+    Max (rhs : Column_Ref|Expression|Any)
+
+    ## Adds a period to a date/time column.
+    Date_Add (length : Column_Ref|Expression|Integer) (period : Date_Period|Time_Period = Date_Period.Day)
+
+    ## Returns part of a date/time column.
+    Date_Part (period : Date_Period|Time_Period)
+
+    ## Returns the difference between two date/time columns.
+    Date_Diff (end : Column_Ref|Expression|Date_Time|Date|Time_Of_Day) (period:Date_Period|Time_Period = Date_Period.Day)
+
+    ## Negate a boolean column.
+    Not
+
+    ## Boolean AND on two boolean columns.
+    And (rhs : Column_Ref|Expression|Boolean)
+
+    ## Boolean OR on two boolean columns.
+    Or (rhs : Column_Ref|Expression|Boolean)
+
+    ## If input meets a condition return true value, otherwise false value.
+
+       The `true_value` and `false_value` can be either a constant or a column.
+    If (condition:Filter_Condition) (true_value:Column_Ref|Expression|Any = True) (false_value:Column_Ref|Expression|Any = False)
+
+    ## Removes the specified characters, by default any whitespace, from the
+       start, the end, or both ends of the input.
+    Trim (where:Location = Location.Both) (what:Column_Ref|Expression|Text = "")
 
 ## Defines a column operation generally acting on each row producing a new
    column.
@@ -78,75 +229,27 @@ type Column_Operation
        start, the end, or both ends of the input.
     Trim (input : Column_Ref|Expression|Text) (where:Location = Location.Both) (what:Text|Column_Ref = "")
 
-    ## PRIVATE
-       Interprets the `Column_Operation` as operation on columns of a provided
-       table, resolving the column references.
-       It creates a new column instance which can be added to the table.
-    evaluate : Table_Ref -> Boolean -> Problem_Behavior -> Any
-    evaluate self table:Table_Ref use_input_name:Boolean on_problems:Problem_Behavior =
-        input_column = table.resolve_as_column self.input
-        derived = case self of
-            Column_Operation.Add _ rhs      -> input_column + (table.resolve rhs)
-            Column_Operation.Subtract _ rhs -> input_column - (table.resolve rhs)
-            Column_Operation.Multiply _ rhs -> input_column * (table.resolve rhs)
-            Column_Operation.Divide _ rhs   -> input_column / (table.resolve rhs)
-            Column_Operation.Mod _ rhs      -> input_column % (table.resolve rhs)
-            Column_Operation.Power _ rhs    -> input_column ^ (table.resolve rhs)
-
-            Column_Operation.Round _ precision use_bankers ->
-                input_column.round precision use_bankers
-            Column_Operation.Ceil _     -> input_column.ceil
-            Column_Operation.Floor _    -> input_column.floor
-            Column_Operation.Truncate _ -> input_column.truncate
-
-            Column_Operation.Min _ rhs -> input_column.min (table.resolve rhs)
-            Column_Operation.Max _ rhs -> input_column.max (table.resolve rhs)
-
-            Column_Operation.Date_Add _ length period ->
-                input_column.date_add (table.resolve length) period
-            Column_Operation.Date_Part _ period ->
-                input_column.date_part period
-            Column_Operation.Date_Diff _ end period ->
-                input_column.date_diff (table.resolve end) period
-
-            Column_Operation.Not _     -> input_column.not
-            Column_Operation.And _ rhs -> input_column && (table.resolve rhs)
-            Column_Operation.Or _ rhs  -> input_column || (table.resolve rhs)
-
-            Column_Operation.If _ condition true_value false_value ->
-                condition_column =  make_filter_column input_column (table.resolve_condition condition) on_problems
-                condition_column.iif (table.resolve true_value) (table.resolve false_value)
-
-            Column_Operation.Trim _ where what ->
-                input_column.trim where (table.resolve what)
-        if use_input_name then derived.rename input_column.name else derived
-
-    ## PRIVATE
-       Create a widget for operation
-    default_widget : Table_Ref -> Display -> Widget
-    default_widget table:Table_Ref display=Display.Always =
-        col_refs = Widget_Helpers.make_column_ref_by_name_selector table
-        filter_cond = Widget_Helpers.make_filter_condition_selector table
-        builder = Vector.new_builder
-        fqn = Meta.get_qualified_type_name Column_Operation
-        builder.append (Option "add" fqn+".Add" [["input", col_refs], ["rhs", col_refs]])
-        builder.append (Option "subtract" fqn+".Subtract" [["input", col_refs], ["rhs", col_refs]])
-        builder.append (Option "multiply" fqn+".Multiply" [["input", col_refs], ["rhs", col_refs]])
-        builder.append (Option "divide" fqn+".Divide" [["input", col_refs], ["rhs", col_refs]])
-        builder.append (Option "mod" fqn+".Mod" [["input", col_refs], ["rhs", col_refs]])
-        builder.append (Option "power" fqn+".Power" [["input", col_refs], ["rhs", col_refs]])
-        builder.append (Option "round" fqn+".Round" [["input", col_refs]])
-        builder.append (Option "ceil" fqn+".Ceil" [["input", col_refs]])
-        builder.append (Option "floor" fqn+".Floor" [["input", col_refs]])
-        builder.append (Option "truncate" fqn+".Truncate" [["input", col_refs]])
-        builder.append (Option "min" fqn+".Min" [["input", col_refs], ["rhs", col_refs]])
-        builder.append (Option "max" fqn+".Max" [["input", col_refs], ["rhs", col_refs]])
-        builder.append (Option "date add" fqn+".Date_Add" [["input", col_refs], ["length", col_refs]])
-        builder.append (Option "date part" fqn+".Date_Part" [["input", col_refs]])
-        builder.append (Option "date diff" fqn+".Date_Diff" [["input", col_refs], ["end", col_refs]])
-        builder.append (Option "not" fqn+".Not" [["input", col_refs]])
-        builder.append (Option "and" fqn+".And" [["input", col_refs], ["rhs", col_refs]])
-        builder.append (Option "or" fqn+".Or" [["input", col_refs], ["rhs", col_refs]])
-        builder.append (Option "if" fqn+".If" [["input", col_refs], ["condition", filter_cond], ["true_value", col_refs], ["false_value", col_refs]])
-        builder.append (Option "trim" fqn+".Trim" [["input", col_refs], ["what", col_refs]])
-        Single_Choice builder.to_vector display=display
+## PRIVATE
+Derived_Column.from (that:Column_Operation) =
+    derived = case that of
+        Column_Operation.Add input rhs -> Derived_Column.From input (Derived_Operation.Add rhs)
+        Column_Operation.Subtract input rhs -> Derived_Column.From input (Derived_Operation.Subtract rhs)
+        Column_Operation.Multiply input rhs -> Derived_Column.From input (Derived_Operation.Multiply rhs)
+        Column_Operation.Divide input rhs -> Derived_Column.From input (Derived_Operation.Divide rhs)
+        Column_Operation.Mod input rhs -> Derived_Column.From input (Derived_Operation.Mod rhs)
+        Column_Operation.Power input rhs -> Derived_Column.From input (Derived_Operation.Power rhs)
+        Column_Operation.Round input precision use_bankers -> Derived_Column.From input (Derived_Operation.Round precision use_bankers)
+        Column_Operation.Ceil input -> Derived_Column.From input Derived_Operation.Ceil
+        Column_Operation.Floor input -> Derived_Column.From input Derived_Operation.Floor
+        Column_Operation.Truncate input -> Derived_Column.From input Derived_Operation.Truncate
+        Column_Operation.Min input rhs -> Derived_Column.From input (Derived_Operation.Min rhs)
+        Column_Operation.Max input rhs -> Derived_Column.From input (Derived_Operation.Max rhs)
+        Column_Operation.Date_Add input length period -> Derived_Column.From input (Derived_Operation.Date_Add length period)
+        Column_Operation.Date_Part input period -> Derived_Column.From input (Derived_Operation.Date_Part period)
+        Column_Operation.Date_Diff input end period -> Derived_Column.From input (Derived_Operation.Date_Diff end period)
+        Column_Operation.Not input -> Derived_Column.From input Derived_Operation.Not
+        Column_Operation.And input rhs -> Derived_Column.From input (Derived_Operation.And rhs)
+        Column_Operation.Or input rhs -> Derived_Column.From input (Derived_Operation.Or rhs)
+        Column_Operation.If input condition true_value false_value -> Derived_Column.From input (Derived_Operation.If condition true_value false_value)
+        Column_Operation.Trim input where what -> Derived_Column.From input (Derived_Operation.Trim where what)
+    Warning.attach (Deprecated.Warning "Standard.Table.Data.Column_Operation.Column_Operation" "" "Deprecated: `Column_Operation` has been replaced by `Derived_Column`.") derived

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Calculations/Column_Operation.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Calculations/Column_Operation.enso
@@ -1,168 +1,15 @@
 from Standard.Base import all
 import Standard.Base.Errors.Deprecated.Deprecated
-import Standard.Base.Metadata.Display
-import Standard.Base.Metadata.Widget
-from Standard.Base.Metadata.Choice import Option
-from Standard.Base.Metadata.Widget import Single_Choice
 
 import project.Data.Column_Ref.Column_Ref
 import project.Data.Expression.Expression
-import project.Extensions.Table_Ref.Table_Ref
-import project.Internal.Widget_Helpers
-from project.Internal.Filter_Condition_Helpers import make_filter_column
+import project.Data.Simple_Expression.Simple_Expression
+import project.Data.Simple_Expression.Simple_Calculation
 
-## Defines a derived column.
-type Derived_Column
-    From (input : Column_Ref|Expression|Number|Text|Boolean) (operation : Derived_Operation)
+## PRIVATE
 
-    ## PRIVATE
-       Interprets the `Derived_Column` as operation on columns of a provided
-       table, resolving the column references.
-       It creates a new column instance which can be added to the table.
-    evaluate : Table_Ref -> Boolean -> Problem_Behavior -> Any
-    evaluate self table:Table_Ref use_input_name:Boolean on_problems:Problem_Behavior =
-        input_column = table.resolve_as_column self.input
-        derived = case self.operation of
-            Derived_Operation.Add rhs -> input_column + (table.resolve rhs)
-            Derived_Operation.Subtract rhs -> input_column - (table.resolve rhs)
-            Derived_Operation.Multiply rhs -> input_column * (table.resolve rhs)
-            Derived_Operation.Divide rhs -> input_column / (table.resolve rhs)
-            Derived_Operation.Mod rhs -> input_column % (table.resolve rhs)
-            Derived_Operation.Power rhs -> input_column ^ (table.resolve rhs)
-            Derived_Operation.Round precision use_bankers -> input_column.round precision use_bankers
-            Derived_Operation.Ceil -> input_column.ceil
-            Derived_Operation.Floor -> input_column.floor
-            Derived_Operation.Truncate -> input_column.truncate
-            Derived_Operation.Min rhs -> input_column.min (table.resolve rhs)
-            Derived_Operation.Max rhs -> input_column.max (table.resolve rhs)
-            Derived_Operation.Date_Add length period -> input_column.date_add (table.resolve length) period
-            Derived_Operation.Date_Part period -> input_column.date_part period
-            Derived_Operation.Date_Diff end period -> input_column.date_diff (table.resolve end) period
-            Derived_Operation.Not -> input_column.not
-            Derived_Operation.And rhs -> input_column && (table.resolve rhs)
-            Derived_Operation.Or rhs -> input_column || (table.resolve rhs)
-            Derived_Operation.Trim where what -> input_column.trim where (table.resolve what)
-            Derived_Operation.If condition true_value false_value ->
-                condition_column =  make_filter_column input_column (table.resolve_condition condition) on_problems
-                condition_column.iif (table.resolve true_value) (table.resolve false_value)
-        if use_input_name then derived.rename input_column.name else derived
-
-    ## PRIVATE
-       Create a widget for operation
-    default_widget : Table_Ref -> Display -> Widget
-    default_widget table:Table_Ref display=Display.Always =
-        ## Constants
-        text = Option "<Text Value>" "''"
-        number = Option "<Number Value>" "0"
-        boolean = Option "<True/False>" "True"
-        expression = Option "<Expression>" "(expr '["+table.column_names.first+"]')"
-
-        col_names = Widget_Helpers.make_column_ref_by_name_selector table
-        with_all_types = Widget_Helpers.make_column_ref_by_name_selector table add_text=True add_number=True add_boolean=True
-        with_number_text = Widget_Helpers.make_column_ref_by_name_selector table add_text=True add_number=True
-        with_number = Widget_Helpers.make_column_ref_by_name_selector table add_number=True
-        with_boolean = Widget_Helpers.make_column_ref_by_name_selector table add_boolean=True
-        with_text = Widget_Helpers.make_column_ref_by_name_selector table add_text=True
-
-        filter_cond = Widget_Helpers.make_filter_condition_selector table
-
-        builder = Vector.new_builder
-        fqn = Meta.get_qualified_type_name Derived_Operation
-        builder.append (Option "add" fqn+".Add" [["rhs", with_number_text]])
-        builder.append (Option "subtract" fqn+".Subtract" [["rhs", with_number]])
-        builder.append (Option "multiply" fqn+".Multiply" [["rhs", with_number]])
-        builder.append (Option "divide" fqn+".Divide" [["rhs", with_number]])
-        builder.append (Option "mod" fqn+".Mod" [["rhs", with_number]])
-        builder.append (Option "power" fqn+".Power" [["rhs", with_number]])
-        builder.append (Option "round" fqn+".Round")
-        builder.append (Option "ceil" fqn+".Ceil")
-        builder.append (Option "floor" fqn+".Floor")
-        builder.append (Option "truncate" fqn+".Truncate")
-        builder.append (Option "min" fqn+".Min" [["rhs", with_number_text]])
-        builder.append (Option "max" fqn+".Max" [["rhs", with_number_text]])
-        builder.append (Option "date add" fqn+".Date_Add" [["length", col_names]])
-        builder.append (Option "date part" fqn+".Date_Part")
-        builder.append (Option "date diff" fqn+".Date_Diff" [["end", col_names]])
-        builder.append (Option "not" fqn+".Not")
-        builder.append (Option "and" fqn+".And" [["rhs", with_boolean]])
-        builder.append (Option "or" fqn+".Or" [["rhs", with_boolean]])
-        builder.append (Option "if" fqn+".If" [["condition", filter_cond], ["true_value", with_all_types], ["false_value", with_all_types]])
-        builder.append (Option "trim" fqn+".Trim" [["what", with_text]])
-
-        fqn_column = Meta.get_qualified_type_name Derived_Column
-        derived = Option "Derived Operation" fqn_column+".From" [["input", col_names], ["operation", Single_Choice builder.to_vector]]
-
-        Single_Choice [text, number, boolean, expression, derived] display=display
-
-## Defines the operation on a derived column.
-type Derived_Operation
-    ## Add two values/columns.
-    Add (rhs : Column_Ref|Expression|Number|Text)
-
-    ## Subtract two values/columns.
-    Subtract (rhs : Column_Ref|Expression|Number)
-
-    ## Multiply two values/columns.
-    Multiply (rhs : Column_Ref|Expression|Number)
-
-    ## Divide a fixed value or column by another value or column.
-    Divide (rhs : Column_Ref|Expression|Number)
-
-    ## Compute the remainder of a fixed value or column divided by another
-       value or column.
-    Mod (rhs : Column_Ref|Expression|Number)
-
-    ## Raise a fixed value or column to the power of another value or column.
-    Power (rhs : Column_Ref|Expression|Number)
-
-    ## Rounds values in the column to the specified precision.
-    Round (precision:Integer = 0) (use_bankers:Boolean = False)
-
-    ## Rounds values in the column up to the nearest integer.
-    Ceil
-
-    ## Rounds values in the column down to the nearest integer.
-    Floor
-
-    ## Truncates the fractional part of values in the column.
-       If a Date_Time, returns the Date.
-    Truncate
-
-    ## Returns the minimum value of two columns.
-    Min (rhs : Column_Ref|Expression|Any)
-
-    ## Returns the maximum value of two columns.
-    Max (rhs : Column_Ref|Expression|Any)
-
-    ## Adds a period to a date/time column.
-    Date_Add (length : Column_Ref|Expression|Integer) (period : Date_Period|Time_Period = Date_Period.Day)
-
-    ## Returns part of a date/time column.
-    Date_Part (period : Date_Period|Time_Period)
-
-    ## Returns the difference between two date/time columns.
-    Date_Diff (end : Column_Ref|Expression|Date_Time|Date|Time_Of_Day) (period:Date_Period|Time_Period = Date_Period.Day)
-
-    ## Negate a boolean column.
-    Not
-
-    ## Boolean AND on two boolean columns.
-    And (rhs : Column_Ref|Expression|Boolean)
-
-    ## Boolean OR on two boolean columns.
-    Or (rhs : Column_Ref|Expression|Boolean)
-
-    ## If input meets a condition return true value, otherwise false value.
-
-       The `true_value` and `false_value` can be either a constant or a column.
-    If (condition:Filter_Condition) (true_value:Column_Ref|Expression|Any = True) (false_value:Column_Ref|Expression|Any = False)
-
-    ## Removes the specified characters, by default any whitespace, from the
-       start, the end, or both ends of the input.
-    Trim (where:Location = Location.Both) (what:Column_Ref|Expression|Text = "")
-
-## Defines a column operation generally acting on each row producing a new
-   column.
+   Defines a column operation generally acting on each row producing a new
+   column. Deprecated in favour of `Simple_Expression`.
 type Column_Operation
     ## Add two values/columns.
     Add (input : Column_Ref|Expression|Number|Text) (rhs : Column_Ref|Expression|Number|Text)
@@ -230,26 +77,26 @@ type Column_Operation
     Trim (input : Column_Ref|Expression|Text) (where:Location = Location.Both) (what:Text|Column_Ref = "")
 
 ## PRIVATE
-Derived_Column.from (that:Column_Operation) =
+Simple_Expression.from (that:Column_Operation) =
     derived = case that of
-        Column_Operation.Add input rhs -> Derived_Column.From input (Derived_Operation.Add rhs)
-        Column_Operation.Subtract input rhs -> Derived_Column.From input (Derived_Operation.Subtract rhs)
-        Column_Operation.Multiply input rhs -> Derived_Column.From input (Derived_Operation.Multiply rhs)
-        Column_Operation.Divide input rhs -> Derived_Column.From input (Derived_Operation.Divide rhs)
-        Column_Operation.Mod input rhs -> Derived_Column.From input (Derived_Operation.Mod rhs)
-        Column_Operation.Power input rhs -> Derived_Column.From input (Derived_Operation.Power rhs)
-        Column_Operation.Round input precision use_bankers -> Derived_Column.From input (Derived_Operation.Round precision use_bankers)
-        Column_Operation.Ceil input -> Derived_Column.From input Derived_Operation.Ceil
-        Column_Operation.Floor input -> Derived_Column.From input Derived_Operation.Floor
-        Column_Operation.Truncate input -> Derived_Column.From input Derived_Operation.Truncate
-        Column_Operation.Min input rhs -> Derived_Column.From input (Derived_Operation.Min rhs)
-        Column_Operation.Max input rhs -> Derived_Column.From input (Derived_Operation.Max rhs)
-        Column_Operation.Date_Add input length period -> Derived_Column.From input (Derived_Operation.Date_Add length period)
-        Column_Operation.Date_Part input period -> Derived_Column.From input (Derived_Operation.Date_Part period)
-        Column_Operation.Date_Diff input end period -> Derived_Column.From input (Derived_Operation.Date_Diff end period)
-        Column_Operation.Not input -> Derived_Column.From input Derived_Operation.Not
-        Column_Operation.And input rhs -> Derived_Column.From input (Derived_Operation.And rhs)
-        Column_Operation.Or input rhs -> Derived_Column.From input (Derived_Operation.Or rhs)
-        Column_Operation.If input condition true_value false_value -> Derived_Column.From input (Derived_Operation.If condition true_value false_value)
-        Column_Operation.Trim input where what -> Derived_Column.From input (Derived_Operation.Trim where what)
-    Warning.attach (Deprecated.Warning "Standard.Table.Data.Column_Operation.Column_Operation" "" "Deprecated: `Column_Operation` has been replaced by `Derived_Column`.") derived
+        Column_Operation.Add input rhs -> Simple_Expression.From input (Simple_Calculation.Add rhs)
+        Column_Operation.Subtract input rhs -> Simple_Expression.From input (Simple_Calculation.Subtract rhs)
+        Column_Operation.Multiply input rhs -> Simple_Expression.From input (Simple_Calculation.Multiply rhs)
+        Column_Operation.Divide input rhs -> Simple_Expression.From input (Simple_Calculation.Divide rhs)
+        Column_Operation.Mod input rhs -> Simple_Expression.From input (Simple_Calculation.Mod rhs)
+        Column_Operation.Power input rhs -> Simple_Expression.From input (Simple_Calculation.Power rhs)
+        Column_Operation.Round input precision use_bankers -> Simple_Expression.From input (Simple_Calculation.Round precision use_bankers)
+        Column_Operation.Ceil input -> Simple_Expression.From input Simple_Calculation.Ceil
+        Column_Operation.Floor input -> Simple_Expression.From input Simple_Calculation.Floor
+        Column_Operation.Truncate input -> Simple_Expression.From input Simple_Calculation.Truncate
+        Column_Operation.Min input rhs -> Simple_Expression.From input (Simple_Calculation.Min rhs)
+        Column_Operation.Max input rhs -> Simple_Expression.From input (Simple_Calculation.Max rhs)
+        Column_Operation.Date_Add input length period -> Simple_Expression.From input (Simple_Calculation.Date_Add length period)
+        Column_Operation.Date_Part input period -> Simple_Expression.From input (Simple_Calculation.Date_Part period)
+        Column_Operation.Date_Diff input end period -> Simple_Expression.From input (Simple_Calculation.Date_Diff end period)
+        Column_Operation.Not input -> Simple_Expression.From input Simple_Calculation.Not
+        Column_Operation.And input rhs -> Simple_Expression.From input (Simple_Calculation.And rhs)
+        Column_Operation.Or input rhs -> Simple_Expression.From input (Simple_Calculation.Or rhs)
+        Column_Operation.If input condition true_value false_value -> Simple_Expression.From input (Simple_Calculation.If condition true_value false_value)
+        Column_Operation.Trim input where what -> Simple_Expression.From input (Simple_Calculation.Trim where what)
+    Warning.attach (Deprecated.Warning "Standard.Table.Data.Column_Operation.Column_Operation" "" "Deprecated: `Column_Operation` has been replaced by `Simple_Expression`.") derived

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column_Ref.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column_Ref.enso
@@ -7,6 +7,3 @@ type Column_Ref
 
     ## Reference to a column by index in a table.
     Index index:Integer
-
-    ## Representation of an expression derived in a table.
-    Expression expression:Text

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column_Ref.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column_Ref.enso
@@ -6,4 +6,4 @@ type Column_Ref
     Name name:Text
 
     ## Reference to a column by index in a table.
-    Index index:Integer
+    Index index:Integer=0

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Expression.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Expression.enso
@@ -4,9 +4,19 @@ polyglot java import java.lang.IllegalArgumentException
 polyglot java import java.lang.UnsupportedOperationException
 polyglot java import org.enso.table.expressions.ExpressionVisitorImpl
 
+## Create an expression from a Text value.
+
+   Arguments:
+   - expression: the expression to create
+expr : Text -> Expression
+expr expression:Text -> Expression = Expression.Value expression
+
 ## PRIVATE
    Functions for parsing and handling Enso expressions.
 type Expression
+    ## Creates an expression from a Text value.
+    Value expression:Text
+
     ## PRIVATE
        ADVANCED
        Evaluates an expression and returns the result
@@ -23,14 +33,14 @@ type Expression
          evaluated against.
        - var_args_functions: a Vector of function names which take a single
          Vector argument but which should be exposed with variable parameters.
-    evaluate : Text -> (Text -> Any) -> (Any -> Any) -> Text -> Text -> Vector Text -> Any
-    evaluate expression get_column make_constant module_name type_name var_args_functions =
+    evaluate : Expression -> (Text -> Any) -> (Any -> Any) -> Text -> Text -> Vector Text -> Any
+    evaluate expression:Expression get_column make_constant module_name type_name var_args_functions =
         handle_parse_error = Panic.catch ExpressionVisitorImpl.SyntaxErrorException handler=(cause-> Error.throw (Expression_Error.Syntax_Error cause.payload.getMessage cause.payload.getLine cause.payload.getColumn))
         handle_unsupported = handle_java_error UnsupportedOperationException Expression_Error.Unsupported_Operation
         handle_arguments = handle_java_error IllegalArgumentException Expression_Error.Argument_Mismatch
 
         handle_parse_error <| handle_unsupported <| handle_arguments <|
-            ExpressionVisitorImpl.evaluate expression get_column make_constant module_name type_name var_args_functions
+            ExpressionVisitorImpl.evaluate expression.expression get_column make_constant module_name type_name var_args_functions
 
 type Expression_Error
     ## PRIVATE
@@ -57,3 +67,6 @@ type Expression_Error
 ## PRIVATE
 handle_java_error java_type enso_constructor =
     Panic.catch java_type handler=(cause-> Error.throw (enso_constructor cause.payload.getMessage))
+
+## PRIVATE
+Expression.from (that:Text) = Expression.Value that

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Expression.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Expression.enso
@@ -67,6 +67,3 @@ type Expression_Error
 ## PRIVATE
 handle_java_error java_type enso_constructor =
     Panic.catch java_type handler=(cause-> Error.throw (enso_constructor cause.payload.getMessage))
-
-## PRIVATE
-Expression.from (that:Text) = Expression.Value that

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Join_Condition.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Join_Condition.enso
@@ -9,7 +9,7 @@ type Join_Condition
        Arguments:
         - left: A name or index of a column in the left table.
         - right: A name or index of a column in the right table.
-    Equals (left : Text | Integer) (right : Text | Integer = left)
+    Equals (left : Text | Integer) (right : Text | Integer = "")
 
     ## Correlates rows from the two tables if the `left` element is equal to the
        `right` element, ignoring case. This is only supported for text columns.
@@ -24,7 +24,7 @@ type Join_Condition
         - right: A name or index of a column in the right table.
         - locale: The locale to use for case insensitive comparisons.
     @locale Locale.default_widget
-    Equals_Ignore_Case (left : Text | Integer) (right : Text | Integer = left) (locale : Locale = Locale.default)
+    Equals_Ignore_Case (left : Text | Integer) (right : Text | Integer = "") (locale : Locale = Locale.default)
 
     ## Correlates rows from the two tables if the `left` element fits between
        the `right_lower` and `right_upper` elements. The comparison is inclusive
@@ -39,4 +39,4 @@ type Join_Condition
           the lower bound for the check.
         - right_upper: A name or index of a column in the right table, used as
           the upper bound for the check.
-    Between (left : Text | Integer) (right_lower : Text | Integer) (right_upper : Text | Integer)
+    Between (left : Text | Integer) (right_lower : Text | Integer = "") (right_upper : Text | Integer = "")

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Simple_Expression.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Simple_Expression.enso
@@ -13,7 +13,7 @@ from project.Internal.Filter_Condition_Helpers import make_filter_column
 
 ## Defines a simple expression based off an input column and an operation to perform.
 type Simple_Expression
-    From (input : Column_Ref|Expression|Any) (operation : Simple_Calculation)
+    From (input : Column_Ref|Expression|Any = Column_Ref.Index) (operation : Simple_Calculation)
 
     ## PRIVATE
        Interprets the `Simple_Expression` as operation on columns of a provided
@@ -100,20 +100,20 @@ type Simple_Calculation
     Add (rhs : Column_Ref|Expression|Number|Text)
 
     ## Subtract two values/columns.
-    Subtract (rhs : Column_Ref|Expression|Number)
+    Subtract (rhs : Column_Ref|Expression|Number = 0)
 
     ## Multiply two values/columns.
-    Multiply (rhs : Column_Ref|Expression|Number)
+    Multiply (rhs : Column_Ref|Expression|Number = 1)
 
     ## Divide a fixed value or column by another value or column.
-    Divide (rhs : Column_Ref|Expression|Number)
+    Divide (rhs : Column_Ref|Expression|Number = 1)
 
     ## Compute the remainder of a fixed value or column divided by another
        value or column.
-    Mod (rhs : Column_Ref|Expression|Number)
+    Mod (rhs : Column_Ref|Expression|Number = 1)
 
     ## Raise a fixed value or column to the power of another value or column.
-    Power (rhs : Column_Ref|Expression|Number)
+    Power (rhs : Column_Ref|Expression|Number = 1)
 
     ## Rounds values in the column to the specified precision.
     Round (precision:Integer = 0) (use_bankers:Boolean = False)
@@ -147,15 +147,15 @@ type Simple_Calculation
     Not
 
     ## Boolean AND on two boolean columns.
-    And (rhs : Column_Ref|Expression|Boolean)
+    And (rhs : Column_Ref|Expression|Boolean = True)
 
     ## Boolean OR on two boolean columns.
-    Or (rhs : Column_Ref|Expression|Boolean)
+    Or (rhs : Column_Ref|Expression|Boolean =  False)
 
     ## If input meets a condition return true value, otherwise false value.
 
        The `true_value` and `false_value` can be either a constant or a column.
-    If (condition:Filter_Condition) (true_value:Column_Ref|Expression|Any = True) (false_value:Column_Ref|Expression|Any = False)
+    If (condition:Filter_Condition=(Filter_Condition.Equal True)) (true_value:Column_Ref|Expression|Any = True) (false_value:Column_Ref|Expression|Any = False)
 
     ## Removes the specified characters, by default any whitespace, from the
        start, the end, or both ends of the input.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Simple_Expression.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Simple_Expression.enso
@@ -13,7 +13,7 @@ from project.Internal.Filter_Condition_Helpers import make_filter_column
 
 ## Defines a simple expression based off an input column and an operation to perform.
 type Simple_Expression
-    From (input : Column_Ref|Expression|Number|Text|Boolean) (operation : Simple_Calculation)
+    From (input : Column_Ref|Expression|Any) (operation : Simple_Calculation)
 
     ## PRIVATE
        Interprets the `Simple_Expression` as operation on columns of a provided

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Simple_Expression.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Simple_Expression.enso
@@ -1,0 +1,162 @@
+from Standard.Base import all
+import Standard.Base.Errors.Deprecated.Deprecated
+import Standard.Base.Metadata.Display
+import Standard.Base.Metadata.Widget
+from Standard.Base.Metadata.Choice import Option
+from Standard.Base.Metadata.Widget import Single_Choice
+
+import project.Data.Column_Ref.Column_Ref
+import project.Data.Expression.Expression
+import project.Extensions.Table_Ref.Table_Ref
+import project.Internal.Widget_Helpers
+from project.Internal.Filter_Condition_Helpers import make_filter_column
+
+## Defines a simple expression based off an input column and an operation to perform.
+type Simple_Expression
+    From (input : Column_Ref|Expression|Number|Text|Boolean) (operation : Simple_Calculation)
+
+    ## PRIVATE
+       Interprets the `Simple_Expression` as operation on columns of a provided
+       table, resolving the column references.
+       It creates a new column instance which can be added to the table.
+    evaluate : Table_Ref -> Boolean -> Problem_Behavior -> Any
+    evaluate self table:Table_Ref use_input_name:Boolean on_problems:Problem_Behavior =
+        input_column = table.resolve_as_column self.input
+        derived = case self.operation of
+            Simple_Calculation.Add rhs -> input_column + (table.resolve rhs)
+            Simple_Calculation.Subtract rhs -> input_column - (table.resolve rhs)
+            Simple_Calculation.Multiply rhs -> input_column * (table.resolve rhs)
+            Simple_Calculation.Divide rhs -> input_column / (table.resolve rhs)
+            Simple_Calculation.Mod rhs -> input_column % (table.resolve rhs)
+            Simple_Calculation.Power rhs -> input_column ^ (table.resolve rhs)
+            Simple_Calculation.Round precision use_bankers -> input_column.round precision use_bankers
+            Simple_Calculation.Ceil -> input_column.ceil
+            Simple_Calculation.Floor -> input_column.floor
+            Simple_Calculation.Truncate -> input_column.truncate
+            Simple_Calculation.Min rhs -> input_column.min (table.resolve rhs)
+            Simple_Calculation.Max rhs -> input_column.max (table.resolve rhs)
+            Simple_Calculation.Date_Add length period -> input_column.date_add (table.resolve length) period
+            Simple_Calculation.Date_Part period -> input_column.date_part period
+            Simple_Calculation.Date_Diff end period -> input_column.date_diff (table.resolve end) period
+            Simple_Calculation.Not -> input_column.not
+            Simple_Calculation.And rhs -> input_column && (table.resolve rhs)
+            Simple_Calculation.Or rhs -> input_column || (table.resolve rhs)
+            Simple_Calculation.Trim where what -> input_column.trim where (table.resolve what)
+            Simple_Calculation.If condition true_value false_value ->
+                condition_column =  make_filter_column input_column (table.resolve_condition condition) on_problems
+                condition_column.iif (table.resolve true_value) (table.resolve false_value)
+        if use_input_name then derived.rename input_column.name else derived
+
+    ## PRIVATE
+       Create a widget for operation
+    default_widget : Table_Ref -> Display -> Widget
+    default_widget table:Table_Ref display=Display.Always =
+        ## Constants
+        text = Option "<Text Value>" "''"
+        number = Option "<Number Value>" "0"
+        boolean = Option "<True/False>" "True"
+        expression = Option "<Expression>" "(expr '["+table.column_names.first+"]')"
+
+        col_names = Widget_Helpers.make_column_ref_by_name_selector table
+        with_all_types = Widget_Helpers.make_column_ref_by_name_selector table add_text=True add_number=True add_boolean=True
+        with_number_text = Widget_Helpers.make_column_ref_by_name_selector table add_text=True add_number=True
+        with_number = Widget_Helpers.make_column_ref_by_name_selector table add_number=True
+        with_boolean = Widget_Helpers.make_column_ref_by_name_selector table add_boolean=True
+        with_text = Widget_Helpers.make_column_ref_by_name_selector table add_text=True
+
+        filter_cond = Widget_Helpers.make_filter_condition_selector table
+
+        builder = Vector.new_builder
+        fqn = Meta.get_qualified_type_name Simple_Calculation
+        builder.append (Option "add" fqn+".Add" [["rhs", with_number_text]])
+        builder.append (Option "subtract" fqn+".Subtract" [["rhs", with_number]])
+        builder.append (Option "multiply" fqn+".Multiply" [["rhs", with_number]])
+        builder.append (Option "divide" fqn+".Divide" [["rhs", with_number]])
+        builder.append (Option "mod" fqn+".Mod" [["rhs", with_number]])
+        builder.append (Option "power" fqn+".Power" [["rhs", with_number]])
+        builder.append (Option "round" fqn+".Round")
+        builder.append (Option "ceil" fqn+".Ceil")
+        builder.append (Option "floor" fqn+".Floor")
+        builder.append (Option "truncate" fqn+".Truncate")
+        builder.append (Option "min" fqn+".Min" [["rhs", with_number_text]])
+        builder.append (Option "max" fqn+".Max" [["rhs", with_number_text]])
+        builder.append (Option "date add" fqn+".Date_Add" [["length", col_names]])
+        builder.append (Option "date part" fqn+".Date_Part")
+        builder.append (Option "date diff" fqn+".Date_Diff" [["end", col_names]])
+        builder.append (Option "not" fqn+".Not")
+        builder.append (Option "and" fqn+".And" [["rhs", with_boolean]])
+        builder.append (Option "or" fqn+".Or" [["rhs", with_boolean]])
+        builder.append (Option "if" fqn+".If" [["condition", filter_cond], ["true_value", with_all_types], ["false_value", with_all_types]])
+        builder.append (Option "trim" fqn+".Trim" [["what", with_text]])
+
+        fqn_column = Meta.get_qualified_type_name Simple_Expression
+        derived = Option "<Simple Expression>" fqn_column+".From" [["input", col_names], ["operation", Single_Choice builder.to_vector]]
+
+        Single_Choice [text, number, boolean, expression, derived] display=display
+
+## Defines the operation on a derived column.
+type Simple_Calculation
+    ## Add two values/columns.
+    Add (rhs : Column_Ref|Expression|Number|Text)
+
+    ## Subtract two values/columns.
+    Subtract (rhs : Column_Ref|Expression|Number)
+
+    ## Multiply two values/columns.
+    Multiply (rhs : Column_Ref|Expression|Number)
+
+    ## Divide a fixed value or column by another value or column.
+    Divide (rhs : Column_Ref|Expression|Number)
+
+    ## Compute the remainder of a fixed value or column divided by another
+       value or column.
+    Mod (rhs : Column_Ref|Expression|Number)
+
+    ## Raise a fixed value or column to the power of another value or column.
+    Power (rhs : Column_Ref|Expression|Number)
+
+    ## Rounds values in the column to the specified precision.
+    Round (precision:Integer = 0) (use_bankers:Boolean = False)
+
+    ## Rounds values in the column up to the nearest integer.
+    Ceil
+
+    ## Rounds values in the column down to the nearest integer.
+    Floor
+
+    ## Truncates the fractional part of values in the column.
+       If a Date_Time, returns the Date.
+    Truncate
+
+    ## Returns the minimum value of two columns.
+    Min (rhs : Column_Ref|Expression|Any)
+
+    ## Returns the maximum value of two columns.
+    Max (rhs : Column_Ref|Expression|Any)
+
+    ## Adds a period to a date/time column.
+    Date_Add (length : Column_Ref|Expression|Integer) (period : Date_Period|Time_Period = Date_Period.Day)
+
+    ## Returns part of a date/time column.
+    Date_Part (period : Date_Period|Time_Period)
+
+    ## Returns the difference between two date/time columns.
+    Date_Diff (end : Column_Ref|Expression|Date_Time|Date|Time_Of_Day) (period:Date_Period|Time_Period = Date_Period.Day)
+
+    ## Negate a boolean column.
+    Not
+
+    ## Boolean AND on two boolean columns.
+    And (rhs : Column_Ref|Expression|Boolean)
+
+    ## Boolean OR on two boolean columns.
+    Or (rhs : Column_Ref|Expression|Boolean)
+
+    ## If input meets a condition return true value, otherwise false value.
+
+       The `true_value` and `false_value` can be either a constant or a column.
+    If (condition:Filter_Condition) (true_value:Column_Ref|Expression|Any = True) (false_value:Column_Ref|Expression|Any = False)
+
+    ## Removes the specified characters, by default any whitespace, from the
+       start, the end, or both ends of the input.
+    Trim (where:Location = Location.Both) (what:Column_Ref|Expression|Text = "")

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1414,7 +1414,7 @@ type Table
          Select people celebrating a jubilee.
 
              people.filter "age" (age -> (age%10 == 0))
-    @column Widget_Helpers.make_column_name_selector
+    @column (Widget_Helpers.make_column_name_selector add_expression=True)
     @filter Widget_Helpers.make_filter_condition_selector
     filter : (Column | Expression | Text | Integer) -> (Filter_Condition | (Any -> Boolean)) -> Problem_Behavior -> Table ! No_Such_Column | Index_Out_Of_Bounds | Invalid_Value_Type
     filter self column (filter : Filter_Condition | (Any -> Boolean) = Filter_Condition.Equal True) on_problems=Report_Warning = case column of
@@ -2463,10 +2463,10 @@ type Table
            ----|---------|---------
             A  | Example | France
     @group_by Widget_Helpers.make_column_name_vector_selector
-    @name_column Widget_Helpers.make_column_name_selector
+    @names Widget_Helpers.make_column_name_selector
     @values Widget_Helpers.make_aggregate_column_selector
     cross_tab : Vector (Integer | Text | Regex | Aggregate_Column) | Text | Integer | Regex -> (Text | Integer) -> Aggregate_Column | Vector Aggregate_Column -> Problem_Behavior -> Table ! Missing_Input_Columns | Invalid_Aggregate_Column | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings | Invalid_Column_Names
-    cross_tab self group_by name_column values=Aggregate_Column.Count (on_problems=Report_Warning) = Out_Of_Memory.handle_java_exception "cross_tab" <|
+    cross_tab self group_by names values=Aggregate_Column.Count (on_problems=Report_Warning) = Out_Of_Memory.handle_java_exception "cross_tab" <|
         columns_helper = self.columns_helper
         problem_builder = Problem_Builder.new error_on_missing_columns=True
 
@@ -2478,7 +2478,7 @@ type Table
             _ -> input
 
         ## validate the name and group_by columns
-        name_column_selector = case name_column of
+        name_column_selector = case names of
             ix : Integer -> [ix]
             name : Text -> [name]
             _ -> Error.throw (Illegal_Argument.Error "name_column must be a column index or name.")

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1467,7 +1467,7 @@ type Table
     filter_by_expression self expression on_problems=Report_Warning =
         column = self.evaluate_expression expression on_problems
         result = self.filter column Filter_Condition.Is_True
-        Warning.attach (Deprecated.Warning "Standard.Table.Data.DB_Table.DB_Table" "filter_by_expression" "Deprecated: use `filter` with an `Expression` instead.") result
+        Warning.attach (Deprecated.Warning "Standard.Table.Data.Table.Table" "filter_by_expression" "Deprecated: use `filter` with an `Expression` instead.") result
 
     ## ALIAS first, last, sample, slice
        GROUP Standard.Base.Selections

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -22,6 +22,7 @@ from Standard.Base.Widget_Helpers import make_delimiter_selector, make_format_ch
 import project.Data.Aggregate_Column.Aggregate_Column
 import project.Data.Blank_Selector.Blank_Selector
 import project.Data.Calculations.Column_Operation.Column_Operation
+import Standard.Table.Data.Calculations.Column_Operation.Derived_Column
 import project.Data.Column as Column_Module
 import project.Data.Column.Column
 import project.Data.Column_Ref.Column_Ref
@@ -1619,9 +1620,9 @@ type Table
                  double_inventory = table.at "total_stock" * 2
                  table.set double_inventory as="total_stock"
                  table.set "2 * [total_stock]" as="total_stock_expr"
-    @column Column_Operation.default_widget
-    set : Text | Expression | Column | Constant_Column | Column_Operation -> Text -> Set_Mode -> Problem_Behavior -> Table ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
-    set self column:(Text | Expression | Column | Constant_Column | Column_Operation) (as : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =
+    @column Derived_Column.default_widget
+    set : Text | Expression | Column | Constant_Column | Derived_Column -> Text -> Set_Mode -> Problem_Behavior -> Table ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
+    set self column:(Text | Expression | Column | Constant_Column | Derived_Column) (as : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =
         problem_builder = Problem_Builder.new
         unique = self.column_naming_helper.create_unique_name_strategy
         unique.mark_used self.column_names
@@ -1631,7 +1632,7 @@ type Table
             _ : Expression -> self.evaluate_expression column on_problems
             _ : Column -> column
             _ : Constant_Column -> self.make_constant_column column.value
-            _ : Column_Operation -> column.evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
+            _ : Derived_Column -> column.evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
             _ -> Error.throw (Illegal_Argument.Error "Unsupported type for `Table.set`.")
 
         ## If `as` was specified, use that. Otherwise, if `column` is a

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1582,7 +1582,7 @@ type Table
        Sets the column value at the given name.
 
        Arguments:
-       - column: The new column or expression to create column.
+       - value: The value, expression or column to create column.
        - as: Optional new name for the column.
        - set_mode: Specifies the expected behaviour in regards to existing
          column with the same name.
@@ -1619,27 +1619,27 @@ type Table
                  double_inventory = table.at "total_stock" * 2
                  table.set double_inventory as="total_stock"
                  table.set (expr "2 * [total_stock]") as="total_stock_expr"
-    @column Simple_Expression.default_widget
+    @value Simple_Expression.default_widget
     set : Text | Expression | Column | Constant_Column | Simple_Expression -> Text -> Set_Mode -> Problem_Behavior -> Table ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
-    set self column:(Text | Expression | Column | Constant_Column | Simple_Expression) (as : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =
+    set self value:(Text | Expression | Column | Constant_Column | Simple_Expression) (as : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =
         problem_builder = Problem_Builder.new
         unique = self.column_naming_helper.create_unique_name_strategy
         unique.mark_used self.column_names
 
-        resolved = case column of
-            _ : Text -> self.make_constant_column column
-            _ : Expression -> self.evaluate_expression column on_problems
-            _ : Column -> column
-            _ : Constant_Column -> self.make_constant_column column.value
-            _ : Simple_Expression -> column.evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
+        resolved = case value of
+            _ : Text -> self.make_constant_column value
+            _ : Expression -> self.evaluate_expression value on_problems
+            _ : Column -> value
+            _ : Constant_Column -> self.make_constant_column value.value
+            _ : Simple_Expression -> value.evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
             _ -> Error.throw (Illegal_Argument.Error "Unsupported type for `Table.set`.")
 
-        ## If `as` was specified, use that. Otherwise, if `column` is a
+        ## If `as` was specified, use that. Otherwise, if `value` is a
            `Column`, use its name. In these two cases, do not make it unique.
            Otherwise, make it unique. If set_mode is Update, however, do not
            make it unique.
         new_column_name = if as != "" then as else
-            if column.is_a Column || set_mode==Set_Mode.Update || set_mode==Set_Mode.Add_Or_Update then resolved.name else unique.make_unique resolved.name
+            if value.is_a Column || set_mode==Set_Mode.Update || set_mode==Set_Mode.Add_Or_Update then resolved.name else unique.make_unique resolved.name
         renamed = resolved.rename new_column_name
         renamed.if_not_error <| self.column_naming_helper.check_ambiguity self.column_names renamed.name <|
             check_add_mode = case set_mode of

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1618,14 +1618,15 @@ type Table
                  table.set double_inventory new_name="total_stock"
                  table.set "2 * [total_stock]" new_name="total_stock_expr"
     @column Column_Operation.default_widget
-    set : Text | Column | Constant_Column | Column_Operation -> Text -> Set_Mode -> Problem_Behavior -> Table ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
-    set self column:(Text | Column | Constant_Column | Column_Operation) (new_name : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =
+    set : Text | Expression | Column | Constant_Column | Column_Operation -> Text -> Set_Mode -> Problem_Behavior -> Table ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
+    set self column:(Text | Expression | Column | Constant_Column | Column_Operation) (new_name : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =
         problem_builder = Problem_Builder.new
         unique = self.column_naming_helper.create_unique_name_strategy
         unique.mark_used self.column_names
 
         resolved = case column of
-            _ : Text -> self.evaluate_expression column on_problems
+            _ : Text -> self.make_constant_column column
+            _ : Expression -> self.evaluate_expression column on_problems
             _ : Column -> column
             _ : Constant_Column -> self.make_constant_column column.value
             _ : Column_Operation -> column.evaluate self (set_mode==Set_Mode.Update && new_name=="") on_problems
@@ -1675,12 +1676,12 @@ type Table
              an `Arithmetic_Error`.
            - If more than 10 rows encounter computation issues,
              an `Additional_Warnings`.
-    evaluate_expression : Text -> Problem_Behavior -> Column ! No_Such_Column | Invalid_Value_Type | Expression_Error
-    evaluate_expression self expression on_problems=Report_Warning =
+    evaluate_expression : Expression -> Problem_Behavior -> Column ! No_Such_Column | Invalid_Value_Type | Expression_Error
+    evaluate_expression self expression:Expression on_problems=Report_Warning =
         get_column name = self.at name
         new_column = Expression.evaluate expression get_column self.make_constant_column "Standard.Table.Data.Column" "Column" Column.var_args_functions
         problems = Warning.get_all new_column . map .value
-        result = new_column.rename (self.column_naming_helper.sanitize_name expression)
+        result = new_column.rename (self.column_naming_helper.sanitize_name expression.expression)
         on_problems.attach_problems_before problems <|
             Warning.set result []
 
@@ -2721,7 +2722,7 @@ type Table
              fill_nothing = table.fill_nothing ["col0", "col1"] 20.5
     @columns Widget_Helpers.make_column_name_vector_selector
     @default (self -> Widget_Helpers.make_fill_default_value_selector column_source=self add_text=True add_number=True add_boolean=True)
-    fill_nothing : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Column | Column_Ref | Previous_Value | Any -> Table
+    fill_nothing : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Column | Column_Ref | Expression | Previous_Value | Any -> Table
     fill_nothing self (columns : Vector | Text | Integer | Regex) default =
         resolved_default = (self:Table_Ref).resolve default
         transformer col = col.fill_nothing resolved_default
@@ -2749,7 +2750,7 @@ type Table
              fill_empty = table.fill_empty ["col0", "col1"] "hello"
     @columns Widget_Helpers.make_column_name_vector_selector
     @default (self -> Widget_Helpers.make_fill_default_value_selector column_source=self add_text=True)
-    fill_empty : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Column | Column_Ref | Previous_Value | Any -> Table
+    fill_empty : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Column | Column_Ref | Expression | Previous_Value | Any -> Table
     fill_empty self (columns : Vector | Text | Integer | Regex) default =
         resolved_default = (self:Table_Ref).resolve default
         transformer col = col.fill_empty resolved_default
@@ -2790,8 +2791,8 @@ type Table
     @columns Widget_Helpers.make_column_name_vector_selector
     @term (Widget_Helpers.make_column_ref_by_name_selector add_regex=True add_text=True)
     @new_text (Widget_Helpers.make_column_ref_by_name_selector add_text=True)
-    text_replace : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Text | Column | Column_Ref | Regex -> Text | Column | Column_Ref -> Case_Sensitivity -> Boolean -> Column
-    text_replace self columns (term : Text | Column | Column_Ref | Regex = "") (new_text : Text | Column | Column_Ref = "") case_sensitivity=Case_Sensitivity.Sensitive only_first=False =
+    text_replace : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Text | Column | Column_Ref | Expression | Regex -> Text | Column | Column_Ref | Expression -> Case_Sensitivity -> Boolean -> Column
+    text_replace self columns (term : Text | Column | Column_Ref | Expression | Regex = "") (new_text : Text | Column | Column_Ref | Expression = "") case_sensitivity=Case_Sensitivity.Sensitive only_first=False =
         table_ref = Table_Ref.from self
         resolved_term = table_ref.resolve term
         resolved_new_text = table_ref.resolve new_text

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1465,7 +1465,7 @@ type Table
              people.filter_by_expression "[age] % 10 == 0"
     filter_by_expression : Text -> Problem_Behavior -> Table ! No_Such_Column | Invalid_Value_Type | Expression_Error
     filter_by_expression self expression on_problems=Report_Warning =
-        column = self.evaluate_expression expression on_problems
+        column = self.evaluate_expression (Expression.Value expression) on_problems
         result = self.filter column Filter_Condition.Is_True
         Warning.attach (Deprecated.Warning "Standard.Table.Data.Table.Table" "filter_by_expression" "Deprecated: use `filter` with an `Expression` instead.") result
 
@@ -1678,8 +1678,8 @@ type Table
              an `Arithmetic_Error`.
            - If more than 10 rows encounter computation issues,
              an `Additional_Warnings`.
-    evaluate_expression : Expression -> Problem_Behavior -> Column ! No_Such_Column | Invalid_Value_Type | Expression_Error
-    evaluate_expression self expression:Expression on_problems=Report_Warning =
+    evaluate_expression : Text | Expression -> Problem_Behavior -> DB_Column ! No_Such_Column | Invalid_Value_Type | Expression_Error
+    evaluate_expression self (expression:Text|Expression) on_problems=Report_Warning = if expression.is_a Text then self.evaluate_expression (Expression.Value expression) on_problems else
         get_column name = self.at name
         new_column = Expression.evaluate expression get_column self.make_constant_column "Standard.Table.Data.Column" "Column" Column.var_args_functions
         problems = Warning.get_all new_column . map .value

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1678,7 +1678,7 @@ type Table
              an `Arithmetic_Error`.
            - If more than 10 rows encounter computation issues,
              an `Additional_Warnings`.
-    evaluate_expression : Text | Expression -> Problem_Behavior -> DB_Column ! No_Such_Column | Invalid_Value_Type | Expression_Error
+    evaluate_expression : Text | Expression -> Problem_Behavior -> Column ! No_Such_Column | Invalid_Value_Type | Expression_Error
     evaluate_expression self (expression:Text|Expression) on_problems=Report_Warning = if expression.is_a Text then self.evaluate_expression (Expression.Value expression) on_problems else
         get_column name = self.at name
         new_column = Expression.evaluate expression get_column self.make_constant_column "Standard.Table.Data.Column" "Column" Column.var_args_functions

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -21,8 +21,6 @@ from Standard.Base.Widget_Helpers import make_delimiter_selector, make_format_ch
 
 import project.Data.Aggregate_Column.Aggregate_Column
 import project.Data.Blank_Selector.Blank_Selector
-import project.Data.Calculations.Column_Operation.Column_Operation
-import Standard.Table.Data.Calculations.Column_Operation.Derived_Column
 import project.Data.Column as Column_Module
 import project.Data.Column.Column
 import project.Data.Column_Ref.Column_Ref
@@ -38,6 +36,7 @@ import project.Data.Position.Position
 import project.Data.Report_Unmatched.Report_Unmatched
 import project.Data.Row.Row
 import project.Data.Set_Mode.Set_Mode
+import project.Data.Simple_Expression.Simple_Expression
 import project.Data.Sort_Column.Sort_Column
 import project.Delimited.Delimited_Format.Delimited_Format
 import project.Extensions.Prefix_Name.Prefix_Name
@@ -1620,9 +1619,9 @@ type Table
                  double_inventory = table.at "total_stock" * 2
                  table.set double_inventory as="total_stock"
                  table.set "2 * [total_stock]" as="total_stock_expr"
-    @column Derived_Column.default_widget
-    set : Text | Expression | Column | Constant_Column | Derived_Column -> Text -> Set_Mode -> Problem_Behavior -> Table ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
-    set self column:(Text | Expression | Column | Constant_Column | Derived_Column) (as : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =
+    @column Simple_Expression.default_widget
+    set : Text | Expression | Column | Constant_Column | Simple_Expression -> Text -> Set_Mode -> Problem_Behavior -> Table ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
+    set self column:(Text | Expression | Column | Constant_Column | Simple_Expression) (as : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =
         problem_builder = Problem_Builder.new
         unique = self.column_naming_helper.create_unique_name_strategy
         unique.mark_used self.column_names
@@ -1632,7 +1631,7 @@ type Table
             _ : Expression -> self.evaluate_expression column on_problems
             _ : Column -> column
             _ : Constant_Column -> self.make_constant_column column.value
-            _ : Derived_Column -> column.evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
+            _ : Simple_Expression -> column.evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
             _ -> Error.throw (Illegal_Argument.Error "Unsupported type for `Table.set`.")
 
         ## If `as` was specified, use that. Otherwise, if `column` is a

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1618,7 +1618,7 @@ type Table
                  table = Examples.inventory_table
                  double_inventory = table.at "total_stock" * 2
                  table.set double_inventory as="total_stock"
-                 table.set "2 * [total_stock]" as="total_stock_expr"
+                 table.set (expr "2 * [total_stock]") as="total_stock_expr"
     @column Simple_Expression.default_widget
     set : Text | Expression | Column | Constant_Column | Simple_Expression -> Text -> Set_Mode -> Problem_Behavior -> Table ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
     set self column:(Text | Expression | Column | Constant_Column | Simple_Expression) (as : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -735,7 +735,7 @@ type Table
                     new_columns = validated.valid_columns.map c->(Aggregate_Column_Helper.java_aggregator c.first c.second)
                     java_table = index.makeTable new_columns
                     if validated.old_style.not then Table.Value java_table else
-                        Warning.attach (Deprecated.Warning "Standard.Database.Data.Aggregate_Column.Aggregate_Column" "Group_By" "Deprecated: `Group_By` constructor has been deprecated, use the `group_by` argument instead.") (Table.Value java_table)
+                        Warning.attach (Deprecated.Warning "Standard.Table.Data.Aggregate_Column.Aggregate_Column" "Group_By" "Deprecated: `Group_By` constructor has been deprecated, use the `group_by` argument instead.") (Table.Value java_table)
 
     ## ALIAS sort
        GROUP Standard.Base.Selections
@@ -1149,7 +1149,7 @@ type Table
         selected = self.columns_helper.select_columns columns Case_Sensitivity.Default reorder=False error_on_missing_columns=error_on_missing_columns on_problems=on_problems error_on_empty=False
         selected.fold self table-> column_to_cast->
             new_column = column_to_cast.cast value_type on_problems
-            table.set new_column new_name=column_to_cast.name set_mode=Set_Mode.Update
+            table.set new_column as=column_to_cast.name set_mode=Set_Mode.Update
 
     ## GROUP Standard.Base.Conversions
        ICON convert
@@ -1195,7 +1195,7 @@ type Table
         selected = self.columns_helper.select_columns columns Case_Sensitivity.Default reorder=False error_on_missing_columns=error_on_missing_columns on_problems=on_problems error_on_empty=False
         selected.fold self table-> column_to_cast->
             new_column = column_to_cast.auto_value_type shrink_types
-            table.set new_column new_name=column_to_cast.name set_mode=Set_Mode.Update
+            table.set new_column as=column_to_cast.name set_mode=Set_Mode.Update
 
     ## GROUP Standard.Base.Conversions
        ICON split_text
@@ -1415,7 +1415,7 @@ type Table
              people.filter "age" (age -> (age%10 == 0))
     @column Widget_Helpers.make_column_name_selector
     @filter Widget_Helpers.make_filter_condition_selector
-    filter : (Column | Text | Integer) -> (Filter_Condition | (Any -> Boolean)) -> Problem_Behavior -> Table ! No_Such_Column | Index_Out_Of_Bounds | Invalid_Value_Type
+    filter : (Column | Expression | Text | Integer) -> (Filter_Condition | (Any -> Boolean)) -> Problem_Behavior -> Table ! No_Such_Column | Index_Out_Of_Bounds | Invalid_Value_Type
     filter self column (filter : Filter_Condition | (Any -> Boolean) = Filter_Condition.Equal True) on_problems=Report_Warning = case column of
         _ : Column ->
             mask filter_column = Table.Value (self.java_table.filter filter_column.java_column)
@@ -1425,6 +1425,7 @@ type Table
                     mask (make_filter_column column resolved on_problems)
                 _ : Function -> Filter_Condition_Module.handle_constructor_missing_arguments filter <|
                     mask (column.map filter)
+        _ : Expression -> self.filter (self.evaluate_expression column on_problems) filter on_problems
         _ ->
             table_at = self.at column
             self.filter table_at filter on_problems
@@ -1465,7 +1466,8 @@ type Table
     filter_by_expression : Text -> Problem_Behavior -> Table ! No_Such_Column | Invalid_Value_Type | Expression_Error
     filter_by_expression self expression on_problems=Report_Warning =
         column = self.evaluate_expression expression on_problems
-        self.filter column Filter_Condition.Is_True
+        result = self.filter column Filter_Condition.Is_True
+        Warning.attach (Deprecated.Warning "Standard.Table.Data.DB_Table.DB_Table" "filter_by_expression" "Deprecated: use `filter` with an `Expression` instead.") result
 
     ## ALIAS first, last, sample, slice
        GROUP Standard.Base.Selections
@@ -1574,14 +1576,14 @@ type Table
     add_row_number self (name:Text="Row") (from:Integer=1) (step:Integer=1) (group_by:(Vector | Text | Integer | Regex)=[]) (order_by:(Vector | Text)=[]) (on_problems:Problem_Behavior=Problem_Behavior.Report_Warning) =
         Add_Row_Number.add_row_number self name from step group_by order_by on_problems
 
-    ## ALIAS add column, new column, update column
+    ## ALIAS add column, new column, update column, formula
        GROUP Standard.Base.Values
        ICON dataframe_map_column
        Sets the column value at the given name.
 
        Arguments:
        - column: The new column or expression to create column.
-       - new_name: Optional new name for the column.
+       - as: Optional new name for the column.
        - set_mode: Specifies the expected behaviour in regards to existing
          column with the same name.
        - on_problems: Specifies how to handle problems with expression
@@ -1615,11 +1617,11 @@ type Table
              example_set =
                  table = Examples.inventory_table
                  double_inventory = table.at "total_stock" * 2
-                 table.set double_inventory new_name="total_stock"
-                 table.set "2 * [total_stock]" new_name="total_stock_expr"
+                 table.set double_inventory as="total_stock"
+                 table.set "2 * [total_stock]" as="total_stock_expr"
     @column Column_Operation.default_widget
     set : Text | Expression | Column | Constant_Column | Column_Operation -> Text -> Set_Mode -> Problem_Behavior -> Table ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
-    set self column:(Text | Expression | Column | Constant_Column | Column_Operation) (new_name : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =
+    set self column:(Text | Expression | Column | Constant_Column | Column_Operation) (as : Text = "") (set_mode : Set_Mode = Set_Mode.Add_Or_Update) (on_problems : Problem_Behavior = Report_Warning) =
         problem_builder = Problem_Builder.new
         unique = self.column_naming_helper.create_unique_name_strategy
         unique.mark_used self.column_names
@@ -1629,14 +1631,14 @@ type Table
             _ : Expression -> self.evaluate_expression column on_problems
             _ : Column -> column
             _ : Constant_Column -> self.make_constant_column column.value
-            _ : Column_Operation -> column.evaluate self (set_mode==Set_Mode.Update && new_name=="") on_problems
+            _ : Column_Operation -> column.evaluate self (set_mode==Set_Mode.Update && as=="") on_problems
             _ -> Error.throw (Illegal_Argument.Error "Unsupported type for `Table.set`.")
 
-        ## If `new_name` was specified, use that. Otherwise, if `column` is a
+        ## If `as` was specified, use that. Otherwise, if `column` is a
            `Column`, use its name. In these two cases, do not make it unique.
            Otherwise, make it unique. If set_mode is Update, however, do not
            make it unique.
-        new_column_name = if new_name != "" then new_name else
+        new_column_name = if as != "" then as else
             if column.is_a Column || set_mode==Set_Mode.Update || set_mode==Set_Mode.Add_Or_Update then resolved.name else unique.make_unique resolved.name
         renamed = resolved.rename new_column_name
         renamed.if_not_error <| self.column_naming_helper.check_ambiguity self.column_names renamed.name <|

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Table_Ref.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Table_Ref.enso
@@ -41,7 +41,7 @@ type Table_Ref
     resolve self value = case value of
         Column_Ref.Name name -> self.at name
         Column_Ref.Index index -> self.at index
-        Expression.Value expression -> self.evaluate_expression expression
+        Expression.Value _ -> self.evaluate_expression value
         _ -> value
 
     ## PRIVATE
@@ -51,7 +51,7 @@ type Table_Ref
     resolve_as_column self value = case value of
         Column_Ref.Name name -> self.at name
         Column_Ref.Index index -> self.at index
-        Expression.Value expression -> self.evaluate_expression expression
+        Expression.Value _ -> self.evaluate_expression value
         _ -> self.underlying.make_constant_column value
 
     ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Table_Ref.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Table_Ref.enso
@@ -4,6 +4,7 @@ import Standard.Base.Errors.Common.Index_Out_Of_Bounds
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
 import project.Data.Column_Ref.Column_Ref
+import project.Data.Expression.Expression
 import project.Data.Expression.Expression_Error
 import project.Data.Set_Mode.Set_Mode
 import project.Data.Table.Table
@@ -31,8 +32,8 @@ type Table_Ref
        - expression: The expression to evaluate.
        - on_problems: Specifies how to handle non-fatal problems, attaching a
          warning by default.
-    evaluate_expression : Text -> Problem_Behavior -> Any ! No_Such_Column | Invalid_Value_Type | Expression_Error
-    evaluate_expression self expression on_problems=Report_Warning = self.underlying.evaluate_expression expression on_problems=on_problems
+    evaluate_expression : Expression -> Problem_Behavior -> Any ! No_Such_Column | Invalid_Value_Type | Expression_Error
+    evaluate_expression self expression:Expression on_problems=Report_Warning = self.underlying.evaluate_expression expression on_problems=on_problems
 
     ## PRIVATE
        Resolve a Column_Ref to a Column, keeping any other values as-is.
@@ -40,7 +41,7 @@ type Table_Ref
     resolve self value = case value of
         Column_Ref.Name name -> self.at name
         Column_Ref.Index index -> self.at index
-        Column_Ref.Expression expression -> self.evaluate_expression expression
+        Expression.Value expression -> self.evaluate_expression expression
         _ -> value
 
     ## PRIVATE
@@ -50,7 +51,7 @@ type Table_Ref
     resolve_as_column self value = case value of
         Column_Ref.Name name -> self.at name
         Column_Ref.Index index -> self.at index
-        Column_Ref.Expression expression -> self.evaluate_expression expression
+        Expression.Value expression -> self.evaluate_expression expression
         _ -> self.underlying.make_constant_column value
 
     ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Table_Ref.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Table_Ref.enso
@@ -76,8 +76,8 @@ type Table_Ref
     ## PRIVATE
        Set a column.
     set : Any -> Text -> Set_Mode -> Problem_Behavior -> Table_Ref ! Existing_Column | Missing_Column | No_Such_Column | Expression_Error
-    set self column new_name:Text set_mode:Set_Mode=Set_Mode.Add_Or_Update on_problems:Problem_Behavior=Report_Warning =
-        new_underlying = self.underlying.set column new_name set_mode=set_mode on_problems=on_problems
+    set self column as:Text set_mode:Set_Mode=Set_Mode.Add_Or_Update on_problems:Problem_Behavior=Report_Warning =
+        new_underlying = self.underlying.set column as set_mode=set_mode on_problems=on_problems
         Table_Ref.from new_underlying
 
     ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Expand_Objects_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Expand_Objects_Helpers.enso
@@ -76,7 +76,6 @@ expand_column (table : Table) (column : Text | Integer) (fields : (Vector Text) 
 
      table = Table.new [["aaa", [1, 2]], ["bbb", [[30, 31], [40, 41]]]]
      # => Table.new [["aaa", [1, 1, 2, 2]], ["bbb", [30, 31, 40, 41]]]
-@column Widget_Helpers.make_column_name_selector
 expand_to_rows : Table -> Text | Integer -> Boolean -> Table ! Type_Error | No_Such_Column | Index_Out_Of_Bounds
 expand_to_rows table column:(Text | Integer) at_least_one_row=False = if column.is_a Integer then expand_to_rows table (table.at column).name at_least_one_row else
     row_expander : Any -> Vector

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Join_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Join_Helpers.enso
@@ -56,11 +56,13 @@ type Join_Condition_Resolver
                     self.make_equals problem_builder left right
         converted = conditions_vector.map on_problems=No_Wrap condition-> case condition of
             Join_Condition.Equals left_selector right_selector ->
-                handle_equals left_selector right_selector
+                right_resovled = if right_selector == "" then left_selector else right_selector
+                handle_equals left_selector right_resovled
             column_name : Text -> handle_equals column_name column_name
             Join_Condition.Equals_Ignore_Case left_selector right_selector locale ->
                 left = resolve_left left_selector
-                right = resolve_right right_selector
+                right_resovled = if right_selector == "" then left_selector else right_selector
+                right = resolve_right right_resovled
                 if is_nothing left || is_nothing right then Nothing else
                     Value_Type.expect_text left <|
                         Value_Type.expect_text right <|

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -6,6 +6,7 @@ import Standard.Base.Errors.Illegal_State.Illegal_State
 import project.Data.Aggregate_Column.Aggregate_Column
 import project.Data.Blank_Selector.Blank_Selector
 import project.Data.Column.Column
+import project.Data.Expression.Expression
 import project.Data.Position.Position
 import project.Data.Set_Mode.Set_Mode
 import project.Data.Sort_Column.Sort_Column
@@ -14,7 +15,7 @@ import project.Data.Type.Value_Type.Value_Type
 import project.Data.Type.Value_Type_Helpers
 import project.Internal.Column_Naming_Helper.Column_Naming_Helper
 import project.Internal.Problem_Builder.Problem_Builder
-from project.Errors import Ambiguous_Column_Rename, Column_Type_Mismatch, Invalid_Aggregate_Column, Missing_Input_Columns, No_Common_Type, No_Input_Columns_Selected, No_Output_Columns, Too_Many_Column_Names_Provided
+from project.Errors import Ambiguous_Column_Rename, Column_Type_Mismatch, Invalid_Aggregate_Column, Missing_Input_Columns, No_Common_Type, No_Input_Columns_Selected, No_Output_Columns, No_Such_Column, Too_Many_Column_Names_Provided
 
 polyglot java import java.util.HashSet
 
@@ -183,10 +184,12 @@ type Table_Column_Helper
             matched_columns = self.internal_columns.filter column->(column.name==selector)
             if matched_columns.length == 1 then matched_columns.first else
                 if matched_columns.length != 0 then Panic.throw (Illegal_State.Error "Bug in Table library: A single exact match should never match more than one column. Perhaps the table breaks the invariant of unique column names?") else
-                    (self.table.evaluate_expression selector).catch Any expression_error->
-                        invalid_column = Invalid_Aggregate_Column.Error selector expression_error
-                        problem_builder.report_other_warning invalid_column
-                        Nothing
+                    problem_builder.report_other_warning (Invalid_Aggregate_Column.Error selector (No_Such_Column.Error selector))
+                    Nothing
+        _ : Expression ->
+            (self.table.evaluate_expression selector).catch Any expression_error->
+                problem_builder.report_other_warning (Invalid_Aggregate_Column.Error selector.expression expression_error)
+                Nothing
         _ : Integer -> case is_index_valid self.internal_columns.length selector of
             True -> self.internal_columns.at selector
             False ->

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -178,7 +178,7 @@ type Table_Column_Helper
 
        It may allow selection of columns by index, name or computing a derived
        expression.
-    resolve_column_or_expression : (Integer | Text) -> Problem_Builder -> Any | Nothing
+    resolve_column_or_expression : (Integer | Text | Expression) -> Problem_Builder -> Any | Nothing
     resolve_column_or_expression self selector problem_builder = case selector of
         _ : Text ->
             matched_columns = self.internal_columns.filter column->(column.name==selector)

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
@@ -143,7 +143,7 @@ make_join_condition_selector : Table -> Display -> Widget
 make_join_condition_selector table display=Display.Always =
     col_names_selector = make_column_name_selector table display=Display.Always
 
-    fqn = "Join_Condition"
+    fqn = Meta.get_qualified_type_name Join_Condition
     equals = Option "Equals" fqn+".Equals" [["left", col_names_selector]]
     equals_ci = Option "Equals (Ignore Case)" fqn+".Equals_Ignore_Case" [["left", col_names_selector]]
     between = Option "Between" fqn+".Between" [["left", col_names_selector]]

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
@@ -150,7 +150,7 @@ make_join_condition_selector table display=Display.Always =
     names=[equals, equals_ci, between]
 
     item_editor = Single_Choice display=display values=names
-    Vector_Editor item_editor=item_editor item_default="("+item_editor.values.first.value+")" display=display
+    Vector_Editor item_editor=item_editor item_default="(Join_Condition.Equal "+table.column_names.first.pretty+")" display=display
 
 ## PRIVATE
    Make a column name selector.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
@@ -86,7 +86,7 @@ make_column_name_vector_selector table display=Display.Always =
 make_column_ref_by_name_selector : Table -> Display -> Boolean -> Boolean -> Boolean -> Boolean -> Widget
 make_column_ref_by_name_selector table display:Display=Display.Always add_text:Boolean=False add_regex:Boolean=False add_number:Boolean=False add_boolean:Boolean=False =
     text = if add_text then [Option "<Text Value>" "''"] else []
-    regex = if add_regex then [Option "<Regular Expression>" "('').to_regex"] else []
+    regex = if add_regex then [Option "<Regular Expression>" "(re '')"] else []
     number = if add_number then [Option "<Number Value>" "0"] else []
     boolean = if add_boolean then [Option "<True/False>" "True"] else []
     expression = if table.is_nothing then [] else [Option "<Expression>" "(Column_Ref.Expression '["+table.column_names.first+"]')"]
@@ -168,7 +168,7 @@ make_order_by_selector table display=Display.Always =
 make_rename_name_vector_selector : Table -> Display -> Widget
 make_rename_name_vector_selector table display=Display.Always =
     col_names = table.column_names
-    names = [Option "<Regular Expression>" "'^.*$'.to_regex"] + (col_names.map n-> Option n n.pretty)
+    names = [Option "<Regular Expression>" "(regex '^.*$')"] + (col_names.map n-> Option n n.pretty)
     fqn = Meta.get_qualified_type_name Pair
     name = Option "Name" fqn+".Value" [["first", Single_Choice values=names display=Display.Always]]
     item_editor = Single_Choice display=Display.Always values=[name]

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base.Metadata.Display
 import Standard.Base.Metadata.Widget
 from Standard.Base.Metadata.Choice import Option
-from Standard.Base.Metadata.Widget import Numeric_Input, Single_Choice, Vector_Editor
+from Standard.Base.Metadata.Widget import Numeric_Input, Single_Choice, Text_Input, Vector_Editor
 from Standard.Base.System.File_Format import format_types
 from Standard.Base.Widget_Helpers import make_format_chooser
 
@@ -144,9 +144,9 @@ make_join_condition_selector table display=Display.Always =
     col_names_selector = make_column_name_selector table display=Display.Always
 
     fqn = Meta.get_qualified_type_name Join_Condition
-    equals = Option "Equals" fqn+".Equals" [["left", col_names_selector]]
-    equals_ci = Option "Equals (Ignore Case)" fqn+".Equals_Ignore_Case" [["left", col_names_selector]]
-    between = Option "Between" fqn+".Between" [["left", col_names_selector]]
+    equals = Option "Equals" fqn+".Equals" [["left", col_names_selector], ["right", Text_Input]]
+    equals_ci = Option "Equals (Ignore Case)" fqn+".Equals_Ignore_Case" [["left", col_names_selector], ["right", Text_Input]]
+    between = Option "Between" fqn+".Between" [["left", col_names_selector], ["right_lower", Text_Input], ["right_upper", Text_Input]]
     names=[equals, equals_ci, between]
 
     item_editor = Single_Choice display=display values=names

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
@@ -68,11 +68,12 @@ make_aggregate_column_vector_selector table display=Display.Always =
 
 ## PRIVATE
    Make a column name selector.
-make_column_name_selector : Table -> Display -> Widget
-make_column_name_selector table display=Display.Always =
+make_column_name_selector : Table -> Boolean -> Display -> Widget
+make_column_name_selector table add_expression:Boolean=False display=Display.Always =
     col_names = table.column_names
     names = col_names.map n-> Option n n.pretty
-    Single_Choice display=display values=names
+    expression = if add_expression then [Option "<Expression>" "(expr '["+table.column_names.first+"]')"] else []
+    Single_Choice display=display values=(expression+names)
 
 ## PRIVATE
    Make a multiple column name selector.
@@ -150,7 +151,7 @@ make_join_condition_selector table display=Display.Always =
     names=[equals, equals_ci, between]
 
     item_editor = Single_Choice display=display values=names
-    Vector_Editor item_editor=item_editor item_default="(Join_Condition.Equal "+table.column_names.first.pretty+")" display=display
+    Vector_Editor item_editor=item_editor item_default="(Join_Condition.Equals "+table.column_names.first.pretty+")" display=display
 
 ## PRIVATE
    Make a column name selector.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
@@ -86,10 +86,10 @@ make_column_name_vector_selector table display=Display.Always =
 make_column_ref_by_name_selector : Table -> Display -> Boolean -> Boolean -> Boolean -> Boolean -> Widget
 make_column_ref_by_name_selector table display:Display=Display.Always add_text:Boolean=False add_regex:Boolean=False add_number:Boolean=False add_boolean:Boolean=False =
     text = if add_text then [Option "<Text Value>" "''"] else []
-    regex = if add_regex then [Option "<Regular Expression>" "(re '')"] else []
+    regex = if add_regex then [Option "<Regular Expression>" "(regex '')"] else []
     number = if add_number then [Option "<Number Value>" "0"] else []
     boolean = if add_boolean then [Option "<True/False>" "True"] else []
-    expression = if table.is_nothing then [] else [Option "<Expression>" "(Column_Ref.Expression '["+table.column_names.first+"]')"]
+    expression = if table.is_nothing then [] else [Option "<Expression>" "(expr '["+table.column_names.first+"]')"]
     col_names = if table.is_nothing then [] else table.column_names.map (name -> Option name "(Column_Ref.Name "+name.pretty+")")
     values = text + regex + number + boolean + expression + col_names
     Single_Choice values=values display=display

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
@@ -3,6 +3,8 @@ from Standard.Base import all
 import project.Data.Aggregate_Column.Aggregate_Column
 import project.Data.Blank_Selector.Blank_Selector
 import project.Data.Calculations.Column_Operation.Column_Operation
+import project.Data.Calculations.Column_Operation.Derived_Column
+import project.Data.Calculations.Column_Operation.Derived_Operation
 import project.Data.Column.Column
 import project.Data.Column_Ref.Column_Ref
 import project.Data.Column_Vector_Extensions
@@ -35,6 +37,8 @@ export project.Data.Aggregate_Column.Aggregate_Column
 
 export project.Data.Blank_Selector.Blank_Selector
 export project.Data.Calculations.Column_Operation.Column_Operation
+export project.Data.Calculations.Column_Operation.Derived_Column
+export project.Data.Calculations.Column_Operation.Derived_Operation
 export project.Data.Column.Column
 export project.Data.Column_Ref.Column_Ref
 export project.Data.Column_Vector_Extensions

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
@@ -25,6 +25,7 @@ import project.Excel.Excel_Section.Excel_Section
 import project.Excel.Excel_Workbook.Excel_Workbook
 import project.Extensions.Prefix_Name.Prefix_Name
 from project.Data.Constants import all
+from project.Data.Expression import expr
 from project.Delimited.Delimited_Format.Delimited_Format import Delimited
 from project.Excel.Excel_Format.Excel_Format import Excel
 from project.Excel.Excel_Section.Excel_Section import Cell_Range, Range_Names, Sheet_Names, Worksheet
@@ -56,8 +57,8 @@ export project.Excel.Excel_Section.Excel_Section
 export project.Excel.Excel_Workbook.Excel_Workbook
 export project.Extensions.Prefix_Name.Prefix_Name
 from project.Data.Constants export all
+from project.Data.Expression export expr
 from project.Delimited.Delimited_Format.Delimited_Format export Delimited
 from project.Excel.Excel_Format.Excel_Format export Excel
 from project.Excel.Excel_Section.Excel_Section export Cell_Range, Range_Names, Sheet_Names, Worksheet
 from project.Extensions.Table_Conversions export all
-

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
@@ -3,8 +3,6 @@ from Standard.Base import all
 import project.Data.Aggregate_Column.Aggregate_Column
 import project.Data.Blank_Selector.Blank_Selector
 import project.Data.Calculations.Column_Operation.Column_Operation
-import project.Data.Calculations.Column_Operation.Derived_Column
-import project.Data.Calculations.Column_Operation.Derived_Operation
 import project.Data.Column.Column
 import project.Data.Column_Ref.Column_Ref
 import project.Data.Column_Vector_Extensions
@@ -15,6 +13,8 @@ import project.Data.Match_Columns.Match_Columns
 import project.Data.Position.Position
 import project.Data.Report_Unmatched.Report_Unmatched
 import project.Data.Set_Mode.Set_Mode
+import project.Data.Simple_Expression.Simple_Expression
+import project.Data.Simple_Expression.Simple_Calculation
 import project.Data.Sort_Column.Sort_Column
 import project.Data.Table.Table
 import project.Data.Type.Value_Type.Auto
@@ -37,8 +37,6 @@ export project.Data.Aggregate_Column.Aggregate_Column
 
 export project.Data.Blank_Selector.Blank_Selector
 export project.Data.Calculations.Column_Operation.Column_Operation
-export project.Data.Calculations.Column_Operation.Derived_Column
-export project.Data.Calculations.Column_Operation.Derived_Operation
 export project.Data.Column.Column
 export project.Data.Column_Ref.Column_Ref
 export project.Data.Column_Vector_Extensions
@@ -49,6 +47,8 @@ export project.Data.Match_Columns.Match_Columns
 export project.Data.Position.Position
 export project.Data.Report_Unmatched.Report_Unmatched
 export project.Data.Set_Mode.Set_Mode
+export project.Data.Simple_Expression.Simple_Expression
+export project.Data.Simple_Expression.Simple_Calculation
 export project.Data.Sort_Column.Sort_Column
 export project.Data.Table.Table
 export project.Data.Type.Value_Type.Auto

--- a/test/Table_Tests/src/Common_Table_Operations/Aggregate_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Aggregate_Spec.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all hiding First, Last
 
-from Standard.Table import Table, Sort_Column
+from Standard.Table import Table, Sort_Column, expr
 from Standard.Table.Data.Aggregate_Column.Aggregate_Column import all
 import Standard.Table.Data.Expression.Expression_Error
 from Standard.Table.Errors import all
@@ -1405,7 +1405,7 @@ add_specs suite_builder setup =
            to verify that  all of them correctly support expressions.
         group_builder.specify "should allow expressions in aggregates" <|
             table = table_builder [["Index", [1, 1, 2, 2]], ["Value", [1, 2, 3, 4]]]
-            t1 = table.aggregate ["Index"] [Sum "Value", Sum "[Value]*[Value]"]
+            t1 = table.aggregate ["Index"] [Sum "Value", Sum (expr "[Value]*[Value]")]
             t1.column_count . should_equal 3
             r1 =  t1 |> materialize |> _.order_by "Index"
             r1.at "Index" . to_vector . should_equal [1, 2]
@@ -1415,19 +1415,19 @@ add_specs suite_builder setup =
             r1.at -1 . to_vector . should_equal [5, 25]
 
         group_builder.specify "should warn when encountering invalid expressions, but try to perform the aggregations that are still valid" <|
-            action1 = data.table.aggregate ["Index"] [Sum "Value", Sum "[MISSING]*[MISSING]"] on_problems=_
+            action1 = data.table.aggregate ["Index"] [Sum "Value", Sum (expr "[MISSING]*[MISSING]")] on_problems=_
             tester1 = expect_column_names ["Index", "Sum Value"]
             problems1 = [Invalid_Aggregate_Column.Error "[MISSING]*[MISSING]" (No_Such_Column.Error "MISSING")]
             Problems.test_problem_handling action1 problems1 tester1
 
-            t2 = data.table.aggregate ["Index"] [Sum "Value", Sum "[[["] on_problems=Problem_Behavior.Ignore
+            t2 = data.table.aggregate ["Index"] [Sum "Value", Sum (expr "[[[")] on_problems=Problem_Behavior.Ignore
             expect_column_names ["Index", "Sum Value"] t2
-            err3 = data.table.aggregate ["Index"] [Sum "Value", Sum "[[["] on_problems=Problem_Behavior.Report_Error
+            err3 = data.table.aggregate ["Index"] [Sum "Value", Sum (expr "[[[")] on_problems=Problem_Behavior.Report_Error
             err3.should_fail_with Invalid_Aggregate_Column
             err3.catch.name . should_equal "[[["
             err3.catch.expression_error . should_be_a Expression_Error.Syntax_Error
 
-            t4 = data.table.aggregate columns=[Sum "[MISSING]*[MISSING]"]
+            t4 = data.table.aggregate columns=[Sum (expr "[MISSING]*[MISSING]")]
             t4 . should_fail_with Invalid_Aggregate_Column
             err4 = t4.catch
             err4.name.should_equal "[MISSING]*[MISSING]"

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Name_Edge_Cases_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Name_Edge_Cases_Spec.enso
@@ -136,7 +136,7 @@ add_specs suite_builder setup =
 
         group_builder.specify "case insensitive name collisions - cross_tab" <|
             t0 = table_builder [["X", ["a", "A", "b"]], ["Y", [4, 5, 6]]]
-            t1 = t0.cross_tab group_by=[] name_column="X" values=[Aggregate_Column.First "Y"] . sort_columns
+            t1 = t0.cross_tab group_by=[] names="X" values=[Aggregate_Column.First "Y"] . sort_columns
             case setup.is_database of
                 # TODO remove this check once implemented
                 True -> t1.should_fail_with Unsupported_Database_Operation

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Name_Edge_Cases_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Name_Edge_Cases_Spec.enso
@@ -38,7 +38,7 @@ add_specs suite_builder setup =
         group_builder.specify "case insensitive name collisions - set" <|
             t1 = table_builder [["X", [1]]]
             Problems.assume_no_problems (t1.at "X" . rename "x")
-            t2 = t1.set "[X] + 100" "x"
+            t2 = t1.set (expr "[X] + 100") "x"
             case is_case_sensitive of
                 False ->
                     t2.should_fail_with Clashing_Column_Name

--- a/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
@@ -193,8 +193,8 @@ add_specs suite_builder setup =
         group_builder.specify "should not affect existing columns that depended on the old column being replaced" <|
             t1 = table_builder [["X", [1,2,3]]]
             t2 = t1.set (t1.at "X" * 100) as="Y"
-            t3 = t2.set "[X] + 10" as="Z"
-            t4 = t3.set "[X] + 1000" as="X"
+            t3 = t2.set (expr "[X] + 10") as="Z"
+            t4 = t3.set (Simple_Expression.From (Column_Ref.Name "X") (Simple_Calculation.Add 1000)) as="X"
 
             t4.at "X" . to_vector . should_equal [1001, 1002, 1003]
             t4.at "Y" . to_vector . should_equal [100, 200, 300]
@@ -202,27 +202,27 @@ add_specs suite_builder setup =
 
         group_builder.specify "should gracefully handle expression failures" <|
             t1 = table_builder [["X", [1,2,3]]]
-            t1.set "[unknown] + 10" as="Z" . should_fail_with No_Such_Column
-            t1.set "[[[[" . should_fail_with Expression_Error
-            t1.set "[[[[" . catch . should_be_a Expression_Error.Syntax_Error
+            t1.set (expr "[unknown] + 10") as="Z" . should_fail_with No_Such_Column
+            t1.set (expr "[[[[") . should_fail_with Expression_Error
+            t1.set (expr "[[[[") . catch . should_be_a Expression_Error.Syntax_Error
 
         group_builder.specify "should forward expression problems" <|
             t1 = table_builder [["X", [1.5, 2.0, 0.0]]]
 
-            r1 = t1.set "([X] == 2) || ([X] + 0.5 == 2)" on_problems=Problem_Behavior.Ignore
+            r1 = t1.set (expr "([X] == 2) || ([X] + 0.5 == 2)") on_problems=Problem_Behavior.Ignore
             Problems.assume_no_problems r1
             r1.at -1 . to_vector . should_equal [True, True, False]
 
-            r2 = t1.set "([X] == 2) || ([X] + 0.5 == 2)" on_problems=Problem_Behavior.Report_Warning
+            r2 = t1.set (expr "([X] == 2) || ([X] + 0.5 == 2)") on_problems=Problem_Behavior.Report_Warning
             Problems.expect_warning Floating_Point_Equality r2
             r2.at -1 . to_vector . should_equal [True, True, False]
 
-            err3 = t1.set "([X] == 2) || ([X] + 0.5 == 2)" on_problems=Problem_Behavior.Report_Error
+            err3 = t1.set (expr "([X] == 2) || ([X] + 0.5 == 2)") on_problems=Problem_Behavior.Report_Error
             err3.should_fail_with Floating_Point_Equality
 
             # These errors currently only work in in-memory.
             if setup.is_database.not then
-                action2 = t1.set "3 / [X]" as="Z" on_problems=_
+                action2 = t1.set (Simple_Expression.From 3 (Simple_Calculation.Divide (Column_Ref.Name "X"))) as="Z" on_problems=_
                 tester2 table =
                     table.at "Z" . to_vector . should_equal [2.0, 1.5, Number.positive_infinity]
                 problems2 = [Arithmetic_Error.Error "Division by zero (at rows [2])."]

--- a/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
@@ -222,7 +222,7 @@ add_specs suite_builder setup =
 
             # These errors currently only work in in-memory.
             if setup.is_database.not then
-                action2 = t1.set (Simple_Expression.From 3 (Simple_Calculation.Divide (Column_Ref.Name "X"))) as="Z" on_problems=_
+                action2 = t1.set (expr "3 / [X]") as="Z" on_problems=_
                 tester2 table =
                     table.at "Z" . to_vector . should_equal [2.0, 1.5, Number.positive_infinity]
                 problems2 = [Arithmetic_Error.Error "Division by zero (at rows [2])."]

--- a/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
@@ -172,7 +172,7 @@ add_specs suite_builder setup =
             t3.column_names . should_equal ["foo", "bar", "Baz", "foo 1", "foo 2", "ab.+123", "abcd123", "bar2", "bar3"]
 
         group_builder.specify "should not allow illegal column names" <|
-            data.table.set (data.table.get "bar") new_name='a\0b' . should_fail_with Invalid_Column_Names
+            data.table.set (data.table.get "bar") as='a\0b' . should_fail_with Invalid_Column_Names
 
         group_builder.specify "should allow replacing a column" <|
             foo = data.table.get "bar" . rename "foo"
@@ -192,9 +192,9 @@ add_specs suite_builder setup =
 
         group_builder.specify "should not affect existing columns that depended on the old column being replaced" <|
             t1 = table_builder [["X", [1,2,3]]]
-            t2 = t1.set (t1.at "X" * 100) new_name="Y"
-            t3 = t2.set "[X] + 10" new_name="Z"
-            t4 = t3.set "[X] + 1000" new_name="X"
+            t2 = t1.set (t1.at "X" * 100) as="Y"
+            t3 = t2.set "[X] + 10" as="Z"
+            t4 = t3.set "[X] + 1000" as="X"
 
             t4.at "X" . to_vector . should_equal [1001, 1002, 1003]
             t4.at "Y" . to_vector . should_equal [100, 200, 300]
@@ -202,7 +202,7 @@ add_specs suite_builder setup =
 
         group_builder.specify "should gracefully handle expression failures" <|
             t1 = table_builder [["X", [1,2,3]]]
-            t1.set "[unknown] + 10" new_name="Z" . should_fail_with No_Such_Column
+            t1.set "[unknown] + 10" as="Z" . should_fail_with No_Such_Column
             t1.set "[[[[" . should_fail_with Expression_Error
             t1.set "[[[[" . catch . should_be_a Expression_Error.Syntax_Error
 
@@ -222,7 +222,7 @@ add_specs suite_builder setup =
 
             # These errors currently only work in in-memory.
             if setup.is_database.not then
-                action2 = t1.set "3 / [X]" new_name="Z" on_problems=_
+                action2 = t1.set "3 / [X]" as="Z" on_problems=_
                 tester2 table =
                     table.at "Z" . to_vector . should_equal [2.0, 1.5, Number.positive_infinity]
                 problems2 = [Arithmetic_Error.Error "Division by zero (at rows [2])."]

--- a/test/Table_Tests/src/Common_Table_Operations/Cross_Tab_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Cross_Tab_Spec.enso
@@ -170,7 +170,7 @@ add_specs suite_builder setup =
             err1.catch.name . should_equal "[MISSING]*10"
             err1.catch.expression_error . should_equal (No_Such_Column.Error "MISSING")
 
-            err2 = data.table.cross_tab [] "Key" values=[Aggregate_Column.Sum "[[["]
+            err2 = data.table.cross_tab [] "Key" values=[Aggregate_Column.Sum (expr "[[[")]
             err2.should_fail_with Invalid_Aggregate_Column
             err2.catch.name . should_equal "[[["
             err2.catch.expression_error . should_be_a Expression_Error.Syntax_Error

--- a/test/Table_Tests/src/Common_Table_Operations/Cross_Tab_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Cross_Tab_Spec.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
-from Standard.Table import Aggregate_Column
+from Standard.Table import Aggregate_Column, expr
 import Standard.Table.Data.Expression.Expression_Error
 from Standard.Table.Errors import all
 
@@ -61,7 +61,7 @@ add_specs suite_builder setup =
             t1.at "z" . to_vector . should_equal [17]
 
         group_builder.specify "should allow a custom expression for the aggregate" <|
-            t1 = data.table.cross_tab [] "Key" values=[Aggregate_Column.Sum "[Value]*[Value]"]
+            t1 = data.table.cross_tab [] "Key" values=[Aggregate_Column.Sum (expr "[Value]*[Value]")]
             t1.column_names . should_equal ["x", "y", "z"]
             t1.row_count . should_equal 1
             t1.at "x" . to_vector . should_equal [30]
@@ -165,7 +165,7 @@ add_specs suite_builder setup =
             err2.catch.criteria . should_equal [42]
 
         group_builder.specify "should fail if aggregate values contain invalid expressions" <|
-            err1 = data.table.cross_tab [] "Key" values=[Aggregate_Column.Sum "[MISSING]*10"]
+            err1 = data.table.cross_tab [] "Key" values=[Aggregate_Column.Sum (expr "[MISSING]*10")]
             err1.should_fail_with Invalid_Aggregate_Column
             err1.catch.name . should_equal "[MISSING]*10"
             err1.catch.expression_error . should_equal (No_Such_Column.Error "MISSING")

--- a/test/Table_Tests/src/Common_Table_Operations/Derived_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Derived_Columns_Spec.enso
@@ -68,7 +68,7 @@ add_specs suite_builder setup =
             t.set (Simple_Expression.From 2 (Simple_Calculation.Power (Column_Ref.Name "A"))) "C" . at "C" . to_vector . should_equal [2, 4]
             t.set (Simple_Expression.From 3 (Simple_Calculation.Power 4)) "C" . at "C" . to_vector . should_equal [81, 81]
 
-            t.set (Simple_Expression.From "x" (Simple_Calculation.Subtract "y")) . should_fail_with Invalid_Value_Type 
+            Test.expect_panic Type_Error <| t.set (Simple_Expression.From "x" (Simple_Calculation.Subtract "y"))
             t.set (Simple_Expression.From 42 (Simple_Calculation.Add "y")) . should_fail_with Illegal_Argument
 
         group_builder.specify "rounding" <|
@@ -114,7 +114,7 @@ add_specs suite_builder setup =
             t2.set (Simple_Expression.From (Column_Ref.Name "C") (Simple_Calculation.Date_Part Time_Period.Second)) . should_fail_with Illegal_Argument
             t2.set (Simple_Expression.From (Column_Ref.Name "D") (Simple_Calculation.Date_Add 5 Date_Period.Year)) . should_fail_with Illegal_Argument
             t.set (Simple_Expression.From (Column_Ref.Name "x") (Simple_Calculation.Date_Part Date_Period.Year)) . should_fail_with Invalid_Value_Type
-            t2.set (Simple_Expression.From 42 (Simple_Calculation.Date_Diff "x" Date_Period.Year)) . should_fail_with Invalid_Value_Type
+            Test.expect_panic Type_Error <| t2.set (Simple_Expression.From 42 (Simple_Calculation.Date_Diff "x" Date_Period.Year))
 
         group_builder.specify "boolean" <|
             t = table_builder [["A", [True, False]], ["T", [True, True]]]
@@ -131,7 +131,7 @@ add_specs suite_builder setup =
             t.set (Simple_Expression.From False Simple_Calculation.Not) "Z" . at "Z" . to_vector . should_equal [True, True]
 
             t.set (Simple_Expression.From 42 (Simple_Calculation.And True)) . should_fail_with Invalid_Value_Type
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Or "x")) . should_fail_with Invalid_Value_Type
+            Test.expect_panic Type_Error <| t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Or "x"))
 
         group_builder.specify "if" <|
             t = table_builder [["A", [1, 100]], ["B", [10, 40]], ["C", [23, 55]]]

--- a/test/Table_Tests/src/Common_Table_Operations/Derived_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Derived_Columns_Spec.enso
@@ -281,6 +281,6 @@ add_specs suite_builder setup =
 
         group_builder.specify "Should not disambiguate if the new name is explicitly set" <|
             t = table_builder [["X", [1, 2, 3]]]
-            t2 = t.set (Column_Operation.Add (Column_Ref.Name "X") 1) new_name="X"
+            t2 = t.set (Column_Operation.Add (Column_Ref.Name "X") 1) as="X"
             t2.column_names . should_equal ["X"]
             t2.at "X" . to_vector . should_equal [2, 3, 4]

--- a/test/Table_Tests/src/Common_Table_Operations/Derived_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Derived_Columns_Spec.enso
@@ -27,7 +27,7 @@ add_specs suite_builder setup =
     prefix = setup.prefix
     create_connection_fn = setup.create_connection_func
     pending_datetime = if setup.test_selection.date_time.not then "Date/Time operations are not supported by this backend."
-    suite_builder.group prefix+"Table.set with Column_Operation" group_builder->
+    suite_builder.group prefix+"Table.set with Simple_Expression" group_builder->
         data = Data.setup create_connection_fn
 
         group_builder.teardown <|
@@ -38,181 +38,181 @@ add_specs suite_builder setup =
 
         group_builder.specify "arithmetics" <|
             t = table_builder [["A", [1, 2]], ["B", [10, 40]]]
-            t.set (Column_Operation.Add (Column_Ref.Name "A") (Column_Ref.Name "B")) "C" . at "C" . to_vector . should_equal [11, 42]
-            t.set (Column_Operation.Add 100 (Column_Ref.Name "B")) "C" . at "C" . to_vector . should_equal [110, 140]
-            t.set (Column_Operation.Add (Column_Ref.Name "A") 100) "C" . at "C" . to_vector . should_equal [101, 102]
-            t.set (Column_Operation.Add 23 100) "C" . at "C" . to_vector . should_equal [123, 123]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Add (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [11, 42]
+            t.set (Simple_Expression.From 100 (Simple_Calculation.Add (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [110, 140]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Add 100)) "C" . at "C" . to_vector . should_equal [101, 102]
+            t.set (Simple_Expression.From 23 (Simple_Calculation.Add 100)) "C" . at "C" . to_vector . should_equal [123, 123]
 
-            t.set (Column_Operation.Subtract (Column_Ref.Name "A") (Column_Ref.Name "B")) "C" . at "C" . to_vector . should_equal [-9, -38]
-            t.set (Column_Operation.Subtract 100 (Column_Ref.Name "B")) "C" . at "C" . to_vector . should_equal [90, 60]
-            t.set (Column_Operation.Subtract (Column_Ref.Name "A") 100) "C" . at "C" . to_vector . should_equal [-99, -98]
-            t.set (Column_Operation.Subtract 23 100) "C" . at "C" . to_vector . should_equal [-77, -77]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Subtract (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [-9, -38]
+            t.set (Simple_Expression.From 100 (Simple_Calculation.Subtract (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [90, 60]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Subtract 100)) "C" . at "C" . to_vector . should_equal [-99, -98]
+            t.set (Simple_Expression.From 23 (Simple_Calculation.Subtract 100)) "C" . at "C" . to_vector . should_equal [-77, -77]
 
-            t.set (Column_Operation.Multiply (Column_Ref.Name "A") (Column_Ref.Name "B")) "C" . at "C" . to_vector . should_equal [10, 80]
-            t.set (Column_Operation.Multiply 100 (Column_Ref.Name "B")) "C" . at "C" . to_vector . should_equal [1000, 4000]
-            t.set (Column_Operation.Multiply (Column_Ref.Name "A") 100) "C" . at "C" . to_vector . should_equal [100, 200]
-            t.set (Column_Operation.Multiply 23 100) "C" . at "C" . to_vector . should_equal [2300, 2300]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Multiply (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [10, 80]
+            t.set (Simple_Expression.From 100 (Simple_Calculation.Multiply (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [1000, 4000]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Multiply 100)) "C" . at "C" . to_vector . should_equal [100, 200]
+            t.set (Simple_Expression.From 23 (Simple_Calculation.Multiply 100)) "C" . at "C" . to_vector . should_equal [2300, 2300]
 
-            t.set (Column_Operation.Divide (Column_Ref.Name "B") (Column_Ref.Name "A")) "C" . at "C" . to_vector . should_equal [10, 20]
-            t.set (Column_Operation.Divide (Column_Ref.Name "A") (Column_Ref.Name "B")) "C" . at "C" . to_vector . should_equal [0.1, 0.05]
-            t.set (Column_Operation.Divide 1 (Column_Ref.Name "A")) "C" . at "C" . to_vector . should_equal [1, 0.5]
-            t.set (Column_Operation.Divide 1 2) "C" . at "C" . to_vector . should_equal [0.5, 0.5]
+            t.set (Simple_Expression.From (Column_Ref.Name "B") (Simple_Calculation.Divide (Column_Ref.Name "A"))) "C" . at "C" . to_vector . should_equal [10, 20]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Divide (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [0.1, 0.05]
+            t.set (Simple_Expression.From 1 (Simple_Calculation.Divide (Column_Ref.Name "A"))) "C" . at "C" . to_vector . should_equal [1, 0.5]
+            t.set (Simple_Expression.From 1 (Simple_Calculation.Divide 2)) "C" . at "C" . to_vector . should_equal [0.5, 0.5]
 
             t2 = table_builder [["A", [23, 42]], ["B", [10, 3]]]
-            t2.set (Column_Operation.Mod (Column_Ref.Name "A") (Column_Ref.Name "B")) "C" . at "C" . to_vector . should_equal [3, 0]
-            t2.set (Column_Operation.Mod (Column_Ref.Name "A") 10) "C" . at "C" . to_vector . should_equal [3, 2]
-            t2.set (Column_Operation.Mod 7 5) "C" . at "C" . to_vector . should_equal [2, 2]
+            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Mod (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [3, 0]
+            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Mod 10)) "C" . at "C" . to_vector . should_equal [3, 2]
+            t2.set (Simple_Expression.From 7 (Simple_Calculation.Mod 5)) "C" . at "C" . to_vector . should_equal [2, 2]
 
-            t.set (Column_Operation.Power (Column_Ref.Name "B") (Column_Ref.Name "A")) "C" . at "C" . to_vector . should_equal [10, 1600]
-            t.set (Column_Operation.Power (Column_Ref.Name "A") 3) "C" . at "C" . to_vector . should_equal [1, 8]
-            t.set (Column_Operation.Power 2 (Column_Ref.Name "A")) "C" . at "C" . to_vector . should_equal [2, 4]
-            t.set (Column_Operation.Power 3 4) "C" . at "C" . to_vector . should_equal [81, 81]
+            t.set (Simple_Expression.From (Column_Ref.Name "B") (Simple_Calculation.Power (Column_Ref.Name "A"))) "C" . at "C" . to_vector . should_equal [10, 1600]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Power 3)) "C" . at "C" . to_vector . should_equal [1, 8]
+            t.set (Simple_Expression.From 2 (Simple_Calculation.Power (Column_Ref.Name "A"))) "C" . at "C" . to_vector . should_equal [2, 4]
+            t.set (Simple_Expression.From 3 (Simple_Calculation.Power 4)) "C" . at "C" . to_vector . should_equal [81, 81]
 
-            Test.expect_panic Type_Error <| t.set (Column_Operation.Subtract "x" "y")
-            t.set (Column_Operation.Add 42 "y") . should_fail_with Illegal_Argument
+            Test.expect_panic Type_Error <| t.set (Simple_Expression.From "x" (Simple_Calculation.Subtract "y"))
+            t.set (Simple_Expression.From 42 (Simple_Calculation.Add "y")) . should_fail_with Illegal_Argument
 
         group_builder.specify "rounding" <|
             t = table_builder [["A", [1.13333, 122.74463, 32.52424, -12.7]]]
-            t.set (Column_Operation.Round (Column_Ref.Name "A")) "Z" . at "Z" . to_vector . should_equal [1, 123, 33, -13]
-            t.set (Column_Operation.Round (Column_Ref.Name "A") precision=1) "Z" . at "Z" . to_vector . should_equal [1.1, 122.7, 32.5, -12.7]
-            t.set (Column_Operation.Round (Column_Ref.Name "A") precision=-1) "Z" . at "Z" . to_vector . should_equal [0, 120, 30, -10]
+            t.set (Simple_Expression.From (Column_Ref.Name (Simple_Calculation.Round "A"))) "Z" . at "Z" . to_vector . should_equal [1, 123, 33, -13]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Round precision=1)) "Z" . at "Z" . to_vector . should_equal [1.1, 122.7, 32.5, -12.7]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Round precision=-1)) "Z" . at "Z" . to_vector . should_equal [0, 120, 30, -10]
 
-            t.set (Column_Operation.Ceil (Column_Ref.Name "A")) "Z" . at "Z" . to_vector . should_equal [2, 123, 33, -12]
-            t.set (Column_Operation.Floor (Column_Ref.Name "A")) "Z" . at "Z" . to_vector . should_equal [1, 122, 32, -13]
-            t.set (Column_Operation.Truncate (Column_Ref.Name "A")) "Z" . at "Z" . to_vector . should_equal [1, 122, 32, -12]
+            t.set (Simple_Expression.From (Column_Ref.Name (Simple_Calculation.Ceil "A"))) "Z" . at "Z" . to_vector . should_equal [2, 123, 33, -12]
+            t.set (Simple_Expression.From (Column_Ref.Name (Simple_Calculation.Floor "A"))) "Z" . at "Z" . to_vector . should_equal [1, 122, 32, -13]
+            t.set (Simple_Expression.From (Column_Ref.Name (Simple_Calculation.Truncate "A"))) "Z" . at "Z" . to_vector . should_equal [1, 122, 32, -12]
 
-            Test.expect_panic Type_Error <| t.set (Column_Operation.Round "1.23")
-            Test.expect_panic Type_Error <| t.set (Column_Operation.Truncate "1.23")
+            Test.expect_panic Type_Error <| t.set (Simple_Expression.From "1.23" Simple_Calculation.Round)
+            Test.expect_panic Type_Error <| t.set (Simple_Expression.From "1.23" Simple_Calculation.Truncate)
 
         group_builder.specify "date/time" pending=pending_datetime <|
             t = table_builder [["A", [Date_Time.new 2023 1 12 12 45, Date_Time.new 2020 5 12 1 45]], ["B", [Date_Time.new 2023 1 15 18 45, Date_Time.new 2020 6 12 22 20]], ["x", [1, 3]]]
 
             # TODO ticket for truncate for DB
             if setup.is_database.not then
-                t.set (Column_Operation.Truncate (Column_Ref.Name "A")) "Z" . at "Z" . to_vector . should_equal [Date.new 2023 1 12, Date.new 2020 5 12]
-                t.set (Column_Operation.Truncate (Date_Time.new 1999 12 10 14 55 11)) "Z" . at "Z" . to_vector . should_equal [Date.new 1999 12 10, Date.new 1999 12 10]
+                t.set (Simple_Expression.From (Column_Ref.Name "A") Simple_Calculation.Truncate) "Z" . at "Z" . to_vector . should_equal [Date.new 2023 1 12, Date.new 2020 5 12]
+                t.set (Simple_Expression.From (Date_Time.new 1999 12 10 14 55 11) Simple_Calculation.Truncate) "Z" . at "Z" . to_vector . should_equal [Date.new 1999 12 10, Date.new 1999 12 10]
 
-            t.set (Column_Operation.Date_Add (Column_Ref.Name "A") (Column_Ref.Name "x")) "Z" . at "Z" . to_vector . should_equal_tz_agnostic [Date_Time.new 2023 1 13 12 45, Date_Time.new 2020 5 15 1 45]
-            t.set (Column_Operation.Date_Add (Column_Ref.Name "A") 10 Date_Period.Year) "Z" . at "Z" . to_vector . should_equal_tz_agnostic [Date_Time.new 2033 1 12 12 45, Date_Time.new 2030 5 12 1 45]
-            t.set (Column_Operation.Date_Add (Date_Time.new 2001 12 15 11 00) 10 Time_Period.Minute) "Z" . at "Z" . to_vector . should_equal_tz_agnostic [Date_Time.new 2001 12 15 11 10, Date_Time.new 2001 12 15 11 10]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Date_Add (Column_Ref.Name "x"))) "Z" . at "Z" . to_vector . should_equal_tz_agnostic [Date_Time.new 2023 1 13 12 45, Date_Time.new 2020 5 15 1 45]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Date_Add 10 Date_Period.Year)) "Z" . at "Z" . to_vector . should_equal_tz_agnostic [Date_Time.new 2033 1 12 12 45, Date_Time.new 2030 5 12 1 45]
+            t.set (Simple_Expression.From (Date_Time.new 2001 12 15 11 00) (Simple_Calculation.Date_Add 10 Time_Period.Minute)) "Z" . at "Z" . to_vector . should_equal_tz_agnostic [Date_Time.new 2001 12 15 11 10, Date_Time.new 2001 12 15 11 10]
 
-            t.set (Column_Operation.Date_Diff (Column_Ref.Name "A") (Column_Ref.Name "B") Date_Period.Day) "Z" . at "Z" . to_vector . should_equal [3, 31]
-            t.set (Column_Operation.Date_Part (Column_Ref.Name "A") Date_Period.Year) "Z" . at "Z" . to_vector . should_equal [2023, 2020]
-            t.set (Column_Operation.Date_Part (Column_Ref.Name "A") Time_Period.Minute) "Z" . at "Z" . to_vector . should_equal [45, 45]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Date_Diff (Column_Ref.Name "B") Date_Period.Day)) "Z" . at "Z" . to_vector . should_equal [3, 31]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Date_Part Date_Period.Year)) "Z" . at "Z" . to_vector . should_equal [2023, 2020]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Date_Part Time_Period.Minute)) "Z" . at "Z" . to_vector . should_equal [45, 45]
 
             t2 = table_builder [["C", [Date.new 2002 12 10, Date.new 2005 01 01]], ["D", [Time_Of_Day.new 12 45, Time_Of_Day.new 01 01]]]
-            t2.set (Column_Operation.Date_Add (Column_Ref.Name "C") 5 Date_Period.Month) "Z" . at "Z" . to_vector . should_equal [Date.new 2003 5 10, Date.new 2005 6 01]
-            t2.set (Column_Operation.Date_Add (Column_Ref.Name "D") 15 Time_Period.Hour) "Z" . at "Z" . to_vector . should_equal [Time_Of_Day.new 03 45, Time_Of_Day.new 16 01]
+            t2.set (Simple_Expression.From (Column_Ref.Name "C") (Simple_Calculation.Date_Add 5 Date_Period.Month)) "Z" . at "Z" . to_vector . should_equal [Date.new 2003 5 10, Date.new 2005 6 01]
+            t2.set (Simple_Expression.From (Column_Ref.Name "D") (Simple_Calculation.Date_Add 15 Time_Period.Hour)) "Z" . at "Z" . to_vector . should_equal [Time_Of_Day.new 03 45, Time_Of_Day.new 16 01]
 
-            t2.set (Column_Operation.Date_Diff (Column_Ref.Name "C") (Date.new 2003) Date_Period.Year) "Z" . at "Z" . to_vector . should_equal [0, -2]
-            t2.set (Column_Operation.Date_Diff (Column_Ref.Name "D") (Time_Of_Day.new 13) Time_Period.Minute) "Z" . at "Z" . to_vector . should_equal [15, 59+(60*11)]
+            t2.set (Simple_Expression.From (Column_Ref.Name "C") (Simple_Calculation.Date_Diff (Date.new 2003) Date_Period.Year)) "Z" . at "Z" . to_vector . should_equal [0, -2]
+            t2.set (Simple_Expression.From (Column_Ref.Name "D") (Simple_Calculation.Date_Diff (Time_Of_Day.new 13) Time_Period.Minute)) "Z" . at "Z" . to_vector . should_equal [15, 59+(60*11)]
 
-            t2.set (Column_Operation.Date_Part (Column_Ref.Name "C") Date_Period.Year) "Z" . at "Z" . to_vector . should_equal [2002, 2005]
-            t2.set (Column_Operation.Date_Part (Column_Ref.Name "D") Time_Period.Minute) "Z" . at "Z" . to_vector . should_equal [45, 1]
+            t2.set (Simple_Expression.From (Column_Ref.Name "C") (Simple_Calculation.Date_Part Date_Period.Year)) "Z" . at "Z" . to_vector . should_equal [2002, 2005]
+            t2.set (Simple_Expression.From (Column_Ref.Name "D") (Simple_Calculation.Date_Part Time_Period.Minute)) "Z" . at "Z" . to_vector . should_equal [45, 1]
 
             # error handling
-            t2.set (Column_Operation.Date_Part (Column_Ref.Name "C") Time_Period.Second) . should_fail_with Illegal_Argument
-            t2.set (Column_Operation.Date_Add (Column_Ref.Name "D") 5 Date_Period.Year) . should_fail_with Illegal_Argument
-            t.set (Column_Operation.Date_Part (Column_Ref.Name "x") Date_Period.Year) . should_fail_with Invalid_Value_Type
-            Test.expect_panic Type_Error <| t2.set (Column_Operation.Date_Diff 42 "x" Date_Period.Year)
+            t2.set (Simple_Expression.From (Column_Ref.Name "C") (Simple_Calculation.Date_Part Time_Period.Second)) . should_fail_with Illegal_Argument
+            t2.set (Simple_Expression.From (Column_Ref.Name "D") (Simple_Calculation.Date_Add 5 Date_Period.Year)) . should_fail_with Illegal_Argument
+            t.set (Simple_Expression.From (Column_Ref.Name "x") (Simple_Calculation.Date_Part Date_Period.Year)) . should_fail_with Invalid_Value_Type
+            Test.expect_panic Type_Error <| t2.set (Simple_Calculation.From 42 (Simple_Calculation.Date_Diff "x" Date_Period.Year))
 
         group_builder.specify "boolean" <|
             t = table_builder [["A", [True, False]], ["T", [True, True]]]
 
-            t.set (Column_Operation.And (Column_Ref.Name "A") (Column_Ref.Name "T")) "Z" . at "Z" . to_vector . should_equal [True, False]
-            t.set (Column_Operation.And (Column_Ref.Name "A") False) "Z" . at "Z" . to_vector . should_equal [False, False]
-            t.set (Column_Operation.And True True) "Z" . at "Z" . to_vector . should_equal [True, True]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.And (Column_Ref.Name "T"))) "Z" . at "Z" . to_vector . should_equal [True, False]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.And False)) "Z" . at "Z" . to_vector . should_equal [False, False]
+            t.set (Simple_Expression.From True (Simple_Calculation.And True)) "Z" . at "Z" . to_vector . should_equal [True, True]
 
-            t.set (Column_Operation.Or (Column_Ref.Name "A") (Column_Ref.Name "T")) "Z" . at "Z" . to_vector . should_equal [True, True]
-            t.set (Column_Operation.Or False (Column_Ref.Name "A")) "Z" . at "Z" . to_vector . should_equal [True, False]
-            t.set (Column_Operation.Or False False) "Z" . at "Z" . to_vector . should_equal [False, False]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Or (Column_Ref.Name "T"))) "Z" . at "Z" . to_vector . should_equal [True, True]
+            t.set (Simple_Expression.From False (Simple_Calculation.Or (Column_Ref.Name "A"))) "Z" . at "Z" . to_vector . should_equal [True, False]
+            t.set (Simple_Expression.From False (Simple_Calculation.Or False)) "Z" . at "Z" . to_vector . should_equal [False, False]
 
-            t.set (Column_Operation.Not (Column_Ref.Name "A")) "Z" . at "Z" . to_vector . should_equal [False, True]
-            t.set (Column_Operation.Not False) "Z" . at "Z" . to_vector . should_equal [True, True]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") Simple_Calculation.Not) "Z" . at "Z" . to_vector . should_equal [False, True]
+            t.set (Simple_Expression.From False Simple_Calculation.Not) "Z" . at "Z" . to_vector . should_equal [True, True]
 
-            Test.expect_panic_with (t.set (Column_Operation.And 42 True)) Type_Error
-            Test.expect_panic_with (t.set (Column_Operation.Or (Column_Ref.Name "A") "x")) Type_Error
+            Test.expect_panic_with (t.set (Simple_Expression.From 42 (Simple_Calculation.And True))) Type_Error
+            Test.expect_panic_with (t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Or "x"))) Type_Error
 
         group_builder.specify "if" <|
             t = table_builder [["A", [1, 100]], ["B", [10, 40]], ["C", [23, 55]]]
-            t.set (Column_Operation.If (Column_Ref.Name "A") (Filter_Condition.Greater than=(Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal [False, True]
-            t.set (Column_Operation.If (Column_Ref.Name "A") (Filter_Condition.Greater than=(Column_Ref.Name "B") Filter_Action.Remove)) "Z" . at "Z" . to_vector . should_equal [True, False]
-            t.set (Column_Operation.If (Column_Ref.Name "A") (Filter_Condition.Greater than=20) "T" "F") "Z" . at "Z" . to_vector . should_equal ["F", "T"]
-            t.set (Column_Operation.If (Column_Ref.Name "A") (Filter_Condition.Less than=20) (Column_Ref.Name "B") (Column_Ref.Name "C")) "Z" . at "Z" . to_vector . should_equal [10, 55]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Greater than=(Column_Ref.Name "B")))) "Z" . at "Z" . to_vector . should_equal [False, True]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Greater than=(Column_Ref.Name "B") Filter_Action.Remove))) "Z" . at "Z" . to_vector . should_equal [True, False]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Greater than=20) "T" "F")) "Z" . at "Z" . to_vector . should_equal ["F", "T"]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Less than=20) (Column_Ref.Name "B") (Column_Ref.Name "C"))) "Z" . at "Z" . to_vector . should_equal [10, 55]
 
-            t.set (Column_Operation.If (Column_Ref.Name "A") (Filter_Condition.Greater than="X") "T" "F") . should_fail_with Invalid_Value_Type
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Greater than="X") "T" "F")) . should_fail_with Invalid_Value_Type
 
             t2 = table_builder [["A", ["a", "c"]], ["B", ["c", "b"]], ["C", [23, 55]]]
-            t2.set (Column_Operation.If (Column_Ref.Name "A") (Filter_Condition.Greater than=(Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal [False, True]
-            t2.set (Column_Operation.If (Column_Ref.Name "A") (Filter_Condition.Greater than=(Column_Ref.Name "B")) (Column_Ref.Name "C") 0) "Z" . at "Z" . to_vector . should_equal [0, 55]
-            t2.set (Column_Operation.If "A" (Filter_Condition.Greater than="B") (Column_Ref.Name "C") 0) "Z" . at "Z" . to_vector . should_equal [0, 0]
-            t2.set (Column_Operation.If (Column_Ref.Name "A") (Filter_Condition.Equal_Ignore_Case "C") "==" "!=") "Z" . at "Z" . to_vector . should_equal ["!=", "=="]
+            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Greater than=(Column_Ref.Name "B")))) "Z" . at "Z" . to_vector . should_equal [False, True]
+            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Greater than=(Column_Ref.Name "B")) (Column_Ref.Name "C") 0)) "Z" . at "Z" . to_vector . should_equal [0, 55]
+            t2.set (Simple_Expression.From "A" (Simple_Calculation.If (Filter_Condition.Greater than="B") (Column_Ref.Name "C") 0)) "Z" . at "Z" . to_vector . should_equal [0, 0]
+            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Equal_Ignore_Case "C") "==" "!=")) "Z" . at "Z" . to_vector . should_equal ["!=", "=="]
 
-            t2.set (Column_Operation.If (Column_Ref.Name "A") (Filter_Condition.Is_In ["x", "a", "dd"]) "TT" "FF") "Z" . at "Z" . to_vector . should_equal ["TT", "FF"]
-            t2.set (Column_Operation.If (Column_Ref.Name "A") (Filter_Condition.Is_In []) "TT" "FF") "Z" . at "Z" . to_vector . should_equal ["FF", "FF"]
+            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In ["x", "a", "dd"]) "TT" "FF")) "Z" . at "Z" . to_vector . should_equal ["TT", "FF"]
+            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In []) "TT" "FF")) "Z" . at "Z" . to_vector . should_equal ["FF", "FF"]
 
             # Passing a column does not work row-by-row, but looks at whole column contents.
-            t2.set (Column_Operation.If (Column_Ref.Name "A") (Filter_Condition.Is_In (t2.at "B")) "TT" "FF") "Z" . at "Z" . to_vector . should_equal ["FF", "TT"]
+            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In (t2.at "B")) "TT" "FF")) "Z" . at "Z" . to_vector . should_equal ["FF", "TT"]
             t3 = table_builder [["x", ["e", "e", "a"]]]
-            t2.set (Column_Operation.If (Column_Ref.Name "A") (Filter_Condition.Is_In (t3.at "x")) "TT" "FF") "Z" . at "Z" . to_vector . should_equal ["TT", "FF"]
+            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In (t3.at "x")) "TT" "FF")) "Z" . at "Z" . to_vector . should_equal ["TT", "FF"]
 
             # Thus, passing a Column_Ref into Is_In is not allowed as it would be confusing.
-            t2.set (Column_Operation.If (Column_Ref.Name "A") (Filter_Condition.Is_In (Column_Ref.Name "B")) "TT" "FF") . should_fail_with Illegal_Argument
+            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In (Column_Ref.Name "B")) "TT" "FF")) . should_fail_with Illegal_Argument
 
         group_builder.specify "text" <|
             t = table_builder [["A", ["  a ", "b"]], ["B", ["c", " d    "]]]
 
-            t.set (Column_Operation.Trim (Column_Ref.Name "A")) "Z" . at "Z" . to_vector . should_equal ["a", "b"]
-            t.set (Column_Operation.Trim (Column_Ref.Name "A") Location.End) "Z" . at "Z" . to_vector . should_equal ["  a", "b"]
-            t.set (Column_Operation.Trim (Column_Ref.Name "A") Location.Start) "Z" . at "Z" . to_vector . should_equal ["a ", "b"]
-            t.set (Column_Operation.Trim (Column_Ref.Name "A") Location.Both "abc") "Z" . at "Z" . to_vector . should_equal ["  a ", ""]
-            t.set (Column_Operation.Trim "bb aaaa" Location.Both (Column_Ref.Name "A")) "Z" . at "Z" . to_vector . should_equal ["bb", " aaaa"]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") Simple_Calculation.Trim) "Z" . at "Z" . to_vector . should_equal ["a", "b"]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Trim Location.End)) "Z" . at "Z" . to_vector . should_equal ["  a", "b"]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Trim Location.Start)) "Z" . at "Z" . to_vector . should_equal ["a ", "b"]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Trim Location.Both "abc")) "Z" . at "Z" . to_vector . should_equal ["  a ", ""]
+            t.set (Simple_Expression.From "bb aaaa" (Simple_Calculation.Trim Location.Both (Column_Ref.Name "A"))) "Z" . at "Z" . to_vector . should_equal ["bb", " aaaa"]
 
-            t.set (Column_Operation.Add (Column_Ref.Name "A") (Column_Ref.Name "B")) "Z" . at "Z" . to_vector . should_equal ["  a c", "b d    "]
-            t.set (Column_Operation.Add "prefix_" (Column_Ref.Name "B")) "Z" . at "Z" . to_vector . should_equal ["prefix_c", "prefix_ d    "]
-            t.set (Column_Operation.Add (Column_Ref.Name "A") "!") "Z" . at "Z" . to_vector . should_equal ["  a !", "b!"]
-            t.set (Column_Operation.Add "O" "!") "Z" . at "Z" . to_vector . should_equal ["O!", "O!"]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Add (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal ["  a c", "b d    "]
+            t.set (Simple_Expression.From "prefix_" (Simple_Calculation.Add (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal ["prefix_c", "prefix_ d    "]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Add "!")) "Z" . at "Z" . to_vector . should_equal ["  a !", "b!"]
+            t.set (Simple_Expression.From "O" (Simple_Calculation.Add "!")) "Z" . at "Z" . to_vector . should_equal ["O!", "O!"]
 
             t2 = table_builder [["A", [42]]]
-            t2.set (Column_Operation.Trim (Column_Ref.Name "A")) . should_fail_with Invalid_Value_Type
+            t2.set (Simple_Expression.From (Column_Ref.Name "A") Simple_Calculation.Not) . should_fail_with Invalid_Value_Type
 
         group_builder.specify "min/max" <|
             t = table_builder [["A", [1, 20]], ["B", [10, 2]]]
 
-            t.set (Column_Operation.Min (Column_Ref.Name "A") (Column_Ref.Name "B")) "Z" . at "Z" . to_vector . should_equal [1, 2]
-            t.set (Column_Operation.Min (Column_Ref.Name "A") 5) "Z" . at "Z" . to_vector . should_equal [1, 5]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Min (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal [1, 2]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Min 5)) "Z" . at "Z" . to_vector . should_equal [1, 5]
 
-            t.set (Column_Operation.Max (Column_Ref.Name "A") (Column_Ref.Name "B")) "Z" . at "Z" . to_vector . should_equal [10, 20]
-            t.set (Column_Operation.Max (Column_Ref.Name "A") 5) "Z" . at "Z" . to_vector . should_equal [5, 20]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Max (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal [10, 20]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Max 5)) "Z" . at "Z" . to_vector . should_equal [5, 20]
 
-            t.set (Column_Operation.Max 2 5) "Z" . at "Z" . to_vector . should_equal [5, 5]
-            t.set (Column_Operation.Min 2 5) "Z" . at "Z" . to_vector . should_equal [2, 2]
+            t.set (Simple_Expression.From 2 (Simple_Calculation.Max 5)) "Z" . at "Z" . to_vector . should_equal [5, 5]
+            t.set (Simple_Expression.From 2 (Simple_Calculation.Min 5)) "Z" . at "Z" . to_vector . should_equal [2, 2]
 
             t2 = table_builder [["A", ["aardvark", "zebra"]], ["B", ["cat", "dog"]], ["x", [1, 20]]]
-            t2.set (Column_Operation.Min (Column_Ref.Name "A") (Column_Ref.Name "B")) "Z" . at "Z" . to_vector . should_equal ["aardvark", "dog"]
-            t2.set (Column_Operation.Max (Column_Ref.Name "A") (Column_Ref.Name "B")) "Z" . at "Z" . to_vector . should_equal ["cat", "zebra"]
-            t2.set (Column_Operation.Min (Column_Ref.Name "A") "animal") "Z" . at "Z" . to_vector . should_equal ["aardvark", "animal"]
-            t2.set (Column_Operation.Max "coyote" (Column_Ref.Name "B")) "Z" . at "Z" . to_vector . should_equal ["coyote", "dog"]
+            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Min (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal ["aardvark", "dog"]
+            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Max (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal ["cat", "zebra"]
+            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Min "animal")) "Z" . at "Z" . to_vector . should_equal ["aardvark", "animal"]
+            t2.set (Simple_Expression.From "coyote" (Simple_Calculation.Max (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal ["coyote", "dog"]
 
             # mixed types result in an error
-            t2.set (Column_Operation.Min (Column_Ref.Name "A") 42) . should_fail_with Invalid_Value_Type
-            t2.set (Column_Operation.Min (Column_Ref.Name "x") "x") . should_fail_with Invalid_Value_Type
-            t2.set (Column_Operation.Min (Column_Ref.Name "x") (Column_Ref.Name "A")) . should_fail_with Invalid_Value_Type
+            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Min 42)) . should_fail_with Invalid_Value_Type
+            t2.set (Simple_Expression.From (Column_Ref.Name "x") (Simple_Calculation.Min "x")) . should_fail_with Invalid_Value_Type
+            t2.set (Simple_Expression.From (Column_Ref.Name "x") (Simple_Calculation.Min (Column_Ref.Name "A"))) . should_fail_with Invalid_Value_Type
 
             if pending_datetime.is_nothing then
                 t3 = table_builder [["A", [Date.new 2002 12 10, Date.new 2005 01 01]]]
-                t3.set (Column_Operation.Min (Column_Ref.Name "A") (Date.new 2003)) "Z" . at "Z" . to_vector . should_equal [Date.new 2002 12 10, Date.new 2003 01 01]
-                t3.set (Column_Operation.Max (Column_Ref.Name "A") (Date.new 2003)) "Z" . at "Z" . to_vector . should_equal [Date.new 2003 01 01, Date.new 2005 01 01]
+                t3.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Min (Date.new 2003))) "Z" . at "Z" . to_vector . should_equal [Date.new 2002 12 10, Date.new 2003 01 01]
+                t3.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Max (Date.new 2003))) "Z" . at "Z" . to_vector . should_equal [Date.new 2003 01 01, Date.new 2005 01 01]
 
         group_builder.specify "allows also indexing columns numerically" <|
             t = table_builder [["X", [1, 2]], ["Y", [3, 4]]]
-            t.set (Column_Operation.Add (Column_Ref.Index 0) (Column_Ref.Index 1)) "Z" . at "Z" . to_vector . should_equal [4, 6]
+            t.set (Simple_Expression.From (Column_Ref.Index 0) (Simple_Calculation.Add (Column_Ref.Index 1))) "Z" . at "Z" . to_vector . should_equal [4, 6]
 
         group_builder.specify "will forward column resolution errors" <|
             t = table_builder [["X", [1, 2]], ["Y", [3, 4]]]
-            t.set (Column_Operation.Add (Column_Ref.Name "X") (Column_Ref.Name "Z")) . should_fail_with No_Such_Column
-            t.set (Column_Operation.Not (Column_Ref.Name "zzz")) . should_fail_with No_Such_Column
-            t.set (Column_Operation.Not (Column_Ref.Index 42)) . should_fail_with Index_Out_Of_Bounds
+            t.set (Simple_Expression.From (Column_Ref.Name "X") (Simple_Calculation.Add (Column_Ref.Name "Z"))) . should_fail_with No_Such_Column
+            t.set (Simple_Expression.From (Column_Ref.Name "zzz") Simple_Calculation.Not) . should_fail_with No_Such_Column
+            t.set (Simple_Expression.From (Column_Ref.Index 42) Simple_Calculation.Not) . should_fail_with Index_Out_Of_Bounds
 
     suite_builder.group prefix+"Unique derived column names" group_builder->
         data = Data.setup create_connection_fn
@@ -225,7 +225,7 @@ add_specs suite_builder setup =
 
         group_builder.specify "Should not disambiguate two derived columns that would otherwise have had the same name, with Set_Mode.Add_Or_Update" <|
             t = table_builder [["X", [1, 2, 3]]]
-            column_op = Column_Operation.Power 2 (Column_Ref.Name "X")
+            column_op = Simple_Expression.From 2 (Simple_Calculation.Power (Column_Ref.Name "X"))
             t2 = t.set column_op . set column_op
             t2.column_names . should_equal ["X", "[2] ^ [X]"]
             t2.at "X" . to_vector . should_equal [1, 2, 3]
@@ -233,7 +233,7 @@ add_specs suite_builder setup =
 
         group_builder.specify "Should disambiguate two derived columns that would otherwise have had the same name, with Set_Mode.Add" <|
             t = table_builder [["X", [1, 2, 3]]]
-            column_op = Column_Operation.Power 2 (Column_Ref.Name "X")
+            column_op = Simple_Expression.From 2 (Simple_Calculation.Power (Column_Ref.Name "X"))
             t2 = t.set column_op set_mode=Set_Mode.Add . set column_op set_mode=Set_Mode.Add
             t2.column_names . should_equal ["X", "[2] ^ [X]", "[2] ^ [X] 1"]
             t2.at "X" . to_vector . should_equal [1, 2, 3]
@@ -258,8 +258,8 @@ add_specs suite_builder setup =
 
         group_builder.specify "Should disambiguate between a column reference and a literal string" <|
             t = table_builder [["X", ["a", "b", "c"]]]
-            t2 = t.set (Column_Operation.Add "prefix" (Column_Ref.Name "X"))
-            t3 = t2.set (Column_Operation.Add "prefix" "X")
+            t2 = t.set (Simple_Expression.From "prefix" (Simple_Calculation.Add (Column_Ref.Name "X")))
+            t3 = t2.set (Simple_Expression.From "prefix" (Simple_Calculation.Add "X"))
 
             t3.column_names . should_equal ['X', "['prefix'] + [X]", "['prefix'] + 'X'"]
             t3.at "['prefix'] + [X]" . to_vector . should_equal ["prefixa", "prefixb", "prefixc"]
@@ -267,20 +267,20 @@ add_specs suite_builder setup =
 
         group_builder.specify "Should not disambiguate if set_mode is Update" <|
             t = table_builder [["X", [1, 2, 3]]]
-            t2 = t.set (Column_Operation.Add (Column_Ref.Name "X") 1) set_mode=Set_Mode.Update
+            t2 = t.set (Simple_Expression.From (Column_Ref.Name "X") (Simple_Calculation.Add 1)) set_mode=Set_Mode.Update
             t2.column_names . should_equal ["X"]
             t2.at "X" . to_vector . should_equal [2, 3, 4]
 
         group_builder.specify "Should not disambiguate if set_mode is Add_Or_Update" <|
             t = table_builder [["X", [1, 2, 3]], ["[X] + 1", [10, 20, 30]]]
             # set_mode=Set_Mode.Add_Or_Update is the default
-            t2 = t.set (Column_Operation.Add (Column_Ref.Name "X") 1)
+            t2 = t.set (Simple_Expression.From (Column_Ref.Name "X") (Simple_Calculation.Add 1))
             t2.column_names . should_equal ["X", "[X] + 1"]
             t2.at "X" . to_vector . should_equal [1, 2, 3]
             t2.at "[X] + 1" . to_vector . should_equal [2, 3, 4]
 
         group_builder.specify "Should not disambiguate if the new name is explicitly set" <|
             t = table_builder [["X", [1, 2, 3]]]
-            t2 = t.set (Column_Operation.Add (Column_Ref.Name "X") 1) as="X"
+            t2 = t.set (Simple_Expression.From (Column_Ref.Name "X") (Simple_Calculation.Add 1)) as="X"
             t2.column_names . should_equal ["X"]
             t2.at "X" . to_vector . should_equal [2, 3, 4]

--- a/test/Table_Tests/src/Common_Table_Operations/Derived_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Derived_Columns_Spec.enso
@@ -68,21 +68,21 @@ add_specs suite_builder setup =
             t.set (Simple_Expression.From 2 (Simple_Calculation.Power (Column_Ref.Name "A"))) "C" . at "C" . to_vector . should_equal [2, 4]
             t.set (Simple_Expression.From 3 (Simple_Calculation.Power 4)) "C" . at "C" . to_vector . should_equal [81, 81]
 
-            Test.expect_panic Type_Error <| t.set (Simple_Expression.From "x" (Simple_Calculation.Subtract "y"))
+            t.set (Simple_Expression.From "x" (Simple_Calculation.Subtract "y")) . should_fail_with Invalid_Value_Type 
             t.set (Simple_Expression.From 42 (Simple_Calculation.Add "y")) . should_fail_with Illegal_Argument
 
         group_builder.specify "rounding" <|
             t = table_builder [["A", [1.13333, 122.74463, 32.52424, -12.7]]]
-            t.set (Simple_Expression.From (Column_Ref.Name (Simple_Calculation.Round "A"))) "Z" . at "Z" . to_vector . should_equal [1, 123, 33, -13]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") Simple_Calculation.Round) "Z" . at "Z" . to_vector . should_equal [1, 123, 33, -13]
             t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Round precision=1)) "Z" . at "Z" . to_vector . should_equal [1.1, 122.7, 32.5, -12.7]
             t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Round precision=-1)) "Z" . at "Z" . to_vector . should_equal [0, 120, 30, -10]
 
-            t.set (Simple_Expression.From (Column_Ref.Name (Simple_Calculation.Ceil "A"))) "Z" . at "Z" . to_vector . should_equal [2, 123, 33, -12]
-            t.set (Simple_Expression.From (Column_Ref.Name (Simple_Calculation.Floor "A"))) "Z" . at "Z" . to_vector . should_equal [1, 122, 32, -13]
-            t.set (Simple_Expression.From (Column_Ref.Name (Simple_Calculation.Truncate "A"))) "Z" . at "Z" . to_vector . should_equal [1, 122, 32, -12]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") Simple_Calculation.Ceil) "Z" . at "Z" . to_vector . should_equal [2, 123, 33, -12]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") Simple_Calculation.Floor) "Z" . at "Z" . to_vector . should_equal [1, 122, 32, -13]
+            t.set (Simple_Expression.From (Column_Ref.Name "A") Simple_Calculation.Truncate) "Z" . at "Z" . to_vector . should_equal [1, 122, 32, -12]
 
-            Test.expect_panic Type_Error <| t.set (Simple_Expression.From "1.23" Simple_Calculation.Round)
-            Test.expect_panic Type_Error <| t.set (Simple_Expression.From "1.23" Simple_Calculation.Truncate)
+            t.set (Simple_Expression.From "1.23" Simple_Calculation.Round) . should_fail_with Invalid_Value_Type
+            t.set (Simple_Expression.From "1.23" Simple_Calculation.Truncate) . should_fail_with Invalid_Value_Type
 
         group_builder.specify "date/time" pending=pending_datetime <|
             t = table_builder [["A", [Date_Time.new 2023 1 12 12 45, Date_Time.new 2020 5 12 1 45]], ["B", [Date_Time.new 2023 1 15 18 45, Date_Time.new 2020 6 12 22 20]], ["x", [1, 3]]]
@@ -114,7 +114,7 @@ add_specs suite_builder setup =
             t2.set (Simple_Expression.From (Column_Ref.Name "C") (Simple_Calculation.Date_Part Time_Period.Second)) . should_fail_with Illegal_Argument
             t2.set (Simple_Expression.From (Column_Ref.Name "D") (Simple_Calculation.Date_Add 5 Date_Period.Year)) . should_fail_with Illegal_Argument
             t.set (Simple_Expression.From (Column_Ref.Name "x") (Simple_Calculation.Date_Part Date_Period.Year)) . should_fail_with Invalid_Value_Type
-            Test.expect_panic Type_Error <| t2.set (Simple_Calculation.From 42 (Simple_Calculation.Date_Diff "x" Date_Period.Year))
+            t2.set (Simple_Expression.From 42 (Simple_Calculation.Date_Diff "x" Date_Period.Year)) . should_fail_with Invalid_Value_Type
 
         group_builder.specify "boolean" <|
             t = table_builder [["A", [True, False]], ["T", [True, True]]]
@@ -130,8 +130,8 @@ add_specs suite_builder setup =
             t.set (Simple_Expression.From (Column_Ref.Name "A") Simple_Calculation.Not) "Z" . at "Z" . to_vector . should_equal [False, True]
             t.set (Simple_Expression.From False Simple_Calculation.Not) "Z" . at "Z" . to_vector . should_equal [True, True]
 
-            Test.expect_panic_with (t.set (Simple_Expression.From 42 (Simple_Calculation.And True))) Type_Error
-            Test.expect_panic_with (t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Or "x"))) Type_Error
+            t.set (Simple_Expression.From 42 (Simple_Calculation.And True)) . should_fail_with Invalid_Value_Type
+            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Or "x")) . should_fail_with Invalid_Value_Type
 
         group_builder.specify "if" <|
             t = table_builder [["A", [1, 100]], ["B", [10, 40]], ["C", [23, 55]]]
@@ -243,7 +243,7 @@ add_specs suite_builder setup =
         group_builder.specify "Should disambiguate two derived columns that would otherwise have had the same name, within the same expression" <|
             t = table_builder [["X", [1, 2, 3]]]
             expression = "2 + (2 * 2) + (2 ^ [X])"
-            t2 = t.set expression
+            t2 = t.set (expr expression)
             t2.column_names . should_equal ["X", expression]
             t2.at "X" . to_vector . should_equal [1, 2, 3]
             t2.at expression . to_vector . should_equal [8, 10, 14]
@@ -251,7 +251,7 @@ add_specs suite_builder setup =
         group_builder.specify "Should use .pretty to distinguish string constants from regular column names" <|
             t = table_builder [["X", ["a", "b", "c"]]]
             expression = '"foo" + [X] + "bar"'
-            t2 = t.set expression
+            t2 = t.set (expr expression)
             t2.column_names . should_equal ["X", expression]
             t2.at "X" . to_vector . should_equal ["a", "b", "c"]
             t2.at expression . to_vector . should_equal ["fooabar", "foobbar", "foocbar"]

--- a/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
@@ -3,7 +3,7 @@ import Standard.Base.Errors.Common.Arithmetic_Error
 import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
-from Standard.Table import Table, Column, Sort_Column, Aggregate_Column, Value_Type
+from Standard.Table import Table, Column, Sort_Column, Aggregate_Column, Value_Type, expr
 from Standard.Table.Errors import all
 import Standard.Table.Data.Expression.Expression_Error
 
@@ -349,8 +349,8 @@ add_specs suite_builder detailed setup =
 
     suite_builder.group prefix+"Expression Errors should be handled" group_builder->
         error_tester expression fail_ctor =
-            test_table.set expression as="NEW_COL" . should_fail_with Expression_Error
-            test_table.set expression as="NEW_COL" . catch . should_be_a fail_ctor
+            test_table.set (expr expression) as="NEW_COL" . should_fail_with Expression_Error
+            test_table.set (expr expression) as="NEW_COL" . catch . should_be_a fail_ctor
 
         specify_test "should fail with Syntax_Error if badly formed" group_builder expression_test=error_tester expression_test->
             expression_test "IIF [A] THEN 1 ELSE 2" Expression_Error.Syntax_Error
@@ -412,10 +412,10 @@ add_specs suite_builder detailed setup =
             c3 = t2.evaluate_expression "[Y] == 42.0" on_problems=Problem_Behavior.Report_Error
             c3.should_fail_with Floating_Point_Equality
 
-            t3 = t2.set 'if [Y] == 42.0 then "A" else "B"' as="Z" on_problems=Problem_Behavior.Report_Error
+            t3 = t2.set (expr 'if [Y] == 42.0 then "A" else "B"') as="Z" on_problems=Problem_Behavior.Report_Error
             t3.should_fail_with Floating_Point_Equality
 
-            t4 = t2.set 'if [Y] >= 42.0 then "A" else "B"' as="Z" on_problems=Problem_Behavior.Report_Error
+            t4 = t2.set (expr 'if [Y] >= 42.0 then "A" else "B"') as="Z" on_problems=Problem_Behavior.Report_Error
             t4.at "Z" . to_vector . should_equal ["B", "B", "A"]
             # Should still keep the inherited warning from "Y".
             Problems.expect_warning Arithmetic_Error t4
@@ -442,10 +442,10 @@ add_specs suite_builder detailed setup =
             # Should still keep the inherited warning from "Y".
             Problems.expect_warning Illegal_State c4
 
-            t3 = t2.set 'if [Y] == 42.0 then "A" else "B"' as="Z" on_problems=Problem_Behavior.Report_Error
+            t3 = t2.set (expr 'if [Y] == 42.0 then "A" else "B"') as="Z" on_problems=Problem_Behavior.Report_Error
             t3.should_fail_with Floating_Point_Equality
 
-            t4 = t2.set 'if [Y] >= 3.5 then "A" else "B"' as="Z" on_problems=Problem_Behavior.Report_Error
+            t4 = t2.set (expr 'if [Y] >= 3.5 then "A" else "B"') as="Z" on_problems=Problem_Behavior.Report_Error
             t4.at "Z" . to_vector . should_equal ["A", "A", "B"]
             # Should still keep the inherited warning from "Y".
             Problems.expect_warning Illegal_State t4

--- a/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Expression_Spec.enso
@@ -349,8 +349,8 @@ add_specs suite_builder detailed setup =
 
     suite_builder.group prefix+"Expression Errors should be handled" group_builder->
         error_tester expression fail_ctor =
-            test_table.set expression new_name="NEW_COL" . should_fail_with Expression_Error
-            test_table.set expression new_name="NEW_COL" . catch . should_be_a fail_ctor
+            test_table.set expression as="NEW_COL" . should_fail_with Expression_Error
+            test_table.set expression as="NEW_COL" . catch . should_be_a fail_ctor
 
         specify_test "should fail with Syntax_Error if badly formed" group_builder expression_test=error_tester expression_test->
             expression_test "IIF [A] THEN 1 ELSE 2" Expression_Error.Syntax_Error
@@ -401,7 +401,7 @@ add_specs suite_builder detailed setup =
             c1 = t1.evaluate_expression "3 / [X]" on_problems=Problem_Behavior.Report_Warning
             Problems.expect_warning Arithmetic_Error c1
 
-            t2 = t1.set c1 new_name="Y"
+            t2 = t1.set c1 as="Y"
             Problems.expect_warning Arithmetic_Error t2
             Problems.expect_warning Arithmetic_Error (t2.at "Y")
 
@@ -412,10 +412,10 @@ add_specs suite_builder detailed setup =
             c3 = t2.evaluate_expression "[Y] == 42.0" on_problems=Problem_Behavior.Report_Error
             c3.should_fail_with Floating_Point_Equality
 
-            t3 = t2.set 'if [Y] == 42.0 then "A" else "B"' new_name="Z" on_problems=Problem_Behavior.Report_Error
+            t3 = t2.set 'if [Y] == 42.0 then "A" else "B"' as="Z" on_problems=Problem_Behavior.Report_Error
             t3.should_fail_with Floating_Point_Equality
 
-            t4 = t2.set 'if [Y] >= 42.0 then "A" else "B"' new_name="Z" on_problems=Problem_Behavior.Report_Error
+            t4 = t2.set 'if [Y] >= 42.0 then "A" else "B"' as="Z" on_problems=Problem_Behavior.Report_Error
             t4.at "Z" . to_vector . should_equal ["B", "B", "A"]
             # Should still keep the inherited warning from "Y".
             Problems.expect_warning Arithmetic_Error t4
@@ -425,7 +425,7 @@ add_specs suite_builder detailed setup =
             c1 = Warning.attach (Illegal_State.Error "FOO") (t1.evaluate_expression "[X] + 3.0")
             Problems.expect_warning Illegal_State c1
 
-            t2 = t1.set c1 new_name="Y"
+            t2 = t1.set c1 as="Y"
             Problems.expect_warning Illegal_State t2
             Problems.expect_warning Illegal_State (t2.at "Y")
 
@@ -442,10 +442,10 @@ add_specs suite_builder detailed setup =
             # Should still keep the inherited warning from "Y".
             Problems.expect_warning Illegal_State c4
 
-            t3 = t2.set 'if [Y] == 42.0 then "A" else "B"' new_name="Z" on_problems=Problem_Behavior.Report_Error
+            t3 = t2.set 'if [Y] == 42.0 then "A" else "B"' as="Z" on_problems=Problem_Behavior.Report_Error
             t3.should_fail_with Floating_Point_Equality
 
-            t4 = t2.set 'if [Y] >= 3.5 then "A" else "B"' new_name="Z" on_problems=Problem_Behavior.Report_Error
+            t4 = t2.set 'if [Y] >= 3.5 then "A" else "B"' as="Z" on_problems=Problem_Behavior.Report_Error
             t4.at "Z" . to_vector . should_equal ["A", "A", "B"]
             # Should still keep the inherited warning from "Y".
             Problems.expect_warning Illegal_State t4

--- a/test/Table_Tests/src/Common_Table_Operations/Filter_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Filter_Spec.enso
@@ -463,7 +463,7 @@ add_specs suite_builder setup =
             Problems.assume_no_problems (t.filter "x" (Filter_Condition.Equal [Nothing, Nothing]))
             Problems.assume_no_problems (t.filter "x" (Filter_Condition.Is_In [[Nothing, Nothing]]))
 
-    suite_builder.group prefix+"Table.filter_by_expression" group_builder->
+    suite_builder.group prefix+"Table.filter by an expression" group_builder->
         data = Data.setup create_connection_fn
 
         group_builder.teardown <|
@@ -474,22 +474,22 @@ add_specs suite_builder setup =
 
         group_builder.specify "by a boolean column" <|
             t = table_builder [["ix", [1, 2, 3, 4, 5]], ["b", [True, False, Nothing, True, True]]]
-            t.filter_by_expression "[b]" . at "ix" . to_vector . should_equal [1, 4, 5]
-            t.filter_by_expression "![b]" . at "ix" . to_vector . should_equal [2]
+            t.filter (expr "[b]") . at "ix" . to_vector . should_equal [1, 4, 5]
+            t.filter (expr "![b]") . at "ix" . to_vector . should_equal [2]
 
         group_builder.specify "by an integer comparison" <|
             t = table_builder [["ix", [1, 2, 3, 4, 5]], ["b", [True, False, Nothing, True, True]]]
-            t.filter_by_expression "[ix]==3" . at "ix" . to_vector . should_equal [3]
-            t.filter_by_expression "[ix]>2" . at "ix" . to_vector . should_equal [3, 4, 5]
+            t.filter (expr "[ix]==3") . at "ix" . to_vector . should_equal [3]
+            t.filter (expr "[ix]>2") . at "ix" . to_vector . should_equal [3, 4, 5]
 
         group_builder.specify "fail gracefully" <|
             t = table_builder [["ix", [1, 2, 3, 4, 5]], ["b", [True, False, Nothing, True, True]]]
-            t.filter_by_expression "[ix" . should_fail_with Expression_Error
-            t.filter_by_expression "[ix" . catch . should_be_a Expression_Error.Syntax_Error
-            t.filter_by_expression "Starts_With([b])" . should_fail_with Expression_Error
-            t.filter_by_expression "Starts_With([b])" . catch . should_be_a Expression_Error.Argument_Mismatch
-            t.filter_by_expression "[missing]" . should_fail_with No_Such_Column
-            t.filter_by_expression "[ix]" . should_fail_with Invalid_Value_Type
+            t.filter (expr "[ix") . should_fail_with Expression_Error
+            t.filter (expr "[ix") . catch . should_be_a Expression_Error.Syntax_Error
+            t.filter (expr "Starts_With([b])") . should_fail_with Expression_Error
+            t.filter (expr "Starts_With([b])") . catch . should_be_a Expression_Error.Argument_Mismatch
+            t.filter (expr "[missing]") . should_fail_with No_Such_Column
+            t.filter (expr "[ix]") . should_fail_with Invalid_Value_Type
 
             ## This used to raise Expression_Error.Argument_Mismatch, but now we
                cannot detect that.
@@ -500,33 +500,33 @@ add_specs suite_builder setup =
                But it first runs the code of the function with as many arguments
                as it needed, thus if the function fails, its error overrides the
                arity error.
-            t.filter_by_expression "is_empty([b],False)" . should_fail_with Invalid_Value_Type
+            t.filter (expr "is_empty([b],False)") . should_fail_with Invalid_Value_Type
             # If we provide good type for the first argument, then the error will be again as expected.
-            t.filter_by_expression "is_empty('', 42)" . should_fail_with Expression_Error
-            t.filter_by_expression "is_empty('', 42)" . catch . should_be_a Expression_Error.Argument_Mismatch
+            t.filter (expr "is_empty('', 42)") . should_fail_with Expression_Error
+            t.filter (expr "is_empty('', 42)") . catch . should_be_a Expression_Error.Argument_Mismatch
 
         group_builder.specify "should report issues: floating point equality" <|
             t = table_builder [["ix", [1, 2, 3, 4, 5]], ["X", [10.0, 2.0001, 2.0, 4.5, -2.0]]]
-            r1 = t.filter_by_expression "[X] * [X] == 4.0" on_problems=Problem_Behavior.Ignore
+            r1 = t.filter (expr "[X] * [X] == 4.0") on_problems=Problem_Behavior.Ignore
             Problems.assume_no_problems r1
             r1.at "ix" . to_vector . should_equal [3, 5]
 
-            r2 = t.filter_by_expression "[X] * [X] == 4.0" on_problems=Problem_Behavior.Report_Warning
+            r2 = t.filter (expr "[X] * [X] == 4.0") on_problems=Problem_Behavior.Report_Warning
 
             r2.at "ix" . to_vector . should_equal [3, 5]
             Problems.expect_warning Floating_Point_Equality r2
 
-            r3 = t.filter_by_expression "[X] * [X] == 4.0" on_problems=Problem_Behavior.Report_Error
+            r3 = t.filter (expr "[X] * [X] == 4.0") on_problems=Problem_Behavior.Report_Error
             r3.should_fail_with Floating_Point_Equality
 
-            r4 = t.filter_by_expression "[X] * [X] != 4.0"
+            r4 = t.filter (expr "[X] * [X] != 4.0")
             r4.at "ix" . to_vector . should_equal [1, 2, 4]
             Problems.expect_warning Floating_Point_Equality r4
 
         db_pending = if setup.is_database then "Arithmetic error handling is currently not implemented for the Database backend."
         group_builder.specify "should report issues: arithmetic error" pending=db_pending <|
             t = table_builder [["ix", [1, 2, 3, 4, 5]], ["X", [2.0, 2.0, 0.0, 1.0, 2.0]]]
-            action = t.filter_by_expression "8.0 / [X] <= 4.0" on_problems=_
+            action = t.filter (expr "8.0 / [X] <= 4.0") on_problems=_
             tester table =
                 table . at "ix" . to_vector . should_equal [1, 2, 5]
             problems = [Arithmetic_Error.Error "Division by zero (at rows [2])."]

--- a/test/Table_Tests/src/Common_Table_Operations/Filter_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Filter_Spec.enso
@@ -413,7 +413,7 @@ add_specs suite_builder setup =
             c1 = Warning.attach (Illegal_State.Error "FOO") (t1.evaluate_expression "3.0 + [X]")
             Problems.expect_warning Illegal_State c1
 
-            t2 = t1.set c1 new_name="Y"
+            t2 = t1.set c1 as="Y"
             Problems.expect_warning Illegal_State t2
 
             r1 = t2.filter "Y" (Filter_Condition.Equal 5)

--- a/test/Table_Tests/src/Common_Table_Operations/Filter_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Filter_Spec.enso
@@ -489,7 +489,7 @@ add_specs suite_builder setup =
             t.filter (expr "Starts_With([b])") . should_fail_with Expression_Error
             t.filter (expr "Starts_With([b])") . catch . should_be_a Expression_Error.Argument_Mismatch
             t.filter (expr "[missing]") . should_fail_with No_Such_Column
-            t.filter (expr "[ix]") . should_fail_with Invalid_Value_Type
+            t.filter (expr "[ix]") Filter_Condition.Is_True . should_fail_with Invalid_Value_Type
 
             ## This used to raise Expression_Error.Argument_Mismatch, but now we
                cannot detect that.

--- a/test/Table_Tests/src/Common_Table_Operations/Filter_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Filter_Spec.enso
@@ -94,7 +94,7 @@ add_specs suite_builder setup =
             t.filter "Y" (Filter_Condition.Between (t.at "ix") 100 action=Filter_Action.Remove) . at "Y" . to_vector . should_equal [2, Nothing]
 
             t.filter "X" (Filter_Condition.Equal to=(Column_Ref.Name "Y")) . at "X" . to_vector . should_equal [100]
-            t.filter "X" (Filter_Condition.Equal to=(Column_Ref.Expression "[Y]-1")) . at "X" . to_vector . should_equal [3]
+            t.filter "X" (Filter_Condition.Equal to=(expr "[Y]-1")) . at "X" . to_vector . should_equal [3]
             t.filter "X" (Filter_Condition.Less than=(Column_Ref.Name "Y")) . at "X" . to_vector . should_equal [3]
             t.filter "X" (Filter_Condition.Equal_Or_Less than=(Column_Ref.Name "Y")) . at "X" . to_vector . should_equal [100, 3]
             t.filter "X" (Filter_Condition.Equal_Or_Greater than=(Column_Ref.Name "Y")) . at "X" . to_vector . should_equal [100, 12]
@@ -127,7 +127,7 @@ add_specs suite_builder setup =
             t3 . at "ix" . to_vector . should_equal [2, 4, 5]
             t.filter "X" (Filter_Condition.Not_Equal to=(t.at "Y")) . at "X" . to_vector . should_equal [3, 12]
             t.filter "X" (Filter_Condition.Not_Equal to=(Column_Ref.Name "Y")) . at "X" . to_vector . should_equal [3, 12]
-            t.filter "X" (Filter_Condition.Not_Equal to=(Column_Ref.Expression "[Y]")) . at "X" . to_vector . should_equal [3, 12]
+            t.filter "X" (Filter_Condition.Not_Equal to=(expr "[Y]")) . at "X" . to_vector . should_equal [3, 12]
 
         group_builder.specify "by text comparisons" <|
             t = table_builder [["ix", [1, 2, 3, 4, 5]], ["X", ["abb", "baca", "b", Nothing, "c"]], ["Y", ["a", "b", "b", "c", "c"]]]

--- a/test/Table_Tests/src/Common_Table_Operations/Join/Join_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Join/Join_Spec.enso
@@ -769,8 +769,8 @@ add_specs suite_builder setup =
         group_builder.specify "should work correctly when the join is performed on a transformed table" <|
             t1 = table_builder [["X", [1, 2, 3]]]
 
-            t1_2 = t1.set "10*[X]+1" as="A"
-            t1_3 = t1.set "[X]+20" as="B"
+            t1_2 = t1.set (expr "10*[X]+1") as="A"
+            t1_3 = t1.set (expr "[X]+20") as="B"
 
             t2 = t1_2.join t1_3 join_kind=Join_Kind.Inner on=(Join_Condition.Equals "A" "B")
             t2.at "A" . to_vector . should_equal [21]
@@ -781,7 +781,7 @@ add_specs suite_builder setup =
             t4 = table_builder [["X", [1, 2, 3]], ["Y", [10, 20, 30]]]
             t5 = table_builder [["X", [5, 7, 1]], ["Z", [100, 200, 300]]]
 
-            t4_2 = t4.set "2*[X]+1" as="C"
+            t4_2 = t4.set (expr "2*[X]+1") as="C"
             t6 = t4_2.join t5 on=(Join_Condition.Equals "C" "X") join_kind=Join_Kind.Inner
             expect_column_names ["X", "Y", "C", "Right X", "Z"] t6
             r2 = materialize t6 . order_by ["Y"] . rows . map .to_vector
@@ -805,7 +805,7 @@ add_specs suite_builder setup =
             t4 = table_builder [["X", [1, 2, 3]], ["Y", [10, 20, 30]]]
             t5 = table_builder [["X", [5, 7, 1]], ["Z", [100, 200, 300]]]
 
-            t4_2 = t4.set "2*[X]+1" as="C"
+            t4_2 = t4.set (expr "2*[X]+1") as="C"
             t6 = t4_2.join t5 on=(Join_Condition.Equals "C" "X") join_kind=Join_Kind.Full
             expect_column_names ["X", "Y", "C", "Right X", "Z"] t6
             r2 = materialize t6 . order_by ["Y"] . rows . map .to_vector

--- a/test/Table_Tests/src/Common_Table_Operations/Join/Join_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Join/Join_Spec.enso
@@ -769,8 +769,8 @@ add_specs suite_builder setup =
         group_builder.specify "should work correctly when the join is performed on a transformed table" <|
             t1 = table_builder [["X", [1, 2, 3]]]
 
-            t1_2 = t1.set "10*[X]+1" new_name="A"
-            t1_3 = t1.set "[X]+20" new_name="B"
+            t1_2 = t1.set "10*[X]+1" as="A"
+            t1_3 = t1.set "[X]+20" as="B"
 
             t2 = t1_2.join t1_3 join_kind=Join_Kind.Inner on=(Join_Condition.Equals "A" "B")
             t2.at "A" . to_vector . should_equal [21]
@@ -781,7 +781,7 @@ add_specs suite_builder setup =
             t4 = table_builder [["X", [1, 2, 3]], ["Y", [10, 20, 30]]]
             t5 = table_builder [["X", [5, 7, 1]], ["Z", [100, 200, 300]]]
 
-            t4_2 = t4.set "2*[X]+1" new_name="C"
+            t4_2 = t4.set "2*[X]+1" as="C"
             t6 = t4_2.join t5 on=(Join_Condition.Equals "C" "X") join_kind=Join_Kind.Inner
             expect_column_names ["X", "Y", "C", "Right X", "Z"] t6
             r2 = materialize t6 . order_by ["Y"] . rows . map .to_vector
@@ -805,7 +805,7 @@ add_specs suite_builder setup =
             t4 = table_builder [["X", [1, 2, 3]], ["Y", [10, 20, 30]]]
             t5 = table_builder [["X", [5, 7, 1]], ["Z", [100, 200, 300]]]
 
-            t4_2 = t4.set "2*[X]+1" new_name="C"
+            t4_2 = t4.set "2*[X]+1" as="C"
             t6 = t4_2.join t5 on=(Join_Condition.Equals "C" "X") join_kind=Join_Kind.Full
             expect_column_names ["X", "Y", "C", "Right X", "Z"] t6
             r2 = materialize t6 . order_by ["Y"] . rows . map .to_vector
@@ -816,7 +816,7 @@ add_specs suite_builder setup =
             r2.at 3 . should_equal [3, 30, 7, 7, 200]
 
             t4_3 = table_builder [["X", [Nothing, 2, 3]], ["Y", [10, 20, 30]]]
-            t4_4 = t4_3.set (t4_3.at "X" . fill_nothing 7) new_name="C"
+            t4_4 = t4_3.set (t4_3.at "X" . fill_nothing 7) as="C"
             t7 = t4_4.join t5 on=(Join_Condition.Equals "C" "X") join_kind=Join_Kind.Full
             within_table t7 <|
                 expect_column_names ["X", "Y", "C", "Right X", "Z"] t7

--- a/test/Table_Tests/src/Database/Codegen_Spec.enso
+++ b/test/Table_Tests/src/Database/Codegen_Spec.enso
@@ -72,7 +72,7 @@ add_specs suite_builder =
             foo = data.t1.at "A" . rename "FOO"
             foo.to_sql.prepare . should_equal ['SELECT "T1"."A" AS "FOO" FROM "T1" AS "T1"', []]
 
-            t3 = t2.set foo new_name="bar"
+            t3 = t2.set foo as="bar"
             t3.to_sql.prepare . should_equal ['SELECT "T1"."C" AS "C", "T1"."B" AS "B", "T1"."A" AS "bar" FROM "T1" AS "T1"', []]
 
         group_builder.specify "should fail if at is called for a non-existent column" <|

--- a/test/Table_Tests/src/Database/Common/Default_Ordering_Spec.enso
+++ b/test/Table_Tests/src/Database/Common/Default_Ordering_Spec.enso
@@ -61,7 +61,7 @@ add_specs (suite_builder : Suite_Builder) (prefix : Text) (create_connection_fn 
             v1.first.expression.name . should_equal "X"
             v1.first.direction . should_equal Sort_Direction.Ascending
 
-            t2 = data.db_table_with_key.set "10 - [X]" "X"
+            t2 = data.db_table_with_key.set (expr "10 - [X]") "X"
             v2 = t2.default_ordering
             v2.length . should_equal 1
             v2.first.expression.name . should_equal "X"

--- a/test/Table_Tests/src/Database/Common/Default_Ordering_Spec.enso
+++ b/test/Table_Tests/src/Database/Common/Default_Ordering_Spec.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 from Standard.Base.Runtime import assert
 
-from Standard.Table import Table, Sort_Column, Aggregate_Column
+from Standard.Table import Table, Sort_Column, Aggregate_Column, expr
 from Standard.Table.Errors import all
 
 from Standard.Database import all

--- a/test/Table_Tests/src/Database/Common/Names_Length_Limits_Spec.enso
+++ b/test/Table_Tests/src/Database/Common/Names_Length_Limits_Spec.enso
@@ -1,6 +1,6 @@
 from Standard.Base import all
 
-from Standard.Table import Table, Join_Kind, Aggregate_Column, Value_Type
+from Standard.Table import Table, Join_Kind, Aggregate_Column, Value_Type, expr
 from Standard.Table.Errors import No_Such_Column, Name_Too_Long, Truncated_Column_Names, Duplicate_Output_Column_Names
 
 from Standard.Database import all

--- a/test/Table_Tests/src/Database/Common/Names_Length_Limits_Spec.enso
+++ b/test/Table_Tests/src/Database/Common/Names_Length_Limits_Spec.enso
@@ -273,8 +273,8 @@ add_specs suite_builder prefix create_connection_func =
                 name_b = "x" * (max_column_name_length + 1) + "B"
                 db_table.rename_columns [["X", name_a], ["Y", name_b]] . should_fail_with Name_Too_Long
 
-                Problems.assume_no_problems <| db_table.set "[X] + [Y] * 10" "Z"
-                db_table.set "[X] + [Y] * 10" long_name . should_fail_with Name_Too_Long
+                Problems.assume_no_problems <| db_table.set (expr "[X] + [Y] * 10") "Z"
+                db_table.set (expr "[X] + [Y] * 10") long_name . should_fail_with Name_Too_Long
 
             group_builder.specify "should prevent upload if column names are too long" <|
                 name_a = "a" * (max_column_name_length + 1)

--- a/test/Table_Tests/src/Database/Common/Names_Length_Limits_Spec.enso
+++ b/test/Table_Tests/src/Database/Common/Names_Length_Limits_Spec.enso
@@ -470,7 +470,7 @@ add_specs suite_builder prefix create_connection_func =
                 db_table = src.select_into_database_table data.connection (Name_Generator.random_name "cross-tab") temporary=True primary_key=[]
 
                 Test.with_clue "cross_tab test will have to be amended once it is implemented: " <|
-                    db_table.cross_tab group_by=[] name_column="X" . should_fail_with Unsupported_Database_Operation
+                    db_table.cross_tab group_by=[] names="X" . should_fail_with Unsupported_Database_Operation
 
                 Test.with_clue "transpose test will have to be amended once it is implemented: " <|
                     db_table.transpose attribute_column_name=name_a . should_fail_with Unsupported_Database_Operation

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -4,7 +4,7 @@ import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Runtime.Ref.Ref
 
 import Standard.Table.Data.Type.Value_Type.Bits
-from Standard.Table import Table, Value_Type, Aggregate_Column
+from Standard.Table import Table, Value_Type, Aggregate_Column, expr
 from Standard.Table.Errors import Invalid_Column_Names, Inexact_Type_Coercion, Duplicate_Output_Column_Names
 
 import Standard.Database.Data.DB_Column.DB_Column

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -393,7 +393,7 @@ postgres_specific_spec suite_builder create_connection_fn db_name setup =
             v1x.should_equal [10, x]
             v1x.each e-> Test.with_clue "("+e.to_text+"): " <| e.should_be_a Integer
 
-            t2 = t1.set "[X] + 10" "Y"
+            t2 = t1.set (expr "[X] + 10") "Y"
             t2.at "X" . value_type . should_be_a (Value_Type.Decimal ...)
             t2.at "Y" . value_type . should_be_a (Value_Type.Decimal ...)
             # Unfortunately, performing operations on a Decimal column in postgres can lose information about it being an integer column.

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -921,7 +921,7 @@ test_table_append group_builder (data : Data) source_table_builder target_table_
         dest = target_table_builder [["X", [1, 2, 3]], ["Y", ['a', 'b', 'c']]] primary_key=["X"] connection=data.connection
         t1 = source_table_builder [["Z", [10, 20]], ["Y", ['D', 'E']]] connection=data.connection
         t2 = source_table_builder [["Z", [20, 10]], ["X", [-99, 10]]] connection=data.connection
-        src = t1.join t2 on=["Z"] join_kind=Join_Kind.Inner . remove_columns "Z" . set (expr "[X] + 100" "X")
+        src = t1.join t2 on=["Z"] join_kind=Join_Kind.Inner . remove_columns "Z" . set (expr "[X] + 100") "X"
         src.at "X" . to_vector . should_contain_the_same_elements_as [1, 110]
 
         r1 = dest.update_rows src key_columns=["X"]

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -488,8 +488,8 @@ add_specs suite_builder make_new_connection prefix persistent_connector=True =
 
             db_table_1 = t1.select_into_database_table data.connection (Name_Generator.random_name "source-table-1") temporary=True primary_key=Nothing
 
-            db_table_2 = db_table_1.set (expr "[Y] + 100 * [X]") "C1" . set '"constant_text"' "C2"
-            db_table_3 = db_table_1.aggregate ["X"] [Aggregate_Column.Sum "[Y]*[Y]" "C3"] . set "[X] + 1" "X"
+            db_table_2 = db_table_1.set (expr "[Y] + 100 * [X]") "C1" . set "constant_text" "C2"
+            db_table_3 = db_table_1.aggregate ["X"] [Aggregate_Column.Sum (expr "[Y]*[Y]") "C3"] . set (expr "[X] + 1") "X"
 
             db_table_4 = db_table_2.join db_table_3 join_kind=Join_Kind.Left_Outer
             db_table_4.is_trivial_query . should_fail_with Table_Not_Found
@@ -921,7 +921,7 @@ test_table_append group_builder (data : Data) source_table_builder target_table_
         dest = target_table_builder [["X", [1, 2, 3]], ["Y", ['a', 'b', 'c']]] primary_key=["X"] connection=data.connection
         t1 = source_table_builder [["Z", [10, 20]], ["Y", ['D', 'E']]] connection=data.connection
         t2 = source_table_builder [["Z", [20, 10]], ["X", [-99, 10]]] connection=data.connection
-        src = t1.join t2 on=["Z"] join_kind=Join_Kind.Inner . remove_columns "Z" . set "[X] + 100" "X"
+        src = t1.join t2 on=["Z"] join_kind=Join_Kind.Inner . remove_columns "Z" . set (expr "[X] + 100" "X")
         src.at "X" . to_vector . should_contain_the_same_elements_as [1, 110]
 
         r1 = dest.update_rows src key_columns=["X"]

--- a/test/Table_Tests/src/Database/Upload_Spec.enso
+++ b/test/Table_Tests/src/Database/Upload_Spec.enso
@@ -488,7 +488,7 @@ add_specs suite_builder make_new_connection prefix persistent_connector=True =
 
             db_table_1 = t1.select_into_database_table data.connection (Name_Generator.random_name "source-table-1") temporary=True primary_key=Nothing
 
-            db_table_2 = db_table_1.set "[Y] + 100 * [X]" "C1" . set '"constant_text"' "C2"
+            db_table_2 = db_table_1.set (expr "[Y] + 100 * [X]") "C1" . set '"constant_text"' "C2"
             db_table_3 = db_table_1.aggregate ["X"] [Aggregate_Column.Sum "[Y]*[Y]" "C3"] . set "[X] + 1" "X"
 
             db_table_4 = db_table_2.join db_table_3 join_kind=Join_Kind.Left_Outer
@@ -514,7 +514,7 @@ add_specs suite_builder make_new_connection prefix persistent_connector=True =
             tmp_connection = make_new_connection Nothing
             t = Table.new [["X", [1, 2, 3]], ["Y", [4, 5, 6]]]
             db_table = t.select_into_database_table tmp_connection (Name_Generator.random_name "source-table") temporary=True
-            db_table_2 = db_table.set "[X] + 100 * [Y]" "computed"
+            db_table_2 = db_table.set (expr "[X] + 100 * [Y]") "computed"
 
             copied_table = db_table_2.select_into_database_table tmp_connection (Name_Generator.random_name "copied-table") temporary=True
             name = copied_table.name

--- a/test/Table_Tests/src/In_Memory/Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Spec.enso
@@ -877,7 +877,7 @@ add_specs suite_builder =
                             Test.with_clue "("+column_vector.to_text+" Is_In "+in_vector.to_text+"): " <|
                                 t.filter "X" (Filter_Condition.Is_In in_vector) . at "X" . to_vector . should_equal expected_vector
                                 t.filter "X" (Filter_Condition.Is_In in_column) . at "X" . to_vector . should_equal expected_vector
-                                t2 = t.set (t.at "X" . not) new_name="Y"
+                                t2 = t.set (t.at "X" . not) as="Y"
                                 t2.filter "Y" (Filter_Condition.Is_In in_vector) . at "Y" . to_vector . should_equal expected_neg_vector
                                 t2.filter "Y" (Filter_Condition.Is_In in_column) . at "Y" . to_vector . should_equal expected_neg_vector
 

--- a/test/Visualization_Tests/src/Widgets/Database_Widgets_Spec.enso
+++ b/test/Visualization_Tests/src/Widgets/Database_Widgets_Spec.enso
@@ -42,7 +42,7 @@ add_specs suite_builder =
             Widgets.get_widget_json mock_table .at ["selector"] . should_equal expect
 
         group_builder.specify "works for `filter`" <|
-            choices = mock_table.column_names . map n-> Choice.Option n n.pretty
+            choices = [Choice.Option "<Expression>" "(expr '[A]')"] + mock_table.column_names . map n-> Choice.Option n n.pretty
             expect = [["column", Widget.Single_Choice choices Nothing Display.Always]] . to_json
             Widgets.get_widget_json mock_table .filter ["column"] . should_equal expect
 

--- a/test/Visualization_Tests/src/Widgets/Table_Widgets_Spec.enso
+++ b/test/Visualization_Tests/src/Widgets/Table_Widgets_Spec.enso
@@ -22,7 +22,7 @@ add_specs suite_builder =
             Widgets.get_widget_json mock_table .at ["selector"] . should_equal expect
 
         group_builder.specify "works for `filter`" <|
-            choices = mock_table.column_names . map n-> Choice.Option n n.pretty
+            choices = [Choice.Option "<Expression>" "(expr '[A]')"] + mock_table.column_names . map n-> Choice.Option n n.pretty
             expect = [["column", Widget.Single_Choice choices Nothing Display.Always]] . to_json
             Widgets.get_widget_json mock_table .filter ["column"] . should_equal expect
 


### PR DESCRIPTION
### Pull Request Description

- Added `regex` function to `Standard.Base` as a way to easily and cleanly make regular expressions.
- Added `expr` and `Expression.Value` to distinguish expressions from text values.
- Fixed issues with `Table.join` widget so dropdown exists.
  - Needed fully qualified name.
  - Added default empty text values for right column to provided text input boxes.
- Deprecate `Table.filter_by_expression` and allow `Table.filter` to take an `Expression`.
- Added `Simple_Expression` and deprecated `Column_Operation`. Changes the order so takes a column then a calculation.
- Rename `column` to `value` and `new_name` to `as` on `Table.set`.
- Rename `name_column` to `names` on `Table.cross_tab`.
- Removed `Column_Ref.Expression` in favour of using `Expression.Value`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
