### PR TITLE
Add write to xml document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -625,6 +625,7 @@
 - [Added `Data.download` and a few other changes.][9249]
 - [Implement Data Links to Postgres (accessing a DB connection or a table
   directly)][9269]
+- [Added `Xml_Document.write`][9299]
 
 [debug-shortcuts]:
   https://github.com/enso-org/enso/blob/develop/app/gui/docs/product/shortcuts.md#debug
@@ -905,6 +906,7 @@
 [9233]: https://github.com/enso-org/enso/pull/9233
 [9249]: https://github.com/enso-org/enso/pull/9249
 [9269]: https://github.com/enso-org/enso/pull/9269
+[9299]: https://github.com/enso-org/enso/pull/9299
 
 #### Enso Compiler
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
@@ -15,6 +15,8 @@ import project.Nothing.Nothing
 import project.Panic.Panic
 import project.System.File.File
 import project.System.File.File_Access.File_Access
+import project.System.File.Generic.Writable_File.Writable_File
+import project.System.File.Existing_File_Behavior.Existing_File_Behavior
 import project.System.Input_Stream.Input_Stream
 from project.Data.Range.Extensions import all
 from project.Data.Text.Extensions import all
@@ -191,7 +193,7 @@ type XML_Document
     outer_xml : Text ! XML_Error
     outer_xml self =
         XML_Error.handle_java_exceptions <|
-            XML_Utils.outerXML self.java_document
+            XML_Utils.outerXML self.java_document Boolean.False Boolean.False
 
     ## Gets the raw XML of the document.
 
@@ -204,6 +206,12 @@ type XML_Document
     inner_xml self =
         XML_Error.handle_java_exceptions <|
             XML_Utils.innerXML self.java_document
+
+    write : Writable_File -> Existing_File_Behavior -> File
+    write self path:Writable_File on_existing_file=Existing_File_Behavior.Backup =
+        XML_Error.handle_java_exceptions <|
+            s = XML_Utils.outerXML self.java_document Boolean.True Boolean.True
+            s.write path on_existing_file
 
     ## GROUP Selections
        Gets the child elements of an XML document.
@@ -480,7 +488,7 @@ type XML_Element
     outer_xml : Text ! XML_Error
     outer_xml self =
         XML_Error.handle_java_exceptions <|
-            XML_Utils.outerXML self.java_element
+            XML_Utils.outerXML self.java_element Boolean.False Boolean.False
 
     ## Gets the raw XML of the contents of the element, not including the
        outermost tag and attributes.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
@@ -1,5 +1,4 @@
 import project.Any.Any
-import project.Data.Boolean.Boolean
 import project.Data.Json.Extensions
 import project.Data.Json.JS_Object
 import project.Data.Map.Map
@@ -21,6 +20,7 @@ import project.System.File.Generic.Writable_File.Writable_File
 import project.System.File.Existing_File_Behavior.Existing_File_Behavior
 import project.System.Input_Stream.Input_Stream
 import project.System.File.Write_Extensions
+from project.Data.Boolean import Boolean, False, True
 from project.Data.Range.Extensions import all
 from project.Data.Text.Extensions import all
 from project.Metadata import make_single_choice, Widget

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
@@ -196,7 +196,7 @@ type XML_Document
     outer_xml : Text ! XML_Error
     outer_xml self =
         XML_Error.handle_java_exceptions <|
-            XML_Utils.outerXML self.java_document Boolean.False
+            XML_Utils.outerXML self.java_document False
 
     ## Gets the raw XML of the document.
 
@@ -251,7 +251,7 @@ type XML_Document
     write self path:Writable_File (encoding : Encoding = Encoding.utf_8) (on_existing_file : Existing_File_Behavior = Existing_File_Behavior.Backup) (include_xml_declaration : Boolean = Boolean.True) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
         declaration = if include_xml_declaration then '<?xml version=\"1.0\" encoding=\"' + encoding.character_set + '\"?>\n' else ""
         XML_Error.handle_java_exceptions <|
-            (declaration + XML_Utils.outerXML self.java_document Boolean.True).write path encoding on_existing_file on_problems
+            (declaration + XML_Utils.outerXML self.java_document True).write path encoding on_existing_file on_problems
 
     ## GROUP Selections
        Gets the child elements of an XML document.
@@ -528,7 +528,7 @@ type XML_Element
     outer_xml : Text ! XML_Error
     outer_xml self =
         XML_Error.handle_java_exceptions <|
-            XML_Utils.outerXML self.java_element Boolean.False
+            XML_Utils.outerXML self.java_element False
 
     ## Gets the raw XML of the contents of the element, not including the
        outermost tag and attributes.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
@@ -4,6 +4,7 @@ import project.Data.Json.Extensions
 import project.Data.Json.JS_Object
 import project.Data.Map.Map
 import project.Data.Numbers.Integer
+import project.Data.Text.Encoding.Encoding
 import project.Data.Text.Text
 import project.Data.Vector.Vector
 import project.Error.Error
@@ -18,6 +19,7 @@ import project.System.File.File_Access.File_Access
 import project.System.File.Generic.Writable_File.Writable_File
 import project.System.File.Existing_File_Behavior.Existing_File_Behavior
 import project.System.Input_Stream.Input_Stream
+import project.System.File.Write_Extensions
 from project.Data.Range.Extensions import all
 from project.Data.Text.Extensions import all
 from project.Metadata import make_single_choice, Widget
@@ -193,7 +195,7 @@ type XML_Document
     outer_xml : Text ! XML_Error
     outer_xml self =
         XML_Error.handle_java_exceptions <|
-            XML_Utils.outerXML self.java_document Boolean.False Boolean.False
+            XML_Utils.outerXML self.java_document Boolean.False
 
     ## Gets the raw XML of the document.
 
@@ -207,11 +209,13 @@ type XML_Document
         XML_Error.handle_java_exceptions <|
             XML_Utils.innerXML self.java_document
 
-    write : Writable_File -> Existing_File_Behavior -> File
-    write self path:Writable_File on_existing_file=Existing_File_Behavior.Backup =
+    @encoding Encoding.default_widget
+    write : Writable_File -> Encoding -> Existing_File_Behavior -> Boolean -> File
+    write self path:Writable_File (encoding : Encoding = Encoding.utf_8) (on_existing_file : Existing_File_Behavior = Existing_File_Behavior.Backup) (include_xml_declaration : Boolean = Boolean.True) =
+        header = if include_xml_declaration then '<?xml version=\"1.0\" encoding=\"' + encoding.character_set + '\"?>\n' else ""
         XML_Error.handle_java_exceptions <|
-            s = XML_Utils.outerXML self.java_document Boolean.True Boolean.True
-            s.write path on_existing_file
+            s = header + XML_Utils.outerXML self.java_document Boolean.True
+            Text.write s path encoding on_existing_file
 
     ## GROUP Selections
        Gets the child elements of an XML document.
@@ -488,7 +492,7 @@ type XML_Element
     outer_xml : Text ! XML_Error
     outer_xml self =
         XML_Error.handle_java_exceptions <|
-            XML_Utils.outerXML self.java_element Boolean.False Boolean.False
+            XML_Utils.outerXML self.java_element Boolean.False
 
     ## Gets the raw XML of the contents of the element, not including the
        outermost tag and attributes.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
@@ -12,6 +12,7 @@ import project.Errors.Common.Index_Out_Of_Bounds
 import project.Errors.File_Error.File_Error
 import project.Errors.Illegal_State.Illegal_State
 import project.Errors.No_Such_Key.No_Such_Key
+import project.Errors.Problem_Behavior.Problem_Behavior
 import project.Nothing.Nothing
 import project.Panic.Panic
 import project.System.File.File
@@ -209,13 +210,48 @@ type XML_Document
         XML_Error.handle_java_exceptions <|
             XML_Utils.innerXML self.java_document
 
+    ## GROUP Output
+       ICON data_output
+       Writes (or appends) the xml to the specified file using the supplied
+       encoding. The behavior specified in the `existing_file` parameter will be
+       used if the file exists.
+
+       Appending will probably not work as expected for XML documents, as it will
+       append after the root element, which is not valid XML.
+   
+       Arguments:
+       - path: The path to the target file.
+       - encoding: The encoding to use when writing the file.
+       - on_existing_file: Specifies how to proceed if the file already exists.
+       - include_xml_declaration: Specifies whether to include the XML declaration
+         in the output. (e.g. `<?xml version="1.0" encoding="UTF-8"?>`)
+       - on_problems: Specifies how to handle any encountered problems.
+   
+       If a character cannot be converted to a byte, an `Encoding_Error` is raised.
+       If `on_problems` is set to `Report_Warning` or `Ignore`, it is replaced with
+       a substitute (either '�' (if Unicode) or '?' depending on the encoding).
+       Otherwise, the process is aborted.
+       If the path to the parent location cannot be found or the filename is
+       invalid, a `File_Error.Not_Found` is raised.
+       If another error occurs, such as access denied, an `File_Error.IO_Error` is
+       raised.
+       Otherwise, the file is created with the encoded xlm written to it.
+   
+       The method returns a `File` object for the written file.
+   
+       ? Dry Run
+   
+           If writing to Output context is not enabled (such as in "Design" mode),
+           then this function will write to a temporary file. This temporary file will
+           be automatically deleted on exit of the Enso process.
+   
+           This allows for building the workflow without affecting the real files.
     @encoding Encoding.default_widget
     write : Writable_File -> Encoding -> Existing_File_Behavior -> Boolean -> File
-    write self path:Writable_File (encoding : Encoding = Encoding.utf_8) (on_existing_file : Existing_File_Behavior = Existing_File_Behavior.Backup) (include_xml_declaration : Boolean = Boolean.True) =
-        header = if include_xml_declaration then '<?xml version=\"1.0\" encoding=\"' + encoding.character_set + '\"?>\n' else ""
+    write self path:Writable_File (encoding : Encoding = Encoding.utf_8) (on_existing_file : Existing_File_Behavior = Existing_File_Behavior.Backup) (include_xml_declaration : Boolean = Boolean.True) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
+        declaration = if include_xml_declaration then '<?xml version=\"1.0\" encoding=\"' + encoding.character_set + '\"?>\n' else ""
         XML_Error.handle_java_exceptions <|
-            s = header + XML_Utils.outerXML self.java_document Boolean.True
-            Text.write s path encoding on_existing_file
+            (declaration + XML_Utils.outerXML self.java_document Boolean.True).write path encoding on_existing_file on_problems
 
     ## GROUP Selections
        Gets the child elements of an XML document.

--- a/std-bits/base/src/main/java/org/enso/base/XML_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/XML_Utils.java
@@ -23,7 +23,7 @@ public class XML_Utils {
    * @throws IllegalAccessException if the DOM implementation class cannot be accessed.
    * @throws InstantiationException if the DOM implementation class cannot be instantiated.
    */
-  public static String outerXML(Node element, boolean prettyPrint, boolean xmlDeclaration)
+  public static String outerXML(Node element, boolean prettyPrint)
       throws ClassNotFoundException, IllegalAccessException, InstantiationException {
     DOMImplementationLS dom =
         (DOMImplementationLS) DOMImplementationRegistry.newInstance().getDOMImplementation("LS");
@@ -32,9 +32,6 @@ public class XML_Utils {
     config.setParameter("xml-declaration", false);
     if (prettyPrint) {
       config.setParameter("format-pretty-print", Boolean.TRUE);
-    }
-    if (xmlDeclaration) {
-      config.setParameter("xml-declaration", true);
     }
     serializer.setNewLine("\n");
     return serializer.writeToString(element);

--- a/std-bits/base/src/main/java/org/enso/base/XML_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/XML_Utils.java
@@ -30,9 +30,7 @@ public class XML_Utils {
     LSSerializer serializer = dom.createLSSerializer();
     DOMConfiguration config = serializer.getDomConfig();
     config.setParameter("xml-declaration", false);
-    if (prettyPrint) {
-      config.setParameter("format-pretty-print", Boolean.TRUE);
-    }
+    config.setParameter("format-pretty-print", prettyPrint);
     serializer.setNewLine("\n");
     return serializer.writeToString(element);
   }

--- a/std-bits/base/src/main/java/org/enso/base/XML_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/XML_Utils.java
@@ -23,13 +23,19 @@ public class XML_Utils {
    * @throws IllegalAccessException if the DOM implementation class cannot be accessed.
    * @throws InstantiationException if the DOM implementation class cannot be instantiated.
    */
-  public static String outerXML(Node element)
+  public static String outerXML(Node element, boolean prettyPrint, boolean xmlDeclaration)
       throws ClassNotFoundException, IllegalAccessException, InstantiationException {
     DOMImplementationLS dom =
         (DOMImplementationLS) DOMImplementationRegistry.newInstance().getDOMImplementation("LS");
     LSSerializer serializer = dom.createLSSerializer();
     DOMConfiguration config = serializer.getDomConfig();
     config.setParameter("xml-declaration", false);
+    if (prettyPrint) {
+      config.setParameter("format-pretty-print", Boolean.TRUE);
+    }
+    if (xmlDeclaration) {
+      config.setParameter("xml-declaration", true);
+    }
     serializer.setNewLine("\n");
     return serializer.writeToString(element);
   }


### PR DESCRIPTION
### Pull Request Description

This adds the ability to write a XML document back out to a file.

![image](https://github.com/enso-org/enso/assets/1720119/d95fa47f-b8f4-4158-8692-45e733196155)

### Important Notes


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [X] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
