### PR TITLE
Equality does not swallow errors

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Enso_Path.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Enso_Path.enso
@@ -27,13 +27,10 @@ type Enso_Path
             if raw_segments.is_empty then Error.throw (Illegal_Argument.Error "Invalid path - it should contain at least one segment.") else
                 organization_name = raw_segments.first
                 segments = raw_segments.drop 1 . filter s-> s.is_empty.not
-                current_user_name = Enso_User.current.name
-                # The `if_not_error` is a workaround for https://github.com/enso-org/enso/issues/9283 and it can be removed after that is fixed.
-                current_user_name.if_not_error <|
-                    if organization_name != current_user_name then Unimplemented.throw "Currently only resolving paths for the current user is supported." else
-                        if segments.is_empty then Enso_Path.Value organization_name [] Nothing else
-                            asset_name = segments.last
-                            Enso_Path.Value organization_name (segments.drop (Index_Sub_Range.Last 1)) asset_name
+                if organization_name != Enso_User.current.name then Unimplemented.throw "Currently only resolving paths for the current user is supported." else
+                    if segments.is_empty then Enso_Path.Value organization_name [] Nothing else
+                        asset_name = segments.last
+                        Enso_Path.Value organization_name (segments.drop (Index_Sub_Range.Last 1)) asset_name
 
     ## PRIVATE
     resolve_parent self =

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/meta/EqualsNode.java
@@ -9,7 +9,6 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.nodes.Node;
-import org.enso.interpreter.dsl.AcceptsError;
 import org.enso.interpreter.dsl.BuiltinMethod;
 import org.enso.interpreter.node.EnsoRootNode;
 import org.enso.interpreter.node.callable.InteropConversionCallNode;
@@ -82,8 +81,7 @@ public final class EqualsNode extends Node {
    * @param other the other object
    * @return {@code true} if {@code self} and {@code that} seem equal
    */
-  public boolean execute(
-      VirtualFrame frame, @AcceptsError Object self, @AcceptsError Object other) {
+  public boolean execute(VirtualFrame frame, Object self, Object other) {
     var areEqual = node.execute(frame, self, other);
     if (!areEqual) {
       var selfType = types.execute(self);

--- a/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/model/MethodDefinition.java
+++ b/lib/scala/interpreter-dsl/src/main/java/org/enso/interpreter/dsl/model/MethodDefinition.java
@@ -630,7 +630,7 @@ public class MethodDefinition {
     }
 
     /**
-     * @return whether thsi argument accepts a dataflow error.
+     * @return whether this argument accepts a dataflow error.
      */
     public boolean acceptsError() {
       return acceptsError;

--- a/test/Base_Tests/src/Data/Ordering_Spec.enso
+++ b/test/Base_Tests/src/Data/Ordering_Spec.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Errors.Common.Incomparable_Values
 import Standard.Base.Errors.Common.Type_Error
+import Standard.Base.Errors.Illegal_State.Illegal_State
 
 from Standard.Test import all
 
@@ -90,6 +91,16 @@ add_specs suite_builder =
 
         group_builder.specify "should throw Incomparable_Values when comparing Number with Nothing" <|
             Ordering.compare 1 Nothing . should_fail_with Incomparable_Values
+
+        group_builder.specify "should propagate errors" <|
+            ((Error.throw (Illegal_State.Error "foo" )) > 42) . should_fail_with Illegal_State
+            ((Error.throw (Illegal_State.Error "foo" )) >= 42) . should_fail_with Illegal_State
+            ((Error.throw (Illegal_State.Error "foo" )) < 42) . should_fail_with Illegal_State
+            ((Error.throw (Illegal_State.Error "foo" )) <= 42) . should_fail_with Illegal_State
+            (42 > (Error.throw (Illegal_State.Error "foo" ))) . should_fail_with Illegal_State
+            (42 >= (Error.throw (Illegal_State.Error "foo" ))) . should_fail_with Illegal_State
+            (42 < (Error.throw (Illegal_State.Error "foo" ))) . should_fail_with Illegal_State
+            (42 <= (Error.throw (Illegal_State.Error "foo" ))) . should_fail_with Illegal_State
 
     suite_builder.group "Ordering" group_builder->
         group_builder.specify "should allow conversion to sign representation" <|

--- a/test/Base_Tests/src/Semantic/Equals_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Equals_Spec.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base.Errors.Illegal_State.Illegal_State
 
 from Standard.Test import all
 
@@ -228,6 +229,13 @@ add_specs suite_builder =
             f1 = CustomEqType.C2 10
             f2 = CustomEqType.C2 10
             f1==f2 . should_be_false
+
+        group_builder.specify "should propagate errors" <|
+            ((Error.throw (Illegal_State.Error "foo" )) == 42) . should_fail_with Illegal_State
+            ((Error.throw (Illegal_State.Error "foo" )) != 42) . should_fail_with Illegal_State
+            (42 == (Error.throw (Illegal_State.Error "foo" ))) . should_fail_with Illegal_State
+            (42 != (Error.throw (Illegal_State.Error "foo" ))) . should_fail_with Illegal_State
+
 
     suite_builder.group "Polyglot Operator ==" group_builder->
         group_builder.specify "should not try to compare members" <|


### PR DESCRIPTION
Fixes #9283

### Pull Request Description

`42 == (Error.throw "foo")` now correctly returns an `Error` rather than False

### Important Notes

The error was in the wrong usage of the `org.enso.interpreter.dsl.AcceptsError` DSL annotation.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
