### PR TITLE
Add some engine jobs that run with Oracle GraalVM

### DIFF
--- a/.github/workflows/engine-benchmark.yml
+++ b/.github/workflows/engine-benchmark.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     env:
-      JAVA_VENDOR: GraalVM CE
+      GRAAL_EDITION: GraalVM CE
     timeout-minutes: 240
   benchmark-engine-oracle-graal-vm:
     name: Benchmark Engine (Oracle GraalVM)
@@ -113,7 +113,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     env:
-      JAVA_VENDOR: Oracle GraalVM
+      GRAAL_EDITION: Oracle GraalVM
     timeout-minutes: 240
 env:
   ENSO_BUILD_MINIMAL_RUN: ${{ true == inputs.just-check }}

--- a/.github/workflows/engine-benchmark.yml
+++ b/.github/workflows/engine-benchmark.yml
@@ -13,8 +13,8 @@ on:
         type: boolean
         default: false
 jobs:
-  benchmark-engine:
-    name: Benchmark Engine
+  benchmark-engine-graal-vm-ce:
+    name: Benchmark Engine (GraalVM CE)
     runs-on:
       - benchmark
     steps:
@@ -61,6 +61,59 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      JAVA_VENDOR: GraalVM CE
+    timeout-minutes: 240
+  benchmark-engine-oracle-graal-vm:
+    name: Benchmark Engine (Oracle GraalVM)
+    runs-on:
+      - benchmark
+    steps:
+      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
+        name: Setup conda (GH runners only)
+        uses: s-weigand/setup-conda@v1.2.1
+        with:
+          update-conda: false
+          conda-channels: anaconda, conda-forge
+      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
+        name: Installing wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: v0.10.2
+      - name: Expose Artifact API and context information.
+        uses: actions/github-script@v7
+        with:
+          script: "\n    core.exportVariable(\"ACTIONS_RUNTIME_TOKEN\", process.env[\"ACTIONS_RUNTIME_TOKEN\"])\n    core.exportVariable(\"ACTIONS_RUNTIME_URL\", process.env[\"ACTIONS_RUNTIME_URL\"])\n    core.exportVariable(\"GITHUB_RETENTION_DAYS\", process.env[\"GITHUB_RETENTION_DAYS\"])\n    console.log(context)\n    "
+      - name: Checking out the repository
+        uses: actions/checkout@v4
+        with:
+          clean: false
+          submodules: recursive
+      - name: Build Script Setup
+        run: ./run --help
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: (always())
+        name: Clean before
+        run: ./run git-clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: ./run backend benchmark runtime
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: failure() && runner.os == 'Windows'
+        name: List files if failed (Windows)
+        run: Get-ChildItem -Force -Recurse
+      - if: failure() && runner.os != 'Windows'
+        name: List files if failed (non-Windows)
+        run: ls -lAR
+      - if: (always())
+        name: Clean after
+        run: ./run git-clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      JAVA_VENDOR: Oracle GraalVM
     timeout-minutes: 240
 env:
   ENSO_BUILD_MINIMAL_RUN: ${{ true == inputs.just-check }}

--- a/.github/workflows/scala-new.yml
+++ b/.github/workflows/scala-new.yml
@@ -273,7 +273,7 @@ jobs:
         uses: dorny/test-reporter@v1
         with:
           max-annotations: 50
-          name: Engine Tests Report (linux, x86_64)
+          name: Engine Tests Report (GraalVM CE, linux, x86_64)
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*.xml
           path-replace-backslashes: true
           reporter: java-junit
@@ -334,7 +334,7 @@ jobs:
         uses: dorny/test-reporter@v1
         with:
           max-annotations: 50
-          name: Engine Tests Report (macos, x86_64)
+          name: Engine Tests Report (GraalVM CE, macos, x86_64)
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*.xml
           path-replace-backslashes: true
           reporter: java-junit
@@ -396,7 +396,7 @@ jobs:
         uses: dorny/test-reporter@v1
         with:
           max-annotations: 50
-          name: Engine Tests Report (windows, x86_64)
+          name: Engine Tests Report (GraalVM CE, windows, x86_64)
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*.xml
           path-replace-backslashes: true
           reporter: java-junit
@@ -458,7 +458,7 @@ jobs:
         uses: dorny/test-reporter@v1
         with:
           max-annotations: 50
-          name: Engine Tests Report (linux, x86_64)
+          name: Engine Tests Report (Oracle GraalVM, linux, x86_64)
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*.xml
           path-replace-backslashes: true
           reporter: java-junit
@@ -523,7 +523,7 @@ jobs:
         uses: dorny/test-reporter@v1
         with:
           max-annotations: 50
-          name: Standard Library Tests Report (linux, x86_64)
+          name: Standard Library Tests Report (GraalVM CE, linux, x86_64)
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
@@ -587,7 +587,7 @@ jobs:
         uses: dorny/test-reporter@v1
         with:
           max-annotations: 50
-          name: Standard Library Tests Report (macos, x86_64)
+          name: Standard Library Tests Report (GraalVM CE, macos, x86_64)
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
@@ -652,7 +652,7 @@ jobs:
         uses: dorny/test-reporter@v1
         with:
           max-annotations: 50
-          name: Standard Library Tests Report (windows, x86_64)
+          name: Standard Library Tests Report (GraalVM CE, windows, x86_64)
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit
@@ -717,7 +717,7 @@ jobs:
         uses: dorny/test-reporter@v1
         with:
           max-annotations: 50
-          name: Standard Library Tests Report (linux, x86_64)
+          name: Standard Library Tests Report (Oracle GraalVM, linux, x86_64)
           path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
           path-replace-backslashes: true
           reporter: java-junit

--- a/.github/workflows/scala-new.yml
+++ b/.github/workflows/scala-new.yml
@@ -27,8 +27,8 @@ jobs:
           access_token: ${{ github.token }}
     permissions:
       actions: write
-  enso-build-ci-gen-job-ci-check-backend-linux-x86_64:
-    name: Engine (linux, x86_64)
+  enso-build-ci-gen-job-ci-check-backend-graal-vm-ce-linux-x86_64:
+    name: Engine (GraalVM CE) (linux, x86_64)
     runs-on:
       - self-hosted
       - Linux
@@ -76,8 +76,10 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  enso-build-ci-gen-job-ci-check-backend-macos-x86_64:
-    name: Engine (macos, x86_64)
+    env:
+      GRAAL_EDITION: GraalVM CE
+  enso-build-ci-gen-job-ci-check-backend-graal-vm-ce-macos-x86_64:
+    name: Engine (GraalVM CE) (macos, x86_64)
     runs-on:
       - macos-latest
     steps:
@@ -124,8 +126,10 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  enso-build-ci-gen-job-ci-check-backend-windows-x86_64:
-    name: Engine (windows, x86_64)
+    env:
+      GRAAL_EDITION: GraalVM CE
+  enso-build-ci-gen-job-ci-check-backend-graal-vm-ce-windows-x86_64:
+    name: Engine (GraalVM CE) (windows, x86_64)
     runs-on:
       - self-hosted
       - Windows
@@ -173,8 +177,61 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  enso-build-ci-gen-job-scala-tests-linux-x86_64:
-    name: Scala Tests (Oracle GraalVM) (linux, x86_64)
+    env:
+      GRAAL_EDITION: GraalVM CE
+  enso-build-ci-gen-job-ci-check-backend-oracle-graal-vm-linux-x86_64:
+    name: Engine (Oracle GraalVM) (linux, x86_64)
+    runs-on:
+      - self-hosted
+      - Linux
+    steps:
+      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
+        name: Setup conda (GH runners only)
+        uses: s-weigand/setup-conda@v1.2.1
+        with:
+          update-conda: false
+          conda-channels: anaconda, conda-forge
+      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
+        name: Installing wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: v0.10.2
+      - name: Expose Artifact API and context information.
+        uses: actions/github-script@v7
+        with:
+          script: "\n    core.exportVariable(\"ACTIONS_RUNTIME_TOKEN\", process.env[\"ACTIONS_RUNTIME_TOKEN\"])\n    core.exportVariable(\"ACTIONS_RUNTIME_URL\", process.env[\"ACTIONS_RUNTIME_URL\"])\n    core.exportVariable(\"GITHUB_RETENTION_DAYS\", process.env[\"GITHUB_RETENTION_DAYS\"])\n    console.log(context)\n    "
+      - name: Checking out the repository
+        uses: actions/checkout@v4
+        with:
+          clean: false
+          submodules: recursive
+      - name: Build Script Setup
+        run: ./run --help
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: "(contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || inputs.clean_build_required)"
+        name: Clean before
+        run: ./run git-clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: ./run backend ci-check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: failure() && runner.os == 'Windows'
+        name: List files if failed (Windows)
+        run: Get-ChildItem -Force -Recurse
+      - if: failure() && runner.os != 'Windows'
+        name: List files if failed (non-Windows)
+        run: ls -lAR
+      - if: "(always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || inputs.clean_build_required)"
+        name: Clean after
+        run: ./run git-clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      GRAAL_EDITION: Oracle GraalVM
+  enso-build-ci-gen-job-scala-tests-graal-vm-ce-linux-x86_64:
+    name: Scala Tests (GraalVM CE) (linux, x86_64)
     runs-on:
       - self-hosted
       - Linux
@@ -232,10 +289,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     env:
-      JAVA_VENDOR: Oracle GraalVM
+      GRAAL_EDITION: GraalVM CE
     permissions:
       checks: write
-  enso-build-ci-gen-job-scala-tests-macos-x86_64:
+  enso-build-ci-gen-job-scala-tests-graal-vm-ce-macos-x86_64:
     name: Scala Tests (GraalVM CE) (macos, x86_64)
     runs-on:
       - macos-latest
@@ -293,10 +350,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     env:
-      JAVA_VENDOR: GraalVM CE
+      GRAAL_EDITION: GraalVM CE
     permissions:
       checks: write
-  enso-build-ci-gen-job-scala-tests-windows-x86_64:
+  enso-build-ci-gen-job-scala-tests-graal-vm-ce-windows-x86_64:
     name: Scala Tests (GraalVM CE) (windows, x86_64)
     runs-on:
       - self-hosted
@@ -355,11 +412,73 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     env:
-      JAVA_VENDOR: GraalVM CE
+      GRAAL_EDITION: GraalVM CE
     permissions:
       checks: write
-  enso-build-ci-gen-job-standard-library-tests-linux-x86_64:
-    name: Standard Library Tests (Oracle GraalVM) (linux, x86_64)
+  enso-build-ci-gen-job-scala-tests-oracle-graal-vm-linux-x86_64:
+    name: Scala Tests (Oracle GraalVM) (linux, x86_64)
+    runs-on:
+      - self-hosted
+      - Linux
+    steps:
+      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
+        name: Setup conda (GH runners only)
+        uses: s-weigand/setup-conda@v1.2.1
+        with:
+          update-conda: false
+          conda-channels: anaconda, conda-forge
+      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
+        name: Installing wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: v0.10.2
+      - name: Expose Artifact API and context information.
+        uses: actions/github-script@v7
+        with:
+          script: "\n    core.exportVariable(\"ACTIONS_RUNTIME_TOKEN\", process.env[\"ACTIONS_RUNTIME_TOKEN\"])\n    core.exportVariable(\"ACTIONS_RUNTIME_URL\", process.env[\"ACTIONS_RUNTIME_URL\"])\n    core.exportVariable(\"GITHUB_RETENTION_DAYS\", process.env[\"GITHUB_RETENTION_DAYS\"])\n    console.log(context)\n    "
+      - name: Checking out the repository
+        uses: actions/checkout@v4
+        with:
+          clean: false
+          submodules: recursive
+      - name: Build Script Setup
+        run: ./run --help
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: "(contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || inputs.clean_build_required)"
+        name: Clean before
+        run: ./run git-clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: ./run backend test scala
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: success() || failure()
+        name: Engine Test Reporter
+        uses: dorny/test-reporter@v1
+        with:
+          max-annotations: 50
+          name: Engine Tests Report (linux, x86_64)
+          path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*.xml
+          path-replace-backslashes: true
+          reporter: java-junit
+      - if: failure() && runner.os == 'Windows'
+        name: List files if failed (Windows)
+        run: Get-ChildItem -Force -Recurse
+      - if: failure() && runner.os != 'Windows'
+        name: List files if failed (non-Windows)
+        run: ls -lAR
+      - if: "(always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || inputs.clean_build_required)"
+        name: Clean after
+        run: ./run git-clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      GRAAL_EDITION: Oracle GraalVM
+    permissions:
+      checks: write
+  enso-build-ci-gen-job-standard-library-tests-graal-vm-ce-linux-x86_64:
+    name: Standard Library Tests (GraalVM CE) (linux, x86_64)
     runs-on:
       - self-hosted
       - Linux
@@ -420,10 +539,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     env:
-      JAVA_VENDOR: Oracle GraalVM
+      GRAAL_EDITION: GraalVM CE
     permissions:
       checks: write
-  enso-build-ci-gen-job-standard-library-tests-macos-x86_64:
+  enso-build-ci-gen-job-standard-library-tests-graal-vm-ce-macos-x86_64:
     name: Standard Library Tests (GraalVM CE) (macos, x86_64)
     runs-on:
       - macos-latest
@@ -484,10 +603,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     env:
-      JAVA_VENDOR: GraalVM CE
+      GRAAL_EDITION: GraalVM CE
     permissions:
       checks: write
-  enso-build-ci-gen-job-standard-library-tests-windows-x86_64:
+  enso-build-ci-gen-job-standard-library-tests-graal-vm-ce-windows-x86_64:
     name: Standard Library Tests (GraalVM CE) (windows, x86_64)
     runs-on:
       - self-hosted
@@ -549,7 +668,72 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     env:
-      JAVA_VENDOR: GraalVM CE
+      GRAAL_EDITION: GraalVM CE
+    permissions:
+      checks: write
+  enso-build-ci-gen-job-standard-library-tests-oracle-graal-vm-linux-x86_64:
+    name: Standard Library Tests (Oracle GraalVM) (linux, x86_64)
+    runs-on:
+      - self-hosted
+      - Linux
+    steps:
+      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
+        name: Setup conda (GH runners only)
+        uses: s-weigand/setup-conda@v1.2.1
+        with:
+          update-conda: false
+          conda-channels: anaconda, conda-forge
+      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
+        name: Installing wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: v0.10.2
+      - name: Expose Artifact API and context information.
+        uses: actions/github-script@v7
+        with:
+          script: "\n    core.exportVariable(\"ACTIONS_RUNTIME_TOKEN\", process.env[\"ACTIONS_RUNTIME_TOKEN\"])\n    core.exportVariable(\"ACTIONS_RUNTIME_URL\", process.env[\"ACTIONS_RUNTIME_URL\"])\n    core.exportVariable(\"GITHUB_RETENTION_DAYS\", process.env[\"GITHUB_RETENTION_DAYS\"])\n    console.log(context)\n    "
+      - name: Checking out the repository
+        uses: actions/checkout@v4
+        with:
+          clean: false
+          submodules: recursive
+      - name: Build Script Setup
+        run: ./run --help
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: "(contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || inputs.clean_build_required)"
+        name: Clean before
+        run: ./run git-clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: ./run backend test standard-library
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.ENSO_LIB_S3_AWS_ACCESS_KEY_ID }}
+          AWS_REGION: ${{ secrets.ENSO_LIB_S3_AWS_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.ENSO_LIB_S3_AWS_SECRET_ACCESS_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: success() || failure()
+        name: Standard Library Test Reporter
+        uses: dorny/test-reporter@v1
+        with:
+          max-annotations: 50
+          name: Standard Library Tests Report (linux, x86_64)
+          path: ${{ env.ENSO_TEST_JUNIT_DIR }}/*/*.xml
+          path-replace-backslashes: true
+          reporter: java-junit
+      - if: failure() && runner.os == 'Windows'
+        name: List files if failed (Windows)
+        run: Get-ChildItem -Force -Recurse
+      - if: failure() && runner.os != 'Windows'
+        name: List files if failed (non-Windows)
+        run: ls -lAR
+      - if: "(always()) && (contains(github.event.pull_request.labels.*.name, 'CI: Clean build required') || inputs.clean_build_required)"
+        name: Clean after
+        run: ./run git-clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      GRAAL_EDITION: Oracle GraalVM
     permissions:
       checks: write
   enso-build-ci-gen-job-verify-license-packages-linux-x86_64:

--- a/.github/workflows/scala-new.yml
+++ b/.github/workflows/scala-new.yml
@@ -174,7 +174,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   enso-build-ci-gen-job-scala-tests-linux-x86_64:
-    name: Scala Tests (linux, x86_64)
+    name: Scala Tests (Oracle GraalVM) (linux, x86_64)
     runs-on:
       - self-hosted
       - Linux
@@ -231,10 +231,12 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      JAVA_VENDOR: Oracle GraalVM
     permissions:
       checks: write
   enso-build-ci-gen-job-scala-tests-macos-x86_64:
-    name: Scala Tests (macos, x86_64)
+    name: Scala Tests (GraalVM CE) (macos, x86_64)
     runs-on:
       - macos-latest
     steps:
@@ -290,10 +292,12 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      JAVA_VENDOR: GraalVM CE
     permissions:
       checks: write
   enso-build-ci-gen-job-scala-tests-windows-x86_64:
-    name: Scala Tests (windows, x86_64)
+    name: Scala Tests (GraalVM CE) (windows, x86_64)
     runs-on:
       - self-hosted
       - Windows
@@ -350,10 +354,12 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      JAVA_VENDOR: GraalVM CE
     permissions:
       checks: write
   enso-build-ci-gen-job-standard-library-tests-linux-x86_64:
-    name: Standard Library Tests (linux, x86_64)
+    name: Standard Library Tests (Oracle GraalVM) (linux, x86_64)
     runs-on:
       - self-hosted
       - Linux
@@ -413,10 +419,12 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      JAVA_VENDOR: Oracle GraalVM
     permissions:
       checks: write
   enso-build-ci-gen-job-standard-library-tests-macos-x86_64:
-    name: Standard Library Tests (macos, x86_64)
+    name: Standard Library Tests (GraalVM CE) (macos, x86_64)
     runs-on:
       - macos-latest
     steps:
@@ -475,10 +483,12 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      JAVA_VENDOR: GraalVM CE
     permissions:
       checks: write
   enso-build-ci-gen-job-standard-library-tests-windows-x86_64:
-    name: Standard Library Tests (windows, x86_64)
+    name: Standard Library Tests (GraalVM CE) (windows, x86_64)
     runs-on:
       - self-hosted
       - Windows
@@ -538,6 +548,8 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      JAVA_VENDOR: GraalVM CE
     permissions:
       checks: write
   enso-build-ci-gen-job-verify-license-packages-linux-x86_64:

--- a/.github/workflows/std-libs-benchmark.yml
+++ b/.github/workflows/std-libs-benchmark.yml
@@ -13,8 +13,8 @@ on:
         type: boolean
         default: false
 jobs:
-  benchmark-standard-libraries:
-    name: Benchmark Standard Libraries
+  benchmark-standard-libraries-graal-vm-ce:
+    name: Benchmark Standard Libraries (GraalVM CE)
     runs-on:
       - benchmark
     steps:
@@ -61,6 +61,59 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      JAVA_VENDOR: GraalVM CE
+    timeout-minutes: 240
+  benchmark-standard-libraries-oracle-graal-vm:
+    name: Benchmark Standard Libraries (Oracle GraalVM)
+    runs-on:
+      - benchmark
+    steps:
+      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
+        name: Setup conda (GH runners only)
+        uses: s-weigand/setup-conda@v1.2.1
+        with:
+          update-conda: false
+          conda-channels: anaconda, conda-forge
+      - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
+        name: Installing wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: v0.10.2
+      - name: Expose Artifact API and context information.
+        uses: actions/github-script@v7
+        with:
+          script: "\n    core.exportVariable(\"ACTIONS_RUNTIME_TOKEN\", process.env[\"ACTIONS_RUNTIME_TOKEN\"])\n    core.exportVariable(\"ACTIONS_RUNTIME_URL\", process.env[\"ACTIONS_RUNTIME_URL\"])\n    core.exportVariable(\"GITHUB_RETENTION_DAYS\", process.env[\"GITHUB_RETENTION_DAYS\"])\n    console.log(context)\n    "
+      - name: Checking out the repository
+        uses: actions/checkout@v4
+        with:
+          clean: false
+          submodules: recursive
+      - name: Build Script Setup
+        run: ./run --help
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: (always())
+        name: Clean before
+        run: ./run git-clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: ./run backend benchmark enso-jmh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: failure() && runner.os == 'Windows'
+        name: List files if failed (Windows)
+        run: Get-ChildItem -Force -Recurse
+      - if: failure() && runner.os != 'Windows'
+        name: List files if failed (non-Windows)
+        run: ls -lAR
+      - if: (always())
+        name: Clean after
+        run: ./run git-clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      JAVA_VENDOR: Oracle GraalVM
     timeout-minutes: 240
 env:
   ENSO_BUILD_MINIMAL_RUN: ${{ true == inputs.just-check }}

--- a/.github/workflows/std-libs-benchmark.yml
+++ b/.github/workflows/std-libs-benchmark.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     env:
-      JAVA_VENDOR: GraalVM CE
+      GRAAL_EDITION: GraalVM CE
     timeout-minutes: 240
   benchmark-standard-libraries-oracle-graal-vm:
     name: Benchmark Standard Libraries (Oracle GraalVM)
@@ -113,7 +113,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     env:
-      JAVA_VENDOR: Oracle GraalVM
+      GRAAL_EDITION: Oracle GraalVM
     timeout-minutes: 240
 env:
   ENSO_BUILD_MINIMAL_RUN: ${{ true == inputs.just-check }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1067,6 +1067,7 @@
 - [Execute and debug individual Enso files in VSCode extension][8923]
 - [Check type of `self` when calling a method using the static syntax][8867]
 - [Autoscoped constructors][9190]
+- [Allow Oracle GraalVM JDK][9322]
 
 [3227]: https://github.com/enso-org/enso/pull/3227
 [3248]: https://github.com/enso-org/enso/pull/3248
@@ -1226,6 +1227,7 @@
 [8923]: https://github.com/enso-org/enso/pull/8923
 [8867]: https://github.com/enso-org/enso/pull/8867
 [9190]: https://github.com/enso-org/enso/pull/9190
+[9322]: https://github.com/enso-org/enso/pull/9322
 
 # Enso 2.0.0-alpha.18 (2021-10-12)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,6 +1325,7 @@ dependencies = [
  "futures-util",
  "glob",
  "handlebars",
+ "heck",
  "ide-ci",
  "mime",
  "new_mime_guess",

--- a/build/build/Cargo.toml
+++ b/build/build/Cargo.toml
@@ -21,6 +21,7 @@ futures = { workspace = true }
 futures-util = "0.3.17"
 glob = "0.3.0"
 handlebars = "4.3.5"
+heck = "0.4.0"
 enso-build-base = { path = "../base" }
 enso-enso-font = { path = "../../lib/rust/enso-font" }
 enso-font = { path = "../../lib/rust/font" }

--- a/build/build/src/ci_gen.rs
+++ b/build/build/src/ci_gen.rs
@@ -605,20 +605,20 @@ pub fn backend() -> Result<Workflow> {
     workflow.add(PRIMARY_TARGET, job::CancelWorkflow);
     workflow.add(PRIMARY_TARGET, job::VerifyLicensePackages);
     for target in CHECKED_TARGETS {
-        workflow.add(target, job::CiCheckBackend::with_graal_edition(graalvm::Edition::Community));
-        workflow.add(target, job::ScalaTests::with_graal_edition(graalvm::Edition::Community));
+        workflow.add(target, job::CiCheckBackend {graal_edition: graalvm::Edition::Community});
+        workflow.add(target, job::ScalaTests {graal_edition: graalvm::Edition::Community});
         workflow.add(
             target,
-            job::StandardLibraryTests::with_graal_edition(graalvm::Edition::Community),
+            job::StandardLibraryTests {graal_edition: graalvm::Edition::Community},
         );
     }
     // Oracle GraalVM jobs run only on Linux
     workflow
-        .add(PRIMARY_TARGET, job::CiCheckBackend::with_graal_edition(graalvm::Edition::Enterprise));
-    workflow.add(PRIMARY_TARGET, job::ScalaTests::with_graal_edition(graalvm::Edition::Enterprise));
+        .add(PRIMARY_TARGET, job::CiCheckBackend {graal_edition: graalvm::Edition::Enterprise});
+    workflow.add(PRIMARY_TARGET, job::ScalaTests {graal_edition: graalvm::Edition::Enterprise});
     workflow.add(
         PRIMARY_TARGET,
-        job::StandardLibraryTests::with_graal_edition(graalvm::Edition::Enterprise),
+        job::StandardLibraryTests {graal_edition: graalvm::Edition::Enterprise},
     );
     Ok(workflow)
 }

--- a/build/build/src/ci_gen.rs
+++ b/build/build/src/ci_gen.rs
@@ -675,10 +675,8 @@ fn benchmark_job(
         .build_job(job_name, BenchmarkRunner);
     job.timeout_minutes = timeout_minutes;
     match graal_edition {
-        graalvm::Edition::Community =>
-            job.env(env::GRAAL_EDITION, graalvm::Edition::Community),
-        graalvm::Edition::Enterprise =>
-            job.env(env::GRAAL_EDITION, graalvm::Edition::Enterprise),
+        graalvm::Edition::Community => job.env(env::GRAAL_EDITION, graalvm::Edition::Community),
+        graalvm::Edition::Enterprise => job.env(env::GRAAL_EDITION, graalvm::Edition::Enterprise),
     }
     job
 }

--- a/build/build/src/ci_gen.rs
+++ b/build/build/src/ci_gen.rs
@@ -657,7 +657,7 @@ fn benchmark_workflow(
     );
 
     for graal_edition in [graalvm::Edition::Community, graalvm::Edition::Enterprise] {
-        let job_name = format!("{} ({})", name, graal_edition);
+        let job_name = format!("{name} ({graal_edition})");
         let job = benchmark_job(&job_name, command_line, timeout_minutes, graal_edition);
         workflow.add_job(job);
     }

--- a/build/build/src/ci_gen.rs
+++ b/build/build/src/ci_gen.rs
@@ -656,7 +656,7 @@ fn benchmark_workflow(
         wrap_expression(format!("true == inputs.{just_check_input_name}")),
     );
 
-    for graal_edition in vec![graalvm::Edition::Community, graalvm::Edition::Enterprise] {
+    for graal_edition in [graalvm::Edition::Community, graalvm::Edition::Enterprise] {
         let job_name = format!("{} ({})", name, graal_edition);
         let job = benchmark_job(&job_name, command_line, timeout_minutes, graal_edition);
         workflow.add_job(job);

--- a/build/build/src/ci_gen.rs
+++ b/build/build/src/ci_gen.rs
@@ -1,9 +1,9 @@
-use crate::engine::env;
 use crate::prelude::*;
 
 use crate::ci_gen::job::plain_job;
 use crate::ci_gen::job::with_packaging_steps;
 use crate::ci_gen::job::RunsOn;
+use crate::engine::env;
 use crate::version::promote::Designation;
 use crate::version::ENSO_EDITION;
 use crate::version::ENSO_RELEASE_MODE;
@@ -605,21 +605,18 @@ pub fn backend() -> Result<Workflow> {
     workflow.add(PRIMARY_TARGET, job::CancelWorkflow);
     workflow.add(PRIMARY_TARGET, job::VerifyLicensePackages);
     for target in CHECKED_TARGETS {
-        workflow.add(target, job::CiCheckBackend {graal_edition: graalvm::Edition::Community});
-        workflow.add(target, job::ScalaTests {graal_edition: graalvm::Edition::Community});
-        workflow.add(
-            target,
-            job::StandardLibraryTests {graal_edition: graalvm::Edition::Community},
-        );
+        workflow.add(target, job::CiCheckBackend { graal_edition: graalvm::Edition::Community });
+        workflow.add(target, job::ScalaTests { graal_edition: graalvm::Edition::Community });
+        workflow
+            .add(target, job::StandardLibraryTests { graal_edition: graalvm::Edition::Community });
     }
     // Oracle GraalVM jobs run only on Linux
     workflow
-        .add(PRIMARY_TARGET, job::CiCheckBackend {graal_edition: graalvm::Edition::Enterprise});
-    workflow.add(PRIMARY_TARGET, job::ScalaTests {graal_edition: graalvm::Edition::Enterprise});
-    workflow.add(
-        PRIMARY_TARGET,
-        job::StandardLibraryTests {graal_edition: graalvm::Edition::Enterprise},
-    );
+        .add(PRIMARY_TARGET, job::CiCheckBackend { graal_edition: graalvm::Edition::Enterprise });
+    workflow.add(PRIMARY_TARGET, job::ScalaTests { graal_edition: graalvm::Edition::Enterprise });
+    workflow.add(PRIMARY_TARGET, job::StandardLibraryTests {
+        graal_edition: graalvm::Edition::Enterprise,
+    });
     Ok(workflow)
 }
 

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -164,11 +164,13 @@ impl JobArchetype for VerifyLicensePackages {
 pub struct ScalaTests {
     graal_edition: graalvm::Edition,
 }
+
 impl ScalaTests {
     pub fn with_graal_edition(graal_edition: graalvm::Edition) -> Self {
         Self { graal_edition }
     }
 }
+
 impl JobArchetype for ScalaTests {
     fn job(&self, target: Target) -> Job {
         let job_name = format!("Scala Tests ({})", self.graal_edition);
@@ -177,8 +179,10 @@ impl JobArchetype for ScalaTests {
             .build_job(job_name, target)
             .with_permission(Permission::Checks, Access::Write);
         match self.graal_edition {
-            graalvm::Edition::Community => job.env(env::JAVA_VENDOR, graalvm::Edition::Community.to_string()),
-            graalvm::Edition::Enterprise => job.env(env::JAVA_VENDOR, graalvm::Edition::Enterprise.to_string()),
+            graalvm::Edition::Community =>
+                job.env(env::GRAAL_EDITION, graalvm::Edition::Community),
+            graalvm::Edition::Enterprise =>
+                job.env(env::GRAAL_EDITION, graalvm::Edition::Enterprise),
         }
         job
     }
@@ -216,9 +220,10 @@ impl JobArchetype for StandardLibraryTests {
             .build_job(job_name, target)
             .with_permission(Permission::Checks, Access::Write);
         match self.graal_edition {
-            graalvm::Edition::Community => job.env(env::JAVA_VENDOR, graalvm::Edition::Community.to_string()),
-            graalvm::Edition::Enterprise => job.env(env::JAVA_VENDOR, graalvm::Edition::Enterprise.to_string()),
-
+            graalvm::Edition::Community =>
+                job.env(env::GRAAL_EDITION, graalvm::Edition::Community.to_string()),
+            graalvm::Edition::Enterprise =>
+                job.env(env::GRAAL_EDITION, graalvm::Edition::Enterprise.to_string()),
         }
         job
     }

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -181,8 +181,7 @@ impl JobArchetype for ScalaTests {
             .build_job(job_name, target)
             .with_permission(Permission::Checks, Access::Write);
         match self.graal_edition {
-            graalvm::Edition::Community =>
-                job.env(env::GRAAL_EDITION, graalvm::Edition::Community),
+            graalvm::Edition::Community => job.env(env::GRAAL_EDITION, graalvm::Edition::Community),
             graalvm::Edition::Enterprise =>
                 job.env(env::GRAAL_EDITION, graalvm::Edition::Enterprise),
         }
@@ -190,7 +189,11 @@ impl JobArchetype for ScalaTests {
     }
 
     fn key(&self, (os, arch): Target) -> String {
-        format!("{}-{}-{os}-{arch}", self.id_key_base(), self.graal_edition.to_string().to_kebab_case())
+        format!(
+            "{}-{}-{os}-{arch}",
+            self.id_key_base(),
+            self.graal_edition.to_string().to_kebab_case()
+        )
     }
 }
 
@@ -237,7 +240,11 @@ impl JobArchetype for StandardLibraryTests {
     }
 
     fn key(&self, (os, arch): Target) -> String {
-        format!("{}-{}-{os}-{arch}", self.id_key_base(), self.graal_edition.to_string().to_kebab_case())
+        format!(
+            "{}-{}-{os}-{arch}",
+            self.id_key_base(),
+            self.graal_edition.to_string().to_kebab_case()
+        )
     }
 }
 
@@ -457,8 +464,7 @@ impl JobArchetype for CiCheckBackend {
         let job_name = format!("Engine ({})", self.graal_edition);
         let mut job = RunStepsBuilder::new("backend ci-check").build_job(job_name, target);
         match self.graal_edition {
-            graalvm::Edition::Community =>
-                job.env(env::GRAAL_EDITION, graalvm::Edition::Community),
+            graalvm::Edition::Community => job.env(env::GRAAL_EDITION, graalvm::Edition::Community),
             graalvm::Edition::Enterprise =>
                 job.env(env::GRAAL_EDITION, graalvm::Edition::Enterprise),
         }
@@ -466,6 +472,10 @@ impl JobArchetype for CiCheckBackend {
     }
 
     fn key(&self, (os, arch): Target) -> String {
-        format!("{}-{}-{os}-{arch}", self.id_key_base(), self.graal_edition.to_string().to_kebab_case())
+        format!(
+            "{}-{}-{os}-{arch}",
+            self.id_key_base(),
+            self.graal_edition.to_string().to_kebab_case()
+        )
     }
 }

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -175,12 +175,13 @@ impl ScalaTests {
 
 impl JobArchetype for ScalaTests {
     fn job(&self, target: Target) -> Job {
-        let job_name = format!("Scala Tests ({})", self.graal_edition);
+        let graal_edition = self.graal_edition.clone();
+        let job_name = format!("Scala Tests ({graal_edition})");
         let mut job = RunStepsBuilder::new("backend test scala")
-            .customize(move |step| vec![step, step::engine_test_reporter(target)])
+            .customize(move |step| vec![step, step::engine_test_reporter(target, graal_edition)])
             .build_job(job_name, target)
             .with_permission(Permission::Checks, Access::Write);
-        match self.graal_edition {
+        match graal_edition {
             graalvm::Edition::Community => job.env(env::GRAAL_EDITION, graalvm::Edition::Community),
             graalvm::Edition::Enterprise =>
                 job.env(env::GRAAL_EDITION, graalvm::Edition::Enterprise),
@@ -210,7 +211,8 @@ impl StandardLibraryTests {
 
 impl JobArchetype for StandardLibraryTests {
     fn job(&self, target: Target) -> Job {
-        let job_name = format!("Standard Library Tests ({})", self.graal_edition);
+        let graal_edition = self.graal_edition.clone();
+        let job_name = format!("Standard Library Tests ({})", graal_edition);
         let mut job = RunStepsBuilder::new("backend test standard-library")
             .customize(move |step| {
                 let main_step = step
@@ -226,11 +228,11 @@ impl JobArchetype for StandardLibraryTests {
                         secret::ENSO_LIB_S3_AWS_SECRET_ACCESS_KEY,
                         crate::aws::env::AWS_SECRET_ACCESS_KEY,
                     );
-                vec![main_step, step::stdlib_test_reporter(target)]
+                vec![main_step, step::stdlib_test_reporter(target, graal_edition)]
             })
             .build_job(job_name, target)
             .with_permission(Permission::Checks, Access::Write);
-        match self.graal_edition {
+        match graal_edition {
             graalvm::Edition::Community =>
                 job.env(env::GRAAL_EDITION, graalvm::Edition::Community.to_string()),
             graalvm::Edition::Enterprise =>

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -164,14 +164,9 @@ impl JobArchetype for VerifyLicensePackages {
 
 #[derive(Clone, Copy, Debug)]
 pub struct ScalaTests {
-    graal_edition: graalvm::Edition,
+    pub graal_edition: graalvm::Edition,
 }
 
-impl ScalaTests {
-    pub fn with_graal_edition(graal_edition: graalvm::Edition) -> Self {
-        Self { graal_edition }
-    }
-}
 
 impl JobArchetype for ScalaTests {
     fn job(&self, target: Target) -> Job {
@@ -200,13 +195,7 @@ impl JobArchetype for ScalaTests {
 
 #[derive(Clone, Copy, Debug)]
 pub struct StandardLibraryTests {
-    graal_edition: graalvm::Edition,
-}
-
-impl StandardLibraryTests {
-    pub fn with_graal_edition(graal_edition: graalvm::Edition) -> Self {
-        Self { graal_edition }
-    }
+    pub graal_edition: graalvm::Edition,
 }
 
 impl JobArchetype for StandardLibraryTests {
@@ -234,9 +223,9 @@ impl JobArchetype for StandardLibraryTests {
             .with_permission(Permission::Checks, Access::Write);
         match graal_edition {
             graalvm::Edition::Community =>
-                job.env(env::GRAAL_EDITION, graalvm::Edition::Community.to_string()),
+                job.env(env::GRAAL_EDITION, graalvm::Edition::Community),
             graalvm::Edition::Enterprise =>
-                job.env(env::GRAAL_EDITION, graalvm::Edition::Enterprise.to_string()),
+                job.env(env::GRAAL_EDITION, graalvm::Edition::Enterprise),
         }
         job
     }
@@ -452,13 +441,7 @@ impl JobArchetype for PackageNewIde {
 
 #[derive(Clone, Copy, Debug)]
 pub struct CiCheckBackend {
-    graal_edition: graalvm::Edition,
-}
-
-impl CiCheckBackend {
-    pub fn with_graal_edition(graal_edition: graalvm::Edition) -> Self {
-        Self { graal_edition }
-    }
+    pub graal_edition: graalvm::Edition,
 }
 
 impl JobArchetype for CiCheckBackend {

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -167,7 +167,7 @@ pub struct ScalaTests {
 
 impl JobArchetype for ScalaTests {
     fn job(&self, target: Target) -> Job {
-        let graal_edition = self.graal_edition.clone();
+        let graal_edition = self.graal_edition;
         let job_name = format!("Scala Tests ({graal_edition})");
         let mut job = RunStepsBuilder::new("backend test scala")
             .customize(move |step| vec![step, step::engine_test_reporter(target, graal_edition)])
@@ -197,8 +197,8 @@ pub struct StandardLibraryTests {
 
 impl JobArchetype for StandardLibraryTests {
     fn job(&self, target: Target) -> Job {
-        let graal_edition = self.graal_edition.clone();
-        let job_name = format!("Standard Library Tests ({})", graal_edition);
+        let graal_edition = self.graal_edition;
+        let job_name = format!("Standard Library Tests ({graal_edition})");
         let mut job = RunStepsBuilder::new("backend test standard-library")
             .customize(move |step| {
                 let main_step = step

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -1,7 +1,5 @@
 use crate::prelude::*;
 
-use heck::ToKebabCase;
-
 use crate::ci_gen::not_default_branch;
 use crate::ci_gen::runs_on;
 use crate::ci_gen::secret;
@@ -9,9 +7,9 @@ use crate::ci_gen::step;
 use crate::ci_gen::RunStepsBuilder;
 use crate::ci_gen::RunnerType;
 use crate::ci_gen::RELEASE_CLEANING_POLICY;
-
 use crate::engine::env;
 
+use heck::ToKebabCase;
 use ide_ci::actions::workflow::definition::cancel_workflow_action;
 use ide_ci::actions::workflow::definition::Access;
 use ide_ci::actions::workflow::definition::Job;
@@ -21,7 +19,6 @@ use ide_ci::actions::workflow::definition::RunnerLabel;
 use ide_ci::actions::workflow::definition::Step;
 use ide_ci::actions::workflow::definition::Strategy;
 use ide_ci::actions::workflow::definition::Target;
-
 use ide_ci::cache::goodie::graalvm;
 
 
@@ -222,8 +219,7 @@ impl JobArchetype for StandardLibraryTests {
             .build_job(job_name, target)
             .with_permission(Permission::Checks, Access::Write);
         match graal_edition {
-            graalvm::Edition::Community =>
-                job.env(env::GRAAL_EDITION, graalvm::Edition::Community),
+            graalvm::Edition::Community => job.env(env::GRAAL_EDITION, graalvm::Edition::Community),
             graalvm::Edition::Enterprise =>
                 job.env(env::GRAAL_EDITION, graalvm::Edition::Enterprise),
         }

--- a/build/build/src/ci_gen/step.rs
+++ b/build/build/src/ci_gen/step.rs
@@ -5,6 +5,7 @@ use crate::paths;
 use ide_ci::actions::workflow::definition::env_expression;
 use ide_ci::actions::workflow::definition::Step;
 use ide_ci::actions::workflow::definition::Target;
+use ide_ci::cache::goodie::graalvm;
 
 
 
@@ -26,16 +27,16 @@ pub fn test_reporter(
     .with_custom_argument("name", report_name)
 }
 
-pub fn stdlib_test_reporter((os, arch): Target) -> Step {
+pub fn stdlib_test_reporter((os, arch): Target, graal_edition: graalvm::Edition) -> Step {
     let step_name = "Standard Library Test Reporter";
-    let report_name = format!("Standard Library Tests Report ({os}, {arch})");
+    let report_name = format!("Standard Library Tests Report ({graal_edition}, {os}, {arch})");
     let path = format!("{}/*/*.xml", env_expression(&paths::ENSO_TEST_JUNIT_DIR));
     test_reporter(step_name, report_name, path)
 }
 
-pub fn engine_test_reporter((os, arch): Target) -> Step {
+pub fn engine_test_reporter((os, arch): Target, graal_edition: graalvm::Edition) -> Step {
     let step_name = "Engine Test Reporter";
-    let report_name = format!("Engine Tests Report ({os}, {arch})");
+    let report_name = format!("Engine Tests Report ({graal_edition}, {os}, {arch})");
     let path = format!("{}/*.xml", env_expression(&paths::ENSO_TEST_JUNIT_DIR));
     test_reporter(step_name, report_name, path)
 }

--- a/build/build/src/engine.rs
+++ b/build/build/src/engine.rs
@@ -311,9 +311,7 @@ pub async fn deduce_graal(
     build_sbt: &generated::RepoRootBuildSbt,
 ) -> Result<ide_ci::cache::goodie::graalvm::GraalVM> {
     let build_sbt_content = ide_ci::fs::tokio::read_to_string(build_sbt).await?;
-    let graal_edition = env::JAVA_VENDOR
-        .get()
-        .map_or(Edition::Community, |f| Edition::from_str(&f).unwrap_or(Edition::Community));
+    let graal_edition = env::GRAAL_EDITION.get().map_or(Edition::Community, |e| e);
 
     Ok(ide_ci::cache::goodie::graalvm::GraalVM {
         client,

--- a/build/build/src/engine.rs
+++ b/build/build/src/engine.rs
@@ -311,7 +311,7 @@ pub async fn deduce_graal(
     build_sbt: &generated::RepoRootBuildSbt,
 ) -> Result<ide_ci::cache::goodie::graalvm::GraalVM> {
     let build_sbt_content = ide_ci::fs::tokio::read_to_string(build_sbt).await?;
-    let graal_edition = env::GRAAL_EDITION.get().map_or(Edition::Community, |e| e);
+    let graal_edition = env::GRAAL_EDITION.get().map_or(Edition::default(), |e| e);
 
     Ok(ide_ci::cache::goodie::graalvm::GraalVM {
         client,

--- a/build/build/src/engine.rs
+++ b/build/build/src/engine.rs
@@ -11,6 +11,7 @@ use crate::paths::generated;
 
 use artifact::IsArtifact;
 use bundle::IsBundle;
+use ide_ci::cache::goodie::graalvm::Edition;
 use ide_ci::future::AsyncPolicy;
 use ide_ci::github::Repo;
 use package::IsPackage;
@@ -310,9 +311,14 @@ pub async fn deduce_graal(
     build_sbt: &generated::RepoRootBuildSbt,
 ) -> Result<ide_ci::cache::goodie::graalvm::GraalVM> {
     let build_sbt_content = ide_ci::fs::tokio::read_to_string(build_sbt).await?;
+    let graal_edition = env::JAVA_VENDOR
+        .get()
+        .map_or(Edition::Community, |f| Edition::from_str(&f).unwrap_or(Edition::Community));
+
     Ok(ide_ci::cache::goodie::graalvm::GraalVM {
         client,
         graal_version: get_graal_version(&build_sbt_content)?,
+        edition: graal_edition,
         os: TARGET_OS,
         arch: TARGET_ARCH,
     })

--- a/build/build/src/engine/env.rs
+++ b/build/build/src/engine/env.rs
@@ -2,6 +2,7 @@
 
 //use crate::prelude::*;
 
+use ide_ci::cache::goodie::graalvm;
 use ide_ci::define_env_var;
 
 
@@ -13,6 +14,6 @@ define_env_var! {
     /// Whether flaku tests should be run.
     CI_TEST_FLAKY_ENABLE, bool;
 
-    /// Java vendor, e.g. "Oracle Corporation", or "GraalVM Community".
-    JAVA_VENDOR, String;
+    /// GraalVM edition. Either Community or Enterprise.
+    GRAAL_EDITION, graalvm::Edition;
 }

--- a/build/build/src/engine/env.rs
+++ b/build/build/src/engine/env.rs
@@ -12,4 +12,7 @@ define_env_var! {
 
     /// Whether flaku tests should be run.
     CI_TEST_FLAKY_ENABLE, bool;
+
+    /// Java vendor, e.g. "Oracle Corporation", or "GraalVM Community".
+    JAVA_VENDOR, String;
 }

--- a/build/ci_utils/src/cache/goodie/graalvm.rs
+++ b/build/ci_utils/src/cache/goodie/graalvm.rs
@@ -46,9 +46,9 @@ impl std::str::FromStr for Edition {
 
 }
 
-impl Into<String> for Edition {
-    fn into(self) -> String {
-        match self {
+impl From<Edition> for String {
+    fn from(edition: Edition) -> String {
+        match edition {
             Edition::Community => CE_JAVA_VENDOR.to_string(),
             Edition::Enterprise => EE_JAVA_VENDOR.to_string(),
         }
@@ -58,8 +58,8 @@ impl Into<String> for Edition {
 impl Display for Edition {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match *self {
-            Edition::Community => write!(f, "{}", CE_JAVA_VENDOR),
-            Edition::Enterprise => write!(f, "{}", EE_JAVA_VENDOR),
+            Edition::Community => write!(f, "{CE_JAVA_VENDOR}"),
+            Edition::Enterprise => write!(f, "{EE_JAVA_VENDOR}"),
         }
     }
 }
@@ -105,7 +105,7 @@ impl Goodie for GraalVM {
 
     fn is_active(&self) -> BoxFuture<'static, Result<bool>> {
         let expected_graal_version = self.graal_version.clone();
-        let expected_graal_edition = self.edition.clone();
+        let expected_graal_edition = self.edition;
         async move {
             let (found_version, found_edition) = find_graal_version().await?;
             ensure!(found_version == expected_graal_version, "GraalVM version mismatch. Expected {expected_graal_version}, found {found_version}.");
@@ -184,7 +184,7 @@ impl GraalVM {
             Arch::AArch64 => "aarch64",
             other_arch => unimplemented!("Architecture `{}` is not supported!", other_arch),
         };
-        format!("{}-{}", os_name, arch_name)
+        format!("{os_name}-{arch_name}")
     }
 
     pub fn platform_string(&self) -> String {

--- a/build/ci_utils/src/cache/goodie/graalvm.rs
+++ b/build/ci_utils/src/cache/goodie/graalvm.rs
@@ -77,7 +77,7 @@ fn graal_version_from_version_string(version_string: &str) -> Result<(Version, E
         bail!("Unknown GraalVM edition")
     };
     let version = Version::find_in_text(line);
-    version.map(|version| (version, edition)).context("Failed to find GraalVM version")
+    version.map(|version| (version, edition)).context("Failed to find GraalVM version.")
 }
 
 async fn find_graal_version() -> Result<(Version, Edition)> {
@@ -166,7 +166,7 @@ impl GraalVM {
                     self.os_arch_string(),
                 );
                 Box::pin(ready(
-                    Url::parse(&url).context("Failed to parse URL")
+                    Url::parse(&url).context("Failed to parse URL.")
                 ))
             }
         }

--- a/build/ci_utils/src/cache/goodie/graalvm.rs
+++ b/build/ci_utils/src/cache/goodie/graalvm.rs
@@ -65,7 +65,7 @@ impl Display for Edition {
 }
 
 
-fn graal_version_from_version_string(version_string: &str) -> Result<(Version, Edition)> {
+pub fn graal_version_from_version_string(version_string: &str) -> Result<(Version, Edition)> {
     let line = version_string.lines().find(|line| line.contains(CE_JAVA_VENDOR) || line.contains(EE_JAVA_VENDOR)).context(
         "There is a Java environment available but it is not recognizable as GraalVM one.",
     )?;
@@ -80,7 +80,7 @@ fn graal_version_from_version_string(version_string: &str) -> Result<(Version, E
     version.map(|version| (version, edition)).context("Failed to find GraalVM version.")
 }
 
-async fn find_graal_version() -> Result<(Version, Edition)> {
+pub async fn find_graal_version() -> Result<(Version, Edition)> {
     let text = Java.version_string().await?;
     graal_version_from_version_string(&text)
 }

--- a/build/ci_utils/src/cache/goodie/graalvm.rs
+++ b/build/ci_utils/src/cache/goodie/graalvm.rs
@@ -43,7 +43,6 @@ impl std::str::FromStr for Edition {
             _ => bail!("Unknown GraalVM edition: {}", s),
         }
     }
-
 }
 
 impl From<Edition> for String {
@@ -66,9 +65,12 @@ impl Display for Edition {
 
 
 pub fn graal_version_from_version_string(version_string: &str) -> Result<(Version, Edition)> {
-    let line = version_string.lines().find(|line| line.contains(CE_JAVA_VENDOR) || line.contains(EE_JAVA_VENDOR)).context(
-        "There is a Java environment available but it is not recognizable as GraalVM one.",
-    )?;
+    let line = version_string
+        .lines()
+        .find(|line| line.contains(CE_JAVA_VENDOR) || line.contains(EE_JAVA_VENDOR))
+        .context(
+            "There is a Java environment available but it is not recognizable as GraalVM one.",
+        )?;
     let edition = if line.contains(CE_JAVA_VENDOR) {
         Edition::Community
     } else if line.contains(EE_JAVA_VENDOR) {
@@ -156,7 +158,7 @@ impl GraalVM {
                     crate::github::find_asset_url_by_text(&release, &platform_string).cloned()
                 }
                 .boxed()
-            },
+            }
             Edition::Enterprise => {
                 let graal_version_tag = self.graal_version.to_string_core();
                 let url = format!(
@@ -165,9 +167,7 @@ impl GraalVM {
                     graal_version_tag,
                     self.os_arch_string(),
                 );
-                Box::pin(ready(
-                    Url::parse(&url).context("Failed to parse URL.")
-                ))
+                Box::pin(ready(Url::parse(&url).context("Failed to parse URL.")))
             }
         }
     }
@@ -222,7 +222,8 @@ mod tests {
 OpenJDK Runtime Environment GraalVM CE 17.0.7+7.1 (build 17.0.7+7-jvmci-23.0-b12)
 OpenJDK 64-Bit Server VM GraalVM CE 17.0.7+7.1 (build 17.0.7+7-jvmci-23.0-b12, mixed mode, sharing)"#;
 
-        let (found_graal_version, found_graal_edition) = graal_version_from_version_string(version_string).unwrap();
+        let (found_graal_version, found_graal_edition) =
+            graal_version_from_version_string(version_string).unwrap();
         let expected_graal_version = Version {
             major: 17,
             minor: 0,
@@ -243,7 +244,8 @@ OpenJDK 64-Bit Server VM GraalVM CE 17.0.7+7.1 (build 17.0.7+7-jvmci-23.0-b12, m
 Java(TM) SE Runtime Environment Oracle GraalVM 21.0.2+13.1 (build 21.0.2+13-LTS-jvmci-23.1-b30)
 Java HotSpot(TM) 64-Bit Server VM Oracle GraalVM 21.0.2+13.1 (build 21.0.2+13-LTS-jvmci-23.1-b30, mixed mode, sharing)"#;
 
-        let (found_graal_version, found_graal_edition) = graal_version_from_version_string(version_string).unwrap();
+        let (found_graal_version, found_graal_edition) =
+            graal_version_from_version_string(version_string).unwrap();
         let expected_graal_version = Version {
             major: 21,
             minor: 0,

--- a/build/ci_utils/src/cache/goodie/graalvm.rs
+++ b/build/ci_utils/src/cache/goodie/graalvm.rs
@@ -25,9 +25,10 @@ crate::define_env_var! {
 const CE_JAVA_VENDOR: &str = "GraalVM CE";
 const EE_JAVA_VENDOR: &str = "Oracle GraalVM";
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Default)]
 pub enum Edition {
     /// GraalVM CE (Community Edition).
+    #[default]
     Community,
     /// Oracle GraalVM (Formerly GraalVM EE, Enterprise Edition)
     Enterprise,

--- a/build/ci_utils/src/cache/goodie/graalvm.rs
+++ b/build/ci_utils/src/cache/goodie/graalvm.rs
@@ -46,6 +46,15 @@ impl std::str::FromStr for Edition {
 
 }
 
+impl Into<String> for Edition {
+    fn into(self) -> String {
+        match self {
+            Edition::Community => CE_JAVA_VENDOR.to_string(),
+            Edition::Enterprise => EE_JAVA_VENDOR.to_string(),
+        }
+    }
+}
+
 impl Display for Edition {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match *self {

--- a/build/ci_utils/src/cache/goodie/graalvm.rs
+++ b/build/ci_utils/src/cache/goodie/graalvm.rs
@@ -188,9 +188,8 @@ impl GraalVM {
     }
 
     pub fn platform_string(&self) -> String {
-        let Self { graal_version: _graal_version, client: _client , ..} = &self;
         let os_arch = self.os_arch_string();
-        let java_version = format!("jdk-{}", _graal_version.to_string_core());
+        let java_version = format!("jdk-{}", self.graal_version.to_string_core());
         format!("{PACKAGE_PREFIX_URL}-{java_version}_{os_arch}")
     }
 }

--- a/project/GraalVM.scala
+++ b/project/GraalVM.scala
@@ -101,6 +101,11 @@ object GraalVM {
 
   val langsPkgs = jsPkgs ++ pythonPkgs ++ espressoPkgs
 
+  private val allowedJavaVendors = Seq(
+    "GraalVM Community",
+    "Oracle Corporation"
+  )
+
   /** Augments a state transition to do GraalVM version check.
     *
     * @param graalVersion  the GraalVM version that should be used for
@@ -125,10 +130,10 @@ object GraalVM {
       throw new IllegalStateException("GraalVM version check failed")
     }
     val javaVendor = System.getProperty("java.vendor")
-    if (javaVendor != "GraalVM Community") {
+    if (!allowedJavaVendors.contains(javaVendor)) {
       log.warn(
         s"Running on non-GraalVM JVM (The actual java.vendor is $javaVendor). " +
-        s"Expected GraalVM Community java.vendor."
+        s"Expected Java vendors: ${allowedJavaVendors.mkString(", ")}."
       )
     }
 


### PR DESCRIPTION
Closes #9266.

### Pull Request Description

Adds `Oracle GraalVM` configuration for some backend jobs. `Oracle GraalVM` jobs run only on Linux so far. The old jobs use `GraalVM CE`.

### Important Notes

- The JDK to download and use is deduced from the `JAVA_VENDOR` environment variable. By default, `GraalVM CE` is used.
- sbt can be started with both GraalVM CE and Oracle GraalVM without any warnings.
  - If you try to start sbt with JDK from a different vendor, but with the same Java version, a warning is printed.

Current list of jobs in the `Engine CI` workflow (these jobs are visible on this PR, because they are scheduled to run on every PR):
- Engine (GraalVM CE) (linux, x86_64)
- Engine (GraalVM CE) (macos, x86_64)
- Engine (GraalVM CE) (windows, x86_64)
- **Engine (Oracle GraalVM) (linux, x86_64)**
- Scala Tests (GraalVM CE) (linux, x86_64)
- Scala Tests (GraalVM CE) (macos, x86_64)
- Scala Tests (GraalVM CE) (windows, x86_64)
- **Scala Tests (Oracle GraalVM) (linux, x86_64)**
- Standard Library Tests (GraalVM CE) (linux, x86_64)
- Standard Library Tests (GraalVM CE) (macos, x86_64)
- Standard Library Tests (GraalVM CE) (windows, x86_64)
- **Standard Library Tests (Oracle GraalVM) (linux x86_64)**
- Verify License Packages (linux, x86_64)

Benchmark Engine workflow (not visible on this PR, cannot schedule manually yet):
- Benchmark Engine (GraalVM CE)
- **Benchmark Engine (Oracle GraalVM)**

Benchmark Standard Libraries workflow (not visible on this PR, cannot schedule manually yet):
- Benchmark Standard Libraries (GraalVM CE)
- **Benchmark Standard Libraries (Oracle GraalVM)**

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Ensure Oracle GraalVM is downloaded and used in the new jobs.
