### PR TITLE
Use secret.path rather than secret.id in data link editor

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/components/JSONSchemaInput.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/JSONSchemaInput.tsx
@@ -73,13 +73,12 @@ export default function JSONSchemaInput(props: JSONSchemaInputProps) {
               setAutocompleteItems([])
               void (async () => {
                 const secrets = await backend.listSecrets()
-                // FIXME: Extract secret path instead of ID.
-                setAutocompleteItems(secrets.map(secret => secret.id))
+                setAutocompleteItems(secrets.map(secret => secret.path))
               })()
             }
             children.push(
               <div
-                className={`rounded-default border ${
+                className={`grow rounded-default border ${
                   isValid ? 'border-primary/10' : 'border-red-700/60'
                 }`}
               >
@@ -220,7 +219,7 @@ export default function JSONSchemaInput(props: JSONSchemaInputProps) {
                         {innerProps => (
                           <UnstyledButton
                             isDisabled={!isOptional}
-                            className={`text inline-block w-json-schema-object-key whitespace-nowrap rounded-full px-button-x text-left ${
+                            className={`text inline-block grow whitespace-nowrap rounded-full px-button-x text-left ${
                               isOptional ? 'hover:bg-hover-bg' : ''
                             }`}
                             onPress={() => {

--- a/app/ide-desktop/lib/dashboard/src/services/Backend.ts
+++ b/app/ide-desktop/lib/dashboard/src/services/Backend.ts
@@ -309,6 +309,7 @@ export interface SecretAndInfo {
 export interface SecretInfo {
   readonly name: string
   readonly id: SecretId
+  readonly path: string
 }
 
 /** A Data Link. */


### PR DESCRIPTION
### Pull Request Details

#### Tl;dr 
Closes: enso-org/cloud-v2#1177

This PR fixes a bug when we send secret.id instead of secret.path while creating/editing a Data link


#### Test Plan:

1) try to create a new Data link, choose type "S3", in next dropdown choose "AWS access key", then in access key id choose "enso secret". Dropdown should suggest paths.
2) try to edit a Data link, choose type "S3", in next dropdown choose "AWS access key", then in access key id choose "enso secret". Dropdown should suggest paths.

---


<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
