### PR TITLE
Display custom unicode instead of `ArrowLeft` in keyboard shortcuts

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/KeyboardShortcut.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/KeyboardShortcut.tsx
@@ -26,7 +26,7 @@ const ICON_SIZE_PX = 13
 const ICON_STYLE = { width: ICON_SIZE_PX, height: ICON_SIZE_PX }
 
 /** Icons for modifier keys (if they exist). */
-const MODIFIER_MAPPINGS: Readonly<
+const MODIFIER_JSX: Readonly<
   Record<detect.Platform, Partial<Record<inputBindingsModule.ModifierKey, React.ReactNode>>>
 > = {
   // The names are intentionally not in `camelCase`, as they are case-sensitive.
@@ -58,6 +58,16 @@ const MODIFIER_MAPPINGS: Readonly<
   },
   /* eslint-enable @typescript-eslint/naming-convention */
 }
+
+const KEY_CHARACTER: Readonly<Record<string, string>> = {
+  // The names come from a third-party API (the DOM spec) and cannot be changed.
+  /* eslint-disable @typescript-eslint/naming-convention */
+  ArrowDown: '↓',
+  ArrowUp: '↑',
+  ArrowLeft: '←',
+  ArrowRight: '→',
+  /* eslint-enable @typescript-eslint/naming-convention */
+} satisfies Partial<Record<inputBindingsModule.Key, React.ReactNode>>
 
 /** Props for a {@link KeyboardShortcut}, specifying the keyboard action. */
 export interface KeyboardShortcutActionProps {
@@ -92,13 +102,15 @@ export default function KeyboardShortcut(props: KeyboardShortcutProps) {
       >
         {modifiers.map(
           modifier =>
-            MODIFIER_MAPPINGS[detect.platform()][modifier] ?? (
+            MODIFIER_JSX[detect.platform()][modifier] ?? (
               <span key={modifier} className="text">
                 {modifier}
               </span>
             )
         )}
-        <span className="text">{shortcut.key === ' ' ? 'Space' : shortcut.key}</span>
+        <span className="text">
+          {shortcut.key === ' ' ? 'Space' : KEY_CHARACTER[shortcut.key] ?? shortcut.key}
+        </span>
       </div>
     )
   }

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/KeyboardShortcut.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/KeyboardShortcut.tsx
@@ -67,7 +67,7 @@ const KEY_CHARACTER: Readonly<Record<string, string>> = {
   ArrowLeft: '←',
   ArrowRight: '→',
   /* eslint-enable @typescript-eslint/naming-convention */
-} satisfies Partial<Record<inputBindingsModule.Key, React.ReactNode>>
+} satisfies Partial<Record<inputBindingsModule.Key, string>>
 
 /** Props for a {@link KeyboardShortcut}, specifying the keyboard action. */
 export interface KeyboardShortcutActionProps {

--- a/app/ide-desktop/lib/dashboard/src/utilities/inputBindings.ts
+++ b/app/ide-desktop/lib/dashboard/src/utilities/inputBindings.ts
@@ -302,7 +302,7 @@ const ALL_KEYS = [
   'F12',
 ] as const
 /** Common keyboard keys. */
-type Key = (typeof ALL_KEYS)[number]
+export type Key = (typeof ALL_KEYS)[number]
 /** Common keyboard keys, normalized to lowercase for autocomplete purposes. */
 type LowercaseKey = Lowercase<Key>
 /** A segment of a keyboard shortcut. */


### PR DESCRIPTION
### Pull Request Description
- Close https://github.com/enso-org/cloud-v2/issues/1006

### Important Notes
None

### Screenshots
After:
![image](https://github.com/enso-org/enso/assets/4046547/ce56e41a-c10a-447c-804a-6c98052befbd)

Before:
![image](https://github.com/enso-org/enso/assets/4046547/3e233b84-d6fe-4907-9b5a-0dbfc83c87c0)


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
