### PR TITLE
Update ~/.enso/credentials file

### DIFF
--- a/app/ide-desktop/lib/client/src/authentication.ts
+++ b/app/ide-desktop/lib/client/src/authentication.ts
@@ -156,38 +156,49 @@ export function onOpenUrl(url: URL, window: () => electron.BrowserWindow) {
  * The credentials file is placed in the user's home directory in the `.enso` subdirectory
  * in the `credentials` file. */
 function initSaveAccessTokenListener() {
-    electron.ipcMain.on(ipc.Channel.saveAccessToken, (event, accessToken: string | null) => {
-        event.preventDefault()
+    electron.ipcMain.on(
+        ipc.Channel.saveAccessToken,
+        (event, accessTokenPayload: SaveAccessTokenPayload | null) => {
+            event.preventDefault()
 
-        /** Home directory for the credentials file.  */
-        const credentialsDirectoryName = `.${common.PRODUCT_NAME.toLowerCase()}`
-        /** File name of the credentials file. */
-        const credentialsFileName = 'credentials'
-        /** System agnostic credentials directory home path. */
-        const credentialsHomePath = path.join(os.homedir(), credentialsDirectoryName)
+            /** Home directory for the credentials file.  */
+            const credentialsDirectoryName = `.${common.PRODUCT_NAME.toLowerCase()}`
+            /** File name of the credentials file. */
+            const credentialsFileName = 'credentials'
+            /** System agnostic credentials directory home path. */
+            const credentialsHomePath = path.join(os.homedir(), credentialsDirectoryName)
 
-        if (accessToken == null) {
-            try {
-                fs.unlinkSync(path.join(credentialsHomePath, credentialsFileName))
-            } catch {
-                // Ignored, most likely the path does not exist.
-            }
-        } else {
-            fs.mkdir(credentialsHomePath, { recursive: true }, error => {
-                if (error) {
-                    logger.error(`Couldn't create ${credentialsDirectoryName} directory.`)
-                } else {
-                    fs.writeFile(
-                        path.join(credentialsHomePath, credentialsFileName),
-                        accessToken,
-                        innerError => {
-                            if (innerError) {
-                                logger.error(`Could not write to ${credentialsFileName} file.`)
-                            }
-                        }
-                    )
+            if (accessTokenPayload == null) {
+                try {
+                    fs.unlinkSync(path.join(credentialsHomePath, credentialsFileName))
+                } catch {
+                    // Ignored, most likely the path does not exist.
                 }
-            })
+            } else {
+                fs.mkdir(credentialsHomePath, { recursive: true }, error => {
+                    if (error) {
+                        logger.error(`Couldn't create ${credentialsDirectoryName} directory.`)
+                    } else {
+                        fs.writeFile(
+                            path.join(credentialsHomePath, credentialsFileName),
+                            JSON.stringify({
+                                /* eslint-disable @typescript-eslint/naming-convention */
+                                client_id: accessTokenPayload.clientId,
+                                access_token: accessTokenPayload.accessToken,
+                                refresh_token: accessTokenPayload.refreshToken,
+                                refresh_uri: accessTokenPayload.refreshUri,
+                                expire_at: accessTokenPayload.expireAt,
+                                /* eslint-enable @typescript-eslint/naming-convention */
+                            }),
+                            innerError => {
+                                if (innerError) {
+                                    logger.error(`Could not write to ${credentialsFileName} file.`)
+                                }
+                            }
+                        )
+                    }
+                })
+            }
         }
-    })
+    )
 }

--- a/app/ide-desktop/lib/client/src/authentication.ts
+++ b/app/ide-desktop/lib/client/src/authentication.ts
@@ -186,13 +186,15 @@ function initSaveAccessTokenListener() {
                                 client_id: accessTokenPayload.clientId,
                                 access_token: accessTokenPayload.accessToken,
                                 refresh_token: accessTokenPayload.refreshToken,
-                                refresh_uri: accessTokenPayload.refreshUri,
+                                refresh_url: accessTokenPayload.refreshUrl,
                                 expire_at: accessTokenPayload.expireAt,
                                 /* eslint-enable @typescript-eslint/naming-convention */
                             }),
                             innerError => {
                                 if (innerError) {
-                                    logger.error(`Could not write to '${credentialsFileName}' file.`)
+                                    logger.error(
+                                        `Could not write to '${credentialsFileName}' file.`
+                                    )
                                 }
                             }
                         )

--- a/app/ide-desktop/lib/client/src/authentication.ts
+++ b/app/ide-desktop/lib/client/src/authentication.ts
@@ -177,7 +177,7 @@ function initSaveAccessTokenListener() {
             } else {
                 fs.mkdir(credentialsHomePath, { recursive: true }, error => {
                     if (error) {
-                        logger.error(`Couldn't create ${credentialsDirectoryName} directory.`)
+                        logger.error(`Could not create '${credentialsDirectoryName}' directory.`)
                     } else {
                         fs.writeFile(
                             path.join(credentialsHomePath, credentialsFileName),
@@ -192,7 +192,7 @@ function initSaveAccessTokenListener() {
                             }),
                             innerError => {
                                 if (innerError) {
-                                    logger.error(`Could not write to ${credentialsFileName} file.`)
+                                    logger.error(`Could not write to '${credentialsFileName}' file.`)
                                 }
                             }
                         )

--- a/app/ide-desktop/lib/client/src/preload.ts
+++ b/app/ide-desktop/lib/client/src/preload.ts
@@ -146,8 +146,8 @@ const AUTHENTICATION_API = {
      *
      * The backend doesn't have access to Electron's `localStorage` so we need to save access token
      * to a file. Then the token will be used to sign cloud API requests. */
-    saveAccessToken: (accessToken: string | null) => {
-        electron.ipcRenderer.send(ipc.Channel.saveAccessToken, accessToken)
+    saveAccessToken: (accessTokenPayload: SaveAccessTokenPayload | null) => {
+        electron.ipcRenderer.send(ipc.Channel.saveAccessToken, accessTokenPayload)
     },
 }
 electron.contextBridge.exposeInMainWorld(AUTHENTICATION_API_KEY, AUTHENTICATION_API)

--- a/app/ide-desktop/lib/dashboard/src/authentication/cognito.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/cognito.ts
@@ -196,7 +196,9 @@ export class Cognito {
     const amplifySession = currentSession.mapErr(intoCurrentSessionErrorType)
 
     return amplifySession
-      .map(session => parseUserSession(session, this.amplifyConfig.userPoolWebClientId, this.amplifyConfig.domain))
+      .map(session =>
+        parseUserSession(session, this.amplifyConfig.userPoolWebClientId, this.amplifyConfig.domain)
+      )
       .unwrapOr(null)
   }
 
@@ -391,6 +393,8 @@ function parseUserSession(
   const payload: Readonly<Record<string, unknown>> = session.getIdToken().payload
   const email = payload.email
 
+  domain = domain.startsWith('https://') ? domain : `https://${domain}`
+
   /** The `email` field is mandatory, so we assert that it exists and is a string. */
   if (typeof email !== 'string') {
     throw new Error('Payload does not have an email field.')
@@ -409,7 +413,7 @@ function parseUserSession(
       expireAt,
       accessToken: session.getAccessToken().getJwtToken(),
       refreshToken: session.getRefreshToken().getToken(),
-      refreshUrl: domain,
+      refreshUrl: new URL(domain).toString(),
     }
   }
 }

--- a/app/ide-desktop/lib/dashboard/src/authentication/service.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/service.ts
@@ -27,7 +27,7 @@ export interface AmplifyConfig {
   readonly userPoolId: string
   readonly userPoolWebClientId: string
   readonly urlOpener: ((url: string, redirectUrl: string) => void) | null
-  readonly saveAccessToken: ((accessToken: string | null) => void) | null
+  readonly saveAccessToken: ((accessToken: SaveAccessTokenPayload | null) => void) | null
   readonly domain: string
   readonly scope: string[]
   readonly redirectSignIn: string
@@ -125,6 +125,7 @@ export function initAuthService(authConfig: AuthConfig): AuthService | null {
     amplifyConfig == null
       ? null
       : new cognitoModule.Cognito(logger, supportsDeepLinks, amplifyConfig)
+
   return cognito == null
     ? null
     : { cognito, registerAuthEventListener: listen.registerAuthEventListener }
@@ -137,14 +138,14 @@ function loadAmplifyConfig(
   navigate: (url: string) => void
 ): AmplifyConfig | null {
   let urlOpener: ((url: string) => void) | null = null
-  let saveAccessToken: ((accessToken: string | null) => void) | null = null
+  let saveAccessToken: ((accessToken: SaveAccessTokenPayload | null) => void) | null = null
   if ('authenticationApi' in window) {
     // When running on desktop we want to have option to save access token to a file,
     // so it can be reused later when issuing requests to the Cloud API.
     //
     // Note: Wrapping this function in an arrow function ensures that the current Authentication API
     // is always used.
-    saveAccessToken = (accessToken: string | null) => {
+    saveAccessToken = (accessToken: SaveAccessTokenPayload | null) => {
       window.authenticationApi.saveAccessToken(accessToken)
     }
   }

--- a/app/ide-desktop/lib/dashboard/src/providers/AuthProvider.tsx
+++ b/app/ide-desktop/lib/dashboard/src/providers/AuthProvider.tsx
@@ -353,7 +353,7 @@ export default function AuthProvider(props: AuthProviderProps) {
             clientId: session.clientId,
             expireAt: session.expireAt,
             refreshToken: session.refreshToken,
-            refreshUri: session.refreshUrl,
+            refreshUrl: session.refreshUrl,
           })
 
           // Execute the callback that should inform the Electron app that the user has logged in.

--- a/app/ide-desktop/lib/dashboard/src/providers/AuthProvider.tsx
+++ b/app/ide-desktop/lib/dashboard/src/providers/AuthProvider.tsx
@@ -348,7 +348,13 @@ export default function AuthProvider(props: AuthProviderProps) {
           document.cookie = `logged_in=yes;max-age=34560000;domain=${parentDomain};samesite=strict;secure`
 
           // Save access token so can it be reused by the backend.
-          cognito?.saveAccessToken(session.accessToken)
+          cognito?.saveAccessToken({
+            accessToken: session.accessToken,
+            clientId: session.clientId,
+            expireAt: session.expireAt,
+            refreshToken: session.refreshToken,
+            refreshUri: session.refreshUrl,
+          })
 
           // Execute the callback that should inform the Electron app that the user has logged in.
           // This is done to transition the app from the authentication/dashboard view to the IDE.

--- a/app/ide-desktop/lib/types/globals.d.ts
+++ b/app/ide-desktop/lib/types/globals.d.ts
@@ -52,7 +52,7 @@ interface AuthenticationApi {
      * via a deep link. See `setDeepLinkHandler` for details. */
     readonly setDeepLinkHandler: (callback: (url: string) => void) => void
     /** Saves the access token to a file. */
-    readonly saveAccessToken: (accessToken: string | null) => void
+    readonly saveAccessToken: (accessToken: SaveAccessTokenPayload | null) => void
 }
 
 // =====================================

--- a/app/ide-desktop/lib/types/ipc.d.ts
+++ b/app/ide-desktop/lib/types/ipc.d.ts
@@ -11,7 +11,7 @@ interface SaveAccessTokenPayload {
      */
     readonly accessToken: string
     /**
-     * The cognito app integration client id
+     * The Cognito app integration client id
      */
     readonly clientId: string
     /**
@@ -19,7 +19,7 @@ interface SaveAccessTokenPayload {
      */
     readonly refreshToken: string
     /**
-     * The cognito url to refresh the token.
+     * The Cognito url to refresh the token.
      */
     readonly refreshUrl: string
     /**

--- a/app/ide-desktop/lib/types/ipc.d.ts
+++ b/app/ide-desktop/lib/types/ipc.d.ts
@@ -2,7 +2,6 @@
  * @file This file contains the types for the IPC events.
  * The IPC events are used to communicate between the main and renderer processes.
  */
-
 /**
  * Payload for the save-access-token event that saves an access token to a credentials file.
  */
@@ -22,7 +21,7 @@ interface SaveAccessTokenPayload {
     /**
      * The cognito url to refresh the token.
      */
-    readonly refreshUri: string
+    readonly refreshUrl: string
     /**
      * Time when the token will expire.
      * This is a string representation of a date in ISO 8601 format (e.g. "2021-01-01T00:00:00Z").

--- a/app/ide-desktop/lib/types/ipc.d.ts
+++ b/app/ide-desktop/lib/types/ipc.d.ts
@@ -1,0 +1,32 @@
+/**
+ * @file This file contains the types for the IPC events.
+ * The IPC events are used to communicate between the main and renderer processes.
+ * The events are defined in the main process and are listened to in the renderer process.
+ */
+
+/**
+ * Payload for the save-access-token event that saves an access token to a credentials file.
+ */
+interface SaveAccessTokenPayload {
+    /**
+     * The JWT token to save.
+     */
+    readonly accessToken: string
+    /**
+     * The cognito app integration client id
+     */
+    readonly clientId: string
+    /**
+     * The refresh token taken from initAuth flow.
+     */
+    readonly refreshToken: string
+    /**
+     * The cognito url to refresh the token.
+     */
+    readonly refreshUri: string
+    /**
+     * Time when the token will expire.
+     * This is a string representation of a date in ISO 8601 format (e.g. "2021-01-01T00:00:00Z").
+     */
+    readonly expireAt: string
+}

--- a/app/ide-desktop/lib/types/ipc.d.ts
+++ b/app/ide-desktop/lib/types/ipc.d.ts
@@ -1,7 +1,6 @@
 /**
  * @file This file contains the types for the IPC events.
  * The IPC events are used to communicate between the main and renderer processes.
- * The events are defined in the main process and are listened to in the renderer process.
  */
 
 /**

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Utils.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Utils.enso
@@ -41,7 +41,8 @@ authorization_header =
     token = AuthenticationProvider.getToken.if_nothing <|
         f = credentials_file
         if f.exists.not then Error.throw Not_Logged_In else
-            AuthenticationProvider.setToken (f.read_text)
+            access_token = read_access_token f
+            AuthenticationProvider.setToken access_token
     Header.authorization_bearer token
 
 ## PRIVATE
@@ -49,6 +50,18 @@ credentials_file : File
 credentials_file = case Environment.get "ENSO_CLOUD_CREDENTIALS_FILE" of
     Nothing -> File.home / ".enso" / "credentials"
     path -> File.new path
+
+## PRIVATE
+   Reads the access token from the provided credentials file.
+
+   It supports both the old (raw string) and new (JSON) formats.
+read_access_token (file:File) -> Text =
+    content = file.read_text
+    as_json = content.parse_json
+    # If this is not valid JSON, we assume old format - raw token.
+    if as_json.is_error then content else
+        # Otherwise, we extract the token from JSON:
+        as_json.get "access_token" if_missing=(Error.throw "Invalid credentials file format: missing field `access_token`.")
 
 ## PRIVATE
    Root address for listing folders


### PR DESCRIPTION
### Pull Request Description

This PR updates the content of ` ~/.enso/credentials` file, where we store jwt token.
Now the content would look like this:
```JSON
{
  "client_id": <id>, <- this is cognito app integration client id
  "access_token": <token>, <- jwt generated for current session
  "refresh_token": <token2>, <- refresh token taken from initAuth flow
  "refresh_uri": <token> <- "https://cognito-idp.eu-west-1.amazonaws.com/"
  "expire_at": <iso datetime> <- datetime when the access token will go expire
}
```

Closes: enso-org/cloud-v2#934

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
