### PR TITLE
Enable splitting for EqualsSimpleNode

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsSimpleNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsSimpleNode.java
@@ -4,6 +4,7 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Cached.Shared;
 import com.oracle.truffle.api.dsl.GenerateUncached;
+import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.InteropLibrary;
@@ -23,6 +24,7 @@ import org.enso.interpreter.runtime.number.EnsoBigInteger;
 import org.enso.polyglot.common_utils.Core_Text_Utils;
 
 @GenerateUncached
+@ReportPolymorphism
 public abstract class EqualsSimpleNode extends Node {
 
   public static EqualsSimpleNode build() {


### PR DESCRIPTION
Fixes #9166

### Pull Request Description

Fixes the regression introduced by #9070 in `org.enso.benchmarks.generated.Collections.list_meta_fold` benchmark.


### Important Notes
As can be seen on the graph in IGV:
![image](https://github.com/enso-org/enso/assets/14013887/31b6ceca-4909-4a8f-987f-b456b3fb0a1b)
For some reason, `EqualsSimpleNode` is POLYMORPHIC. That seems to be the most visible performance problem.

First, I tried to introduce `ConditionProfile` with:
```diff
diff --git a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsNode.java b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsNode.java
index b368fb7fe..57274b37e 100644
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsNode.java
@@ -9,6 +9,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.profiles.ConditionProfile;
 import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.EnsoRootNode;
@@ -46,6 +47,7 @@ public final class EqualsNode extends Node {
   @Child private EqualsSimpleNode node;
   @Child private TypeOfNode types;
   @Child private WithConversionNode convert;
+  private final ConditionProfile equalsProfile = ConditionProfile.create();
 
   private static final EqualsNode UNCACHED =
       new EqualsNode(EqualsSimpleNodeGen.getUncached(), TypeOfNode.getUncached(), true);
@@ -85,7 +87,7 @@ public final class EqualsNode extends Node {
   public boolean execute(
       VirtualFrame frame, @AcceptsError Object self, @AcceptsError Object other) {
     var areEqual = node.execute(frame, self, other);
-    if (!areEqual) {
+    if (!equalsProfile.profile(areEqual)) {
       var selfType = types.execute(self);
       var otherType = types.execute(other);
       if (selfType != otherType) {

```
But that did not resolve the issue.

My second attempt was to enable splitting for `EqualsSimpleNode` with `@com.oracle.truffle.api.dsl.ReportPolymorphism` annotation, which seems to resolve the issue. The benchmark is back to its original score, and `EqualsSimpleNode` is no longer POLYMORPHIC.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Run benchmarks and ensure that the regression is resolved, and no other introduced.
