### PR TITLE
Manage analytics client to avoid leaks

### DIFF
--- a/distribution/lib/Standard/Google_Api/0.0.0-dev/src/Internal/Google_Analytics_Internal.enso
+++ b/distribution/lib/Standard/Google_Api/0.0.0-dev/src/Internal/Google_Analytics_Internal.enso
@@ -2,6 +2,7 @@ private
 
 from Standard.Base import all
 from Standard.Table import Table, Delimited_Format
+from Standard.Base.Runtime.Managed_Resource import Managed_Resource
 
 import project.Google_Credential.Google_Credential
 from project.Internal.Google_Credential_Internal import all
@@ -14,13 +15,13 @@ polyglot java import com.google.analytics.data.v1beta.Metric
 polyglot java import com.google.analytics.data.v1beta.RunReportRequest
 
 read_api_data property_id:Text dimensions:Vector metrics:Vector start_date:Date end_date:Date credentials:Google_Credential -> Table =
-    analytics_data = case credentials of 
-        Google_Credential.Default -> BetaAnalyticsDataClient.create
+    managed_analytics_data = case credentials of
+        Google_Credential.Default -> Managed_Resource (BetaAnalyticsDataClient.create) r-> r.close
         Google_Credential.From_File _ -> 
             betaAnalyticsDataSettings = BetaAnalyticsDataSettings.newBuilder
                . setCredentialsProvider credentials.as_java
                . build
-            BetaAnalyticsDataClient.create betaAnalyticsDataSettings
+            Managed_Resource.register (BetaAnalyticsDataClient.create betaAnalyticsDataSettings) r-> r.close
     request_builder = RunReportRequest.newBuilder
         . setProperty ("properties/"+property_id)
         . addDateRanges (DateRange.newBuilder.setStartDate start_date.to_text . setEndDate end_date.to_text)
@@ -30,7 +31,8 @@ read_api_data property_id:Text dimensions:Vector metrics:Vector start_date:Date 
         request_builder.addMetrics (Metric.newBuilder.setName metric)
 
     request = request_builder.build
-    response = analytics_data.runReport request
+    response = managed_analytics_data.with (analytics_data-> analytics_data.runReport request)
+    managed_analytics_data.finalize
 
     dimension_count = response.getDimensionHeadersCount
     dimension_headers = 0.up_to dimension_count . map i-> response.getDimensionHeaders i . getName


### PR DESCRIPTION
### Pull Request Description

This change makes sure to close the Google Analytics client after usage. This will a) ensure that resources are released properly b) potentially fix the exception that is causing problems on some platforms

### Important Notes

After this change I no longer see in **my** logs:
```
 io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference cleanQueue
SEVERE: *~*~*~ Previous channel ManagedChannelImpl{logId=1, target=analyticsdata.googleapis.com:443} was not shutdown properly!!! ~*~*~*
    Make sure to call shutdown()/shutdownNow() and wait until awaitTermination() returns true.
java.lang.RuntimeException: ManagedChannel allocation site
	at io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference.<init>(ManagedChannelOrphanWrapper.java:102)
	at io.grpc.internal.ManagedChannelOrphanWrapper.<init>(ManagedChannelOrphanWrapper.java:60)
	at io.grpc.internal.ManagedChannelOrphanWrapper.<init>(ManagedChannelOrphanWrapper.java:51)
	at io.grpc.internal.ManagedChannelImplBuilder.build(ManagedChannelImplBuilder.java:668)
	at io.grpc.ForwardingChannelBuilder2.build(ForwardingChannelBuilder2.java:260)
	at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.createSingleChannel(InstantiatingGrpcChannelProvider.java:436)
	at com.google.api.gax.grpc.ChannelPool.<init>(ChannelPool.java:107)
	at com.google.api.gax.grpc.ChannelPool.create(ChannelPool.java:85)
	at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.createChannel(InstantiatingGrpcChannelProvider.java:243)
	at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.getTransportChannel(InstantiatingGrpcChannelProvider.java:237)
	at com.google.api.gax.rpc.ClientContext.create(ClientContext.java:226)
	at com.google.analytics.data.v1beta.stub.GrpcBetaAnalyticsDataStub.create(GrpcBetaAnalyticsDataStub.java:217)
	at com.google.analytics.data.v1beta.stub.BetaAnalyticsDataStubSettings.createStub(BetaAnalyticsDataStubSettings.java:288)
	at com.google.analytics.data.v1beta.BetaAnalyticsDataClient.<init>(BetaAnalyticsDataClient.java:376)
	at com.google.analytics.data.v1beta.BetaAnalyticsDataClient.create(BetaAnalyticsDataClient.java:358)
	at org.graalvm.truffle/com.oracle.truffle.host.HostMethodDesc$SingleMethod$MHBase.invokeHandle(HostMethodDesc.java:371)
```
It's important because apparently that's where it would get stuck when trying to log that message.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
