### PR TITLE
Allow setting CB viz type; determine default from suggestion type info.

### DIFF
--- a/app/gui2/e2e/componentBrowser.spec.ts
+++ b/app/gui2/e2e/componentBrowser.spec.ts
@@ -182,3 +182,43 @@ test('Editing existing nodes', async ({ page }) => {
   await expect(node.locator('.WidgetToken')).toHaveText(['Data', '.', 'read'])
   await expect(node.locator('.WidgetText')).not.toBeVisible()
 })
+
+test('Visualization preview: type-based visualization selection', async ({ page }) => {
+  await actions.goToGraph(page)
+  const nodeCount = await locate.graphNode(page).count()
+  await locate.addNewNodeButton(page).click()
+  await customExpect.toExist(locate.componentBrowser(page))
+  await customExpect.toExist(locate.componentBrowserEntry(page))
+  const input = locate.componentBrowserInput(page).locator('input')
+  await input.fill('4')
+  await expect(input).toHaveValue('4')
+  await customExpect.toExist(locate.jsonVisualization(page))
+  await input.fill('Table.ne')
+  await expect(input).toHaveValue('Table.ne')
+  // The table visualization is not currently working with `executeExpression` (#9194), but we can test that the JSON
+  // visualization is no longer selected.
+  await expect(locate.jsonVisualization(page)).not.toBeVisible()
+  await page.keyboard.press('Escape')
+  await expect(locate.componentBrowser(page)).not.toBeVisible()
+  await expect(locate.graphNode(page)).toHaveCount(nodeCount)
+})
+
+test('Visualization preview: user visualization selection', async ({ page }) => {
+  await actions.goToGraph(page)
+  const nodeCount = await locate.graphNode(page).count()
+  await locate.addNewNodeButton(page).click()
+  await customExpect.toExist(locate.componentBrowser(page))
+  await customExpect.toExist(locate.componentBrowserEntry(page))
+  const input = locate.componentBrowserInput(page).locator('input')
+  await input.fill('4')
+  await expect(input).toHaveValue('4')
+  await customExpect.toExist(locate.jsonVisualization(page))
+  await locate.showVisualizationSelectorButton(page).click()
+  await page.getByRole('button', { name: 'Table' }).click()
+  // The table visualization is not currently working with `executeExpression` (#9194), but we can test that the JSON
+  // visualization is no longer selected.
+  await expect(locate.jsonVisualization(page)).not.toBeVisible()
+  await page.keyboard.press('Escape')
+  await expect(locate.componentBrowser(page)).not.toBeVisible()
+  await expect(locate.graphNode(page)).toHaveCount(nodeCount)
+})

--- a/app/gui2/shared/ast/index.ts
+++ b/app/gui2/shared/ast/index.ts
@@ -69,11 +69,16 @@ export function subtreeRoots(module: Module, ids: Set<AstId>): Set<AstId> {
   return roots
 }
 
-function unwrapGroup(ast: Ast) {
+function unwrapGroups(ast: Ast) {
   while (ast instanceof Group && ast.expression) ast = ast.expression
   return ast
 }
 
+/** Tries to recognize inputs that are semantically-equivalent to a sequence of `App`s, and returns the arguments
+ *  identified and LHS of the analyzable chain.
+ *
+ *  In particular, this function currently recognizes syntax used in visualization-preprocessor expressions.
+ */
 export function analyzeAppLike(ast: Ast): { func: Ast; args: Ast[] } {
   const deferredOperands = new Array<Ast>()
   while (
@@ -83,14 +88,14 @@ export function analyzeAppLike(ast: Ast): { func: Ast; args: Ast[] } {
     ast.lhs &&
     ast.rhs
   ) {
-    deferredOperands.push(unwrapGroup(ast.rhs))
-    ast = unwrapGroup(ast.lhs)
+    deferredOperands.push(unwrapGroups(ast.rhs))
+    ast = unwrapGroups(ast.lhs)
   }
   deferredOperands.reverse()
   const args = new Array<Ast>()
   while (ast instanceof App) {
     const deferredOperand = ast.argument instanceof Wildcard ? deferredOperands.pop() : undefined
-    args.push(deferredOperand ?? unwrapGroup(ast.argument))
+    args.push(deferredOperand ?? unwrapGroups(ast.argument))
     ast = ast.function
   }
   args.reverse()

--- a/app/gui2/shared/ast/tree.ts
+++ b/app/gui2/shared/ast/tree.ts
@@ -531,6 +531,13 @@ export class App extends Ast {
     )
   }
 
+  static PositionalSequence(func: Owned, args: Owned[]): Owned {
+    return args.reduce(
+      (expression, argument) => App.new(func.module, expression, undefined, argument),
+      func,
+    )
+  }
+
   get function(): Ast {
     return this.module.get(this.fields.get('function').node)
   }
@@ -763,10 +770,12 @@ export class OprApp extends Ast {
   static new(
     module: MutableModule,
     lhs: Owned | undefined,
-    operator: Token,
+    operator: Token | string,
     rhs: Owned | undefined,
   ) {
-    return OprApp.concrete(module, unspaced(lhs), [autospaced(operator)], autospaced(rhs))
+    const operatorToken =
+      operator instanceof Token ? operator : Token.new(operator, RawAst.Token.Type.Operator)
+    return OprApp.concrete(module, unspaced(lhs), [autospaced(operatorToken)], autospaced(rhs))
   }
 
   get lhs(): Ast | undefined {

--- a/app/gui2/src/components/GraphEditor/GraphVisualization.vue
+++ b/app/gui2/src/components/GraphEditor/GraphVisualization.vue
@@ -2,7 +2,6 @@
 import LoadingErrorVisualization from '@/components/visualizations/LoadingErrorVisualization.vue'
 import LoadingVisualization from '@/components/visualizations/LoadingVisualization.vue'
 import { provideVisualizationConfig } from '@/providers/visualizationConfig'
-import { useGraphStore } from '@/stores/graph'
 import { useProjectStore, type NodeVisualizationConfiguration } from '@/stores/project'
 import {
   DEFAULT_VISUALIZATION_CONFIGURATION,
@@ -11,6 +10,7 @@ import {
   type VisualizationDataSource,
 } from '@/stores/visualization'
 import type { Visualization } from '@/stores/visualization/runtimeTypes'
+import { Ast } from '@/util/ast'
 import { toError } from '@/util/data/error'
 import type { Opt } from '@/util/data/opt'
 import { Rect } from '@/util/data/rect'
@@ -19,6 +19,7 @@ import type { URLString } from '@/util/data/urlString'
 import { Vec2 } from '@/util/data/vec2'
 import type { Icon } from '@/util/iconName'
 import { computedAsync } from '@vueuse/core'
+import { isIdentifier } from 'shared/ast'
 import type { VisualizationIdentifier } from 'shared/yjsModel'
 import {
   computed,
@@ -34,6 +35,9 @@ import {
 const TOP_WITHOUT_TOOLBAR_PX = 36
 const TOP_WITH_TOOLBAR_PX = 72
 
+// Used for testing.
+type RawDataSource = { type: 'raw'; data: any }
+
 const props = defineProps<{
   currentType?: Opt<VisualizationIdentifier>
   isCircularMenuVisible: boolean
@@ -41,8 +45,7 @@ const props = defineProps<{
   nodeSize: Vec2
   scale: number
   typename?: string | undefined
-  dataSource?: VisualizationDataSource | undefined
-  data?: any | undefined
+  dataSource: VisualizationDataSource | RawDataSource | undefined
 }>()
 const emit = defineEmits<{
   'update:rect': [rect: Rect | undefined]
@@ -54,15 +57,7 @@ const visPreprocessor = ref(DEFAULT_VISUALIZATION_CONFIGURATION)
 const vueError = ref<Error>()
 
 const projectStore = useProjectStore()
-const graphStore = useGraphStore()
 const visualizationStore = useVisualizationStore()
-
-const expressionInfo = computed(() =>
-  props.dataSource?.type === 'node'
-    ? graphStore.db.getExpressionInfo(props.dataSource.nodeId)
-    : undefined,
-)
-const typeName = computed(() => expressionInfo.value?.typename ?? 'Any')
 
 const configForGettingDefaultVisualization = computed<NodeVisualizationConfiguration | undefined>(
   () => {
@@ -80,22 +75,25 @@ const defaultVisualizationRaw = projectStore.useVisualizationData(
   configForGettingDefaultVisualization,
 ) as ShallowRef<Result<{ library: { name: string } | null; name: string } | undefined>>
 
-const defaultVisualization = computed<VisualizationIdentifier | undefined>(() => {
-  const raw = defaultVisualizationRaw.value
-  if (!raw?.ok || !raw.value) return
-  return {
-    name: raw.value.name,
-    module:
-      raw.value.library == null
-        ? { kind: 'Builtin' }
-        : { kind: 'Library', name: raw.value.library.name },
-  }
-})
+const defaultVisualizationForCurrentNodeSource = computed<VisualizationIdentifier | undefined>(
+  () => {
+    const raw = defaultVisualizationRaw.value
+    if (!raw?.ok || !raw.value) return
+    return {
+      name: raw.value.name,
+      module:
+        raw.value.library == null
+          ? { kind: 'Builtin' }
+          : { kind: 'Library', name: raw.value.library.name },
+    }
+  },
+)
 
 const currentType = computed(() => {
   if (props.currentType) return props.currentType
-  if (defaultVisualization.value) return defaultVisualization.value
-  const [id] = visualizationStore.types(typeName.value)
+  if (defaultVisualizationForCurrentNodeSource.value)
+    return defaultVisualizationForCurrentNodeSource.value
+  const [id] = visualizationStore.types(props.typename)
   return id
 })
 
@@ -107,36 +105,49 @@ onErrorCaptured((error) => {
   return false
 })
 
-const visualizationData = projectStore.useVisualizationData(() => {
-  return props.data == null && props.dataSource?.type === 'node'
-    ? {
-        ...visPreprocessor.value,
-        expressionId: props.dataSource.nodeId,
-      }
-    : null
+const nodeVisualizationData = projectStore.useVisualizationData(() => {
+  if (props.dataSource?.type !== 'node') return
+  return {
+    ...visPreprocessor.value,
+    expressionId: props.dataSource.nodeId,
+  }
 })
 
 const expressionVisualizationData = computedAsync(() => {
   if (props.dataSource?.type !== 'expression') return
+  if (preprocessorLoading.value) return
   const preprocessor = visPreprocessor.value
   const args = preprocessor.positionalArgumentsExpressions
-  const argsCode = args.length ? `(${args.join(') (')})` : ''
+  const tempModule = Ast.MutableModule.Transient()
+  const preprocessorModule = Ast.parse(preprocessor.visualizationModule, tempModule)
   // TODO[ao]: it work with builtin visualization, but does not work in general case.
   // Tracked in https://github.com/orgs/enso-org/discussions/6832#discussioncomment-7754474.
-  const preprocessorCode = `${preprocessor.visualizationModule}.${preprocessor.expression} _ ${argsCode}`
-  const expression = `${preprocessorCode} <| ${props.dataSource.expression}`
-  return projectStore.executeExpression(props.dataSource.contextId, expression)
+  if (!isIdentifier(preprocessor.expression)) {
+    console.error(`Unsupported visualization preprocessor definition`, preprocessor)
+    return
+  }
+  const preprocessorQn = Ast.PropertyAccess.new(
+    tempModule,
+    preprocessorModule,
+    preprocessor.expression,
+  )
+  const preprocessorInvocation = Ast.App.PositionalSequence(preprocessorQn, [
+    Ast.Wildcard.new(tempModule),
+    ...args.map((arg) => Ast.Group.new(tempModule, Ast.parse(arg, tempModule))),
+  ])
+  const rhs = Ast.parse(props.dataSource.expression, tempModule)
+  const expression = Ast.OprApp.new(tempModule, preprocessorInvocation, '<|', rhs)
+  return projectStore.executeExpression(props.dataSource.contextId, expression.code())
 })
 
 const effectiveVisualizationData = computed(() => {
   const name = currentType.value?.name
-  if (props.data) return props.data
+  if (props.dataSource?.type === 'raw') return props.dataSource.data
   if (vueError.value) return { name, error: vueError.value }
-  if (visualizationData.value && !visualizationData.value.ok)
-    return { name, error: new Error(visualizationData.value.error.payload) }
-  if (expressionVisualizationData.value && !expressionVisualizationData.value.ok)
-    return { name, error: new Error(expressionVisualizationData.value.error.payload) }
-  return visualizationData.value?.value ?? expressionVisualizationData.value?.value
+  const visualizationData = nodeVisualizationData.value ?? expressionVisualizationData.value
+  if (!visualizationData) return
+  if (visualizationData.ok) return visualizationData.value
+  else return { name, error: new Error(visualizationData.error.payload) }
 })
 
 function updatePreprocessor(
@@ -158,7 +169,11 @@ watch(
   () => (vueError.value = undefined),
 )
 
+// Flag used to prevent rendering the visualization with a stale preprocessor while the new preprocessor is being
+// prepared asynchronously.
+const preprocessorLoading = ref(false)
 watchEffect(async () => {
+  preprocessorLoading.value = true
   if (currentType.value == null) return
   visualization.value = undefined
   icon.value = undefined
@@ -197,6 +212,7 @@ watchEffect(async () => {
   } catch (caughtError) {
     vueError.value = toError(caughtError)
   }
+  preprocessorLoading.value = false
 })
 
 const isBelowToolbar = ref(false)
@@ -263,7 +279,7 @@ provideVisualizationConfig({
 const effectiveVisualization = computed(() => {
   if (
     vueError.value ||
-    (visualizationData.value && !visualizationData.value.ok) ||
+    (nodeVisualizationData.value && !nodeVisualizationData.value.ok) ||
     (expressionVisualizationData.value && !expressionVisualizationData.value.ok)
   ) {
     return LoadingErrorVisualization

--- a/app/gui2/src/util/ast/__tests__/abstract.test.ts
+++ b/app/gui2/src/util/ast/__tests__/abstract.test.ts
@@ -3,7 +3,6 @@ import { Ast } from '@/util/ast'
 import { initializeFFI } from 'shared/ast/ffi'
 import { expect, test } from 'vitest'
 import { MutableModule, type Identifier } from '../abstract'
-import { escape, unescape } from '../text'
 import { findExpressions, testCase, tryFindExpressions } from './testCase'
 
 await initializeFFI()
@@ -771,4 +770,11 @@ test('Code edit merging', () => {
   module.applyEdit(editA)
   module.applyEdit(editB)
   expect(module.root()?.code()).toBe('a = 10\nb = 20')
+})
+
+test('Analyze app-like', () => {
+  const appLike = Ast.parse('(Preprocessor.default_preprocessor 3 _ 5 _ <| 4) <| 6')
+  const { func, args } = Ast.analyzeAppLike(appLike)
+  expect(func.code()).toBe('Preprocessor.default_preprocessor')
+  expect(args.map((ast) => ast.code())).toEqual(['3', '4', '5', '6'])
 })

--- a/app/gui2/stories/UserDefinedVisualization.story.vue
+++ b/app/gui2/stories/UserDefinedVisualization.story.vue
@@ -81,7 +81,7 @@ const mockFsWrapperProps = computed(() => ({
       <MockFSWrapper v-bind="mockFsWrapperProps">
         <GraphVisualization
           :currentType="currentType"
-          :data="data"
+          :dataSource="{ type: 'raw', data }"
           :scale="1"
           :nodePosition="nodePosition"
           :nodeSize="nodeSize"

--- a/app/gui2/stories/mockSuggestions.json
+++ b/app/gui2/stories/mockSuggestions.json
@@ -1039,6 +1039,17 @@
   {
     "type": "method",
     "module": "Standard.Table.Data.Table",
+    "name": "new",
+    "arguments": [],
+    "selfType": "Standard.Table.Data.Table.Table",
+    "returnType": "Standard.Table.Data.Table.Table",
+    "isStatic": true,
+    "documentation": "",
+    "annotations": []
+  },
+  {
+    "type": "method",
+    "module": "Standard.Table.Data.Table",
     "name": "aggregate",
     "arguments": [
       {


### PR DESCRIPTION
### Pull Request Description

Fixes #8570.

- Visualization type can be set per suggestion entry.
- Default visualization type for each suggestion is determined by suggestion type info.

### Important Notes

Previewing non-default visualizations seems to be broken (#9194), but this PR updates the GUI to select visualization types appropriately.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
