### PR TITLE
Subprocess does not freeze when it generates a lot of output to stdout

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/system/System.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/system/System.java
@@ -109,8 +109,9 @@ public class System {
       if (startedWritingtoOut) throw e;
     }
 
-    p.waitFor();
-
+    // First read from stdout and stderr from the subprocess to prevent a deadlock.
+    // In other words, call `p.waitFor()` after reading from the streams.
+    // For more info, see https://stackoverflow.com/a/882795/4816269
     try (InputStream processOut = p.getInputStream()) {
       OutputStream stdout;
       if (redirectOut) {
@@ -139,6 +140,7 @@ public class System {
       }
     }
 
+    p.waitFor();
     long exitCode = p.exitValue();
     Text returnOut = Text.create(out.toString());
     Text returnErr = Text.create(err.toString());


### PR DESCRIPTION

Fixes #9549

### Pull Request Description

According to [this SO answer](https://stackoverflow.com/a/882795/4816269), one has to first read the streams from `java.lang.Process` before calling `process.waitFor()`. Otherwise, the current thread will block. I have encountered this when I tried to invoke a subprocess via `System.Process.run` that generates a long output to its stdout.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
