### PR TITLE
E2E test fixing and bring back reports

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules/
+playwright-report/

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,0 @@
-node_modules/
-playwright-report/

--- a/app/gui2/e2e/collapsingAndEntering.spec.ts
+++ b/app/gui2/e2e/collapsingAndEntering.spec.ts
@@ -89,7 +89,7 @@ test('Collapsing nodes', async ({ page }) => {
   await customExpect.toExist(locate.graphNodeByBinding(page, 'sum'))
   await customExpect.toExist(locate.graphNodeByBinding(page, 'prod'))
 
-  locate
+  await locate
     .graphNodeByBinding(page, 'ten')
     .locator('.icon')
     .click({ modifiers: ['Shift'] })

--- a/app/gui2/e2e/componentBrowser.spec.ts
+++ b/app/gui2/e2e/componentBrowser.spec.ts
@@ -133,7 +133,7 @@ test('Filling input with suggestions', async ({ page }) => {
   )
 
   // Applying suggestion
-  page.keyboard.press('Tab')
+  await page.keyboard.press('Tab')
   await customExpect.toExist(locate.componentBrowser(page))
   await expect(locate.componentBrowserInput(page).locator('input')).toHaveValue(
     'Standard.Base.Data.read ',

--- a/app/gui2/e2e/fullscreenVisualisation.spec.ts
+++ b/app/gui2/e2e/fullscreenVisualisation.spec.ts
@@ -5,19 +5,11 @@ import * as locate from './locate'
 import { graphNodeByBinding } from './locate'
 
 /**
- * Prepare the graph for the tests.
- */
-async function initGraph(page: Page) {
-  await actions.goToGraph(page)
-}
-
-/**
  Scenario: We open the default visualisation of the `aggregated` node. We then make it fullscreen and expect it to show
  the JSON data of the node. We also expect it to cover the whole screen and to have a button to exit fullscreen mode.
  */
 test('Load Fullscreen Visualisation', async ({ page }) => {
-  await initGraph(page)
-
+  await actions.goToGraph(page)
   const aggregatedNode = graphNodeByBinding(page, 'aggregated')
   await aggregatedNode.click()
   await page.keyboard.press('Space')

--- a/app/gui2/eslint.config.js
+++ b/app/gui2/eslint.config.js
@@ -57,7 +57,7 @@ const conf = [
       'vue/multi-word-component-names': 0,
     },
   },
-  // We must make sure our E2E tests await all steps, otherwise they're flacky.
+  // We must make sure our E2E tests await all steps, otherwise they're flaky.
   {
     files: ['e2e/**/*.spec.ts'],
     languageOptions: {

--- a/app/gui2/eslint.config.js
+++ b/app/gui2/eslint.config.js
@@ -9,7 +9,14 @@ const DIR_NAME = path.dirname(url.fileURLToPath(import.meta.url))
 
 const conf = [
   {
-    ignores: ['rust-ffi/pkg', 'rust-ffi/node-pkg', 'dist', 'shared/ast/generated', 'templates'],
+    ignores: [
+      'rust-ffi/pkg',
+      'rust-ffi/node-pkg',
+      'dist',
+      'shared/ast/generated',
+      'templates',
+      'playwright-report',
+    ],
   },
   ...compat.extends('plugin:vue/vue3-recommended'),
   eslintJs.configs.recommended,

--- a/app/gui2/eslint.config.js
+++ b/app/gui2/eslint.config.js
@@ -50,6 +50,16 @@ const conf = [
       'vue/multi-word-component-names': 0,
     },
   },
+  // We must make sure our E2E tests await all steps, otherwise they're flacky.
+  {
+    files: ['e2e/**/*.spec.ts'],
+    languageOptions: {
+      parser: await import('@typescript-eslint/parser'),
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 2,
+    },
+  },
 ]
 
 export default conf

--- a/app/gui2/playwright.config.ts
+++ b/app/gui2/playwright.config.ts
@@ -38,16 +38,18 @@ export default defineConfig({
   testDir: './e2e',
   forbidOnly: !!process.env.CI,
   repeatEach: process.env.CI ? 3 : 1,
-  retries: 2,
   ...(process.env.CI ? { workers: 1 } : {}),
   timeout: 60000,
   expect: {
     timeout: 5000,
     toHaveScreenshot: { threshold: 0 },
   },
+  reporter: 'html',
   use: {
     headless: !DEBUG,
-    trace: 'on-first-retry',
+    // We have a problem with many transient failures; to investigate them, we need trace on all
+    // tests.
+    trace: 'on',
     viewport: { width: 1920, height: 1600 },
     ...(DEBUG
       ? {}

--- a/app/gui2/playwright.config.ts
+++ b/app/gui2/playwright.config.ts
@@ -38,7 +38,9 @@ export default defineConfig({
   testDir: './e2e',
   forbidOnly: !!process.env.CI,
   repeatEach: process.env.CI ? 3 : 1,
+  retries: 2,
   ...(process.env.CI ? { workers: 1 } : {}),
+  timeout: 60000,
   expect: {
     timeout: 5000,
     toHaveScreenshot: { threshold: 0 },

--- a/app/gui2/playwright.config.ts
+++ b/app/gui2/playwright.config.ts
@@ -47,9 +47,7 @@ export default defineConfig({
   reporter: 'html',
   use: {
     headless: !DEBUG,
-    // We have a problem with many transient failures; to investigate them, we need trace on all
-    // tests.
-    trace: 'on',
+    trace: 'retain-on-failure',
     viewport: { width: 1920, height: 1600 },
     ...(DEBUG
       ? {}

--- a/app/ide-desktop/eslint.config.js
+++ b/app/ide-desktop/eslint.config.js
@@ -244,7 +244,7 @@ export default [
     eslintJs.configs.recommended,
     {
         // Playwright build cache.
-        ignores: ['**/.cache/**'],
+        ignores: ['**/.cache/**', '**/playwright-report'],
     },
     {
         settings: {

--- a/app/ide-desktop/lib/dashboard/playwright.config.ts
+++ b/app/ide-desktop/lib/dashboard/playwright.config.ts
@@ -19,8 +19,12 @@ export default test.defineConfig({
     timeout: 30_000,
   },
   timeout: 30_000,
+  reporter: 'html',
   use: {
     baseURL: 'http://localhost:8080',
+    // We have a problem with many transient failures; to investigate them, we need trace on all
+    // tests.
+    trace: 'on',
     launchOptions: {
       ignoreDefaultArgs: ['--headless'],
       args: [

--- a/app/ide-desktop/lib/dashboard/playwright.config.ts
+++ b/app/ide-desktop/lib/dashboard/playwright.config.ts
@@ -22,9 +22,7 @@ export default test.defineConfig({
   reporter: 'html',
   use: {
     baseURL: 'http://localhost:8080',
-    // We have a problem with many transient failures; to investigate them, we need trace on all
-    // tests.
-    trace: 'on',
+    trace: 'retain-on-failure',
     launchOptions: {
       ignoreDefaultArgs: ['--headless'],
       args: [

--- a/build/build/paths.yaml
+++ b/build/build/paths.yaml
@@ -17,6 +17,7 @@
     gui/:
     gui2/: # The new, Vue-based GUI.
       dist/:
+      playwright-report/: # Test results for the new GUI that we want to keep as artifacts.
       public/:
         font-enso/:
         font-mplus1/:
@@ -33,6 +34,8 @@
         content-config/:
           src/:
             config.json:
+        dashboard/:
+          playwright-report/: # Test results for the dashboard that we want to keep as artifacts.
         icons/:
         project-manager/:
   build/:

--- a/build/build/src/engine/context.rs
+++ b/build/build/src/engine/context.rs
@@ -233,7 +233,7 @@ impl RunContext {
         ];
         for (argfile, artifact_name) in native_image_arg_files {
             if argfile.exists() {
-                ide_ci::actions::artifacts::upload_single_file(&argfile, artifact_name).await?;
+                ide_ci::actions::artifacts::upload_single_file(argfile, artifact_name).await?;
             } else {
                 warn!(
                     "Native Image Arg File for {} not found at {}",

--- a/build/ci_utils/src/actions/artifacts.rs
+++ b/build/ci_utils/src/actions/artifacts.rs
@@ -12,6 +12,7 @@ use serde::de::DeserializeOwned;
 use tempfile::tempdir;
 
 
+
 // ==============
 // === Export ===
 // ==============
@@ -67,36 +68,47 @@ pub fn discover_recursive(
     rx.into_stream()
 }
 
-pub async fn upload(
+
+pub fn upload(
     file_provider: impl Stream<Item = FileToUpload> + Send + 'static,
-    artifact_name: impl AsRef<str>,
+    artifact_name: impl Into<String>,
     options: UploadOptions,
-) -> Result {
-    let handler =
-        ArtifactUploader::new(SessionClient::new_from_env()?, artifact_name.as_ref()).await?;
-    let result = handler.upload_artifact_to_file_container(file_provider, &options).await;
-    // We want to patch size even if there were some failures.
-    handler.patch_artifact_size().await?;
-    result
+) -> BoxFuture<'static, Result> {
+    let artifact_name = artifact_name.into();
+    let span = info_span!("Artifact upload", artifact_name);
+    async move {
+        let handler = ArtifactUploader::new(SessionClient::new_from_env()?, artifact_name).await?;
+        let result = handler.upload_artifact_to_file_container(file_provider, &options).await;
+        // We want to patch size even if there were some failures.
+        handler.patch_artifact_size().await?;
+        result
+    }
+    .instrument(span)
+    .boxed()
 }
 
 pub fn upload_single_file(
     file: impl Into<PathBuf>,
-    artifact_name: impl AsRef<str>,
-) -> impl Future<Output = Result> {
+    artifact_name: impl Into<String>,
+) -> BoxFuture<'static, Result> {
     let file = file.into();
-    let files = single_file_provider(file);
-    (async move || -> Result { upload(files?, artifact_name, default()).await })()
+    let artifact_name = artifact_name.into();
+    info!("Uploading file {} as artifact {artifact_name}.", file.display());
+    single_file_provider(file)
+        .and_then_async(move |stream| upload(stream, artifact_name, default()))
+        .boxed()
 }
 
 pub fn upload_directory(
     dir: impl Into<PathBuf>,
-    artifact_name: impl AsRef<str>,
-) -> impl Future<Output = Result> {
+    artifact_name: impl Into<String>,
+) -> BoxFuture<'static, Result> {
     let dir = dir.into();
-    info!("Uploading directory {}.", dir.display());
-    let files = single_dir_provider(&dir);
-    (async move || -> Result { upload(files?, artifact_name, default()).await })()
+    let artifact_name = artifact_name.into();
+    info!("Uploading directory {} as artifact {artifact_name}.", dir.display());
+    single_dir_provider(&dir)
+        .and_then_async(move |stream| upload(stream, artifact_name, default()))
+        .boxed()
 }
 
 #[tracing::instrument(skip_all , fields(artifact_name = %artifact_name.as_ref(), target = %target.as_ref().display()), err)]


### PR DESCRIPTION
### Pull Request Description

After investigating some errors, I found another two missing awaits in our tests. Because those are so easy to overlook, I added a lint rule which makes failure on unhandled promise (for e2e tests only).

Also, enabled HTML reports again, with traces this time, to enable closer investigation of any failure in the future. @mwu-tow added code for uploading them in GH.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - ~~[ ] Unit tests have been written where possible.~~
  - ~~[ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
