### PR TITLE
Display parens in groups

### DIFF
--- a/app/gui2/src/components/GraphEditor/widgets/WidgetGroup.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetGroup.vue
@@ -15,6 +15,9 @@ const child = computed(() => {
     }
   else return undefined
 })
+
+// There is no need to display parenthesis for top-level groups.
+const displayParenthesis = computed(() => props.nesting >= 2)
 </script>
 
 <script lang="ts">
@@ -27,5 +30,21 @@ export const widgetDefinition = defineWidget(WidgetInput.astMatcher(Ast.Group), 
 </script>
 
 <template>
-  <NodeWidget v-if="child" :input="child" />
+  <div class="WidgetGroup">
+    <span v-if="displayParenthesis" class="token">(</span>
+    <NodeWidget v-if="child" :input="child" />
+    <span v-if="displayParenthesis" class="token">)</span>
+  </div>
 </template>
+
+<style scoped>
+.WidgetGroup {
+  display: flex;
+  align-items: center;
+}
+
+.token {
+  color: rgb(255 255 255 / 0.33);
+  user-select: none;
+}
+</style>

--- a/app/gui2/src/components/widgets/ListWidget.vue
+++ b/app/gui2/src/components/widgets/ListWidget.vue
@@ -370,7 +370,7 @@ function addItem() {
       !$event.shiftKey && !$event.altKey && !$event.metaKey && $event.stopImmediatePropagation()
     "
   >
-    <div class="vector-literal literal">
+    <div class="vector-literal">
       <span class="token">[</span>
       <TransitionGroup
         tag="ul"

--- a/app/gui2/src/stores/graph/index.ts
+++ b/app/gui2/src/stores/graph/index.ts
@@ -750,7 +750,6 @@ export const useGraphStore = defineStore('graph', () => {
     isConnectedTarget,
     currentMethodPointer() {
       const currentMethod = proj.executionContext.getStackTop()
-      console.log('currentMethod', currentMethod)
       if (currentMethod.type === 'ExplicitCall') return currentMethod.methodPointer
       return db.getExpressionInfo(currentMethod.expressionId)?.methodCall?.methodPointer
     },


### PR DESCRIPTION
### Pull Request Description

Fixes another point in #9354 

Displays parens for Group AST (except top-level arguments).

<img width="630" alt="Screenshot 2024-04-11 at 3 08 01 PM" src="https://github.com/enso-org/enso/assets/6566674/8e3be87a-975b-404e-8a15-2752bd94cd4c">


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
