### PR TITLE
Hide scrollbars until track hovered

### DIFF
--- a/app/gui2/src/components/SceneScroller.vue
+++ b/app/gui2/src/components/SceneScroller.vue
@@ -52,6 +52,13 @@ function scroll(event: ScrollbarEvent) {
       scrollingState.value = undefined
       break
     }
+    case 'jump': {
+      const proportionalPos = event.position / scrollInputs.value.range.getAxis(event.axis)
+      const scaledPos = proportionalPos * props.scrollableArea.size.getAxis(event.axis)
+      const pos = scaledPos + props.scrollableArea.pos.getAxis(event.axis)
+      props.navigator.scrollTo(props.navigator.viewport.center().setAxis(event.axis, pos))
+      break
+    }
   }
 }
 </script>

--- a/app/gui2/src/components/ScrollBar.vue
+++ b/app/gui2/src/components/ScrollBar.vue
@@ -100,8 +100,8 @@ export type ScrollbarEvent =
 
 <template>
   <div ref="element" class="ScrollBar" @click.stop @pointerdown.stop @pointerup.stop>
-    <div class="bar vertical" :class="{ full: yFull }" v-on="yDrag.events" />
-    <div class="bar horizontal" :class="{ full: xFull }" v-on="xDrag.events" />
+    <div class="bar vertical" v-on="yDrag.events" />
+    <div class="bar horizontal" v-on="xDrag.events" />
   </div>
 </template>
 
@@ -148,7 +148,8 @@ export type ScrollbarEvent =
   }
 }
 
-.full {
+/* Hide until hovered */
+.bar {
   transition: opacity 0.2s ease-in;
   opacity: 0;
   &:hover {

--- a/app/gui2/src/util/data/vec2.ts
+++ b/app/gui2/src/util/data/vec2.ts
@@ -98,6 +98,14 @@ export class Vec2 {
   toString(): string {
     return `(${this.x}, ${this.y})`
   }
+
+  getAxis(axis: 'x' | 'y'): number {
+    return axis === 'x' ? this.x : this.y
+  }
+
+  setAxis(axis: 'x' | 'y', value: number) {
+    return new Vec2(axis === 'x' ? value : this.x, axis === 'y' ? value : this.y)
+  }
 }
 
 Vec2.Zero = new Vec2(0, 0)


### PR DESCRIPTION
### Pull Request Description

Hide scrollbars until track area is hovered
- Hovering track area now shows a track
- Clicking in track moves center of scrollbar to position

(Small change requested by @wdanilo)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
