### PR TITLE
Add delete node icon to circular menu

### DIFF
--- a/app/gui2/src/components/CircularMenu.vue
+++ b/app/gui2/src/components/CircularMenu.vue
@@ -15,6 +15,8 @@ const emit = defineEmits<{
   'update:isVisualizationVisible': [isVisualizationVisible: boolean]
   startEditing: []
   startEditingComment: []
+  openFullMenu: []
+  delete: []
 }>()
 </script>
 
@@ -25,10 +27,20 @@ const emit = defineEmits<{
     @pointerup.stop
     @click.stop
   >
+    <div v-if="!isFullMenuVisible" class="More" @pointerdown.stop="emit('openFullMenu')"></div>
     <SvgIcon
+      v-if="isFullMenuVisible"
       name="comment"
       class="icon-container button slot2"
+      :alt="`Edit comment`"
       @click.stop="emit('startEditingComment')"
+    />
+    <SvgIcon
+      v-if="isFullMenuVisible"
+      name="trash2"
+      class="icon-container button slot4"
+      :alt="`Delete component`"
+      @click.stop="emit('delete')"
     />
     <ToggleIcon
       icon="eye"

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -428,6 +428,8 @@ const documentation = computed<string | undefined>({
       @update:isVisualizationVisible="emit('update:visualizationVisible', $event)"
       @startEditing="startEditingNode"
       @startEditingComment="editingComment = true"
+      @openFullMenu="openFullMenu"
+      @delete="emit('delete')"
     />
     <GraphVisualization
       v-if="isVisualizationVisible"

--- a/app/gui2/src/components/GraphEditor/GraphNodes.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNodes.vue
@@ -48,6 +48,7 @@ const uploadingFiles = computed<[FileName, File][]>(() => {
     :edited="id === graphStore.editedNodeInfo?.id"
     @pointerenter="hoverNode(id)"
     @pointerleave="hoverNode(undefined)"
+    @delete="graphStore.deleteNodes([id])"
     @dragging="nodeIsDragged(id, $event)"
     @draggingCommited="dragging.finishDrag()"
     @outputPortClick="graphStore.createEdgeFromOutput($event)"


### PR DESCRIPTION
### Pull Request Description

Closes #9168, also adds `Show full menu` icon back and hides `edit comment`.

https://github.com/enso-org/enso/assets/6566674/43af88a7-2b08-4f7d-8f4a-f47b41e51b2e

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
