### PR TITLE
Fix node arguments hiding animation, clipping and dropdown styles.

### DIFF
--- a/app/gui2/e2e/widgets.spec.ts
+++ b/app/gui2/e2e/widgets.spec.ts
@@ -12,7 +12,7 @@ class DropDownLocator {
 
   constructor(ancestor: Locator) {
     this.rootWidget = ancestor.locator('.WidgetSelection')
-    this.dropDown = ancestor.locator('.Dropdown')
+    this.dropDown = ancestor.locator('.DropdownWidget')
     this.items = this.dropDown.locator('.item')
     this.selectedItems = this.dropDown.locator('.item.selected')
   }
@@ -94,7 +94,7 @@ test('Multi-selection widget', async ({ page }) => {
 
   // Add-item button opens dropdown, after closing with escape.
   await page.keyboard.press('Escape')
-  await expect(page.locator('.Dropdown')).not.toBeVisible()
+  await expect(page.locator('.DropdownWidget')).not.toBeVisible()
   await vector.locator('.add-item').click()
   await expect(dropDown.items).toHaveCount(2)
   await expect(dropDown.selectedItems).toHaveCount(1)
@@ -181,7 +181,7 @@ test('Selection widgets in Data.read node', async ({ page }) => {
   // Set value on `path` (dynamic config)
   const pathArg = argumentNames.filter({ has: page.getByText('path') })
   await pathArg.click()
-  await expect(page.locator('.Dropdown')).toBeVisible()
+  await expect(page.locator('.DropdownWidget')).toBeVisible()
   await dropDown.expectVisibleWithOptions(['Choose file…', 'File 1', 'File 2'])
   await dropDown.clickOption('File 2')
   await expect(pathArg.locator('.WidgetText > input')).toHaveValue('File 2')
@@ -210,7 +210,7 @@ test('Selection widget with text widget as input', async ({ page }) => {
   const pathArg = argumentNames.filter({ has: page.getByText('path') })
   const pathArgInput = pathArg.locator('.WidgetText > input')
   await pathArg.click()
-  await expect(page.locator('.Dropdown')).toBeVisible()
+  await expect(page.locator('.DropdownWidget')).toBeVisible()
   await dropDown.clickOption('File 2')
   await expect(pathArgInput).toHaveValue('File 2')
 

--- a/app/gui2/package.json
+++ b/app/gui2/package.json
@@ -43,6 +43,7 @@
     "@ag-grid-enterprise/range-selection": "^30.2.1",
     "@babel/parser": "^7.22.16",
     "@fast-check/vitest": "^0.0.8",
+    "@floating-ui/vue": "^1.0.6",
     "@lezer/common": "^1.1.0",
     "@lezer/highlight": "^1.1.6",
     "@noble/hashes": "^1.3.2",

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -550,6 +550,7 @@ const documentation = computed<string | undefined>({
       <NodeWidgetTree
         :ast="props.node.innerExpr"
         :nodeId="nodeId"
+        :nodeElement="rootNode"
         :icon="icon"
         :connectedSelfArgumentId="connectedSelfArgumentId"
         :potentialSelfArgumentId="potentialSelfArgumentId"

--- a/app/gui2/src/components/GraphEditor/NodeWidgetTree.vue
+++ b/app/gui2/src/components/GraphEditor/NodeWidgetTree.vue
@@ -14,6 +14,7 @@ import { computed, ref, toRef, watch } from 'vue'
 const props = defineProps<{
   ast: Ast.Ast
   nodeId: NodeId
+  nodeElement: HTMLElement | undefined
   icon: Icon
   connectedSelfArgumentId: Ast.AstId | undefined
   potentialSelfArgumentId: Ast.AstId | undefined
@@ -78,30 +79,11 @@ function handleWidgetUpdates(update: WidgetUpdate) {
 const currentEdit = ref<WidgetEditHandler>()
 watch(currentEdit, (edit) => edit && selectNode())
 
-/**
- * We have two goals for our DOM/CSS that are somewhat in conflict:
- * - We position widget dialogs drawn outside the widget, like dropdowns, relative to their parents. If we teleported
- *   them, we'd have to maintain their positions through JS; the focus hierarchy would also be affected.
- * - We animate showing/hiding conditionally-visible placeholder arguments; the implementation of this animation
- *   requires the use of `overflow-x: clip` for the placeholder argument. There doesn't seem to be any good alternative
- *   to clipping in order to achieve a suitable style of animation with CSS.
- * Because clipping is absolute (there is no way for an element to draw outside its clipped ancestor), it is hard to
- * reconcile with dropdowns.
- *
- * However, we can have our cake and eat it to--as long as we don't need both at once. The solution implemented here is
- * for the widget tree to provide an interface for a widget to signal that it is in a state requiring drawing outside
- * the node, and for widgets implementing clipping-based animations to mark them with a CSS class.
- *
- * This is not a perfect solution; it's possible for the user to cause a dropdown to be displayed before the
- * showing-placeholders animation finishes. In that case the animation will run without clipping, which looks a little
- * off. However, it allows us to use the DOM/CSS both for positioning the dropdown and animating the placeholders.
- */
-const deepDisableClipping = ref(false)
-
 const layoutTransitions = useTransitioning(observedLayoutTransitions)
 provideWidgetTree(
   toRef(props, 'ast'),
   toRef(props, 'nodeId'),
+  toRef(props, 'nodeElement'),
   toRef(props, 'icon'),
   toRef(props, 'connectedSelfArgumentId'),
   toRef(props, 'potentialSelfArgumentId'),
@@ -112,7 +94,6 @@ provideWidgetTree(
   () => {
     emit('openFullMenu')
   },
-  (clippingInhibitorsExist) => (deepDisableClipping.value = clippingInhibitorsExist),
 )
 </script>
 <script lang="ts">
@@ -122,12 +103,7 @@ export const ICON_WIDTH = 16
 </script>
 
 <template>
-  <div
-    class="NodeWidgetTree"
-    :class="{ deepDisableClipping }"
-    spellcheck="false"
-    v-on="layoutTransitions.events"
-  >
+  <div class="NodeWidgetTree" spellcheck="false" v-on="layoutTransitions.events">
     <!-- Display an icon for the node if no widget in the tree provides one. -->
     <SvgIcon
       v-if="!props.connectedSelfArgumentId"
@@ -168,9 +144,5 @@ export const ICON_WIDTH = 16
 .grab-handle {
   color: white;
   margin: 0 v-bind('GRAB_HANDLE_X_MARGIN_PX');
-}
-
-.deepDisableClipping :deep(.overridableClipState) {
-  overflow: visible !important;
 }
 </style>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetApplication.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetApplication.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import NodeWidget from '@/components/GraphEditor/NodeWidget.vue'
+import SizeTransition from '@/components/SizeTransition.vue'
 import { WidgetInput, defineWidget, widgetProps } from '@/providers/widgetRegistry'
 import { injectWidgetTree } from '@/providers/widgetTree'
 import { Ast } from '@/util/ast'
@@ -51,14 +52,11 @@ export const widgetDefinition = defineWidget(
     <div v-if="application.infixOperator" class="infixOp" :style="operatorStyle">
       <NodeWidget :input="WidgetInput.FromAst(application.infixOperator)" />
     </div>
-    <Transition name="collapse-argument">
-      <div
-        v-if="tree.extended || !application.argument.hideByDefault"
-        class="argument overridableClipState"
-      >
+    <SizeTransition width leftGap>
+      <div v-if="tree.extended || !application.argument.hideByDefault" class="argument">
         <NodeWidget :input="application.argument.toWidgetInput()" nest />
       </div>
-    </Transition>
+    </SizeTransition>
   </span>
 </template>
 
@@ -93,28 +91,5 @@ export const widgetDefinition = defineWidget(
   display: flex;
   flex-direction: row;
   place-items: center;
-  max-width: 2000px;
-}
-
-.collapse-argument-enter-active {
-  transition: max-width 4800ms 100ms cubic-bezier(0.38, 0.97, 0.56, 0.76);
-}
-
-.collapse-argument-leave-active {
-  transition: max-width 0.5s cubic-bezier(0, 0.76, 0, 0.99);
-}
-
-/* Clipping is part of the show/hide animation, but must not be applied when the argument is fully-shown because
-   attachments such as dropdowns extend beyond the element and may be children of the argument. */
-.collapse-argument-enter-active,
-.collapse-argument-leave-active,
-.collapse-argument-enter-from,
-.collapse-argument-leave-to {
-  overflow-x: clip;
-}
-
-.collapse-argument-enter-from,
-.collapse-argument-leave-to {
-  max-width: 0;
 }
 </style>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import NodeWidget from '@/components/GraphEditor/NodeWidget.vue'
+import SizeTransition from '@/components/SizeTransition.vue'
 import SvgIcon from '@/components/SvgIcon.vue'
 import DropdownWidget, { type DropdownEntry } from '@/components/widgets/DropdownWidget.vue'
 import { unrefElement } from '@/composables/events'
@@ -24,7 +25,8 @@ import { ArgumentInfoKey } from '@/util/callTree'
 import { arrayEquals } from '@/util/data/array'
 import type { Opt } from '@/util/data/opt'
 import { qnLastSegment, tryQualifiedName } from '@/util/qualifiedName'
-import { computed, ref, watch, type ComponentInstance } from 'vue'
+import { autoUpdate, offset, size, useFloating } from '@floating-ui/vue'
+import { computed, ref, type ComponentInstance } from 'vue'
 
 const props = defineProps(widgetProps(widgetDefinition))
 const suggestions = useSuggestionDbStore()
@@ -32,11 +34,33 @@ const graph = useGraphStore()
 
 const tree = injectWidgetTree()
 
+const widgetRoot = ref<HTMLElement>()
 const dropdownElement = ref<ComponentInstance<typeof DropdownWidget>>()
 
 const editedWidget = ref<string>()
 const editedValue = ref<Ast.Owned | string | undefined>()
 const isHovered = ref(false)
+
+const { floatingStyles } = useFloating(widgetRoot, dropdownElement, {
+  middleware: computed(() => {
+    return [
+      offset((state) => {
+        const NODE_HEIGHT = 32
+        return {
+          mainAxis: (NODE_HEIGHT - state.rects.reference.height) / 2,
+        }
+      }),
+      size({
+        apply({ elements, rects }) {
+          Object.assign(elements.floating.style, {
+            minWidth: `${rects.reference.width + 16}px`,
+          })
+        },
+      }),
+    ]
+  }),
+  whileElementsMounted: autoUpdate,
+})
 
 class ExpressionTag {
   private cachedExpressionAst: Ast.Ast | undefined
@@ -269,17 +293,6 @@ function expressionTagClicked(tag: ExpressionTag, previousState: boolean) {
     props.onUpdate({ edit, portUpdate: { value: tagValue, origin: props.input.portId } })
   }
 }
-
-let endClippingInhibition: (() => void) | undefined
-watch(dropDownInteraction.active, (visible) => {
-  if (visible) {
-    const { unregister } = tree.inhibitClipping()
-    endClippingInhibition = unregister
-  } else {
-    endClippingInhibition?.()
-    endClippingInhibition = undefined
-  }
-})
 </script>
 
 <script lang="ts">
@@ -327,6 +340,7 @@ declare module '@/providers/widgetRegistry' {
 <template>
   <!-- See comment in GraphNode next to dragPointer definition about stopping pointerdown and pointerup -->
   <div
+    ref="widgetRoot"
     class="WidgetSelection"
     :class="{ multiSelect: isMulti }"
     @pointerdown.stop
@@ -337,13 +351,18 @@ declare module '@/providers/widgetRegistry' {
   >
     <NodeWidget :input="innerWidgetInput" />
     <SvgIcon v-if="isHovered" name="arrow_right_head_only" class="arrow" />
-    <DropdownWidget
-      v-if="dropDownInteraction.active.value"
-      ref="dropdownElement"
-      :color="'var(--node-color-primary)'"
-      :entries="entries"
-      @clickEntry="onClick"
-    />
+    <Teleport v-if="tree.nodeElement" :to="tree.nodeElement">
+      <SizeTransition height :duration="100">
+        <DropdownWidget
+          v-if="dropDownInteraction.active.value"
+          ref="dropdownElement"
+          :style="floatingStyles"
+          :color="'var(--node-color-primary)'"
+          :entries="entries"
+          @clickEntry="onClick"
+        />
+      </SizeTransition>
+    </Teleport>
   </div>
 </template>
 
@@ -355,6 +374,7 @@ declare module '@/providers/widgetRegistry' {
 
 .arrow {
   position: absolute;
+  pointer-events: none;
   bottom: -7px;
   left: 50%;
   transform: translateX(-50%) rotate(90deg) scale(0.7);

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
@@ -115,7 +115,6 @@ export const widgetDefinition = defineWidget(
   display: inline-flex;
   background: var(--color-widget);
   border-radius: var(--radius-full);
-  position: relative;
   user-select: none;
   border-radius: var(--radius-full);
   padding: 0px 4px;

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetTopLevelArgument.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetTopLevelArgument.vue
@@ -31,7 +31,6 @@ export const widgetDefinition = defineWidget(
   display: inline-flex;
   flex-direction: row;
   place-items: center;
-  position: relative;
   height: var(--node-height);
 
   &:before {

--- a/app/gui2/src/components/SizeTransition.vue
+++ b/app/gui2/src/components/SizeTransition.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts" functional>
+import { nextTick } from 'process'
+
+const props = withDefaults(
+  defineProps<{
+    width?: boolean
+    height?: boolean
+    leftGap?: boolean
+    duration?: number
+    easing?: string
+  }>(),
+  { duration: 200, easing: 'ease-out' },
+)
+
+type Done = (cancelled: boolean) => void
+type StyleSnapshot = { width: string; height: string; marginLeft: string }
+const styleSnapshots = new WeakMap<HTMLElement, StyleSnapshot>()
+const animationsMap = new WeakMap<HTMLElement, Animation>()
+let leavingElement: HTMLElement | undefined = undefined
+
+function onEnter(e: Element, done: Done) {
+  if (e instanceof HTMLElement) animRun(e, done, true)
+}
+
+function onBeforeLeave(e: Element) {
+  if (e instanceof HTMLElement) {
+    leavingElement = e
+    snapshotCurrentStyles(e)
+  }
+}
+
+function onLeave(e: Element, done: Done) {
+  if (e instanceof HTMLElement) {
+    // In case the "leave" animation is interrupted by another "enter", we need to grab a
+    // style shapshot from leaving element right before it is removed from DOM.
+    //
+    // HACK: Unfortunately, all standard Vue transition hooks are called after the element has
+    // already been removed from the document. In fact, `leaveCancelled` and `afterLeave` are called
+    // right after that happens. In order to intercept the removal, we need to gently override the
+    // vue's internal hook that performs the removal and calls the aforementioned public hooks.
+    {
+      const leaveCbKey = Object.getOwnPropertySymbols(e).find((sym) =>
+        sym.toString().includes('_leaveCb'),
+      )
+      const el = leaveCbKey && (e as HTMLElement & Record<typeof leaveCbKey, Function>)
+      if (el && typeof el[leaveCbKey] === 'function') {
+        const originalHook = el[leaveCbKey]!
+        el[leaveCbKey] = function (...args: any[]) {
+          snapshotCurrentStyles(e)
+          originalHook.apply(this, args)
+        }
+      }
+    }
+
+    animRun(e, done, false)
+  }
+}
+
+function onAfterLeave(e: Element) {
+  nextTick(() => {
+    if (leavingElement === e) leavingElement = undefined
+  })
+}
+
+function snapshotCurrentStyles(e: HTMLElement) {
+  const { width, height, marginLeft } = getComputedStyle(e)
+  styleSnapshots.set(e, { width, height, marginLeft })
+}
+
+function animRun(e: HTMLElement, done: Done, isEnter: boolean) {
+  const lastSnapshot =
+    styleSnapshots.get(e) ?? (leavingElement ? styleSnapshots.get(leavingElement) : undefined)
+
+  // If there already is an animation running, stop it before reading final state styles.
+  const prevAnimation = animationsMap.get(e)
+  if (prevAnimation && !prevAnimation.finished) {
+    prevAnimation.cancel()
+  }
+  const current = getComputedStyle(e)
+
+  const start: Keyframe = { composite: 'replace', easing: props.easing }
+  const end: Keyframe = { composite: 'replace', easing: props.easing }
+
+  if (props.width) {
+    start.width = lastSnapshot?.width || '0px'
+    end.width = isEnter ? current.width : '0px'
+    start.overflowX = end.overflowX = 'clip'
+  }
+  if (props.height) {
+    start.height = lastSnapshot?.height || '0px'
+    end.height = isEnter ? current.height : '0px'
+    start.overflowY = end.overflowY = 'clip'
+  }
+  if (props.leftGap && e.parentElement) {
+    const parentStyle = getComputedStyle(e.parentElement)
+    const negativeGap = `calc(${parentStyle.gap} * -1)`
+    start.marginLeft = lastSnapshot?.marginLeft || negativeGap
+    end.marginLeft = isEnter ? current.marginLeft : negativeGap
+  }
+  const animation = e.animate([start, end], { duration: props.duration })
+  animation.addEventListener('finish', () => done(false))
+  animation.addEventListener('cancel', () => done(true))
+  animation.play()
+  animationsMap.set(e, animation)
+}
+</script>
+
+<template>
+  <Transition
+    :css="false"
+    @enter="onEnter"
+    @beforeLeave="onBeforeLeave"
+    @leave="onLeave"
+    @afterLeave="onAfterLeave"
+  >
+    <slot />
+  </Transition>
+</template>

--- a/app/gui2/src/components/widgets/DropdownWidget.vue
+++ b/app/gui2/src/components/widgets/DropdownWidget.vue
@@ -61,8 +61,14 @@ export interface DropdownEntry {
 </script>
 
 <template>
-  <div class="Dropdown" @pointerdown.stop @pointerup.stop @click.stop>
-    <ul class="list scrollable" :style="{ background: color, borderColor: color }" @wheel.stop>
+  <div
+    class="DropdownWidget"
+    :style="{ '--dropdown-bg': color }"
+    @pointerdown.stop
+    @pointerup.stop
+    @click.stop
+  >
+    <ul class="list scrollable" @wheel.stop>
       <template v-for="entry in sortedValues" :key="entry.value">
         <li v-if="entry.selected">
           <div class="item selected button" @click.stop="emit('clickEntry', entry, $event.altKey)">
@@ -75,7 +81,7 @@ export interface DropdownEntry {
       </template>
     </ul>
     <div v-if="enableSortButton" class="sort button">
-      <div class="sort-background" :style="{ background: color }"></div>
+      <div class="sort-background"></div>
       <SvgIcon
         :name="ICON_LOOKUP[sortDirection]"
         @click="sortDirection = NEXT_SORT_DIRECTION[sortDirection]"
@@ -85,25 +91,44 @@ export interface DropdownEntry {
 </template>
 
 <style scoped>
-.Dropdown {
-  position: absolute;
-  top: 100%;
-  margin-top: 8px;
-  overflow: visible;
-}
-
-.list {
+.DropdownWidget {
   position: relative;
   user-select: none;
-  overflow: auto;
+  overflow: clip;
+  min-width: 100%;
+
+  /* When dropdown is displayed right below the last node's argument, the rounded corner needs to be
+     covered. This is done by covering extra node-sized space at the top of the dropdown. */
+  --dropdown-extend: calc(var(--node-height) - 1px);
+  margin-top: calc(0px - var(--dropdown-extend));
+  padding-top: var(--dropdown-extend);
+  background-color: var(--dropdown-bg);
   border-radius: 16px;
+
+  &:before {
+    content: '';
+    display: block;
+    position: absolute;
+    top: var(--dropdown-extend);
+    left: 4px;
+    right: 4px;
+    border-top: 1px solid rgb(0 0 0 / 0.12);
+    z-index: 1;
+  }
+}
+.list {
+  overflow: auto;
   width: min-content;
+  border-radius: 0 0 16px 16px;
+  min-width: 100%;
   max-height: 152px;
   list-style-type: none;
   color: var(--color-text-light);
+  background: var(--dropdown-bg);
   scrollbar-width: thin;
   padding: 4px 0;
-  border: 2px solid;
+  border: 2px solid var(--dropdown-bg);
+  position: relative;
 }
 
 li {
@@ -124,6 +149,7 @@ li {
   position: absolute;
   border-top-left-radius: var(--radius-full);
   border-bottom-left-radius: var(--radius-full);
+  background: var(--dropdown-bg);
   opacity: 0.5;
   left: 0;
   top: 0;
@@ -146,15 +172,17 @@ li {
 }
 
 .item {
-  margin-right: 8px;
+  margin-right: 4px;
+  margin-left: 4px;
   padding-left: 8px;
   padding-right: 8px;
-}
-
-.item.selected {
-  margin-left: 8px;
   border-radius: var(--radius-full);
-  background-color: var(--color-port-connected);
-  width: min-content;
+
+  &:hover {
+    background-color: color-mix(in oklab, var(--color-port-connected) 50%, transparent 50%);
+  }
+  &.selected {
+    background-color: var(--color-port-connected);
+  }
 }
 </style>

--- a/app/gui2/src/providers/widgetTree.ts
+++ b/app/gui2/src/providers/widgetTree.ts
@@ -6,30 +6,13 @@ import type { Icon } from '@/util/iconName'
 import { computed, proxyRefs, type Ref } from 'vue'
 import type { WidgetEditHandler } from './widgetRegistry/editHandler'
 
-function makeExistenceRegistry(onChange: (anyExist: boolean) => void) {
-  const registered = new Set<number>()
-  let nextId = 0
-  return {
-    register: () => {
-      const id = nextId++
-      if (registered.size === 0) onChange(true)
-      registered.add(id)
-      return {
-        unregister: () => {
-          registered.delete(id)
-          if (registered.size === 0) onChange(false)
-        },
-      }
-    },
-  }
-}
-
 export { injectFn as injectWidgetTree, provideFn as provideWidgetTree }
 const { provideFn, injectFn } = createContextStore(
   'Widget tree',
   (
     astRoot: Ref<Ast.Ast>,
     nodeId: Ref<NodeId>,
+    nodeElement: Ref<HTMLElement | undefined>,
     icon: Ref<Icon>,
     connectedSelfArgumentId: Ref<Ast.AstId | undefined>,
     potentialSelfArgumentId: Ref<Ast.AstId | undefined>,
@@ -38,14 +21,13 @@ const { provideFn, injectFn } = createContextStore(
     hasActiveAnimations: Ref<boolean>,
     currentEdit: Ref<WidgetEditHandler | undefined>,
     emitOpenFullMenu: () => void,
-    clippingInhibitorsChanged: (anyExist: boolean) => void,
   ) => {
     const graph = useGraphStore()
     const nodeSpanStart = computed(() => graph.moduleSource.getSpan(astRoot.value.id)![0])
-    const { register: inhibitClipping } = makeExistenceRegistry(clippingInhibitorsChanged)
     return proxyRefs({
       astRoot,
       nodeId,
+      nodeElement,
       icon,
       connectedSelfArgumentId,
       potentialSelfArgumentId,
@@ -55,7 +37,6 @@ const { provideFn, injectFn } = createContextStore(
       hasActiveAnimations,
       currentEdit,
       emitOpenFullMenu,
-      inhibitClipping,
     })
   },
 )

--- a/app/gui2/src/util/patching.ts
+++ b/app/gui2/src/util/patching.ts
@@ -1,0 +1,13 @@
+/**
+ * Replace a function under given key on provided object and provide a hook that is called right
+ * before the original function is executed.
+ */
+export function hookBeforeFunctionCall(object: any, key: PropertyKey, hook: () => void) {
+  const original = object[key] as unknown
+  if (typeof original === 'function') {
+    object[key] = function (this: unknown, ...args: unknown[]) {
+      hook()
+      return original.apply(this, args)
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@ag-grid-enterprise/range-selection": "^30.2.1",
         "@babel/parser": "^7.22.16",
         "@fast-check/vitest": "^0.0.8",
+        "@floating-ui/vue": "^1.0.6",
         "@lezer/common": "^1.1.0",
         "@lezer/highlight": "^1.1.6",
         "@noble/hashes": "^1.3.2",
@@ -2781,7 +2782,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
       "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
-      "dev": true,
       "dependencies": {
         "@floating-ui/utils": "^0.2.1"
       }
@@ -2798,8 +2798,26 @@
     "node_modules/@floating-ui/utils": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
-      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==",
-      "dev": true
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+    },
+    "node_modules/@floating-ui/vue": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.0.6.tgz",
+      "integrity": "sha512-EdrOljjkpkkqZnrpqUcPoz9NvHxuTjUtSInh6GMv3+Mcy+giY2cE2pHh9rpacRcZ2eMSCxel9jWkWXTjLmY55w==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1",
+        "@floating-ui/utils": "^0.2.1",
+        "vue-demi": ">=0.13.0"
+      }
+    },
+    "node_modules/@floating-ui/vue/node_modules/@floating-ui/dom": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
+      }
     },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "1.18.2",


### PR DESCRIPTION
### Pull Request Description

Fixes #9492 

Implemented generic component for flawless size-based transitions, then used it for hiding arguments and dropdown animation. That replaced the `max-size`-based CSS animation that caused original issue. Refactored dropdown positioning to avoid further issues related to animation overflow clipping. The dropdown also got a bit of a lift to fit closer to styles in current Figma designs.

https://github.com/enso-org/enso/assets/919491/e85fd68c-b2e8-4d58-90e1-4fd7b33f1c9b


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
