### PR TITLE
Align XML_Document and XML_Element APIs more.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -619,6 +619,7 @@
 - [Separate `Group_By` from `columns` into new argument on `aggregate`.][9027]
 - [Allow `copy_to` and `move_to` to work between local and S3 files.][9054]
 - [Adjusted expression handling and new `Simple_Expression` type.][9128]
+- [Update the XML methods and add more capabilities to document.][9233]
 
 [debug-shortcuts]:
   https://github.com/enso-org/enso/blob/develop/app/gui/docs/product/shortcuts.md#debug
@@ -894,6 +895,7 @@
 [9027]: https://github.com/enso-org/enso/pull/9027
 [9054]: https://github.com/enso-org/enso/pull/9054
 [9128]: https://github.com/enso-org/enso/pull/9128
+[9233]: https://github.com/enso-org/enso/pull/9233
 
 #### Enso Compiler
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Any.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Any.enso
@@ -21,6 +21,7 @@ from project.Function import const
 @Builtin_Type
 type Any
     ## GROUP Conversions
+       ICON convert
        Generic conversion of an arbitrary Enso value to requested type.
        Delegates to appropriate `.from` conversion method, if it exists.
        If such method doesn't exist, `No_Such_Conversion` panic is raised.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
@@ -18,6 +18,7 @@ import project.System.File.File_Access.File_Access
 import project.System.Input_Stream.Input_Stream
 from project.Data.Range.Extensions import all
 from project.Data.Text.Extensions import all
+from project.Metadata import make_single_choice, Widget
 
 polyglot java import java.io.StringReader
 polyglot java import java.lang.Exception as JException
@@ -100,6 +101,10 @@ type XML_Document
         XML_Utils.setCustomErrorHandler document_builder
         XML_Document.Value (document_builder.parse input_source)
 
+    ## PRIVATE
+    Value (java_document:Document)
+
+
     ## GROUP Metadata
        Get the root element of the document.
 
@@ -114,6 +119,126 @@ type XML_Document
             java_element = self.java_document.getDocumentElement
             XML_Element.new java_element
 
+    ## GROUP Metadata
+       Gets the tag of the root XML element.
+
+       > Example
+         Get the tag of an XML document's root element.
+
+             XML_Document.from_text '<foo>hello</foo>' . name
+             # => "foo"
+    name : Text ! XML_Error
+    name self = self.root_element.name
+
+    ## GROUP Selections
+       Gets a child of an XML document.
+
+       Arguments:
+       - key: If an `Integer`, returns the element at position `at` in its list
+         of children. If a `Text`, treats `key` starts with `"@"`, returns the
+         attribute with the given name otherwise returns the first child element
+         with the given name.
+
+       > Example
+         Get the first child of the document (the root element).
+
+             XML_Document.from_text '<foo><baz>hello</baz></foo>' . get 0
+             # => XML_Document.from_text "<foo><baz>hello</baz></foo>" . root_element
+
+       > Example
+         Get the child of the document (the root element) by name.
+
+             root = XML_Document.from_text '<foo bar="one">hello</foo>' . get "foo"
+             # => XML_Document.from_text "<foo><baz>hello</baz></foo>" . root_element
+    @key child_selector
+    get : Text | Integer -> Any -> Any | Text | XML_Element | Vector (Text | XML_Element) ! No_Such_Key | Index_Out_Of_Bounds | XML_Error
+    get self key:(Text | Integer)="." ~if_missing=Nothing = case key of
+        _ : Integer -> if key == 0 then self.root_element else if_missing
+        _ : Text -> if key == self.root_element.name then self.root_element else if_missing
+
+    ## GROUP Selections
+       Gets a child or attribute of an XML document.
+
+       Arguments:
+       - key: If an `Integer`, returns the element at position `at` in its list
+         of children. If a `Text`, treats `key` starts with `"@"`, returns the
+         attribute with the given name otherwise returns the first child element
+         with the given name.
+       - if_missing: The value returned if the key does not exist.
+
+       > Example
+         Get the first child of the document (the root element).
+
+             XML_Document.from_text '<foo><baz>hello</baz></foo>' . at 0
+             # => XML_Document.from_text "<foo><baz>hello</baz></foo>" . root_element
+
+       > Example
+         Get the child of the document (the root element) by name.
+
+             root = XML_Document.from_text '<foo bar="one">hello</foo>' . get "foo"
+             # => XML_Document.from_text "<foo><baz>hello</baz></foo>" . root_element
+    @key child_selector
+    at : Text | Integer -> Text | XML_Element | Vector (Text | XML_Element) ! No_Such_Key | Index_Out_Of_Bounds | XML_Error
+    at self key:(Text | Integer)="." =
+        if_missing = case key of
+            _ : Integer -> Error.throw (Index_Out_Of_Bounds.Error key self.child_count)
+            _ : Text -> Error.throw (No_Such_Key.Error self key)
+        self.get key if_missing
+
+    ## Gets the raw XML of the document (including tag, attributes and contents).
+
+       > Example
+         Get the outer XML of the document.
+
+             XML_Document.from_text '<foo>hello</foo>' . outer_xml
+             # => '<foo>hello</foo>'
+    outer_xml : Text ! XML_Error
+    outer_xml self =
+        XML_Error.handle_java_exceptions <|
+            XML_Utils.outerXML self.java_document
+
+    ## Gets the raw XML of the contents of the document, not including the
+       outermost tag and attributes.
+
+       > Example
+         Get the inner XML of the document.
+
+             XML_Document.from_text '<foo><bar>hello</bar></foo>' . inner_xml
+             # => '<foo><bar>hello</bar></foo>'
+    inner_xml : Text ! XML_Error
+    inner_xml self =
+        XML_Error.handle_java_exceptions <|
+            XML_Utils.innerXML self.java_document
+
+    ## GROUP Selections
+       Gets the child elements of an XML document.
+
+       > Example
+             XML_Document.from_text '<foo><baz>hello</baz></foo>' . children
+             # => [XML_Element'<foo><baz>hello</baz></foo>']
+    children : Vector (XML_Element | Text) ! XML_Error
+    children self = [self.root_element]
+
+    ## GROUP Metadata
+       Gets the number children of an XML document.
+
+       `child_count` only counts child elements and child text nodes that are
+       not 100% whitespace. Other node types, such as comments, are not included
+       in the count.
+
+       > Example
+         Get the number of children of an element.
+
+             XML_Document.from_text '<foo> <bar>hello</bar> <bar>hello2</bar>< </foo>' . child_count
+             # => 1
+    child_count : Integer
+    child_count self = 1
+
+    ## GROUP Metadata
+       Gets the unique set of child names of an XML document.
+    child_names : Vector Text ! XML_Error
+    child_names self = [self.root_element.name]
+
     ## PRIVATE
        Convert to a JavaScript Object representing this XML_Document.
     to_js_object : JS_Object
@@ -123,9 +248,6 @@ type XML_Document
        Convert to a display representation of this XML_Document.
     to_display_text : Text
     to_display_text self = "XML_Document (" + self.root_element.to_display_text + ")"
-
-    ## PRIVATE
-    Value (java_document:Document)
 
 type XML_Element
     ## GROUP Metadata
@@ -146,9 +268,9 @@ type XML_Element
 
        Arguments:
        - key: If an `Integer`, returns the element at position `at` in its list
-         of children. If a `Text`, treats `key` as an XPath specifier, and
-         returns the elements it points to. If a `Text` that starts with `"@"`,
-         returns the attribute with the given name.
+         of children. If a `Text`, treats `key` starts with `"@"`, returns the
+         attribute with the given name otherwise returns the first child element
+         with the given name.
 
        > Example
            XML_Document.from_text '<foo><baz>hello</baz></foo>' . root_element . get 0
@@ -157,14 +279,14 @@ type XML_Element
        > Example
          Get a tag attribute.
 
-             root = XML_Document.from_text '<foo bar="one">hello</foo>' . root_element
-             root.get "@bar"
+             root = XML_Document.from_text '<foo bar="one">hello</foo>' . root_element . get "@bar"
              # => "one"
+    @key child_selector
     get : Text | Integer -> Any -> Any | Text | XML_Element | Vector (Text | XML_Element) ! No_Such_Key | Index_Out_Of_Bounds | XML_Error
-    get self key:(Text | Integer) ~if_missing=Nothing =
-        case key of
+    get self key:(Text | Integer)="." ~if_missing=Nothing = case key of
             _ : Integer -> self.children_cache.get key if_missing
-            _ : Text -> if is_attribute_key key then self.get_xpath key . get 0 if_missing else self.get_xpath key
+            _ : Text -> if key.starts_with "@" then self.attribute (key.drop 1) else
+                self.children.find (c-> c.name == key) . if_nothing if_missing
 
     ## GROUP Selections
        Gets a child or attribute of an XML element.
@@ -187,29 +309,13 @@ type XML_Element
              root = XML_Document.from_text '<foo bar="one">hello</foo>' . root_element
              root.at "@bar"
              # => "one"
+    @key child_selector
     at : Text | Integer -> Text | XML_Element | Vector (Text | XML_Element) ! No_Such_Key | Index_Out_Of_Bounds | XML_Error
-    at self key:(Text | Integer) =
+    at self key:(Text | Integer)="." =
         if_missing = case key of
             _ : Integer -> Error.throw (Index_Out_Of_Bounds.Error key self.child_count)
             _ : Text -> Error.throw (No_Such_Key.Error self key)
         self.get key if_missing
-
-    ## Get elements denoted by the given XPath key.
-
-       Arguments:
-       - key: The XPath string to use to search for elements.
-
-       > Example
-         Get an element by xpath.
-
-             root = XML_Document.from_file test_file . root_element
-             root.at "/class/teacher[1]/firstname"
-             # => [XML_Document.from_text "<firstname>Alice</firstname>" . root_element]
-    get_xpath : Text -> Vector (Text | XML_Element) ! XML_Error
-    get_xpath self key:Text =
-        XML_Error.handle_java_exceptions <|
-            xpath = XPathFactory.newInstance.newXPath
-            only_wanted_nodes (xpath.evaluate key self.java_element XPathConstants.NODESET)
 
     ## GROUP Selections
        Gets the child elements of an XML element.
@@ -238,6 +344,13 @@ type XML_Element
     child_count : Integer ! XML_Error
     child_count self = self.children_cache.length
 
+    ## GROUP Metadata
+       Gets the unique set of child names of an XML element.
+    child_names : Vector Text ! XML_Error
+    child_names self =
+        XML_Error.handle_java_exceptions <|
+            self.children_cache.map _.name . distinct
+
     ## GROUP Selections
        Get an attribute of an XML element.
 
@@ -251,11 +364,19 @@ type XML_Element
              root = XML_Document.from_text '<foo bar="one">hello</foo>' . root_element
              root.attribute "bar"
              # => "one"
+    @name (e-> make_single_choice e.attribute_names)
     attribute : Text -> Any -> Text | Any ! XML_Error
     attribute self name:Text ~if_missing=(Error.throw (No_Such_Key.Error self name)) =
         XML_Error.handle_java_exceptions <|
             attr = self.java_element.getAttributeNode name
             if attr.is_nothing then if_missing else attr.getValue
+
+    ## PRIVATE
+       Gets a set of the attributes of an XML element.
+    attribute_names : Vector Text ! XML_Error
+    attribute_names self = XML_Error.handle_java_exceptions <|
+        named_node_map = self.java_element.getAttributes
+        Vector.new named_node_map.getLength i-> named_node_map.item i . getNodeName
 
     ## GROUP Selections
        Gets a map containing of the attributes of an XML element.
@@ -310,6 +431,23 @@ type XML_Element
     inner_xml self =
         XML_Error.handle_java_exceptions <|
             XML_Utils.innerXML self.java_element
+
+    ## Get elements denoted by the given XPath key.
+
+       Arguments:
+       - key: The XPath string to use to search for elements.
+
+       > Example
+         Get an element by xpath.
+
+             root = XML_Document.from_file test_file . root_element
+             root.at "/class/teacher[1]/firstname"
+             # => [XML_Document.from_text "<firstname>Alice</firstname>" . root_element]
+    get_xpath : Text -> Vector (Text | XML_Element) ! XML_Error
+    get_xpath self key:Text =
+        XML_Error.handle_java_exceptions <|
+            xpath = XPathFactory.newInstance.newXPath
+            only_wanted_nodes (xpath.evaluate key self.java_element XPathConstants.NODESET)
 
     ## Gets elements matching a given tag name.
 
@@ -416,6 +554,10 @@ build_child_list java_element =
         only_wanted_nodes java_element.getChildNodes
 
 ## PRIVATE
-   Returns true if `key` starts with "@".
-is_attribute_key : Text -> Boolean
-is_attribute_key s:Text = s.starts_with "@"
+   Create the element selector for an XML document or element.
+child_selector : XML_Element | XML_Document -> Widget
+child_selector node:(XML_Element|XML_Document) =
+    attributes = case node of
+        _ : XML_Element -> node.attribute_names.map (n->"@"+n)
+        _ -> []
+    make_single_choice attributes+node.child_names

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
@@ -239,6 +239,46 @@ type XML_Document
     child_names : Vector Text ! XML_Error
     child_names self = [self.root_element.name]
 
+    ## Get elements denoted by the given XPath key.
+
+       Arguments:
+       - key: The XPath string to use to search for elements.
+
+       > Example
+         Get an element by xpath.
+
+             root = XML_Document.from_file test_file
+             root.at "/class/teacher[1]/firstname"
+             # => [XML_Document.from_text "<firstname>Alice</firstname>" . root_element]
+    get_xpath : Text -> Vector (Text | XML_Element) ! XML_Error
+    get_xpath self key:Text =
+        XML_Error.handle_java_exceptions <|
+            xpath = XPathFactory.newInstance.newXPath
+            only_wanted_nodes (xpath.evaluate key self.java_document XPathConstants.NODESET)
+
+    ## Gets child elements matching a given tag name.
+
+       Arguments:
+       - tag_name: The tag name to search for.
+    @tag_name (e-> make_single_choice e.child_names)
+    get_children_by_tag_name : Text -> Vector XML_Element ! XML_Error
+    get_children_by_tag_name self tag_name:Text =
+        if tag_name=="*" || tag_name==self.root_element.name then [self.root_element] else []
+
+    ## Gets descendant elements matching a given tag name.
+       This searches through all descendants of the node, not just immediate children.
+
+       Arguments:
+       - tag_name: The tag name to search for.
+
+       > Example
+             XML_Document.from_text '<foo> <baz>hello</baz> <bar>and</bar> <baz>goodbye</baz> </foo>' . root_element . get_elements_by_tag_name "baz"
+             # => [XML_Document.from_text "<baz>hello</baz>" . root_element, XML_Document.from_text "<baz>goodbye</baz>" . root_element]
+    get_descendants_by_tag_name : Text -> Vector XML_Element ! XML_Error
+    get_descendants_by_tag_name self tag_name:Text =
+        root = if tag_name == self.root_element.name then [self.root_element] else []
+        root + (self.root_element.get_descendants_by_tag_name tag_name)
+
     ## PRIVATE
        Convert to a JavaScript Object representing this XML_Document.
     to_js_object : JS_Object
@@ -284,9 +324,9 @@ type XML_Element
     @key child_selector
     get : Text | Integer -> Any -> Any | Text | XML_Element | Vector (Text | XML_Element) ! No_Such_Key | Index_Out_Of_Bounds | XML_Error
     get self key:(Text | Integer)="." ~if_missing=Nothing = case key of
-            _ : Integer -> self.children_cache.get key if_missing
-            _ : Text -> if key.starts_with "@" then self.attribute (key.drop 1) else
-                self.children.find (c-> c.name == key) . if_nothing if_missing
+        _ : Integer -> self.children_cache.get key if_missing
+        _ : Text -> if key.starts_with "@" then self.attribute (key.drop 1) if_missing else
+            self.children.find (c-> c.name == key) . if_nothing if_missing
 
     ## GROUP Selections
        Gets a child or attribute of an XML element.
@@ -349,7 +389,7 @@ type XML_Element
     child_names : Vector Text ! XML_Error
     child_names self =
         XML_Error.handle_java_exceptions <|
-            self.children_cache.map _.name . distinct
+            self.children_cache.map  n->n.name . distinct
 
     ## GROUP Selections
        Get an attribute of an XML element.
@@ -449,15 +489,27 @@ type XML_Element
             xpath = XPathFactory.newInstance.newXPath
             only_wanted_nodes (xpath.evaluate key self.java_element XPathConstants.NODESET)
 
-    ## Gets elements matching a given tag name.
+    ## Gets child elements matching a given tag name.
 
+       Arguments:
+       - tag_name: The tag name to search for.
+    @tag_name (e-> make_single_choice e.child_names)
+    get_children_by_tag_name : Text -> Vector XML_Element ! XML_Error
+    get_children_by_tag_name self tag_name:Text = if tag_name == "*" then self.children_cache else
+        XML_Error.handle_java_exceptions <|
+           self.children_cache.filter (c-> c.name == tag_name)
+
+    ## Gets descendant elements matching a given tag name.
        This searches through all descendants of the node, not just immediate children.
+
+       Arguments:
+       - tag_name: The tag name to search for.
 
        > Example
              XML_Document.from_text '<foo> <baz>hello</baz> <bar>and</bar> <baz>goodbye</baz> </foo>' . root_element . get_elements_by_tag_name "baz"
              # => [XML_Document.from_text "<baz>hello</baz>" . root_element, XML_Document.from_text "<baz>goodbye</baz>" . root_element]
-    get_elements_by_tag_name : Text -> Vector XML_Element ! XML_Error
-    get_elements_by_tag_name self tag_name:Text =
+    get_descendants_by_tag_name : Text -> Vector XML_Element ! XML_Error
+    get_descendants_by_tag_name self tag_name:Text =
         XML_Error.handle_java_exceptions <|
             only_wanted_nodes (self.java_element.getElementsByTagName tag_name)
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
@@ -39,13 +39,11 @@ polyglot java import org.xml.sax.SAXParseException
 type XML_Document
     ## GROUP Input
        Read an XML document from a file.
+       If there is an error reading the file, `File_Error` is thrown.
+       If there is a parsing error, `XML_Error.Parse_Error` is thrown.
 
        Arguments:
        - file: the `File` to read the XML document from.
-
-       If there is an error reading the file, `File_Error` is thrown.
-
-       If there is a parsing error, `XML_Error.Parse_Error` is thrown.
 
        > Example
          Read an XML document in 'doc.xml'.
@@ -58,11 +56,10 @@ type XML_Document
             file.with_input_stream [File_Access.Read] XML_Document.from_stream
 
     ## Read an XML document from an input stream.
+       If there is a parsing error, `XML_Error.Parse_Error` is thrown.
 
        Arguments:
        - input_stream: the input stread to read the XML document from.
-
-       If there is a parsing error, `XML_Error.Parse_Error` is thrown.
 
        > Example
          Read an XML document from an input_stream.
@@ -75,11 +72,10 @@ type XML_Document
 
     ## GROUP Conversions
        Read an XML document from a string.
+       If there is a parsing error, `XML_Error.Parse_Error` is thrown.
 
        Arguments:
        - xml_string: The string to read the XML document from.
-
-       If there is a parsing error, `XML_Error.Parse_Error` is thrown.
 
        > Example
          Read an XML document from an string.
@@ -120,7 +116,7 @@ type XML_Document
             XML_Element.new java_element
 
     ## GROUP Metadata
-       Gets the tag of the root XML element.
+       Gets the tag of the root XML element of the document.
 
        > Example
          Get the tag of an XML document's root element.
@@ -131,11 +127,11 @@ type XML_Document
     name self = self.root_element.name
 
     ## GROUP Selections
-       Gets a child of an XML document.
+       Gets a child element of an XML document.
 
        Arguments:
        - key: If an `Integer`, returns the element at position `at` in its list
-         of children. If a `Text`, treats `key` starts with `"@"`, returns the
+         of children. If `Text`, then if starts with `"@"`, returns the
          attribute with the given name otherwise returns the first child element
          with the given name.
 
@@ -185,7 +181,7 @@ type XML_Document
             _ : Text -> Error.throw (No_Such_Key.Error self key)
         self.get key if_missing
 
-    ## Gets the raw XML of the document (including tag, attributes and contents).
+    ## Gets the raw XML of the document.
 
        > Example
          Get the outer XML of the document.
@@ -197,8 +193,7 @@ type XML_Document
         XML_Error.handle_java_exceptions <|
             XML_Utils.outerXML self.java_document
 
-    ## Gets the raw XML of the contents of the document, not including the
-       outermost tag and attributes.
+    ## Gets the raw XML of the document.
 
        > Example
          Get the inner XML of the document.
@@ -227,7 +222,7 @@ type XML_Document
        in the count.
 
        > Example
-         Get the number of children of an element.
+         Get the number of children of an document.
 
              XML_Document.from_text '<foo> <bar>hello</bar> <bar>hello2</bar>< </foo>' . child_count
              # => 1
@@ -239,6 +234,33 @@ type XML_Document
     child_names : Vector Text ! XML_Error
     child_names self = [self.root_element.name]
 
+    ## GROUP Selections
+       Get an attribute of an XML document.
+
+       Arguments:
+       - name: The name of the attribute to get.
+       - if_missing: The value returned if the attribute does not exist.
+    @name (e-> make_single_choice e.attribute_names)
+    attribute : Text -> Any -> Text | Any ! XML_Error
+    attribute self name:Text ~if_missing=(Error.throw (No_Such_Key.Error self name)) =
+        if_missing
+
+    ## PRIVATE
+       Gets a set of the attributes of an XML document.
+    attribute_names : Vector Text ! XML_Error
+    attribute_names self = []
+
+    ## GROUP Selections
+       Gets a map containing of the attributes of an XML document.
+    attributes : Map Text Text ! XML_Error
+    attributes self = Map.empty
+
+    ## GROUP Selections
+       Gets the text (non-markup) contents of the element and its descendants,
+       if any.
+    text : Text ! XML_Error
+    text self = self.root_element.text
+
     ## Get elements denoted by the given XPath key.
 
        Arguments:
@@ -248,7 +270,7 @@ type XML_Document
          Get an element by xpath.
 
              root = XML_Document.from_file test_file
-             root.at "/class/teacher[1]/firstname"
+             root.get_xpath "/class/teacher[1]/firstname"
              # => [XML_Document.from_text "<firstname>Alice</firstname>" . root_element]
     get_xpath : Text -> Vector (Text | XML_Element) ! XML_Error
     get_xpath self key:Text =
@@ -272,7 +294,7 @@ type XML_Document
        - tag_name: The tag name to search for.
 
        > Example
-             XML_Document.from_text '<foo> <baz>hello</baz> <bar>and</bar> <baz>goodbye</baz> </foo>' . root_element . get_elements_by_tag_name "baz"
+             XML_Document.from_text '<foo> <baz>hello</baz> <bar>and</bar> <baz>goodbye</baz> </foo>' . root_element . get_descendants_by_tag_name "baz"
              # => [XML_Document.from_text "<baz>hello</baz>" . root_element, XML_Document.from_text "<baz>goodbye</baz>" . root_element]
     get_descendants_by_tag_name : Text -> Vector XML_Element ! XML_Error
     get_descendants_by_tag_name self tag_name:Text =
@@ -308,9 +330,10 @@ type XML_Element
 
        Arguments:
        - key: If an `Integer`, returns the element at position `at` in its list
-         of children. If a `Text`, treats `key` starts with `"@"`, returns the
+         of children. If a `Text`, if `key` starts with `"@"`, returns the
          attribute with the given name otherwise returns the first child element
          with the given name.
+       - if_missing: The value returned if the key does not exist.
 
        > Example
            XML_Document.from_text '<foo><baz>hello</baz></foo>' . root_element . get 0
@@ -333,9 +356,9 @@ type XML_Element
 
        Arguments:
        - key: If an `Integer`, returns the element at position `at` in its list
-         of children. If a `Text`, treats `key` as an XPath specifier, and
-         returns the elements it points to. If a `Text` that starts with `"@"`,
-         returns the attribute with the given name.
+         of children. If a `Text`, if `key` starts with `"@"`, returns the
+         attribute with the given name otherwise returns the first child element
+         with the given name.
 
        > Example
          Get a nested tag:
@@ -481,7 +504,7 @@ type XML_Element
          Get an element by xpath.
 
              root = XML_Document.from_file test_file . root_element
-             root.at "/class/teacher[1]/firstname"
+             root.get_xpath "/class/teacher[1]/firstname"
              # => [XML_Document.from_text "<firstname>Alice</firstname>" . root_element]
     get_xpath : Text -> Vector (Text | XML_Element) ! XML_Error
     get_xpath self key:Text =
@@ -506,7 +529,7 @@ type XML_Element
        - tag_name: The tag name to search for.
 
        > Example
-             XML_Document.from_text '<foo> <baz>hello</baz> <bar>and</bar> <baz>goodbye</baz> </foo>' . root_element . get_elements_by_tag_name "baz"
+             XML_Document.from_text '<foo> <baz>hello</baz> <bar>and</bar> <baz>goodbye</baz> </foo>' . root_element . get_descendants_by_tag_name "baz"
              # => [XML_Document.from_text "<baz>hello</baz>" . root_element, XML_Document.from_text "<baz>goodbye</baz>" . root_element]
     get_descendants_by_tag_name : Text -> Vector XML_Element ! XML_Error
     get_descendants_by_tag_name self tag_name:Text =

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Column.enso
@@ -88,6 +88,7 @@ type DB_Column
 
     ## ALIAS metadata
        GROUP Standard.Base.Metadata
+       ICON metadata
        Returns a Table describing this column's contents.
 
        The table behaves like `Table.info` - it lists the column name, the count

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
@@ -2031,7 +2031,7 @@ type DB_Table
     @names Widget_Helpers.make_column_name_selector
     @values Widget_Helpers.make_aggregate_column_selector
     cross_tab : Vector (Integer | Text | Regex | Aggregate_Column) | Text | Integer | Regex -> (Text | Integer) -> Aggregate_Column | Vector Aggregate_Column -> Problem_Behavior -> DB_Table ! Missing_Input_Columns | Invalid_Aggregate_Column | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings | Invalid_Column_Names
-    cross_tab self group_by names values=Aggregate_Column.Count (on_problems=Report_Warning) =
+    cross_tab self group_by=[] names=self.column_names.first values=Aggregate_Column.Count (on_problems=Report_Warning) =
         ## Avoid unused arguments warning. We cannot rename arguments to `_`,
            because we need to keep the API consistent with the in-memory table.
         _ = [group_by, names, values, on_problems]

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Data/DB_Table.enso
@@ -2516,6 +2516,7 @@ type DB_Table
 
     ## ALIAS metadata
        GROUP Standard.Base.Metadata
+       ICON metadata
        Returns a Table describing this table's contents.
 
        The table lists all columns, counts of non-null items and value types of

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Column.enso
@@ -2223,6 +2223,7 @@ type Column
 
     ## ALIAS metadata
        GROUP Standard.Base.Metadata
+       ICON metadata
        Returns a Table describing this column's contents.
 
        The table behaves like `Table.info` - it lists the column name, the count

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Simple_Expression.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Simple_Expression.enso
@@ -90,7 +90,7 @@ type Simple_Expression
         builder.append (Option "trim" fqn+".Trim" [["what", with_text]])
 
         fqn_column = Meta.get_qualified_type_name Simple_Expression
-        derived = Option "<Simple Expression>" fqn_column+".From" [["input", col_names], ["operation", Single_Choice builder.to_vector]]
+        derived = Option "<Simple Expression>" fqn_column+".From" [["input", with_all_types], ["operation", Single_Choice builder.to_vector]]
 
         Single_Choice [text, number, boolean, expression, derived] display=display
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -2333,6 +2333,7 @@ type Table
 
     ## ALIAS metadata
        GROUP Standard.Base.Metadata
+       ICON metadata
        Returns a Table describing this table's contents.
 
        The table lists all columns, counts of non-null items and value types of

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -16,7 +16,7 @@ import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Errors.Unimplemented.Unimplemented
 import Standard.Base.Runtime.Context
 import Standard.Base.System.File.Generic.Writable_File.Writable_File
-from Standard.Base.Metadata import make_single_choice
+from Standard.Base.Metadata import make_single_choice, Widget
 from Standard.Base.Widget_Helpers import make_delimiter_selector, make_format_chooser
 
 import project.Data.Aggregate_Column.Aggregate_Column
@@ -150,8 +150,9 @@ type Table
                  row_2 =  [ 2     , False , 'b'   ]
                  row_3 =  [ 3     , True  , 'c'   ]
                  Table.from_rows header [row_1, row_2, row_3]
+    @header (Widget.Vector_Editor item_default='"Column"')
     from_rows : Vector -> Vector -> Table
-    from_rows header rows =
+    from_rows header:Vector rows =
         columns = header.map_with_index i-> name-> [name, rows.map (_.at i)]
         Table.new columns
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -150,9 +150,9 @@ type Table
                  row_2 =  [ 2     , False , 'b'   ]
                  row_3 =  [ 3     , True  , 'c'   ]
                  Table.from_rows header [row_1, row_2, row_3]
-    @header (Widget.Vector_Editor item_default='"Column"')
+    @header (Widget.Vector_Editor item_editor=Widget.Text_Input item_default='"Column"')
     from_rows : Vector -> Vector -> Table
-    from_rows header:Vector rows =
+    from_rows header rows =
         columns = header.map_with_index i-> name-> [name, rows.map (_.at i)]
         Table.new columns
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -2477,7 +2477,7 @@ type Table
     @names Widget_Helpers.make_column_name_selector
     @values Widget_Helpers.make_aggregate_column_selector
     cross_tab : Vector (Integer | Text | Regex | Aggregate_Column) | Text | Integer | Regex -> (Text | Integer) -> Aggregate_Column | Vector Aggregate_Column -> Problem_Behavior -> Table ! Missing_Input_Columns | Invalid_Aggregate_Column | Floating_Point_Equality | Invalid_Aggregation | Unquoted_Delimiter | Additional_Warnings | Invalid_Column_Names
-    cross_tab self group_by names values=Aggregate_Column.Count (on_problems=Report_Warning) = Out_Of_Memory.handle_java_exception "cross_tab" <|
+    cross_tab self group_by=[] names=self.column_names.first values=Aggregate_Column.Count (on_problems=Report_Warning) = Out_Of_Memory.handle_java_exception "cross_tab" <|
         columns_helper = self.columns_helper
         problem_builder = Problem_Builder.new error_on_missing_columns=True
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Table_Conversions.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Table_Conversions.enso
@@ -24,6 +24,37 @@ Vector.to_table : Vector | Nothing -> Table ! Type_Error
 Vector.to_table self fields=Nothing =
     Table.from_objects self fields
 
+## GROUP Standard.Base.Conversions
+   ICON convert
+   Converts this `Range` into a `Table`.
+
+   Arguments:
+   - name: The name of the column to use for the range.
+Range.to_table : Text -> Table
+Range.to_table self name:Text="Range" =
+    self.to Table name
+
+## GROUP Standard.Base.Conversions
+   ICON convert
+   Converts this `Date_Range` into a `Table`.
+
+   Arguments:
+   - name: The name of the column to use for the range.
+Date_Range.to_table : Text -> Table
+Date_Range.to_table self name:Text=self.default_column_name =
+    self.to Table name
+
+## GROUP Standard.Base.Conversions
+   ICON convert
+   Converts this `JS_Object` into a `Table`.
+
+   Arguments:
+   - fields: a Vector of Text representing the names of fields to look up.
+     If `Nothing` then all fields found are added.
+JS_Object.to_table : Vector | Nothing -> Table ! Type_Error
+JS_Object.to_table self fields=Nothing =
+    self.to Table fields
+
 ## GROUP Standard.Base.Constants
    ICON data_input
    Converts an object or a Vector of object into a Table, by looking up the

--- a/std-bits/base/src/main/java/org/enso/base/XML_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/XML_Utils.java
@@ -65,8 +65,7 @@ public class XML_Utils {
     documentBuilder.setErrorHandler(
         new ErrorHandler() {
           @Override
-          public void warning(SAXParseException e) throws SAXException {
-            ;
+          public void warning(SAXParseException e) {
           }
 
           @Override

--- a/std-bits/base/src/main/java/org/enso/base/XML_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/XML_Utils.java
@@ -2,9 +2,8 @@ package org.enso.base;
 
 import java.io.ByteArrayOutputStream;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.transform.TransformerException;
 import org.w3c.dom.DOMConfiguration;
-import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.bootstrap.DOMImplementationRegistry;
 import org.w3c.dom.ls.DOMImplementationLS;
@@ -20,9 +19,11 @@ public class XML_Utils {
    *
    * @param element the element to convert to a string
    * @return the string representation of the element
-   * @throws TransformerException
+   * @throws ClassNotFoundException if the DOM implementation class cannot be found.
+   * @throws IllegalAccessException if the DOM implementation class cannot be accessed.
+   * @throws InstantiationException if the DOM implementation class cannot be instantiated.
    */
-  public static String outerXML(Element element)
+  public static String outerXML(Node element)
       throws ClassNotFoundException, IllegalAccessException, InstantiationException {
     DOMImplementationLS dom =
         (DOMImplementationLS) DOMImplementationRegistry.newInstance().getDOMImplementation("LS");
@@ -38,9 +39,11 @@ public class XML_Utils {
    *
    * @param element the element to convert to a string
    * @return the string representation of the element's contents
-   * @throws TransformerException
+   * @throws ClassNotFoundException if the DOM implementation class cannot be found.
+   * @throws IllegalAccessException if the DOM implementation class cannot be accessed.
+   * @throws InstantiationException if the DOM implementation class cannot be instantiated.
    */
-  public static String innerXML(Element element)
+  public static String innerXML(Node element)
       throws ClassNotFoundException, IllegalAccessException, InstantiationException {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     DOMImplementationLS dom =

--- a/std-bits/base/src/main/java/org/enso/base/XML_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/XML_Utils.java
@@ -65,8 +65,7 @@ public class XML_Utils {
     documentBuilder.setErrorHandler(
         new ErrorHandler() {
           @Override
-          public void warning(SAXParseException e) {
-          }
+          public void warning(SAXParseException e) {}
 
           @Override
           public void fatalError(SAXParseException e) throws SAXException {

--- a/test/Base_Tests/src/Data/XML/XML_Spec.enso
+++ b/test/Base_Tests/src/Data/XML/XML_Spec.enso
@@ -56,6 +56,8 @@ add_specs suite_builder =
 
     suite_builder.group "at/get" group_builder->
         group_builder.specify "Can get children by index" <|
+            data.document.at 0 . name . should_equal "class"
+
             data.root.at 0 . name . should_equal "teacher"
 
             data.root.at 0 . at 0 . name . should_equal "firstname"
@@ -91,44 +93,45 @@ add_specs suite_builder =
             data.root.at 3 . attributes . should_equal (Map.from_vector [["studentId", "1001"], ["year", "3"]])
 
         group_builder.specify "Can get nodes via xpath" <|
-            classes = data.root.at "/class"
+            classes = data.root.get_xpath "/class"
             classes.length . should_equal 1
             classes.at 0 . name . should_equal "class"
 
-            teachers = data.root.at "/class/teacher"
+            teachers = data.root.get_xpath "/class/teacher"
             teachers.length . should_equal 2
             teachers.at 0 . at "@id" . should_equal "100"
             teachers.at 1 . at "@id" . should_equal "101"
 
-            students = data.root.at "/class/student"
+            students = data.root.get_xpath "/class/student"
             students.length . should_equal 3
             students.at 0 . at "@studentId" . should_equal "1000"
             students.at 1 . at "@studentId" . should_equal "1001"
 
-            data.root.at "/class/teacher[1]/firstname" . at 0 . text . should_equal "Mary"
-            data.root.at "/class/teacher[2]/firstname" . at 0 . text . should_equal "Bob"
-            data.root.at "/class/teacher[1]/firstname/text()" . should_equal ["Mary"]
-            data.root.at "/class/teacher[2]/firstname/text()" . should_equal ["Bob"]
-            data.root.at "/class/teacher/firstname/text()" . should_equal ["Mary", "Bob"]
-            data.root.at "/class/teacher[1]/bio" . at 0 . text . should_equal '\n            Blah blah\n        '
-            data.root.at "/class/teacher[2]/bio" . at 0 . text . should_equal '\n            This that\n        '
-            data.root.get "/class/teacher[23]" . should_equal []
+            data.root.get_xpath "/class/teacher[1]/firstname" . at 0 . text . should_equal "Mary"
+            data.root.get_xpath "/class/teacher[2]/firstname" . at 0 . text . should_equal "Bob"
+            data.root.get_xpath "/class/teacher[1]/firstname/text()" . should_equal ["Mary"]
+            data.root.get_xpath "/class/teacher[2]/firstname/text()" . should_equal ["Bob"]
+            data.root.get_xpath "/class/teacher/firstname/text()" . should_equal ["Mary", "Bob"]
+            data.root.get_xpath "/class/teacher[1]/bio" . at 0 . text . should_equal '\n            Blah blah\n        '
+            data.root.get_xpath "/class/teacher[2]/bio" . at 0 . text . should_equal '\n            This that\n        '
+            data.root.get_xpath "/class/teacher[23]" . should_equal []
 
-            data.root.at "teacher[1]/firstname" . at 0 . text . should_equal "Mary"
-            data.root.at "teacher[2]/firstname" . at 0 . text . should_equal "Bob"
-            data.root.at "teacher[1]/bio" . at 0 . text . should_equal '\n            Blah blah\n        '
-            data.root.at "teacher[2]/bio" . at 0 . text . should_equal '\n            This that\n        '
+            data.root.get_xpath "teacher[1]/firstname" . at 0 . text . should_equal "Mary"
+            data.root.get_xpath "teacher[2]/firstname" . at 0 . text . should_equal "Bob"
+            data.root.get_xpath "teacher[1]/bio" . at 0 . text . should_equal '\n            Blah blah\n        '
+            data.root.get_xpath "teacher[2]/bio" . at 0 . text . should_equal '\n            This that\n        '
+
+            data.root.get_xpath "/class/teacher[1]/firstname" . get 0 . text . should_equal "Mary"
 
         group_builder.specify "Can get children using .get" <|
             data.root.get 0 . get 0 . name . should_equal "firstname"
             data.root.get 0 . get "@id" . should_equal "100"
-            data.root.get "/class/teacher[1]/firstname" . get 0 . text . should_equal "Mary"
 
             data.root.get 0 . get 32 "if_missing" . should_equal "if_missing"
             data.root.get 0 . get "@not_there" "if_missing" . should_equal "if_missing"
 
         group_builder.specify "Can handle a bad xpath" <|
-            data.root.at "/qqq[[[[1" . at 0 . text . should_fail_with XML_Error
+            data.root.get_xpath "/qqq[[[[1" . at 0 . text . should_fail_with XML_Error
 
     suite_builder.group "tag name" group_builder->
         group_builder.specify "Can get the tag name" <|
@@ -156,20 +159,26 @@ add_specs suite_builder =
 
     suite_builder.group "inner / outer xml" group_builder->
         group_builder.specify "Can get the inner xml" <|
-            (data.root.at "/class/teacher[1]" . at 0 . inner_xml) . should_equal '\n        <firstname>Mary</firstname>\n        <lastname>Smith</lastname>\n        <bio>\n            Blah blah\n        </bio>\n    '
-            (data.root.at "/class/teacher[1]/bio" . at 0 . inner_xml) . should_equal '\n            Blah blah\n        '
-            (data.root.at "/class/teacher[2]/bio" . at 0 . inner_xml) . should_equal '\n            This that\n        '
-            (data.root.at "/class/teacher[2]" . at 0 . inner_xml) . should_equal '\n        <firstname>Bob</firstname>\n        <lastname>Jones</lastname>\n        <bio>\n            This that\n        </bio>\n    '
+            (data.root.get_xpath "/class/teacher[1]" . at 0 . inner_xml) . should_equal '\n        <firstname>Mary</firstname>\n        <lastname>Smith</lastname>\n        <bio>\n            Blah blah\n        </bio>\n    '
+            (data.root.get_xpath "/class/teacher[1]/bio" . at 0 . inner_xml) . should_equal '\n            Blah blah\n        '
+            (data.root.get_xpath "/class/teacher[2]/bio" . at 0 . inner_xml) . should_equal '\n            This that\n        '
+            (data.root.get_xpath "/class/teacher[2]" . at 0 . inner_xml) . should_equal '\n        <firstname>Bob</firstname>\n        <lastname>Jones</lastname>\n        <bio>\n            This that\n        </bio>\n    '
 
         group_builder.specify "Can get the outer xml" <|
-            (data.root.at "/class/teacher[1]/bio" . at 0 . outer_xml) . should_equal '<bio>\n            Blah blah\n        </bio>'
-            (data.root.at "/class/teacher[2]/bio" . at 0 . outer_xml) . should_equal '<bio>\n            This that\n        </bio>'
+            (data.root.get_xpath "/class/teacher[1]/bio" . at 0 . outer_xml) . should_equal '<bio>\n            Blah blah\n        </bio>'
+            (data.root.get_xpath "/class/teacher[2]/bio" . at 0 . outer_xml) . should_equal '<bio>\n            This that\n        </bio>'
 
-    suite_builder.group "get_elements_by_tag_name" group_builder->
+    suite_builder.group "Get by tag name" group_builder->
         group_builder.specify "Can get elements by tag name" <|
-            teachers = data.root.get_elements_by_tag_name "teacher"
-            students = data.root.get_elements_by_tag_name "student"
-            gpas = data.root.get_elements_by_tag_name "gpa"
+            class = data.document.get_children_by_tag_name "class"
+            class.length . should_equal 1
+
+            teacher_direct = data.root.get_children_by_tag_name "teacher"
+            teacher_direct.length . should_equal 2
+
+            teachers = data.document.get_descendants_by_tag_name "teacher"
+            students = data.root.get_descendants_by_tag_name "student"
+            gpas = data.root.get_descendants_by_tag_name "gpa"
 
             teachers.length . should_equal 2
             students.length . should_equal 3
@@ -187,12 +196,14 @@ add_specs suite_builder =
         group_builder.specify "Can get nested elements" <|
             test_file = enso_project.data / "xml" / "nested.xml"
             root = XML_Document.from_file test_file . root_element
-            bars = root.get_elements_by_tag_name "bar"
+            bars = root.get_descendants_by_tag_name "bar"
             bars.length . should_equal 4
             bars.map (t-> t.at "@id") . should_equal ["2", "4", "5", "6"]
+            root.get_children_by_tag_name "bar" . length . should_equal 2
 
         group_builder.specify "Can get elements by name with a wildcard" <|
-            data.root.get_elements_by_tag_name "*" . length . should_equal 20
+            data.root.get_children_by_tag_name "*" . length . should_equal 5
+            data.root.get_descendants_by_tag_name "*" . length . should_equal 20
 
     suite_builder.group "Data.read / File_Format" group_builder->
         group_builder.specify "Can read from a file" <|


### PR DESCRIPTION
### Pull Request Description

- Added `to_table` extensions on some core types.
- Added ICON to `Any.to`.
- Added ICON to `Column.info`, `Table.info`, `DB_Column.info` and `DB_Table.info`.
- Added defaults to `Table.cross_tab` and `DB_Table.cross_tab`.
- Added `name`, `get`, `at`, `inner_xml` and `outer_xml` to `XML_Document`.
- Added constants into left hand side of simple expressions.
- Added widget to `get` and `at` on `XML_Document` and `XML_Element`. (Some bug in annotation code with Dmitry)
- Altered `get` and `at` to not allow XPath and just get direct child/attribute values.
- Added `get_xpath` to `XML_Document`.
- Renamed `get_elements_by_tag_name` to `get_descendants_by_tag_name` and added new `get_children_by_tag_name`.
- Added `child_names` and `attribute_names` to `XML_Document` and `XML_Element`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
