### PR TITLE
Make Table.To_Xml return a XML_Document

### DIFF
--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -2649,7 +2649,7 @@ type Table
     to_csv self = Text.from self (Delimited_Format.Delimited delimiter=",")
 
     ## GROUP Standard.Base.Conversions
-       Returns a string containing an XML representation of the table.
+       Returns an `XML_Document` representation of the table.
        Arguments:
        - element_columns: Columns to be used as elements in the XML.
        - attribute_columns: Columns to be used as attributes in the XML.
@@ -2691,7 +2691,7 @@ type Table
     @element_columns Widget_Helpers.make_column_name_vector_selector
     @attribute_columns Widget_Helpers.make_column_name_vector_selector
     @value_column Widget_Helpers.make_column_name_selector
-    to_xml self (element_columns : (Vector (Integer | Text | Regex) | Text | Integer | Regex) = self.column_names) (attribute_columns : (Vector (Integer | Text | Regex) | Text | Integer | Regex) = []) (value_column : Text | Integer | Nothing = Nothing) (root_name : Text = "Table") (row_name : Text = "Row") (on_problems : Problem_Behavior = Report_Warning) -> Text =
+    to_xml self (element_columns : (Vector (Integer | Text | Regex) | Text | Integer | Regex) = self.column_names) (attribute_columns : (Vector (Integer | Text | Regex) | Text | Integer | Regex) = []) (value_column : Text | Integer | Nothing = Nothing) (root_name : Text = "Table") (row_name : Text = "Row") (on_problems : Problem_Behavior = Report_Warning) -> XML_Document =
         columns_helper = self.columns_helper
         problem_builder = Problem_Builder.new error_on_missing_columns=True
         resolved_element_columns = columns_helper.select_columns_helper element_columns Case_Sensitivity.Default False problem_builder
@@ -2707,7 +2707,7 @@ type Table
         if unused_columns.length > 0 then problem_builder.report_other_warning (Unexpected_Extra_Columns.Warning unused_columns)
         
         problem_builder.attach_problems_before on_problems <|
-            Java_TableToXml.to_xml self.row_count java_element_columns java_attribute_column java_value_column root_name row_name
+            XML_Document.Value (Java_TableToXml.to_xml self.row_count java_element_columns java_attribute_column java_value_column root_name row_name)
 
     ## PRIVATE
     columns_helper : Table_Column_Helper

--- a/std-bits/table/src/main/java/org/enso/table/data/table/TableToXml.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/TableToXml.java
@@ -15,7 +15,7 @@ import org.w3c.dom.ls.LSSerializer;
 
 public class TableToXml {
 
-  public static String to_xml(
+  public static Document to_xml(
       int rowCount,
       Column[] element_columns,
       Column[] attribute_columns,
@@ -56,16 +56,7 @@ public class TableToXml {
       context.safepoint();
     }
 
-    return convert_to_string(doc);
-  }
-
-  private static String convert_to_string(Document doc) throws XmlException {
-    DOMImplementationLS domImplementation = (DOMImplementationLS) doc.getImplementation();
-    LSSerializer lsSerializer = domImplementation.createLSSerializer();
-    lsSerializer.getDomConfig().setParameter("format-pretty-print", Boolean.TRUE);
-    lsSerializer.getDomConfig().setParameter("xml-declaration", false);
-    lsSerializer.setNewLine("\n");
-    return lsSerializer.writeToString(doc);
+    return doc;
   }
 
   private static void get_set_attribute(

--- a/std-bits/table/src/main/java/org/enso/table/data/table/TableToXml.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/table/TableToXml.java
@@ -10,8 +10,6 @@ import org.graalvm.polyglot.Context;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.ls.DOMImplementationLS;
-import org.w3c.dom.ls.LSSerializer;
 
 public class TableToXml {
 

--- a/test/Table_Tests/src/In_Memory/Table_Xml_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Xml_Spec.enso
@@ -4,8 +4,7 @@ from Standard.Test import all
 from Standard.Table.Errors import all
 import Standard.Base.Errors.Common.Type_Error
 
-# pretty printed xml actually makes the tests less pretty
-# so all but one tests depretty the xml before comparing
+# pretty xml makes the tests easier to read
 depretty xmlText =
     xmlText.replace (Regex.compile "\n\s*") ""
 
@@ -36,7 +35,7 @@ add_specs suite_builder =
             t = data.table . take 0
             r = t.to_xml
             e = "<Table/>"
-            (depretty r).should_equal (depretty e)
+            r.outer_xml.should_equal (depretty e)
         group_builder.specify "if no columns are specified all fields become child elements" <|
             t = data.table . select_columns ['Title', 'Year']
             r = t.to_xml
@@ -59,7 +58,7 @@ add_specs suite_builder =
                     <Year>1939</Year>
                   </Row>
                 </Table>
-            (depretty r).should_equal (depretty e)
+            r.outer_xml.should_equal (depretty e)
         group_builder.specify "Single column as element" <|
             t = data.table . take 4
             r = t.to_xml ["Year"]
@@ -78,7 +77,7 @@ add_specs suite_builder =
                     <Year>1939</Year>
                   </Row>
                 </Table>
-            (depretty r).should_equal (depretty e)
+            r.outer_xml.should_equal (depretty e)
         group_builder.specify "Single column as attribute" <|
             t = data.table . take 4
             r = t.to_xml [] ["Year"]
@@ -89,7 +88,7 @@ add_specs suite_builder =
                   <Row Year="1951"/>
                   <Row Year="1939"/>
                 </Table>
-            (depretty r).should_equal (depretty e)
+            r.outer_xml.should_equal (depretty e)
         group_builder.specify "Single column as value" <|
             t = data.table . take 4
             r = t.to_xml [] [] "Year"
@@ -100,7 +99,7 @@ add_specs suite_builder =
                   <Row>1951</Row>
                   <Row>1939</Row>
                 </Table>
-            (depretty r).should_equal (depretty e)
+            r.outer_xml.should_equal (depretty e)
         group_builder.specify "Different fields can be used as attributes, elements and value" <|
             t = data.table . take 1
             r = t.to_xml ["Year"] ["Author", "Price"] "Title"
@@ -111,7 +110,7 @@ add_specs suite_builder =
                     <Year>1859</Year>
                   </Row>
                 </Table>
-           (depretty r).should_equal (depretty e)
+           r.outer_xml.should_equal (depretty e)
         group_builder.specify "Can use indexes to specify columns" <|
             t = data.table . take 1
             r = t.to_xml [3] [1, 2] 0
@@ -122,7 +121,7 @@ add_specs suite_builder =
                     <Year>1859</Year>
                   </Row>
                 </Table>
-            (depretty r).should_equal (depretty e)
+            r.outer_xml.should_equal (depretty e)
         group_builder.specify "Can use regex to specify columns for element and attribute" <|
             t = data.table . take 1
             r = t.to_xml (Regex.compile ".*e") (Regex.compile ".*a.*") "Author"
@@ -134,7 +133,7 @@ add_specs suite_builder =
                     <Price>9.99</Price>
                   </Row>
                 </Table>
-            (depretty r).should_equal (depretty e)
+            r.outer_xml.should_equal (depretty e)
         group_builder.specify "The same fields can be used as attributes, elements and value" <|
             t = data.table . take 1
             r = t.to_xml ["Author", "Price"] ["Author", "Price"] "Author"
@@ -146,7 +145,7 @@ add_specs suite_builder =
                     <Price>9.99</Price>
                   </Row>
                 </Table>
-            (depretty r).should_equal (depretty e)
+            r.outer_xml.should_equal (depretty e)
         group_builder.specify "If a field is specified duplicate times as an attribute or element it is only included once" <|
             t = data.table . take 1
             r = t.to_xml ["Author", "Price", "Author"] ["Author", "Price", "Price"] "Author"
@@ -158,7 +157,7 @@ add_specs suite_builder =
                     <Price>9.99</Price>
                   </Row>
                 </Table>
-           (depretty r).should_equal (depretty e)
+           r.outer_xml.should_equal (depretty e)
         group_builder.specify "Root and Row tags can be set" <|
             t = data.table . take 1
             r = t.to_xml ["Year"] ["Author", "Price"] "Title" "library" "book"
@@ -169,7 +168,7 @@ add_specs suite_builder =
                     <Year>1859</Year>
                   </book>
                 </library>
-            (depretty r).should_equal (depretty e)
+            r.outer_xml.should_equal (depretty e)
         group_builder.specify "Will warn if not all incoming columns specified" <|
             t = data.table . take 1
             r = t.to_xml ["Year"] ["Author", "Price"] "Title"
@@ -180,7 +179,7 @@ add_specs suite_builder =
                     <Year>1859</Year>
                   </Row>
                 </Table>
-            (depretty r).should_equal (depretty e)
+            r.outer_xml.should_equal (depretty e)
             Problems.expect_warning (Unexpected_Extra_Columns.Warning ["Last Borrowed"]) r
         group_builder.specify "Will not warn if not all incoming columns specified, but warnings are ignored" <|
             t = data.table . take 1
@@ -192,7 +191,7 @@ add_specs suite_builder =
                     <Year>1859</Year>
                   </Row>
                 </Table>
-           (depretty r).should_equal (depretty e)
+           r.outer_xml.should_equal (depretty e)
             Problems.assume_no_problems r
         group_builder.specify "Will error if not all incoming columns specified and on_problems set to Report_Error" <|
             t = data.table
@@ -210,23 +209,6 @@ add_specs suite_builder =
             t = data.table
             r = t.to_xml ["Author", "Price"] ["Year"] "Not In Table"
             r.should_fail_with (No_Such_Column.Error "Not In Table")
-        group_builder.specify "XML should be pretty printed" <|
-            # pretty printed xml actually makes the tests less pretty
-            # so all the other tests depretty the xml before comparing
-            # this one makes sure it actually is pretty printed for users
-            t = data.table . take 2
-            r = t.to_xml ["Year"] ["Author", "Price"] "Title"
-            e = '<Table>\n'
-                + '    <Row Author="Charles Dickens" Price="9.99">\n'
-                + '        A Tale Of Two Cities\n'
-                + '        <Year>1859</Year>\n'
-                + '    </Row>\n'
-                + '    <Row Author="F. Scott Fitzgerald" Price="5.99">\n'
-                + '        The Great Gatsby\n'
-                + '        <Year>1925</Year>\n'
-                + '    </Row>\n'
-                + '</Table>\n'
-            r . should_equal e
         group_builder.specify "Illegal xml names are cleaned up in root_name and row_name" <|
             t = data.table . take 1
             r = t.to_xml ["Year"] ["Author", "Price"] "Title" "the library" "22book"
@@ -237,7 +219,7 @@ add_specs suite_builder =
                     <Year>1859</Year>
                   </_22book>
                 </the_library>
-            (depretty r).should_equal (depretty e)
+            r.outer_xml.should_equal (depretty e)
         group_builder.specify "Illegal xml names are cleaned up" <|
             numeric_column_name = ["1", [10]]
             illegal_column_name = ["Bad <chars> & symbols", [1]]
@@ -255,7 +237,7 @@ add_specs suite_builder =
                     <Last_Borrowed>1999-01-02T03:40Z[UTC]</Last_Borrowed>
                   </Row>
                 </Table>
-            (depretty r).should_equal (depretty e)
+            r.outer_xml.should_equal (depretty e)
         group_builder.specify "Empty strings are empty attributes/elements. Nothing values omit the entire attribute/element" <|
             desc_column = ["desc", ["Col1 and Col2 both have values", "Col1 has value, Col2 Nothing", "Col1 empty string, Col2 has value", "Col1 and Col2 both blank string", "Col1 and Col2 both Nothing" ]]
             col1 = ["Col1", ["Value1", "Value2", "", "", Nothing]]
@@ -290,7 +272,7 @@ add_specs suite_builder =
                   </Row>
                   <Row desc="Col1 and Col2 both Nothing"/>
                 </Table>
-            (depretty r).should_equal (depretty e)
+            r.outer_xml.should_equal (depretty e)
         group_builder.specify "Panic if wrong types passed in element_columns" <|
             t = data.table
             r = Panic.recover Any (t.to_xml 1.23)
@@ -342,7 +324,7 @@ add_specs suite_builder =
                     <unicode>👩‍🔬</unicode>
                   </Row>
                 </Table>
-            (depretty r).should_equal (depretty e)
+            r.outer_xml.should_equal (depretty e)
         group_builder.specify "xml or special characters get escaped" <|
             xml_column = ["xml", ["</Table>", "<tag>12</tag>", '<r><c v="1"></c></r>']]
             special_chars_column = ["special", ["<", "&>", "'"]]
@@ -371,7 +353,7 @@ add_specs suite_builder =
                     <special>'</special>
                   </Row>
                 </Table>
-            (depretty r).should_equal (depretty e)
+            r.outer_xml.should_equal (depretty e)
 
 main filter=Nothing =
     suite = Test.build suite_builder->

--- a/test/Table_Tests/src/In_Memory/Table_Xml_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Xml_Spec.enso
@@ -4,7 +4,9 @@ from Standard.Test import all
 from Standard.Table.Errors import all
 import Standard.Base.Errors.Common.Type_Error
 
-# pretty xml makes the tests easier to read
+## Pretty xml makes the tests easier to read, 
+   so this function allows to convert a pretty-formatted expected XML value
+   into a raw value that can be compared with the generated XML.
 depretty xmlText =
     xmlText.replace (Regex.compile "\n\s*") ""
 


### PR DESCRIPTION
### Pull Request Description

As part of the XML improvements it makes more sense for Table.To_Xml to return a XML_Document.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
