### PR TITLE
Fix expectations in lock manager test

### DIFF
--- a/lib/scala/connected-lock-manager/src/test/scala/org/enso/lockmanager/ConnectedLockManagerTest.scala
+++ b/lib/scala/connected-lock-manager/src/test/scala/org/enso/lockmanager/ConnectedLockManagerTest.scala
@@ -150,8 +150,7 @@ class ConnectedLockManagerTest
       }
 
       sync.join()
-      sync.summarizeReports() shouldEqual
-      Seq(
+      sync.summarizeReports() shouldEqual Seq(
         "primary-acquired",
         "connected-acquired",
         "released",

--- a/lib/scala/connected-lock-manager/src/test/scala/org/enso/lockmanager/ConnectedLockManagerTest.scala
+++ b/lib/scala/connected-lock-manager/src/test/scala/org/enso/lockmanager/ConnectedLockManagerTest.scala
@@ -74,8 +74,8 @@ class ConnectedLockManagerTest
               )
           )
         ) { _ =>
-          sync.signal("primary-acquired")
           sync.report("primary-acquired")
+          sync.signal("primary-acquired")
           sync.waitFor("connected-is-waiting")
           sync.report("primary-releasing")
         }
@@ -122,8 +122,8 @@ class ConnectedLockManagerTest
               )
           )
         ) { _ =>
-          sync.signal("primary-acquired")
           sync.report("primary-acquired")
+          sync.signal("primary-acquired")
           sync.waitFor("connected-acquired")
         }
 
@@ -150,31 +150,12 @@ class ConnectedLockManagerTest
       }
 
       sync.join()
-      sync.summarizeReports() should (
-        equal(
-          Seq(
-            "primary-acquired",
-            "connected-acquired",
-            "released",
-            "released"
-          )
-        ) or
-        equal(
-          Seq(
-            "connected-acquired",
-            "primary-acquired",
-            "released",
-            "released"
-          )
-        ) or
-        equal(
-          Seq(
-            "connected-acquired",
-            "released",
-            "primary-acquired",
-            "released"
-          )
-        )
+      sync.summarizeReports() shouldEqual
+      Seq(
+        "primary-acquired",
+        "connected-acquired",
+        "released",
+        "released"
       )
     }
   }

--- a/lib/scala/connected-lock-manager/src/test/scala/org/enso/lockmanager/ConnectedLockManagerTest.scala
+++ b/lib/scala/connected-lock-manager/src/test/scala/org/enso/lockmanager/ConnectedLockManagerTest.scala
@@ -150,11 +150,31 @@ class ConnectedLockManagerTest
       }
 
       sync.join()
-      sync.summarizeReports() shouldEqual Seq(
-        "primary-acquired",
-        "connected-acquired",
-        "released",
-        "released"
+      sync.summarizeReports() should (
+        equal(
+          Seq(
+            "primary-acquired",
+            "connected-acquired",
+            "released",
+            "released"
+          )
+        ) or
+        equal(
+          Seq(
+            "connected-acquired",
+            "primary-acquired",
+            "released",
+            "released"
+          )
+        ) or
+        equal(
+          Seq(
+            "connected-acquired",
+            "released",
+            "primary-acquired",
+            "released"
+          )
+        )
       )
     }
   }


### PR DESCRIPTION
### Pull Request Description

The test optimistically assumed that threads will mostly execute in order, while ignoring all other possibilities.
Changes the order of the report so that we remove the potential non-determinism.

As discovered in https://github.com/enso-org/enso/actions/runs/8516468592/job/23325541262?pr=9584#step:8:1530

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
