### PR TITLE
Fix file browser on Linux and Windows

### DIFF
--- a/app/gui2/env.d.ts
+++ b/app/gui2/env.d.ts
@@ -23,5 +23,7 @@ interface Window {
  */
 interface FileBrowserApi {
   /** Select path for local file or directory using the system file browser. */
-  readonly openFileBrowser: (kind: 'file' | 'directory' | 'any') => Promise<string[] | undefined>
+  readonly openFileBrowser: (
+    kind: 'file' | 'directory' | 'default',
+  ) => Promise<string[] | undefined>
 }

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetFileBrowser.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetFileBrowser.vue
@@ -57,7 +57,7 @@ const onClick = async () => {
   const kind =
     strictlyDirectory.value ? 'directory'
     : strictlyFile.value ? 'file'
-    : 'any'
+    : 'default'
   const selected = await window.fileBrowserApi.openFileBrowser(kind)
   if (selected != null && selected[0] != null) {
     const edit = graph.startEdit()

--- a/app/ide-desktop/lib/client/src/index.ts
+++ b/app/ide-desktop/lib/client/src/index.ts
@@ -381,7 +381,8 @@ class App {
         })
         electron.ipcMain.handle(
             ipc.Channel.openFileBrowser,
-            async (_event, kind: 'any' | 'directory' | 'file') => {
+            async (_event, kind: 'default' | 'directory' | 'file') => {
+                logger.log('Request for opening browser for ', kind)
                 /** Helper for `showOpenDialog`, which has weird types by default. */
                 type Properties = ('openDirectory' | 'openFile')[]
                 const properties: Properties =
@@ -389,7 +390,9 @@ class App {
                         ? ['openFile']
                         : kind === 'directory'
                           ? ['openDirectory']
-                          : ['openFile', 'openDirectory']
+                          : process.platform === 'darwin'
+                            ? ['openFile', 'openDirectory']
+                            : ['openFile']
                 const { canceled, filePaths } = await electron.dialog.showOpenDialog({ properties })
                 if (!canceled) {
                     return filePaths


### PR DESCRIPTION
### Pull Request Description

Fixes #9503 

[The `showFileBrowser` documentation has a note](https://www.electronjs.org/docs/latest/api/dialog#dialogshowopendialogsyncbrowserwindow-options), that Linux and Windows don't support enabling picking dir and file.

### Important Notes



### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - ~~[ ] Unit tests have been written where possible.~~
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
