### PR TITLE
Add --disable-private-check runner option

### DIFF
--- a/engine/runner/src/main/scala/org/enso/runner/Main.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/Main.scala
@@ -400,6 +400,11 @@ object Main {
       )
       .build()
 
+    val disablePrivateCheckOption = CliOption.builder
+      .longOpt(DISABLE_PRIVATE_CHECK_OPTION)
+      .desc("Disables private module checking at runtime. Useful for tests.")
+      .build()
+
     val options = new Options
     options
       .addOption(help)
@@ -445,6 +450,7 @@ object Main {
       .addOption(skipGraalVMUpdater)
       .addOption(executionEnvironmentOption)
       .addOption(warningsLimitOption)
+      .addOption(disablePrivateCheckOption)
 
     options
   }


### PR DESCRIPTION
### Pull Request Description

I forgot to add the `--disable-private-check` cmdline option in https://github.com/enso-org/enso/pull/8202. This PR fixes this:
```
> enso -h | grep -A2 private
    --disable-private-check                Disables private module
                                           checking at runtime. Useful for
                                           tests.

```

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
