### PR TITLE
Disable everything except restore / hard delete in trash

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/AssetRow.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/AssetRow.tsx
@@ -811,44 +811,44 @@ export default function AssetRow(props: AssetRowProps) {
                 }}
                 onDrop={event => {
                   if (state.category !== Category.trash) {
-                  props.onDrop?.(event)
-                  clearDragState()
-                  const [directoryKey, directoryId, directoryTitle] =
-                    item.item.type === backendModule.AssetType.directory
-                      ? [item.key, item.item.id, asset.title]
-                      : [item.directoryKey, item.directoryId, null]
-                  const payload = drag.ASSET_ROWS.lookup(event)
-                  if (
-                    payload != null &&
-                    payload.every(innerItem => innerItem.key !== directoryKey)
-                  ) {
-                    event.preventDefault()
-                    event.stopPropagation()
-                    unsetModal()
-                    doToggleDirectoryExpansion(directoryId, directoryKey, directoryTitle, true)
-                    const ids = payload
-                      .filter(payloadItem => payloadItem.asset.parentId !== directoryId)
-                      .map(dragItem => dragItem.key)
-                    dispatchAssetEvent({
-                      type: AssetEventType.move,
-                      newParentKey: directoryKey,
-                      newParentId: directoryId,
-                      ids: new Set(ids),
-                    })
-                  } else if (event.dataTransfer.types.includes('Files')) {
-                    event.preventDefault()
-                    event.stopPropagation()
-                    doToggleDirectoryExpansion(directoryId, directoryKey, directoryTitle, true)
-                    dispatchAssetListEvent({
-                      type: AssetListEventType.uploadFiles,
-                      // This is SAFE, as it is guarded by the condition above:
-                      // `item.item.type === backendModule.AssetType.directory`
-                      // eslint-disable-next-line no-restricted-syntax
-                      parentKey: directoryKey as backendModule.DirectoryId,
-                      parentId: directoryId,
-                      files: Array.from(event.dataTransfer.files),
-                    })
-                  }
+                    props.onDrop?.(event)
+                    clearDragState()
+                    const [directoryKey, directoryId, directoryTitle] =
+                      item.item.type === backendModule.AssetType.directory
+                        ? [item.key, item.item.id, asset.title]
+                        : [item.directoryKey, item.directoryId, null]
+                    const payload = drag.ASSET_ROWS.lookup(event)
+                    if (
+                      payload != null &&
+                      payload.every(innerItem => innerItem.key !== directoryKey)
+                    ) {
+                      event.preventDefault()
+                      event.stopPropagation()
+                      unsetModal()
+                      doToggleDirectoryExpansion(directoryId, directoryKey, directoryTitle, true)
+                      const ids = payload
+                        .filter(payloadItem => payloadItem.asset.parentId !== directoryId)
+                        .map(dragItem => dragItem.key)
+                      dispatchAssetEvent({
+                        type: AssetEventType.move,
+                        newParentKey: directoryKey,
+                        newParentId: directoryId,
+                        ids: new Set(ids),
+                      })
+                    } else if (event.dataTransfer.types.includes('Files')) {
+                      event.preventDefault()
+                      event.stopPropagation()
+                      doToggleDirectoryExpansion(directoryId, directoryKey, directoryTitle, true)
+                      dispatchAssetListEvent({
+                        type: AssetListEventType.uploadFiles,
+                        // This is SAFE, as it is guarded by the condition above:
+                        // `item.item.type === backendModule.AssetType.directory`
+                        // eslint-disable-next-line no-restricted-syntax
+                        parentKey: directoryKey as backendModule.DirectoryId,
+                        parentId: directoryId,
+                        files: Array.from(event.dataTransfer.files),
+                      })
+                    }
                   }
                 }}
               >

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/DataLinkNameColumn.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/DataLinkNameColumn.tsx
@@ -34,7 +34,7 @@ export interface DataLinkNameColumnProps extends column.AssetColumnProps {}
  * @throws {Error} when the asset is not a {@link backendModule.DataLinkAsset}.
  * This should never happen. */
 export default function DataLinkNameColumn(props: DataLinkNameColumnProps) {
-  const { item, setItem, selected, state, rowState, setRowState } = props
+  const { item, setItem, selected, state, rowState, setRowState, isEditable } = props
   const { assetEvents, dispatchAssetListEvent, setIsAssetPanelTemporarilyVisible } = state
   const toastAndLog = toastAndLogHooks.useToastAndLog()
   const { backend } = backendProvider.useBackend()
@@ -46,6 +46,12 @@ export default function DataLinkNameColumn(props: DataLinkNameColumnProps) {
   }
   const setAsset = setAssetHooks.useSetAsset(asset, setItem)
 
+  const setIsEditing = (isEditingName: boolean) => {
+    if (isEditable) {
+      setRowState(object.merger({ isEditingName }))
+    }
+  }
+
   // TODO[sb]: Wait for backend implementation. `editable` should also be re-enabled, and the
   // context menu entry should be re-added.
   // Backend implementation is tracked here: https://github.com/enso-org/cloud-v2/issues/505.
@@ -53,64 +59,68 @@ export default function DataLinkNameColumn(props: DataLinkNameColumnProps) {
     await Promise.resolve(null)
   }
 
-  eventHooks.useEventHandler(assetEvents, async event => {
-    switch (event.type) {
-      case AssetEventType.newProject:
-      case AssetEventType.newFolder:
-      case AssetEventType.uploadFiles:
-      case AssetEventType.newSecret:
-      case AssetEventType.openProject:
-      case AssetEventType.updateFiles:
-      case AssetEventType.closeProject:
-      case AssetEventType.copy:
-      case AssetEventType.cut:
-      case AssetEventType.cancelCut:
-      case AssetEventType.move:
-      case AssetEventType.delete:
-      case AssetEventType.deleteForever:
-      case AssetEventType.restore:
-      case AssetEventType.download:
-      case AssetEventType.downloadSelected:
-      case AssetEventType.removeSelf:
-      case AssetEventType.temporarilyAddLabels:
-      case AssetEventType.temporarilyRemoveLabels:
-      case AssetEventType.addLabels:
-      case AssetEventType.removeLabels:
-      case AssetEventType.deleteLabel: {
-        // Ignored. These events should all be unrelated to secrets.
-        // `delete`, `deleteForever`, `restoreMultiple`, `download`, and `downloadSelected`
-        // are handled by `AssetRow`.
-        break
-      }
-      case AssetEventType.newDataLink: {
-        if (item.key === event.placeholderId) {
-          if (backend.type !== backendModule.BackendType.remote) {
-            toastAndLog('localBackendDataLinkError')
-          } else {
-            rowState.setVisibility(Visibility.faded)
-            try {
-              const { id } = await backend.createConnector({
-                parentDirectoryId: asset.parentId,
-                connectorId: null,
-                name: asset.title,
-                value: event.value,
-              })
-              rowState.setVisibility(Visibility.visible)
-              setAsset(object.merger({ id }))
-            } catch (error) {
-              dispatchAssetListEvent({ type: AssetListEventType.delete, key: item.key })
-              toastAndLog('createDataLinkError', error)
+  eventHooks.useEventHandler(
+    assetEvents,
+    async event => {
+      switch (event.type) {
+        case AssetEventType.newProject:
+        case AssetEventType.newFolder:
+        case AssetEventType.uploadFiles:
+        case AssetEventType.newSecret:
+        case AssetEventType.openProject:
+        case AssetEventType.updateFiles:
+        case AssetEventType.closeProject:
+        case AssetEventType.copy:
+        case AssetEventType.cut:
+        case AssetEventType.cancelCut:
+        case AssetEventType.move:
+        case AssetEventType.delete:
+        case AssetEventType.deleteForever:
+        case AssetEventType.restore:
+        case AssetEventType.download:
+        case AssetEventType.downloadSelected:
+        case AssetEventType.removeSelf:
+        case AssetEventType.temporarilyAddLabels:
+        case AssetEventType.temporarilyRemoveLabels:
+        case AssetEventType.addLabels:
+        case AssetEventType.removeLabels:
+        case AssetEventType.deleteLabel: {
+          // Ignored. These events should all be unrelated to secrets.
+          // `delete`, `deleteForever`, `restoreMultiple`, `download`, and `downloadSelected`
+          // are handled by `AssetRow`.
+          break
+        }
+        case AssetEventType.newDataLink: {
+          if (item.key === event.placeholderId) {
+            if (backend.type !== backendModule.BackendType.remote) {
+              toastAndLog('localBackendDataLinkError')
+            } else {
+              rowState.setVisibility(Visibility.faded)
+              try {
+                const { id } = await backend.createConnector({
+                  parentDirectoryId: asset.parentId,
+                  connectorId: null,
+                  name: asset.title,
+                  value: event.value,
+                })
+                rowState.setVisibility(Visibility.visible)
+                setAsset(object.merger({ id }))
+              } catch (error) {
+                dispatchAssetListEvent({ type: AssetListEventType.delete, key: item.key })
+                toastAndLog('createDataLinkError', error)
+              }
             }
           }
+          break
         }
-        break
       }
-    }
-  })
+    },
+    { isDisabled: !isEditable }
+  )
 
   const handleClick = inputBindings.handler({
     editName: () => {
-      setRowState(object.merger({ isEditingName: true }))
+      setIsEditing(true)
     },
   })
 
@@ -128,7 +138,7 @@ export default function DataLinkNameColumn(props: DataLinkNameColumnProps) {
         if (handleClick(event)) {
           // Already handled.
         } else if (eventModule.isSingleClick(event) && selected) {
-          setRowState(object.merger({ isEditingName: true }))
+          setIsEditing(true)
         } else if (eventModule.isDoubleClick(event)) {
           event.stopPropagation()
           setIsAssetPanelTemporarilyVisible(true)
@@ -139,7 +149,8 @@ export default function DataLinkNameColumn(props: DataLinkNameColumnProps) {
       <EditableSpan
         editable={false}
         onSubmit={async newTitle => {
-          setRowState(object.merger({ isEditingName: false }))
+          setIsEditing(false)
+
           if (newTitle !== asset.title) {
             const oldTitle = asset.title
             setAsset(object.merger({ title: newTitle }))
@@ -151,7 +162,7 @@ export default function DataLinkNameColumn(props: DataLinkNameColumnProps) {
           }
         }}
         onCancel={() => {
-          setRowState(object.merger({ isEditingName: false }))
+          setIsEditing(false)
         }}
         className="text grow bg-transparent"
       >

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/DirectoryNameColumn.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/DirectoryNameColumn.tsx
@@ -38,7 +38,7 @@ export interface DirectoryNameColumnProps extends column.AssetColumnProps {}
  * @throws {Error} when the asset is not a {@link backendModule.DirectoryAsset}.
  * This should never happen. */
 export default function DirectoryNameColumn(props: DirectoryNameColumnProps) {
-  const { item, setItem, selected, state, rowState, setRowState } = props
+  const { item, setItem, selected, state, rowState, setRowState, isEditable } = props
   const { selectedKeys, assetEvents, dispatchAssetListEvent, nodeMap } = state
   const { doToggleDirectoryExpansion } = state
   const toastAndLog = toastAndLogHooks.useToastAndLog()
@@ -53,74 +53,86 @@ export default function DirectoryNameColumn(props: DirectoryNameColumnProps) {
   const setAsset = setAssetHooks.useSetAsset(asset, setItem)
   const isCloud = backend.type === backendModule.BackendType.remote
 
+  const setIsEditing = (isEditingName: boolean) => {
+    if (isEditable) {
+      setRowState(object.merger({ isEditingName }))
+    }
+  }
+
   const doRename = async (newTitle: string) => {
-    setRowState(object.merger({ isEditingName: false }))
-    if (string.isWhitespaceOnly(newTitle)) {
-      // Do nothing.
-    } else if (isCloud && newTitle !== asset.title) {
-      const oldTitle = asset.title
-      setAsset(object.merger({ title: newTitle }))
-      try {
-        await backend.updateDirectory(asset.id, { title: newTitle }, asset.title)
-      } catch (error) {
-        toastAndLog('renameFolderError', error)
-        setAsset(object.merger({ title: oldTitle }))
+    if (isEditable) {
+      setIsEditing(false)
+      if (string.isWhitespaceOnly(newTitle)) {
+        // Do nothing.
+      } else if (isCloud && newTitle !== asset.title) {
+        const oldTitle = asset.title
+        setAsset(object.merger({ title: newTitle }))
+        try {
+          await backend.updateDirectory(asset.id, { title: newTitle }, asset.title)
+        } catch (error) {
+          toastAndLog('renameFolderError', error)
+          setAsset(object.merger({ title: oldTitle }))
+        }
       }
     }
   }
 
-  eventHooks.useEventHandler(assetEvents, async event => {
-    switch (event.type) {
-      case AssetEventType.newProject:
-      case AssetEventType.uploadFiles:
-      case AssetEventType.newDataLink:
-      case AssetEventType.newSecret:
-      case AssetEventType.openProject:
-      case AssetEventType.updateFiles:
-      case AssetEventType.closeProject:
-      case AssetEventType.copy:
-      case AssetEventType.cut:
-      case AssetEventType.cancelCut:
-      case AssetEventType.move:
-      case AssetEventType.delete:
-      case AssetEventType.deleteForever:
-      case AssetEventType.restore:
-      case AssetEventType.download:
-      case AssetEventType.downloadSelected:
-      case AssetEventType.removeSelf:
-      case AssetEventType.temporarilyAddLabels:
-      case AssetEventType.temporarilyRemoveLabels:
-      case AssetEventType.addLabels:
-      case AssetEventType.removeLabels:
-      case AssetEventType.deleteLabel: {
-        // Ignored. These events should all be unrelated to directories.
-        // `delete`, `deleteForever`, `restore`, `download`, and `downloadSelected`
-        // are handled by`AssetRow`.
-        break
-      }
-      case AssetEventType.newFolder: {
-        if (item.key === event.placeholderId) {
-          rowState.setVisibility(Visibility.faded)
-          try {
-            const createdDirectory = await backend.createDirectory({
-              parentId: asset.parentId,
-              title: asset.title,
-            })
-            rowState.setVisibility(Visibility.visible)
-            setAsset(object.merge(asset, createdDirectory))
-          } catch (error) {
-            dispatchAssetListEvent({ type: AssetListEventType.delete, key: item.key })
-            toastAndLog('createFolderError', error)
-          }
+  eventHooks.useEventHandler(
+    assetEvents,
+    async event => {
+      switch (event.type) {
+        case AssetEventType.newProject:
+        case AssetEventType.uploadFiles:
+        case AssetEventType.newDataLink:
+        case AssetEventType.newSecret:
+        case AssetEventType.openProject:
+        case AssetEventType.updateFiles:
+        case AssetEventType.closeProject:
+        case AssetEventType.copy:
+        case AssetEventType.cut:
+        case AssetEventType.cancelCut:
+        case AssetEventType.move:
+        case AssetEventType.delete:
+        case AssetEventType.deleteForever:
+        case AssetEventType.restore:
+        case AssetEventType.download:
+        case AssetEventType.downloadSelected:
+        case AssetEventType.removeSelf:
+        case AssetEventType.temporarilyAddLabels:
+        case AssetEventType.temporarilyRemoveLabels:
+        case AssetEventType.addLabels:
+        case AssetEventType.removeLabels:
+        case AssetEventType.deleteLabel: {
+          // Ignored. These events should all be unrelated to directories.
+          // `delete`, `deleteForever`, `restore`, `download`, and `downloadSelected`
+          // are handled by`AssetRow`.
+          break
         }
-        break
+        case AssetEventType.newFolder: {
+          if (item.key === event.placeholderId) {
+            rowState.setVisibility(Visibility.faded)
+            try {
+              const createdDirectory = await backend.createDirectory({
+                parentId: asset.parentId,
+                title: asset.title,
+              })
+              rowState.setVisibility(Visibility.visible)
+              setAsset(object.merge(asset, createdDirectory))
+            } catch (error) {
+              dispatchAssetListEvent({ type: AssetListEventType.delete, key: item.key })
+              toastAndLog('createFolderError', error)
+            }
+          }
+          break
+        }
       }
-    }
-  })
+    },
+    { isDisabled: !isEditable }
+  )
 
   const handleClick = inputBindings.handler({
     editName: () => {
-      setRowState(object.merger({ isEditingName: true }))
+      setIsEditing(true)
     },
   })
 
@@ -143,7 +155,7 @@ export default function DirectoryNameColumn(props: DirectoryNameColumnProps) {
           selectedKeys.current.size === 1
         ) {
           event.stopPropagation()
-          setRowState(object.merger({ isEditingName: true }))
+          setIsEditing(true)
         }
       }}
     >
@@ -179,7 +191,7 @@ export default function DirectoryNameColumn(props: DirectoryNameColumnProps) {
         }
         onSubmit={doRename}
         onCancel={() => {
-          setRowState(object.merger({ isEditingName: false }))
+          setIsEditing(false)
         }}
       >
         {asset.title}

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/FileNameColumn.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/FileNameColumn.tsx
@@ -34,7 +34,7 @@ export interface FileNameColumnProps extends column.AssetColumnProps {}
  * @throws {Error} when the asset is not a {@link backendModule.FileAsset}.
  * This should never happen. */
 export default function FileNameColumn(props: FileNameColumnProps) {
-  const { item, setItem, selected, state, rowState, setRowState } = props
+  const { item, setItem, selected, state, rowState, setRowState, isEditable } = props
   const { nodeMap, assetEvents, dispatchAssetListEvent } = state
   const toastAndLog = toastAndLogHooks.useToastAndLog()
   const { backend } = backendProvider.useBackend()
@@ -46,6 +46,12 @@ export default function FileNameColumn(props: FileNameColumnProps) {
   }
   const setAsset = setAssetHooks.useSetAsset(asset, setItem)
 
+  const setIsEditing = (isEditingName: boolean) => {
+    if (isEditable) {
+      setRowState(object.merger({ isEditingName }))
+    }
+  }
+
   // TODO[sb]: Wait for backend implementation. `editable` should also be re-enabled, and the
   // context menu entry should be re-added.
   // Backend implementation is tracked here: https://github.com/enso-org/cloud-v2/issues/505.
@@ -53,69 +59,73 @@ export default function FileNameColumn(props: FileNameColumnProps) {
     return await Promise.resolve(null)
   }
 
-  eventHooks.useEventHandler(assetEvents, async event => {
-    switch (event.type) {
-      case AssetEventType.newProject:
-      case AssetEventType.newFolder:
-      case AssetEventType.newDataLink:
-      case AssetEventType.newSecret:
-      case AssetEventType.openProject:
-      case AssetEventType.closeProject:
-      case AssetEventType.copy:
-      case AssetEventType.cut:
-      case AssetEventType.cancelCut:
-      case AssetEventType.move:
-      case AssetEventType.delete:
-      case AssetEventType.deleteForever:
-      case AssetEventType.restore:
-      case AssetEventType.download:
-      case AssetEventType.downloadSelected:
-      case AssetEventType.removeSelf:
-      case AssetEventType.temporarilyAddLabels:
-      case AssetEventType.temporarilyRemoveLabels:
-      case AssetEventType.addLabels:
-      case AssetEventType.removeLabels:
-      case AssetEventType.deleteLabel: {
-        // Ignored. These events should all be unrelated to projects.
-        // `delete`, `deleteForever`, `restoreMultiple`, `download`, and `downloadSelected`
-        // are handled by `AssetRow`.
-        break
-      }
-      case AssetEventType.updateFiles:
-      case AssetEventType.uploadFiles: {
-        const file = event.files.get(item.item.id)
-        if (file != null) {
-          const fileId = event.type !== AssetEventType.updateFiles ? null : asset.id
-          rowState.setVisibility(Visibility.faded)
-          try {
-            const createdFile = await backend.uploadFile(
-              { fileId, fileName: asset.title, parentDirectoryId: asset.parentId },
-              file
-            )
-            rowState.setVisibility(Visibility.visible)
-            setAsset(object.merge(asset, { id: createdFile.id }))
-          } catch (error) {
-            switch (event.type) {
-              case AssetEventType.uploadFiles: {
-                dispatchAssetListEvent({ type: AssetListEventType.delete, key: item.key })
-                toastAndLog(null, error)
-                break
-              }
-              case AssetEventType.updateFiles: {
-                toastAndLog(null, error)
-                break
+  eventHooks.useEventHandler(
+    assetEvents,
+    async event => {
+      switch (event.type) {
+        case AssetEventType.newProject:
+        case AssetEventType.newFolder:
+        case AssetEventType.newDataLink:
+        case AssetEventType.newSecret:
+        case AssetEventType.openProject:
+        case AssetEventType.closeProject:
+        case AssetEventType.copy:
+        case AssetEventType.cut:
+        case AssetEventType.cancelCut:
+        case AssetEventType.move:
+        case AssetEventType.delete:
+        case AssetEventType.deleteForever:
+        case AssetEventType.restore:
+        case AssetEventType.download:
+        case AssetEventType.downloadSelected:
+        case AssetEventType.removeSelf:
+        case AssetEventType.temporarilyAddLabels:
+        case AssetEventType.temporarilyRemoveLabels:
+        case AssetEventType.addLabels:
+        case AssetEventType.removeLabels:
+        case AssetEventType.deleteLabel: {
+          // Ignored. These events should all be unrelated to projects.
+          // `delete`, `deleteForever`, `restoreMultiple`, `download`, and `downloadSelected`
+          // are handled by `AssetRow`.
+          break
+        }
+        case AssetEventType.updateFiles:
+        case AssetEventType.uploadFiles: {
+          const file = event.files.get(item.item.id)
+          if (file != null) {
+            const fileId = event.type !== AssetEventType.updateFiles ? null : asset.id
+            rowState.setVisibility(Visibility.faded)
+            try {
+              const createdFile = await backend.uploadFile(
+                { fileId, fileName: asset.title, parentDirectoryId: asset.parentId },
+                file
+              )
+              rowState.setVisibility(Visibility.visible)
+              setAsset(object.merge(asset, { id: createdFile.id }))
+            } catch (error) {
+              switch (event.type) {
+                case AssetEventType.uploadFiles: {
+                  dispatchAssetListEvent({ type: AssetListEventType.delete, key: item.key })
+                  toastAndLog(null, error)
+                  break
+                }
+                case AssetEventType.updateFiles: {
+                  toastAndLog(null, error)
+                  break
+                }
               }
             }
           }
+          break
         }
-        break
       }
-    }
-  })
+    },
+    { isDisabled: !isEditable }
+  )
 
   const handleClick = inputBindings.handler({
     editName: () => {
-      setRowState(object.merger({ isEditingName: true }))
+      setIsEditing(true)
     },
   })
 
@@ -133,7 +143,7 @@ export default function FileNameColumn(props: FileNameColumnProps) {
         if (handleClick(event)) {
           // Already handled.
         } else if (eventModule.isSingleClick(event) && selected) {
-          setRowState(object.merger({ isEditingName: true }))
+          setIsEditing(true)
         }
       }}
     >
@@ -155,7 +165,7 @@ export default function FileNameColumn(props: FileNameColumnProps) {
           )
         }
         onSubmit={async newTitle => {
-          setRowState(object.merger({ isEditingName: false }))
+          setIsEditing(false)
           if (newTitle !== asset.title) {
             const oldTitle = asset.title
             setAsset(object.merger({ title: newTitle }))
@@ -167,7 +177,7 @@ export default function FileNameColumn(props: FileNameColumnProps) {
           }
         }}
         onCancel={() => {
-          setRowState(object.merger({ isEditingName: false }))
+          setIsEditing(false)
         }}
       >
         {asset.title}

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/ProjectNameColumn.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/ProjectNameColumn.tsx
@@ -43,7 +43,7 @@ export interface ProjectNameColumnProps extends column.AssetColumnProps {}
  * @throws {Error} when the asset is not a {@link backendModule.ProjectAsset}.
  * This should never happen. */
 export default function ProjectNameColumn(props: ProjectNameColumnProps) {
-  const { item, setItem, selected, rowState, setRowState, state } = props
+  const { item, setItem, selected, rowState, setRowState, state, isEditable } = props
   const { selectedKeys, assetEvents, dispatchAssetEvent, dispatchAssetListEvent } = state
   const { nodeMap, doOpenManually, doOpenEditor, doCloseEditor } = state
   const toastAndLog = toastAndLogHooks.useToastAndLog()
@@ -67,15 +67,24 @@ export default function ProjectNameColumn(props: ProjectNameColumnProps) {
   }
   const isRunning = backendModule.IS_OPENING_OR_OPENED[projectState.type]
   const canExecute =
-    backend.type === backendModule.BackendType.local ||
-    (ownPermission != null && permissions.PERMISSION_ACTION_CAN_EXECUTE[ownPermission.permission])
+    isEditable &&
+    (backend.type === backendModule.BackendType.local ||
+      (ownPermission != null &&
+        permissions.PERMISSION_ACTION_CAN_EXECUTE[ownPermission.permission]))
   const isOtherUserUsingProject =
     backend.type !== backendModule.BackendType.local &&
     projectState.opened_by != null &&
     projectState.opened_by !== user?.email
 
+  const setIsEditing = (isEditingName: boolean) => {
+    if (isEditable) {
+      setRowState(object.merger({ isEditingName }))
+    }
+  }
+
   const doRename = async (newTitle: string) => {
-    setRowState(object.merger({ isEditingName: false }))
+    setIsEditing(false)
+
     if (string.isWhitespaceOnly(newTitle)) {
       // Do nothing.
     } else if (newTitle !== asset.title) {
@@ -94,144 +103,152 @@ export default function ProjectNameColumn(props: ProjectNameColumnProps) {
     }
   }
 
-  eventHooks.useEventHandler(assetEvents, async event => {
-    switch (event.type) {
-      case AssetEventType.newFolder:
-      case AssetEventType.newDataLink:
-      case AssetEventType.newSecret:
-      case AssetEventType.openProject:
-      case AssetEventType.closeProject:
-      case AssetEventType.copy:
-      case AssetEventType.cut:
-      case AssetEventType.cancelCut:
-      case AssetEventType.move:
-      case AssetEventType.delete:
-      case AssetEventType.deleteForever:
-      case AssetEventType.restore:
-      case AssetEventType.download:
-      case AssetEventType.downloadSelected:
-      case AssetEventType.removeSelf:
-      case AssetEventType.temporarilyAddLabels:
-      case AssetEventType.temporarilyRemoveLabels:
-      case AssetEventType.addLabels:
-      case AssetEventType.removeLabels:
-      case AssetEventType.deleteLabel: {
-        // Ignored. Any missing project-related events should be handled by `ProjectIcon`.
-        // `delete`, `deleteForever`, `restore`, `download`, and `downloadSelected`
-        // are handled by`AssetRow`.
-        break
-      }
-      case AssetEventType.newProject: {
-        // This should only run before this project gets replaced with the actual project
-        // by this event handler. In both cases `key` will match, so using `key` here
-        // is a mistake.
-        if (asset.id === event.placeholderId) {
-          rowState.setVisibility(Visibility.faded)
-          try {
-            const createdProject = await backend.createProject({
-              parentDirectoryId: asset.parentId,
-              projectName: asset.title,
-              projectTemplateName: event.templateId,
-            })
-            rowState.setVisibility(Visibility.visible)
-            setAsset(
-              object.merge(asset, {
-                id: createdProject.projectId,
-                projectState: object.merge(projectState, {
-                  type: backendModule.ProjectState.placeholder,
-                  ...(backend.type === backendModule.BackendType.remote
-                    ? {}
-                    : { path: createdProject.state.path }),
-                }),
+  eventHooks.useEventHandler(
+    assetEvents,
+    async event => {
+      switch (event.type) {
+        case AssetEventType.newFolder:
+        case AssetEventType.newDataLink:
+        case AssetEventType.newSecret:
+        case AssetEventType.openProject:
+        case AssetEventType.closeProject:
+        case AssetEventType.copy:
+        case AssetEventType.cut:
+        case AssetEventType.cancelCut:
+        case AssetEventType.move:
+        case AssetEventType.delete:
+        case AssetEventType.deleteForever:
+        case AssetEventType.restore:
+        case AssetEventType.download:
+        case AssetEventType.downloadSelected:
+        case AssetEventType.removeSelf:
+        case AssetEventType.temporarilyAddLabels:
+        case AssetEventType.temporarilyRemoveLabels:
+        case AssetEventType.addLabels:
+        case AssetEventType.removeLabels:
+        case AssetEventType.deleteLabel: {
+          // Ignored. Any missing project-related events should be handled by `ProjectIcon`.
+          // `delete`, `deleteForever`, `restore`, `download`, and `downloadSelected`
+          // are handled by`AssetRow`.
+          break
+        }
+        case AssetEventType.newProject: {
+          // This should only run before this project gets replaced with the actual project
+          // by this event handler. In both cases `key` will match, so using `key` here
+          // is a mistake.
+          if (asset.id === event.placeholderId) {
+            rowState.setVisibility(Visibility.faded)
+            try {
+              const createdProject = await backend.createProject({
+                parentDirectoryId: asset.parentId,
+                projectName: asset.title,
+                projectTemplateName: event.templateId,
               })
-            )
-            dispatchAssetEvent({
-              type: AssetEventType.openProject,
-              id: createdProject.projectId,
-              shouldAutomaticallySwitchPage: true,
-              runInBackground: false,
-            })
-          } catch (error) {
-            dispatchAssetListEvent({ type: AssetListEventType.delete, key: item.key })
-            toastAndLog('createProjectError', error)
-          }
-        }
-        break
-      }
-      case AssetEventType.updateFiles:
-      case AssetEventType.uploadFiles: {
-        const file = event.files.get(item.key)
-        if (file != null) {
-          const fileId = event.type !== AssetEventType.updateFiles ? null : asset.id
-          rowState.setVisibility(Visibility.faded)
-          const { extension } = backendModule.extractProjectExtension(file.name)
-          const title = backendModule.stripProjectExtension(asset.title)
-          setAsset(object.merge(asset, { title }))
-          try {
-            if (backend.type === backendModule.BackendType.local) {
-              const directory = localBackend.extractTypeAndId(item.directoryId).id
-              let id: string
-              if (
-                'backendApi' in window &&
-                // This non-standard property is defined in Electron.
-                'path' in file &&
-                typeof file.path === 'string'
-              ) {
-                id = await window.backendApi.importProjectFromPath(file.path, directory, title)
-              } else {
-                const searchParams = new URLSearchParams({ directory, name: title }).toString()
-                // Ideally this would use `file.stream()`, to minimize RAM
-                // requirements. for uploading large projects. Unfortunately,
-                // this requires HTTP/2, which is HTTPS-only, so it will not
-                // work on `http://localhost`.
-                const body =
-                  window.location.protocol === 'https:' ? file.stream() : await file.arrayBuffer()
-                const path = `./api/upload-project?${searchParams}`
-                const response = await fetch(path, { method: 'POST', body })
-                id = await response.text()
-              }
-              const projectId = localBackend.newProjectId(projectManager.UUID(id))
-              const listedProject = await backend.getProjectDetails(
-                projectId,
-                asset.parentId,
-                file.name
-              )
               rowState.setVisibility(Visibility.visible)
-              setAsset(object.merge(asset, { title: listedProject.packageName, id: projectId }))
-            } else {
-              const createdFile = await backend.uploadFile(
-                { fileId, fileName: `${title}.${extension}`, parentDirectoryId: asset.parentId },
-                file
+              setAsset(
+                object.merge(asset, {
+                  id: createdProject.projectId,
+                  projectState: object.merge(projectState, {
+                    type: backendModule.ProjectState.placeholder,
+                    ...(backend.type === backendModule.BackendType.remote
+                      ? {}
+                      : { path: createdProject.state.path }),
+                  }),
+                })
               )
-              const project = createdFile.project
-              if (project == null) {
-                throw new Error('The uploaded file was not a project.')
-              } else {
-                rowState.setVisibility(Visibility.visible)
-                setAsset(
-                  object.merge(asset, { title, id: project.projectId, projectState: project.state })
-                )
-                return
-              }
+              dispatchAssetEvent({
+                type: AssetEventType.openProject,
+                id: createdProject.projectId,
+                shouldAutomaticallySwitchPage: true,
+                runInBackground: false,
+              })
+            } catch (error) {
+              dispatchAssetListEvent({ type: AssetListEventType.delete, key: item.key })
+              toastAndLog('createProjectError', error)
             }
-          } catch (error) {
-            switch (event.type) {
-              case AssetEventType.uploadFiles: {
-                dispatchAssetListEvent({ type: AssetListEventType.delete, key: item.key })
-                toastAndLog('uploadProjectError', error)
-                break
+          }
+          break
+        }
+        case AssetEventType.updateFiles:
+        case AssetEventType.uploadFiles: {
+          const file = event.files.get(item.key)
+          if (file != null) {
+            const fileId = event.type !== AssetEventType.updateFiles ? null : asset.id
+            rowState.setVisibility(Visibility.faded)
+            const { extension } = backendModule.extractProjectExtension(file.name)
+            const title = backendModule.stripProjectExtension(asset.title)
+            setAsset(object.merge(asset, { title }))
+            try {
+              if (backend.type === backendModule.BackendType.local) {
+                const directory = localBackend.extractTypeAndId(item.directoryId).id
+                let id: string
+                if (
+                  'backendApi' in window &&
+                  // This non-standard property is defined in Electron.
+                  'path' in file &&
+                  typeof file.path === 'string'
+                ) {
+                  id = await window.backendApi.importProjectFromPath(file.path, directory, title)
+                } else {
+                  const searchParams = new URLSearchParams({ directory, name: title }).toString()
+                  // Ideally this would use `file.stream()`, to minimize RAM
+                  // requirements. for uploading large projects. Unfortunately,
+                  // this requires HTTP/2, which is HTTPS-only, so it will not
+                  // work on `http://localhost`.
+                  const body =
+                    window.location.protocol === 'https:' ? file.stream() : await file.arrayBuffer()
+                  const path = `./api/upload-project?${searchParams}`
+                  const response = await fetch(path, { method: 'POST', body })
+                  id = await response.text()
+                }
+                const projectId = localBackend.newProjectId(projectManager.UUID(id))
+                const listedProject = await backend.getProjectDetails(
+                  projectId,
+                  asset.parentId,
+                  file.name
+                )
+                rowState.setVisibility(Visibility.visible)
+                setAsset(object.merge(asset, { title: listedProject.packageName, id: projectId }))
+              } else {
+                const createdFile = await backend.uploadFile(
+                  { fileId, fileName: `${title}.${extension}`, parentDirectoryId: asset.parentId },
+                  file
+                )
+                const project = createdFile.project
+                if (project == null) {
+                  throw new Error('The uploaded file was not a project.')
+                } else {
+                  rowState.setVisibility(Visibility.visible)
+                  setAsset(
+                    object.merge(asset, {
+                      title,
+                      id: project.projectId,
+                      projectState: project.state,
+                    })
+                  )
+                  return
+                }
               }
-              case AssetEventType.updateFiles: {
-                toastAndLog('updateProjectError', error)
-                break
+            } catch (error) {
+              switch (event.type) {
+                case AssetEventType.uploadFiles: {
+                  dispatchAssetListEvent({ type: AssetListEventType.delete, key: item.key })
+                  toastAndLog('uploadProjectError', error)
+                  break
+                }
+                case AssetEventType.updateFiles: {
+                  toastAndLog('updateProjectError', error)
+                  break
+                }
               }
             }
           }
+          break
         }
-        break
       }
-    }
-  })
+    },
+    { isDisabled: !isEditable }
+  )
 
   const handleClick = inputBindings.handler({
     open: () => {
@@ -251,7 +268,7 @@ export default function ProjectNameColumn(props: ProjectNameColumnProps) {
       })
     },
     editName: () => {
-      setRowState(object.merger({ isEditingName: true }))
+      setIsEditing(true)
     },
   })
 
@@ -276,7 +293,7 @@ export default function ProjectNameColumn(props: ProjectNameColumnProps) {
           selected &&
           selectedKeys.current.size === 1
         ) {
-          setRowState(object.merger({ isEditingName: true }))
+          setIsEditing(true)
         }
       }}
     >
@@ -323,7 +340,7 @@ export default function ProjectNameColumn(props: ProjectNameColumnProps) {
         }
         onSubmit={doRename}
         onCancel={() => {
-          setRowState(object.merger({ isEditingName: false }))
+          setIsEditing(false)
         }}
         {...(backend.type === backendModule.BackendType.local
           ? {

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/column.ts
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/column.ts
@@ -1,4 +1,6 @@
 /** @file Column types and column display modes. */
+import type * as React from 'react'
+
 import type * as assetsTable from '#/layouts/AssetsTable'
 
 import * as columnUtils from '#/components/dashboard/column/columnUtils'
@@ -28,6 +30,7 @@ export interface AssetColumnProps {
   readonly state: assetsTable.AssetsTableState
   readonly rowState: assetsTable.AssetRowState
   readonly setRowState: React.Dispatch<React.SetStateAction<assetsTable.AssetRowState>>
+  readonly isEditable: boolean
 }
 
 /** Props for a {@link AssetColumn}. */
@@ -39,8 +42,8 @@ export interface AssetColumnHeadingProps {
 export interface AssetColumn {
   readonly id: string
   readonly className?: string
-  readonly heading: (props: AssetColumnHeadingProps) => JSX.Element
-  readonly render: (props: AssetColumnProps) => JSX.Element
+  readonly heading: (props: AssetColumnHeadingProps) => React.JSX.Element
+  readonly render: (props: AssetColumnProps) => React.JSX.Element
 }
 
 // =======================
@@ -49,7 +52,7 @@ export interface AssetColumn {
 
 /** React components for every column. */
 export const COLUMN_RENDERER: Readonly<
-  Record<columnUtils.Column, (props: AssetColumnProps) => JSX.Element>
+  Record<columnUtils.Column, (props: AssetColumnProps) => React.JSX.Element>
 > = {
   [columnUtils.Column.name]: NameColumn,
   [columnUtils.Column.modified]: LastModifiedColumn,

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/column/SharedWithColumn.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/column/SharedWithColumn.tsx
@@ -31,12 +31,13 @@ interface SharedWithColumnStateProp
 
 /** Props for a {@link SharedWithColumn}. */
 interface SharedWithColumnPropsInternal extends Pick<column.AssetColumnProps, 'item' | 'setItem'> {
+  readonly isReadonly?: boolean
   readonly state: SharedWithColumnStateProp
 }
 
 /** A column listing the users with which this asset is shared. */
 export default function SharedWithColumn(props: SharedWithColumnPropsInternal) {
-  const { item, setItem, state } = props
+  const { item, setItem, state, isReadonly = false } = props
   const { category, dispatchAssetEvent, setQuery } = state
   const asset = item.item
   const { user } = authProvider.useNonPartialUserSession()
@@ -44,6 +45,7 @@ export default function SharedWithColumn(props: SharedWithColumnPropsInternal) {
   const plusButtonRef = React.useRef<HTMLButtonElement>(null)
   const self = asset.permissions?.find(permission => permission.user.userId === user?.userId)
   const managesThisAsset =
+    !isReadonly &&
     category !== Category.trash &&
     (self?.permission === permissions.PermissionAction.own ||
       self?.permission === permissions.PermissionAction.admin)

--- a/app/ide-desktop/lib/dashboard/src/layouts/AssetPanel.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/AssetPanel.tsx
@@ -57,6 +57,7 @@ export interface AssetPanelRequiredProps {
 
 /** Props for an {@link AssetPanel}. */
 export interface AssetPanelProps extends AssetPanelRequiredProps {
+  readonly isReadonly?: boolean
   readonly setQuery: React.Dispatch<React.SetStateAction<AssetQuery>>
   readonly category: Category
   readonly labels: backend.Label[]
@@ -65,7 +66,15 @@ export interface AssetPanelProps extends AssetPanelRequiredProps {
 
 /** A panel containing the description and settings for an asset. */
 export default function AssetPanel(props: AssetPanelProps) {
-  const { item, setItem, setQuery, category, labels, dispatchAssetEvent } = props
+  const {
+    item,
+    setItem,
+    setQuery,
+    category,
+    labels,
+    dispatchAssetEvent,
+    isReadonly = false,
+  } = props
 
   const { getText } = textProvider.useText()
   const { localStorage } = localStorageProvider.useLocalStorage()
@@ -135,6 +144,7 @@ export default function AssetPanel(props: AssetPanelProps) {
         <>
           {tab === AssetPanelTab.properties && (
             <AssetProperties
+              isReadonly={isReadonly}
               item={item}
               setItem={setItem}
               category={category}

--- a/app/ide-desktop/lib/dashboard/src/layouts/AssetProperties.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/AssetProperties.tsx
@@ -42,11 +42,19 @@ export interface AssetPropertiesProps {
   readonly labels: backendModule.Label[]
   readonly setQuery: React.Dispatch<React.SetStateAction<AssetQuery>>
   readonly dispatchAssetEvent: (event: assetEvent.AssetEvent) => void
+  readonly isReadonly?: boolean
 }
 
 /** Display and modify the properties of an asset. */
 export default function AssetProperties(props: AssetPropertiesProps) {
-  const { item: itemRaw, setItem: setItemRaw, category, labels, setQuery } = props
+  const {
+    item: itemRaw,
+    setItem: setItemRaw,
+    category,
+    labels,
+    setQuery,
+    isReadonly = false,
+  } = props
   const { dispatchAssetEvent } = props
 
   const { user } = authProvider.useNonPartialUserSession()
@@ -130,7 +138,7 @@ export default function AssetProperties(props: AssetPropertiesProps) {
           className="flex h-side-panel-heading items-center gap-side-panel-section py-side-panel-heading-y text-lg leading-snug"
         >
           {getText('description')}
-          {ownsThisAsset && !isEditingDescription && (
+          {!isReadonly && ownsThisAsset && !isEditingDescription && (
             <Button
               image={PenIcon}
               onPress={() => {
@@ -204,6 +212,7 @@ export default function AssetProperties(props: AssetPropertiesProps) {
               </td>
               <td className="w-full p">
                 <SharedWithColumn
+                  isReadonly={isReadonly}
                   item={item}
                   setItem={setItem}
                   state={{ category, dispatchAssetEvent, setQuery }}

--- a/app/ide-desktop/lib/dashboard/src/layouts/AssetsTable.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/AssetsTable.tsx
@@ -330,6 +330,7 @@ export interface AssetsTableState {
 export interface AssetRowState {
   readonly setVisibility: (visibility: Visibility) => void
   readonly isEditingName: boolean
+  readonly isReadonly: boolean
   readonly temporarilyAddedLabels: ReadonlySet<backendModule.LabelName>
   readonly temporarilyRemovedLabels: ReadonlySet<backendModule.LabelName>
 }
@@ -1878,9 +1879,9 @@ export default function AssetsTable(props: AssetsTableProps) {
     }
   }
 
-  const state = React.useMemo(
+  const state = React.useMemo<AssetsTableState>(
     // The type MUST be here to trigger excess property errors at typecheck time.
-    (): AssetsTableState => ({
+    () => ({
       visibilities,
       selectedKeys: selectedKeysRef,
       scrollContainerRef: rootRef,
@@ -2264,6 +2265,7 @@ export default function AssetsTable(props: AssetsTableProps) {
                     setSelected={() => {}}
                     setItem={() => {}}
                     setRowState={() => {}}
+                    isEditable={false}
                   />
                 ))}
               </DragModal>
@@ -2403,9 +2405,13 @@ export default function AssetsTable(props: AssetsTableProps) {
           <tr className="hidden h-row first:table-row">
             <td colSpan={columns.length} className="bg-transparent">
               {category === Category.trash ? (
-                <aria.Text className="px-cell-x placeholder">
-                  {getText('yourTrashIsEmpty')}
-                </aria.Text>
+                query.query !== '' ? (
+                  <aria.Text className="px-cell-x placeholder">
+                    {getText('noFilesMatchTheCurrentFilters')}
+                  </aria.Text>
+                ) : (
+                  <aria.Text className="px-cell-x placeholder">{getText('yourTrashIsEmpty')}</aria.Text>
+                )
               ) : query.query !== '' ? (
                 <aria.Text className="px-cell-x placeholder">
                   {getText('noFilesMatchTheCurrentFilters')}

--- a/app/ide-desktop/lib/dashboard/src/layouts/AssetsTable.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/AssetsTable.tsx
@@ -330,7 +330,6 @@ export interface AssetsTableState {
 export interface AssetRowState {
   readonly setVisibility: (visibility: Visibility) => void
   readonly isEditingName: boolean
-  readonly isReadonly: boolean
   readonly temporarilyAddedLabels: ReadonlySet<backendModule.LabelName>
   readonly temporarilyRemovedLabels: ReadonlySet<backendModule.LabelName>
 }

--- a/app/ide-desktop/lib/dashboard/src/layouts/AssetsTable.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/AssetsTable.tsx
@@ -2409,7 +2409,9 @@ export default function AssetsTable(props: AssetsTableProps) {
                     {getText('noFilesMatchTheCurrentFilters')}
                   </aria.Text>
                 ) : (
-                  <aria.Text className="px-cell-x placeholder">{getText('yourTrashIsEmpty')}</aria.Text>
+                  <aria.Text className="px-cell-x placeholder">
+                    {getText('yourTrashIsEmpty')}
+                  </aria.Text>
                 )
               ) : query.query !== '' ? (
                 <aria.Text className="px-cell-x placeholder">

--- a/app/ide-desktop/lib/dashboard/src/layouts/Drive.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/Drive.tsx
@@ -406,6 +406,7 @@ export default function Drive(props: DriveProps) {
                   dispatchAssetEvent={dispatchAssetEvent}
                 />
                 <Labels
+                  draggable={category !== Category.trash}
                   labels={labels}
                   query={query}
                   setQuery={setQuery}

--- a/app/ide-desktop/lib/dashboard/src/layouts/Drive.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/Drive.tsx
@@ -5,7 +5,6 @@ import * as appUtils from '#/appUtils'
 
 import * as eventCallback from '#/hooks/eventCallbackHooks'
 import * as navigateHooks from '#/hooks/navigateHooks'
-import * as searchParamsState from '#/hooks/searchParamsStateHooks'
 import * as toastAndLogHooks from '#/hooks/toastAndLogHooks'
 
 import * as authProvider from '#/providers/AuthProvider'
@@ -33,29 +32,11 @@ import UnstyledButton from '#/components/UnstyledButton'
 import * as backendModule from '#/services/Backend'
 import * as projectManager from '#/services/ProjectManager'
 
-import * as array from '#/utilities/array'
 import type AssetQuery from '#/utilities/AssetQuery'
 import type AssetTreeNode from '#/utilities/AssetTreeNode'
 import * as download from '#/utilities/download'
 import * as github from '#/utilities/github'
-import LocalStorage from '#/utilities/LocalStorage'
 import * as uniqueString from '#/utilities/uniqueString'
-
-// ============================
-// === Global configuration ===
-// ============================
-
-declare module '#/utilities/LocalStorage' {
-  /** */
-  interface LocalStorageData {
-    readonly driveCategory: Category
-  }
-}
-
-const CATEGORIES = Object.values(Category)
-LocalStorage.registerKey('driveCategory', {
-  tryParse: value => (array.includes(CATEGORIES, value) ? value : null),
-})
 
 // ===================
 // === DriveStatus ===
@@ -81,6 +62,8 @@ enum DriveStatus {
 
 /** Props for a {@link Drive}. */
 export interface DriveProps {
+  readonly category: Category
+  readonly setCategory: (category: Category) => void
   readonly supportsLocalBackend: boolean
   readonly hidden: boolean
   readonly hideRows: boolean
@@ -116,6 +99,7 @@ export default function Drive(props: DriveProps) {
   const { assetListEvents, dispatchAssetListEvent, assetEvents, dispatchAssetEvent } = props
   const { setAssetPanelProps, doOpenEditor, doCloseEditor } = props
   const { setIsAssetPanelTemporarilyVisible } = props
+  const { category, setCategory } = props
 
   const navigate = navigateHooks.useNavigate()
   const toastAndLog = toastAndLogHooks.useToastAndLog()
@@ -125,11 +109,6 @@ export default function Drive(props: DriveProps) {
   const { getText } = textProvider.useText()
   const [canDownload, setCanDownload] = React.useState(false)
   const [didLoadingProjectManagerFail, setDidLoadingProjectManagerFail] = React.useState(false)
-  const [category, setCategory] = searchParamsState.useSearchParamsState(
-    'driveCategory',
-    () => localStorage.get('driveCategory') ?? Category.home,
-    (value): value is Category => array.includes(Object.values(Category), value)
-  )
   const [newLabelNames, setNewLabelNames] = React.useState(new Set<backendModule.LabelName>())
   const [deletedLabelNames, setDeletedLabelNames] = React.useState(
     new Set<backendModule.LabelName>()

--- a/app/ide-desktop/lib/dashboard/src/layouts/Labels.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/Labels.tsx
@@ -31,6 +31,7 @@ import * as string from '#/utilities/string'
 
 /** Props for a {@link Labels}. */
 export interface LabelsProps {
+  readonly draggable: boolean
   readonly labels: backend.Label[]
   readonly query: AssetQuery
   readonly setQuery: React.Dispatch<React.SetStateAction<AssetQuery>>
@@ -42,8 +43,16 @@ export interface LabelsProps {
 
 /** A list of selectable labels. */
 export default function Labels(props: LabelsProps) {
-  const { labels, query, setQuery, doCreateLabel, doDeleteLabel, newLabelNames } = props
-  const { deletedLabelNames } = props
+  const {
+    labels,
+    query,
+    setQuery,
+    doCreateLabel,
+    doDeleteLabel,
+    newLabelNames,
+    draggable = true,
+    deletedLabelNames,
+  } = props
   const currentLabels = query.labels
   const currentNegativeLabels = query.negativeLabels
   const { setModal } = modalProvider.useSetModal()
@@ -79,7 +88,7 @@ export default function Labels(props: LabelsProps) {
               return (
                 <div key={label.id} className="group relative flex items-center gap-label-icons">
                   <Label
-                    draggable
+                    draggable={draggable}
                     color={label.color}
                     active={
                       negated || currentLabels.some(term => array.shallowEqual(term, [label.value]))

--- a/app/ide-desktop/lib/dashboard/src/pages/dashboard/Dashboard.tsx
+++ b/app/ide-desktop/lib/dashboard/src/pages/dashboard/Dashboard.tsx
@@ -56,6 +56,7 @@ import * as sanitizedEventTargets from '#/utilities/sanitizedEventTargets'
 declare module '#/utilities/LocalStorage' {
   /** */
   interface LocalStorageData {
+    readonly driveCategory: Category
     readonly isAssetPanelVisible: boolean
     readonly page: pageSwitcher.Page
     readonly projectStartupInfo: backendModule.ProjectStartupInfo
@@ -69,6 +70,11 @@ LocalStorage.registerKey('isAssetPanelVisible', {
 const PAGES = Object.values(pageSwitcher.Page)
 LocalStorage.registerKey('page', {
   tryParse: value => (array.includes(PAGES, value) ? value : null),
+})
+
+const CATEGORIES = Object.values(Category)
+LocalStorage.registerKey('driveCategory', {
+  tryParse: value => (array.includes(CATEGORIES, value) ? value : null),
 })
 
 const BACKEND_TYPES = Object.values(backendModule.BackendType)
@@ -155,6 +161,12 @@ export default function Dashboard(props: DashboardProps) {
     () => localStorage.get('isAssetPanelVisible') ?? false
   )
   const [isAssetPanelTemporarilyVisible, setIsAssetPanelTemporarilyVisible] = React.useState(false)
+  const [category, setCategory] = searchParamsState.useSearchParamsState(
+    'driveCategory',
+    () => localStorage.get('driveCategory') ?? Category.home,
+    (value): value is Category => array.includes(Object.values(Category), value)
+  )
+
   const isCloud = backend.type === backendModule.BackendType.remote
   const rootDirectoryId = React.useMemo(
     () => session.user?.rootDirectoryId ?? backendModule.DirectoryId(''),
@@ -498,6 +510,8 @@ export default function Dashboard(props: DashboardProps) {
           />
           <Home hidden={page !== pageSwitcher.Page.home} createProject={doCreateProject} />
           <Drive
+            category={category}
+            setCategory={setCategory}
             supportsLocalBackend={supportsLocalBackend}
             hidden={page !== pageSwitcher.Page.drive}
             hideRows={page !== pageSwitcher.Page.drive && page !== pageSwitcher.Page.home}
@@ -558,6 +572,7 @@ export default function Dashboard(props: DashboardProps) {
               category={Category.home}
               labels={labels}
               dispatchAssetEvent={dispatchAssetEvent}
+              isReadonly={category === Category.trash}
             />
           )}
         </div>


### PR DESCRIPTION
### Pull Request Description

Closes: enso-org/cloud-v2#1084

Tl;dr: This PR disable almost all actions in trash folder, except restore/hard delete.
Context:
Currently, we can do a lot of actions it trash folder: arrange files in folders, create new folders, edit files and so on. We want to disable most of these actions.


This Change:

- Disables d&d support within trash folder, but leaves the ability to drag thigs back to home folder.
- Disables most of the keyboard shortcuts(copy,paste,new...etc) except hard delete/restore
- Disables launching projects
- Disables rename
- Disables assigning labels
- Disabled editing the description & sharing




https://github.com/enso-org/enso/assets/61194245/35c6532d-719f-46b2-a2f7-b54b54856bbd





Test Plan:

This PR expects thorough testing to make sure we have disabled everything except hard delete/restore and the same way we didn't break the home folder :)


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
