### PR TITLE
refr(enso-org/cloud-v2#1088): Make `Project` fields `camelCase`

### DIFF
--- a/app/ide-desktop/lib/dashboard/e2e/api.ts
+++ b/app/ide-desktop/lib/dashboard/e2e/api.ts
@@ -111,8 +111,7 @@ export async function mockApi({ page }: MockParams) {
         id: backend.ProjectId('project-' + uniqueString.uniqueString()),
         projectState: {
           type: backend.ProjectState.opened,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          volume_id: '',
+          volumeId: '',
         },
         title,
         modifiedAt: dateTime.toRfc3339(new Date()),
@@ -350,23 +349,23 @@ export async function mockApi({ page }: MockParams) {
         const projectId = request.url().match(/[/]projects[/](.+?)[/]copy/)?.[1] ?? ''
         await route.fulfill({
           json: {
-            /* eslint-disable @typescript-eslint/naming-convention */
             organizationId: defaultOrganizationId,
             projectId: backend.ProjectId(projectId),
             name: 'example project name',
             state: {
               type: backend.ProjectState.opened,
-              volume_id: '',
-              opened_by: defaultEmail,
+              volumeId: '',
+              openedBy: defaultEmail,
             },
             packageName: 'Project_root',
+            /* eslint-disable @typescript-eslint/naming-convention */
             ide_version: null,
             engine_version: {
+              /* eslint-enable @typescript-eslint/naming-convention */
               value: '2023.2.1-nightly.2023.9.29',
               lifecycle: backend.VersionLifecycle.development,
             },
             address: backend.Address('ws://example.com/'),
-            /* eslint-enable @typescript-eslint/naming-convention */
           } satisfies backend.ProjectRaw,
         })
       }
@@ -626,8 +625,7 @@ export async function mockApi({ page }: MockParams) {
             organizationId: defaultOrganizationId,
             packageName: 'Project_root',
             projectId: id,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            state: { type: backend.ProjectState.opened, volume_id: '' },
+            state: { type: backend.ProjectState.opened, volumeId: '' },
           }
           addProject(title, {
             description: null,

--- a/app/ide-desktop/lib/dashboard/e2e/api.ts
+++ b/app/ide-desktop/lib/dashboard/e2e/api.ts
@@ -358,10 +358,10 @@ export async function mockApi({ page }: MockParams) {
               openedBy: defaultEmail,
             },
             packageName: 'Project_root',
-            /* eslint-disable @typescript-eslint/naming-convention */
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             ide_version: null,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
             engine_version: {
-              /* eslint-enable @typescript-eslint/naming-convention */
               value: '2023.2.1-nightly.2023.9.29',
               lifecycle: backend.VersionLifecycle.development,
             },

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/ProjectIcon.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/ProjectIcon.tsx
@@ -103,9 +103,7 @@ export default function ProjectIcon(props: ProjectIconProps) {
           type: newState,
         })
         if (!backendModule.IS_OPENING_OR_OPENED[newState]) {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { openedBy, ...newProjectState2 } = newProjectState
-          newProjectState = newProjectState2
+          newProjectState = object.omit(newProjectState, 'openedBy')
         } else if (user != null) {
           newProjectState = object.merge(newProjectState, {
             openedBy: user.email,

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/ProjectIcon.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/ProjectIcon.tsx
@@ -103,13 +103,12 @@ export default function ProjectIcon(props: ProjectIconProps) {
           type: newState,
         })
         if (!backendModule.IS_OPENING_OR_OPENED[newState]) {
-          // eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-unused-vars
-          const { opened_by, ...newProjectState2 } = newProjectState
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { openedBy, ...newProjectState2 } = newProjectState
           newProjectState = newProjectState2
         } else if (user != null) {
           newProjectState = object.merge(newProjectState, {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            opened_by: user.email,
+            openedBy: user.email,
           })
         }
         return object.merge(oldItem, { projectState: newProjectState })
@@ -123,7 +122,7 @@ export default function ProjectIcon(props: ProjectIconProps) {
   >(null)
   const [shouldOpenWhenReady, setShouldOpenWhenReady] = React.useState(false)
   const [isRunningInBackground, setIsRunningInBackground] = React.useState(
-    item.projectState.execute_async ?? false
+    item.projectState.executeAsync ?? false
   )
   const [shouldSwitchPage, setShouldSwitchPage] = React.useState(false)
   const [toastId, setToastId] = React.useState<toast.Id | null>(null)
@@ -132,7 +131,7 @@ export default function ProjectIcon(props: ProjectIconProps) {
   const [closeProjectAbortController, setCloseProjectAbortController] =
     React.useState<AbortController | null>(null)
   const isOtherUserUsingProject =
-    backend.type !== backendModule.BackendType.local && item.projectState.opened_by !== user?.email
+    backend.type !== backendModule.BackendType.local && item.projectState.openedBy !== user?.email
 
   const openProject = React.useCallback(
     async (shouldRunInBackground: boolean) => {

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/ProjectNameColumn.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/ProjectNameColumn.tsx
@@ -71,8 +71,8 @@ export default function ProjectNameColumn(props: ProjectNameColumnProps) {
     (ownPermission != null && permissions.PERMISSION_ACTION_CAN_EXECUTE[ownPermission.permission])
   const isOtherUserUsingProject =
     backend.type !== backendModule.BackendType.local &&
-    projectState.opened_by != null &&
-    projectState.opened_by !== user?.email
+    projectState.openedBy != null &&
+    projectState.openedBy !== user?.email
 
   const doRename = async (newTitle: string) => {
     setRowState(object.merger({ isEditingName: false }))

--- a/app/ide-desktop/lib/dashboard/src/layouts/AssetContextMenu.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/AssetContextMenu.tsx
@@ -96,8 +96,8 @@ export default function AssetContextMenu(props: AssetContextMenuProps) {
   const isOtherUserUsingProject =
     backend.type !== backendModule.BackendType.local &&
     backendModule.assetIsProject(asset) &&
-    asset.projectState.opened_by != null &&
-    asset.projectState.opened_by !== user?.email
+    asset.projectState.openedBy != null &&
+    asset.projectState.openedBy !== user?.email
   const setAsset = setAssetHooks.useSetAsset(asset, setItem)
 
   return category === Category.trash ? (

--- a/app/ide-desktop/lib/dashboard/src/layouts/AssetsTable.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/AssetsTable.tsx
@@ -1492,10 +1492,8 @@ export default function AssetsTable(props: AssetsTableProps) {
           permissions: permissions.tryGetSingletonOwnerPermission(user),
           projectState: {
             type: backendModule.ProjectState.placeholder,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            volume_id: '',
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            ...(user != null ? { opened_by: user.email } : {}),
+            volumeId: '',
+            ...(user != null ? { openedBy: user.email } : {}),
             ...(path != null ? { path } : {}),
           },
           labels: [],

--- a/app/ide-desktop/lib/dashboard/src/services/Backend.ts
+++ b/app/ide-desktop/lib/dashboard/src/services/Backend.ts
@@ -159,19 +159,17 @@ export enum ProjectState {
 /** Wrapper around a project state value. */
 export interface ProjectStateType {
   readonly type: ProjectState
-  /* eslint-disable @typescript-eslint/naming-convention */
-  readonly volume_id: string
-  readonly instance_id?: string
-  readonly execute_async?: boolean
+  readonly volumeId: string
+  readonly instanceId?: string
+  readonly executeAsync?: boolean
   readonly address?: string
-  readonly security_group_id?: string
-  readonly ec2_id?: string
-  readonly ec2_public_ip_address?: string
-  readonly current_session_id?: string
-  readonly opened_by?: EmailAddress
+  readonly securityGroupId?: string
+  readonly ec2Id?: string
+  readonly ec2PublicIpAddress?: string
+  readonly currentSessionId?: string
+  readonly openedBy?: EmailAddress
   /** Only present on the Local backend. */
   readonly path?: Path
-  /* eslint-enable @typescript-eslint/naming-convention */
 }
 
 export const IS_OPENING: Readonly<Record<ProjectState, boolean>> = {
@@ -709,10 +707,8 @@ export function createPlaceholderProjectAsset(
     modifiedAt: dateTime.toRfc3339(new Date()),
     projectState: {
       type: ProjectState.new,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      volume_id: '',
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      ...(organization != null ? { opened_by: organization.email } : {}),
+      volumeId: '',
+      ...(organization != null ? { openedBy: organization.email } : {}),
       ...(path != null ? { path } : {}),
     },
     labels: [],

--- a/app/ide-desktop/lib/dashboard/src/services/LocalBackend.ts
+++ b/app/ide-desktop/lib/dashboard/src/services/LocalBackend.ts
@@ -152,8 +152,7 @@ export default class LocalBackend extends Backend {
                 type:
                   this.projectManager.projects.get(entry.metadata.id)?.state ??
                   backend.ProjectState.closed,
-                // eslint-disable-next-line @typescript-eslint/naming-convention
-                volume_id: '',
+                volumeId: '',
                 path: entry.path,
               },
               labels: [],
@@ -189,8 +188,7 @@ export default class LocalBackend extends Backend {
       packageName: project.name,
       state: {
         type: backend.ProjectState.closed,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        volume_id: '',
+        volumeId: '',
       },
       jsonAddress: null,
       binaryAddress: null,
@@ -221,8 +219,7 @@ export default class LocalBackend extends Backend {
       packageName: project.projectName,
       state: {
         type: backend.ProjectState.closed,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        volume_id: '',
+        volumeId: '',
         path,
       },
     }
@@ -284,8 +281,7 @@ export default class LocalBackend extends Backend {
           projectId,
           state: {
             type: this.projectManager.projects.get(id)?.state ?? backend.ProjectState.closed,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            volume_id: '',
+            volumeId: '',
           },
         }
       }
@@ -308,8 +304,7 @@ export default class LocalBackend extends Backend {
         projectId,
         state: {
           type: backend.ProjectState.opened,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          volume_id: '',
+          volumeId: '',
         },
       }
     }

--- a/app/ide-desktop/lib/dashboard/src/utilities/object.ts
+++ b/app/ide-desktop/lib/dashboard/src/utilities/object.ts
@@ -91,7 +91,7 @@ export function singletonObjectOrNull(value: unknown): [] | [object] {
 // === omit ===
 // ============
 
-/** UNSAFE when `Ks` contains strings that are not in the runtie array. */
+/** UNSAFE when `Ks` contains strings that are not in the runtime array. */
 export function omit<T, Ks extends readonly (string & keyof T)[] | []>(
   object: T,
   ...keys: Ks


### PR DESCRIPTION
Modifies fields of `Project`-like structs to be `camelCase`. This brings more of the backend API into line with the existing style guide.

Note that the changes in this commit are breaking if the IDE is run against a backend that hasn't been updated to account for the corresponding API changes.

### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
