### PR TITLE
Fix node edits

### DIFF
--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -420,10 +420,10 @@ function openFullMenu() {
     <div
       ref="contentNode"
       class="node"
-      v-on="dragPointer.events"
       @click.stop
-      @pointerdown.stop
+      @pointerdown.stop="handleNodeClick"
       @pointerup.stop
+      v-on="dragPointer.events"
     >
       <NodeWidgetTree
         :ast="displayedExpression"


### PR DESCRIPTION
### Pull Request Description

After #9127, Mod+Click on a node doesn't begin editing the node's code. This is a quick fix to re-enable node code edits.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
