### PR TITLE
refr(enso/cloud-v2#912): Rename `SimpleUser.id` to `SimpleUser.userSubject`

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/modals/ManagePermissionsModal.tsx
+++ b/app/ide-desktop/lib/dashboard/src/modals/ManagePermissionsModal.tsx
@@ -156,7 +156,7 @@ export default function ManagePermissionsModal<
             /* eslint-disable @typescript-eslint/naming-convention */
             pk: newUser.organizationId,
             sk: newUser.userId,
-            user_subject: newUser.id,
+            user_subject: newUser.userSubject,
             user_email: newUser.email,
             user_name: newUser.name,
             /* eslint-enable @typescript-eslint/naming-convention */
@@ -295,7 +295,7 @@ export default function ManagePermissionsModal<
                     values={users}
                     setValues={setUsers}
                     items={allUsers}
-                    itemToKey={otherUser => otherUser.id}
+                    itemToKey={otherUser => otherUser.userSubject}
                     itemToString={otherUser => `${otherUser.name} (${otherUser.email})`}
                     matches={(otherUser, text) =>
                       otherUser.email.toLowerCase().includes(text.toLowerCase()) ||

--- a/app/ide-desktop/lib/dashboard/src/services/Backend.ts
+++ b/app/ide-desktop/lib/dashboard/src/services/Backend.ts
@@ -408,7 +408,7 @@ export interface OrganizationInfo {
 export interface SimpleUser {
   readonly organizationId: OrganizationId
   readonly userId: UserId
-  readonly id: Subject
+  readonly userSubject: Subject
   readonly name: string
   readonly email: EmailAddress
 }

--- a/app/ide-desktop/lib/dashboard/src/utilities/permissions.ts
+++ b/app/ide-desktop/lib/dashboard/src/utilities/permissions.ts
@@ -235,7 +235,7 @@ export function tryGetSingletonOwnerPermission(
             /* eslint-disable @typescript-eslint/naming-convention */
             pk: owner.id,
             sk: backend.UserId(''),
-            user_subject: user?.id ?? backend.Subject(''),
+            user_subject: user?.userSubject ?? backend.Subject(''),
             user_email: owner.email,
             user_name: owner.name,
             /* eslint-enable @typescript-eslint/naming-convention */


### PR DESCRIPTION
**NOTE: This PR is part of a series of PRs for implementing #912. They should be merged in order:**

1. enso-org/cloud-v2#1073
1. enso-org/cloud-v2#1075
2.  #9489
3. **(THIS PR)**#9490

### Pull Request Description

This PR updates the model types for the request/response bodies to match the backend.

These changes are for the (yet to be merged) changes to the `User` types:
- https://github.com/enso-org/cloud-v2/pull/1075

Note that this PR must be **merged after the above PRs have been merged and deployed** to the backend.

- Rename `SimpleUser::id` to `SimpleUser::userSubject` to match the backend

### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

On the backend, `SimpleUser.id` has been renamed to `SimpleUser.userSubject` for consistency.  This commit updates the frontend to account for this change.
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
