### PR TITLE
Fix reported content-length in project manager shim.

### DIFF
--- a/app/ide-desktop/lib/project-manager-shim/src/projectManagerShimMiddleware.ts
+++ b/app/ide-desktop/lib/project-manager-shim/src/projectManagerShimMiddleware.ts
@@ -307,13 +307,14 @@ export default function projectManagerShimMiddleware(
                         } catch {
                             // Ignored. `result` retains its original value indicating an error.
                         }
+                        const buffer = Buffer.from(result)
                         response
                             .writeHead(HTTP_STATUS_OK, [
-                                ['Content-Length', String(result.length)],
+                                ['Content-Length', String(buffer.byteLength)],
                                 ['Content-Type', 'application/json'],
                                 ...common.COOP_COEP_CORP_HEADERS,
                             ])
-                            .end(result)
+                            .end(buffer)
                     })()
                 }
                 break


### PR DESCRIPTION
### Pull Request Description

Fixes dashboard errors that prevented the project list from loading when using node shim implementation of project listing commands, such as:
```
Could not list root folder.: Unterminated string in JSON at position 10021 (line 1 column 10022)
```

The issue was caused by a cut-off JSON response, due to incorrect calculation of encoded response byte length.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
