### PR TITLE
Render quote characters outside of the text pills

### DIFF
--- a/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
@@ -37,7 +37,7 @@ export const widgetDefinition = defineWidget(WidgetInput.isAstOrPlaceholder, {
 
 <template>
   <!-- See comment in GraphNode next to dragPointer definition about stopping pointerdown -->
-  <EnsoTextInputWidget v-model="value" class="WidgetText r-24" @pointerdown.stop />
+  '<EnsoTextInputWidget v-model="value" class="WidgetText r-24" @pointerdown.stop />'
 </template>
 
 <style scoped>


### PR DESCRIPTION
### Pull Request Description
- Close #9161
  - UI is tentative - but I think white instead of faded makes sense here, otherwise the quotes will be too hard to see

### Important Notes
None

### Screenshots
![image](https://github.com/enso-org/enso/assets/4046547/ac501be1-dd74-4901-8176-7d980cfe6686)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
