### PR TITLE
Fix attaching generic annotations

### DIFF
--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/ComplexType.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/ComplexType.scala
@@ -26,7 +26,7 @@ import org.enso.compiler.pass.analyse.{
   TailCall
 }
 import org.enso.compiler.pass.lint.UnusedBindings
-import org.enso.compiler.pass.optimise.{LambdaConsolidate}
+import org.enso.compiler.pass.optimise.LambdaConsolidate
 import org.enso.compiler.pass.resolve.{
   DocumentationComments,
   IgnoredBindings,
@@ -125,6 +125,7 @@ case object ComplexType extends IRPass {
           lastAnnotations = Seq()
           res
         case _ =>
+          lastAnnotations = Seq()
           None
       }
       // TODO[MK] this is probably removable

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/ComplexTypeTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/ComplexTypeTest.scala
@@ -86,6 +86,28 @@ class ComplexTypeTest extends CompilerTest {
       tp.members(1).name.name shouldEqual "Bar"
     }
 
+    "have their annotations correct" in {
+      val ir =
+        """
+          |type MyType
+          |    @a 42
+          |    bar self = self
+          |
+          |    Foo
+          |""".stripMargin.preprocessModule.desugar
+      ir.bindings.length shouldEqual 3
+
+      val tp = ir.bindings(0).asInstanceOf[Definition.Type]
+      tp.name.name shouldEqual "MyType"
+      tp.members(0).name.name shouldEqual "Foo"
+
+      val a = ir.bindings(1).asInstanceOf[Name.GenericAnnotation]
+      a.name shouldEqual "a"
+
+      val bar = ir.bindings(2).asInstanceOf[definition.Method.Binding]
+      bar.methodName.name shouldEqual "bar"
+    }
+
     "have their methods desugared to binding methods" in {
       ir.bindings(3) shouldBe an[definition.Method.Binding]
       val isJust = ir.bindings(3).asInstanceOf[definition.Method.Binding]


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Fixes the issue with attaching generic annotations in complex types.

Annotations in the type body could be lost during the compilation if its constructor was defined at the end of the type definition.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
