### PR TITLE
Avoid Interop TypeOfNode specializations for EnsoObject

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeTest.java
@@ -4,22 +4,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.oracle.truffle.api.interop.TruffleObject;
-import java.lang.System.Logger.Level;
-import java.nio.file.Paths;
-import java.util.concurrent.Callable;
 import org.enso.interpreter.runtime.callable.UnresolvedConstructor;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.error.DataflowError;
-import org.enso.polyglot.RuntimeOptions;
+import org.enso.interpreter.test.TestBase;
 import org.graalvm.polyglot.Context;
-import org.graalvm.polyglot.Value;
-import org.graalvm.polyglot.io.IOAccess;
-import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TypeOfNodeTest {
+public class TypeOfNodeTest extends TestBase {
 
   private static Context ctx;
 
@@ -71,47 +65,5 @@ public class TypeOfNodeTest {
           assertEquals(expectedTypeName, symbolTypeValue.getMetaSimpleName());
           return null;
         });
-  }
-
-  private static Context.Builder defaultContextBuilder(String... languages) {
-    return Context.newBuilder(languages)
-        .allowExperimentalOptions(true)
-        .allowIO(IOAccess.ALL)
-        .allowAllAccess(true)
-        .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
-        .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
-        .logHandler(System.err)
-        .option(RuntimeOptions.STRICT_ERRORS, "true")
-        .option(
-            RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
-            Paths.get("../../distribution/component").toFile().getAbsolutePath());
-  }
-
-  private static Value executeInContext(Context ctx, Callable<Object> callable) {
-    // Force initialization of the context
-    ctx.eval("enso", "42");
-    var err = new Exception[1];
-    ctx.getPolyglotBindings()
-        .putMember(
-            "testSymbol",
-            (ProxyExecutable)
-                (Value... args) -> {
-                  try {
-                    return callable.call();
-                  } catch (Exception e) {
-                    err[0] = e;
-                    return null;
-                  }
-                });
-    var res = ctx.getPolyglotBindings().getMember("testSymbol").execute();
-    if (err[0] != null) {
-      throw raise(RuntimeException.class, err[0]);
-    }
-    return res;
-  }
-
-  @SuppressWarnings("unchecked")
-  private static <E extends Throwable> E raise(Class<E> clazz, Throwable t) throws E {
-    throw (E) t;
   }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeTest.java
@@ -4,62 +4,95 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.oracle.truffle.api.interop.TruffleObject;
+import java.util.ArrayList;
 import org.enso.interpreter.runtime.callable.UnresolvedConstructor;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.test.TestBase;
+import org.enso.interpreter.test.ValuesGenerator;
 import org.graalvm.polyglot.Context;
 import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class TypeOfNodeTest extends TestBase {
+  @Parameterized.Parameter(0)
+  public Object value;
+
+  @Parameterized.Parameter(1)
+  public String type;
 
   private static Context ctx;
 
-  @BeforeClass
-  public static void initCtx() throws Exception {
-    ctx = defaultContextBuilder().build();
+  private static Context ctx() {
+    if (ctx == null) {
+      ctx = defaultContextBuilder().build();
+    }
+    return ctx;
+  }
+
+  @Parameterized.Parameters
+  public static Object[][] allPossibleEnsoInterpreterValues() throws Exception {
+    var g = ValuesGenerator.create(ctx());
+    var typeOf =
+        evalModule(
+            ctx(),
+            """
+    from Standard.Base import all
+
+    typ obj = Meta.type_of obj
+    main = typ
+    """);
+    var data = new ArrayList<Object[]>();
+    for (var v : g.allValues()) {
+      var t = typeOf.execute(v);
+      if (!v.isNull()) {
+        assertTrue("Type of " + v + " is " + t, t.isMetaObject());
+        var n = t.getMetaSimpleName();
+        var raw = unwrapValue(ctx(), v);
+        data.add(new Object[] {raw, n});
+      }
+    }
+    data.add(new Object[] {UnresolvedSymbol.build("unknown_name", null), "Function"});
+    data.add(new Object[] {UnresolvedConstructor.build("Unknown_Name"), "Function"});
+    return data.toArray(new Object[0][]);
   }
 
   @AfterClass
   public static void disposeCtx() throws Exception {
-    ctx.close();
+    if (ctx != null) {
+      ctx.close();
+    }
   }
 
   @Test
-  public void typeOfUnknownSymbol() throws Exception {
-    assertType(UnresolvedSymbol.build("unknown_name", null), "Function", false);
+  public void typeOfCheck() {
+    assertType(value, type, false);
   }
 
   @Test
-  public void primeThenTypeUnknownSymbol() throws Exception {
-    assertType(UnresolvedSymbol.build("unknown_name", null), "Function", true);
-  }
-
-  @Test
-  public void typeOfUnknownConstructor() throws Exception {
-    assertType(UnresolvedConstructor.build("Unknown_Name"), "Function", false);
-  }
-
-  @Test
-  public void primeThenTypeUnknownConstructor() throws Exception {
-    assertType(UnresolvedConstructor.build("Unknown_Name"), "Function", true);
+  public void typeOfCheckAfterPriming() {
+    assertType(value, type, true);
   }
 
   private void assertType(Object symbol, String expectedTypeName, boolean withPriming) {
     executeInContext(
-        ctx,
+        ctx(),
         () -> {
           var node = TypeOfNode.build();
+          var root = new TestRootNode((frame) -> node.execute(frame.getArguments()[0]));
+          root.insertChildren(node);
+          var call = root.getCallTarget();
 
           if (withPriming) {
             class ForeignObject implements TruffleObject {}
-            var foreignType = node.execute(new ForeignObject());
+            var foreignType = call.call(new ForeignObject());
             assertTrue(
                 "Empty foreign is unknown: " + foreignType, foreignType instanceof DataflowError);
           }
-          var symbolType = node.execute(symbol);
+          var symbolType = call.call(symbol);
           var symbolTypeValue = ctx.asValue(symbolType);
           assertTrue("It is meta object: " + symbolTypeValue, symbolTypeValue.isMetaObject());
           assertEquals(expectedTypeName, symbolTypeValue.getMetaSimpleName());

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/TestBase.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/TestBase.java
@@ -153,19 +153,19 @@ public abstract class TestBase {
    * node inside a context, all the other nodes, and insert them via {@link
    * #insertChildren(Node...)}.
    */
-  static class TestRootNode extends RootNode {
+  protected static final class TestRootNode extends RootNode {
     private final Function<VirtualFrame, Object> callback;
 
-    TestRootNode() {
+    public TestRootNode() {
       this(null);
     }
 
-    TestRootNode(Function<VirtualFrame, Object> callback) {
+    public TestRootNode(Function<VirtualFrame, Object> callback) {
       super(EnsoLanguage.get(null));
       this.callback = callback;
     }
 
-    void insertChildren(Node... children) {
+    public void insertChildren(Node... children) {
       for (Node child : children) {
         insert(child);
       }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNode.java
@@ -212,7 +212,7 @@ public abstract class TypeOfNode extends Node {
       META_OBJECT;
 
       static Interop resolve(Object value, InteropLibrary interop) {
-        assert !(value instanceof EnsoObject)
+        assert !(value instanceof EnsoObject) || AtomWithAHoleNode.isHole(value)
             : "Don't use interop for EnsoObject: " + value.getClass().getName();
         if (interop.isString(value)) {
           return STRING;

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNode.java
@@ -15,6 +15,7 @@ import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.builtin.Builtins;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
+import org.enso.interpreter.runtime.data.EnsoObject;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.error.DataflowError;
 import org.enso.interpreter.runtime.error.PanicException;
@@ -59,11 +60,6 @@ public abstract class TypeOfNode extends Node {
   @Specialization
   Object doBigInteger(EnsoBigInteger value) {
     return EnsoContext.get(this).getBuiltins().number().getInteger();
-  }
-
-  @Specialization
-  Object doString(String value) {
-    return EnsoContext.get(this).getBuiltins().text();
   }
 
   @Specialization
@@ -216,6 +212,8 @@ public abstract class TypeOfNode extends Node {
       META_OBJECT;
 
       static Interop resolve(Object value, InteropLibrary interop) {
+        assert !(value instanceof EnsoObject)
+            : "Don't use interop for EnsoObject: " + value.getClass().getName();
         if (interop.isString(value)) {
           return STRING;
         }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -222,7 +222,7 @@ public final class EnsoContext {
 
   private static final Assumption checkNodes =
       Truffle.getRuntime().createAssumption("context check");
-  private static final Set<Node> reportedNulllRootNodes = new HashSet<>();
+  private static final Set<Node> reportedNullRootNodes = new HashSet<>();
   private static long checkUntil = Long.MAX_VALUE;
 
   @TruffleBoundary
@@ -230,9 +230,9 @@ public final class EnsoContext {
     if (System.currentTimeMillis() > checkUntil) {
       checkNodes.invalidate();
     }
-    if (reportedNulllRootNodes.add(n)) {
+    if (reportedNullRootNodes.add(n)) {
       var ex =
-          new Exception(
+          new AssertionError(
               """
         no root node for {n}
         with section: {s}
@@ -243,6 +243,11 @@ public final class EnsoContext {
                   .replace("{r}", "" + n.getRootNode()));
       ex.printStackTrace();
       checkUntil = System.currentTimeMillis() + 10000;
+      var assertsOn = false;
+      assert assertsOn = true;
+      if (assertsOn) {
+        throw ex;
+      }
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedConstructor.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedConstructor.java
@@ -6,6 +6,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.Node;
@@ -14,10 +15,12 @@ import java.util.Objects;
 import org.enso.interpreter.node.callable.InvokeCallableNode.ArgumentsExecutionMode;
 import org.enso.interpreter.node.callable.InvokeCallableNode.DefaultsExecutionMode;
 import org.enso.interpreter.node.callable.dispatch.InvokeFunctionNode;
+import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
 import org.enso.interpreter.runtime.data.EnsoObject;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.data.atom.AtomConstructor;
+import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 import org.enso.interpreter.runtime.state.State;
 
 /**
@@ -29,6 +32,7 @@ import org.enso.interpreter.runtime.state.State;
  * known.
  */
 @ExportLibrary(InteropLibrary.class)
+@ExportLibrary(TypesLibrary.class)
 public final class UnresolvedConstructor implements EnsoObject {
   private static final CallArgumentInfo[] NONE = new CallArgumentInfo[0];
   private final String name;
@@ -157,5 +161,16 @@ public final class UnresolvedConstructor implements EnsoObject {
       var r = invoke.execute(fn, frame, state, unresolved.args);
       return r;
     }
+  }
+
+  @ExportMessage
+  boolean hasType() {
+    return true;
+  }
+
+  @ExportMessage
+  Type getType(@CachedLibrary("this") TypesLibrary thisLib) {
+    var ctx = EnsoContext.get(thisLib);
+    return ctx.getBuiltins().function();
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedConstructor.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedConstructor.java
@@ -1,12 +1,12 @@
 package org.enso.interpreter.runtime.callable;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.InteropLibrary;
-import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.Node;
@@ -169,8 +169,8 @@ public final class UnresolvedConstructor implements EnsoObject {
   }
 
   @ExportMessage
-  Type getType(@CachedLibrary("this") TypesLibrary thisLib) {
-    var ctx = EnsoContext.get(thisLib);
+  Type getType(@Bind("$node") Node node) {
+    var ctx = EnsoContext.get(node);
     return ctx.getBuiltins().function();
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedConversion.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedConversion.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.runtime.callable;
 
+import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -8,16 +9,19 @@ import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
+import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.Constants;
 import org.enso.interpreter.node.callable.InteropConversionCallNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.data.EnsoObject;
 import org.enso.interpreter.runtime.data.Type;
+import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 import org.enso.interpreter.runtime.scope.ModuleScope;
 
 /** Simple runtime value representing a yet-unresolved by-name symbol. */
 @ExportLibrary(InteropLibrary.class)
+@ExportLibrary(TypesLibrary.class)
 public final class UnresolvedConversion implements EnsoObject {
   private final ModuleScope scope;
 
@@ -105,5 +109,16 @@ public final class UnresolvedConversion implements EnsoObject {
       return interopConversionCallNode.execute(
           conversion, EnsoContext.get(thisLib).emptyState(), arguments);
     }
+  }
+
+  @ExportMessage
+  boolean hasType() {
+    return true;
+  }
+
+  @ExportMessage
+  Type getType(@Bind("$node") Node node) {
+    var ctx = EnsoContext.get(node);
+    return ctx.getBuiltins().function();
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedSymbol.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedSymbol.java
@@ -1,6 +1,7 @@
 package org.enso.interpreter.runtime.callable;
 
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -131,8 +132,8 @@ public final class UnresolvedSymbol implements EnsoObject {
   }
 
   @ExportMessage
-  Type getType(@CachedLibrary("this") TypesLibrary thisLib) {
-    var ctx = EnsoContext.get(thisLib);
+  Type getType(@Bind("$node") Node node) {
+    var ctx = EnsoContext.get(node);
     return ctx.getBuiltins().function();
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedSymbol.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedSymbol.java
@@ -132,7 +132,7 @@ public final class UnresolvedSymbol implements EnsoObject {
   }
 
   @ExportMessage
-  Type getType(@Bind("$node") Node node) {
+  Type getType(@Bind("$node") Node node, @Cached("1") int ignore) {
     var ctx = EnsoContext.get(node);
     return ctx.getBuiltins().function();
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedSymbol.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedSymbol.java
@@ -16,11 +16,13 @@ import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.function.Function;
 import org.enso.interpreter.runtime.data.EnsoObject;
 import org.enso.interpreter.runtime.data.Type;
+import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 import org.enso.interpreter.runtime.scope.ModuleScope;
 import org.graalvm.collections.Pair;
 
 /** Simple runtime value representing a yet-unresolved by-name symbol. */
 @ExportLibrary(InteropLibrary.class)
+@ExportLibrary(TypesLibrary.class)
 public final class UnresolvedSymbol implements EnsoObject {
   private final String name;
   private final ModuleScope scope;
@@ -121,5 +123,16 @@ public final class UnresolvedSymbol implements EnsoObject {
       return interopMethodCallNode.execute(
           symbol, EnsoContext.get(thisLib).emptyState(), arguments);
     }
+  }
+
+  @ExportMessage
+  boolean hasType() {
+    return true;
+  }
+
+  @ExportMessage
+  Type getType(@CachedLibrary("this") TypesLibrary thisLib) {
+    var ctx = EnsoContext.get(thisLib);
+    return ctx.getBuiltins().function();
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/vector/ArrayOverBuffer.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/vector/ArrayOverBuffer.java
@@ -1,12 +1,18 @@
 package org.enso.interpreter.runtime.data.vector;
 
+import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.InvalidArrayIndexException;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
+import com.oracle.truffle.api.nodes.Node;
 import java.nio.ByteBuffer;
+import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.data.EnsoObject;
+import org.enso.interpreter.runtime.data.Type;
+import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 
+@ExportLibrary(TypesLibrary.class)
 @ExportLibrary(InteropLibrary.class)
 final class ArrayOverBuffer implements EnsoObject {
   private final ByteBuffer buffer;
@@ -37,6 +43,17 @@ final class ArrayOverBuffer implements EnsoObject {
   @ExportMessage
   long getArraySize() {
     return buffer.remaining();
+  }
+
+  @ExportMessage
+  boolean hasType() {
+    return true;
+  }
+
+  @ExportMessage
+  Type getType(@Bind("$node") Node node) {
+    var ctx = EnsoContext.get(node);
+    return ctx.getBuiltins().array();
   }
 
   static ArrayOverBuffer wrapBuffer(ByteBuffer buffer) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/vector/ArraySlice.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/vector/ArraySlice.java
@@ -1,6 +1,7 @@
 package org.enso.interpreter.runtime.data.vector;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Cached.Shared;
 import com.oracle.truffle.api.interop.InteropLibrary;
@@ -13,10 +14,13 @@ import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.node.expression.builtin.interop.syntax.HostValueToEnsoNode;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.data.EnsoObject;
+import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.error.Warning;
 import org.enso.interpreter.runtime.error.WarningsLibrary;
 import org.enso.interpreter.runtime.error.WithWarnings;
+import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 
+@ExportLibrary(TypesLibrary.class)
 @ExportLibrary(InteropLibrary.class)
 @ExportLibrary(WarningsLibrary.class)
 final class ArraySlice implements EnsoObject {
@@ -169,5 +173,16 @@ final class ArraySlice implements EnsoObject {
   @ExportMessage
   boolean isLimitReached(@Shared("warnsLib") @CachedLibrary(limit = "3") WarningsLibrary warnings) {
     return warnings.isLimitReached(this.storage);
+  }
+
+  @ExportMessage
+  boolean hasType() {
+    return true;
+  }
+
+  @ExportMessage
+  Type getType(@Bind("$node") Node node) {
+    var ctx = EnsoContext.get(node);
+    return ctx.getBuiltins().array();
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -20,6 +20,7 @@ import org.enso.interpreter.node.expression.builtin.text.util.TypeToDisplayTextN
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.callable.argument.CallArgumentInfo;
+import org.enso.interpreter.runtime.data.EnsoObject;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.data.text.Text;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
@@ -28,7 +29,7 @@ import org.enso.interpreter.runtime.state.State;
 /** An exception type for user thrown panic exceptions. */
 @ExportLibrary(value = InteropLibrary.class, delegateTo = "payload")
 @ExportLibrary(TypesLibrary.class)
-public final class PanicException extends AbstractTruffleException {
+public final class PanicException extends AbstractTruffleException implements EnsoObject {
   final Object payload;
   private String cacheMessage;
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicSentinel.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicSentinel.java
@@ -4,6 +4,7 @@ import com.oracle.truffle.api.exception.AbstractTruffleException;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.Node;
+import org.enso.interpreter.runtime.data.EnsoObject;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 
 /**
@@ -13,7 +14,7 @@ import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
  * not function in textual mode.
  */
 @ExportLibrary(TypesLibrary.class)
-public class PanicSentinel extends AbstractTruffleException {
+public final class PanicSentinel extends AbstractTruffleException implements EnsoObject {
   final PanicException panic;
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
@@ -12,6 +12,7 @@ import com.oracle.truffle.api.nodes.Node;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.data.ArrayRope;
 import org.enso.interpreter.runtime.data.EnsoObject;
+import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 import org.graalvm.collections.EconomicSet;
 import org.graalvm.collections.Equivalence;
@@ -219,6 +220,16 @@ public final class WithWarnings implements EnsoObject {
   @ExportMessage
   public boolean isLimitReached() {
     return limitReached;
+  }
+
+  @ExportMessage
+  boolean hasType(@Shared("typesLib") @CachedLibrary(limit = "3") TypesLibrary types) {
+    return types.hasType(value);
+  }
+
+  @ExportMessage
+  Type getType(@Shared("typesLib") @CachedLibrary(limit = "3") TypesLibrary types) {
+    return types.getType(value);
   }
 
   @ExportMessage

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/scope/ModuleScope.java
@@ -1,6 +1,8 @@
 package org.enso.interpreter.runtime.scope;
 
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.library.ExportLibrary;
+import com.oracle.truffle.api.library.ExportMessage;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -18,9 +20,11 @@ import org.enso.interpreter.runtime.data.EnsoObject;
 import org.enso.interpreter.runtime.data.Type;
 import org.enso.interpreter.runtime.error.RedefinedConversionException;
 import org.enso.interpreter.runtime.error.RedefinedMethodException;
+import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 import org.enso.interpreter.runtime.util.CachingSupplier;
 
 /** A representation of Enso's per-file top-level scope. */
+@ExportLibrary(TypesLibrary.class)
 public final class ModuleScope implements EnsoObject {
   private final Type associatedType;
   private final Module module;
@@ -300,6 +304,7 @@ public final class ModuleScope implements EnsoObject {
     return types;
   }
 
+  @ExportMessage.Ignore
   public Optional<Type> getType(String name) {
     if (associatedType.getName().equals(name)) {
       return Optional.of(associatedType);
@@ -424,6 +429,16 @@ public final class ModuleScope implements EnsoObject {
         conversions,
         imports,
         exports);
+  }
+
+  @ExportMessage
+  boolean hasType() {
+    return true;
+  }
+
+  @ExportMessage
+  Type getType() {
+    return getAssociatedType();
   }
 
   @Override

--- a/engine/runtime/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeTest.java
@@ -4,12 +4,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.oracle.truffle.api.interop.TruffleObject;
+import java.lang.System.Logger.Level;
+import java.nio.file.Paths;
 import java.util.concurrent.Callable;
 import org.enso.interpreter.runtime.callable.UnresolvedConstructor;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.error.DataflowError;
+import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
+import org.graalvm.polyglot.io.IOAccess;
 import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -21,7 +25,7 @@ public class TypeOfNodeTest {
 
   @BeforeClass
   public static void initCtx() throws Exception {
-    ctx = Context.create();
+    ctx = defaultContextBuilder().build();
   }
 
   @AfterClass
@@ -67,6 +71,20 @@ public class TypeOfNodeTest {
           assertEquals(expectedTypeName, symbolTypeValue.getMetaSimpleName());
           return null;
         });
+  }
+
+  private static Context.Builder defaultContextBuilder(String... languages) {
+    return Context.newBuilder(languages)
+        .allowExperimentalOptions(true)
+        .allowIO(IOAccess.ALL)
+        .allowAllAccess(true)
+        .option(RuntimeOptions.LOG_LEVEL, Level.WARNING.getName())
+        .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
+        .logHandler(System.err)
+        .option(RuntimeOptions.STRICT_ERRORS, "true")
+        .option(
+            RuntimeOptions.LANGUAGE_HOME_OVERRIDE,
+            Paths.get("../../distribution/component").toFile().getAbsolutePath());
   }
 
   private static Value executeInContext(Context ctx, Callable<Object> callable) {

--- a/engine/runtime/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeTest.java
@@ -50,7 +50,6 @@ public class TypeOfNodeTest {
   }
 
   private void assertType(Object symbol, String expectedTypeName, boolean withPriming) {
-    var ctx = Context.create();
     executeInContext(
         ctx,
         () -> {

--- a/engine/runtime/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeTest.java
@@ -1,0 +1,90 @@
+package org.enso.interpreter.node.expression.builtin.meta;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.oracle.truffle.api.interop.TruffleObject;
+import java.util.concurrent.Callable;
+import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
+import org.enso.interpreter.runtime.error.DataflowError;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+import org.graalvm.polyglot.proxy.ProxyExecutable;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TypeOfNodeTest {
+
+  private static Context ctx;
+
+  @BeforeClass
+  public static void initCtx() throws Exception {
+    ctx = Context.create();
+  }
+
+  @AfterClass
+  public static void disposeCtx() throws Exception {
+    ctx.close();
+  }
+
+  @Test
+  public void typeOfUnknownSymbol() throws Exception {
+    assertType("Function", false);
+  }
+
+  @Test
+  public void primeThenTypeUnknownSymbol() throws Exception {
+    assertType("Function", true);
+  }
+
+  private void assertType(String expectedTypeName, boolean withPriming) {
+    var ctx = Context.create();
+    executeInContext(
+        ctx,
+        () -> {
+          var node = TypeOfNode.build();
+
+          if (withPriming) {
+            class ForeignObject implements TruffleObject {}
+            var foreignType = node.execute(new ForeignObject());
+            assertTrue(
+                "Empty foreign is unknown: " + foreignType, foreignType instanceof DataflowError);
+          }
+          var symbol = UnresolvedSymbol.build("unknown_name", null);
+          var symbolType = node.execute(symbol);
+          var symbolTypeValue = ctx.asValue(symbolType);
+          assertTrue("It is meta object: " + symbolTypeValue, symbolTypeValue.isMetaObject());
+          assertEquals(expectedTypeName, symbolTypeValue.getMetaSimpleName());
+          return null;
+        });
+  }
+
+  private static Value executeInContext(Context ctx, Callable<Object> callable) {
+    // Force initialization of the context
+    ctx.eval("enso", "42");
+    var err = new Exception[1];
+    ctx.getPolyglotBindings()
+        .putMember(
+            "testSymbol",
+            (ProxyExecutable)
+                (Value... args) -> {
+                  try {
+                    return callable.call();
+                  } catch (Exception e) {
+                    err[0] = e;
+                    return null;
+                  }
+                });
+    var res = ctx.getPolyglotBindings().getMember("testSymbol").execute();
+    if (err[0] != null) {
+      throw raise(RuntimeException.class, err[0]);
+    }
+    return res;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <E extends Throwable> E raise(Class<E> clazz, Throwable t) throws E {
+    throw (E) t;
+  }
+}

--- a/engine/runtime/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeTest.java
+++ b/engine/runtime/src/test/java/org/enso/interpreter/node/expression/builtin/meta/TypeOfNodeTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.oracle.truffle.api.interop.TruffleObject;
 import java.util.concurrent.Callable;
+import org.enso.interpreter.runtime.callable.UnresolvedConstructor;
 import org.enso.interpreter.runtime.callable.UnresolvedSymbol;
 import org.enso.interpreter.runtime.error.DataflowError;
 import org.graalvm.polyglot.Context;
@@ -30,15 +31,25 @@ public class TypeOfNodeTest {
 
   @Test
   public void typeOfUnknownSymbol() throws Exception {
-    assertType("Function", false);
+    assertType(UnresolvedSymbol.build("unknown_name", null), "Function", false);
   }
 
   @Test
   public void primeThenTypeUnknownSymbol() throws Exception {
-    assertType("Function", true);
+    assertType(UnresolvedSymbol.build("unknown_name", null), "Function", true);
   }
 
-  private void assertType(String expectedTypeName, boolean withPriming) {
+  @Test
+  public void typeOfUnknownConstructor() throws Exception {
+    assertType(UnresolvedConstructor.build("Unknown_Name"), "Function", false);
+  }
+
+  @Test
+  public void primeThenTypeUnknownConstructor() throws Exception {
+    assertType(UnresolvedConstructor.build("Unknown_Name"), "Function", true);
+  }
+
+  private void assertType(Object symbol, String expectedTypeName, boolean withPriming) {
     var ctx = Context.create();
     executeInContext(
         ctx,
@@ -51,7 +62,6 @@ public class TypeOfNodeTest {
             assertTrue(
                 "Empty foreign is unknown: " + foreignType, foreignType instanceof DataflowError);
           }
-          var symbol = UnresolvedSymbol.build("unknown_name", null);
           var symbolType = node.execute(symbol);
           var symbolTypeValue = ctx.asValue(symbolType);
           assertTrue("It is meta object: " + symbolTypeValue, symbolTypeValue.isMetaObject());


### PR DESCRIPTION
### Pull Request Description

Fixing inconsistency in `@Specialization` in `TypeOfNode` discovered by Radek. Testing the node in two situations - directly and after being _primed_ to access interop `TruffleObject` first.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides.- All code has been tested:
  - [x] Unit tests have been written where possible.
