### PR TITLE
Fix escaping `\`

### DIFF
--- a/app/gui2/src/util/ast/__tests__/abstract.test.ts
+++ b/app/gui2/src/util/ast/__tests__/abstract.test.ts
@@ -508,23 +508,6 @@ test('Construct app', () => {
   expect(namedApp.code()).toBe('func name=arg')
 })
 
-test.each([
-  ['Hello, World!', 'Hello, World!'],
-  ['Hello\t\tWorld!', 'Hello\\t\\tWorld!'],
-  ['He\nllo, W\rorld!', 'He\\nllo, W\\rorld!'],
-  ['Hello,\vWorld!', 'Hello,\\vWorld!'],
-  ['Hello, \\World!', 'Hello, \\World!'],
-  ['Hello, `World!`', 'Hello, ``World!``'],
-  ["'Hello, World!'", "\\'Hello, World!\\'"],
-  ['"Hello, World!"', '\\"Hello, World!\\"'],
-  ['Hello, \fWorld!', 'Hello, \\fWorld!'],
-  ['Hello, \bWorld!', 'Hello, \\bWorld!'],
-])('Text literals escaping and unescaping', (original, expectedEscaped) => {
-  const escaped = escape(original)
-  expect(escaped).toBe(expectedEscaped)
-  expect(unescape(escaped)).toBe(original)
-})
-
 test('Automatic parenthesis', () => {
   const block = Ast.parseBlock('main = func arg1 arg2')
   let arg1: Ast.MutableAst | undefined

--- a/app/gui2/src/util/ast/__tests__/text.ts
+++ b/app/gui2/src/util/ast/__tests__/text.ts
@@ -1,4 +1,5 @@
 import * as astText from '@/util/ast/text'
+import { unescape } from 'querystring'
 import { expect, test } from 'vitest'
 
 test.each([
@@ -6,5 +7,7 @@ test.each([
   { string: '\t\r\n\v"\'`', escaped: '\\t\\r\\n\\v\\"\\\'``' },
   { string: '`foo` `bar` `baz`', escaped: '``foo`` ``bar`` ``baz``' },
 ])('`escape`', ({ string, escaped }) => {
-  expect(astText.escape(string)).toBe(escaped)
+  const result = astText.escape(string)
+  expect(result).toBe(escaped)
+  expect(unescape(escaped)).toBe(string)
 })

--- a/app/gui2/src/util/ast/text.ts
+++ b/app/gui2/src/util/ast/text.ts
@@ -7,6 +7,7 @@ const mapping: Record<string, string> = {
   '\r': '\\r',
   '\t': '\\t',
   '\v': '\\v',
+  '\\': '\\\\',
   '"': '\\"',
   "'": "\\'",
   '`': '``',
@@ -17,10 +18,10 @@ const reverseMapping = swapKeysAndValues(mapping)
 /** Escape a string so it can be safely spliced into an interpolated (`''`) Enso string.
  * NOT USABLE to insert into raw strings. Does not include quotes. */
 export function escape(string: string) {
-  return string.replace(/[\0\b\f\n\r\t\v"'`]/g, (match) => mapping[match]!)
+  return string.replace(/[\0\b\f\n\r\t\v\\"'`]/g, (match) => mapping[match]!)
 }
 
 /** The reverse of `escape`: transform the string into human-readable form, not suitable for interpolation. */
 export function unescape(string: string) {
-  return string.replace(/\\[0bfnrtv"']|``/g, (match) => reverseMapping[match]!)
+  return string.replace(/\\[0bfnrtv\\"']|``/g, (match) => reverseMapping[match]!)
 }


### PR DESCRIPTION
### Pull Request Description

Fixes #9151

In one of my previous PRs I merged two `escape` implementations having exactly the same documentation. However, one of it missed escaping `\` character.

### Important Notes

One test even expected that `\` are _not_ escaped, but I doubt it should, given the above bug report? 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
