### PR TITLE
Added Table.running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -629,6 +629,7 @@
 - [Added `select_by_type` and `remove_by_type` to `Table` and `DB_Table`][9334]
 - [Make File./ only accept Text][9330]
 - [Implemented Excel Data Link][9346]
+- [Added Table.running][9346]
 
 [debug-shortcuts]:
   https://github.com/enso-org/enso/blob/develop/app/gui/docs/product/shortcuts.md#debug
@@ -913,6 +914,7 @@
 [9330]: https://github.com/enso-org/enso/pull/9330
 [9334]: https://github.com/enso-org/enso/pull/9334
 [9346]: https://github.com/enso-org/enso/pull/9346
+[9382]: https://github.com/enso-org/enso/pull/9382
 
 #### Enso Compiler
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -2848,6 +2848,47 @@ type DB_Table
         transformer col = col.text_replace resolved_term resolved_new_text case_sensitivity only_first
         Table_Helpers.replace_columns_with_transformed_columns self columns transformer
 
+    ## ALIAS cumulative
+       GROUP Standard.Base.Values
+       ICON dataframe_map_column
+       Adds a new column to the table with a running calculation.
+
+       Arguments:
+       - statistic: The running statistic to calculate.
+       - of: The existing column to run the statistic over.
+       - as: The name of the new column.
+       - group_by: Specifies the columns to group by. The running statistic is
+         calculated separately for each group. By default, all rows are treated as
+         a single group.
+       - order_by: Specifies the columns to order by. Defaults to the order of
+         the rows in the table. The running statistic is calculated according to the
+         specified ordering.
+
+       ? Ordering of rows
+
+         Note that the ordering of rows from the original table is preserved in
+         all cases. The grouping and ordering settings affect how the running statistic is
+         calculated for each row, but the order of the rows itself is
+         not changed by this operation.
+
+       ! Error Conditions
+
+         - If the columns specified in `group_by` or `order_by` are not present
+           in the table, a `Missing_Input_Columns` error is raised.
+         - If the column with the same name as provided by `as` already exists,
+           a `Duplicate_Output_Column_Names` problem is reported and the
+           existing column is renamed to avoid the clash.
+         - If grouping on floating point numbers, a `Floating_Point_Equality`
+           problem is reported.
+    @group_by Widget_Helpers.make_column_name_vector_selector
+    @order_by Widget_Helpers.make_order_by_selector
+    @of Widget_Helpers.make_column_name_selector
+    running : Statistic -> (Text | Integer) -> Text -> Vector (Text | Integer | Regex) | Text | Integer | Regex -> Vector (Text | Sort_Column) | Text -> Problem_Behavior -> Table
+    running self (statistic:Statistic=Statistic.Count) (of:Text|Integer=0) (as:Text='') (group_by:(Vector | Text | Integer | Regex)=[]) (order_by:(Vector | Text)=[]) (on_problems:Problem_Behavior=Problem_Behavior.Report_Warning) =
+        _ = [statistic, of, as, group_by, order_by, on_problems]
+        Error.throw (Unsupported_Database_Operation.Error "DB_Table.running is currently not implemented for the Database backend. You may download the table to memory using `.read` to use this feature.")
+
+
 ## PRIVATE
 
    Creates a Table out of a connection, name and list of column names.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -2868,6 +2868,47 @@ type Table
         transformer col = col.text_replace resolved_term resolved_new_text case_sensitivity only_first
         Table_Helpers.replace_columns_with_transformed_columns self columns transformer
 
+    ## ALIAS cumulative
+       GROUP Standard.Base.Values
+       ICON dataframe_map_column
+       Adds a new column to the table with a running calculation.
+
+       Arguments:
+       - statistic: The running statistic to calculate.
+       - of: The existing column to run the statistic over.
+       - as: The name of the new column.
+       - group_by: Specifies the columns to group by. The running statistic is
+         calculated separately for each group. By default, all rows are treated as
+         a single group.
+       - order_by: Specifies the columns to order by. Defaults to the order of
+         the rows in the table. The running statistic is calculated according to the
+         specified ordering.
+
+       ? Ordering of rows
+
+         Note that the ordering of rows from the original table is preserved in
+         all cases. The grouping and ordering settings affect how the running statistic is
+         calculated for each row, but the order of the rows itself is
+         not changed by this operation.
+
+       ! Error Conditions
+
+         - If the columns specified in `group_by` or `order_by` are not present
+           in the table, a `Missing_Input_Columns` error is raised.
+         - If the column with the same name as provided by `as` already exists,
+           a `Duplicate_Output_Column_Names` problem is reported and the
+           existing column is renamed to avoid the clash.
+         - If grouping on floating point numbers, a `Floating_Point_Equality`
+           problem is reported.
+    @group_by Widget_Helpers.make_column_name_vector_selector
+    @order_by Widget_Helpers.make_order_by_selector
+    @of Widget_Helpers.make_column_name_selector
+    running : Statistic -> (Text | Integer) -> Text -> Vector (Text | Integer | Regex) | Text | Integer | Regex -> Vector (Text | Sort_Column) | Text -> Problem_Behavior -> Table
+    running self (statistic:Statistic=Statistic.Count) (of:Text|Integer) (as:Text='') (group_by:(Vector | Text | Integer | Regex)=[]) (order_by:(Vector | Text)=[]) (on_problems:Problem_Behavior=Problem_Behavior.Report_Warning) =
+        if statistic != Statistic.Count then Error.throw (Illegal_Argument.Error ("Currently only Statistic.Count is supported in Table.running.")) else
+          new_name = if as == '' then 'Running ' + statistic.to_text + ' of ' + of else as
+          Add_Row_Number.add_row_number self new_name 1 1 group_by order_by on_problems
+
     ## PRIVATE
     column_naming_helper : Column_Naming_Helper
     column_naming_helper self = Column_Naming_Helper.in_memory

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -2868,7 +2868,8 @@ type Table
         transformer col = col.text_replace resolved_term resolved_new_text case_sensitivity only_first
         Table_Helpers.replace_columns_with_transformed_columns self columns transformer
 
-    ## ALIAS cumulative
+    ## PRIVATE
+       ALIAS cumulative
        GROUP Standard.Base.Values
        ICON dataframe_map_column
        Adds a new column to the table with a running calculation.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -2904,9 +2904,10 @@ type Table
     @order_by Widget_Helpers.make_order_by_selector
     @of Widget_Helpers.make_column_name_selector
     running : Statistic -> (Text | Integer) -> Text -> Vector (Text | Integer | Regex) | Text | Integer | Regex -> Vector (Text | Sort_Column) | Text -> Problem_Behavior -> Table
-    running self (statistic:Statistic=Statistic.Count) (of:Text|Integer) (as:Text='') (group_by:(Vector | Text | Integer | Regex)=[]) (order_by:(Vector | Text)=[]) (on_problems:Problem_Behavior=Problem_Behavior.Report_Warning) =
+    running self (statistic:Statistic=Statistic.Count) (of:Text|Integer=0) (as:Text='') (group_by:(Vector | Text | Integer | Regex)=[]) (order_by:(Vector | Text)=[]) (on_problems:Problem_Behavior=Problem_Behavior.Report_Warning) =
         if statistic != Statistic.Count then Error.throw (Illegal_Argument.Error ("Currently only Statistic.Count is supported in Table.running.")) else
-          new_name = if as == '' then 'Running ' + statistic.to_text + ' of ' + of else as
+          of_col = self.at of
+          new_name = if as == '' then 'Running ' + statistic.to_text + ' of ' + of_col.name else as
           Add_Row_Number.add_row_number self new_name 1 1 group_by order_by on_problems
 
     ## PRIVATE

--- a/test/Table_Tests/src/In_Memory/Main.enso
+++ b/test/Table_Tests/src/In_Memory/Main.enso
@@ -17,6 +17,7 @@ import project.In_Memory.Table_Conversion_Spec
 import project.In_Memory.Table_Date_Spec
 import project.In_Memory.Table_Date_Time_Spec
 import project.In_Memory.Table_Time_Of_Day_Spec
+import project.In_Memory.Table_Running_Spec
 
 add_specs suite_builder =
     Table_Spec.add_specs suite_builder
@@ -30,6 +31,7 @@ add_specs suite_builder =
     Table_Date_Spec.add_specs suite_builder
     Table_Date_Time_Spec.add_specs suite_builder
     Table_Time_Of_Day_Spec.add_specs suite_builder
+    Table_Running_Spec.add_specs suite_builder
     Aggregate_Column_Spec.add_specs suite_builder
     Builders_Spec.add_specs suite_builder
     Split_Tokenize_Spec.add_specs suite_builder

--- a/test/Table_Tests/src/In_Memory/Table_Running_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Running_Spec.enso
@@ -1,0 +1,96 @@
+from Standard.Base import all
+from Standard.Table import Column, Table
+from Standard.Test import all
+from Standard.Table.Errors import all
+import Standard.Base.Errors.Common.Type_Error
+
+from project.Util import all
+
+type Data
+    #   | Flight | Passenger | Ticket Price
+    #---+--------+-----------+--------------
+    # 0 | BA0123 | A         | 100.5
+    # 1 | BA0123 | B         | 575.99
+    # 2 | SG0456 | A         | 73.23
+    # 3 | BA0123 | C         | 112.34
+    # 4 | SG0456 | E         | 73.77
+    Value ~table
+
+    setup =
+        make_table =
+            flight = ["Flight", ["BA0123", "BA0123", "SG0456", "BA0123", "SG0456"]]
+            passenger = ["Passenger", ["A", "B", "A", "C", "E"]]
+            ticket_price = ["Ticket Price", [100.50, 575.99, 73.23, 112.34, 73.77]]
+
+            Table.new [flight, passenger, ticket_price]
+        Data.Value make_table
+
+add_specs suite_builder =
+    suite_builder.group "running" group_builder->
+        data = Data.setup
+        group_builder.specify "Defaults add running count of first column" <|
+            result = data.table.running
+            expected_column = Column.from_vector "Running Count of Flight" [1, 2, 3, 4, 5]
+            #   | Flight | Passenger | Ticket Price | Running Count of Flight
+            #---+--------+-----------+--------------+-------------------------
+            # 0 | BA0123 | A         | 100.5        | 1
+            # 1 | BA0123 | B         | 575.99       | 2
+            # 2 | SG0456 | A         | 73.23        | 3
+            # 3 | BA0123 | C         | 112.34       | 4
+            # 4 | SG0456 | E         | 73.77        | 5
+            expected_table = data.table.zip expected_column
+            result.should_equal expected_table
+        group_builder.specify "Not setting the as name gives default name based on of column" <|
+            result = data.table.running Statistic.Count "Passenger"
+            expected_column = Column.from_vector "Running Count of Passenger" [1, 2, 3, 4, 5]
+            #   | Flight | Passenger | Ticket Price | Running Count of Passenger
+            #---+--------+-----------+--------------+-------------------------
+            # 0 | BA0123 | A         | 100.5        | 1
+            # 1 | BA0123 | B         | 575.99       | 2
+            # 2 | SG0456 | A         | 73.23        | 3
+            # 3 | BA0123 | C         | 112.34       | 4
+            # 4 | SG0456 | E         | 73.77        | 5
+            expected_table = data.table.zip expected_column
+            result.should_equal expected_table
+        group_builder.specify "Can set the as name" <|
+            result = data.table.running Statistic.Count "Passenger" "My Custom Name"
+            expected_column = Column.from_vector "My Custom Name" [1, 2, 3, 4, 5]
+            #   | Flight | Passenger | Ticket Price | My Custom Name
+            #---+--------+-----------+--------------+-------------------------
+            # 0 | BA0123 | A         | 100.5        | 1
+            # 1 | BA0123 | B         | 575.99       | 2
+            # 2 | SG0456 | A         | 73.23        | 3
+            # 3 | BA0123 | C         | 112.34       | 4
+            # 4 | SG0456 | E         | 73.77        | 5
+            expected_table = data.table.zip expected_column
+            result.should_equal expected_table
+        group_builder.specify "Can group by and provide running count per group" <|
+            result = data.table.running Statistic.Count "Passenger" "Passenger num per flight" ["Flight"]
+            expected_column = Column.from_vector "Passenger num per flight" [1, 2, 1, 3, 2]
+            #   | Flight | Passenger | Ticket Price | Passenger num per flight
+            #---+--------+-----------+--------------+-------------------------
+            # 0 | BA0123 | A         | 100.5        | 1
+            # 1 | BA0123 | B         | 575.99       | 2
+            # 2 | SG0456 | A         | 73.23        | 1
+            # 3 | BA0123 | C         | 112.34       | 3
+            # 4 | SG0456 | E         | 73.77        | 2
+            expected_table = data.table.zip expected_column
+            result.should_equal expected_table
+        group_builder.specify "Can group by and provide running count per group based on order by" <|
+            result = data.table.running Statistic.Count "Passenger" "Ranked ticket cost per pass" ["Passenger"] ["Ticket Price"]
+            expected_column = Column.from_vector "Ranked ticket cost per pass" [2, 1, 1, 1, 1]
+            #   | Flight | Passenger | Ticket Price | Ranked ticket cost per pass
+            #---+--------+-----------+--------------+-------------------------
+            # 0 | BA0123 | A         | 100.5        | 2
+            # 1 | BA0123 | B         | 575.99       | 1
+            # 2 | SG0456 | A         | 73.23        | 1
+            # 3 | BA0123 | C         | 112.34       | 1
+            # 4 | SG0456 | E         | 73.77        | 1
+            expected_table = data.table.zip expected_column
+            result.should_equal expected_table
+
+main filter=Nothing =
+    suite = Test.build suite_builder->
+        add_specs suite_builder
+    suite.run_with_filter filter
+


### PR DESCRIPTION
### Pull Request Description

This is a first naïve implementation of Table.running that only supports count. Adding it as a scaffold for the rest of the functionality and to give us a place to agree on the API. (Which I changed slightly from the design)

![image](https://github.com/enso-org/enso/assets/1720119/a62a83ed-f864-4295-98ea-1007f62381b1)

### Important Notes

Only supports Statistic.Count. Other functionality to follow.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
