### PR TITLE
More type-checking for concrete children

### DIFF
--- a/app/gui2/shared/ast/tree.ts
+++ b/app/gui2/shared/ast/tree.ts
@@ -608,7 +608,9 @@ export class App extends Ast {
     const spacedEquals = useParens && !!nameSpecification?.equals.whitespace
     if (useParens) yield ensureSpaced(parens.open, verbatim)
     if (nameSpecification) {
-      yield useParens ? preferUnspaced(nameSpecification.name) : ensureSpaced(nameSpecification.name, verbatim)
+      yield useParens ?
+        preferUnspaced(nameSpecification.name)
+      : ensureSpaced(nameSpecification.name, verbatim)
       yield ensureSpacedOnlyIf(nameSpecification.equals, spacedEquals, verbatim)
     }
     yield ensureSpacedOnlyIf(argument, !nameSpecification || spacedEquals, verbatim)
@@ -1778,7 +1780,7 @@ export class Function extends Ast {
     }
   }
 
-  *concreteChildren(verbatim?: boolean): IterableIterator<RawNodeChild> {
+  *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
     const { name, argumentDefinitions, equals, body } = getAll(this.fields)
     yield name
     for (const def of argumentDefinitions) yield* def

--- a/app/gui2/shared/ast/tree.ts
+++ b/app/gui2/shared/ast/tree.ts
@@ -608,7 +608,7 @@ export class App extends Ast {
     const spacedEquals = useParens && !!nameSpecification?.equals.whitespace
     if (useParens) yield ensureSpaced(parens.open, verbatim)
     if (nameSpecification) {
-      yield ensureSpacedIf(nameSpecification.name, !useParens, verbatim)
+      yield useParens ? preferUnspaced(nameSpecification.name) : ensureSpaced(nameSpecification.name, verbatim)
       yield ensureSpacedOnlyIf(nameSpecification.equals, spacedEquals, verbatim)
     }
     yield ensureSpacedOnlyIf(argument, !nameSpecification || spacedEquals, verbatim)
@@ -626,36 +626,39 @@ export class App extends Ast {
     return super.printSubtree(info, offset, parentIndent, verbatim_)
   }
 }
-function ensureSpacedIf<T>(
-  child: NodeChild<T>,
-  condition: boolean,
-  verbatim: boolean | undefined,
-): NodeChild<T> {
-  return condition ? ensureSpaced(child, verbatim) : child
-}
 function ensureSpacedOnlyIf<T>(
   child: NodeChild<T>,
   condition: boolean,
   verbatim: boolean | undefined,
-): NodeChild<T> {
+): ConcreteChild<T> {
   return condition ? ensureSpaced(child, verbatim) : ensureUnspaced(child, verbatim)
 }
-function ensureSpaced<T>(child: NodeChild<T>, verbatim: boolean | undefined): NodeChild<T> {
-  if (verbatim && child.whitespace != null) return child
-  return child.whitespace ? child : { ...child, whitespace: ' ' }
+
+type ConcreteChild<T> = { whitespace: string; node: T }
+function isConcrete<T>(child: NodeChild<T>): child is ConcreteChild<T> {
+  return child.whitespace !== undefined
 }
-function ensureUnspaced<T>(child: NodeChild<T>, verbatim: boolean | undefined): NodeChild<T> {
-  if (verbatim && child.whitespace != null) return child
-  return child.whitespace === '' ? child : { ...child, whitespace: '' }
+function tryAsConcrete<T>(child: NodeChild<T>): ConcreteChild<T> | undefined {
+  return isConcrete(child) ? child : undefined
 }
-function preferSpacedIf<T>(child: NodeChild<T>, condition: boolean): NodeChild<T> {
+function ensureSpaced<T>(child: NodeChild<T>, verbatim: boolean | undefined): ConcreteChild<T> {
+  const concreteInput = tryAsConcrete(child)
+  if (verbatim && concreteInput) return concreteInput
+  return concreteInput?.whitespace ? concreteInput : { ...child, whitespace: ' ' }
+}
+function ensureUnspaced<T>(child: NodeChild<T>, verbatim: boolean | undefined): ConcreteChild<T> {
+  const concreteInput = tryAsConcrete(child)
+  if (verbatim && concreteInput) return concreteInput
+  return concreteInput?.whitespace === '' ? concreteInput : { ...child, whitespace: '' }
+}
+function preferSpacedIf<T>(child: NodeChild<T>, condition: boolean): ConcreteChild<T> {
   return condition ? preferSpaced(child) : preferUnspaced(child)
 }
-function preferUnspaced<T>(child: NodeChild<T>): NodeChild<T> {
-  return child.whitespace === undefined ? { ...child, whitespace: '' } : child
+function preferUnspaced<T>(child: NodeChild<T>): ConcreteChild<T> {
+  return tryAsConcrete(child) ?? { ...child, whitespace: '' }
 }
-function preferSpaced<T>(child: NodeChild<T>): NodeChild<T> {
-  return child.whitespace === undefined ? { ...child, whitespace: ' ' } : child
+function preferSpaced<T>(child: NodeChild<T>): ConcreteChild<T> {
+  return tryAsConcrete(child) ?? { ...child, whitespace: ' ' }
 }
 export class MutableApp extends App implements MutableAst {
   declare readonly module: MutableModule
@@ -1865,9 +1868,9 @@ export class Assignment extends Ast {
 
   *concreteChildren(verbatim?: boolean): IterableIterator<RawNodeChild> {
     const { pattern, equals, expression } = getAll(this.fields)
-    yield pattern
+    yield ensureUnspaced(pattern, verbatim)
     yield ensureSpacedOnlyIf(equals, expression.whitespace !== '', verbatim)
-    yield expression
+    yield preferSpaced(expression)
   }
 }
 export class MutableAssignment extends Assignment implements MutableAst {
@@ -1926,7 +1929,7 @@ export class BodyBlock extends Ast {
 
   *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
     for (const line of this.fields.get('lines')) {
-      yield line.newline ?? { node: Token.new('\n', RawAst.Token.Type.Newline) }
+      yield preferUnspaced(line.newline)
       if (line.expression) yield line.expression
     }
   }
@@ -2223,15 +2226,15 @@ export class Vector extends Ast {
     return Vector.tryBuild(inputs, elementBuilder, edit)
   }
 
-  *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
+  *concreteChildren(verbatim?: boolean): IterableIterator<RawNodeChild> {
     const { open, elements, close } = getAll(this.fields)
-    yield unspaced(open.node)
+    yield ensureUnspaced(open, verbatim)
     let isFirst = true
     for (const { delimiter, value } of elements) {
       if (isFirst && value) {
         yield preferUnspaced(value)
       } else {
-        yield delimiter
+        yield preferUnspaced(delimiter)
         if (value) yield preferSpaced(value)
       }
       isFirst = false


### PR DESCRIPTION
### Pull Request Description

Introduce a concrete NodeChild subtype; use it to statically check for the kind of bug that #9357 fixed.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
