### PR TITLE
Fix Component Browser aliases

### DIFF
--- a/app/gui2/src/components/ComponentBrowser/filtering.ts
+++ b/app/gui2/src/components/ComponentBrowser/filtering.ts
@@ -98,7 +98,7 @@ class FilteringWithPattern {
 
   private firstMatchingAlias(entry: SuggestionEntry) {
     for (const alias of entry.aliases) {
-      const match = this.wordMatchRegex.exec(alias) ?? this.initialsMatchRegex?.exec(alias)
+      const match = this.wordMatchRegex.exec(alias)
       if (match != null) return { alias, match }
     }
     return null

--- a/app/gui2/src/components/ComponentBrowser/filtering.ts
+++ b/app/gui2/src/components/ComponentBrowser/filtering.ts
@@ -59,7 +59,9 @@ class FilteringWithPattern {
     // - The unmatched rest of the word, up to, but excluding, the next underscore
     // - The unmatched words before the next matched word, including any underscores
     this.wordMatchRegex = new RegExp(
-      '(^|.*?_)(' + escapeStringRegexp(pattern).replace(/_/g, ')([^_]*)(.*?)(_') + ')([^_]*)(.*)',
+      '(^|.*?_)(' +
+        escapeStringRegexp(pattern).replace(/_/g, ')([^_]*)(.*?)([_ ]') +
+        ')([^_]*)(.*)',
       'i',
     )
     if (pattern.length > 1 && !/_/.test(pattern)) {
@@ -72,7 +74,7 @@ class FilteringWithPattern {
       const regex = pattern
         .split('')
         .map((c) => `(${c})`)
-        .join('([^_]*?_)')
+        .join('([^_]*?[_ ])')
       this.initialsMatchRegex = new RegExp('(^|.*?_)' + regex + '(.*)', 'i')
     }
   }
@@ -96,7 +98,7 @@ class FilteringWithPattern {
 
   private firstMatchingAlias(entry: SuggestionEntry) {
     for (const alias of entry.aliases) {
-      const match = this.wordMatchRegex.exec(alias)
+      const match = this.wordMatchRegex.exec(alias) ?? this.initialsMatchRegex?.exec(alias)
       if (match != null) return { alias, match }
     }
     return null

--- a/app/gui2/src/components/ComponentBrowser/filtering.ts
+++ b/app/gui2/src/components/ComponentBrowser/filtering.ts
@@ -99,10 +99,7 @@ class FilteringWithPattern {
   private firstMatchingAlias(entry: SuggestionEntry) {
     for (const alias of entry.aliases) {
       const match = this.wordMatchRegex.exec(alias) ?? this.initialsMatchRegex?.exec(alias)
-      if (match != null) {
-        console.log(entry.aliases, alias)
-        return { alias, match }
-      }
+      if (match != null) return { alias, match }
     }
     return null
   }

--- a/app/gui2/src/components/ComponentBrowser/filtering.ts
+++ b/app/gui2/src/components/ComponentBrowser/filtering.ts
@@ -99,7 +99,10 @@ class FilteringWithPattern {
   private firstMatchingAlias(entry: SuggestionEntry) {
     for (const alias of entry.aliases) {
       const match = this.wordMatchRegex.exec(alias) ?? this.initialsMatchRegex?.exec(alias)
-      if (match != null) return { alias, match }
+      if (match != null) {
+        console.log(entry.aliases, alias)
+        return { alias, match }
+      }
     }
     return null
   }

--- a/app/gui2/src/stores/suggestionDatabase/documentation.ts
+++ b/app/gui2/src/stores/suggestionDatabase/documentation.ts
@@ -57,7 +57,10 @@ export function documentationData(
     documentation: parsed,
     ...(iconName != null ? { iconName } : {}),
     ...(groupIndex != null ? { groupIndex } : {}),
-    aliases: tagValue(parsed, 'Alias')?.split(',') ?? [],
+    aliases:
+      tagValue(parsed, 'Alias')
+        ?.trim()
+        .split(/\s*,\s*/g) ?? [],
     isPrivate: isSome(tagValue(parsed, 'Private')),
     isUnstable: isSome(tagValue(parsed, 'Unstable')) || isSome(tagValue(parsed, 'Advanced')),
   }


### PR DESCRIPTION
### Pull Request Description
- Fix #9107
  - Allow matching initials of aliases
  - Allow matching spaces instead of underscores (aliases use spaces, not underscores)
  - Fix only the first alias being detected. This is due to incorrect docs parsing keeping the leading space - `foo, bar` turns into `["foo", " bar"]`

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
