### PR TITLE
Ignore repeated key events for bound shortcuts, adjust visualization min width

### DIFF
--- a/app/gui2/src/components/VisualizationContainer.vue
+++ b/app/gui2/src/components/VisualizationContainer.vue
@@ -15,10 +15,10 @@ const props = defineProps<{
   belowToolbar?: boolean
 }>()
 
-/** The total width of:
+/** The minimum width must be at least the total width of:
  * - both of toolbars that are always visible (32px + 60px), and
  * - the 4px flex gap between the toolbars. */
-const MIN_WIDTH_PX = 96
+const MIN_WIDTH_PX = 200
 
 const config = useVisualizationConfig()
 
@@ -194,7 +194,7 @@ const resizeBottomRight = usePointer((pos, _, type) => {
 <style scoped>
 .VisualizationContainer {
   --node-height: 32px;
-  --permanent-toolbar-width: 96px;
+  --permanent-toolbar-width: 200px;
   color: var(--color-text);
   background: var(--color-visualization-bg);
   position: absolute;

--- a/app/gui2/src/util/shortcuts.ts
+++ b/app/gui2/src/util/shortcuts.ts
@@ -391,6 +391,9 @@ export function defineKeybinds<
     >,
   ): (event: Event_, stopAndPrevent?: boolean) => boolean {
     return (event, stopAndPrevent = true) => {
+      // Do not handle repeated keyboard events (held down key).
+      if (event instanceof KeyboardEvent && event.repeat) return false
+
       const eventModifierFlags = modifierFlagsForEvent(event)
       const keybinds =
         event instanceof KeyboardEvent ?


### PR DESCRIPTION
### Pull Request Description

Fixes #8538 #9515 

All repeated keyboard events handled through `defineShortcuts` are now ignored. For example, holding ctrl+v no longer pastes nodes repeatedly.

Also adjusted visualization min-width to 200px, since it was a trivial change.

![image](https://github.com/enso-org/enso/assets/919491/7997898f-bcee-45f2-aacb-e10a49b159d6)



### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
