### PR TITLE
Context menu should have a Edit Description on files

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/components/AriaComponents/Button/Button.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/AriaComponents/Button/Button.tsx
@@ -42,15 +42,16 @@ const SIZE_CLASSES = 'px-2 py-1'
 /**
  * A button allows a user to perform an action, with mouse, touch, and keyboard interactions.
  */
-export function Button(props: ButtonProps) {
+export function Button(props: ButtonProps): React.JSX.Element {
   const { className, children, variant, icon, loading = false, ...ariaButtonProps } = props
 
-  const classes = clsx(DEFAULT_CLASSES, DISABLED_CLASSES, FOCUS_CLASSES, SIZE_CLASSES, {
-    [SUBMIT_CLASSES]: variant === 'submit',
-    [CANCEL_CLASSES]: variant === 'cancel',
-    [DELETE_CLASSES]: variant === 'delete',
-    [ICON_CLASSES]: variant === 'icon',
-  })
+  const classes = clsx(
+    DEFAULT_CLASSES,
+    DISABLED_CLASSES,
+    FOCUS_CLASSES,
+    SIZE_CLASSES,
+    VARIANT_TO_CLASSES[variant]
+  )
 
   const childrenFactory = (): React.ReactNode => {
     if (loading) {
@@ -81,4 +82,11 @@ export function Button(props: ButtonProps) {
       {childrenFactory()}
     </reactAriaComponents.Button>
   )
+}
+
+const VARIANT_TO_CLASSES: Record<ButtonProps['variant'], string> = {
+  cancel: CANCEL_CLASSES,
+  delete: DELETE_CLASSES,
+  icon: ICON_CLASSES,
+  submit: SUBMIT_CLASSES,
 }

--- a/app/ide-desktop/lib/dashboard/src/components/AriaComponents/Button/Button.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/AriaComponents/Button/Button.tsx
@@ -3,17 +3,21 @@
  *
  * Button component
  */
+import * as React from 'react'
+
 import clsx from 'clsx'
 import * as reactAriaComponents from 'react-aria-components'
 import * as tailwindMerge from 'tailwind-merge'
 
+import Spinner, * as spinnerModule from '#/components/Spinner'
 import SvgMask from '#/components/SvgMask'
 
 /**
  * Props for the Button component
  */
 export interface ButtonProps extends reactAriaComponents.ButtonProps {
-  readonly variant: 'icon'
+  readonly loading?: boolean
+  readonly variant: 'cancel' | 'delete' | 'icon' | 'submit'
   readonly icon?: string
   /**
    * FIXME: This is not yet implemented
@@ -24,31 +28,44 @@ export interface ButtonProps extends reactAriaComponents.ButtonProps {
 }
 
 const DEFAULT_CLASSES =
-  'flex cursor-pointer rounded-sm border border-transparent transition-opacity duration-200 ease-in-out'
+  'flex cursor-pointer rounded-full border border-transparent transition-opacity duration-200 ease-in-out'
 const FOCUS_CLASSES =
   'focus-visible:outline-offset-2 focus:outline-none focus-visible:outline focus-visible:outline-primary'
+const SUBMIT_CLASSES = 'bg-invite text-white opacity-80 hover:opacity-100'
+const CANCEL_CLASSES = 'bg-selected-frame opacity-80 hover:opacity-100'
+const DELETE_CLASSES = 'bg-delete text-white'
 const ICON_CLASSES = 'opacity-50 hover:opacity-100'
 const EXTRA_CLICK_ZONE_CLASSES = 'flex relative before:inset-[-12px] before:absolute before:z-10'
 const DISABLED_CLASSES = 'disabled:opacity-50 disabled:cursor-not-allowed'
+const SIZE_CLASSES = 'px-2 py-1'
 
 /**
  * A button allows a user to perform an action, with mouse, touch, and keyboard interactions.
  */
 export function Button(props: ButtonProps) {
-  const { className, children, icon, ...ariaButtonProps } = props
+  const { className, children, variant, icon, loading = false, ...ariaButtonProps } = props
 
-  const classes = clsx(DEFAULT_CLASSES, DISABLED_CLASSES, FOCUS_CLASSES, ICON_CLASSES)
+  const classes = clsx(DEFAULT_CLASSES, DISABLED_CLASSES, FOCUS_CLASSES, SIZE_CLASSES, {
+    [SUBMIT_CLASSES]: variant === 'submit',
+    [CANCEL_CLASSES]: variant === 'cancel',
+    [DELETE_CLASSES]: variant === 'delete',
+    [ICON_CLASSES]: variant === 'icon',
+  })
 
-  const childrenFactory = () => {
-    return icon != null ? (
-      <>
-        <div className={EXTRA_CLICK_ZONE_CLASSES}>
-          <SvgMask src={icon} />
-        </div>
-      </>
-    ) : (
-      children
-    )
+  const childrenFactory = (): React.ReactNode => {
+    if (loading) {
+      return <Spinner state={spinnerModule.SpinnerState.loadingMedium} size={16} />
+    } else if (variant === 'icon' && icon != null) {
+      return (
+        <>
+          <div className={EXTRA_CLICK_ZONE_CLASSES}>
+            <SvgMask src={icon} />
+          </div>
+        </>
+      )
+    } else {
+      return <>{children}</>
+    }
   }
 
   return (

--- a/app/ide-desktop/lib/dashboard/src/components/MenuEntry.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/MenuEntry.tsx
@@ -27,6 +27,7 @@ const ACTION_TO_TEXT_ID: Readonly<Record<inputBindings.DashboardBindingKey, text
   uploadToCloud: 'uploadToCloudShortcut',
   rename: 'renameShortcut',
   edit: 'editShortcut',
+  editDescription: 'editDescriptionShortcut',
   snapshot: 'snapshotShortcut',
   delete: 'deleteShortcut',
   undelete: 'undeleteShortcut',

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/AssetRow.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/AssetRow.tsx
@@ -23,6 +23,8 @@ import * as columnModule from '#/components/dashboard/column'
 import * as columnUtils from '#/components/dashboard/column/columnUtils'
 import StatelessSpinner, * as statelessSpinner from '#/components/StatelessSpinner'
 
+import EditAssetDescriptionModal from '#/modals/EditAssetDescriptionModal'
+
 import * as backendModule from '#/services/Backend'
 import * as localBackend from '#/services/LocalBackend'
 import * as projectManager from '#/services/ProjectManager'
@@ -80,11 +82,19 @@ export interface AssetRowProps
     props: AssetRowInnerProps,
     event: React.MouseEvent<HTMLTableRowElement>
   ) => void
+  readonly focusEditDescriptionField: () => void
 }
 
 /** A row containing an {@link backendModule.AnyAsset}. */
 export default function AssetRow(props: AssetRowProps) {
-  const { item: rawItem, hidden: hiddenRaw, selected, isSoleSelected, isKeyboardSelected } = props
+  const {
+    item: rawItem,
+    hidden: hiddenRaw,
+    selected,
+    isSoleSelected,
+    isKeyboardSelected,
+    focusEditDescriptionField,
+  } = props
   const { setSelected, allowContextMenu, onContextMenu, state, columns, onClick } = props
   const { visibilities, assetEvents, dispatchAssetEvent, dispatchAssetListEvent, nodeMap } = state
   const { setAssetPanelProps, doToggleDirectoryExpansion, doCopy, doCut, doPaste } = state
@@ -358,6 +368,26 @@ export default function AssetRow(props: AssetRowProps) {
       toastAndLog('restoreAssetError', error, asset.title)
     }
   }, [backend, dispatchAssetListEvent, asset, toastAndLog, /* should never change */ item.key])
+
+  const doTriggerDescriptionEdit = React.useCallback(() => {
+    setModal(
+      <EditAssetDescriptionModal
+        doChangeDescription={async description => {
+          if (description !== asset.description) {
+            setAsset(object.merger({ description }))
+
+            await backend
+              .updateAsset(item.item.id, { parentDirectoryId: null, description }, item.item.title)
+              .catch(error => {
+                setAsset(object.merger({ description: asset.description }))
+                throw error
+              })
+          }
+        }}
+        initialDescription={asset.description}
+      />
+    )
+  }, [setModal, asset.description, backend, item.item.id, item.item.title])
 
   eventHooks.useEventHandler(assetEvents, async event => {
     switch (event.type) {
@@ -691,6 +721,7 @@ export default function AssetRow(props: AssetRowProps) {
                       doCut={doCut}
                       doPaste={doPaste}
                       doDelete={doDelete}
+                      doTriggerDescriptionEdit={doTriggerDescriptionEdit}
                     />
                   )
                 } else {
@@ -821,6 +852,7 @@ export default function AssetRow(props: AssetRowProps) {
               doCut={doCut}
               doPaste={doPaste}
               doDelete={doDelete}
+              doTriggerDescriptionEdit={doTriggerDescriptionEdit}
             />
           )}
         </>

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/AssetRow.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/AssetRow.tsx
@@ -82,19 +82,11 @@ export interface AssetRowProps
     props: AssetRowInnerProps,
     event: React.MouseEvent<HTMLTableRowElement>
   ) => void
-  readonly focusEditDescriptionField: () => void
 }
 
 /** A row containing an {@link backendModule.AnyAsset}. */
 export default function AssetRow(props: AssetRowProps) {
-  const {
-    item: rawItem,
-    hidden: hiddenRaw,
-    selected,
-    isSoleSelected,
-    isKeyboardSelected,
-    focusEditDescriptionField,
-  } = props
+  const { item: rawItem, hidden: hiddenRaw, selected, isSoleSelected, isKeyboardSelected } = props
   const { setSelected, allowContextMenu, onContextMenu, state, columns, onClick } = props
   const { visibilities, assetEvents, dispatchAssetEvent, dispatchAssetListEvent, nodeMap } = state
   const { setAssetPanelProps, doToggleDirectoryExpansion, doCopy, doCut, doPaste } = state
@@ -387,7 +379,7 @@ export default function AssetRow(props: AssetRowProps) {
         initialDescription={asset.description}
       />
     )
-  }, [setModal, asset.description, backend, item.item.id, item.item.title])
+  }, [setModal, asset.description, setAsset, backend, item.item.id, item.item.title])
 
   eventHooks.useEventHandler(assetEvents, async event => {
     switch (event.type) {

--- a/app/ide-desktop/lib/dashboard/src/configurations/inputBindings.ts
+++ b/app/ide-desktop/lib/dashboard/src/configurations/inputBindings.ts
@@ -56,6 +56,7 @@ export const BINDINGS = inputBindings.defineBindings({
   rename: { name: 'Rename', bindings: ['Mod+R'], icon: PenIcon },
   edit: { name: 'Edit', bindings: ['Mod+E'], icon: PenIcon },
   snapshot: { name: 'Snapshot', bindings: ['Mod+S'], icon: CameraIcon },
+  editDescription: { name: 'Edit Description', bindings: ['Mod+Shift+E'], icon: PenIcon },
   delete: {
     name: 'Delete',
     bindings: ['OsDelete'],

--- a/app/ide-desktop/lib/dashboard/src/layouts/AssetContextMenu.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/AssetContextMenu.tsx
@@ -49,6 +49,7 @@ export interface AssetContextMenuProps {
   readonly doDelete: () => void
   readonly doCopy: () => void
   readonly doCut: () => void
+  readonly doTriggerDescriptionEdit: () => void
   readonly doPaste: (
     newParentKey: backendModule.AssetId,
     newParentId: backendModule.DirectoryId
@@ -57,7 +58,16 @@ export interface AssetContextMenuProps {
 
 /** The context menu for an arbitrary {@link backendModule.Asset}. */
 export default function AssetContextMenu(props: AssetContextMenuProps) {
-  const { innerProps, event, eventTarget, doCopy, doCut, doPaste, doDelete } = props
+  const {
+    innerProps,
+    event,
+    eventTarget,
+    doCopy,
+    doCut,
+    doPaste,
+    doDelete,
+    doTriggerDescriptionEdit,
+  } = props
   const { hidden = false } = props
   const { item, setItem, state, setRowState } = innerProps
   const { category, hasPasteData, labels, dispatchAssetEvent, dispatchAssetListEvent } = state
@@ -254,6 +264,16 @@ export default function AssetContextMenu(props: AssetContextMenuProps) {
                   }}
                 />
               )
+            }}
+          />
+        )}
+        {isCloud && (
+          <ContextMenuEntry
+            hidden={hidden}
+            action="editDescription"
+            label="Edit Description"
+            doAction={() => {
+              doTriggerDescriptionEdit()
             }}
           />
         )}

--- a/app/ide-desktop/lib/dashboard/src/layouts/AssetContextMenu.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/AssetContextMenu.tsx
@@ -271,7 +271,7 @@ export default function AssetContextMenu(props: AssetContextMenuProps) {
           <ContextMenuEntry
             hidden={hidden}
             action="editDescription"
-            label="Edit Description"
+            label={getText('editDescriptionShortcut')}
             doAction={() => {
               doTriggerDescriptionEdit()
             }}

--- a/app/ide-desktop/lib/dashboard/src/modals/EditAssetDescriptionModal.tsx
+++ b/app/ide-desktop/lib/dashboard/src/modals/EditAssetDescriptionModal.tsx
@@ -9,6 +9,7 @@ import * as React from 'react'
 import * as reactQuery from '@tanstack/react-query'
 
 import * as modalProvider from '#/providers/ModalProvider'
+import * as textProvider from '#/providers/TextProvider'
 
 import * as ariaComponents from '#/components/AriaComponents'
 import Modal from '#/components/Modal'
@@ -29,7 +30,12 @@ export interface EditAssetDescriptionModalProps {
  * Modal for editing an asset's description.
  */
 export default function EditAssetDescriptionModal(props: EditAssetDescriptionModalProps) {
-  const { doChangeDescription, initialDescription, actionButtonLabel = 'Submit' } = props
+  const { getText } = textProvider.useText()
+  const {
+    doChangeDescription,
+    initialDescription,
+    actionButtonLabel = getText('editAssetDescriptionModalSubmit'),
+  } = props
   const { unsetModal } = modalProvider.useSetModal()
   const [description, setDescription] = React.useState(initialDescription ?? '')
   const initialdescriptionRef = React.useRef(initialDescription)
@@ -70,11 +76,13 @@ export default function EditAssetDescriptionModal(props: EditAssetDescriptionMod
           mutate(description)
         }}
       >
-        <div className="relative text-sm font-semibold">Edit Description</div>
+        <div className="relative text-sm font-semibold">
+          {getText('editAssetDescriptionModalTitle')}
+        </div>
         <textarea
           ref={textareaRef}
           className="relative h-16 resize-none rounded-default bg-selected-frame px-4 py-2"
-          placeholder="Enter a description"
+          placeholder={getText('editAssetDescriptionModalPlaceholder')}
           onChange={event => {
             setDescription(event.target.value)
           }}
@@ -95,7 +103,7 @@ export default function EditAssetDescriptionModal(props: EditAssetDescriptionMod
             onPress={unsetModal}
             isDisabled={isPending}
           >
-            Cancel
+            {getText('editAssetDescriptionModalCancel')}
           </ariaComponents.Button>
         </div>
       </form>

--- a/app/ide-desktop/lib/dashboard/src/text/english.json
+++ b/app/ide-desktop/lib/dashboard/src/text/english.json
@@ -406,6 +406,7 @@
   "uploadToCloudShortcut": "Upload To Cloud",
   "renameShortcut": "Rename",
   "editShortcut": "Edit",
+  "editDescriptionShortcut": "Edit Description",
   "snapshotShortcut": "Snapshot",
   "deleteShortcut": "Delete",
   "undeleteShortcut": "Restore From Trash",

--- a/app/ide-desktop/lib/dashboard/src/text/english.json
+++ b/app/ide-desktop/lib/dashboard/src/text/english.json
@@ -476,5 +476,10 @@
   "thursdayAbbr": "Th",
   "fridayAbbr": "F",
   "saturdayAbbr": "Sa",
-  "sundayAbbr": "Su"
+  "sundayAbbr": "Su",
+
+  "editAssetDescriptionModalTitle": "Edit Asset Description",
+  "editAssetDescriptionModalPlaceholder": "Enter a description for the asset",
+  "editAssetDescriptionModalSubmit": "Submit",
+  "editAssetDescriptionModalCancel": "Cancel"
 }


### PR DESCRIPTION
### Pull Request Description

Closes: enso-org/cloud-v2#1083

Tl;dr: This PR introduces a new menu entry that allows to open edit description dialog from context menu in dashboard. This supposed to work only in cloud.
When you right-click on an item in Cloud Drive, you can choose "Edit description" option to change the description of the selected item.


https://github.com/enso-org/enso/assets/61194245/53e949df-8a31-401c-ba48-52eddad468fa



Context:
See enso-org/cloud-v2#1083 . I decided to open a dialog insted of the sidebar because latter takes to much time and effort to make it properly.


This Change:

<!--
What this change does in the larger context. Specific details to highlight for review:


<highlight1>
<highlight2>
<highlight3>
-->

Added new variants for button component(submit & cancel), also - loading state.Added a new dialog that opens when you select "Edit description" in context menu.


Test Plan:

1. We shouldn't allow users to change the description for local files
2. Changes in the Dialog(after save) should reflect in sidebar(Description should update in sidebar)
3. Loading state/Errors should be displayed in dialog.

<!--
Go over how you plan to test it. Your test plan should be more thorough the riskier the change is. For major changes, I like to describe how I E2E tested it and will monitor the rollout.
-->



<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
