### PR TITLE
Wrong type dropdown for join_kind.

### DIFF
--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
@@ -143,8 +143,8 @@ make_filter_condition_selector table display=Display.Always =
    Make a join kind selector - Needed to override display.
 make_join_kind_selector : Display -> Widget
 make_join_kind_selector display=Display.Always =
-    meta = Meta.meta Join_Kind
-    options = meta.constructors.map c-> Option c.name meta.qualified_name+"."+c.name
+    fqn = Meta.get_qualified_type_name Join_Kind
+    options = ["Inner", "Left_Outer", "Right_Outer", "Full", "Left_Exclusive", "Right_Exclusive"].map n-> Option n fqn+"."+n
     Single_Choice display=display values=options
 
 ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
@@ -8,6 +8,7 @@ from Standard.Base.Widget_Helpers import make_format_chooser
 
 import project.Data.Aggregate_Column.Aggregate_Column
 import project.Data.Join_Condition.Join_Condition
+import project.Data.Join_Kind.Join_Kind
 import project.Data.Sort_Column.Sort_Column
 import project.Data.Table.Table
 import project.Data.Type.Value_Type.Auto
@@ -142,7 +143,7 @@ make_filter_condition_selector table display=Display.Always =
    Make a join kind selector - Needed to override display.
 make_join_kind_selector : Display -> Widget
 make_join_kind_selector display=Display.Always =
-    meta = Meta.meta Value_Type
+    meta = Meta.meta Join_Kind
     options = meta.constructors.map c-> Option c.name meta.qualified_name+"."+c.name
     Single_Choice display=display values=options
 


### PR DESCRIPTION
### Pull Request Description

Had the incorrect type in the join_kind drop down when overriding for display.

![image](https://github.com/enso-org/enso/assets/4699705/dbf0e569-62c4-444b-901d-28c0251c2ef2)


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
