### PR TITLE
sbt graalVMVersionCheck does not fail during reload

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,19 +47,14 @@ val currentEdition = sys.env.getOrElse(
 val stdLibVersion       = defaultDevEnsoVersion
 val targetStdlibVersion = ensoVersion
 
-lazy val graalVMVersionCheck = taskKey[Unit]("Check GraalVM and Java versions")
-graalVMVersionCheck := {
+// Inspired by https://www.scala-sbt.org/1.x/docs/Howto-Startup.html#How+to+take+an+action+on+startup
+lazy val startupStateTransition: State => State = { s: State =>
   GraalVM.versionCheck(
     graalVersion,
     graalMavenPackagesVersion,
     javaVersion,
-    state.value.log
+    s
   )
-}
-
-// Inspired by https://www.scala-sbt.org/1.x/docs/Howto-Startup.html#How+to+take+an+action+on+startup
-lazy val startupStateTransition: State => State = { s: State =>
-  "graalVMVersionCheck" :: s
 }
 Global / onLoad := {
   val old = (Global / onLoad).value


### PR DESCRIPTION
Fixes #9395

### Pull Request Description

Reload of sbt used to fail on "Not a valid command: graalVMVersionCheck" This PR fixes this issue.

### Important Notes

Checked:
- Manually running `reload` inside sbt shell
- Temporarily setting a key in the current sbt shell with `set javaOptions += "foo"` and then `reload`.

Invoking sbt with incompatible java:
```
[info] welcome to sbt 1.9.7 (GraalVM Community Java 21)
[info] loading settings for project enso-build from plugins.sbt ...
[info] loading project definition from /home/pavel/dev/enso/project
[info] loading settings for project enso from build.sbt ...
[info] resolving key references (66170 settings) ...
[info] set current project to enso (in build file:/home/pavel/dev/enso/)
[error] Running on GraalVM version 21. Expected GraalVM version 21.0.2.
[warn] Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? (default: r)
```

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [X] Unit tests have been written where possible.
  - [X] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
