### PR TITLE
Add google analytics sample data

### DIFF
--- a/distribution/lib/Standard/Google_Api/0.0.0-dev/data/Google_Analytics_Sample.csv
+++ b/distribution/lib/Standard/Google_Api/0.0.0-dev/data/Google_Analytics_Sample.csv
@@ -1,0 +1,203 @@
+﻿city,activeUsers
+(not set),467
+Brisbane,280
+Aurora,105
+Krakow,211
+Columbus,102
+Amadora,164
+New York,123
+Brno,166
+Moses Lake,497
+Wroclaw,340
+Bengaluru,339
+Bielsko-Biala,394
+Cheyenne,251
+Des Moines,319
+London,125
+San Antonio,77
+Warsaw,277
+Washington,393
+Adachi City,23
+Bhopal,266
+Boulder,366
+Gamlingay,417
+Gold Coast,385
+Moscow,149
+Prague,484
+Skawina,356
+Sydney,111
+Toronto,207
+Ashburn,35
+Chennai,488
+Coimbra,254
+Opole,53
+Paris,71
+Riyadh,436
+San Jose,313
+Sao Paulo,368
+Seattle,486
+Seoul,356
+Singapore,196
+Stavropol,266
+Sunnyvale,370
+Tbilisi,324
+Vilnius,22
+3956,355
+Bacoor,6
+Bage,467
+Barcelona,456
+Belo Horizonte,422
+Biggleswade,272
+Boydton,266
+Burnaby,212
+Caen,194
+Cascina,434
+Chiang Mai,56
+Chicago,477
+Colombo,299
+Cuiaba,56
+Delhi,122
+Dhaka,174
+Epinay-sur-Seine,442
+Gothenburg,297
+Las Vegas,407
+Los Angeles,321
+Lubeck,431
+Madrid,418
+Milan,366
+Ontario,233
+Oslo Municipality,496
+Philadelphia,473
+Plano,488
+Pleven,21
+Richmond,26
+Ruda Slaska,73
+Setagaya City,74
+Shanghai,393
+South Tangerang,76
+Stuttgart,165
+Tallinn,222
+Tel Aviv-Yafo,248
+Truckee,449
+Upice,416
+Varna,64
+Warner Robins,54
+Westfield,307
+2861,464
+Adana,483
+Afyonkarahisar,365
+Akron,367
+Anaheim,87
+Antananarivo,52
+Auckland,424
+Beijing,179
+Belgrade,465
+Belmont,400
+Berlin,351
+Boardman,54
+Boston,64
+Bowie,4
+Brasilia,50
+Brondby Strand,10
+Bucharest,377
+Burlington,263
+Bytom,275
+Cambridge,5
+Cancun,144
+Canterbury,105
+Carson City,61
+Casas Adobes,476
+Chorzow,153
+Christchurch,282
+Chula Vista,153
+Clifford,68
+Cluj-Napoca,46
+Copenhagen,22
+Coventry,139
+Czestochowa,157
+Daejeon,417
+Denpasar,157
+Dortmund,144
+Edinburgh,362
+Falkenberg,42
+Fort Worth,460
+Gdansk,46
+Gebze,446
+Gurugram,463
+Hamburg,258
+Havirov,427
+Helsinki,299
+Heric,251
+Ho Chi Minh City,279
+Hue,72
+Irvine,410
+Istanbul,333
+Jakarta,256
+Juiz de Fora,390
+Kathmandu,15
+Kendale Lakes,483
+Kenitra,119
+Khimki,34
+Komarno,429
+Koper,403
+Kyiv,191
+Lecce,451
+Little Rock,32
+Ljubljana,225
+Lodz,193
+Los Altos,195
+Loughborough,341
+Lublin,71
+Lviv,280
+Manila,363
+Melbourne,418
+Meppen,116
+Metoubes,410
+Milly-la-Foret,143
+Morrisville,260
+Mueang Chiang Mai District,24
+Munich,423
+Mytishchi,135
+Nai Mueang,232
+Nairobi,466
+Navi Mumbai,380
+Newcastle,195
+Newport,225
+Oakland,499
+Osaka,314
+Panama City,183
+Parkville,359
+Petaluma,117
+Poznan,481
+Prentiss,128
+Pruszkow,98
+Rabat,258
+Redwood City,459
+Rennes,429
+Rovaniemi,404
+Rzeszow,104
+Saint Petersburg,93
+Saint-Constant,252
+Sainte-Adele,469
+Sale,312
+San Diego,31
+Sandusky South,118
+Saugeen Shores,0
+Shenzhen,178
+Sint-Truiden,487
+Skidaway Island,78
+Sofia,198
+Somerville,235
+Templeuve-en-Pevele,85
+Thornton,413
+Tolyatti,58
+Union,231
+Vienna,500
+Weilheim in Oberbayern,343
+Wellington,489
+Wellington North,398
+Winterthur,84
+Yangon,388
+Zabrze,484
+Zagreb,340
+Zug,166

--- a/distribution/lib/Standard/Google_Api/0.0.0-dev/src/Google_Analytics.enso
+++ b/distribution/lib/Standard/Google_Api/0.0.0-dev/src/Google_Analytics.enso
@@ -35,8 +35,3 @@ make_metrics_vector_selector =
 read : Text -> (Vector Text) -> (Vector Text) -> Date -> Date -> Google_Credential -> Table
 read property_id:Text dimensions:Vector=['country'] metrics:Vector=['activeUsers'] start_date:Date=(Date.today.previous Date_Period.Year) end_date:Date=Date.today credentials:Google_Credential=Google_Credential.Default -> Table =
     read_api_data property_id dimensions metrics start_date end_date credentials
-
-
-    case credentials of
-    Google_Credential.Sample -> read_sample_data property_id dimensions metrics start_date end_date
-    _ -> read_api_data property_id dimensions metrics start_date end_date credentials

--- a/distribution/lib/Standard/Google_Api/0.0.0-dev/src/Google_Analytics.enso
+++ b/distribution/lib/Standard/Google_Api/0.0.0-dev/src/Google_Analytics.enso
@@ -7,7 +7,6 @@ from Standard.Base.Metadata.Widget import Single_Choice, Vector_Editor
 from Standard.Table import Table
 
 import project.Google_Credential.Google_Credential
-from project.Internal.Google_Credential_Internal import all
 from project.Internal.Google_Analytics_Internal import all
 
 ## PRIVATE
@@ -34,4 +33,6 @@ make_metrics_vector_selector =
 @metrics make_metrics_vector_selector
 read : Text -> (Vector Text) -> (Vector Text) -> Date -> Date -> Google_Credential -> Table
 read property_id:Text dimensions:Vector=['country'] metrics:Vector=['activeUsers'] start_date:Date=(Date.today.previous Date_Period.Year) end_date:Date=Date.today credentials:Google_Credential=Google_Credential.Default -> Table =
-    read_api_data property_id dimensions metrics start_date end_date credentials
+    case credentials of
+        Google_Credential.Sample -> read_sample_data dimensions metrics start_date end_date
+        _ -> read_api_data property_id dimensions metrics start_date end_date credentials

--- a/distribution/lib/Standard/Google_Api/0.0.0-dev/src/Google_Analytics.enso
+++ b/distribution/lib/Standard/Google_Api/0.0.0-dev/src/Google_Analytics.enso
@@ -8,24 +8,7 @@ from Standard.Table import Table
 
 import project.Google_Credential.Google_Credential
 from project.Internal.Google_Credential_Internal import all
-
-polyglot java import com.google.analytics.data.v1beta.BetaAnalyticsDataClient
-polyglot java import com.google.analytics.data.v1beta.BetaAnalyticsDataSettings
-polyglot java import com.google.analytics.data.v1beta.DateRange
-polyglot java import com.google.analytics.data.v1beta.Dimension
-polyglot java import com.google.analytics.data.v1beta.Metric
-polyglot java import com.google.analytics.data.v1beta.Row
-polyglot java import com.google.analytics.data.v1beta.RunReportRequest
-polyglot java import com.google.analytics.data.v1beta.RunReportResponse
-polyglot java import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
-polyglot java import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
-polyglot java import com.google.api.client.json.gson.GsonFactory
-polyglot java import com.google.api.gax.core.CredentialsProvider
-polyglot java import com.google.api.gax.core.FixedCredentialsProvider
-polyglot java import com.google.api.services.sheets.v4.Sheets
-polyglot java import com.google.api.services.sheets.v4.SheetsScopes
-polyglot java import com.google.auth.oauth2.GoogleCredentials
-polyglot java import java.util.Collections
+from project.Internal.Google_Analytics_Internal import all
 
 ## PRIVATE
 make_dimensions_vector_selector : Widget
@@ -50,36 +33,10 @@ make_metrics_vector_selector =
 @dimensions make_dimensions_vector_selector
 @metrics make_metrics_vector_selector
 read : Text -> (Vector Text) -> (Vector Text) -> Date -> Date -> Google_Credential -> Table
-read property_id:Text dimensions:Vector=['country'] metrics:Vector=['activeUsers'] start_date:Date=(Date.today.previous Date_Period.Year) end_date:Date=Date.today credentials=Google_Credential.Default -> Table =
-    analytics_data = case credentials of 
-        Google_Credential.Default -> BetaAnalyticsDataClient.create
-        Google_Credential.From_File _ -> 
-            betaAnalyticsDataSettings = BetaAnalyticsDataSettings.newBuilder
-               . setCredentialsProvider credentials.as_java
-               . build
-            BetaAnalyticsDataClient.create betaAnalyticsDataSettings
-    request_builder = RunReportRequest.newBuilder
-        . setProperty ("properties/"+property_id)
-        . addDateRanges (DateRange.newBuilder.setStartDate start_date.to_text . setEndDate end_date.to_text)
-    dimensions.distinct.each dimension->
-        request_builder.addDimensions (Dimension.newBuilder.setName dimension)
-    metrics.distinct.each metric->
-        request_builder.addMetrics (Metric.newBuilder.setName metric)
+read property_id:Text dimensions:Vector=['country'] metrics:Vector=['activeUsers'] start_date:Date=(Date.today.previous Date_Period.Year) end_date:Date=Date.today credentials:Google_Credential=Google_Credential.Default -> Table =
+    read_api_data property_id dimensions metrics start_date end_date credentials
 
-    request = request_builder.build
-    response = analytics_data.runReport request
 
-    dimension_count = response.getDimensionHeadersCount
-    dimension_headers = 0.up_to dimension_count . map i-> response.getDimensionHeaders i . getName
-    metric_count = response.getMetricHeadersCount
-    metric_headers = 0.up_to metric_count . map i-> response.getMetricHeaders i . getName
-    headers = dimension_headers + metric_headers
-
-    row_count = response.getRowCount
-    rows = Vector.new row_count i->
-        row = response.getRows i
-        dimension_values = 0.up_to dimension_count . map i-> row.getDimensionValues i . getValue
-        metric_values = 0.up_to metric_count . map i-> row.getMetricValues i . getValue
-        dimension_values + metric_values
-
-    Table.from_rows headers rows
+    case credentials of
+    Google_Credential.Sample -> read_sample_data property_id dimensions metrics start_date end_date
+    _ -> read_api_data property_id dimensions metrics start_date end_date credentials

--- a/distribution/lib/Standard/Google_Api/0.0.0-dev/src/Google_Credential.enso
+++ b/distribution/lib/Standard/Google_Api/0.0.0-dev/src/Google_Credential.enso
@@ -13,3 +13,7 @@ type Google_Credential
     ## ICON key
        Access using the defaults provided by the environment variables.
     Default
+
+    ## ICON key
+       Feeding this into supporting components will give sample data for that commponent.
+    Sample

--- a/distribution/lib/Standard/Google_Api/0.0.0-dev/src/Internal/Google_Analytics_Internal.enso
+++ b/distribution/lib/Standard/Google_Api/0.0.0-dev/src/Internal/Google_Analytics_Internal.enso
@@ -1,7 +1,7 @@
 private
 
 from Standard.Base import all
-from Standard.Table import Table
+from Standard.Table import Table, Delimited_Format
 
 import project.Google_Credential.Google_Credential
 from project.Internal.Google_Credential_Internal import all
@@ -11,18 +11,7 @@ polyglot java import com.google.analytics.data.v1beta.BetaAnalyticsDataSettings
 polyglot java import com.google.analytics.data.v1beta.DateRange
 polyglot java import com.google.analytics.data.v1beta.Dimension
 polyglot java import com.google.analytics.data.v1beta.Metric
-polyglot java import com.google.analytics.data.v1beta.Row
 polyglot java import com.google.analytics.data.v1beta.RunReportRequest
-polyglot java import com.google.analytics.data.v1beta.RunReportResponse
-polyglot java import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
-polyglot java import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
-polyglot java import com.google.api.client.json.gson.GsonFactory
-polyglot java import com.google.api.gax.core.CredentialsProvider
-polyglot java import com.google.api.gax.core.FixedCredentialsProvider
-polyglot java import com.google.api.services.sheets.v4.Sheets
-polyglot java import com.google.api.services.sheets.v4.SheetsScopes
-polyglot java import com.google.auth.oauth2.GoogleCredentials
-polyglot java import java.util.Collections
 
 read_api_data property_id:Text dimensions:Vector metrics:Vector start_date:Date end_date:Date credentials:Google_Credential -> Table =
     analytics_data = case credentials of 
@@ -58,6 +47,6 @@ read_api_data property_id:Text dimensions:Vector metrics:Vector start_date:Date 
 
     Table.from_rows headers rows
 
-read_sample_data property_id:Text dimensions:Vector metrics:Vector start_date:Date end_date:Date -> Table =
-    _ = [property_id, dimensions, metrics, start_date, end_date]
-    Data.read (enso_project.data / "food_shop_inventory.csv")
+read_sample_data dimensions:Vector metrics:Vector start_date:Date end_date:Date -> Table =
+    _ = [dimensions, metrics, start_date, end_date]
+    Data.read ((Project_Description.new Standard.Google_Api . data) / "Google_Analytics_Sample.csv") (Delimited_Format.Delimited value_formatter=Standard.Base.Nothing)

--- a/distribution/lib/Standard/Google_Api/0.0.0-dev/src/Internal/Google_Analytics_Internal.enso
+++ b/distribution/lib/Standard/Google_Api/0.0.0-dev/src/Internal/Google_Analytics_Internal.enso
@@ -1,0 +1,63 @@
+private
+
+from Standard.Base import all
+from Standard.Table import Table
+
+import project.Google_Credential.Google_Credential
+from project.Internal.Google_Credential_Internal import all
+
+polyglot java import com.google.analytics.data.v1beta.BetaAnalyticsDataClient
+polyglot java import com.google.analytics.data.v1beta.BetaAnalyticsDataSettings
+polyglot java import com.google.analytics.data.v1beta.DateRange
+polyglot java import com.google.analytics.data.v1beta.Dimension
+polyglot java import com.google.analytics.data.v1beta.Metric
+polyglot java import com.google.analytics.data.v1beta.Row
+polyglot java import com.google.analytics.data.v1beta.RunReportRequest
+polyglot java import com.google.analytics.data.v1beta.RunReportResponse
+polyglot java import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
+polyglot java import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
+polyglot java import com.google.api.client.json.gson.GsonFactory
+polyglot java import com.google.api.gax.core.CredentialsProvider
+polyglot java import com.google.api.gax.core.FixedCredentialsProvider
+polyglot java import com.google.api.services.sheets.v4.Sheets
+polyglot java import com.google.api.services.sheets.v4.SheetsScopes
+polyglot java import com.google.auth.oauth2.GoogleCredentials
+polyglot java import java.util.Collections
+
+read_api_data property_id:Text dimensions:Vector metrics:Vector start_date:Date end_date:Date credentials:Google_Credential -> Table =
+    analytics_data = case credentials of 
+        Google_Credential.Default -> BetaAnalyticsDataClient.create
+        Google_Credential.From_File _ -> 
+            betaAnalyticsDataSettings = BetaAnalyticsDataSettings.newBuilder
+               . setCredentialsProvider credentials.as_java
+               . build
+            BetaAnalyticsDataClient.create betaAnalyticsDataSettings
+    request_builder = RunReportRequest.newBuilder
+        . setProperty ("properties/"+property_id)
+        . addDateRanges (DateRange.newBuilder.setStartDate start_date.to_text . setEndDate end_date.to_text)
+    dimensions.distinct.each dimension->
+        request_builder.addDimensions (Dimension.newBuilder.setName dimension)
+    metrics.distinct.each metric->
+        request_builder.addMetrics (Metric.newBuilder.setName metric)
+
+    request = request_builder.build
+    response = analytics_data.runReport request
+
+    dimension_count = response.getDimensionHeadersCount
+    dimension_headers = 0.up_to dimension_count . map i-> response.getDimensionHeaders i . getName
+    metric_count = response.getMetricHeadersCount
+    metric_headers = 0.up_to metric_count . map i-> response.getMetricHeaders i . getName
+    headers = dimension_headers + metric_headers
+
+    row_count = response.getRowCount
+    rows = Vector.new row_count i->
+        row = response.getRows i
+        dimension_values = 0.up_to dimension_count . map i-> row.getDimensionValues i . getValue
+        metric_values = 0.up_to metric_count . map i-> row.getMetricValues i . getValue
+        dimension_values + metric_values
+
+    Table.from_rows headers rows
+
+read_sample_data property_id:Text dimensions:Vector metrics:Vector start_date:Date end_date:Date -> Table =
+    _ = [property_id, dimensions, metrics, start_date, end_date]
+    Data.read (enso_project.data / "food_shop_inventory.csv")


### PR DESCRIPTION
### Pull Request Description

This adds a new Google_Credential type of Sample. Which when passed to supporting components (like Google analytics) makes that component produce sample data. This can then be used to publish example workflows.

Sample data is fairly basic right now, but could be extended in the future.

![image](https://github.com/enso-org/enso/assets/1720119/d5b2ba32-3f7d-4276-92dc-34262c124c3a)

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
