### PR TITLE
Debug JavaScript/Python in Enso Source

### DIFF
--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -1916,6 +1916,7 @@ class IrToTruffle(
           case Foreign.Definition(lang, code, _, _, _) =>
             buildForeignBody(
               lang,
+              body.location,
               code,
               arguments.map(_.name.name),
               argSlotIdxs
@@ -1977,12 +1978,18 @@ class IrToTruffle(
 
     private def buildForeignBody(
       language: String,
+      location: Option[IdentifiedLocation],
       code: String,
       argumentNames: List[String],
       argumentSlotIdxs: List[Int]
     ): RuntimeExpression = {
-      val src =
-        Source.newBuilder("epb", language + "#" + code, scopeName).build()
+      val line = location
+        .map(l => source.createSection(l.start, l.length).getStartLine())
+        .getOrElse(0)
+      val name = scopeName.replace('.', '_') + "." + language
+      val b    = Source.newBuilder("epb", language + ":" + line + "#" + code, name)
+      b.uri(source.getURI())
+      val src       = b.build()
       val foreignCt = context.parseInternal(src, argumentNames: _*)
       val argumentReaders = argumentSlotIdxs
         .map(slotIdx =>

--- a/tools/enso4igv/pom.xml
+++ b/tools/enso4igv/pom.xml
@@ -232,6 +232,13 @@
             <type>jar</type>
         </dependency>
         <dependency>
+            <groupId>org.netbeans.modules</groupId>
+            <artifactId>org-netbeans-modules-lexer-nbbridge</artifactId>
+            <version>${netbeans.version}</version>
+            <scope>test</scope>
+            <type>jar</type>
+        </dependency>
+        <dependency>
             <groupId>org.netbeans.api</groupId>
             <artifactId>org-netbeans-modules-extexecution-base</artifactId>
             <version>${netbeans.version}</version>

--- a/tools/enso4igv/src/main/resources/org/enso/tools/enso4igv/enso.tmLanguage.json
+++ b/tools/enso4igv/src/main/resources/org/enso/tools/enso4igv/enso.tmLanguage.json
@@ -86,6 +86,30 @@
 					}]
 				},
 				{
+					"name": "entity.name.function",
+					"contentName": "foreign.js",
+					"begin": "^(\\s*)(foreign)\\s+js\\s*([^\\s]+).*=(.*$)",
+					"end": "^(?!\\1\\s+)(?!\\s*$)",
+					"beginCaptures": {
+						"2" : { "name": "keyword.other" },
+						"3" : { "name": "entity.name.function"},
+						"4" : { "name": "header"}
+					},
+					"patterns": [ { "include": "source.js" }]
+				},
+				{
+					"name": "entity.name.function",
+					"contentName": "foreign.python",
+					"begin": "^(\\s*)(foreign)\\s+python\\s*([^\\s]+).*=(.*$)",
+					"end": "^(?!\\1\\s+)(?!\\s*$)",
+					"beginCaptures": {
+						"2" : { "name": "keyword.other" },
+						"3" : { "name": "entity.name.function"},
+						"4" : { "name": "header"}
+					},
+					"patterns": [ { "include": "source.python" }]
+				},
+				{
 					"contentName": "string.quoted.triple.begin",
 					"begin": "^(\\s*)(\"\"\"|''')",
 					"end": "^(?!\\1\\s+)(?!\\s*$)",

--- a/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/EnsoTextMateTest.java
+++ b/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/EnsoTextMateTest.java
@@ -1,0 +1,53 @@
+package org.enso.tools.enso4igv;
+
+import java.util.List;
+import static org.junit.Assert.assertEquals;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import org.netbeans.api.lexer.Language;
+import org.netbeans.api.lexer.TokenId;
+import org.netbeans.api.lexer.TokenSequence;
+
+public class EnsoTextMateTest {
+
+    private static Language<? extends TokenId> ensoLanguage;
+
+    @BeforeClass
+    public static void findEnsoLanguage() {
+        ensoLanguage = org.netbeans.api.lexer.Language.find("application/x-enso");
+        assertNotNull("Needs org-netbeans-modules-lexer-nbbridge dependency", ensoLanguage);
+    }
+
+    @Test
+    public void testSimpleMain() {
+        var code = """
+                  main = 42
+                  """;
+        var hier = org.netbeans.api.lexer.TokenHierarchy.create(code, ensoLanguage);
+        assertNotNull(hier);
+        var seq = hier.tokenSequence();
+        assertEquals(6, seq.tokenCount());
+        assertNextToken(seq, "main", "entity.name.function");
+        assertNextToken(seq, " ", null);
+        assertNextToken(seq, "=", "keyword.operator");
+        assertNextToken(seq, " ", null);
+        assertNextToken(seq, "42", "constant.character.numeric");
+    }
+
+    private static void assertNextToken(TokenSequence<?> seq, String expectedText, String expectedCategory) {
+        assertTrue("Can move next", seq.moveNext());
+        var tok = seq.token();
+        assertNotNull("Token found", tok);
+        if (expectedText != null) {
+            assertEquals(expectedText, tok.text().toString());
+        }
+        if (expectedCategory != null) {
+            var categories = (List<String>) tok.getProperty("categories");
+            var at = categories.indexOf(expectedCategory);
+            assertNotEquals("Category " + expectedCategory + " found in " + categories, -1, at);
+        }
+    }
+}

--- a/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/EnsoTextMateTest.java
+++ b/tools/enso4igv/src/test/java/org/enso/tools/enso4igv/EnsoTextMateTest.java
@@ -2,6 +2,7 @@ package org.enso.tools.enso4igv;
 
 import java.util.List;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.assertNotEquals;
@@ -37,7 +38,40 @@ public class EnsoTextMateTest {
         assertNextToken(seq, "42", "constant.character.numeric");
     }
 
+    @Test
+    public void testForeignJavaScriptFunction() {
+        var code = """
+                  foreign js dbg = '''
+                      debugger;
+                  """;
+        var hier = org.netbeans.api.lexer.TokenHierarchy.create(code, ensoLanguage);
+        assertNotNull(hier);
+        var seq = hier.tokenSequence();
+        assertEquals(4, seq.tokenCount());
+        assertNextToken(seq, "foreign js dbg = ", null);
+        assertNextToken(seq, "'''", "string.quoted.triple.begin");
+        assertNextToken(seq, "\n", null);
+        assertNextToken(seq, "    debugger;\n", null);
+        assertFalse("EOF", seq.moveNext());
+    }
+
     private static void assertNextToken(TokenSequence<?> seq, String expectedText, String expectedCategory) {
+        try {
+            assertNextTokenImpl(seq, expectedText, expectedCategory);
+        } catch (AssertionError err) {
+            var sb = new StringBuilder();
+            sb.append(err.getMessage()).append("\n");
+            sb.append("Remaining tokens:\n");
+            seq.movePrevious();
+            while (seq.moveNext()) {
+                final Object categories = seq.token().getProperty("categories");
+                sb.append(seq.token().text()).append(" categories: ").append(categories).append("\n");
+            }
+            throw new AssertionError(sb.toString(), err);
+        }
+    }
+
+    private static void assertNextTokenImpl(TokenSequence<?> seq, String expectedText, String expectedCategory) {
         assertTrue("Can move next", seq.moveNext());
         var tok = seq.token();
         assertNotNull("Token found", tok);
@@ -46,6 +80,7 @@ public class EnsoTextMateTest {
         }
         if (expectedCategory != null) {
             var categories = (List<String>) tok.getProperty("categories");
+            assertNotNull("Categories found", categories);
             var at = categories.indexOf(expectedCategory);
             assertNotEquals("Category " + expectedCategory + " found in " + categories, -1, at);
         }


### PR DESCRIPTION
### Pull Request Description

Extends the TextMate grammar to recognize `foreign js` and `foreign python` blocks and colorize them properly. Assigns URI and line numbers to properly match the location of the embedded `foreign` code blocks. As a result VSCode debugger smoothly steps from Enso to JavaScript or Python code.

### Picture

![image](https://github.com/enso-org/enso/assets/26887752/7e3c0fad-d312-4016-9218-2380f93f7e03)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides.
- All code has been tested:
  - [x] Code was manually tested
  - [x] Unit test written in 43ef037