### PR TITLE
Declare HTTPDownloaderTest as flaky

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1092,9 +1092,11 @@ lazy val testkit = project
   .settings(
     frgaalJavaCompilerSetting,
     libraryDependencies ++= Seq(
-      "org.apache.commons" % "commons-lang3" % commonsLangVersion,
-      "commons-io"         % "commons-io"    % commonsIoVersion,
-      "org.scalatest"     %% "scalatest"     % scalatestVersion
+      "org.apache.commons" % "commons-lang3"   % commonsLangVersion,
+      "commons-io"         % "commons-io"      % commonsIoVersion,
+      "org.scalatest"     %% "scalatest"       % scalatestVersion,
+      "junit"              % "junit"           % junitVersion,
+      "com.github.sbt"     % "junit-interface" % junitIfVersion
     )
   )
 
@@ -2552,6 +2554,7 @@ lazy val downloader = (project in file("lib/scala/downloader"))
   )
   .dependsOn(cli)
   .dependsOn(`http-test-helper`)
+  .dependsOn(testkit % Test)
 
 lazy val `edition-updater` = project
   .in(file("lib/scala/edition-updater"))

--- a/lib/scala/downloader/src/test/java/org/enso/downloader/http/HttpDownloaderTest.java
+++ b/lib/scala/downloader/src/test/java/org/enso/downloader/http/HttpDownloaderTest.java
@@ -27,8 +27,10 @@ import org.enso.cli.task.TaskProgress;
 import org.enso.shttp.HTTPTestHelperServer;
 import org.enso.shttp.HybridHTTPServer;
 import org.enso.shttp.SimpleHttpHandler;
+import org.enso.testkit.RetryTestRule;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import scala.Option;
 import scala.util.Try;
@@ -40,6 +42,8 @@ public class HttpDownloaderTest {
   public static final String REDIRECT_URI = "/redirect";
   private static HybridHTTPServer server;
   private static ExecutorService serverExecutor;
+
+  @Rule public RetryTestRule retry = new RetryTestRule(3);
 
   @BeforeClass
   public static void initServer() throws URISyntaxException, IOException {

--- a/lib/scala/testkit/src/main/java/org/enso/testkit/RetryTestRule.java
+++ b/lib/scala/testkit/src/main/java/org/enso/testkit/RetryTestRule.java
@@ -1,0 +1,56 @@
+package org.enso.testkit;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Flaky test specification for JUnit.
+ *
+ * <p>Inspired by <a href="https://stackoverflow.com/a/8301639/4816269">this SO answer</a>.
+ *
+ * <p>Use it like this:
+ *
+ * <pre>
+ * public class MyTest {
+ *   &#64;Rule
+ *   public RetryTestRule retry = new RetryTestRule(3);
+ *   &#64;Test
+ *   public void myTest() {...}
+ * }
+ * </pre>
+ */
+public class RetryTestRule implements TestRule {
+  private int retryCount;
+
+  public RetryTestRule(int retryCount) {
+    this.retryCount = retryCount;
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    return statement(base, description);
+  }
+
+  private Statement statement(final Statement base, final Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        Throwable caughtThrowable = null;
+
+        for (int i = 0; i < retryCount; i++) {
+          try {
+            base.evaluate();
+            return;
+          } catch (Throwable t) {
+            caughtThrowable = t;
+            System.err.println(description.getDisplayName() + ": run " + (i + 1) + " failed");
+          }
+        }
+        System.err.println(
+            description.getDisplayName() + ": giving up after " + retryCount + " failures");
+        throw caughtThrowable;
+      }
+    };
+  }
+}

--- a/lib/scala/testkit/src/main/java/org/enso/testkit/RetryTestRule.java
+++ b/lib/scala/testkit/src/main/java/org/enso/testkit/RetryTestRule.java
@@ -1,7 +1,7 @@
 package org.enso.testkit;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -38,7 +38,7 @@ public class RetryTestRule implements TestRule {
     return new Statement() {
       @Override
       public void evaluate() {
-        Set<Throwable> caughtThrowables = new HashSet<>();
+        List<Throwable> caughtThrowables = new ArrayList<>();
 
         for (int i = 0; i < retryCount; i++) {
           try {


### PR DESCRIPTION
### Pull Request Description

`HTTPDownloaderTest` failed recently transiently. Let's declare it as flaky.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [X] Unit tests have been written where possible.
