### PR TITLE
Display comments

### DIFF
--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -666,7 +666,7 @@ const documentation = computed<string | undefined>(() => props.node.documentatio
   position: absolute;
   bottom: 100%;
   left: 60px;
-  margin-bottom: 4px;
+  margin-bottom: 2px;
 }
 
 .afterNode {

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { nodeEditBindings } from '@/bindings'
 import CircularMenu from '@/components/CircularMenu.vue'
+import GraphNodeComment from '@/components/GraphEditor/GraphNodeComment.vue'
 import GraphNodeError from '@/components/GraphEditor/GraphNodeMessage.vue'
 import GraphVisualization from '@/components/GraphEditor/GraphVisualization.vue'
 import NodeWidgetTree from '@/components/GraphEditor/NodeWidgetTree.vue'
@@ -362,6 +363,8 @@ function openFullMenu() {
   }
   menuVisible.value = MenuState.Full
 }
+
+const documentation = computed<string | undefined>(() => props.node.documentation)
 </script>
 
 <template>
@@ -417,6 +420,7 @@ function openFullMenu() {
       @update:id="emit('update:visualizationId', $event)"
       @update:visible="emit('update:visualizationVisible', $event)"
     />
+    <GraphNodeComment v-if="documentation" v-model="documentation" class="beforeNode" />
     <div
       ref="contentNode"
       class="node"
@@ -434,10 +438,10 @@ function openFullMenu() {
         @openFullMenu="openFullMenu"
       />
     </div>
-    <GraphNodeError v-if="error" class="message" :message="error" type="error" />
+    <GraphNodeError v-if="error" class="afterNode" :message="error" type="error" />
     <GraphNodeError
       v-if="warning && (nodeHovered || isSelected)"
-      class="message warning"
+      class="afterNode warning"
       :class="menuVisible === MenuState.Off ? '' : 'messageWithMenu'"
       :message="warning"
       type="warning"
@@ -658,7 +662,14 @@ function openFullMenu() {
   z-index: 1;
 }
 
-.message {
+.beforeNode {
+  position: absolute;
+  bottom: 100%;
+  left: 60px;
+  margin-bottom: 4px;
+}
+
+.afterNode {
   position: absolute;
   top: 100%;
   margin-top: 4px;

--- a/app/gui2/src/components/GraphEditor/GraphNodeComment.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNodeComment.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{ modelValue: string }>()
+
+const paragraphs = computed(() => props.modelValue.split('\n\n'))
+</script>
+
+<template>
+  <div class="GraphNodeComment">
+    <p v-for="(paragraph, i) in paragraphs" :key="i" v-text="paragraph" />
+  </div>
+</template>
+
+<style scoped>
+.GraphNodeComment {
+  padding: 1px 8px;
+  font-weight: 800;
+  white-space: nowrap;
+  border-radius: var(--radius-full);
+  color: var(--color-text);
+  line-height: 20px;
+  background-color: white;
+}
+</style>

--- a/app/gui2/src/components/GraphEditor/GraphNodeComment.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNodeComment.vue
@@ -15,11 +15,11 @@ const paragraphs = computed(() => props.modelValue.split('\n\n'))
 <style scoped>
 .GraphNodeComment {
   padding: 1px 8px;
-  font-weight: 800;
+  font-weight: 400;
   white-space: nowrap;
   border-radius: var(--radius-full);
-  color: var(--color-text);
+  color: var(--color-text-inversed);
   line-height: 20px;
-  background-color: white;
+  background-color: var(--node-color-no-type);
 }
 </style>

--- a/app/gui2/src/stores/graph/graphDatabase.ts
+++ b/app/gui2/src/stores/graph/graphDatabase.ts
@@ -1,4 +1,3 @@
-import type { Node, NodeAstData, NodeMetadataData } from '@/stores/graph'
 import { ComputedValueRegistry, type ExpressionInfo } from '@/stores/project/computedValueRegistry'
 import { SuggestionDb, groupColorStyle, type Group } from '@/stores/suggestionDatabase'
 import type { SuggestionEntry } from '@/stores/suggestionDatabase/entry'
@@ -16,13 +15,9 @@ import { ReactiveDb, ReactiveIndex, ReactiveMapping } from '@/util/database/reac
 import * as random from 'lib0/random'
 import * as set from 'lib0/set'
 import { methodPointerEquals, type MethodCall, type StackItem } from 'shared/languageServerTypes'
-import {
-  isUuid,
-  sourceRangeKey,
-  visMetadataEquals,
-  type ExternalId,
-  type SourceRange,
-} from 'shared/yjsModel'
+import type { Opt } from 'shared/util/data/opt'
+import type { ExternalId, SourceRange, VisualizationMetadata } from 'shared/yjsModel'
+import { isUuid, sourceRangeKey, visMetadataEquals } from 'shared/yjsModel'
 import { reactive, ref, type Ref } from 'vue'
 
 export interface BindingInfo {
@@ -350,7 +345,7 @@ export class GraphDb {
       const nodeMeta = (node ?? newNode).rootSpan.nodeMetadata
       currentNodeIds.add(nodeId)
       if (node == null) {
-        let metadataFields: NodeMetadataData = {
+        let metadataFields: NodeDataFromMetadata = {
           position: new Vec2(0, 0),
           vis: undefined,
         }
@@ -380,7 +375,7 @@ export class GraphDb {
           rootSpan,
           primarySubject,
           documentation,
-        } satisfies NodeAstData
+        } satisfies NodeDataFromAst
       }
     }
     for (const nodeId of this.nodeIdToNode.keys()) {
@@ -465,6 +460,22 @@ export type NodeId = AstId & { [brandNodeId]: never }
 export function asNodeId(id: Ast.AstId): NodeId {
   return id as NodeId
 }
+
+export interface NodeDataFromAst {
+  outerExprId: Ast.AstId
+  pattern: Ast.Ast | undefined
+  rootSpan: Ast.Ast
+  /** A child AST in a syntactic position to be a self-argument input to the node. */
+  primarySubject: Ast.AstId | undefined
+  documentation: string | undefined
+}
+
+export interface NodeDataFromMetadata {
+  position: Vec2
+  vis: Opt<VisualizationMetadata>
+}
+
+export interface Node extends NodeDataFromAst, NodeDataFromMetadata {}
 
 const baseMockNode = {
   position: Vec2.Zero,

--- a/app/gui2/src/stores/graph/graphDatabase.ts
+++ b/app/gui2/src/stores/graph/graphDatabase.ts
@@ -342,7 +342,6 @@ export class GraphDb {
       if (!newNode) continue
       const nodeId = asNodeId(newNode.rootSpan.id)
       const node = this.nodeIdToNode.get(nodeId)
-      const nodeMeta = (node ?? newNode).rootSpan.nodeMetadata
       currentNodeIds.add(nodeId)
       if (node == null) {
         let metadataFields: NodeDataFromMetadata = {
@@ -352,6 +351,7 @@ export class GraphDb {
         // We are notified of new or changed metadata by `updateMetadata`, so we only need to read existing metadata
         // when we switch to a different function.
         if (functionChanged) {
+          const nodeMeta = newNode.rootSpan.nodeMetadata
           const pos = nodeMeta.get('position') ?? { x: 0, y: 0 }
           metadataFields = {
             position: new Vec2(pos.x, pos.y),

--- a/app/gui2/src/stores/graph/index.ts
+++ b/app/gui2/src/stores/graph/index.ts
@@ -38,23 +38,12 @@ import type {
 import { defaultLocalOrigin, sourceRangeKey, visMetadataEquals } from 'shared/yjsModel'
 import { computed, markRaw, reactive, ref, toRef, watch, type ShallowRef } from 'vue'
 
-export { type NodeId } from '@/stores/graph/graphDatabase'
-
-export interface NodeAstData {
-  outerExprId: Ast.AstId
-  pattern: Ast.Ast | undefined
-  rootSpan: Ast.Ast
-  /** A child AST in a syntactic position to be a self-argument input to the node. */
-  primarySubject: Ast.AstId | undefined
-  documentation: string | undefined
-}
-
-export interface NodeMetadataData {
-  position: Vec2
-  vis: Opt<VisualizationMetadata>
-}
-
-export interface Node extends NodeAstData, NodeMetadataData {}
+export type {
+  Node,
+  NodeDataFromAst,
+  NodeDataFromMetadata,
+  NodeId,
+} from '@/stores/graph/graphDatabase'
 
 export interface NodeEditInfo {
   id: NodeId

--- a/app/gui2/src/stores/graph/index.ts
+++ b/app/gui2/src/stores/graph/index.ts
@@ -38,7 +38,23 @@ import type {
 import { defaultLocalOrigin, sourceRangeKey, visMetadataEquals } from 'shared/yjsModel'
 import { computed, markRaw, reactive, ref, toRef, watch, type ShallowRef } from 'vue'
 
-export { type Node, type NodeId } from '@/stores/graph/graphDatabase'
+export { type NodeId } from '@/stores/graph/graphDatabase'
+
+export interface NodeAstData {
+  outerExprId: Ast.AstId
+  pattern: Ast.Ast | undefined
+  rootSpan: Ast.Ast
+  /** A child AST in a syntactic position to be a self-argument input to the node. */
+  primarySubject: Ast.AstId | undefined
+  documentation: string | undefined
+}
+
+export interface NodeMetadataData {
+  position: Vec2
+  vis: Opt<VisualizationMetadata>
+}
+
+export interface Node extends NodeAstData, NodeMetadataData {}
 
 export interface NodeEditInfo {
   id: NodeId

--- a/app/gui2/src/util/ast/node.ts
+++ b/app/gui2/src/util/ast/node.ts
@@ -1,8 +1,7 @@
-import type { Node } from '@/stores/graph'
+import type { NodeAstData } from '@/stores/graph'
 import { Ast } from '@/util/ast'
-import { Vec2 } from '@/util/data/vec2'
 
-export function nodeFromAst(ast: Ast.Ast): Node | undefined {
+export function nodeFromAst(ast: Ast.Ast): NodeAstData | undefined {
   const { nodeCode, documentation } =
     ast instanceof Ast.Documented
       ? { nodeCode: ast.expression, documentation: ast.documentation() }
@@ -14,8 +13,6 @@ export function nodeFromAst(ast: Ast.Ast): Node | undefined {
     outerExprId: ast.id,
     pattern,
     rootSpan,
-    position: Vec2.Zero,
-    vis: undefined,
     primarySubject: primaryApplicationSubject(rootSpan),
     documentation,
   }

--- a/app/gui2/src/util/ast/node.ts
+++ b/app/gui2/src/util/ast/node.ts
@@ -1,7 +1,7 @@
-import type { NodeAstData } from '@/stores/graph'
+import type { NodeDataFromAst } from '@/stores/graph'
 import { Ast } from '@/util/ast'
 
-export function nodeFromAst(ast: Ast.Ast): NodeAstData | undefined {
+export function nodeFromAst(ast: Ast.Ast): NodeDataFromAst | undefined {
   const { nodeCode, documentation } =
     ast instanceof Ast.Documented
       ? { nodeCode: ast.expression, documentation: ast.documentation() }


### PR DESCRIPTION
### Pull Request Description

Introduce basic display of node documentation-comments.

![image](https://github.com/enso-org/enso/assets/1047859/b1960097-d265-4d77-a924-fd3c309dc3fd)

Part of #9162.

### Important Notes

- Add synchronization of `documentation` updates to the GraphDB; add a type assertion that ensures `Node` synchronization is updated when new fields are added to `Node`.
- Introduce read-only comment rendering.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
