### PR TITLE
Update widget visibility

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
@@ -109,7 +109,7 @@ type File_Format
     default_widget =
         all_types = [Auto_Detect] + format_types
         make_name type_obj = type_obj.to_text.replace "_Format" "" . replace "_" " "
-        Single_Choice display=Display.Always values=(all_types.map n->(Option (make_name n) (File_Format.constructor_code n)))
+        Single_Choice values=(all_types.map n->(Option (make_name n) (File_Format.constructor_code n)))
 
 ## A file format for plain text files.
 type Plain_Text_Format

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Widget_Helpers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Widget_Helpers.enso
@@ -5,6 +5,7 @@ import project.Data.Time.Date_Time.Date_Time
 import project.Data.Time.Date_Time_Formatter.Date_Time_Formatter
 import project.Data.Time.Time_Of_Day.Time_Of_Day
 import project.Meta
+import project.Metadata.Display
 import project.Metadata.Widget
 from project.Data.Boolean import Boolean, False, True
 from project.Metadata import make_single_choice
@@ -111,4 +112,4 @@ make_format_chooser include_number:Boolean=True include_date:Boolean=True includ
     time = if include_time.not then [] else
         ['HH:mm[:ss]', 'h:mm[:ss] a'].map f-> [f + " (e.g. " + (Time_Of_Day.new 13 30 55 123).format f + ")", f.pretty]
     boolean = if include_boolean.not then [] else ['Yes|No', '1|0'].map f-> [f + " (Boolean)", f.pretty]
-    make_single_choice (numeric + date + date_time + time + custom_locale_format + boolean)
+    make_single_choice (numeric + date + date_time + time + custom_locale_format + boolean) display=Display.When_Modified

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
@@ -188,7 +188,8 @@ parse_type_selector include_auto=True =
     choice = names.map n-> if n=='Auto' then (Meta.get_qualified_type_name Auto) else fqn+'.'+n
 
     options = names.zip choice . map pair-> Option pair.first pair.second
-    Single_Choice display=Display.Always values=options
+    display = if include_auto then Display.Always else Display.When_Modified
+    Single_Choice display=display values=options
 
 ## PRIVATE
    Selector for writing a table to a file.
@@ -198,7 +199,7 @@ write_table_selector =
         Meta.meta type . methods . contains "write_table"
     all_types = [Auto_Detect] + (format_types.filter can_write)
     make_name type_obj = type_obj.to_text.replace "_Format" "" . replace "_" " "
-    Single_Choice display=Display.Always values=(all_types.map n->(Option (make_name n) (File_Format.constructor_code n)))
+    Single_Choice display=Display.When_Modified values=(all_types.map n->(Option (make_name n) (File_Format.constructor_code n)))
 
 ## PRIVATE
    Make format selector based off value type


### PR DESCRIPTION
### Pull Request Description

Make a few more widgets visible on modification. I think if there is an auto mode then the widget should only be visible when modified.

Takes Preppin Data 2024 Week 1 from:

![image](https://github.com/enso-org/enso/assets/1720119/caf55077-f21d-443f-9a26-ddbc06d57e24)

To:

![image](https://github.com/enso-org/enso/assets/1720119/3f8ea9ca-c59b-4753-a1c0-b1bee6ad9504)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [X] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
