### PR TITLE
working hot reload for widget definitions

### DIFF
--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -41,7 +41,7 @@ import { Rect } from '@/util/data/rect'
 import { Vec2 } from '@/util/data/vec2'
 import { encoding, set } from 'lib0'
 import { encodeMethodPointer } from 'shared/languageServerTypes'
-import { computed, onMounted, ref, toRef, watch } from 'vue'
+import { computed, onMounted, ref, shallowRef, toRef, watch } from 'vue'
 import { type Usage } from './ComponentBrowser/input'
 import { useGraphEditorClipboard } from './GraphEditor/clipboard'
 
@@ -91,6 +91,7 @@ useGraphEditorToasts()
 
 // === Selection ===
 
+const graphNodeSelections = shallowRef<HTMLElement>()
 const nodeSelection = provideGraphSelection(
   graphNavigator,
   graphStore.nodeRects,
@@ -543,6 +544,7 @@ const groupColors = computed(() => {
   >
     <div class="layer" :style="{ transform: graphNavigator.transform }">
       <GraphNodes
+        :graphNodeSelections="graphNodeSelections"
         @nodeOutputPortDoubleClick="handleNodeOutputPortDoubleClick"
         @nodeDoubleClick="(id) => stackNavigator.enterNode(id)"
         @createNodes="createNodesFromSource"
@@ -558,7 +560,7 @@ const groupColors = computed(() => {
       />
     </div>
     <div
-      id="graphNodeSelections"
+      ref="graphNodeSelections"
       class="layer"
       :style="{ transform: graphNavigator.transform, 'z-index': -1 }"
     />

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -46,6 +46,7 @@ const MENU_CLOSE_TIMEOUT_MS = 300
 const props = defineProps<{
   node: Node
   edited: boolean
+  graphNodeSelections: HTMLElement | undefined
 }>()
 
 const emit = defineEmits<{
@@ -470,7 +471,7 @@ const documentation = computed<string | undefined>({
     @pointerleave="(nodeHovered = false), updateNodeHover(undefined)"
     @pointermove="updateNodeHover"
   >
-    <Teleport to="#graphNodeSelections">
+    <Teleport :to="graphNodeSelections">
       <GraphNodeSelection
         v-if="navigator"
         :nodePosition="props.node.position"

--- a/app/gui2/src/components/GraphEditor/GraphNodes.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNodes.vue
@@ -13,11 +13,9 @@ import type { Vec2 } from '@/util/data/vec2'
 import { stackItemsEqual } from 'shared/languageServerTypes'
 import { computed, toRaw } from 'vue'
 
-const projectStore = useProjectStore()
-const graphStore = useGraphStore()
-const dragging = useDragging()
-const selection = injectGraphSelection(true)
-const navigator = injectGraphNavigator(true)
+const props = defineProps<{
+  graphNodeSelections: HTMLElement | undefined
+}>()
 
 const emit = defineEmits<{
   nodeOutputPortDoubleClick: [portId: AstId]
@@ -25,6 +23,12 @@ const emit = defineEmits<{
   createNodes: [source: NodeId, options: NodeCreationOptions[]]
   toggleColorPicker: []
 }>()
+
+const projectStore = useProjectStore()
+const graphStore = useGraphStore()
+const dragging = useDragging()
+const selection = injectGraphSelection(true)
+const navigator = injectGraphNavigator(true)
 
 function nodeIsDragged(movedId: NodeId, offset: Vec2) {
   const scaledOffset = offset.scale(1 / (navigator?.scale ?? 1))
@@ -49,6 +53,7 @@ const uploadingFiles = computed<[FileName, File][]>(() => {
     :key="id"
     :node="node"
     :edited="id === graphStore.editedNodeInfo?.id"
+    :graphNodeSelections="props.graphNodeSelections"
     @pointerenter="hoverNode(id)"
     @pointerleave="hoverNode(undefined)"
     @delete="graphStore.deleteNodes([id])"

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetApplication.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetApplication.vue
@@ -36,9 +36,13 @@ const operatorStyle = computed(() => {
 </script>
 
 <script lang="ts">
-export const widgetDefinition = defineWidget(ArgumentApplicationKey, {
-  priority: -20,
-})
+export const widgetDefinition = defineWidget(
+  ArgumentApplicationKey,
+  {
+    priority: -20,
+  },
+  import.meta.hot,
+)
 </script>
 
 <template>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetArgumentName.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetArgumentName.vue
@@ -36,15 +36,19 @@ function hasKnownArgumentName(input: WidgetInput): input is WidgetInput & {
   return !WidgetInput.isToken(input) && input[ArgumentInfoKey]?.info != null
 }
 
-export const widgetDefinition = defineWidget(hasKnownArgumentName, {
-  priority: 100,
-  score: (props) => {
-    const isPlaceholder = !(props.input.value instanceof Ast.Ast)
-    const isTopArg =
-      props.nesting < 2 && props.input[ArgumentInfoKey].appKind === ApplicationKind.Prefix
-    return isPlaceholder || isTopArg ? Score.Perfect : Score.Mismatch
+export const widgetDefinition = defineWidget(
+  hasKnownArgumentName,
+  {
+    priority: 100,
+    score: (props) => {
+      const isPlaceholder = !(props.input.value instanceof Ast.Ast)
+      const isTopArg =
+        props.nesting < 2 && props.input[ArgumentInfoKey].appKind === ApplicationKind.Prefix
+      return isPlaceholder || isTopArg ? Score.Perfect : Score.Mismatch
+    },
   },
-})
+  import.meta.hot,
+)
 
 export const ArgumentNameShownKey: unique symbol = Symbol('ArgumentNameShownKey')
 </script>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetBlank.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetBlank.vue
@@ -5,10 +5,14 @@ const _props = defineProps(widgetProps(widgetDefinition))
 </script>
 
 <script lang="ts">
-export const widgetDefinition = defineWidget(WidgetInput.astMatcher(Ast.Wildcard), {
-  priority: 500,
-  score: Score.Good,
-})
+export const widgetDefinition = defineWidget(
+  WidgetInput.astMatcher(Ast.Wildcard),
+  {
+    priority: 500,
+    score: Score.Good,
+  },
+  import.meta.hot,
+)
 </script>
 
 <template>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetCheckbox.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetCheckbox.vue
@@ -82,15 +82,20 @@ function setBoolNode(ast: Ast.Mutable, value: Identifier): { requiresImport: boo
   }
 }
 
-export const widgetDefinition = defineWidget(WidgetInput.isAstOrPlaceholder, {
-  priority: 500,
-  score: (props) => {
-    if (props.input.value instanceof Ast.Ast && isBoolNode(props.input.value)) return Score.Perfect
-    return props.input.expectedType === 'Standard.Base.Data.Boolean.Boolean' ?
-        Score.Good
-      : Score.Mismatch
+export const widgetDefinition = defineWidget(
+  WidgetInput.isAstOrPlaceholder,
+  {
+    priority: 500,
+    score: (props) => {
+      if (props.input.value instanceof Ast.Ast && isBoolNode(props.input.value))
+        return Score.Perfect
+      return props.input.expectedType === 'Standard.Base.Data.Boolean.Boolean' ?
+          Score.Good
+        : Score.Mismatch
+    },
   },
-})
+  import.meta.hot,
+)
 </script>
 
 <template>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetFileBrowser.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetFileBrowser.vue
@@ -91,18 +91,22 @@ const TEXT_TYPE = 'Standard.Base.Data.Text.Text'
 const FILE_MODULE = 'Standard.Base.System.File'
 const FILE_TYPE = FILE_MODULE + '.File'
 
-export const widgetDefinition = defineWidget(WidgetInput.isAstOrPlaceholder, {
-  priority: 49,
-  score: (props) => {
-    if (
-      props.input.dynamicConfig?.kind === 'File_Browse' ||
-      props.input.dynamicConfig?.kind === 'Folder_Browse'
-    )
-      return Score.Perfect
-    if (props.input[ArgumentInfoKey]?.info?.reprType.includes(FILE_TYPE)) return Score.Perfect
-    return Score.Mismatch
+export const widgetDefinition = defineWidget(
+  WidgetInput.isAstOrPlaceholder,
+  {
+    priority: 49,
+    score: (props) => {
+      if (
+        props.input.dynamicConfig?.kind === 'File_Browse' ||
+        props.input.dynamicConfig?.kind === 'Folder_Browse'
+      )
+        return Score.Perfect
+      if (props.input[ArgumentInfoKey]?.info?.reprType.includes(FILE_TYPE)) return Score.Perfect
+      return Score.Mismatch
+    },
   },
-})
+  import.meta.hot,
+)
 </script>
 
 <template>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetFunction.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetFunction.vue
@@ -291,30 +291,38 @@ function handleArgUpdate(update: WidgetUpdate): boolean {
 }
 </script>
 <script lang="ts">
-export const widgetDefinition = defineWidget(WidgetInput.isFunctionCall, {
-  priority: 200,
-  score: (props, db) => {
-    // If ArgumentApplicationKey is stored, we already are handled by some WidgetFunction.
-    if (props.input[ArgumentApplicationKey]) return Score.Mismatch
-    const ast = props.input.value
-    if (ast.id == null) return Score.Mismatch
-    const prevFunctionState = injectFunctionInfo(true)
+export const widgetDefinition = defineWidget(
+  WidgetInput.isFunctionCall,
+  {
+    priority: 200,
+    score: (props, db) => {
+      // If ArgumentApplicationKey is stored, we already are handled by some WidgetFunction.
+      if (props.input[ArgumentApplicationKey]) return Score.Mismatch
+      const ast = props.input.value
+      if (ast.id == null) return Score.Mismatch
+      const prevFunctionState = injectFunctionInfo(true)
 
-    // It is possible to try to render the same function application twice, e.g. when detected an
-    // application with no arguments applied yet, but the application target is also an infix call.
-    // In that case, the reentrant call method info must be ignored to not create an infinite loop,
-    // and to resolve the infix call as its own application.
-    if (prevFunctionState?.callId === ast.id) return Score.Mismatch
+      // It is possible to try to render the same function application twice, e.g. when detected an
+      // application with no arguments applied yet, but the application target is also an infix call.
+      // In that case, the reentrant call method info must be ignored to not create an infinite loop,
+      // and to resolve the infix call as its own application.
+      if (prevFunctionState?.callId === ast.id) return Score.Mismatch
 
-    if (ast instanceof Ast.App || ast instanceof Ast.OprApp) return Score.Perfect
+      if (ast instanceof Ast.App || ast instanceof Ast.OprApp) return Score.Perfect
 
-    const info = db.getMethodCallInfo(ast.id)
-    if (prevFunctionState != null && info?.partiallyApplied === true && ast instanceof Ast.Ident) {
-      return Score.Mismatch
-    }
-    return info != null ? Score.Perfect : Score.Mismatch
+      const info = db.getMethodCallInfo(ast.id)
+      if (
+        prevFunctionState != null &&
+        info?.partiallyApplied === true &&
+        ast instanceof Ast.Ident
+      ) {
+        return Score.Mismatch
+      }
+      return info != null ? Score.Perfect : Score.Mismatch
+    },
   },
-})
+  import.meta.hot,
+)
 </script>
 
 <template>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetGroup.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetGroup.vue
@@ -20,10 +20,14 @@ const child = computed(() => {
 <script lang="ts">
 import { Ast } from '@/util/ast'
 
-export const widgetDefinition = defineWidget(WidgetInput.astMatcher(Ast.Group), {
-  priority: 999,
-  score: Score.Perfect,
-})
+export const widgetDefinition = defineWidget(
+  WidgetInput.astMatcher(Ast.Group),
+  {
+    priority: 999,
+    score: Score.Perfect,
+  },
+  import.meta.hot,
+)
 </script>
 
 <template>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetHierarchy.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetHierarchy.vue
@@ -38,9 +38,13 @@ function transformChild(child: Ast.Ast | Ast.Token) {
 </script>
 
 <script lang="ts">
-export const widgetDefinition = defineWidget(WidgetInput.isAst, {
-  priority: 1000,
-})
+export const widgetDefinition = defineWidget(
+  WidgetInput.isAst,
+  {
+    priority: 1000,
+  },
+  import.meta.hot,
+)
 </script>
 
 <template>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetNumber.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetNumber.vue
@@ -36,25 +36,29 @@ const editHandler = WidgetEditHandler.New(props.input, {
 </script>
 
 <script lang="ts">
-export const widgetDefinition = defineWidget(WidgetInput.isAstOrPlaceholder, {
-  priority: 1001,
-  score: (props) => {
-    if (
-      props.input.value instanceof Ast.NumericLiteral ||
-      (props.input.value instanceof Ast.NegationApp &&
-        props.input.value.argument instanceof Ast.NumericLiteral)
-    )
-      return Score.Perfect
-    const type = props.input.expectedType
-    if (
-      type === 'Standard.Base.Data.Numbers.Number' ||
-      type === 'Standard.Base.Data.Numbers.Integer' ||
-      type === 'Standard.Base.Data.Numbers.Float'
-    )
-      return Score.Good
-    return Score.Mismatch
+export const widgetDefinition = defineWidget(
+  WidgetInput.isAstOrPlaceholder,
+  {
+    priority: 1001,
+    score: (props) => {
+      if (
+        props.input.value instanceof Ast.NumericLiteral ||
+        (props.input.value instanceof Ast.NegationApp &&
+          props.input.value.argument instanceof Ast.NumericLiteral)
+      )
+        return Score.Perfect
+      const type = props.input.expectedType
+      if (
+        type === 'Standard.Base.Data.Numbers.Number' ||
+        type === 'Standard.Base.Data.Numbers.Integer' ||
+        type === 'Standard.Base.Data.Numbers.Float'
+      )
+        return Score.Good
+      return Score.Mismatch
+    },
   },
-})
+  import.meta.hot,
+)
 </script>
 
 <template>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetPort.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetPort.vue
@@ -135,38 +135,42 @@ useRaf(toRef(tree, 'hasActiveAnimations'), updateRect)
 </script>
 
 <script lang="ts">
-export const widgetDefinition = defineWidget(WidgetInput.isAstOrPlaceholder, {
-  priority: 0,
-  score: (props, _db) => {
-    const portInfo = injectPortInfo(true)
-    const value = props.input.value
-    if (portInfo != null && value instanceof Ast.Ast && portInfo.portId === value.id) {
+export const widgetDefinition = defineWidget(
+  WidgetInput.isAstOrPlaceholder,
+  {
+    priority: 0,
+    score: (props, _db) => {
+      const portInfo = injectPortInfo(true)
+      const value = props.input.value
+      if (portInfo != null && value instanceof Ast.Ast && portInfo.portId === value.id) {
+        return Score.Mismatch
+      }
+
+      if (
+        props.input.forcePort ||
+        WidgetInput.isPlaceholder(props.input) ||
+        props.input[ArgumentInfoKey] != undefined
+      )
+        return Score.Perfect
+
+      if (
+        props.input.value instanceof Ast.Invalid ||
+        props.input.value instanceof Ast.BodyBlock ||
+        props.input.value instanceof Ast.Group ||
+        props.input.value instanceof Ast.NumericLiteral ||
+        props.input.value instanceof Ast.OprApp ||
+        props.input.value instanceof Ast.PropertyAccess ||
+        props.input.value instanceof Ast.UnaryOprApp ||
+        props.input.value instanceof Ast.Wildcard ||
+        props.input.value instanceof Ast.TextLiteral
+      )
+        return Score.Perfect
+
       return Score.Mismatch
-    }
-
-    if (
-      props.input.forcePort ||
-      WidgetInput.isPlaceholder(props.input) ||
-      props.input[ArgumentInfoKey] != undefined
-    )
-      return Score.Perfect
-
-    if (
-      props.input.value instanceof Ast.Invalid ||
-      props.input.value instanceof Ast.BodyBlock ||
-      props.input.value instanceof Ast.Group ||
-      props.input.value instanceof Ast.NumericLiteral ||
-      props.input.value instanceof Ast.OprApp ||
-      props.input.value instanceof Ast.PropertyAccess ||
-      props.input.value instanceof Ast.UnaryOprApp ||
-      props.input.value instanceof Ast.Wildcard ||
-      props.input.value instanceof Ast.TextLiteral
-    )
-      return Score.Perfect
-
-    return Score.Mismatch
+    },
   },
-})
+  import.meta.hot,
+)
 </script>
 
 <template>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
@@ -307,16 +307,20 @@ function isHandledByCheckboxWidget(parameter: SuggestionEntryArgument | undefine
   )
 }
 
-export const widgetDefinition = defineWidget(WidgetInput.isAstOrPlaceholder, {
-  priority: 50,
-  score: (props) =>
-    props.input[CustomDropdownItemsKey] != null ? Score.Perfect
-    : props.input.dynamicConfig?.kind === 'Single_Choice' ? Score.Perfect
-    : props.input.dynamicConfig?.kind === 'Multiple_Choice' ? Score.Perfect
-    : isHandledByCheckboxWidget(props.input[ArgumentInfoKey]?.info) ? Score.Mismatch
-    : props.input[ArgumentInfoKey]?.info?.tagValues != null ? Score.Perfect
-    : Score.Mismatch,
-})
+export const widgetDefinition = defineWidget(
+  WidgetInput.isAstOrPlaceholder,
+  {
+    priority: 50,
+    score: (props) =>
+      props.input[CustomDropdownItemsKey] != null ? Score.Perfect
+      : props.input.dynamicConfig?.kind === 'Single_Choice' ? Score.Perfect
+      : props.input.dynamicConfig?.kind === 'Multiple_Choice' ? Score.Perfect
+      : isHandledByCheckboxWidget(props.input[ArgumentInfoKey]?.info) ? Score.Mismatch
+      : props.input[ArgumentInfoKey]?.info?.tagValues != null ? Score.Perfect
+      : Score.Mismatch,
+  },
+  import.meta.hot,
+)
 
 /** Custom item added to dropdown. These items can’t be selected, but can be clicked. */
 export interface CustomDropdownItem {

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetSelfIcon.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetSelfIcon.vue
@@ -11,13 +11,17 @@ const icon = computed(() => tree.icon)
 </script>
 
 <script lang="ts">
-export const widgetDefinition = defineWidget(WidgetInput.isAst, {
-  priority: 1,
-  score: (props, _db) =>
-    props.input.value.id === injectWidgetTree().connectedSelfArgumentId ?
-      Score.Perfect
-    : Score.Mismatch,
-})
+export const widgetDefinition = defineWidget(
+  WidgetInput.isAst,
+  {
+    priority: 1,
+    score: (props, _db) =>
+      props.input.value.id === injectWidgetTree().connectedSelfArgumentId ?
+        Score.Perfect
+      : Score.Mismatch,
+  },
+  import.meta.hot,
+)
 </script>
 
 <template>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
@@ -76,16 +76,20 @@ watch(textContents, (value) => (editedContents.value = value))
 </script>
 
 <script lang="ts">
-export const widgetDefinition = defineWidget(WidgetInput.isAstOrPlaceholder, {
-  priority: 1001,
-  score: (props) => {
-    if (props.input.value instanceof Ast.TextLiteral) return Score.Perfect
-    if (props.input.dynamicConfig?.kind === 'Text_Input') return Score.Perfect
-    const type = props.input.expectedType
-    if (type === 'Standard.Base.Data.Text.Text') return Score.Good
-    return Score.Mismatch
+export const widgetDefinition = defineWidget(
+  WidgetInput.isAstOrPlaceholder,
+  {
+    priority: 1001,
+    score: (props) => {
+      if (props.input.value instanceof Ast.TextLiteral) return Score.Perfect
+      if (props.input.dynamicConfig?.kind === 'Text_Input') return Score.Perfect
+      const type = props.input.expectedType
+      if (type === 'Standard.Base.Data.Text.Text') return Score.Good
+      return Score.Mismatch
+    },
   },
-})
+  import.meta.hot,
+)
 </script>
 
 <template>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetToken.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetToken.vue
@@ -9,10 +9,14 @@ const repr = computed(() => props.input.value.code())
 </script>
 
 <script lang="ts">
-export const widgetDefinition = defineWidget(WidgetInput.isToken, {
-  priority: 0,
-  score: Score.Good,
-})
+export const widgetDefinition = defineWidget(
+  WidgetInput.isToken,
+  {
+    priority: 0,
+    score: Score.Good,
+  },
+  import.meta.hot,
+)
 </script>
 
 <template>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetTopLevelArgument.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetTopLevelArgument.vue
@@ -7,13 +7,17 @@ const props = defineProps(widgetProps(widgetDefinition))
 </script>
 
 <script lang="ts">
-export const widgetDefinition = defineWidget(ArgumentInfoKey, {
-  priority: -1,
-  score: (props) =>
-    props.nesting < 2 && props.input[ArgumentInfoKey].appKind === ApplicationKind.Prefix ?
-      Score.Perfect
-    : Score.Mismatch,
-})
+export const widgetDefinition = defineWidget(
+  ArgumentInfoKey,
+  {
+    priority: -1,
+    score: (props) =>
+      props.nesting < 2 && props.input[ArgumentInfoKey].appKind === ApplicationKind.Prefix ?
+        Score.Perfect
+      : Score.Mismatch,
+  },
+  import.meta.hot,
+)
 </script>
 
 <template>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetVector.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetVector.vue
@@ -44,15 +44,19 @@ const navigator = injectGraphNavigator(true)
 </script>
 
 <script lang="ts">
-export const widgetDefinition = defineWidget(WidgetInput.placeholderOrAstMatcher(Ast.Vector), {
-  priority: 500,
-  score: (props) =>
-    props.input.dynamicConfig?.kind === 'Vector_Editor' ? Score.Perfect
-    : props.input.dynamicConfig?.kind === 'SomeOfFunctionCalls' ? Score.Perfect
-    : props.input.value instanceof Ast.Vector ? Score.Good
-    : props.input.expectedType?.startsWith('Standard.Base.Data.Vector.Vector') ? Score.Good
-    : Score.Mismatch,
-})
+export const widgetDefinition = defineWidget(
+  WidgetInput.placeholderOrAstMatcher(Ast.Vector),
+  {
+    priority: 500,
+    score: (props) =>
+      props.input.dynamicConfig?.kind === 'Vector_Editor' ? Score.Perfect
+      : props.input.dynamicConfig?.kind === 'SomeOfFunctionCalls' ? Score.Perfect
+      : props.input.value instanceof Ast.Vector ? Score.Good
+      : props.input.expectedType?.startsWith('Standard.Base.Data.Vector.Vector') ? Score.Good
+      : Score.Mismatch,
+  },
+  import.meta.hot,
+)
 
 const DEFAULT_ITEM = computed(() => Ast.Wildcard.new())
 </script>

--- a/app/gui2/src/providers/widgetRegistry.ts
+++ b/app/gui2/src/providers/widgetRegistry.ts
@@ -5,6 +5,7 @@ import type { GraphDb } from '@/stores/graph/graphDatabase'
 import type { Typename } from '@/stores/suggestionDatabase/entry'
 import { Ast } from '@/util/ast'
 import { MutableModule } from '@/util/ast/abstract.ts'
+import type { ViteHotContext } from 'vite/types/hot'
 import { computed, shallowReactive, type Component, type PropType } from 'vue'
 import type { WidgetEditHandler } from './widgetRegistry/editHandler'
 
@@ -251,7 +252,6 @@ function isWidgetComponent(component: unknown): component is WidgetComponent<any
 function isWidgetDefinition(config: unknown): config is WidgetDefinition<any> {
   return typeof config === 'object' && config !== null && 'priority' in config && 'match' in config
 }
-
 /**
  *
  * @param matchInputs Filter the widget input to only accept specific types of input. The
@@ -265,6 +265,7 @@ function isWidgetDefinition(config: unknown): config is WidgetDefinition<any> {
 export function defineWidget<M extends InputMatcher<any> | InputMatcher<any>[]>(
   matchInputs: M,
   definition: WidgetOptions<InputTy<M>>,
+  hmr?: ViteHotContext,
 ): WidgetDefinition<InputTy<M>> {
   let score: WidgetDefinition<InputTy<M>>['score']
   if (typeof definition.score === 'function') {
@@ -274,12 +275,22 @@ export function defineWidget<M extends InputMatcher<any> | InputMatcher<any>[]>(
     score = () => staticScore
   }
 
-  return {
+  const resolved: WidgetDefinition<InputTy<M>> = {
     priority: definition.priority,
     match: makeInputMatcher<InputTy<M>>(matchInputs),
     score,
     prevent: definition.prevent,
   }
+
+  if (import.meta.hot && hmr) {
+    if (hmr.data.widgetDefinition) {
+      Object.assign(hmr.data.widgetDefinition, resolved)
+    } else {
+      hmr.data.widgetDefinition = shallowReactive(resolved)
+    }
+    return hmr.data.widgetDefinition
+  }
+  return resolved
 }
 
 function makeInputMatcher<T extends WidgetInput>(
@@ -321,15 +332,11 @@ export class WidgetRegistry {
   async loadAndCheckWidgetModules(
     asyncModules: [path: string, asyncModule: () => Promise<unknown>][],
   ) {
-    const modules = await Promise.allSettled(
-      asyncModules.map(([path, mod]) => mod().then((m) => [path, m] as const)),
-    )
-    for (const result of modules) {
-      if (result.status === 'fulfilled') {
-        const [path, mod] = result.value
+    for (const [path, mod] of asyncModules) {
+      mod().then((mod) => {
         if (isWidgetModule(mod)) this.registerWidgetModule(mod)
         else console.error('Invalid widget module:', path, mod)
-      }
+      })
     }
   }
 
@@ -376,5 +383,3 @@ export class WidgetRegistry {
     return best
   }
 }
-
-// TODO: add tests for select


### PR DESCRIPTION
### Pull Request Description

Fixed a long-standing annoyance that widgets weren't fully hot-reloadable. Now when the widget definition (e.g. `score` function) is modified, it is hot-reloaded and new version immediately takes effect.

https://github.com/enso-org/enso/assets/919491/8e6d5a67-68ec-4353-8235-32657b32e2ec

### Important Notes

Because of how HMR API works, it needs to be passed from each widget module to the `widgetDefinition` function as an argument. When not provided, the definition will not be hot-reloadable (but the widget will still work as it used to).

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
