### PR TITLE
Block FQN substitution in drop downs

### DIFF
--- a/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
@@ -236,8 +236,11 @@ function resolveTagExpression(edit: Ast.MutableModule, tag: ExpressionTag) {
   if (tag.requiredImports) {
     const conflicts = graph.addMissingImports(edit, tag.requiredImports)
     if (conflicts != null && conflicts.length > 0) {
-      // Is there is a conflict, it would be a single one, because we only ask about a single entry.
-      return conflicts[0]?.fullyQualified!
+      // TODO: Substitution does not work, because we interpret imports wrongly. To be fixed in
+      // https://github.com/enso-org/enso/issues/9356
+      // And here it was wrong anyway: we should replace only conflicting name, not entire expression!
+      // // Is there is a conflict, it would be a single one, because we only ask about a single entry.
+      // return conflicts[0]?.fullyQualified!
     }
   }
   // Unless a conflict occurs, we use the selected expression as is.

--- a/app/gui2/src/stores/graph/index.ts
+++ b/app/gui2/src/stores/graph/index.ts
@@ -284,7 +284,8 @@ export const useGraphStore = defineStore('graph', () => {
     rhs.setNodeMetadata(metadata)
     const assignment = Ast.Assignment.new(edit, ident, rhs)
     for (const _conflict of conflicts) {
-      // TODO: Sort out issues with FQN with the engine.
+      // TODO: Substitution does not work, because we interpret imports wrongly. To be fixed in
+      // https://github.com/enso-org/enso/issues/9356
       // substituteQualifiedName(edit, assignment, conflict.pattern, conflict.fullyQualified)
     }
     const id = asNodeId(rhs.id)
@@ -378,7 +379,8 @@ export const useGraphStore = defineStore('graph', () => {
           return
         }
         for (const _conflict of conflicts) {
-          // TODO: Sort out issues with FQN with the engine.
+          // TODO: Substitution does not work, because we interpret imports wrongly. To be fixed in
+          // https://github.com/enso-org/enso/issues/9356
           // substituteQualifiedName(edit, wholeAssignment, conflict.pattern, conflict.fullyQualified)
         }
       }


### PR DESCRIPTION
### Pull Request Description

While blocked FQN substitution when creating/editing node, the drop-downs still used it, and it does not work.

This amends that + added a reference to a task where we want to fix the original issue.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - ~~[] Unit tests have been written where possible.~~
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
