### PR TITLE
Add prefixes for cloud url params

### DIFF
--- a/app/gui2/src/appRunner.ts
+++ b/app/gui2/src/appRunner.ts
@@ -11,6 +11,14 @@ async function runApp(
   _metadata?: object | undefined,
   pinia?: Pinia | undefined,
 ) {
+  const ignoreParamsRegex = (() => {
+    if (_metadata)
+      if ('ignoreParamsRegex' in _metadata)
+        if (_metadata['ignoreParamsRegex'] instanceof RegExp) return _metadata['ignoreParamsRegex']
+
+    return null
+  })()
+
   running = true
   const { mountProjectApp } = await import('./createApp')
   if (!running) return
@@ -19,7 +27,11 @@ async function runApp(
   function onUnrecognizedOption(path: string[]) {
     unrecognizedOptions.push(path.join('.'))
   }
-  const intermediateConfig = mergeConfig(baseConfig, urlParams(), { onUnrecognizedOption })
+  const intermediateConfig = mergeConfig(
+    baseConfig,
+    urlParams({ ignoreKeysRegExp: ignoreParamsRegex }),
+    { onUnrecognizedOption },
+  )
   const appConfig = mergeConfig(intermediateConfig, config ?? {})
   unmount = await mountProjectApp({ config: appConfig, accessToken, unrecognizedOptions }, pinia)
 }

--- a/app/gui2/src/util/urlParams.ts
+++ b/app/gui2/src/util/urlParams.ts
@@ -1,13 +1,25 @@
 import type { StringConfig } from './config'
 
+export interface UrlParamsProps {
+  ignoreKeysRegExp?: RegExp | null
+}
+
 /** Returns the parameters passed in the URL query string. */
-export function urlParams(): StringConfig {
+export function urlParams(props: UrlParamsProps = {}): StringConfig {
+  const { ignoreKeysRegExp } = props
+
   const params: StringConfig = {}
   const urlParams = new URLSearchParams(window.location.search)
+
   for (const [name, value] of urlParams.entries()) {
     let obj = params
     const path = name.split('.')
     const lastSegment = path.pop()
+
+    if (ignoreKeysRegExp != null && ignoreKeysRegExp.test(name)) {
+      continue
+    }
+
     if (lastSegment == null) {
       console.error(`Invalid URL parameter name: '${name}'`)
     } else {

--- a/app/ide-desktop/lib/dashboard/src/appUtils.tsx
+++ b/app/ide-desktop/lib/dashboard/src/appUtils.tsx
@@ -4,6 +4,10 @@
 // === Constants ===
 // =================
 
+// =============
+// === Paths ===
+// =============
+
 /** Path to the root of the app (i.e., the Cloud dashboard). */
 export const DASHBOARD_PATH = '/'
 /** Path to the login page. */
@@ -28,3 +32,9 @@ export const ALL_PATHS_REGEX = new RegExp(
     `${FORGOT_PASSWORD_PATH}|${RESET_PASSWORD_PATH}|${SET_USERNAME_PATH}|` +
     `${ENTER_OFFLINE_MODE_PATH}|${SUBSCRIBE_PATH})$`
 )
+
+// ===========
+// === URL ===
+// ===========
+
+export const SEARCH_PARAMS_PREFIX = 'cloud-ide_'

--- a/app/ide-desktop/lib/dashboard/src/layouts/Editor.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/Editor.tsx
@@ -1,6 +1,8 @@
 /** @file The container that launches the IDE. */
 import * as React from 'react'
 
+import * as appUtils from '#/appUtils'
+
 import * as toastAndLogHooks from '#/hooks/toastAndLogHooks'
 
 import * as backendModule from '#/services/Backend'
@@ -114,7 +116,10 @@ export default function Editor(props: EditorProps) {
                   },
                 },
                 accessToken,
-                { projectId: project.projectId }
+                {
+                  projectId: project.projectId,
+                  ignoreParamsRegex: new RegExp(`^${appUtils.SEARCH_PARAMS_PREFIX}(.+)$`),
+                }
               )
             } catch (error) {
               toastAndLog('openEditorError', error)


### PR DESCRIPTION
### Pull Request Description

This PR adds an ability to exclude some keys in URLSearchParams from being parsed by GUI.

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
