### PR TITLE
Fix numeric input widget

### DIFF
--- a/app/gui2/src/components/widgets/NumericInputWidget.vue
+++ b/app/gui2/src/components/widgets/NumericInputWidget.vue
@@ -121,6 +121,7 @@ defineExpose({
       autoSelect
       :style="inputStyle"
       v-on="dragPointer.events"
+      @click.stop
       @blur="blurred"
       @focus="focused"
       @input="emit('input', editedValue)"


### PR DESCRIPTION
### Pull Request Description

Fixes the issue with numeric input being unclickable if the WidgetSelection is present. The issue was caused by double handling of the click event both in numeric input (it opened the dropdown) and in dropdown (it closed itself).

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
