### PR TITLE
Represent documentation in AST, load into Node

### DIFF
--- a/app/gui2/shared/ast/index.ts
+++ b/app/gui2/shared/ast/index.ts
@@ -25,7 +25,8 @@ export function asOwned<T>(t: T): Owned<T> {
   return t as Owned<T>
 }
 
-export type NodeChild<T = AstId | SyncTokenId> = { whitespace?: string | undefined; node: T }
+export type NodeChild<T> = { whitespace?: string | undefined; node: T }
+export type RawNodeChild = NodeChild<AstId> | NodeChild<SyncTokenId>
 
 export function newExternalId(): ExternalId {
   return random.uuidv4() as ExternalId

--- a/app/gui2/shared/ast/mutableModule.ts
+++ b/app/gui2/shared/ast/mutableModule.ts
@@ -1,15 +1,7 @@
 import * as random from 'lib0/random'
 import * as Y from 'yjs'
-import {
-  Token,
-  asOwned,
-  isTokenId,
-  newExternalId,
-  subtreeRoots,
-  type AstId,
-  type Owned,
-  type SyncTokenId,
-} from '.'
+import type { AstId, NodeChild, Owned, RawNodeChild, SyncTokenId } from '.'
+import { Token, asOwned, isTokenId, newExternalId, subtreeRoots } from '.'
 import { assert, assertDefined } from '../util/assert'
 import type { SourceRangeEdit } from '../util/data/text'
 import { defaultLocalOrigin, tryAsOrigin, type ExternalId, type Origin } from '../yjsModel'
@@ -38,6 +30,7 @@ export interface Module {
   getToken(token: SyncTokenId): Token
   getToken(token: SyncTokenId | undefined): Token | undefined
   getAny(node: AstId | SyncTokenId): Ast | Token
+  getConcrete(child: RawNodeChild): NodeChild<Ast> | NodeChild<Token>
   has(id: AstId): boolean
 }
 
@@ -320,6 +313,12 @@ export class MutableModule implements Module {
 
   getAny(node: AstId | SyncTokenId): MutableAst | Token {
     return isTokenId(node) ? this.getToken(node) : this.get(node)
+  }
+
+  getConcrete(child: RawNodeChild): NodeChild<Ast> | NodeChild<Token> {
+    if (isTokenId(child.node))
+      return { whitespace: child.whitespace, node: this.getToken(child.node) }
+    else return { whitespace: child.whitespace, node: this.get(child.node) }
   }
 
   /** @internal Copy a node into the module, if it is bound to a different module. */

--- a/app/gui2/shared/ast/parse.ts
+++ b/app/gui2/shared/ast/parse.ts
@@ -1,5 +1,5 @@
 import * as map from 'lib0/map'
-import type { AstId, Module, NodeChild, Owned } from '.'
+import type { AstId, Module, NodeChild, Owned, OwnedRefs, TextElement, TextToken } from '.'
 import {
   Token,
   asOwned,
@@ -255,20 +255,16 @@ class Abstractor {
       case RawAst.Tree.Type.TextLiteral: {
         const open = tree.open ? this.abstractToken(tree.open) : undefined
         const newline = tree.newline ? this.abstractToken(tree.newline) : undefined
-        const elements = []
-        for (const e of tree.elements) {
-          elements.push(...this.abstractChildren(e))
-        }
+        const elements = Array.from(tree.elements, (raw) => this.abstractTextElement(raw))
         const close = tree.close ? this.abstractToken(tree.close) : undefined
         node = TextLiteral.concrete(this.module, open, newline, elements, close)
         break
       }
       case RawAst.Tree.Type.Documented: {
         const open = this.abstractToken(tree.documentation.open)
-        const elements = []
-        for (const e of tree.documentation.elements) {
-          elements.push(...this.abstractChildren(e))
-        }
+        const elements = Array.from(tree.documentation.elements, (raw) =>
+          this.abstractTextToken(raw),
+        )
         const newlines = Array.from(tree.documentation.newlines, this.abstractToken.bind(this))
         const expression = tree.expression ? this.abstractTree(tree.expression) : undefined
         node = Documented.concrete(this.module, open, elements, newlines, expression)
@@ -315,8 +311,8 @@ class Abstractor {
     return { whitespace, node }
   }
 
-  private abstractChildren(tree: LazyObject): NodeChild<Owned | Token>[] {
-    const children: NodeChild<Owned | Token>[] = []
+  private abstractChildren(tree: LazyObject): (NodeChild<Owned> | NodeChild<Token>)[] {
+    const children: (NodeChild<Owned> | NodeChild<Token>)[] = []
     const visitor = (child: LazyObject) => {
       if (RawAst.Tree.isInstance(child)) {
         children.push(this.abstractTree(child))
@@ -328,6 +324,42 @@ class Abstractor {
     }
     tree.visitChildren(visitor)
     return children
+  }
+
+  private abstractTextElement(raw: RawAst.TextElement): TextElement<OwnedRefs> {
+    switch (raw.type) {
+      case RawAst.TextElement.Type.Newline:
+      case RawAst.TextElement.Type.Escape:
+      case RawAst.TextElement.Type.Section:
+        return this.abstractTextToken(raw)
+      case RawAst.TextElement.Type.Splice:
+        return {
+          type: 'splice',
+          open: this.abstractToken(raw.open),
+          expression: raw.expression && this.abstractTree(raw.expression),
+          close: this.abstractToken(raw.close),
+        }
+    }
+  }
+
+  private abstractTextToken(raw: RawAst.TextElement): TextToken<OwnedRefs> {
+    switch (raw.type) {
+      case RawAst.TextElement.Type.Newline:
+        return { type: 'token', token: this.abstractToken(raw.newline) }
+      case RawAst.TextElement.Type.Escape: {
+        const negativeOneU32 = 4294967295
+        return {
+          type: 'token',
+          token: this.abstractToken(raw.token),
+          interpreted:
+            raw.token.value !== negativeOneU32 ? String.fromCodePoint(raw.token.value) : undefined,
+        }
+      }
+      case RawAst.TextElement.Type.Section:
+        return { type: 'token', token: this.abstractToken(raw.text) }
+      case RawAst.TextElement.Type.Splice:
+        throw new Error('Unreachable: Splice in non-interpolated text field')
+    }
   }
 }
 

--- a/app/gui2/shared/ast/tree.ts
+++ b/app/gui2/shared/ast/tree.ts
@@ -1402,7 +1402,8 @@ export class Documented extends Ast {
 
   /** Return the string value of the documentation. */
   documentation(): string {
-    return uninterpolatedText(this.fields.get('elements'), this.module)
+    const raw = uninterpolatedText(this.fields.get('elements'), this.module)
+    return raw.startsWith(' ') ? raw.slice(1) : raw
   }
 
   *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {

--- a/app/gui2/shared/ast/tree.ts
+++ b/app/gui2/shared/ast/tree.ts
@@ -6,6 +6,7 @@ import type {
   Module,
   NodeChild,
   Owned,
+  RawNodeChild,
   SpanMap,
   SyncTokenId,
 } from '.'
@@ -176,7 +177,7 @@ export abstract class Ast {
   /** @internal
    *  Returns child subtrees, including information about the whitespace between them.
    */
-  abstract concreteChildren(verbatim?: boolean): IterableIterator<NodeChild>
+  abstract concreteChildren(verbatim?: boolean): IterableIterator<RawNodeChild>
 }
 export interface MutableAst {}
 export abstract class MutableAst extends Ast {
@@ -338,22 +339,22 @@ export abstract class MutableAst extends Ast {
 }
 
 /** Values that may be found in fields of `Ast` subtypes. */
-type FieldData =
-  | NodeChild<AstId>
-  | NodeChild
-  | NodeChild<SyncTokenId>
-  | FieldData[]
+type FieldData<T extends TreeRefs = RawRefs> =
+  | T['ast']
+  | T['token']
+  | FieldData<T>[]
   | undefined
-  | StructuralField
+  | StructuralField<T>
 /** Objects that do not directly contain `AstId`s or `SyncTokenId`s, but may have `NodeChild` fields. */
-type StructuralField =
-  | RawMultiSegmentAppSegment
-  | RawBlockLine
-  | RawOpenCloseTokens
-  | RawNameSpecification
+type StructuralField<T extends TreeRefs = RawRefs> =
+  | MultiSegmentAppSegment<T>
+  | Line<T>
+  | OpenCloseTokens<T>
+  | NameSpecification<T>
+  | TextElement<T>
 /** Type whose fields are all suitable for storage as `Ast` fields. */
-interface FieldObject {
-  [field: string]: FieldData
+interface FieldObject<T extends TreeRefs> {
+  [field: string]: FieldData<T>
 }
 /** Returns the fields of an `Ast` subtype that are not part of `AstFields`. */
 function* fieldDataEntries<Fields>(map: FixedMapView<Fields>) {
@@ -363,13 +364,26 @@ function* fieldDataEntries<Fields>(map: FixedMapView<Fields>) {
   }
 }
 
+function idRewriter(
+  f: (id: AstId) => AstId | undefined,
+): (field: FieldData) => FieldData | undefined {
+  return (field: FieldData) => {
+    if (typeof field !== 'object') return
+    if (!('node' in field)) return
+    if (isTokenId(field.node)) return
+    const newId = f(field.node)
+    if (!newId) return
+    return { whitespace: field.whitespace, node: newId }
+  }
+}
+
 /** Apply the given function to each `AstId` in the fields of `ast`. For each value that it returns an output, that
  *  output will be substituted for the input ID.
  */
 export function rewriteRefs(ast: MutableAst, f: (id: AstId) => AstId | undefined) {
   let fieldsChanged = 0
   for (const [key, value] of fieldDataEntries(ast.fields)) {
-    const newValue = rewriteFieldRefs(value, f)
+    const newValue = rewriteFieldRefs(value, idRewriter(f))
     if (newValue !== undefined) {
       ast.fields.set(key as any, newValue)
       fieldsChanged += 1
@@ -383,8 +397,7 @@ export function rewriteRefs(ast: MutableAst, f: (id: AstId) => AstId | undefined
  */
 export function syncFields(ast1: MutableAst, ast2: Ast, f: (id: AstId) => AstId | undefined) {
   for (const [key, value] of fieldDataEntries(ast2.fields)) {
-    const changedValue = rewriteFieldRefs(value, f)
-    const newValue = changedValue ?? value
+    const newValue = mapRefs(value, idRewriter(f))
     if (!fieldEqual(ast1.fields.get(key as any), newValue)) ast1.fields.set(key as any, newValue)
   }
 }
@@ -397,17 +410,14 @@ export function syncNodeMetadata(target: MutableNodeMetadata, source: NodeMetada
   if (!visMetadataEquals(target.get('visualization'), newVis)) target.set('visualization', newVis)
 }
 
-function rewriteFieldRefs(field: FieldData, f: (id: AstId) => AstId | undefined): FieldData {
-  if (field === undefined) return field
-  if ('node' in field) {
-    const child = field.node
-    if (isTokenId(child)) return
-    const newValue = f(child)
-    if (newValue !== undefined) {
-      field.node = newValue
-      return field
-    }
-  } else if (Array.isArray(field)) {
+function rewriteFieldRefs<T extends TreeRefs, U extends TreeRefs>(
+  field: FieldData<T>,
+  f: (t: FieldData<T>) => FieldData<U> | undefined,
+): FieldData<U> {
+  const newValue = f(field)
+  if (newValue) return newValue
+  if (typeof field !== 'object') return
+  if (Array.isArray(field)) {
     let fieldChanged = false
     field.forEach((subfield, i) => {
       const newValue = rewriteFieldRefs(subfield, f)
@@ -433,9 +443,40 @@ function rewriteFieldRefs(field: FieldData, f: (id: AstId) => AstId | undefined)
   }
 }
 
+type MapRef<T extends TreeRefs, U extends TreeRefs> = (t: FieldData<T>) => FieldData<U> | undefined
+
+// This operation can transform any `FieldData` type parameterized by some `TreeRefs` into the same type parameterized
+// by another `TreeRefs`, but it is not possible to express that generalization to TypeScript as such.
+function mapRefs<T extends TreeRefs, U extends TreeRefs>(
+  field: ImportFields<T>,
+  f: MapRef<T, U>,
+): ImportFields<U>
+function mapRefs<T extends TreeRefs, U extends TreeRefs>(
+  field: TextToken<T>,
+  f: MapRef<T, U>,
+): TextToken<U>
+function mapRefs<T extends TreeRefs, U extends TreeRefs>(
+  field: TextElement<T>,
+  f: MapRef<T, U>,
+): TextElement<U>
+function mapRefs<T extends TreeRefs, U extends TreeRefs>(
+  field: ArgumentDefinition<T>,
+  f: MapRef<T, U>,
+): ArgumentDefinition<U>
+function mapRefs<T extends TreeRefs, U extends TreeRefs>(
+  field: FieldData<T>,
+  f: MapRef<T, U>,
+): FieldData<U>
+function mapRefs<T extends TreeRefs, U extends TreeRefs>(
+  field: FieldData<T>,
+  f: MapRef<T, U>,
+): FieldData<U> {
+  return rewriteFieldRefs(field, f) ?? field
+}
+
 function fieldEqual(field1: FieldData, field2: FieldData): boolean {
-  if (field1 === undefined) return field2 === undefined
-  if (field2 === undefined) return false
+  if (typeof field1 !== 'object') return field1 === field2
+  if (typeof field2 !== 'object') return false
   if ('node' in field1 && 'node' in field2) {
     if (field1['whitespace'] !== field2['whitespace']) return false
     if (isTokenId(field1.node) && isTokenId(field2.node))
@@ -475,17 +516,17 @@ function applyMixins(derivedCtor: any, constructors: any[]) {
 
 interface AppFields {
   function: NodeChild<AstId>
-  parens: RawOpenCloseTokens | undefined
-  nameSpecification: RawNameSpecification | undefined
+  parens: OpenCloseTokens | undefined
+  nameSpecification: NameSpecification | undefined
   argument: NodeChild<AstId>
 }
-interface RawOpenCloseTokens {
-  open: NodeChild<SyncTokenId>
-  close: NodeChild<SyncTokenId>
+interface OpenCloseTokens<T extends TreeRefs = RawRefs> {
+  open: T['token']
+  close: T['token']
 }
-interface RawNameSpecification {
-  name: NodeChild<SyncTokenId>
-  equals: NodeChild<SyncTokenId>
+interface NameSpecification<T extends TreeRefs = RawRefs> {
+  name: T['token']
+  equals: T['token']
 }
 export class App extends Ast {
   declare fields: FixedMap<AstFields & AppFields>
@@ -501,8 +542,8 @@ export class App extends Ast {
   static concrete(
     module: MutableModule,
     func: NodeChild<Owned>,
-    parens: { open: NodeChild<Token>; close: NodeChild<Token> } | undefined,
-    nameSpecification: { name: NodeChild<Token>; equals: NodeChild<Token> } | undefined,
+    parens: OpenCloseTokens | undefined,
+    nameSpecification: NameSpecification | undefined,
     argument: NodeChild<Owned>,
   ) {
     const base = module.baseObject('App')
@@ -548,7 +589,7 @@ export class App extends Ast {
     return this.module.get(this.fields.get('argument').node)
   }
 
-  *concreteChildren(verbatim?: boolean): IterableIterator<NodeChild> {
+  *concreteChildren(verbatim?: boolean): IterableIterator<RawNodeChild> {
     const { function: function_, parens, nameSpecification, argument } = getAll(this.fields)
     yield ensureUnspaced(function_, verbatim)
     const useParens = !!(parens && (nameSpecification || verbatim))
@@ -658,7 +699,7 @@ export class UnaryOprApp extends Ast {
     return this.module.get(this.fields.get('argument')?.node)
   }
 
-  *concreteChildren(_verbatim?: boolean): IterableIterator<NodeChild> {
+  *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
     const { operator, argument } = getAll(this.fields)
     yield operator
     if (argument) yield argument
@@ -716,7 +757,7 @@ export class NegationApp extends Ast {
     return this.module.get(this.fields.get('argument').node)
   }
 
-  *concreteChildren(_verbatim?: boolean): IterableIterator<NodeChild> {
+  *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
     const { operator, argument } = getAll(this.fields)
     yield operator
     if (argument) yield argument
@@ -794,7 +835,7 @@ export class OprApp extends Ast {
     return this.module.get(this.fields.get('rhs')?.node)
   }
 
-  *concreteChildren(_verbatim?: boolean): IterableIterator<NodeChild> {
+  *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
     const { lhs, operators, rhs } = getAll(this.fields)
     if (lhs) yield lhs
     yield* operators
@@ -904,7 +945,7 @@ export class PropertyAccess extends Ast {
     return ast.token as IdentifierOrOperatorIdentifierToken
   }
 
-  *concreteChildren(_verbatim?: boolean): IterableIterator<NodeChild> {
+  *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
     const { lhs, operator, rhs } = getAll(this.fields)
     if (lhs) yield lhs
     yield operator
@@ -930,7 +971,7 @@ export interface MutablePropertyAccess extends PropertyAccess, MutableAst {
 applyMixins(MutablePropertyAccess, [MutableAst])
 
 interface GenericFields {
-  children: NodeChild[]
+  children: RawNodeChild[]
 }
 export class Generic extends Ast {
   declare fields: FixedMapView<AstFields & GenericFields>
@@ -938,7 +979,7 @@ export class Generic extends Ast {
     super(module, fields)
   }
 
-  static concrete(module: MutableModule, children: NodeChild<Owned | Token>[]) {
+  static concrete(module: MutableModule, children: (NodeChild<Owned> | NodeChild<Token>)[]) {
     const base = module.baseObject('Generic')
     const id_ = base.get('id')
     const fields = composeFieldData(base, {
@@ -947,7 +988,7 @@ export class Generic extends Ast {
     return asOwned(new MutableGeneric(module, fields))
   }
 
-  concreteChildren(_verbatim?: boolean): IterableIterator<NodeChild> {
+  concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
     return this.fields.get('children')[Symbol.iterator]()
   }
 }
@@ -958,26 +999,22 @@ export class MutableGeneric extends Generic implements MutableAst {
 export interface MutableGeneric extends Generic, MutableAst {}
 applyMixins(MutableGeneric, [MutableAst])
 
-interface RawMultiSegmentAppSegment {
-  header: NodeChild<Token>
-  body: NodeChild<AstId> | undefined
-}
-interface OwnedMultiSegmentAppSegment {
-  header: NodeChild<Token>
-  body: NodeChild<Owned> | undefined
+interface MultiSegmentAppSegment<T extends TreeRefs = RawRefs> {
+  header: T['token']
+  body: T['ast'] | undefined
 }
 function multiSegmentAppSegment<T extends MutableAst>(
   header: string,
   body: Owned<T>,
-): OwnedMultiSegmentAppSegment
+): MultiSegmentAppSegment<OwnedRefs>
 function multiSegmentAppSegment<T extends MutableAst>(
   header: string,
   body: Owned<T> | undefined,
-): OwnedMultiSegmentAppSegment | undefined
+): MultiSegmentAppSegment<OwnedRefs> | undefined
 function multiSegmentAppSegment<T extends MutableAst>(
   header: string,
   body: Owned<T> | undefined,
-): OwnedMultiSegmentAppSegment | undefined {
+): MultiSegmentAppSegment<OwnedRefs> | undefined {
   return {
     header: { node: Token.new(header, RawAst.Token.Type.Ident) },
     body: spaced(body ? (body as any) : undefined),
@@ -986,38 +1023,24 @@ function multiSegmentAppSegment<T extends MutableAst>(
 
 function multiSegmentAppSegmentToRaw(
   module: MutableModule,
-  msas: OwnedMultiSegmentAppSegment,
+  msas: MultiSegmentAppSegment<OwnedRefs> | undefined,
   parent: AstId,
-): RawMultiSegmentAppSegment
-function multiSegmentAppSegmentToRaw(
-  module: MutableModule,
-  msas: OwnedMultiSegmentAppSegment,
-  parent: AstId,
-): RawMultiSegmentAppSegment
-function multiSegmentAppSegmentToRaw(
-  module: MutableModule,
-  msas: OwnedMultiSegmentAppSegment | undefined,
-  parent: AstId,
-): RawMultiSegmentAppSegment | undefined
-function multiSegmentAppSegmentToRaw(
-  module: MutableModule,
-  msas: OwnedMultiSegmentAppSegment | undefined,
-  parent: AstId,
-): RawMultiSegmentAppSegment | undefined {
+): MultiSegmentAppSegment | undefined {
   if (!msas) return undefined
   return {
     ...msas,
     body: concreteChild(module, msas.body, parent),
   }
 }
-interface ImportFields {
-  polyglot: RawMultiSegmentAppSegment | undefined
-  from: RawMultiSegmentAppSegment | undefined
-  import: RawMultiSegmentAppSegment
-  all: NodeChild<SyncTokenId> | undefined
-  as: RawMultiSegmentAppSegment | undefined
-  hiding: RawMultiSegmentAppSegment | undefined
+interface ImportFields<T extends TreeRefs = RawRefs> extends FieldObject<T> {
+  polyglot: MultiSegmentAppSegment<T> | undefined
+  from: MultiSegmentAppSegment<T> | undefined
+  import: MultiSegmentAppSegment<T>
+  all: T['token'] | undefined
+  as: MultiSegmentAppSegment<T> | undefined
+  hiding: MultiSegmentAppSegment<T> | undefined
 }
+
 export class Import extends Ast {
   declare fields: FixedMapView<AstFields & ImportFields>
   constructor(module: Module, fields: FixedMapView<AstFields & ImportFields>) {
@@ -1050,23 +1073,25 @@ export class Import extends Ast {
 
   static concrete(
     module: MutableModule,
-    polyglot: OwnedMultiSegmentAppSegment | undefined,
-    from: OwnedMultiSegmentAppSegment | undefined,
-    import_: OwnedMultiSegmentAppSegment,
+    polyglot: MultiSegmentAppSegment<OwnedRefs> | undefined,
+    from: MultiSegmentAppSegment<OwnedRefs> | undefined,
+    import_: MultiSegmentAppSegment<OwnedRefs>,
     all: NodeChild<Token> | undefined,
-    as: OwnedMultiSegmentAppSegment | undefined,
-    hiding: OwnedMultiSegmentAppSegment | undefined,
+    as: MultiSegmentAppSegment<OwnedRefs> | undefined,
+    hiding: MultiSegmentAppSegment<OwnedRefs> | undefined,
   ) {
     const base = module.baseObject('Import')
     const id_ = base.get('id')
-    const fields = composeFieldData(base, {
-      polyglot: multiSegmentAppSegmentToRaw(module, polyglot, id_),
-      from: multiSegmentAppSegmentToRaw(module, from, id_),
-      import: multiSegmentAppSegmentToRaw(module, import_, id_),
+    const ownedFields: ImportFields<OwnedRefs> = {
+      polyglot,
+      from,
+      import: import_,
       all,
-      as: multiSegmentAppSegmentToRaw(module, as, id_),
-      hiding: multiSegmentAppSegmentToRaw(module, hiding, id_),
-    })
+      as,
+      hiding,
+    }
+    const rawFields = mapRefs(ownedFields, ownedToRaw(module, id_))
+    const fields = composeFieldData(base, rawFields)
     return asOwned(new MutableImport(module, fields))
   }
 
@@ -1103,8 +1128,8 @@ export class Import extends Ast {
     )
   }
 
-  *concreteChildren(_verbatim?: boolean): IterableIterator<NodeChild> {
-    const segment = (segment: RawMultiSegmentAppSegment | undefined) => {
+  *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
+    const segment = (segment: MultiSegmentAppSegment | undefined) => {
       const parts = []
       if (segment) parts.push(segment.header)
       if (segment?.body) parts.push(segment.body)
@@ -1123,13 +1148,13 @@ export class MutableImport extends Import implements MutableAst {
   declare readonly module: MutableModule
   declare readonly fields: FixedMap<AstFields & ImportFields>
 
-  private toRaw(msas: OwnedMultiSegmentAppSegment): RawMultiSegmentAppSegment
+  private toRaw(msas: MultiSegmentAppSegment<OwnedRefs>): MultiSegmentAppSegment
   private toRaw(
-    msas: OwnedMultiSegmentAppSegment | undefined,
-  ): RawMultiSegmentAppSegment | undefined
+    msas: MultiSegmentAppSegment<OwnedRefs> | undefined,
+  ): MultiSegmentAppSegment | undefined
   private toRaw(
-    msas: OwnedMultiSegmentAppSegment | undefined,
-  ): RawMultiSegmentAppSegment | undefined {
+    msas: MultiSegmentAppSegment<OwnedRefs> | undefined,
+  ): MultiSegmentAppSegment | undefined {
     return multiSegmentAppSegmentToRaw(this.module, msas, this.id)
   }
 
@@ -1182,10 +1207,98 @@ function escape(string: string) {
   return string.replace(/[\0\b\f\n\r\t\v"'`]/g, (match) => mapping[match]!)
 }
 
+interface TreeRefs {
+  token: any
+  ast: any
+}
+type RefMap<T extends TreeRefs, U extends TreeRefs> = (
+  field: FieldData<T>,
+) => FieldData<U> | undefined
+type RawRefs = {
+  token: NodeChild<SyncTokenId>
+  ast: NodeChild<AstId>
+}
+export type OwnedRefs = {
+  token: NodeChild<Token>
+  ast: NodeChild<Owned>
+}
+type ConcreteRefs = {
+  token: NodeChild<Token>
+  ast: NodeChild<Ast>
+}
+function ownedToRaw(module: MutableModule, parentId: AstId): RefMap<OwnedRefs, RawRefs> {
+  return (child: FieldData<OwnedRefs>) => {
+    if (typeof child !== 'object') return
+    if (!('node' in child)) return
+    if (isToken(child.node)) return
+    return { ...child, node: claimChild(module, child.node, parentId) }
+  }
+}
+function rawToConcrete(module: Module): RefMap<RawRefs, ConcreteRefs> {
+  return (child: FieldData) => {
+    if (typeof child !== 'object') return
+    if (!('node' in child)) return
+    if (isTokenId(child.node)) return { ...child, node: module.getToken(child.node) }
+    else return { ...child, node: module.get(child.node) }
+  }
+}
+export interface TextToken<T extends TreeRefs = RawRefs> {
+  type: 'token'
+  readonly token: T['token']
+  readonly interpreted?: string | undefined
+}
+export interface TextSplice<T extends TreeRefs = RawRefs> {
+  type: 'splice'
+  readonly open: T['token']
+  readonly expression: T['ast'] | undefined
+  readonly close: T['token']
+}
+
+export type TextElement<T extends TreeRefs = RawRefs> = TextToken<T> | TextSplice<T>
+
+function textElementValue(element: TextElement<ConcreteRefs>): string {
+  switch (element.type) {
+    case 'token': {
+      if (element.interpreted != null) return element.interpreted
+      // The logical newline is not necessarily the same as the concrete token, e.g. the token could be a CRLF.
+      if (element.token.node.tokenType_ === RawAst.Token.Type.TextNewline) return '\n'
+      // The token is an invalid escape-sequence or a text-section; return it verbatim.
+      return element.token.node.code()
+    }
+    case 'splice': {
+      let s = ''
+      s += element.open.node.code()
+      if (element.expression) {
+        s += element.expression.whitespace ?? ''
+        s += element.expression.node.code()
+      }
+      s += element.close.whitespace ?? ''
+      s += element.close.node.code()
+      return s
+    }
+  }
+}
+
+function rawTextElementValue(raw: TextElement, module: Module): string {
+  return textElementValue(mapRefs(raw, rawToConcrete(module)))
+}
+
+function uninterpolatedText(elements: TextElement[], module: Module): string {
+  return elements.reduce((s, e) => s + rawTextElementValue(e, module), '')
+}
+
+function fieldConcreteChildren(field: FieldData) {
+  const children = new Array<RawNodeChild>()
+  rewriteFieldRefs(field, (subfield: FieldData) => {
+    if (typeof subfield === 'object' && 'node' in subfield) children.push(subfield)
+  })
+  return children
+}
+
 interface TextLiteralFields {
   open: NodeChild<SyncTokenId> | undefined
   newline: NodeChild<SyncTokenId> | undefined
-  elements: NodeChild[]
+  elements: TextElement[]
   close: NodeChild<SyncTokenId> | undefined
 }
 export class TextLiteral extends Ast {
@@ -1203,7 +1316,7 @@ export class TextLiteral extends Ast {
     module: MutableModule,
     open: NodeChild<Token> | undefined,
     newline: NodeChild<Token> | undefined,
-    elements: NodeChild<Owned | Token>[],
+    elements: TextElement<OwnedRefs>[],
     close: NodeChild<Token> | undefined,
   ) {
     const base = module.baseObject('TextLiteral')
@@ -1211,24 +1324,33 @@ export class TextLiteral extends Ast {
     const fields = composeFieldData(base, {
       open,
       newline,
-      elements: elements.map((elem) => concreteChild(module, elem, id_)),
+      elements: elements.map((e) => mapRefs(e, ownedToRaw(module, id_))),
       close,
     })
     return asOwned(new MutableTextLiteral(module, fields))
   }
 
-  static new(rawText: string, module: MutableModule) {
-    const open = unspaced(Token.new("'"))
-    const elements = [unspaced(Token.new(escape(rawText)))]
-    const close = unspaced(Token.new("'"))
-    return this.concrete(module, open, undefined, elements, close)
+  static new(rawText: string, module: MutableModule): Owned<MutableTextLiteral> {
+    const escaped = escape(rawText)
+    const parsed = parse(`'${escaped}'`, module)
+    if (!(parsed instanceof MutableTextLiteral)) {
+      console.error(`Failed to escape string for interpolated text`, rawText, escaped, parsed)
+      const safeText = rawText.replaceAll(/[^-+A-Za-z0-9_. ]/, '')
+      return this.new(safeText, module)
+    }
+    return parsed
   }
 
-  *concreteChildren(_verbatim?: boolean): IterableIterator<NodeChild> {
+  /** Return the value of the string, interpreted except for any interpolated expressions. */
+  contentUninterpolated(): string {
+    return uninterpolatedText(this.fields.get('elements'), this.module)
+  }
+
+  *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
     const { open, newline, elements, close } = getAll(this.fields)
     if (open) yield open
     if (newline) yield newline
-    yield* elements
+    for (const e of elements) yield* fieldConcreteChildren(e)
     if (close) yield close
   }
 }
@@ -1241,7 +1363,7 @@ applyMixins(MutableTextLiteral, [MutableAst])
 
 interface DocumentedFields {
   open: NodeChild<SyncTokenId> | undefined
-  elements: NodeChild[]
+  elements: TextToken[]
   newlines: NodeChild<SyncTokenId>[]
   expression: NodeChild<AstId> | undefined
 }
@@ -1259,7 +1381,7 @@ export class Documented extends Ast {
   static concrete(
     module: MutableModule,
     open: NodeChild<Token> | undefined,
-    elements: NodeChild<Owned | Token>[],
+    elements: TextToken<OwnedRefs>[],
     newlines: NodeChild<Token>[],
     expression: NodeChild<Owned> | undefined,
   ) {
@@ -1267,7 +1389,7 @@ export class Documented extends Ast {
     const id_ = base.get('id')
     const fields = composeFieldData(base, {
       open,
-      elements: elements.map((elem) => concreteChild(module, elem, id_)),
+      elements: elements.map((e) => mapRefs(e, ownedToRaw(module, id_))),
       newlines,
       expression: concreteChild(module, expression, id_),
     })
@@ -1278,10 +1400,15 @@ export class Documented extends Ast {
     return this.module.get(this.fields.get('expression')?.node)
   }
 
-  *concreteChildren(_verbatim?: boolean): IterableIterator<NodeChild> {
+  /** Return the string value of the documentation. */
+  documentation(): string {
+    return uninterpolatedText(this.fields.get('elements'), this.module)
+  }
+
+  *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
     const { open, elements, newlines, expression } = getAll(this.fields)
     if (open) yield open
-    yield* elements
+    for (const e of elements) yield* fieldConcreteChildren(e)
     yield* newlines
     if (expression) yield expression
   }
@@ -1317,7 +1444,7 @@ export class Invalid extends Ast {
     return this.module.get(this.fields.get('expression').node)
   }
 
-  *concreteChildren(_verbatim?: boolean): IterableIterator<NodeChild> {
+  *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
     yield this.fields.get('expression')
   }
 
@@ -1341,11 +1468,6 @@ export function invalidFields(
 export class MutableInvalid extends Invalid implements MutableAst {
   declare readonly module: MutableModule
   declare readonly fields: FixedMap<AstFields & InvalidFields>
-
-  /** Private, because it makes more sense to `.replace` the `Invalid` node. */
-  private setExpression<T extends MutableAst>(value: Owned<T>) {
-    this.fields.set('expression', unspaced(this.claimChild(value)))
-  }
 }
 export interface MutableInvalid extends Invalid, MutableAst {
   /** The `expression` getter is intentionally not narrowed to provide mutable access:
@@ -1395,7 +1517,7 @@ export class Group extends Ast {
     return this.module.get(this.fields.get('expression')?.node)
   }
 
-  *concreteChildren(_verbatim?: boolean): IterableIterator<NodeChild> {
+  *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
     const { open, expression, close } = getAll(this.fields)
     if (open) yield open
     if (expression) yield expression
@@ -1438,7 +1560,7 @@ export class NumericLiteral extends Ast {
     return asOwned(new MutableNumericLiteral(module, fields))
   }
 
-  concreteChildren(_verbatim?: boolean): IterableIterator<NodeChild> {
+  concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
     return this.fields.get('tokens')[Symbol.iterator]()
   }
 }
@@ -1451,26 +1573,11 @@ applyMixins(MutableNumericLiteral, [MutableAst])
 
 /** The actual contents of an `ArgumentDefinition` are complex, but probably of more interest to the compiler than the
  *  GUI. We just need to represent them faithfully and create the simple cases. */
-type ArgumentDefinition = NodeChild<Ast | Token>[]
-type RawArgumentDefinition = NodeChild[]
-type OwnedArgumentDefinition = NodeChild<Owned | Token>[]
-
-function argumentDefinitionsToRaw(
-  module: MutableModule,
-  defs: OwnedArgumentDefinition[],
-  parent: AstId,
-): RawArgumentDefinition[] {
-  return defs.map((def) =>
-    def.map((part) => ({
-      ...part,
-      node: part.node instanceof Token ? part.node : claimChild(module, part.node, parent),
-    })),
-  )
-}
+type ArgumentDefinition<T extends TreeRefs = RawRefs> = (T['ast'] | T['token'])[]
 
 interface FunctionFields {
   name: NodeChild<AstId>
-  argumentDefinitions: RawArgumentDefinition[]
+  argumentDefinitions: ArgumentDefinition[]
   equals: NodeChild<SyncTokenId>
   body: NodeChild<AstId> | undefined
 }
@@ -1491,19 +1598,16 @@ export class Function extends Ast {
   get body(): Ast | undefined {
     return this.module.get(this.fields.get('body')?.node)
   }
-  get argumentDefinitions(): ArgumentDefinition[] {
-    return this.fields.get('argumentDefinitions').map((raw) =>
-      raw.map((part) => ({
-        ...part,
-        node: this.module.getAny(part.node),
-      })),
-    )
+  get argumentDefinitions(): ArgumentDefinition<ConcreteRefs>[] {
+    return this.fields
+      .get('argumentDefinitions')
+      .map((raw) => raw.map((part) => this.module.getConcrete(part)))
   }
 
   static concrete(
     module: MutableModule,
     name: NodeChild<Owned>,
-    argumentDefinitions: OwnedArgumentDefinition[],
+    argumentDefinitions: ArgumentDefinition<OwnedRefs>[],
     equals: NodeChild<Token>,
     body: NodeChild<Owned> | undefined,
   ) {
@@ -1511,7 +1615,7 @@ export class Function extends Ast {
     const id_ = base.get('id')
     const fields = composeFieldData(base, {
       name: concreteChild(module, name, id_),
-      argumentDefinitions: argumentDefinitionsToRaw(module, argumentDefinitions, id_),
+      argumentDefinitions: argumentDefinitions.map((def) => mapRefs(def, ownedToRaw(module, id_))),
       equals,
       body: concreteChild(module, body, id_),
     })
@@ -1521,7 +1625,7 @@ export class Function extends Ast {
   static new(
     module: MutableModule,
     name: IdentLike,
-    argumentDefinitions: OwnedArgumentDefinition[],
+    argumentDefinitions: ArgumentDefinition<OwnedRefs>[],
     body: Owned,
   ): Owned<MutableFunction> {
     // Note that a function name may not be an operator if the function is not in the body of a type definition, but we
@@ -1560,7 +1664,7 @@ export class Function extends Ast {
     }
   }
 
-  *concreteChildren(verbatim?: boolean): IterableIterator<NodeChild> {
+  *concreteChildren(verbatim?: boolean): IterableIterator<RawNodeChild> {
     const { name, argumentDefinitions, equals, body } = getAll(this.fields)
     yield name
     for (const def of argumentDefinitions) yield* def
@@ -1583,8 +1687,11 @@ export class MutableFunction extends Function implements MutableAst {
   setBody<T extends MutableAst>(value: Owned<T> | undefined) {
     this.fields.set('body', unspaced(this.claimChild(value)))
   }
-  setArgumentDefinitions(defs: OwnedArgumentDefinition[]) {
-    this.fields.set('argumentDefinitions', argumentDefinitionsToRaw(this.module, defs, this.id))
+  setArgumentDefinitions(defs: ArgumentDefinition<OwnedRefs>[]) {
+    this.fields.set(
+      'argumentDefinitions',
+      defs.map((def) => mapRefs(def, ownedToRaw(this.module, this.id))),
+    )
   }
 
   /** Returns the body, after converting it to a block if it was empty or an inline expression. */
@@ -1650,7 +1757,7 @@ export class Assignment extends Ast {
     return this.module.get(this.fields.get('expression').node)
   }
 
-  *concreteChildren(verbatim?: boolean): IterableIterator<NodeChild> {
+  *concreteChildren(verbatim?: boolean): IterableIterator<RawNodeChild> {
     const { pattern, equals, expression } = getAll(this.fields)
     yield pattern
     yield ensureSpacedOnlyIf(equals, expression.whitespace !== '', verbatim)
@@ -1711,7 +1818,7 @@ export class BodyBlock extends Ast {
     }
   }
 
-  *concreteChildren(_verbatim?: boolean): IterableIterator<NodeChild> {
+  *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
     for (const line of this.fields.get('lines')) {
       yield line.newline ?? { node: Token.new('\n', RawAst.Token.Type.Newline) }
       if (line.expression) yield line.expression
@@ -1778,18 +1885,19 @@ export interface MutableBodyBlock extends BodyBlock, MutableAst {
 }
 applyMixins(MutableBodyBlock, [MutableAst])
 
-interface RawLine<T> {
-  newline: NodeChild<SyncTokenId>
-  expression: NodeChild<T> | undefined
-}
-interface Line<T> {
-  newline?: NodeChild<Token> | undefined
-  expression: NodeChild<T> | undefined
+interface RawLine<T extends TreeRefs> {
+  newline: T['token']
+  expression: T['ast'] | undefined
 }
 
-interface RawBlockLine extends RawLine<AstId> {}
-export type BlockLine = Line<Ast>
-export type OwnedBlockLine = Line<Owned>
+interface Line<T extends TreeRefs> {
+  newline?: T['token'] | undefined
+  expression: T['ast'] | undefined
+}
+
+type RawBlockLine = RawLine<RawRefs>
+export type BlockLine = Line<ConcreteRefs>
+export type OwnedBlockLine = Line<OwnedRefs>
 
 function lineFromRaw(raw: RawBlockLine, module: Module): BlockLine {
   const expression = raw.expression ? module.get(raw.expression.node) : undefined
@@ -1862,7 +1970,7 @@ export class Ident extends Ast {
     return Ident.concrete(module, unspaced(toIdent(ident)))
   }
 
-  *concreteChildren(_verbatim?: boolean): IterableIterator<NodeChild> {
+  *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
     yield this.fields.get('token')
   }
 
@@ -1914,7 +2022,7 @@ export class Wildcard extends Ast {
     return this.concrete(module, unspaced(token))
   }
 
-  *concreteChildren(_verbatim?: boolean): IterableIterator<NodeChild> {
+  *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
     yield this.fields.get('token')
   }
 }
@@ -2084,7 +2192,7 @@ export function setAll<Fields1, Fields2 extends Record<string, any>>(
 
 /** Modifies the input `map`. Returns the same object with an extended type. The added fields are required to have only
  *  types extending `FieldData`; the returned object is branded as `LegalFieldContent`. */
-export function composeFieldData<Fields1, Fields2 extends FieldObject>(
+export function composeFieldData<Fields1, Fields2 extends FieldObject<RawRefs>>(
   map: FixedMap<Fields1>,
   fields: Fields2,
 ): FixedMap<Fields1 & Fields2 & LegalFieldContent> {
@@ -2116,42 +2224,32 @@ function concreteChild(
   module: MutableModule,
   child: NodeChild<Owned | Token>,
   parent: AstId,
-): NodeChild<AstId | Token>
+): NodeChild<AstId> | NodeChild<Token>
 function concreteChild(
   module: MutableModule,
   child: NodeChild<Owned | Token> | undefined,
   parent: AstId,
-): NodeChild<AstId | Token> | undefined
+): NodeChild<AstId> | NodeChild<Token> | undefined
 function concreteChild(
   module: MutableModule,
   child: NodeChild<Owned | Token> | undefined,
   parent: AstId,
-): NodeChild<AstId | Token> | undefined {
+): NodeChild<AstId> | NodeChild<Token> | undefined {
   if (!child) return undefined
   if (isTokenId(child.node)) return child as NodeChild<Token>
   return { ...child, node: claimChild(module, child.node, parent) }
 }
 
 type StrictIdentLike = Identifier | IdentifierToken
-function toIdentStrict(ident: StrictIdentLike): IdentifierToken
-function toIdentStrict(ident: StrictIdentLike | undefined): IdentifierToken | undefined
-function toIdentStrict(ident: StrictIdentLike | undefined): IdentifierToken | undefined {
-  return ident
-    ? isToken(ident)
-      ? ident
-      : (Token.new(ident, RawAst.Token.Type.Ident) as IdentifierToken)
-    : undefined
+function toIdentStrict(ident: StrictIdentLike): IdentifierToken {
+  return isToken(ident) ? ident : (Token.new(ident, RawAst.Token.Type.Ident) as IdentifierToken)
 }
 
 type IdentLike = IdentifierOrOperatorIdentifier | IdentifierOrOperatorIdentifierToken
-function toIdent(ident: IdentLike): IdentifierOrOperatorIdentifierToken
-function toIdent(ident: IdentLike | undefined): IdentifierOrOperatorIdentifierToken | undefined
-function toIdent(ident: IdentLike | undefined): IdentifierOrOperatorIdentifierToken | undefined {
-  return ident
-    ? isToken(ident)
-      ? ident
-      : (Token.new(ident, RawAst.Token.Type.Ident) as IdentifierOrOperatorIdentifierToken)
-    : undefined
+function toIdent(ident: IdentLike): IdentifierOrOperatorIdentifierToken {
+  return isToken(ident)
+    ? ident
+    : (Token.new(ident, RawAst.Token.Type.Ident) as IdentifierOrOperatorIdentifierToken)
 }
 
 function makeEquals(): Token {

--- a/app/gui2/src/stores/graph/graphDatabase.ts
+++ b/app/gui2/src/stores/graph/graphDatabase.ts
@@ -462,12 +462,14 @@ export interface Node {
   vis: Opt<VisualizationMetadata>
   /** A child AST in a syntactic position to be a self-argument input to the node. */
   primarySubject: Ast.AstId | undefined
+  documentation: string | undefined
 }
 
 const baseMockNode = {
   position: Vec2.Zero,
   vis: undefined,
   primarySubject: undefined,
+  documentation: undefined,
 }
 
 /** This should only be used for supplying as initial props when testing.

--- a/app/gui2/src/util/ast/node.ts
+++ b/app/gui2/src/util/ast/node.ts
@@ -44,8 +44,8 @@ if (import.meta.vitest) {
     line                               | pattern      | rootSpan   | documentation
     ${'2 + 2'}                         | ${undefined} | ${'2 + 2'} | ${undefined}
     ${'foo = bar'}                     | ${'foo'}     | ${'bar'}   | ${undefined}
-    ${'## Documentation\n2 + 2'}       | ${undefined} | ${'2 + 2'} | ${' Documentation'}
-    ${'## Documentation\nfoo = 2 + 2'} | ${'foo'}     | ${'2 + 2'} | ${' Documentation'}
+    ${'## Documentation\n2 + 2'}       | ${undefined} | ${'2 + 2'} | ${'Documentation'}
+    ${'## Documentation\nfoo = 2 + 2'} | ${'foo'}     | ${'2 + 2'} | ${'Documentation'}
   `('Node information from AST $line line', ({ line, pattern, rootSpan, documentation }) => {
     const ast = Ast.Ast.parse(line)
     const node = nodeFromAst(ast)

--- a/app/gui2/src/util/ast/node.ts
+++ b/app/gui2/src/util/ast/node.ts
@@ -3,7 +3,10 @@ import { Ast } from '@/util/ast'
 import { Vec2 } from '@/util/data/vec2'
 
 export function nodeFromAst(ast: Ast.Ast): Node | undefined {
-  const nodeCode = ast instanceof Ast.Documented ? ast.expression : ast
+  const { nodeCode, documentation } =
+    ast instanceof Ast.Documented
+      ? { nodeCode: ast.expression, documentation: ast.documentation() }
+      : { nodeCode: ast, documentation: undefined }
   if (!nodeCode) return
   const pattern = nodeCode instanceof Ast.Assignment ? nodeCode.pattern : undefined
   const rootSpan = nodeCode instanceof Ast.Assignment ? nodeCode.expression : nodeCode
@@ -14,6 +17,7 @@ export function nodeFromAst(ast: Ast.Ast): Node | undefined {
     position: Vec2.Zero,
     vis: undefined,
     primarySubject: primaryApplicationSubject(rootSpan),
+    documentation,
   }
 }
 
@@ -37,17 +41,18 @@ if (import.meta.vitest) {
   await initializeFFI()
 
   test.each`
-    line                               | pattern      | rootSpan
-    ${'2 + 2'}                         | ${undefined} | ${'2 + 2'}
-    ${'foo = bar'}                     | ${'foo'}     | ${'bar'}
-    ${'## Documentation\n2 + 2'}       | ${undefined} | ${'2 + 2'}
-    ${'## Documentation\nfoo = 2 + 2'} | ${'foo'}     | ${'2 + 2'}
-  `('Node information from AST $line line', ({ line, pattern, rootSpan }) => {
+    line                               | pattern      | rootSpan   | documentation
+    ${'2 + 2'}                         | ${undefined} | ${'2 + 2'} | ${undefined}
+    ${'foo = bar'}                     | ${'foo'}     | ${'bar'}   | ${undefined}
+    ${'## Documentation\n2 + 2'}       | ${undefined} | ${'2 + 2'} | ${' Documentation'}
+    ${'## Documentation\nfoo = 2 + 2'} | ${'foo'}     | ${'2 + 2'} | ${' Documentation'}
+  `('Node information from AST $line line', ({ line, pattern, rootSpan, documentation }) => {
     const ast = Ast.Ast.parse(line)
     const node = nodeFromAst(ast)
     expect(node?.outerExprId).toBe(ast.id)
     expect(node?.pattern?.code()).toBe(pattern)
     expect(node?.rootSpan.code()).toBe(rootSpan)
+    expect(node?.documentation).toBe(documentation)
   })
 
   test.each(['## Documentation only'])("'%s' should not be a node", (line) => {


### PR DESCRIPTION
### Pull Request Description

Part of #9162.

- Add support for representing and interpreting the full text-literal/documentation syntax (escape codes, platform-independent newlines, string interpolations); build on generalized operations for structured-fields that will simplify future representation of other types like `Vector`.
- Load parsed and interpreted node documentation into `Node`s.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
