### PR TITLE
Fix typechecking

### DIFF
--- a/app/ide-desktop/lib/dashboard/e2e/driveView.spec.ts
+++ b/app/ide-desktop/lib/dashboard/e2e/driveView.spec.ts
@@ -13,6 +13,7 @@ test.test('drive view', async ({ page }) => {
   await actions.expectPlaceholderRow(page)
   // Assets table with one asset
   await actions.locateNewProjectButton(page).click()
+  await actions.locateDrivePageIcon(page).click()
   // The placeholder row becomes hidden.
   await test.expect(assetRows).toHaveCount(1)
   await test.expect(actions.locateAssetsTable(page)).toBeVisible()

--- a/app/ide-desktop/lib/dashboard/tsconfig.json
+++ b/app/ide-desktop/lib/dashboard/tsconfig.json
@@ -6,6 +6,7 @@
     "./**/*.json",
     "../../utils.ts",
     ".prettierrc.cjs"
+    "tailwind.config.js"
   ],
   "exclude": ["./dist"],
   "compilerOptions": {

--- a/app/ide-desktop/lib/dashboard/tsconfig.json
+++ b/app/ide-desktop/lib/dashboard/tsconfig.json
@@ -5,7 +5,7 @@
     "../types",
     "./**/*.json",
     "../../utils.ts",
-    ".prettierrc.cjs"
+    ".prettierrc.cjs",
     "tailwind.config.js"
   ],
   "exclude": ["./dist"],

--- a/app/ide-desktop/lib/dashboard/tsconfig.json
+++ b/app/ide-desktop/lib/dashboard/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "include": [
+    "src",
     "../types",
-    ".",
     "./**/*.json",
     "../../utils.ts",
     ".prettierrc.cjs"

--- a/app/ide-desktop/lib/dashboard/tsconfig.json
+++ b/app/ide-desktop/lib/dashboard/tsconfig.json
@@ -2,11 +2,13 @@
   "extends": "../../tsconfig.json",
   "include": [
     "src",
+    "e2e",
     "../types",
     "./**/*.json",
     "../../utils.ts",
     ".prettierrc.cjs",
-    "tailwind.config.js"
+    "*.js",
+    "*.ts"
   ],
   "exclude": ["./dist"],
   "compilerOptions": {


### PR DESCRIPTION
### Pull Request Description
- Fix issue where `playwright-report/` is being typechecked by `npm run typecheck` in the dashboard, causing CI to fail
- Attempt to fix flaky dashboard test

### Important Notes
To test that typechecking isn't completely broken, it's recommended to intentionally create a type error in the dashboard code base.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
