### PR TITLE
Fix dropdowns no longer opening after first open

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/components/Dropdown.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/Dropdown.tsx
@@ -206,7 +206,7 @@ function Dropdown<T>(props: DropdownProps<T>, ref: React.ForwardedRef<HTMLDivEle
               onClick={event => {
                 event.stopPropagation()
                 if (!justFocusedRef.current && !readOnly) {
-                  setIsDropdownVisible(false)
+                  setIsDropdownVisible(!isDropdownVisible)
                 }
                 justFocusedRef.current = false
               }}
@@ -285,8 +285,7 @@ function Dropdown<T>(props: DropdownProps<T>, ref: React.ForwardedRef<HTMLDivEle
           onClick={event => {
             event.stopPropagation()
             if (!justFocusedRef.current && !readOnly) {
-              setIsDropdownVisible(false)
-              justBlurredRef.current = true
+              setIsDropdownVisible(!isDropdownVisible)
             }
             justFocusedRef.current = false
           }}


### PR DESCRIPTION
### Pull Request Description
- Fix https://github.com/enso-org/cloud-v2/issues/1178
  - Fix dropdowns not reopening after a third click (open -> close -> should open again)

### Important Notes
None

### Testing Instructions
- Should test both dropdowns in various places:
  - The "Create New Data Link" modal
  - The "Edit Data Link" component in the assets sidebar
  - The Activity Log settings page

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] ~~Unit tests have been written where possible.~~
  - [x] ~~If GUI codebase was changed, the GUI was tested when built using `./run ide build`.~~
