### PR TITLE
Fix termination of http-test-helper on Ctrl-C

### DIFF
--- a/tools/http-test-helper/src/main/java/org/enso/shttp/HTTPTestHelperServer.java
+++ b/tools/http-test-helper/src/main/java/org/enso/shttp/HTTPTestHelperServer.java
@@ -48,7 +48,8 @@ public class HTTPTestHelperServer {
       // Make sure the main thread is blocked for as long as the server is running.
       stopNotification.acquire();
     } catch (InterruptedException e) {
-      System.out.println("Server main thread was unexpectedly interrupted. The server will now stop.");
+      System.out.println(
+          "Server main thread was unexpectedly interrupted. The server will now stop.");
     } finally {
       server.stop();
     }


### PR DESCRIPTION
### Pull Request Description

After some recent changes, the HTTP server helper would no longer stop when Ctrl-C was issued. That is because the semaphore was being used in the wrong way: it was released on the same thread that was supposed to acquire it - but the acquire never returned as it would be waiting for the release, so the release could also never happen. Thus the main thread was in a constant dead-lock.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
