### PR TITLE
Create and edit comments

### DIFF
--- a/app/gui2/shared/ast/tree.ts
+++ b/app/gui2/shared/ast/tree.ts
@@ -1388,7 +1388,7 @@ export class Documented extends Ast {
       expression.module,
       undefined,
       textToUninterpolatedElements(text),
-      [],
+      undefined,
       autospaced(expression),
     )
   }
@@ -1397,7 +1397,7 @@ export class Documented extends Ast {
     module: MutableModule,
     open: NodeChild<Token> | undefined,
     elements: TextToken<OwnedRefs>[],
-    newlines: NodeChild<Token>[],
+    newlines: NodeChild<Token>[] | undefined,
     expression: NodeChild<Owned> | undefined,
   ) {
     const base = module.baseObject('Documented')
@@ -1405,7 +1405,9 @@ export class Documented extends Ast {
     const fields = composeFieldData(base, {
       open: open ?? unspaced(Token.new('##', RawAst.Token.Type.Operator)),
       elements: elements.map((e) => mapRefs(e, ownedToRaw(module, id_))),
-      newlines,
+      newlines: newlines?.length
+        ? newlines
+        : [unspaced(Token.new('\n', RawAst.Token.Type.Newline))],
       expression: concreteChild(module, expression, id_),
     })
     return asOwned(new MutableDocumented(module, fields))

--- a/app/gui2/shared/ast/tree.ts
+++ b/app/gui2/shared/ast/tree.ts
@@ -1405,9 +1405,7 @@ export class Documented extends Ast {
     const fields = composeFieldData(base, {
       open: open ?? unspaced(Token.new('##', RawAst.Token.Type.Operator)),
       elements: elements.map((e) => mapRefs(e, ownedToRaw(module, id_))),
-      newlines: newlines?.length
-        ? newlines
-        : [unspaced(Token.new('\n', RawAst.Token.Type.Newline))],
+      newlines: newlines ?? [unspaced(Token.new('\n', RawAst.Token.Type.Newline))],
       expression: concreteChild(module, expression, id_),
     })
     return asOwned(new MutableDocumented(module, fields))

--- a/app/gui2/shared/ast/tree.ts
+++ b/app/gui2/shared/ast/tree.ts
@@ -36,6 +36,7 @@ import {
   print,
   printAst,
   printBlock,
+  printDocumented,
   syncToCode,
 } from './parse'
 
@@ -1366,7 +1367,7 @@ export interface MutableTextLiteral extends TextLiteral, MutableAst {}
 applyMixins(MutableTextLiteral, [MutableAst])
 
 interface DocumentedFields {
-  open: NodeChild<SyncTokenId> | undefined
+  open: NodeChild<SyncTokenId>
   elements: TextToken[]
   newlines: NodeChild<SyncTokenId>[]
   expression: NodeChild<AstId> | undefined
@@ -1382,6 +1383,16 @@ export class Documented extends Ast {
     if (parsed instanceof MutableDocumented) return parsed
   }
 
+  static new(text: string, expression: Owned) {
+    return this.concrete(
+      expression.module,
+      undefined,
+      textToUninterpolatedElements(text),
+      [],
+      autospaced(expression),
+    )
+  }
+
   static concrete(
     module: MutableModule,
     open: NodeChild<Token> | undefined,
@@ -1392,7 +1403,7 @@ export class Documented extends Ast {
     const base = module.baseObject('Documented')
     const id_ = base.get('id')
     const fields = composeFieldData(base, {
-      open,
+      open: open ?? unspaced(Token.new('##', RawAst.Token.Type.Operator)),
       elements: elements.map((e) => mapRefs(e, ownedToRaw(module, id_))),
       newlines,
       expression: concreteChild(module, expression, id_),
@@ -1412,15 +1423,33 @@ export class Documented extends Ast {
 
   *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
     const { open, elements, newlines, expression } = getAll(this.fields)
-    if (open) yield open
-    for (const e of elements) yield* fieldConcreteChildren(e)
+    yield open
+    for (const { token } of elements) yield token
     yield* newlines
     if (expression) yield expression
+  }
+
+  printSubtree(
+    info: SpanMap,
+    offset: number,
+    parentIndent: string | undefined,
+    verbatim?: boolean,
+  ): string {
+    return printDocumented(this, info, offset, parentIndent, verbatim)
   }
 }
 export class MutableDocumented extends Documented implements MutableAst {
   declare readonly module: MutableModule
   declare readonly fields: FixedMap<AstFields & DocumentedFields>
+
+  setDocumentationText(text: string) {
+    this.fields.set(
+      'elements',
+      textToUninterpolatedElements(text).map((owned) =>
+        mapRefs(owned, ownedToRaw(this.module, this.id)),
+      ),
+    )
+  }
 
   setExpression<T extends MutableAst>(value: Owned<T> | undefined) {
     this.fields.set('expression', unspaced(this.claimChild(value)))
@@ -1430,6 +1459,22 @@ export interface MutableDocumented extends Documented, MutableAst {
   get expression(): MutableAst | undefined
 }
 applyMixins(MutableDocumented, [MutableAst])
+
+function textToUninterpolatedElements(text: string): TextToken<OwnedRefs>[] {
+  const elements = new Array<TextToken<OwnedRefs>>()
+  text.split('\n').forEach((line, i) => {
+    if (i)
+      elements.push({
+        type: 'token',
+        token: unspaced(Token.new('\n', RawAst.Token.Type.TextNewline)),
+      })
+    elements.push({
+      type: 'token',
+      token: autospaced(Token.new(line, RawAst.Token.Type.TextSection)),
+    })
+  })
+  return elements
+}
 
 interface InvalidFields {
   expression: NodeChild<AstId>

--- a/app/gui2/src/components/CircularMenu.vue
+++ b/app/gui2/src/components/CircularMenu.vue
@@ -14,6 +14,7 @@ const emit = defineEmits<{
   'update:isDocsVisible': [isDocsVisible: boolean]
   'update:isVisualizationVisible': [isVisualizationVisible: boolean]
   startEditing: []
+  startEditingComment: []
 }>()
 </script>
 
@@ -24,6 +25,11 @@ const emit = defineEmits<{
     @pointerup.stop
     @click.stop
   >
+    <SvgIcon
+      name="comment"
+      class="icon-container button slot2"
+      @click.stop="emit('startEditingComment')"
+    />
     <ToggleIcon
       icon="eye"
       class="icon-container button slot5"

--- a/app/gui2/src/components/CodeEditor.vue
+++ b/app/gui2/src/components/CodeEditor.vue
@@ -35,6 +35,7 @@ const {
   forceLinting,
   lsDiagnosticsToCMDiagnostics,
   hoverTooltip,
+  textEditToChangeSpec,
 } = await import('@/components/CodeEditor/codemirror')
 
 const projectStore = useProjectStore()
@@ -186,9 +187,6 @@ function changeSetToTextEdits(changes: ChangeSet) {
     textEdits.push({ range: [from, to], insert: insert.toString() }),
   )
   return textEdits
-}
-function textEditToChangeSpec({ range: [from, to], insert }: SourceRangeEdit) {
-  return { from, to, insert }
 }
 
 let pendingChanges: ChangeSet | undefined

--- a/app/gui2/src/components/CodeEditor.vue
+++ b/app/gui2/src/components/CodeEditor.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { ChangeSet, Diagnostic, Highlighter } from '@/components/CodeEditor/codemirror'
-import { Annotation, StateEffect, StateField } from '@/components/CodeEditor/codemirror'
 import { usePointer } from '@/composables/events'
 import { useGraphStore, type NodeId } from '@/stores/graph'
 import { useProjectStore } from '@/stores/project'
@@ -18,6 +17,9 @@ import { computed, onMounted, onUnmounted, ref, shallowRef, watch, watchEffect }
 
 // Use dynamic imports to aid code splitting. The codemirror dependency is quite large.
 const {
+  Annotation,
+  StateEffect,
+  StateField,
   bracketMatching,
   foldGutter,
   lintGutter,

--- a/app/gui2/src/components/CodeEditor/codemirror.ts
+++ b/app/gui2/src/components/CodeEditor/codemirror.ts
@@ -28,6 +28,7 @@ import {
   syntaxTree,
 } from '@codemirror/language'
 import { type Diagnostic } from '@codemirror/lint'
+import type { ChangeSpec } from '@codemirror/state'
 import { hoverTooltip as originalHoverTooltip, type TooltipView } from '@codemirror/view'
 import {
   NodeProp,
@@ -43,6 +44,7 @@ import { styleTags, tags } from '@lezer/highlight'
 import { EditorView } from 'codemirror'
 import type { Diagnostic as LSDiagnostic } from 'shared/languageServerTypes'
 import { tryGetSoleValue } from 'shared/util/data/iterable'
+import type { SourceRangeEdit } from 'shared/util/data/text'
 
 export function lsDiagnosticsToCMDiagnostics(
   source: string,
@@ -192,4 +194,8 @@ export function hoverTooltip(
       create: typeof domOrCreate !== 'function' ? () => domOrCreate : domOrCreate,
     }
   })
+}
+
+export function textEditToChangeSpec({ range: [from, to], insert }: SourceRangeEdit): ChangeSpec {
+  return { from, to, insert }
 }

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -369,8 +369,10 @@ function openFullMenu() {
   menuVisible.value = MenuState.Full
 }
 
+const editingComment = ref(false)
+
 const documentation = computed<string | undefined>({
-  get: () => props.node.documentation,
+  get: () => props.node.documentation ?? (editingComment.value ? '' : undefined),
   set: (text) => {
     graph.edit((edit) => {
       const outerExpr = edit.get(props.node.outerExprId)
@@ -424,6 +426,7 @@ const documentation = computed<string | undefined>({
       :isFullMenuVisible="menuVisible === MenuState.Full"
       @update:isVisualizationVisible="emit('update:visualizationVisible', $event)"
       @startEditing="startEditingNode"
+      @startEditingComment="editingComment = true"
     />
     <GraphVisualization
       v-if="isVisualizationVisible"
@@ -447,7 +450,12 @@ const documentation = computed<string | undefined>({
       @update:width="emit('update:visualizationWidth', $event)"
     />
     <Suspense>
-      <GraphNodeComment v-if="documentation" v-model="documentation" class="beforeNode" />
+      <GraphNodeComment
+        v-if="documentation != null"
+        v-model="documentation"
+        v-model:editing="editingComment"
+        class="beforeNode"
+      />
     </Suspense>
     <div
       ref="contentNode"

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -423,7 +423,7 @@ const documentation = computed<string | undefined>({
       v-model:isDocsVisible="isDocsVisible"
       :isOutputContextEnabledGlobally="projectStore.isOutputContextEnabled"
       :isVisualizationVisible="isVisualizationVisible"
-      :isFullMenuVisible="menuVisible === MenuState.Full"
+      :isFullMenuVisible="true"
       @update:isVisualizationVisible="emit('update:visualizationVisible', $event)"
       @startEditing="startEditingNode"
       @startEditingComment="editingComment = true"

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -423,7 +423,7 @@ const documentation = computed<string | undefined>({
       v-model:isDocsVisible="isDocsVisible"
       :isOutputContextEnabledGlobally="projectStore.isOutputContextEnabled"
       :isVisualizationVisible="isVisualizationVisible"
-      :isFullMenuVisible="true"
+      :isFullMenuVisible="menuVisible === MenuState.Full"
       @update:isVisualizationVisible="emit('update:visualizationVisible', $event)"
       @startEditing="startEditingNode"
       @startEditingComment="editingComment = true"

--- a/app/gui2/src/components/GraphEditor/GraphNodeComment.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNodeComment.vue
@@ -37,20 +37,25 @@ const handleClick = defineKeybinds(`comment-${random.uint53()}`, {
 }).handler({ startEdit })
 
 function startEdit() {
-  const editorView = new EditorView()
-  editorView.setState(EditorState.create({ extensions: [minimalSetup] }))
-  contentElement.value!.prepend(editorView.dom)
-  editor.value = editorView
+  if (editor.value) {
+    editor.value.focus()
+  } else {
+    const editorView = new EditorView()
+    editorView.setState(EditorState.create({ extensions: [minimalSetup] }))
+    contentElement.value!.prepend(editorView.dom)
+    editor.value = editorView
+    setTimeout(() => editorView.focus())
+  }
   if (!props.editing) emit('update:editing', true)
-  setTimeout(() => editorView.focus())
 }
 
 function finishEdit() {
-  if (!editor.value) return
-  if (editor.value.state.doc.toString() !== props.modelValue)
-    emit('update:modelValue', editor.value.state.doc.toString())
-  editor.value.dom.remove()
-  editor.value = undefined
+  if (editor.value) {
+    if (editor.value.state.doc.toString() !== props.modelValue)
+      emit('update:modelValue', editor.value.state.doc.toString())
+    editor.value.dom.remove()
+    editor.value = undefined
+  }
   if (props.editing) emit('update:editing', false)
 }
 

--- a/app/gui2/src/components/GraphEditor/GraphNodeComment.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNodeComment.vue
@@ -1,25 +1,102 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import type { EditorView as EditorViewType } from '@/components/CodeEditor/codemirror'
+import { injectInteractionHandler } from '@/providers/interactionHandler'
+import { defineKeybinds } from '@/util/shortcuts'
+import * as random from 'lib0/random'
+import { textChangeToEdits } from 'shared/util/data/text'
+import { computed, ref, watchEffect } from 'vue'
+
+const { minimalSetup, EditorState, EditorView, textEditToChangeSpec } = await import(
+  '@/components/CodeEditor/codemirror'
+)
 
 const props = defineProps<{ modelValue: string }>()
+const emit = defineEmits<{ 'update:modelValue': [modelValue: string | undefined] }>()
 
 const paragraphs = computed(() => props.modelValue.split('\n\n'))
+
+const contentElement = ref<HTMLElement>()
+const editor = ref<EditorViewType>()
+
+const interaction = injectInteractionHandler()
+interaction.setWhen(() => editor.value != null, {
+  cancel() {
+    finishEdit()
+  },
+  click(e: Event) {
+    if (e.target instanceof Element && !contentElement.value?.contains(e.target)) finishEdit()
+    return false
+  },
+})
+
+const handleClick = defineKeybinds(`comment-${random.uint53()}`, {
+  startEdit: ['Mod+PointerMain'],
+}).handler({ startEdit })
+
+function startEdit() {
+  const editorView = new EditorView()
+  editorView.setState(EditorState.create({ extensions: [minimalSetup] }))
+  contentElement.value!.prepend(editorView.dom)
+  editor.value = editorView
+  setTimeout(() => editorView.focus())
+}
+
+function finishEdit() {
+  if (!editor.value) return
+  if (editor.value.state.doc.toString() !== props.modelValue)
+    emit('update:modelValue', editor.value.state.doc.toString())
+  editor.value.dom.remove()
+  editor.value = undefined
+}
+
+watchEffect(() => {
+  const text = props.modelValue
+  if (!editor.value) return
+  const viewText = editor.value.state.doc.toString()
+  editor.value.dispatch({
+    changes: textChangeToEdits(viewText, text).map(textEditToChangeSpec),
+  })
+})
 </script>
 
 <template>
-  <div class="GraphNodeComment">
-    <p v-for="(paragraph, i) in paragraphs" :key="i" v-text="paragraph" />
+  <div
+    class="GraphNodeComment"
+    @keydown.enter.stop
+    @keydown.backspace.stop
+    @keydown.space.stop
+    @keydown.delete.stop
+    @wheel.stop.passive
+    @blur="finishEdit"
+    @pointerdown.stop="handleClick"
+    @pointerup.stop
+    @click.stop
+    @contextmenu.stop
+  >
+    <div ref="contentElement" class="content">
+      <template v-if="!editor">
+        <p v-for="(paragraph, i) in paragraphs" :key="i" v-text="paragraph" />
+      </template>
+    </div>
   </div>
 </template>
 
 <style scoped>
 .GraphNodeComment {
-  padding: 1px 8px;
+  width: max(100% - 60px, 800px);
+}
+
+.content {
+  position: absolute;
+  bottom: 100%;
+  display: inline-block;
+  padding: 0 8px 2px;
   font-weight: 400;
-  white-space: nowrap;
-  border-radius: var(--radius-full);
+  border-radius: var(--radius-default);
   color: var(--color-text-inversed);
-  line-height: 20px;
+  line-height: 18px;
   background-color: var(--node-color-no-type);
+  max-width: 100%;
+  overflow-x: auto;
 }
 </style>

--- a/app/gui2/src/util/ast/__tests__/abstract.test.ts
+++ b/app/gui2/src/util/ast/__tests__/abstract.test.ts
@@ -816,3 +816,10 @@ test.each(docEditCases)('Documentation edit round trip: $code', (docCase) => {
   edited.setDocumentationText(parsedDocumentation)
   expect(edited.code()).toBe(docCase.normalized ?? code)
 })
+
+test('Adding comments', () => {
+  const expr = Ast.parse('2 + 2')
+  expr.module.replaceRoot(expr)
+  expr.update((expr) => Ast.Documented.new('Calculate five', expr))
+  expect(expr.module.root()?.code()).toBe('## Calculate five\n2 + 2')
+})


### PR DESCRIPTION
### Pull Request Description

Implements #9162:
- Add comment icon; clicking it creates and begins editing a comment.
- Edit an existing comment by clicking the icon or ctrl-clicking the comment.
- If all text is removed, the comment is removed.

https://github.com/enso-org/enso/assets/1047859/6b81f803-6c29-4a53-9c46-b5c301bcc934

### Important Notes

- Ending edit with Escape will work once #9206 is merged.
- Added a width-limit to comments: A comment can be as wide as its node, or up to 800px if its node is small. In display mode, text wraps; in edit mode, a scrollbar is shown when needed.
- In this initial implementation, changes are committed when leaving the editor. Continuous synchronization would depend on implementing Y.Text-tokens, and probably on the engine not re-evaluating the graph each time documentation is modified.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
