### PR TITLE
Improve perf of Graph.Scope.scopeFor hotspot

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
@@ -121,14 +121,14 @@ public final class PassPersistance {
   @org.openide.util.lookup.ServiceProvider(service = Persistance.class)
   public static final class PersistAliasAnalysisGraphScope extends Persistance<Graph.Scope> {
     public PersistAliasAnalysisGraphScope() {
-      super(Graph.Scope.class, false, 1267);
+      super(Graph.Scope.class, false, 1269);
     }
 
     @Override
     @SuppressWarnings("unchecked")
     protected Graph.Scope readObject(Input in) throws IOException {
       var childScopes = in.readInline(scala.collection.immutable.List.class);
-      var occurrences = (scala.collection.immutable.Set) in.readObject();
+      var occurrences = (scala.collection.immutable.Map) in.readObject();
       var allDefinitions = in.readInline(scala.collection.immutable.List.class);
       var parent = new Graph.Scope(childScopes, occurrences, allDefinitions);
       var optionParent = Option.apply(parent);

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
@@ -23,9 +23,7 @@ import org.enso.compiler.pass.resolve.TypeSignatures$;
 import org.enso.persist.Persistable;
 import org.enso.persist.Persistance;
 import org.openide.util.lookup.ServiceProvider;
-import scala.$less$colon$less;
 import scala.Option;
-import scala.Tuple2;
 import scala.Tuple2$;
 
 @Persistable(clazz = CachePreferenceAnalysis.WeightInfo.class, id = 1111)
@@ -132,8 +130,7 @@ public final class PassPersistance {
     protected Graph.Scope readObject(Input in) throws IOException {
       var childScopes = in.readInline(scala.collection.immutable.List.class);
       var occurrencesValues = (scala.collection.immutable.Set<Graph.Occurrence>) in.readObject();
-      var ev = ($less$colon$less<Graph.Occurrence, Tuple2<Object, Graph.Occurrence>>) null;
-      var occurrences = occurrencesValues.map(v -> Tuple2$.MODULE$.apply(v.id(), v)).toMap(ev);
+      var occurrences = occurrencesValues.map(v -> Tuple2$.MODULE$.apply(v.id(), v)).toMap(null);
       var allDefinitions = in.readInline(scala.collection.immutable.List.class);
       var parent = new Graph.Scope(childScopes, occurrences, allDefinitions);
       var optionParent = Option.apply(parent);

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
@@ -23,7 +23,10 @@ import org.enso.compiler.pass.resolve.TypeSignatures$;
 import org.enso.persist.Persistable;
 import org.enso.persist.Persistance;
 import org.openide.util.lookup.ServiceProvider;
+import scala.$less$colon$less;
 import scala.Option;
+import scala.Tuple2;
+import scala.Tuple2$;
 
 @Persistable(clazz = CachePreferenceAnalysis.WeightInfo.class, id = 1111)
 @Persistable(clazz = DataflowAnalysis.DependencyInfo.class, id = 1112)
@@ -121,14 +124,16 @@ public final class PassPersistance {
   @org.openide.util.lookup.ServiceProvider(service = Persistance.class)
   public static final class PersistAliasAnalysisGraphScope extends Persistance<Graph.Scope> {
     public PersistAliasAnalysisGraphScope() {
-      super(Graph.Scope.class, false, 1269);
+      super(Graph.Scope.class, false, 1267);
     }
 
     @Override
     @SuppressWarnings("unchecked")
     protected Graph.Scope readObject(Input in) throws IOException {
       var childScopes = in.readInline(scala.collection.immutable.List.class);
-      var occurrences = (scala.collection.immutable.Map) in.readObject();
+      var occurrencesValues = (scala.collection.immutable.Set<Graph.Occurrence>) in.readObject();
+      var ev = ($less$colon$less<Graph.Occurrence, Tuple2<Object, Graph.Occurrence>>) null;
+      var occurrences = occurrencesValues.map(v -> Tuple2$.MODULE$.apply(v.id(), v)).toMap(ev);
       var allDefinitions = in.readInline(scala.collection.immutable.List.class);
       var parent = new Graph.Scope(childScopes, occurrences, allDefinitions);
       var optionParent = Option.apply(parent);
@@ -145,7 +150,7 @@ public final class PassPersistance {
     @SuppressWarnings("unchecked")
     protected void writeObject(Graph.Scope obj, Output out) throws IOException {
       out.writeInline(scala.collection.immutable.List.class, obj.childScopes());
-      out.writeObject(obj.occurrences());
+      out.writeObject(obj.occurrences().values().toSet());
       out.writeInline(scala.collection.immutable.List.class, obj.allDefinitions());
     }
   }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/context/LocalScope.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/context/LocalScope.scala
@@ -140,10 +140,10 @@ class LocalScope(
       .getOrElse(Map())
 
     scope.occurrences.foreach {
-      case x: AliasGraph.Occurrence.Def =>
+      case (id, x: AliasGraph.Occurrence.Def) =>
         parentResult += x.symbol -> new FramePointer(
           level,
-          allFrameSlotIdxs(x.id)
+          allFrameSlotIdxs(id)
         )
       case _ =>
     }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
@@ -602,12 +602,12 @@ case object AliasAnalysis extends IRPass {
               )
             )
         } else {
-          val f = scope.occurrences.collectFirst {
+          val f = scope.occurrences.values.collectFirst {
             case x if x.symbol == name.name => x
           }
           arg
             .copy(
-              ascribedType = Some(new Redefined.Arg(name, arg.location))
+              ascribedType = Some(Redefined.Arg(name, arg.location))
             )
             .updateMetadata(
               new MetadataPair(

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/IrPersistance.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/IrPersistance.java
@@ -193,24 +193,6 @@ public final class IrPersistance {
   }
 
   @ServiceProvider(service = Persistance.class)
-  public static final class PersistInteger extends Persistance<Integer> {
-    public PersistInteger() {
-      super(Integer.class, true, 4441);
-    }
-
-    @Override
-    protected void writeObject(Integer obj, Output out) throws IOException {
-      out.writeDouble(obj);
-    }
-
-    @Override
-    protected Integer readObject(Input in) throws IOException, ClassNotFoundException {
-      var obj = in.readInt();
-      return obj;
-    }
-  }
-
-  @ServiceProvider(service = Persistance.class)
   public static final class PersistScalaList extends Persistance<List> {
     public PersistScalaList() {
       super(List.class, true, 4432);

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/IrPersistance.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/IrPersistance.java
@@ -193,6 +193,24 @@ public final class IrPersistance {
   }
 
   @ServiceProvider(service = Persistance.class)
+  public static final class PersistInteger extends Persistance<Integer> {
+    public PersistInteger() {
+      super(Integer.class, true, 4441);
+    }
+
+    @Override
+    protected void writeObject(Integer obj, Output out) throws IOException {
+      out.writeDouble(obj);
+    }
+
+    @Override
+    protected Integer readObject(Input in) throws IOException, ClassNotFoundException {
+      var obj = in.readInt();
+      return obj;
+    }
+  }
+
+  @ServiceProvider(service = Persistance.class)
   public static final class PersistScalaList extends Persistance<List> {
     public PersistScalaList() {
       super(List.class, true, 4432);


### PR DESCRIPTION

### Pull Request Description

`scopeFor` appears to be a hotspot of the compiler. By choosing a more suitable data structure that indexes on the occurrence's id we seem to gain about 25% on some benchmarks. Quick win.

Related to #9235.

### Important Notes

Local benchmark runs of `org.enso.compiler.benchmarks.module.ManyLocalVarsBenchmark.longMethodWithLotOfLocalVars
`
Before
```
[info] # Warmup Iteration   1: 61.638 ms/op
[info] # Warmup Iteration   2: 49.224 ms/op
[info] # Warmup Iteration   3: 47.341 ms/op
[info] # Warmup Iteration   4: 46.946 ms/op
[info] # Warmup Iteration   5: 46.901 ms/op
[info] # Warmup Iteration   6: 49.536 ms/op
[info] Iteration   1: 50.438 ms/op
[info] Iteration   2: 47.326 ms/op
[info] Iteration   3: 46.917 ms/op
[info] Iteration   4: 45.824 ms/op
```

After
```
[info] # Warmup Iteration   1: 86.493 ms/op
[info] # Warmup Iteration   2: 36.084 ms/op
[info] # Warmup Iteration   3: 32.588 ms/op
[info] # Warmup Iteration   4: 33.895 ms/op
[info] # Warmup Iteration   5: 31.986 ms/op
[info] # Warmup Iteration   6: 31.236 ms/op
[info] Iteration   1: 31.258 ms/op
[info] Iteration   2: 31.673 ms/op
[info] Iteration   3: 30.931 ms/op
[info] Iteration   4: 30.902 ms/op
```

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
