### PR TITLE
Make expand_to_rows, expand_column support Rows, Tables, Column data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -638,6 +638,7 @@
 - [Allow `Table.replace` to take mutiple target columns.][9406]
 - [Initial Snowflake Support - ability to read and query, not a completed
   dialect yet.][9435]
+- [Make expand_to_rows, expand_column support Rows, Tables, Column data types][9533]
 
 [debug-shortcuts]:
   https://github.com/enso-org/enso/blob/develop/app/gui/docs/product/shortcuts.md#debug
@@ -928,6 +929,7 @@
 [9343]: https://github.com/enso-org/enso/pull/9343
 [9406]: https://github.com/enso-org/enso/pull/9406
 [9435]: https://github.com/enso-org/enso/pull/9435
+[9533]: https://github.com/enso-org/enso/pull/9533
 
 #### Enso Compiler
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -638,7 +638,8 @@
 - [Allow `Table.replace` to take mutiple target columns.][9406]
 - [Initial Snowflake Support - ability to read and query, not a completed
   dialect yet.][9435]
-- [Make expand_to_rows, expand_column support Rows, Tables, Column data types][9533]
+- [Make expand_to_rows, expand_column support Rows, Tables, Column data
+  types][9533]
 
 [debug-shortcuts]:
   https://github.com/enso-org/enso/blob/develop/app/gui/docs/product/shortcuts.md#debug

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -2391,7 +2391,9 @@ type DB_Table
        - `List`
        - `Range`
        - `Date_Range`
-       - `Pair
+       - `Pair`
+       - `Table`
+       - `Column`
 
        Any other values are treated as non-aggregate values, and their rows are kept
        unchanged.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Conversions/Convertible_To_Columns.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Conversions/Convertible_To_Columns.enso
@@ -1,4 +1,6 @@
 from Standard.Base import all
+from Standard.Table import Column, Table
+import project.Data.Row.Row
 import Standard.Base.Data.Java_Json.Jackson_Object
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
@@ -30,12 +32,21 @@ Convertible_To_Columns.from (that:Map) =
 
 ## PRIVATE
 Convertible_To_Columns.from (that:Pair) =
-    Convertible_To_Columns.Value ["0", "1"] (k-> if k == "0" then that.first else that.second)
+    Convertible_To_Columns.Value ["0", "1"] (k-> index_get that k)
+
+## PRIVATE
+Convertible_To_Columns.from (that:Column) =
+    fields = 0.up_to that.length . map _.to_text
+    Convertible_To_Columns.Value fields (k-> index_get that k)
+
+## PRIVATE
+Convertible_To_Columns.from (that:Row) =
+    Convertible_To_Columns.Value that.column_names that.get
 
 ## PRIVATE
 Convertible_To_Columns.from (that:Vector) =
     fields = 0.up_to that.length . map _.to_text
-    Convertible_To_Columns.Value fields (k-> that.at (Integer.parse k))
+    Convertible_To_Columns.Value fields (k-> index_get that k)
 
 ## PRIVATE
 Convertible_To_Columns.from (that:Array) = Convertible_To_Columns.from that.to_vector
@@ -61,3 +72,8 @@ Convertible_To_Columns.from (that:XML_Element) =
     value = if that_children.is_empty.not && has_child_nodes.not then [["Value", that.text]] else []
     as_map = Map.from_vector (name + tags + children + value)
     Convertible_To_Columns.from as_map
+
+## PRIVATE
+index_get that index:Text =
+    val = Integer.parse index
+    if val.is_error then Nothing else that.get val

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Conversions/Convertible_To_Columns.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Conversions/Convertible_To_Columns.enso
@@ -32,12 +32,12 @@ Convertible_To_Columns.from (that:Map) =
 
 ## PRIVATE
 Convertible_To_Columns.from (that:Pair) =
-    Convertible_To_Columns.Value ["0", "1"] (k-> index_get that k)
+    Convertible_To_Columns.Value ["0", "1"] (k-> that.at (Integer.parse k))
 
 ## PRIVATE
 Convertible_To_Columns.from (that:Column) =
     fields = 0.up_to that.length . map _.to_text
-    Convertible_To_Columns.Value fields (k-> index_get that k)
+    Convertible_To_Columns.Value fields (k-> that.at (Integer.parse k))
 
 ## PRIVATE
 Convertible_To_Columns.from (that:Row) =
@@ -46,7 +46,7 @@ Convertible_To_Columns.from (that:Row) =
 ## PRIVATE
 Convertible_To_Columns.from (that:Vector) =
     fields = 0.up_to that.length . map _.to_text
-    Convertible_To_Columns.Value fields (k-> index_get that k)
+    Convertible_To_Columns.Value fields (k-> that.at (Integer.parse k))
 
 ## PRIVATE
 Convertible_To_Columns.from (that:Array) = Convertible_To_Columns.from that.to_vector
@@ -72,8 +72,3 @@ Convertible_To_Columns.from (that:XML_Element) =
     value = if that_children.is_empty.not && has_child_nodes.not then [["Value", that.text]] else []
     as_map = Map.from_vector (name + tags + children + value)
     Convertible_To_Columns.from as_map
-
-## PRIVATE
-index_get that index:Text =
-    val = Integer.parse index
-    if val.is_error then Nothing else that.get val

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Conversions/Convertible_To_Rows.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Conversions/Convertible_To_Rows.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+from Standard.Table import Column, Table
 import Standard.Base.Data.Java_Json.Jackson_Object
 
 import project.Data.Conversions.Convertible_To_Columns.Convertible_To_Columns
@@ -25,6 +26,14 @@ type Convertible_To_Rows
        Return the iterator values as a `Vector`.
     to_vector : Vector Any
     to_vector self = 0.up_to self.length . map self.getter
+
+## PRIVATE
+Convertible_To_Rows.from that:Table =
+    rows = that.rows
+    Convertible_To_Rows.from rows
+
+## PRIVATE
+Convertible_To_Rows.from that:Column = Convertible_To_Rows.Value that.length that.get
 
 ## PRIVATE
 Convertible_To_Rows.from that:Vector = Convertible_To_Rows.Value that.length that.get

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data/Table.enso
@@ -1404,7 +1404,9 @@ type Table
        - `List`
        - `Range`
        - `Date_Range`
-       - `Pair
+       - `Pair`
+       - `Table`
+       - `Column`
 
        Any other values are treated as non-aggregate values, and their rows are kept
        unchanged.

--- a/test/Table_Tests/src/In_Memory/Table_Conversion_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Conversion_Spec.enso
@@ -214,6 +214,13 @@ add_specs suite_builder =
             expected = Table.new [["tables aaa", [1, 2, 3, 10]], ["tables bbb", [4, 5, 6, 11]], ["tables ccc", [7, 8, 9, 12]]]
             table.expand_to_rows "tables" . expand_column "tables" . should_equal expected
 
+        group_builder.specify "Expands rows within a column for ragged tables" <|
+            table1 = Table.new [["aaa", [1, 2, 3]], ["bbb", [4, 5, 6]]]
+            table2 = Table.new [["aaa", [10]], ["bbb", [11]], ["ccc", [12]]]
+            table = Table.new [["tables", [table1, table2]]]
+            expected = Table.new [["tables aaa", [1, 2, 3, 10]], ["tables bbb", [4, 5, 6, 11]], ["tables ccc", [Nothing, Nothing, Nothing, 12]]]
+            table.expand_to_rows "tables" . expand_column "tables" . should_equal expected
+
         group_builder.specify "Expands columns within a column" <|
             column1 = Column.from_vector "c1" ["a", "b", "c"]
             column2 = Column.from_vector "c2" ["d", "e"]

--- a/test/Table_Tests/src/In_Memory/Table_Conversion_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Conversion_Spec.enso
@@ -206,6 +206,20 @@ add_specs suite_builder =
             table = Table.new [["aaa", [1, 2]], ["bbb", [Date.new 2020 12 1 . up_to (Date.new 2020 12 3), Date.new 2022 12 1 . up_to (Date.new 2022 12 2)]]]
             expected = Table.new [["aaa", [1, 2]], ["bbb 0", [Date.new 2020 12 1, Date.new 2022 12 1]], ["bbb 1", [Date.new 2020 12 2, Nothing]]]
             table.expand_column "bbb" . should_equal expected
+        
+        group_builder.specify "Expands rows within a column" <|
+            table1 = Table.new [["aaa", [1, 2, 3]], ["bbb", [4, 5, 6]], ["ccc", [7, 8, 9]]]
+            table2 = Table.new [["aaa", [10]], ["bbb", [11]], ["ccc", [12]]]
+            table = Table.new [["tables", [table1, table2]]]
+            expected = Table.new [["tables aaa", [1, 2, 3, 10]], ["tables bbb", [4, 5, 6, 11]], ["tables ccc", [7, 8, 9, 12]]]
+            table.expand_to_rows "tables" . expand_column "tables" . should_equal expected
+
+        group_builder.specify "Expands columns within a column" <|
+            column1 = Column.from_vector "c1" ["a", "b", "c"]
+            column2 = Column.from_vector "c2" ["d", "e"]
+            table = Table.new [["cols", [column1, column2]]]
+            expected = Table.new [["cols 0", ["a", "d"]], ["cols 1", ["b", "e"]], ["cols 2", ["c", Nothing]]]
+            table.expand_column "cols" . should_equal expected
 
         group_builder.specify "will work even if keys are not Text" <|
             table = Table.new [["a", [1, 2]], ["b", [Map.from_vector [[1, "x"], [2, "y"]], Map.from_vector [[2, "z"], [3, "w"]]]]]
@@ -335,6 +349,20 @@ add_specs suite_builder =
             table = Table.new [["aaa", [1, 2, 3]], ["bbb", values_to_expand], ["ccc", [5, 6, 7]]]
             expected = Table.new [["aaa", [1, 1, 2, 2, 2, 2, 3, 3]], ["bbb", values_expanded], ["ccc", [5, 5, 6, 6, 6, 6, 7, 7]]]
             table.expand_to_rows "bbb" . should_equal expected
+        
+        group_builder.specify "Can expand tables" <|
+            table1 = Table.new [["aaa", [1, 2, 3]], ["bbb", [4, 5, 6]], ["ccc", [7, 8, 9]]]
+            table2 = Table.new [["aaa", [10]], ["bbb", [11]], ["ccc", [12]]]
+            table = Table.new [["tables", [table1, table2]]]
+            expected = Table.new [["tables", [table1.rows.at 0, table1.rows.at 1, table1.rows.at 2, table2.rows.at 0]]]
+            table.expand_to_rows "tables" . should_equal expected
+        
+        group_builder.specify "Can expand column of columns" <|
+            column1 = Column.from_vector "c1" ["a", "b", "c"]
+            column2 = Column.from_vector "c2" ["d", "e"]
+            table = Table.new [["cols", [column1, column2]]]
+            expected = Table.new [["cols", ["a", "b", "c", "d", "e"]]]
+            table.expand_to_rows "cols" . should_equal expected
 
         group_builder.specify "Respects `at_least_one_row=True`" <|
             values_to_expand = [[10, 11], [], [30]]


### PR DESCRIPTION
### Pull Request Description

Make expand_to_rows work for Table and Column
Make expand_column work for Column and Row

Makes solving the book club exercise easier

![image](https://github.com/enso-org/enso/assets/1720119/4532fc38-8765-43d9-b6a0-61254f52239f)

### Important Notes

We decided expand_column did not make sense for Table as the resulting Table of Columns would rarely be what was wanted.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
