### PR TITLE
Restore whenReady, as I do not see the freeze

### DIFF
--- a/app/ide-desktop/lib/client/src/index.ts
+++ b/app/ide-desktop/lib/client/src/index.ts
@@ -75,13 +75,7 @@ class App {
             this.setChromeOptions(chromeOptions)
             security.enableAll()
             electron.app.on('before-quit', () => (this.isQuitting = true))
-            /** TODO [NP]: https://github.com/enso-org/enso/issues/5851
-             * The `electron.app.whenReady()` listener is preferable to the
-             * `electron.app.on('ready', ...)` listener. When the former is used in combination with
-             * the `authentication.initModule` call that is called in the listener, the application
-             * freezes. This freeze should be diagnosed and fixed. Then, the `whenReady()` listener
-             * should be used here instead. */
-            electron.app.on('ready', () => {
+            electron.app.whenReady().then(() => {
                 logger.log('Electron application is ready.')
                 void this.main(windowSize)
             })

--- a/app/ide-desktop/lib/client/src/index.ts
+++ b/app/ide-desktop/lib/client/src/index.ts
@@ -75,10 +75,15 @@ class App {
             this.setChromeOptions(chromeOptions)
             security.enableAll()
             electron.app.on('before-quit', () => (this.isQuitting = true))
-            electron.app.whenReady().then(() => {
-                logger.log('Electron application is ready.')
-                void this.main(windowSize)
-            })
+            electron.app.whenReady().then(
+                () => {
+                    logger.log('Electron application is ready.')
+                    void this.main(windowSize)
+                },
+                err => {
+                    logger.error('Failed to initialize electron.', err)
+                }
+            )
             this.registerShortcuts()
         }
     }


### PR DESCRIPTION
### Pull Request Description

When cleaning up board, I stumbled upon https://github.com/enso-org/enso/issues/5851 I tried to replace whenReady, and it just worked. Perhaps the freeze was fixed during some electron version bump.

Tests on other platforms (I'm using Garuda Linux) advised.

Fixes #5851 

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - ~~[ ] Unit tests have been written where possible.~~
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
