### PR TITLE
Make `alt` key keep dropdown open

### DIFF
--- a/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
@@ -124,9 +124,9 @@ function toggleDropdownWidget() {
   showDropdownWidget.value = !showDropdownWidget.value
 }
 
-function onClick(index: number) {
+function onClick(index: number, keepOpen: boolean) {
   selectedIndex.value = index
-  showDropdownWidget.value = false
+  showDropdownWidget.value = keepOpen
 }
 
 // When the selected index changes, we update the expression content.
@@ -181,7 +181,7 @@ export const widgetDefinition = defineWidget(WidgetInput.isAstOrPlaceholder, {
       :color="'var(--node-color-primary)'"
       :values="tagLabels"
       :selectedValue="selectedLabel"
-      @click="onClick($event)"
+      @click="onClick"
     />
   </div>
 </template>

--- a/app/gui2/src/components/widgets/DropdownWidget.vue
+++ b/app/gui2/src/components/widgets/DropdownWidget.vue
@@ -10,7 +10,7 @@ enum SortDirection {
 }
 
 const props = defineProps<{ color: string; selectedValue: string | undefined; values: string[] }>()
-const emit = defineEmits<{ click: [index: number] }>()
+const emit = defineEmits<{ click: [index: number, keepOpen: boolean] }>()
 
 const sortDirection = ref<SortDirection>(SortDirection.none)
 
@@ -51,11 +51,11 @@ const NEXT_SORT_DIRECTION: Record<SortDirection, SortDirection> = {
     <ul class="list" :style="{ background: color }" @wheel.stop>
       <template v-for="[value, index] in sortedValuesAndIndices" :key="value">
         <li v-if="value === selectedValue">
-          <div class="selected-item button" @click.stop="emit('click', index)">
+          <div class="selected-item button" @click.stop="emit('click', index, $event.altKey)">
             <span v-text="value"></span>
           </div>
         </li>
-        <li v-else class="selectable-item button" @click.stop="emit('click', index)">
+        <li v-else class="selectable-item button" @click.stop="emit('click', index, $event.altKey)">
           <span v-text="value"></span>
         </li>
       </template>


### PR DESCRIPTION
### Pull Request Description
- Fix #9083

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
