### PR TITLE
Workaround for failing test

### DIFF
--- a/app/gui2/e2e/componentBrowser.spec.ts
+++ b/app/gui2/e2e/componentBrowser.spec.ts
@@ -264,7 +264,7 @@ test('Visualization preview: user visualization selection', async ({ page }) => 
   await expect(locate.graphNode(page)).toHaveCount(nodeCount)
 })
 
-test.only('Component browser handling of overridden record-mode', async ({ page }) => {
+test('Component browser handling of overridden record-mode', async ({ page }) => {
   await actions.goToGraph(page)
   const node = locate.graphNodeByBinding(page, 'data')
   const ADDED_PATH = '"/home/enso/Input.txt"'

--- a/app/gui2/e2e/componentBrowser.spec.ts
+++ b/app/gui2/e2e/componentBrowser.spec.ts
@@ -275,6 +275,10 @@ test.only('Component browser handling of overridden record-mode', async ({ page 
   await locate.graphNodeIcon(node).hover()
   await expect(recordModeToggle).not.toHaveClass(/recording-overridden/)
   await recordModeToggle.click()
+  // TODO[ao]: The simple move near top-left corner not always works i.e. not always
+  //  `pointerleave` event is emitted. Investigated in https://github.com/enso-org/enso/issues/9478
+  //  once fixed, remember to change the second `await page.mouse.move(700, 1200, { steps: 20 })`
+  //  line below.
   await page.mouse.move(700, 1200, { steps: 20 })
   await expect(recordModeIndicator).toBeVisible()
   await locate.graphNodeIcon(node).hover()
@@ -289,6 +293,7 @@ test.only('Component browser handling of overridden record-mode', async ({ page 
   await input.pressSequentially(` ${ADDED_PATH}`)
   await page.keyboard.press('Enter')
   await expect(locate.componentBrowser(page)).not.toBeVisible()
+  // See TODO above.
   await page.mouse.move(700, 1200, { steps: 20 })
   await expect(recordModeIndicator).toBeVisible()
   // Ensure after editing the node, editing still doesn't display the override expression.

--- a/app/gui2/e2e/componentBrowser.spec.ts
+++ b/app/gui2/e2e/componentBrowser.spec.ts
@@ -264,20 +264,18 @@ test('Visualization preview: user visualization selection', async ({ page }) => 
   await expect(locate.graphNode(page)).toHaveCount(nodeCount)
 })
 
-test('Component browser handling of overridden record-mode', async ({ page }) => {
+test.only('Component browser handling of overridden record-mode', async ({ page }) => {
   await actions.goToGraph(page)
   const node = locate.graphNodeByBinding(page, 'data')
   const ADDED_PATH = '"/home/enso/Input.txt"'
   const recordModeToggle = node.getByTestId('overrideRecordingButton')
   const recordModeIndicator = node.getByTestId('recordingOverriddenButton')
-  const MENU_UNHOVER_CLOSE_DELAY = 300
 
   // Enable record mode for the node.
   await locate.graphNodeIcon(node).hover()
   await expect(recordModeToggle).not.toHaveClass(/recording-overridden/)
   await recordModeToggle.click()
-  await page.mouse.move(100, 80)
-  await page.waitForTimeout(MENU_UNHOVER_CLOSE_DELAY)
+  await page.mouse.move(700, 1200, { steps: 20 })
   await expect(recordModeIndicator).toBeVisible()
   await locate.graphNodeIcon(node).hover()
   await expect(recordModeToggle).toHaveClass(/recording-overridden/)
@@ -291,7 +289,7 @@ test('Component browser handling of overridden record-mode', async ({ page }) =>
   await input.pressSequentially(` ${ADDED_PATH}`)
   await page.keyboard.press('Enter')
   await expect(locate.componentBrowser(page)).not.toBeVisible()
-  await page.mouse.move(100, 80)
+  await page.mouse.move(700, 1200, { steps: 20 })
   await expect(recordModeIndicator).toBeVisible()
   // Ensure after editing the node, editing still doesn't display the override expression.
   await locate.graphNodeIcon(node).click({ modifiers: [CONTROL_KEY] })

--- a/app/gui2/playwright.config.ts
+++ b/app/gui2/playwright.config.ts
@@ -36,8 +36,8 @@ process.env.PLAYWRIGHT_PORT = `${PORT}`
 export default defineConfig({
   globalSetup: './e2e/setup.ts',
   testDir: './e2e',
-  // forbidOnly: !!process.env.CI,
-  repeatEach: process.env.CI ? 100 : 1,
+  forbidOnly: !!process.env.CI,
+  repeatEach: process.env.CI ? 3 : 1,
   ...(process.env.CI ? { workers: 1 } : {}),
   timeout: 60000,
   expect: {

--- a/app/gui2/playwright.config.ts
+++ b/app/gui2/playwright.config.ts
@@ -36,8 +36,8 @@ process.env.PLAYWRIGHT_PORT = `${PORT}`
 export default defineConfig({
   globalSetup: './e2e/setup.ts',
   testDir: './e2e',
-  forbidOnly: !!process.env.CI,
-  repeatEach: process.env.CI ? 3 : 1,
+  // forbidOnly: !!process.env.CI,
+  repeatEach: process.env.CI ? 100 : 1,
   ...(process.env.CI ? { workers: 1 } : {}),
   timeout: 60000,
   expect: {


### PR DESCRIPTION
### Pull Request Description

One of our tests had transient failures, which were very tricky to track - it seems that not every `mouse.move` action actually emits 'pointerleave' action, on which we rely when hiding node menu.

I played with different configurations, and this one looks quite reliable (100 runs of tests in a row passed, at least). But I still don't understand what is happening there, and the investigation will be in scope of #9478 

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
