### PR TITLE
Add IRDumper for Scala IR

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/dump/GraphVizEdge.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/dump/GraphVizEdge.java
@@ -1,0 +1,63 @@
+package org.enso.compiler.dump;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents an edge in the GraphViz graph.
+ *
+ * @param from Identifier of the source node.
+ * @param to Identifier of the target node.
+ * @param label The label to display on the edge.
+ * @param additionalAttrs Additional attributes to specify for the edge, except for label which is
+ *     handled by the {@code label} field.
+ */
+record GraphVizEdge(String from, String to, String label, Map<String, String> additionalAttrs) {
+  static GraphVizEdge newEdge(String from, String to) {
+    Objects.requireNonNull(from);
+    Objects.requireNonNull(to);
+    return new GraphVizEdge(from, to, "", Map.of());
+  }
+
+  static GraphVizEdge newEdgeWithLabel(String from, String to, String label) {
+    Objects.requireNonNull(from);
+    Objects.requireNonNull(to);
+    Objects.requireNonNull(label);
+    return new GraphVizEdge(from, to, label, Map.of());
+  }
+
+  static GraphVizEdge newEdgeWithAttributes(
+      String from, String to, String label, Map<String, String> attrs) {
+    Objects.requireNonNull(from);
+    Objects.requireNonNull(to);
+    Objects.requireNonNull(label);
+    Objects.requireNonNull(attrs);
+    return new GraphVizEdge(from, to, label, attrs);
+  }
+
+  String toGraphViz() {
+    var sb = new StringBuilder();
+    sb.append(from).append(" -> ").append(to);
+    if (!additionalAttrs.isEmpty()) {
+      sb.append(" [");
+      additionalAttrs.forEach(
+          (k, v) -> {
+            assert Utils.hasOneLine(k) : k;
+            assert Utils.hasOneLine(v) : v;
+            sb.append(k);
+            sb.append("=");
+            if (!Utils.isSurroundedByQuotes(v)) {
+              sb.append("\"").append(v).append("\"");
+            } else {
+              sb.append(v);
+            }
+            sb.append(", ");
+          });
+      sb.append("label=\"");
+    } else {
+      sb.append(" [label=\"");
+    }
+    sb.append(label).append("\"];");
+    return sb.toString();
+  }
+}

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/dump/GraphVizNode.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/dump/GraphVizNode.java
@@ -1,0 +1,181 @@
+package org.enso.compiler.dump;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.enso.compiler.core.IR;
+import org.enso.compiler.core.ir.MetadataStorage;
+
+/**
+ * Represents a node in the GraphViz graph.
+ *
+ * @param id Identifier of the node. Used to refer to the node in edges. Must be unique.
+ * @param header The first line of the label. It is not justified to the left. Can be null.
+ * @param multiLineLabel A label in GraphViz is a simple textual attribute. To make it multi-line,
+ *     we need to escape newlines with "\\n".
+ * @param additionalAttrs Additional attributes to specify for the node, apart from `label`.
+ * @param object The underlying object from which the node was created.
+ */
+record GraphVizNode(
+    String id,
+    String header,
+    List<String> multiLineLabel,
+    Map<String, String> additionalAttrs,
+    Object object) {
+  public String toGraphViz() {
+    var sb = new StringBuilder();
+    sb.append(id);
+    if (!additionalAttrs.isEmpty()) {
+      sb.append(" [");
+      additionalAttrs.forEach(
+          (k, v) -> {
+            assert Utils.hasOneLine(k) : k;
+            assert Utils.hasOneLine(v) : v;
+            sb.append(k);
+            sb.append("=");
+            if (!Utils.isSurroundedByQuotes(v)) {
+              sb.append("\"").append(v).append("\"");
+            } else {
+              sb.append(v);
+            }
+            sb.append(", ");
+          });
+      sb.append("label=\"");
+    } else {
+      sb.append(" [label=\"");
+    }
+    // Id is the "header" of the node - the first line of the label.
+    // It is not justified to the left.
+    if (header != null) {
+      sb.append(header).append("\\n");
+    }
+    for (var line : multiLineLabel) {
+      var formattedLine = line.replace("\"", "\\\"");
+      assert Utils.hasOneLine(formattedLine);
+      sb.append(formattedLine);
+      // Justify every line to the left - it looks better in the resulting graph.
+      sb.append("\\l");
+    }
+    sb.append("\"];");
+    return sb.toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return id.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object otherObj) {
+    if (otherObj instanceof GraphVizNode otherNode) {
+      return id.equals(otherNode.id);
+    }
+    return false;
+  }
+
+  static class Builder {
+    private String id;
+    private String header;
+    private List<String> labelLines = new ArrayList<>();
+    private Map<String, String> additionalAttrs = new HashMap<>();
+    private Object object;
+
+    static Builder fromObject(Object obj) {
+      var className = className(obj);
+      var id = Utils.id(obj);
+      var bldr = new Builder();
+      bldr.object = obj;
+      bldr.id = id;
+      bldr.header = id;
+      bldr.addLabelLine("className: " + className);
+      return bldr;
+    }
+
+    /**
+     * Does not include some common info in the labels like class name, only create an empty
+     * builder.
+     */
+    static Builder fromObjectPlain(Object obj) {
+      var id = Utils.id(obj);
+      var bldr = new Builder();
+      bldr.object = obj;
+      bldr.id = id;
+      bldr.header = null;
+      return bldr;
+    }
+
+    static Builder fromIr(IR ir) {
+      var className = className(ir);
+      var bldr = new Builder();
+      var id = Utils.id(ir);
+      bldr.object = ir;
+      bldr.id = id;
+      bldr.header = id;
+      bldr.addLabelLine("className: " + className);
+      if (ir.location().isDefined()) {
+        var loc = ir.location().get();
+        bldr.addLabelLine("location_start: " + loc.start());
+        bldr.addLabelLine("location_end: " + loc.end());
+      } else {
+        bldr.addLabelLine("location: null");
+      }
+      bldr.addLabelLine("id: " + ir.getId());
+      if (!isPassDataEmpty(ir.passData())) {
+        bldr.addLabelLine("pass_data: ");
+        ir.passData()
+            .map(
+                (pass, metadata) -> {
+                  var metaName = metadata.metadataName();
+                  bldr.addLabelLine("  - " + metaName);
+                  return null;
+                });
+      } else {
+        bldr.addLabelLine("pass_data: []");
+      }
+      return bldr;
+    }
+
+    private static boolean isPassDataEmpty(MetadataStorage passData) {
+      int[] counter = new int[] {0};
+      passData.map(
+          (pass, data) -> {
+            counter[0]++;
+            return null;
+          });
+      return counter[0] == 0;
+    }
+
+    Builder addLabelLine(String line) {
+      labelLines.add(line);
+      return this;
+    }
+
+    Builder addAttribute(String key, String value) {
+      additionalAttrs.put(key, value);
+      return this;
+    }
+
+    GraphVizNode build() {
+      Objects.requireNonNull(id);
+      Objects.requireNonNull(labelLines);
+      Objects.requireNonNull(additionalAttrs);
+      Objects.requireNonNull(object);
+      return new GraphVizNode(id, header, labelLines, additionalAttrs, object);
+    }
+
+    private static String className(Object obj) {
+      return Arrays.stream(obj.getClass().getName().split("\\."))
+          .dropWhile(
+              item ->
+                  item.equals("org")
+                      || item.equals("enso")
+                      || item.equals("compiler")
+                      || item.equals("core"))
+          .collect(Collectors.joining("."));
+    }
+  }
+}

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/dump/IRDumper.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/dump/IRDumper.java
@@ -1,0 +1,698 @@
+package org.enso.compiler.dump;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.enso.compiler.core.IR;
+import org.enso.compiler.core.ir.CallArgument;
+import org.enso.compiler.core.ir.DefinitionArgument;
+import org.enso.compiler.core.ir.Expression;
+import org.enso.compiler.core.ir.Function;
+import org.enso.compiler.core.ir.Literal.Number;
+import org.enso.compiler.core.ir.Literal.Text;
+import org.enso.compiler.core.ir.Module;
+import org.enso.compiler.core.ir.Name;
+import org.enso.compiler.core.ir.Pattern;
+import org.enso.compiler.core.ir.expression.Application;
+import org.enso.compiler.core.ir.expression.Case;
+import org.enso.compiler.core.ir.module.scope.Definition;
+import org.enso.compiler.core.ir.module.scope.Definition.Data;
+import org.enso.compiler.core.ir.module.scope.Export;
+import org.enso.compiler.core.ir.module.scope.Import;
+import org.enso.compiler.core.ir.module.scope.definition.Method;
+import org.enso.compiler.core.ir.module.scope.imports.Polyglot;
+import org.enso.compiler.data.BindingsMap;
+import org.enso.compiler.data.BindingsMap.ResolvedConstructor;
+import org.enso.compiler.data.BindingsMap.ResolvedMethod;
+import org.enso.compiler.data.BindingsMap.ResolvedPolyglotField;
+import org.enso.compiler.data.BindingsMap.ResolvedPolyglotSymbol;
+import org.enso.compiler.data.BindingsMap.ResolvedType;
+import org.enso.compiler.pass.resolve.FullyQualifiedNames.FQNResolution;
+import org.enso.compiler.pass.resolve.FullyQualifiedNames.ResolvedLibraryNamespace;
+import org.enso.compiler.pass.resolve.FullyQualifiedNames.ResolvedModule;
+
+/**
+ * Utility class that dumps {@link IR} to a <a href="https://graphviz.org">GraphViz</a> file. This
+ * file can be processed by a {@code dot} command to generate a visual representation of the IR. The
+ * GraphViz command line utilities are easy to install. See the <a
+ * href="https://graphviz.org/download/">download page</a>. Alternatively, the resulting file can be
+ * interactivelly visualized in VSCode with the <a
+ * href="https://marketplace.visualstudio.com/items?itemName=tintinweb.graphviz-interactive-preview">GraphViz
+ * Interactive Preview extension</a>.
+ */
+public class IRDumper {
+  /**
+   * Whether to include the code of the IR nodes in the Graphviz file. This can make the file very
+   * large.
+   */
+  private static final boolean INCLUDE_CODE = true;
+
+  /** Whether to include some pass data in the GraphViz file. */
+  private static final boolean INCLUDE_PASS_DATA = true;
+
+  private final OutputStream out;
+  private final Set<GraphVizNode> nodes = new HashSet<>();
+  private final Set<GraphVizEdge> edges = new HashSet<>();
+
+  /**
+   * @param out the output stream to write the Graphviz file to.
+   */
+  private IRDumper(OutputStream out) {
+    Objects.requireNonNull(out);
+    this.out = out;
+  }
+
+  /**
+   * Creates a new {@link IRDumper} that dumps the graph into the given {@code path}.
+   *
+   * @param path the path to write the Graphviz file to.
+   */
+  public static IRDumper fromPath(Path path) {
+    OutputStream out = null;
+    try {
+      out =
+          Files.newOutputStream(
+              path,
+              StandardOpenOption.CREATE,
+              StandardOpenOption.WRITE,
+              StandardOpenOption.TRUNCATE_EXISTING);
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+    return new IRDumper(out);
+  }
+
+  /**
+   * Creates a new {@link IRDumper} that dumps the graph into the given {@code out}.
+   *
+   * @param out the output stream to write the Graphviz file to.
+   */
+  public static IRDumper fromOut(OutputStream out) {
+    return new IRDumper(out);
+  }
+
+  /**
+   * Dumps the given IR into the Graphviz file. Any {@link IOException} is translated to a {@link
+   * IllegalStateException} within this class.
+   *
+   * @param ir the IR to dump.
+   */
+  public void dump(IR ir) {
+    createIRGraph(ir);
+    dumpGraph();
+    try {
+      out.flush();
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private void createIRGraph(IR ir) {
+    switch (ir) {
+      case Module moduleIr -> createIRGraph(moduleIr);
+      default -> throw unimpl(ir);
+    }
+  }
+
+  private void createIRGraph(Module moduleIr) {
+    var moduleNode = GraphVizNode.Builder.fromIr(moduleIr).build();
+    addNode(moduleNode);
+
+    for (int i = 0; i < moduleIr.bindings().size(); i++) {
+      var bindingIr = moduleIr.bindings().apply(i);
+      createIRGraph(bindingIr);
+      var edgeDescr = "binding[" + i + "]";
+      createEdge(moduleIr, bindingIr, edgeDescr);
+    }
+
+    for (int i = 0; i < moduleIr.imports().size(); i++) {
+      var importIr = moduleIr.imports().apply(i);
+      createIRGraph(importIr);
+      var edgeDescr = "import[" + i + "]";
+      createEdge(moduleIr, importIr, edgeDescr);
+    }
+
+    for (int i = 0; i < moduleIr.exports().size(); i++) {
+      var exportIr = moduleIr.exports().apply(i);
+      createIRGraph(exportIr);
+      var edgeDescr = "export[" + i + "]";
+      createEdge(moduleIr, exportIr, edgeDescr);
+    }
+  }
+
+  private void createIRGraph(Definition definitionIr) {
+    switch (definitionIr) {
+      case Method.Explicit explicitMethodIr -> {
+        var bldr =
+            GraphVizNode.Builder.fromIr(explicitMethodIr)
+                .addLabelLine("methodName: " + explicitMethodIr.methodName().name())
+                .addLabelLine("isStatic: " + explicitMethodIr.isStatic());
+        if (explicitMethodIr.typeName().isDefined()) {
+          bldr.addLabelLine("typeName: " + explicitMethodIr.typeName().get().name());
+        } else {
+          bldr.addLabelLine("typeName: null");
+        }
+        addNode(bldr.build());
+        var body = explicitMethodIr.body();
+        createIRGraph(body);
+        createEdge(explicitMethodIr, body, "body");
+      }
+      case Method.Conversion conversionMethod -> {
+        var bldr =
+            GraphVizNode.Builder.fromIr(conversionMethod)
+                .addLabelLine("methodName: " + conversionMethod.methodName().name());
+        addNode(bldr.build());
+        var body = conversionMethod.body();
+        createIRGraph(body);
+        createEdge(conversionMethod, body, "body");
+      }
+      case Method.Binding binding -> {
+        var bldr = GraphVizNode.Builder.fromIr(binding);
+        addNode(bldr.build());
+        for (int i = 0; i < binding.arguments().size(); i++) {
+          var arg = binding.arguments().apply(i);
+          createIRGraph(arg);
+          createEdge(binding, arg, "arg[" + i + "]");
+        }
+        var body = binding.body();
+        createIRGraph(body);
+        createEdge(binding, body, "body");
+      }
+      case Definition.Type type -> {
+        var typeNode =
+            GraphVizNode.Builder.fromIr(type).addLabelLine("name: " + type.name().name()).build();
+        addNode(typeNode);
+        for (int i = 0; i < type.members().size(); i++) {
+          var member = type.members().apply(i);
+          createIRGraph(member);
+          createEdge(type, member, "member[" + i + "]");
+        }
+      }
+      case Name.GenericAnnotation genericAnnotation -> {
+        var bldr =
+            GraphVizNode.Builder.fromIr(genericAnnotation)
+                .addLabelLine("name: " + genericAnnotation.name())
+                .addLabelLine("isMethod: " + genericAnnotation.isMethod());
+        addNode(bldr.build());
+        var expr = genericAnnotation.expression();
+        createIRGraph(expr);
+        createEdge(genericAnnotation, expr, "expression");
+      }
+      case Name.BuiltinAnnotation builtinAnnotation -> {
+        var bldr =
+            GraphVizNode.Builder.fromIr(builtinAnnotation)
+                .addLabelLine("name: " + builtinAnnotation.name());
+        addNode(bldr.build());
+      }
+      default -> throw unimpl(definitionIr);
+    }
+  }
+
+  private void createIRGraph(Data atomCons) {
+    var consNode =
+        GraphVizNode.Builder.fromIr(atomCons)
+            .addLabelLine("name: " + atomCons.name().name())
+            .build();
+    addNode(consNode);
+    for (int i = 0; i < atomCons.arguments().size(); i++) {
+      var arg = atomCons.arguments().apply(i);
+      createIRGraph(arg);
+      createEdge(atomCons, arg, "arg[" + i + "]");
+    }
+  }
+
+  private void createIRGraph(Expression expression) {
+    switch (expression) {
+      case Expression.Block block -> {
+        var blockNode = GraphVizNode.Builder.fromIr(block).build();
+        addNode(blockNode);
+        for (int i = 0; i < block.expressions().size(); i++) {
+          var expr = block.expressions().apply(i);
+          createIRGraph(expr);
+          createEdge(block, expr, "expression[" + i + "]");
+        }
+        var retVal = block.returnValue();
+        createIRGraph(retVal);
+        createEdge(block, retVal, "returnValue");
+      }
+      case Case.Expr caseExpr -> {
+        var isNested = caseExpr.isNested();
+        var caseNode =
+            GraphVizNode.Builder.fromIr(caseExpr).addLabelLine("isNested: " + isNested).build();
+        addNode(caseNode);
+        var scrutineeExpr = caseExpr.scrutinee();
+        createIRGraph(scrutineeExpr);
+        createEdge(caseExpr, scrutineeExpr, "scrutinee");
+        var branches = caseExpr.branches();
+        for (int i = 0; i < branches.size(); i++) {
+          var branch = branches.apply(i);
+          createIRGraph(branch);
+          createEdge(caseExpr, branch, "branch[" + i + "]");
+        }
+      }
+      case Case.Branch caseBranch -> {
+        var isTerminalBranch = caseBranch.terminalBranch();
+        var caseBranchNode =
+            GraphVizNode.Builder.fromIr(caseBranch)
+                .addLabelLine("terminalBranch: " + isTerminalBranch)
+                .build();
+        addNode(caseBranchNode);
+        var pattern = caseBranch.pattern();
+        createIRGraph(pattern);
+        createEdge(caseBranch, pattern, "pattern");
+        var expr = caseBranch.expression();
+        createIRGraph(expr);
+        createEdge(caseBranch, expr, "expression");
+      }
+      case Application.Prefix prefixApp -> {
+        var prefixAppNode =
+            GraphVizNode.Builder.fromIr(prefixApp)
+                .addLabelLine("hasDefaultsSuspended: " + prefixApp.hasDefaultsSuspended())
+                .build();
+        addNode(prefixAppNode);
+
+        var func = prefixApp.function();
+        createIRGraph(func);
+        createEdge(prefixApp, func, "function");
+
+        for (int i = 0; i < prefixApp.arguments().size(); i++) {
+          var arg = prefixApp.arguments().apply(i);
+          createIRGraph(arg);
+          createEdge(prefixApp, arg, "arg[" + i + "]");
+        }
+      }
+      case Function.Lambda lambda -> {
+        var lambdaNode = GraphVizNode.Builder.fromIr(lambda).build();
+        addNode(lambdaNode);
+        var body = lambda.body();
+        createIRGraph(body);
+        createEdge(lambda, body, "body");
+        for (int i = 0; i < lambda.arguments().size(); i++) {
+          var arg = lambda.arguments().apply(i);
+          createIRGraph(arg);
+          createEdge(lambda, arg, "arg[" + i + "]");
+        }
+      }
+      case Expression.Binding exprBinding -> {
+        var exprBindNode =
+            GraphVizNode.Builder.fromIr(exprBinding)
+                .addLabelLine("name: " + exprBinding.name().name())
+                .build();
+        addNode(exprBindNode);
+        createIRGraph(exprBinding.expression());
+        createEdge(exprBinding, exprBinding.expression(), "expression");
+      }
+      case Number number -> {
+        var numNode =
+            GraphVizNode.Builder.fromIr(number).addLabelLine("value: " + number.value()).build();
+        addNode(numNode);
+      }
+      case Text text -> {
+        var textNode =
+            GraphVizNode.Builder.fromIr(text).addLabelLine("text: " + text.text()).build();
+        addNode(textNode);
+      }
+      case Name.Literal literal -> {
+        var bldr = GraphVizNode.Builder.fromIr(literal);
+        bldr.addLabelLine("name: " + literal.name());
+        bldr.addLabelLine("isMethod: " + literal.isMethod());
+        if (literal.originalName().isDefined()) {
+          var origName = literal.originalName().get();
+          bldr.addLabelLine("originalName: " + origName.name());
+        } else {
+          bldr.addLabelLine("originalName: null");
+        }
+        var literalNode = bldr.build();
+        addNode(literalNode);
+      }
+      default -> {
+        var node = GraphVizNode.Builder.fromIr(expression).build();
+        addNode(node);
+      }
+    }
+  }
+
+  private void createIRGraph(Pattern pattern) {
+    var bldr = GraphVizNode.Builder.fromIr(pattern);
+    switch (pattern) {
+      case Pattern.Constructor constrPat -> {
+        var constr = constrPat.constructor();
+        bldr.addLabelLine("constructor: " + constr.name());
+        addNode(bldr.build());
+        var fields = constrPat.fields();
+        for (int i = 0; i < fields.size(); i++) {
+          var field = fields.apply(i);
+          createIRGraph(field);
+          createEdge(constrPat, field, "field[" + i + "]");
+        }
+      }
+      case Pattern.Type tp -> {
+        var name = tp.name();
+        var tpe = tp.tpe();
+        bldr.addLabelLine("name: " + name.name());
+        bldr.addLabelLine("tpe: " + tpe.name());
+        addNode(bldr.build());
+      }
+      case Pattern.Literal litPat -> {
+        addNode(bldr.build());
+        var lit = litPat.literal();
+        createIRGraph(lit);
+        createEdge(litPat, lit, "literal");
+      }
+      case Pattern.Name name -> {
+        bldr.addLabelLine("name: " + name.name().name());
+        addNode(bldr.build());
+      }
+      case Pattern.Documentation doc -> {
+        bldr.addLabelLine("doc: " + doc.doc());
+        addNode(bldr.build());
+      }
+      default -> throw unimpl(pattern);
+    }
+  }
+
+  private void createIRGraph(CallArgument argument) {
+    switch (argument) {
+      case CallArgument.Specified specifiedArg -> {
+        var bldr = GraphVizNode.Builder.fromIr(specifiedArg);
+        if (specifiedArg.name().isDefined()) {
+          bldr.addLabelLine("name: " + specifiedArg.name().get().name());
+        } else {
+          bldr.addLabelLine("name: null");
+        }
+        addNode(bldr.build());
+
+        var value = specifiedArg.value();
+        createIRGraph(value);
+        createEdge(specifiedArg, value, "value");
+      }
+      default -> throw unimpl(argument);
+    }
+  }
+
+  private void createIRGraph(DefinitionArgument argument) {
+    switch (argument) {
+      case DefinitionArgument.Specified specifiedArg -> {
+        var bldr =
+            GraphVizNode.Builder.fromIr(specifiedArg)
+                .addLabelLine("name: " + specifiedArg.name().name())
+                .addLabelLine("suspended: " + specifiedArg.suspended());
+        var node = bldr.build();
+        addNode(node);
+
+        if (specifiedArg.ascribedType().isDefined()) {
+          var ascribedType = specifiedArg.ascribedType().get();
+          createIRGraph(ascribedType);
+          createEdge(specifiedArg, ascribedType, "ascribedType");
+        }
+        if (specifiedArg.defaultValue().isDefined()) {
+          var defaultValue = specifiedArg.defaultValue().get();
+          createIRGraph(defaultValue);
+          createEdge(specifiedArg, defaultValue, "defaultValue");
+        }
+      }
+      default -> throw unimpl(argument);
+    }
+  }
+
+  private void createIRGraph(Import importIr) {
+    switch (importIr) {
+      case Import.Module importModIr -> {
+        var bldr =
+            GraphVizNode.Builder.fromIr(importModIr)
+                .addLabelLine("isSynthetic: " + importModIr.isSynthetic())
+                .addLabelLine("name: " + importModIr.name().name())
+                .addLabelLine("isAll: " + importModIr.isAll());
+        if (importModIr.rename().isDefined()) {
+          var rename = importModIr.rename().get();
+          bldr.addLabelLine("rename: " + rename.name());
+        } else {
+          bldr.addLabelLine("rename: null");
+        }
+        addNode(bldr.build());
+      }
+      case Polyglot polyImport -> {
+        var bldr = GraphVizNode.Builder.fromIr(polyImport);
+        bldr.addLabelLine(
+            "entity: Entity(langName="
+                + polyImport.entity().langName()
+                + ", visibleName="
+                + polyImport.entity().getVisibleName()
+                + ")");
+        if (polyImport.rename().isDefined()) {
+          var rename = polyImport.rename().get();
+          bldr.addLabelLine("rename: " + rename);
+        } else {
+          bldr.addLabelLine("rename: null");
+        }
+        addNode(bldr.build());
+      }
+      default -> throw unimpl(importIr);
+    }
+  }
+
+  private void createIRGraph(Export exportIr) {
+    switch (exportIr) {
+      case Export.Module exportModIr -> {
+        var node =
+            GraphVizNode.Builder.fromIr(exportIr)
+                .addLabelLine("isSynthetic: " + exportModIr.isSynthetic())
+                .addLabelLine("name: " + exportModIr.name().name())
+                .addLabelLine("isAll: " + exportModIr.isAll())
+                .build();
+        addNode(node);
+      }
+      default -> throw unimpl(exportIr);
+    }
+  }
+
+  private void createPassDataGraph(IR ir) {
+    var passData = ir.passData();
+    passData.map(
+        (pass, data) -> {
+          var bldr = GraphVizNode.Builder.fromObject(data);
+          bldr.addAttribute("shape", "box");
+          bldr.addAttribute("color", "blue");
+          bldr.addLabelLine("metadataName: " + data.metadataName());
+          switch (data) {
+            case BindingsMap.Resolution resolution -> {
+              switch (resolution.target()) {
+                case BindingsMap.ResolvedModule resolvedModule -> {
+                  bldr.addLabelLine(
+                      "target: ResolvedModule("
+                          + resolvedModule.module().getName().toString()
+                          + ")");
+                }
+                case ResolvedConstructor resolvedConstructor -> {
+                  bldr.addLabelLine(
+                      "target: ResolvedConstructor(" + resolvedConstructor.cons().name() + ")");
+                }
+                case ResolvedMethod resolvedMethod -> {
+                  bldr.addLabelLine(
+                      "target: ResolvedMethod(" + resolvedMethod.method().name() + ")");
+                }
+                case ResolvedPolyglotField resolvedPolyglotField -> {
+                  bldr.addLabelLine(
+                      "target: ResolvedPolyglotField(" + resolvedPolyglotField.name() + ")");
+                }
+                case ResolvedPolyglotSymbol resolvedPolyglotSymbol -> {
+                  bldr.addLabelLine(
+                      "target: ResolvedPolyglotSymbol("
+                          + resolvedPolyglotSymbol.symbol().name()
+                          + ")");
+                }
+                case ResolvedType resolvedType -> {
+                  bldr.addLabelLine("target: ResolvedType(" + resolvedType.tp().name() + ")");
+                }
+                default -> throw unimpl(resolution.target());
+              }
+              var metaNode = bldr.build();
+              addNode(metaNode);
+              createEdge(ir, resolution, "BindingsMap.Resolution");
+            }
+            case FQNResolution fqnResolution -> {
+              switch (fqnResolution.target()) {
+                case ResolvedLibraryNamespace resolvedLibraryNamespace -> {
+                  bldr.addLabelLine(
+                      "target: ResolvedLibraryNamespace("
+                          + resolvedLibraryNamespace.namespace()
+                          + ")");
+                }
+                case ResolvedModule resolvedModule -> {
+                  bldr.addLabelLine(
+                      "target: ResolvedModule("
+                          + resolvedModule.moduleRef().getName().toString()
+                          + ")");
+                }
+                default -> throw unimpl(fqnResolution.target());
+              }
+              var fqnMetaNode = bldr.build();
+              addNode(fqnMetaNode);
+              createEdge(ir, fqnResolution, "FullyQualifiedNames.FQNResolution");
+            }
+            case BindingsMap bindingsMap -> {
+              if (bindingsMap.definedEntities().isEmpty()) {
+                bldr.addLabelLine("definedEntities: []");
+              } else {
+                bldr.addLabelLine("definedEntities: ");
+                for (int i = 0; i < bindingsMap.definedEntities().size(); i++) {
+                  var entity = bindingsMap.definedEntities().apply(i);
+                  switch (entity) {
+                    case BindingsMap.Type tp -> bldr.addLabelLine("  - Type(" + tp.name() + ")");
+                    case BindingsMap.ModuleMethod method -> bldr.addLabelLine(
+                        "  - Method(" + method.name() + ")");
+                    case BindingsMap.PolyglotSymbol polySym -> bldr.addLabelLine(
+                        "  - PolyglotSymbol(" + polySym.name() + ")");
+                    default -> throw unimpl(entity);
+                  }
+                }
+              }
+
+              if (bindingsMap.resolvedImports().isEmpty()) {
+                bldr.addLabelLine("resolvedImports: []");
+              } else {
+                bldr.addLabelLine("resolvedImports: ");
+                for (int i = 0; i < bindingsMap.resolvedImports().size(); i++) {
+                  var resolvedImport = bindingsMap.resolvedImports().apply(i);
+                  switch (resolvedImport.target()) {
+                    case ResolvedType resolvedType -> bldr.addLabelLine(
+                        "  - ResolvedType(" + resolvedType.tp().name() + ")");
+                    case BindingsMap.ResolvedModule resolvedModule -> bldr.addLabelLine(
+                        "  - ResolvedModule(" + resolvedModule.qualifiedName() + ")");
+                    default -> throw unimpl(resolvedImport.target());
+                  }
+                }
+              }
+
+              if (bindingsMap.resolvedExports().isEmpty()) {
+                bldr.addLabelLine("resolvedExports: []");
+              } else {
+                bldr.addLabelLine("resolvedExports: ");
+                for (int i = 0; i < bindingsMap.resolvedExports().size(); i++) {
+                  var resolvedExport = bindingsMap.resolvedExports().apply(i);
+                  switch (resolvedExport.target()) {
+                    case ResolvedType resolvedType -> bldr.addLabelLine(
+                        "  - ResolvedType(" + resolvedType.tp().name() + ")");
+                    case BindingsMap.ResolvedModule resolvedModule -> bldr.addLabelLine(
+                        "  - ResolvedModule(" + resolvedModule.qualifiedName() + ")");
+                    default -> throw unimpl(resolvedExport.target());
+                  }
+                }
+              }
+              var bmNode = bldr.build();
+              addNode(bmNode);
+              createEdge(ir, bindingsMap, "BindingsMap");
+            }
+              // The rest is ignored
+            default -> {}
+          }
+          return null;
+        });
+  }
+
+  private void addNode(GraphVizNode node) {
+    var isNodeAlreadyDefined = nodes.stream().anyMatch(n -> n.equals(node));
+    if (isNodeAlreadyDefined) {
+      // Skip duplicate nodes.
+      return;
+    }
+    nodes.add(node);
+    if (INCLUDE_CODE) {
+      if (node.object() instanceof IR ir) {
+        var code = new Code(ir.showCode());
+        var codeNode =
+            GraphVizNode.Builder.fromObjectPlain(code)
+                .addAttribute("shape", "box")
+                .addAttribute("color", "grey")
+                .addLabelLine(code.code)
+                .build();
+        nodes.add(codeNode);
+        var edgeAttrs = Map.of("color", "grey", "style", "dotted");
+        createEdge(ir, code, "code", edgeAttrs);
+      }
+    }
+    if (INCLUDE_PASS_DATA) {
+      if (node.object() instanceof IR ir) {
+        createPassDataGraph(ir);
+      }
+    }
+  }
+
+  private void createEdge(Object from, Object to, String label, Map<String, String> attrs) {
+    assert !(from instanceof String);
+    assert !(to instanceof String);
+    assert !(from instanceof GraphVizNode);
+    assert !(to instanceof GraphVizNode);
+    var fromId = Utils.id(from);
+    var toId = Utils.id(to);
+    var edge = GraphVizEdge.newEdgeWithAttributes(fromId, toId, label, attrs);
+    var nodesContainsFrom = nodes.stream().anyMatch(node -> node.id().equals(fromId));
+    var nodesContainsTo = nodes.stream().anyMatch(node -> node.id().equals(toId));
+    assert nodesContainsFrom
+        : "Node " + fromId + " not found. You must first create it before creating an edge from it";
+    assert nodesContainsTo
+        : "Node " + toId + " not found. You must first create it before creating an edge to it";
+    var edgeAlreadyExists = edges.stream().anyMatch(e -> e.equals(edge));
+    if (!edgeAlreadyExists) {
+      edges.add(edge);
+    }
+  }
+
+  private void createEdge(Object from, Object to, String label) {
+    createEdge(from, to, label, Map.of());
+  }
+
+  /** Dump all the nodes and edges definitions into the GraphViz format. */
+  private void dumpGraph() {
+    write("digraph {");
+    write(System.lineSeparator());
+    for (GraphVizNode node : nodes) {
+      var nodeRepr = node.toGraphViz();
+      write(nodeRepr);
+      write(System.lineSeparator());
+    }
+    for (GraphVizEdge edge : edges) {
+      var containsFromNode = nodes.stream().anyMatch(node -> node.id().equals(edge.from()));
+      var containsToNode = nodes.stream().anyMatch(node -> node.id().equals(edge.to()));
+      assert containsFromNode;
+      assert containsToNode;
+      var edgeRepr = edge.toGraphViz();
+      write(edgeRepr);
+      write(System.lineSeparator());
+    }
+    write("}");
+  }
+
+  private static RuntimeException unimpl(Object obj) {
+    throw new UnsupportedOperationException(obj.getClass().getName());
+  }
+
+  private void write(String str) {
+    try {
+      out.write(str.getBytes());
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  /** Just a wrapper for code, we need this to be able to add the code to the graph. */
+  private record Code(String code) {
+
+    private Code(String code) {
+      // Replace new lines with left-justify literals, so that all the lines
+      // in the code are justified to the left side of the box.
+      String formattedCode = code.replace("\r", "\\l").replace("\n", "\\l");
+      if (code.contains("\"")) {
+        formattedCode = formattedCode.replace("\"", "\\\"");
+      }
+      assert Utils.hasOneLine(formattedCode);
+      this.code = formattedCode;
+    }
+  }
+}

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/dump/IRDumper.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/dump/IRDumper.java
@@ -34,7 +34,7 @@ import org.enso.compiler.data.BindingsMap.ResolvedPolyglotField;
 import org.enso.compiler.data.BindingsMap.ResolvedPolyglotSymbol;
 import org.enso.compiler.data.BindingsMap.ResolvedType;
 import org.enso.compiler.pass.resolve.FullyQualifiedNames.FQNResolution;
-import org.enso.compiler.pass.resolve.FullyQualifiedNames.ResolvedLibraryNamespace;
+import org.enso.compiler.pass.resolve.FullyQualifiedNames.ResolvedLibrary;
 import org.enso.compiler.pass.resolve.FullyQualifiedNames.ResolvedModule;
 
 /**
@@ -518,11 +518,8 @@ public class IRDumper {
             }
             case FQNResolution fqnResolution -> {
               switch (fqnResolution.target()) {
-                case ResolvedLibraryNamespace resolvedLibraryNamespace -> {
-                  bldr.addLabelLine(
-                      "target: ResolvedLibraryNamespace("
-                          + resolvedLibraryNamespace.namespace()
-                          + ")");
+                case ResolvedLibrary resolvedLibrary -> {
+                  bldr.addLabelLine("target: ResolvedLibrary(" + resolvedLibrary.namespace() + ")");
                 }
                 case ResolvedModule resolvedModule -> {
                   bldr.addLabelLine(

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/dump/Utils.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/dump/Utils.java
@@ -1,0 +1,19 @@
+package org.enso.compiler.dump;
+
+final class Utils {
+  private Utils() {}
+
+  static String id(Object obj) {
+    var className = obj.getClass().getSimpleName();
+    var hash = Integer.toHexString(System.identityHashCode(obj));
+    return className + "_" + hash;
+  }
+
+  static boolean hasOneLine(String label) {
+    return label.lines().count() == 1;
+  }
+
+  static boolean isSurroundedByQuotes(String str) {
+    return str.startsWith("\"") && str.endsWith("\"");
+  }
+}


### PR DESCRIPTION
### Pull Request Description

Debugging/inspecting/watching changes in the [Scala IR](https://github.com/enso-org/enso/blob/fe0f9046dbff0c005adfb69a5eb6e3787e7cdda9/engine/runtime-parser/src/main/java/org/enso/compiler/core/IR.java) has always been very tricky. The only way to do that, other than attaching the debugger and inspecting nested object structures, has been [IR.pretty](https://github.com/enso-org/enso/blob/fe0f9046dbff0c005adfb69a5eb6e3787e7cdda9/engine/runtime-parser/src/main/java/org/enso/compiler/core/IR.java#L91) method, that is not useful for large IRs. This PR add an [IRDumper](https://github.com/enso-org/enso/blob/a98b674f9ec109b01c7d7e3600c5e01b1c9d5ce5/engine/runtime-compiler/src/main/java/org/enso/compiler/dump/IRDumper.java) utility class that dumps the `IR` into a [GraphViz](https://graphviz.org/) textual format that can be further processed by the [dot](https://graphviz.org/download/) program to generate, e.g., svg files from these IRs.

A simple example (dumped by `IRDumper` into a file that is processed with `dot -O -Tsvg file`):
![fqn_end_tmp gv](https://github.com/enso-org/enso/assets/14013887/7441dc31-45ac-469e-9e06-4c98795a95eb)


### Important Notes

- GraphViz format is even simpler than JSON format.
- No dependencies added, just 3 simple Java classes.
- Dumping the IR is optional and not used anywhere, when desired, one can dump IRs for example from [Compiler.runPipeline](https://github.com/enso-org/enso/blob/9a91b7bcc61ec4b72cdfb25aadafe08fcbe93ae8/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala#L438)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
