### PR TITLE
impr(enso/cloud-v2#912): Add `organization_id` and `user_id` fields to `SimpleUser`

### DIFF
--- a/app/ide-desktop/lib/dashboard/e2e/api.ts
+++ b/app/ide-desktop/lib/dashboard/e2e/api.ts
@@ -633,11 +633,12 @@ export async function mockApi({ page }: MockParams) {
             permissions: [
               {
                 user: {
-                  pk: backend.Subject(''),
+                  pk: defaultOrganizationId,
+                  sk: backend.UserId(''),
+                  user_subject: backend.Subject(''),
                   /* eslint-disable @typescript-eslint/naming-convention */
                   user_name: defaultUsername,
                   user_email: defaultEmail,
-                  organization_id: defaultOrganizationId,
                   /* eslint-enable @typescript-eslint/naming-convention */
                 },
                 permission: permissions.PermissionAction.own,
@@ -671,11 +672,12 @@ export async function mockApi({ page }: MockParams) {
             permissions: [
               {
                 user: {
-                  pk: backend.Subject(''),
+                  pk: defaultOrganizationId,
+                  sk: backend.UserId(''),
+                  user_subject: backend.Subject(''),
                   /* eslint-disable @typescript-eslint/naming-convention */
                   user_name: defaultUsername,
                   user_email: defaultEmail,
-                  organization_id: defaultOrganizationId,
                   /* eslint-enable @typescript-eslint/naming-convention */
                 },
                 permission: permissions.PermissionAction.own,

--- a/app/ide-desktop/lib/dashboard/e2e/api.ts
+++ b/app/ide-desktop/lib/dashboard/e2e/api.ts
@@ -635,8 +635,8 @@ export async function mockApi({ page }: MockParams) {
                 user: {
                   pk: defaultOrganizationId,
                   sk: backend.UserId(''),
-                  user_subject: backend.Subject(''),
                   /* eslint-disable @typescript-eslint/naming-convention */
+                  user_subject: backend.Subject(''),
                   user_name: defaultUsername,
                   user_email: defaultEmail,
                   /* eslint-enable @typescript-eslint/naming-convention */
@@ -674,8 +674,8 @@ export async function mockApi({ page }: MockParams) {
                 user: {
                   pk: defaultOrganizationId,
                   sk: backend.UserId(''),
-                  user_subject: backend.Subject(''),
                   /* eslint-disable @typescript-eslint/naming-convention */
+                  user_subject: backend.Subject(''),
                   user_name: defaultUsername,
                   user_email: defaultEmail,
                   /* eslint-enable @typescript-eslint/naming-convention */

--- a/app/ide-desktop/lib/dashboard/e2e/assetPanel.spec.ts
+++ b/app/ide-desktop/lib/dashboard/e2e/assetPanel.spec.ts
@@ -34,8 +34,9 @@ test.test('asset panel contents', async ({ page }) => {
         permission: permissions.PermissionAction.own,
         user: {
           /* eslint-disable @typescript-eslint/naming-convention */
-          pk: backend.Subject(''),
-          organization_id: defaultOrganizationId,
+          pk: defaultOrganizationId,
+          sk: backend.UserId(''),
+          user_subject: backend.Subject(''),
           user_name: username,
           user_email: backend.EmailAddress(email),
           /* eslint-enable @typescript-eslint/naming-convention */

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/AssetRow.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/AssetRow.tsx
@@ -430,7 +430,7 @@ export default function AssetRow(props: AssetRowProps) {
             await backend.createPermission({
               action: null,
               resourceId: asset.id,
-              actorsIds: userInfo.userId == null ? [] : [userInfo.userId],
+              actorsIds: [userInfo.userId],
             })
             dispatchAssetListEvent({ type: AssetListEventType.delete, key: item.key })
           } catch (error) {

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/AssetRow.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/AssetRow.tsx
@@ -430,7 +430,7 @@ export default function AssetRow(props: AssetRowProps) {
             await backend.createPermission({
               action: null,
               resourceId: asset.id,
-              userSubjects: [userInfo.id],
+              actorsIds: userInfo.userId == null ? [] : [userInfo.userId],
             })
             dispatchAssetListEvent({ type: AssetListEventType.delete, key: item.key })
           } catch (error) {

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/UserPermission.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/UserPermission.tsx
@@ -53,7 +53,7 @@ export default function UserPermission(props: UserPermissionProps) {
     <div className="flex items-center gap-user-permission">
       <PermissionSelector
         showDelete
-        disabled={isOnlyOwner && userPermission.user.pk === self.user.pk}
+        disabled={isOnlyOwner && userPermission.user.sk === self.user.sk}
         error={
           isOnlyOwner
             ? `This ${backendModule.ASSET_TYPE_NAME[asset.type]} must have at least one owner.`

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/UserPermission.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/UserPermission.tsx
@@ -38,7 +38,7 @@ export default function UserPermission(props: UserPermissionProps) {
       setUserPermission(newUserPermissions)
       outerSetUserPermission(newUserPermissions)
       await backend.createPermission({
-        userSubjects: [newUserPermissions.user.pk],
+        actorsIds: [newUserPermissions.user.sk],
         resourceId: asset.id,
         action: newUserPermissions.permission,
       })

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/column/SharedWithColumn.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/column/SharedWithColumn.tsx
@@ -61,7 +61,7 @@ export default function SharedWithColumn(props: SharedWithColumnPropsInternal) {
     <div className="group flex items-center gap-column-items">
       {(asset.permissions ?? []).map(otherUser => (
         <PermissionDisplay
-          key={otherUser.user.pk}
+          key={otherUser.user.sk}
           action={otherUser.permission}
           onClick={event => {
             setQuery(oldQuery =>

--- a/app/ide-desktop/lib/dashboard/src/layouts/Settings/MembersSettingsTab.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/Settings/MembersSettingsTab.tsx
@@ -61,7 +61,7 @@ export default function MembersSettingsTab() {
               </tr>
             ) : (
               members.map(member => (
-                <tr key={member.id} className="h-row">
+                <tr key={member.userId} className="h-row">
                   <td className="text border-x-2 border-transparent bg-clip-padding px-cell-x first:rounded-l-full last:rounded-r-full last:border-r-0 ">
                     {member.name}
                   </td>

--- a/app/ide-desktop/lib/dashboard/src/modals/ManagePermissionsModal.tsx
+++ b/app/ide-desktop/lib/dashboard/src/modals/ManagePermissionsModal.tsx
@@ -163,15 +163,15 @@ export default function ManagePermissionsModal<
           },
           permission: action,
         }))
-        const addedUsersPks = new Set(addedUsersPermissions.map(newUser => newUser.user.pk))
+        const addedUsersSks = new Set(addedUsersPermissions.map(newUser => newUser.user.sk))
         const oldUsersPermissions = permissions.filter(userPermission =>
-          addedUsersPks.has(userPermission.user.pk)
+          addedUsersSks.has(userPermission.user.sk)
         )
         try {
           setPermissions(oldPermissions =>
             [
               ...oldPermissions.filter(
-                oldUserPermissions => !addedUsersPks.has(oldUserPermissions.user.pk)
+                oldUserPermissions => !addedUsersSks.has(oldUserPermissions.user.sk)
               ),
               ...addedUsersPermissions,
             ].sort(backendModule.compareUserPermissions)
@@ -184,7 +184,7 @@ export default function ManagePermissionsModal<
         } catch (error) {
           setPermissions(oldPermissions =>
             [
-              ...oldPermissions.filter(permission => !addedUsersPks.has(permission.user.pk)),
+              ...oldPermissions.filter(permission => !addedUsersSks.has(permission.user.sk)),
               ...oldUsersPermissions,
             ].sort(backendModule.compareUserPermissions)
           )
@@ -197,16 +197,16 @@ export default function ManagePermissionsModal<
     }
 
     const doDelete = async (userToDelete: backendModule.UserInfo) => {
-      if (userToDelete.pk === self.user.pk) {
+      if (userToDelete.sk === self.user.sk) {
         doRemoveSelf()
       } else {
         const oldPermission = permissions.find(
-          userPermission => userPermission.user.pk === userToDelete.pk
+          userPermission => userPermission.user.sk === userToDelete.sk
         )
         try {
           setPermissions(oldPermissions =>
             oldPermissions.filter(
-              oldUserPermissions => oldUserPermissions.user.pk !== userToDelete.pk
+              oldUserPermissions => oldUserPermissions.user.sk !== userToDelete.sk
             )
           )
           await backend.createPermission({
@@ -323,7 +323,7 @@ export default function ManagePermissionsModal<
             </form>
             <div className="max-h-manage-permissions-modal-permissions-list overflow-auto px-manage-permissions-modal-input">
               {editablePermissions.map(userPermission => (
-                <div key={userPermission.user.pk} className="flex h-row items-center">
+                <div key={userPermission.user.sk} className="flex h-row items-center">
                   <UserPermission
                     asset={item}
                     self={self}
@@ -332,12 +332,12 @@ export default function ManagePermissionsModal<
                     setUserPermission={newUserPermission => {
                       setPermissions(oldPermissions =>
                         oldPermissions.map(oldUserPermission =>
-                          oldUserPermission.user.pk === newUserPermission.user.pk
+                          oldUserPermission.user.sk === newUserPermission.user.sk
                             ? newUserPermission
                             : oldUserPermission
                         )
                       )
-                      if (newUserPermission.user.pk === self.user.pk) {
+                      if (newUserPermission.user.sk === self.user.sk) {
                         // This must run only after the permissions have
                         // been updated through `setItem`.
                         setTimeout(() => {
@@ -346,7 +346,7 @@ export default function ManagePermissionsModal<
                       }
                     }}
                     doDelete={userToDelete => {
-                      if (userToDelete.pk === self.user.pk) {
+                      if (userToDelete.sk === self.user.sk) {
                         unsetModal()
                       }
                       void doDelete(userToDelete)

--- a/app/ide-desktop/lib/dashboard/src/modals/ManagePermissionsModal.tsx
+++ b/app/ide-desktop/lib/dashboard/src/modals/ManagePermissionsModal.tsx
@@ -154,8 +154,9 @@ export default function ManagePermissionsModal<
             // The names come from a third-party API and cannot be
             // changed.
             /* eslint-disable @typescript-eslint/naming-convention */
-            organization_id: user.id,
-            pk: newUser.id,
+            pk: newUser.organizationId,
+            sk: newUser.userId,
+            user_subject: newUser.id,
             user_email: newUser.email,
             user_name: newUser.name,
             /* eslint-enable @typescript-eslint/naming-convention */
@@ -176,7 +177,7 @@ export default function ManagePermissionsModal<
             ].sort(backendModule.compareUserPermissions)
           )
           await backend.createPermission({
-            userSubjects: addedUsersPermissions.map(userPermissions => userPermissions.user.pk),
+            actorsIds: addedUsersPermissions.map(userPermissions => userPermissions.user.sk),
             resourceId: item.id,
             action: action,
           })
@@ -209,7 +210,7 @@ export default function ManagePermissionsModal<
             )
           )
           await backend.createPermission({
-            userSubjects: [userToDelete.pk],
+            actorsIds: [userToDelete.sk],
             resourceId: item.id,
             action: null,
           })

--- a/app/ide-desktop/lib/dashboard/src/services/Backend.ts
+++ b/app/ide-desktop/lib/dashboard/src/services/Backend.ts
@@ -14,9 +14,13 @@ import * as uniqueString from '#/utilities/uniqueString'
 // These are constructor functions that construct values of the type they are named after.
 /* eslint-disable @typescript-eslint/no-redeclare */
 
-/** Unique identifier for a user/organization. */
+/** Unique identifier for an organization. */
 export type OrganizationId = newtype.Newtype<string, 'OrganizationId'>
 export const OrganizationId = newtype.newtypeConstructor<OrganizationId>()
+
+/** Unique identifier for a user. */
+export type UserId = newtype.Newtype<string, 'UserId'>
+export const UserId = newtype.newtypeConstructor<UserId>()
 
 /** Unique identifier for a directory. */
 export type DirectoryId = newtype.Newtype<string, 'DirectoryId'>
@@ -380,10 +384,11 @@ export interface ResourceUsage {
 /** Metadata uniquely identifying a user. */
 export interface UserInfo {
   /* eslint-disable @typescript-eslint/naming-convention */
-  readonly pk: Subject
+  readonly pk: OrganizationId
+  readonly sk: UserId
+  readonly user_subject: Subject
   readonly user_name: string
   readonly user_email: EmailAddress
-  readonly organization_id: OrganizationId
   /* eslint-enable @typescript-eslint/naming-convention */
 }
 
@@ -399,8 +404,10 @@ export interface OrganizationInfo {
 }
 
 /** Metadata uniquely identifying a user inside an organization.
- * This is similar to {@link UserInfo}, but without `organization_id`. */
+ * This is similar to {@link UserInfo}, but with different field names. */
 export interface SimpleUser {
+  readonly organizationId: OrganizationId
+  readonly userId: UserId
   readonly id: Subject
   readonly name: string
   readonly email: EmailAddress
@@ -901,7 +908,7 @@ export interface InviteUserRequestBody {
 
 /** HTTP request body for the "create permission" endpoint. */
 export interface CreatePermissionRequestBody {
-  readonly userSubjects: Subject[]
+  readonly actorsIds: UserId[]
   readonly resourceId: AssetId
   readonly action: permissions.PermissionAction | null
 }

--- a/app/ide-desktop/lib/dashboard/src/utilities/permissions.ts
+++ b/app/ide-desktop/lib/dashboard/src/utilities/permissions.ts
@@ -233,8 +233,9 @@ export function tryGetSingletonOwnerPermission(
           user: {
             // The names are defined by the backend and cannot be changed.
             /* eslint-disable @typescript-eslint/naming-convention */
-            pk: user?.id ?? backend.Subject(''),
-            organization_id: owner.id,
+            pk: owner.id,
+            sk: backend.UserId(''),
+            user_subject: user?.id ?? backend.Subject(''),
             user_email: owner.email,
             user_name: owner.name,
             /* eslint-enable @typescript-eslint/naming-convention */


### PR DESCRIPTION
**NOTE: This PR is part of a series of PRs for implementing enso-org/cloud-v2#912. They should be merged in order:**

1. enso-org/cloud-v2#1073
2. **(THIS PR)** #9489
3. #9490

### Pull Request Description

This PR updates the model types for the request/response bodies to match the backend.

Some of these changes are for the (already merged) user groups PRs, (i.e., the switch to `actorsIds`):
- https://github.com/enso-org/cloud-v2/pull/926
- https://github.com/enso-org/cloud-v2/pull/939

Some of these changes are for the (yet to be merged) changes to the `User` types:
- https://github.com/enso-org/cloud-v2/pull/1073

Note that this PR must be **merged after the above PRs have been merged and deployed** to the backend.

- Rename `CreatePermissionRequestBody::userSubjects` to match `CreatePermissionRequestBody::actorsIds` on the backend
- Add `SimpleUser::organizationId` to match the backend
- Add `SimpleUser::userId` to match the backend
- Rename `UserInfo::pk` to `UserInfo::user_subject` to match the backend
- Rename `UserInfo::organization_id` to `UserInfo::pk` to match the backend
- Add `UserInfo::sk: UserId` to match the backend
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
