### PR TITLE
Fix selection tests

### DIFF
--- a/app/gui2/src/composables/__tests__/selection.test.ts
+++ b/app/gui2/src/composables/__tests__/selection.test.ts
@@ -1,6 +1,6 @@
 import { Rect } from '@/util/data/rect'
 import { Vec2 } from '@/util/data/vec2'
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import { proxyRefs, ref, type Ref } from 'vue'
 import { useSelection } from '../selection'
 
@@ -23,7 +23,7 @@ function selectionWithMockData(sceneMousePos?: Ref<Vec2>) {
 
 // TODO[ao]: Skipping test, as they often fail in CI
 // (for example https://github.com/enso-org/enso/actions/runs/8102076908/job/22163122663)
-test.skip.each`
+test.each`
   click | modifiers                  | expected
   ${1}  | ${[]}                      | ${[1]}
   ${3}  | ${[]}                      | ${[3]}
@@ -54,7 +54,7 @@ const areas: Record<string, Rect> = {
 
 // TODO[ao]: Skipping test, as they often fail in CI
 // (for example https://github.com/enso-org/enso/actions/runs/8102076908/job/22163122663)
-test.skip.each`
+test.each`
   areaId      | modifiers                  | expected
   ${'left'}   | ${[]}                      | ${[1, 3]}
   ${'right'}  | ${[]}                      | ${[2, 4]}
@@ -103,12 +103,12 @@ test.skip.each`
   dragCase(new Vec2(area.right, area.top), new Vec2(area.left, area.bottom))
 })
 
+// There is no PointerEvent class in jsdom (yet).
 class MockPointerEvent extends MouseEvent {
-  currentTarget: EventTarget | null
-  pointerId: number
+  readonly pointerId: number
   constructor(type: string, options: MouseEventInit & { currentTarget?: Element | undefined }) {
     super(type, options)
-    this.currentTarget = options.currentTarget ?? null
+    vi.spyOn(this, 'currentTarget', 'get').mockReturnValue(options.currentTarget ?? null)
     this.pointerId = 4
   }
 }


### PR DESCRIPTION
### Pull Request Description

Sometimes our test realizes, that `currentTarget` of `MouseEvent` is a read-only property. I have no idea why it does not do it every time, but this fix should work.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- ~~[ ] The documentation has been updated, if necessary.~~
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - ~~[ ] Unit tests have been written where possible.~~
  - ~~[ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
