### PR TITLE
PathProgressBodyHandler does not return immediately

### DIFF
--- a/lib/scala/downloader/src/main/java/org/enso/downloader/http/PathProgressBodyHandler.java
+++ b/lib/scala/downloader/src/main/java/org/enso/downloader/http/PathProgressBodyHandler.java
@@ -86,7 +86,7 @@ class PathProgressBodyHandler implements HttpResponse.BodyHandler<Path> {
         for (ByteBuffer item : items) {
           var len = item.remaining();
           downloaded += len;
-          progress.reportProgress(downloaded, total == null ? Option.empty() : Some.apply(total));
+          progress.reportProgress(downloaded, Option.apply(total));
           destChannel.write(item);
         }
         subscription.request(1);

--- a/lib/scala/downloader/src/main/java/org/enso/downloader/http/StringProgressBodyHandler.java
+++ b/lib/scala/downloader/src/main/java/org/enso/downloader/http/StringProgressBodyHandler.java
@@ -6,7 +6,6 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodySubscriber;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -15,12 +14,13 @@ import org.enso.cli.task.TaskProgressImplementation;
 import scala.Option;
 import scala.Some;
 
-/** A {@link HttpResponse} body handler for {@link Path} that keeps track of the progress. */
+/** A {@link HttpResponse} body handler for {@link String} that keeps track of the progress. */
 public class StringProgressBodyHandler implements HttpResponse.BodyHandler<String> {
   private final ByteArrayOutputStream destination = new ByteArrayOutputStream();
   private final TaskProgressImplementation<?> progress;
   private final Charset encoding;
   private Long total;
+  private long downloaded;
 
   private StringProgressBodyHandler(
       TaskProgressImplementation<?> progress, Charset encoding, Long total) {
@@ -64,7 +64,8 @@ public class StringProgressBodyHandler implements HttpResponse.BodyHandler<Strin
     public void onNext(List<ByteBuffer> items) {
       for (ByteBuffer item : items) {
         var len = item.remaining();
-        progress.reportProgress(len, total == null ? Option.empty() : Some.apply(total));
+        downloaded += len;
+        progress.reportProgress(downloaded, total == null ? Option.empty() : Some.apply(total));
         byte[] bytes = new byte[len];
         item.get(bytes);
         destination.write(bytes, 0, bytes.length);

--- a/lib/scala/downloader/src/main/java/org/enso/downloader/http/StringProgressBodyHandler.java
+++ b/lib/scala/downloader/src/main/java/org/enso/downloader/http/StringProgressBodyHandler.java
@@ -65,7 +65,7 @@ public class StringProgressBodyHandler implements HttpResponse.BodyHandler<Strin
       for (ByteBuffer item : items) {
         var len = item.remaining();
         downloaded += len;
-        progress.reportProgress(downloaded, total == null ? Option.empty() : Some.apply(total));
+        progress.reportProgress(downloaded, Option.apply(total));
         byte[] bytes = new byte[len];
         item.get(bytes);
         destination.write(bytes, 0, bytes.length);


### PR DESCRIPTION
Fixes #9221

### Pull Request Description

Fixes downloading of files. It used to fail because it returned almost immediately. Also fixes progress reporting when fetching a String.

### Important Notes

Tested by removing appropriate engine and runtime from `$HOME/.local/share/enso` and with manually running:
```
java -jar launcher.jar --launcher-log-level trace install engine 2024.1.1-nightly.2024.2.29
```

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
