### PR TITLE
Fix e2e tests on Mac

### DIFF
--- a/app/gui2/e2e/actions.ts
+++ b/app/gui2/e2e/actions.ts
@@ -18,6 +18,10 @@ export async function goToGraph(page: Page) {
 }
 
 export async function expectNodePositionsInitialized(page: Page, yPos: number) {
+  // Wait until edges are initialized and displayed correctly.
+  await expect(page.getByTestId('broken-edge')).toHaveCount(0)
+  // Wait until node sizes are initialized.
+  await expect(locate.graphNode(page).first().locator('.bgFill')).toBeVisible()
   // TODO: The yPos should not need to be a variable. Instead, first automatically positioned nodes
   // should always have constant known position. This is a bug caused by incorrect layout after
   // entering a function. To be fixed with #9255

--- a/app/gui2/src/components/GraphEditor/GraphEdge.vue
+++ b/app/gui2/src/components/GraphEditor/GraphEdge.vue
@@ -79,6 +79,15 @@ const sourceRect = computed<Rect | undefined>(() => {
   }
 })
 
+/** Edges which do not have `sourceRect` and `targetPos` initialized are marked by a special
+ * `broken-edge` data-testid, for debugging and e2e test purposes. */
+const edgeIsBroken = computed(
+  () =>
+    sourceRect.value == null ||
+    targetPos.value == null ||
+    (sourceRect.value.pos.equals(targetPos.value) && sourceRect.value.size.equals(Vec2.Zero)),
+)
+
 type NodeMask = {
   id: string
   rect: Rect
@@ -508,6 +517,7 @@ const connected = computed(() => isConnected(props.edge))
         class="edge io"
         :data-source-node-id="sourceNode"
         :data-target-node-id="targetNode"
+        :data-testid="edgeIsBroken ? 'broken-edge' : null"
         @pointerdown.stop="click"
         @pointerenter="hovered = true"
         @pointerleave="hovered = false"


### PR DESCRIPTION
### Pull Request Description

Some e2e tests (about leaving nodes) were always failing on my machine because of the race condition in the tests. The issue was caused by edges positions lagging behind for a few frames when switching Enso functions, which caused incorrect handling of clicks in the test code.

Now we wait for edges being initialized *and* node sizes being updated.

Thanks to @farmaazon for helping with debugging.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
