### PR TITLE
Show circular menu on icon-hover

### DIFF
--- a/app/gui2/e2e/componentBrowser.spec.ts
+++ b/app/gui2/e2e/componentBrowser.spec.ts
@@ -65,6 +65,21 @@ test('Different ways of opening Component Browser', async ({ page }) => {
   await page.mouse.click(outputPortX, outputPortY)
   await page.mouse.click(outputPortX, outputPortY)
   await expectAndCancelBrowser(page, 'final.')
+  // Small (+) button shown when node is hovered
+  await page.keyboard.press('Escape')
+  await page.mouse.move(100, 80)
+  await expect(locate.smallPlusButton(page)).not.toBeVisible()
+  await locate.graphNodeIcon(locate.graphNodeByBinding(page, 'aggregated')).hover()
+  await expect(locate.smallPlusButton(page)).toBeVisible()
+  await locate.smallPlusButton(page).click()
+  await expectAndCancelBrowser(page, 'aggregated.')
+  // Small (+) button shown when node is sole selection
+  await page.keyboard.press('Escape')
+  await expect(locate.smallPlusButton(page)).not.toBeVisible()
+  await locate.graphNodeByBinding(page, 'aggregated').click()
+  await expect(locate.smallPlusButton(page)).toBeVisible()
+  await locate.smallPlusButton(page).click()
+  await expectAndCancelBrowser(page, 'aggregated.')
 })
 
 test('Graph Editor pans to Component Browser', async ({ page }) => {

--- a/app/gui2/e2e/componentBrowser.spec.ts
+++ b/app/gui2/e2e/componentBrowser.spec.ts
@@ -65,6 +65,11 @@ test('Different ways of opening Component Browser', async ({ page }) => {
   await page.mouse.click(outputPortX, outputPortY)
   await page.mouse.click(outputPortX, outputPortY)
   await expectAndCancelBrowser(page, 'final.')
+})
+
+test('Opening Component Browser with small plus buttons', async ({ page }) => {
+  await actions.goToGraph(page)
+
   // Small (+) button shown when node is hovered
   await page.keyboard.press('Escape')
   await page.mouse.move(100, 80)
@@ -73,6 +78,7 @@ test('Different ways of opening Component Browser', async ({ page }) => {
   await expect(locate.smallPlusButton(page)).toBeVisible()
   await locate.smallPlusButton(page).click()
   await expectAndCancelBrowser(page, 'aggregated.')
+
   // Small (+) button shown when node is sole selection
   await page.keyboard.press('Escape')
   await expect(locate.smallPlusButton(page)).not.toBeVisible()

--- a/app/gui2/e2e/locate.ts
+++ b/app/gui2/e2e/locate.ts
@@ -127,7 +127,7 @@ export function graphNodeByBinding(page: Locator | Page, binding: string): Node 
   }) as Node
 }
 export function graphNodeIcon(node: Node) {
-  return node.locator('.icon')
+  return node.locator('.nodeCategoryIcon')
 }
 
 // === Data locators ===
@@ -150,6 +150,7 @@ export const circularMenu = componentLocator('CircularMenu')
 export const addNewNodeButton = componentLocator('PlusButton')
 export const componentBrowser = componentLocator('ComponentBrowser')
 export const nodeOutputPort = componentLocator('outputPortHoverArea')
+export const smallPlusButton = componentLocator('SmallPlusButton')
 
 export function componentBrowserEntry(
   page: Locator | Page,

--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -374,7 +374,7 @@ const groupColors = computed(() => {
   return styles
 })
 
-function showComponentBrowser(nodePosition?: Vec2, usage?: Usage) {
+function showComponentBrowser(nodePosition?: Vec2 | undefined, usage?: Usage) {
   componentBrowserUsage.value = usage ?? { type: 'newNode', sourcePort: sourcePortForSelection() }
   componentBrowserNodePosition.value = nodePosition ?? targetComponentBrowserNodePosition()
   componentBrowserVisible.value = true
@@ -390,9 +390,9 @@ function addNodeAuto() {
   showComponentBrowser(targetPos)
 }
 
-function addNodeAt(pos: Vec2 | undefined) {
-  if (!pos) return addNodeAuto()
-  showComponentBrowser(pos)
+function addNodeAt(sourceNode: NodeId, pos: Vec2 | undefined) {
+  const sourcePort = graphStore.db.getNodeFirstOutputPort(sourceNode)
+  showComponentBrowser(pos, { type: 'newNode', sourcePort })
 }
 
 function hideComponentBrowser() {
@@ -612,7 +612,7 @@ function handleEdgeDrop(source: AstId, position: Vec2) {
       <GraphNodes
         @nodeOutputPortDoubleClick="handleNodeOutputPortDoubleClick"
         @nodeDoubleClick="(id) => stackNavigator.enterNode(id)"
-        @addNode="addNodeAt($event)"
+        @addNode="addNodeAt"
       />
     </div>
     <div

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -5,7 +5,10 @@ import GraphNodeComment from '@/components/GraphEditor/GraphNodeComment.vue'
 import GraphNodeError from '@/components/GraphEditor/GraphNodeMessage.vue'
 import GraphNodeSelection from '@/components/GraphEditor/GraphNodeSelection.vue'
 import GraphVisualization from '@/components/GraphEditor/GraphVisualization.vue'
-import NodeWidgetTree from '@/components/GraphEditor/NodeWidgetTree.vue'
+import NodeWidgetTree, {
+  GRAB_HANDLE_X_MARGIN,
+  ICON_WIDTH,
+} from '@/components/GraphEditor/NodeWidgetTree.vue'
 import SvgIcon from '@/components/SvgIcon.vue'
 import { useApproach } from '@/composables/animation'
 import { useDoubleClick } from '@/composables/doubleClick'
@@ -28,6 +31,11 @@ import { computed, onUnmounted, ref, watch, watchEffect } from 'vue'
 
 const MAXIMUM_CLICK_LENGTH_MS = 300
 const MAXIMUM_CLICK_DISTANCE_SQ = 50
+const CONTENT_PADDING = 4
+const CONTENT_PADDING_RIGHT = 8
+const CONTENT_PADDING_PX = `${CONTENT_PADDING}px`
+const CONTENT_PADDING_RIGHT_PX = `${CONTENT_PADDING_RIGHT}px`
+const MENU_CLOSE_TIMEOUT_MS = 300
 
 const props = defineProps<{
   node: Node
@@ -102,13 +110,53 @@ const warning = computed(() => {
   return 'Warning: ' + warning!
 })
 
-const isSelected = computed(() => nodeSelection?.isSelected(nodeId.value) ?? false)
+const nodeHovered = ref(false)
+
+const selected = computed(() => nodeSelection?.isSelected(nodeId.value) ?? false)
+const selectionVisible = ref(false)
+
 const isOnlyOneSelected = computed(
-  () => isSelected.value && nodeSelection?.selected.size === 1 && !nodeSelection.isChanging,
+  () => selected.value && nodeSelection?.selected.size === 1 && !nodeSelection.isChanging,
 )
 
-const menuVisible = isOnlyOneSelected
+const menuVisible = computed(() => menuEnabledByHover.value || isOnlyOneSelected.value)
 const menuFull = ref(false)
+const menuHovered = ref(false)
+
+function eventScenePos(event: MouseEvent) {
+  const clientPos = event && new Vec2(event.clientX, event.clientY)
+  return clientPos && navigator?.clientToScenePos(clientPos)
+}
+
+const nodeHoverPos = ref<Vec2>()
+const selectionHoverPos = ref<Vec2>()
+function updateNodeHover(event: PointerEvent | undefined) {
+  nodeHoverPos.value = event && eventScenePos(event)
+}
+function updateSelectionHover(event: PointerEvent | undefined) {
+  selectionHoverPos.value = event && eventScenePos(event)
+}
+
+let menuCloseTimeout = ref<ReturnType<typeof setTimeout>>()
+const menuEnabledByHover = ref(false)
+watchEffect(() => {
+  if (menuCloseTimeout.value) clearTimeout(menuCloseTimeout.value)
+  const inZone = (pos: Vec2 | undefined) =>
+    pos != null &&
+    pos.sub(props.node.position).x < CONTENT_PADDING + ICON_WIDTH + GRAB_HANDLE_X_MARGIN * 2
+  const hovered =
+    menuHovered.value ||
+    inZone(nodeHoverPos.value) ||
+    (menuEnabledByHover.value && inZone(selectionHoverPos.value))
+  if (hovered) {
+    menuEnabledByHover.value = true
+  } else if (!hovered && menuEnabledByHover.value) {
+    menuCloseTimeout.value = setTimeout(() => {
+      menuEnabledByHover.value =
+        menuHovered.value || inZone(nodeHoverPos.value) || inZone(selectionHoverPos.value)
+    }, MENU_CLOSE_TIMEOUT_MS)
+  }
+})
 
 watch(menuVisible, (visible) => {
   if (!visible) menuFull.value = false
@@ -310,8 +358,6 @@ watchEffect(() => {
   }
 })
 
-const nodeHovered = ref(false)
-
 function portGroupStyle(port: PortData) {
   const [start, end] = port.clipRange
   return {
@@ -340,9 +386,6 @@ const documentation = computed<string | undefined>({
     })
   },
 })
-
-const selected = computed(() => nodeSelection?.isSelected(nodeId.value) ?? false)
-const selectionVisible = ref(false)
 </script>
 
 <template>
@@ -362,8 +405,9 @@ const selectionVisible = ref(false)
       ['executionState-' + executionState]: true,
     }"
     :data-node-id="nodeId"
-    @pointerenter="nodeHovered = true"
-    @pointerleave="nodeHovered = false"
+    @pointerenter="(nodeHovered = true), updateNodeHover($event)"
+    @pointerleave="(nodeHovered = false), updateNodeHover(undefined)"
+    @pointermove="updateNodeHover"
   >
     <Teleport to="#graphNodeSelections">
       <GraphNodeSelection
@@ -374,6 +418,9 @@ const selectionVisible = ref(false)
         :nodeId
         :color
         @visible="selectionVisible = $event"
+        @pointerenter="updateSelectionHover"
+        @pointermove="updateSelectionHover"
+        @pointerleave="updateSelectionHover(undefined)"
         v-on="dragPointer.events"
       />
     </Teleport>
@@ -398,6 +445,8 @@ const selectionVisible = ref(false)
       @openFullMenu="openFullMenu"
       @delete="emit('delete')"
       @addNode="emit('addNode', $event)"
+      @pointerenter="menuHovered = true"
+      @pointerleave="menuHovered = false"
     />
     <GraphVisualization
       v-if="isVisualizationVisible"
@@ -449,7 +498,7 @@ const selectionVisible = ref(false)
     </div>
     <GraphNodeError v-if="error" class="afterNode" :message="error" type="error" />
     <GraphNodeError
-      v-if="warning && (nodeHovered || isSelected)"
+      v-if="warning && (nodeHovered || selected)"
       class="afterNode warning"
       :class="{ messageWithMenu: menuVisible }"
       :message="warning"
@@ -596,8 +645,8 @@ const selectionVisible = ref(false)
   flex-direction: row;
   align-items: center;
   white-space: nowrap;
-  padding: 4px;
-  padding-right: 8px;
+  padding: v-bind('CONTENT_PADDING_PX');
+  padding-right: v-bind('CONTENT_PADDING_RIGHT_PX');
   z-index: 2;
   transition: outline 0.2s ease;
   outline: 0px solid transparent;

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -140,7 +140,10 @@ function updateSelectionHover(event: PointerEvent | undefined) {
 let menuCloseTimeout = ref<ReturnType<typeof setTimeout>>()
 const menuEnabledByHover = ref(false)
 watchEffect(() => {
-  if (menuCloseTimeout.value) clearTimeout(menuCloseTimeout.value)
+  if (menuCloseTimeout.value != null) {
+    clearTimeout(menuCloseTimeout.value)
+    menuCloseTimeout.value = undefined
+  }
   const inZone = (pos: Vec2 | undefined) =>
     pos != null &&
     pos.sub(props.node.position).x < CONTENT_PADDING + ICON_WIDTH + GRAB_HANDLE_X_MARGIN * 2

--- a/app/gui2/src/components/GraphEditor/GraphNodes.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNodes.vue
@@ -21,7 +21,7 @@ const navigator = injectGraphNavigator(true)
 const emit = defineEmits<{
   nodeOutputPortDoubleClick: [portId: AstId]
   nodeDoubleClick: [nodeId: NodeId]
-  addNode: [pos: Vec2 | undefined]
+  addNode: [source: NodeId, pos: Vec2 | undefined]
 }>()
 
 function nodeIsDragged(movedId: NodeId, offset: Vec2) {
@@ -55,7 +55,7 @@ const uploadingFiles = computed<[FileName, File][]>(() => {
     @outputPortClick="graphStore.createEdgeFromOutput($event)"
     @outputPortDoubleClick="emit('nodeOutputPortDoubleClick', $event)"
     @doubleClick="emit('nodeDoubleClick', id)"
-    @addNode="emit('addNode', $event)"
+    @addNode="emit('addNode', id, $event)"
     @update:edited="graphStore.setEditedNode(id, $event)"
     @update:rect="graphStore.updateNodeRect(id, $event)"
     @update:visualizationId="

--- a/app/gui2/src/components/GraphEditor/NodeWidgetTree.vue
+++ b/app/gui2/src/components/GraphEditor/NodeWidgetTree.vue
@@ -79,13 +79,18 @@ provideWidgetTree(
   },
 )
 </script>
+<script lang="ts">
+export const GRAB_HANDLE_X_MARGIN = 4
+const GRAB_HANDLE_X_MARGIN_PX = `${GRAB_HANDLE_X_MARGIN}px`
+export const ICON_WIDTH = 16
+</script>
 
 <template>
   <div class="NodeWidgetTree" spellcheck="false" v-on="layoutTransitions.events">
     <!-- Display an icon for the node if no widget in the tree provides one. -->
     <SvgIcon
       v-if="!props.connectedSelfArgumentId"
-      class="icon grab-handle"
+      class="icon grab-handle nodeCategoryIcon"
       :name="props.icon"
       @click.right.stop.prevent="emit('openFullMenu')"
     />
@@ -121,6 +126,6 @@ provideWidgetTree(
 
 .grab-handle {
   color: white;
-  margin: 0 4px;
+  margin: 0 v-bind('GRAB_HANDLE_X_MARGIN_PX');
 }
 </style>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetSelfIcon.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetSelfIcon.vue
@@ -21,7 +21,11 @@ export const widgetDefinition = defineWidget(WidgetInput.isAst, {
 </script>
 
 <template>
-  <SvgIcon class="icon" :name="icon" @click.right.stop.prevent="tree.emitOpenFullMenu()" />
+  <SvgIcon
+    class="icon nodeCategoryIcon"
+    :name="icon"
+    @click.right.stop.prevent="tree.emitOpenFullMenu()"
+  />
 </template>
 
 <style scoped>


### PR DESCRIPTION
### Pull Request Description

Open the circular menu if the mouse hovers over the icon-end of the node (highlighted in red):
<img width="454" alt="image" src="https://github.com/enso-org/enso/assets/1047859/3db37323-b4f6-448f-9087-90e457c5415f">

Close the menu if it is outside all highlighted areas for 300ms:
<img width="505" alt="image" src="https://github.com/enso-org/enso/assets/1047859/6eb3ee52-e7d3-4a45-b522-6a56d19849b7">

Demo:

https://github.com/enso-org/enso/assets/1047859/364b72fb-8198-4fb2-a490-17fab0286766

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
