### PR TITLE
Fix benchmark run build

### DIFF
--- a/build/build/src/engine/context.rs
+++ b/build/build/src/engine/context.rs
@@ -356,7 +356,10 @@ impl RunContext {
             if self.config.build_launcher_package() {
                 tasks.push("buildLauncherDistribution");
             }
-            sbt.call_arg(Sbt::concurrent_tasks(tasks)).await?;
+
+            if !tasks.is_empty() {
+                sbt.call_arg(Sbt::concurrent_tasks(tasks)).await?;
+            }
         } else {
             // If we are run on a weak machine (like GH-hosted runner), we need to build things one
             // by one.


### PR DESCRIPTION
Fixes a regression introduced by #9134

### Pull Request Description

Make sure that `sbt` is invoked only if there are some tasks to run. If not, `sbt all` is invoked, which fails, as `all` is not a command.

### Important Notes

The first `Engine Benchmarks` job failure is in https://github.com/enso-org/enso/actions/runs/8073012762/job/22055882533#step:8:923

`Benchmark Standard Libraries` are failing since the same time, and on the same error, for example at https://github.com/enso-org/enso/actions/runs/8073051776/job/22056002795

### Checklist
- [x] Make sure that (dry-run) benchmarks are fine
