### PR TITLE
Highlight stack trace elements from the current project in Test suite reports

### DIFF
--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Internal/Stack_Trace_Helpers.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Internal/Stack_Trace_Helpers.enso
@@ -1,0 +1,21 @@
+private
+
+from Standard.Base import all
+
+## PRIVATE
+decorate_stack_trace_text (project_root : File) (decorator : Text -> Text) (stack_trace_text : Text) -> Text =
+    ## This regex matches lines like:
+           at <enso> something(/path/to/file.enso:123:4-5)
+       and extracts the path `/path/to/file.enso`.
+    regex = Regex.compile "\s+at [^()]+\(([^()]*?):[\d:-]+\)"
+    normalized_root = project_root.absolute.normalize
+    stack_trace_text.lines
+        . map line->
+            is_line_from_current_project = case regex.match line . get 1 of
+                Nothing -> False
+                matched_path ->
+                    f = File.new matched_path . catch Any _->Nothing
+                    if f.is_nothing then False else
+                        f.absolute.normalize.is_descendant_of normalized_root
+            if is_line_from_current_project then decorator line else line
+        . join '\n'

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Suite.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Suite.enso
@@ -58,7 +58,7 @@ type Suite
          If false, return boolean from the method indicating whether some tests failed.
 
        Returns: Boolean if `should_exit` is False, otherwise exits the process.
-    run_with_filter self (filter : (Text | Nothing) = Nothing) should_exit=True -> (Boolean | Nothing) =
+    run_with_filter self (filter : (Text | Nothing) = Nothing) (should_exit : Boolean = True) -> (Boolean | Nothing) =
         config = Suite_Config.from_environment
 
         # Map of groups to vector of specs that match the filter

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Suite_Config.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Suite_Config.enso
@@ -1,6 +1,7 @@
 private
 
 from Standard.Base import all
+import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Runtime.Source_Location.Source_Location
 import Standard.Base.Runtime.Stack_Trace_Element
 
@@ -18,7 +19,7 @@ find_project_root path =
 ## PRIVATE
 find_caller_script : Vector Stack_Trace_Element -> File
 find_caller_script stack =
-    find_main idx =
+    find_main idx = if idx >= stack.length then Error.throw (Illegal_State.Error "Could not find `main` method.") else
         if stack.at idx . name . split "." . last == "main" then idx else
             @Tail_Call find_main (idx + 1)
     main_index = find_main 0
@@ -39,9 +40,12 @@ type Suite_Config
        Construct a configuration
 
        Arguments:
+       - print_only_failures: Should only failures be printed.
        - output_path: The path to the JUnit XML file to write to. If Nothing, no JUnit XML file
          will be written.
-    Value (print_only_failures : Boolean) (output_path : (File | Nothing)) (use_ansi_colors : Boolean)
+       - use_ansi_colors: Should ANSI colors be used in the output.
+       - caller_project_root: The root project path of the caller.
+    Value (print_only_failures : Boolean) (output_path : (File | Nothing)) (use_ansi_colors : Boolean) (caller_project_root : File | Nothing)
 
     ## Creates an Suite_Config based off environment and caller location
     from_environment : Suite_Config
@@ -49,17 +53,17 @@ type Suite_Config
         print_only_failures = Environment.get "REPORT_ONLY_FAILED" != Nothing
         junit_folder = Environment.get "ENSO_TEST_JUNIT_DIR"
         use_ansi_colors = Environment.get "ENSO_TEST_ANSI_COLORS" . is_nothing . not
+        caller_script = find_caller_script Runtime.get_stack_trace
+        project_root = find_project_root caller_script . catch Any _->Nothing
         results_path = if junit_folder.is_nothing then Nothing else
-            caller_script = find_caller_script Runtime.get_stack_trace
-            project_root = find_project_root caller_script
-            case project_root.is_error || project_root.is_nothing of
+            case project_root.is_nothing of
                 True ->
                     IO.println "Unable to determine root project path. JUnit output disabled."
                     Nothing
                 False ->
                     (File.new junit_folder) / project_root.name / "JUnit.xml"
 
-        Suite_Config.Value print_only_failures results_path use_ansi_colors
+        Suite_Config.Value print_only_failures results_path use_ansi_colors project_root
 
     ## Should the results be written to JUnit XML file.
     should_output_junit self =

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Test_Reporter.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Test_Reporter.enso
@@ -37,11 +37,17 @@ red text =
 green text =
     '\u001b[32;1m' + text + '\u001b[0m'
 
+highlighted text =
+    '\u001b[1;1m' + text + '\u001b[0m'
+
 maybe_red_text (text : Text) (config : Suite_Config) =
     if config.use_ansi_colors then (red text) else text
 
 maybe_green_text (text : Text) (config : Suite_Config) =
     if config.use_ansi_colors then (green text) else text
+
+maybe_highlighted_text (text : Text) (config : Suite_Config) =
+    if config.use_ansi_colors then (highlighted text) else text
 
 ## Print result for a single Spec run
 print_single_result : Test_Result -> Suite_Config -> Nothing
@@ -49,6 +55,10 @@ print_single_result (test_result : Test_Result) (config : Suite_Config) =
     times_suffix =
         times = test_result.time_taken.total_milliseconds.to_text + "ms"
         "[" + times + "]"
+
+    decorate_stack_trace = case config.use_ansi_colors && config.caller_project_root.is_nothing.not of
+        True -> decorate_stack_trace_text config.caller_project_root (maybe_highlighted_text _ config)
+        False -> (x->x)
 
     case test_result.spec_result of
         Spec_Result.Success ->
@@ -60,7 +70,7 @@ print_single_result (test_result : Test_Result) (config : Suite_Config) =
             IO.println (maybe_red_text txt config)
             IO.println ("        Reason: " + msg)
             if details.is_nothing.not then
-                IO.println details
+                IO.println (decorate_stack_trace details)
         Spec_Result.Pending reason ->
             if config.print_only_failures.not then
                 IO.println ("    - [PENDING] " + test_result.spec_name)
@@ -146,3 +156,21 @@ print_group_report group_name test_results config builder =
 escape_xml : Text -> Text
 escape_xml input =
     input.replace '&' '&amp;' . replace '"' '&quot;' . replace "'" '&apos;' . replace '<' '&lt;' . replace '>' '&gt;'
+
+## PRIVATE
+decorate_stack_trace_text (project_root : File) (decorator : Text -> Text) (stack_trace_text : Text) -> Text =
+    ## This regex matches lines like:
+           at <enso> something(/path/to/file.enso:123:4-5)
+       and extracts the path `/path/to/file.enso`.
+    regex = Regex.compile "\s+at [^()]+\(([^()]*?):[\d:-]+\)"
+    normalized_root = project_root.absolute.normalize
+    stack_trace_text.lines
+        . map line->
+            is_line_from_current_project = case regex.match line . get 1 of
+                Nothing -> False
+                matched_path ->
+                    f = File.new matched_path . catch Any _->Nothing
+                    if f.is_nothing then False else
+                        f.absolute.normalize.is_descendant_of normalized_root
+            if is_line_from_current_project then decorator line else line
+        . join '\n'

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Test_Reporter.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Test_Reporter.enso
@@ -4,6 +4,7 @@ from Standard.Base import all
 import Standard.Base.Runtime.Context
 from Standard.Base.Runtime import assert
 
+import project.Internal.Stack_Trace_Helpers
 import project.Spec_Result.Spec_Result
 import project.Suite_Config.Suite_Config
 import project.Test.Test
@@ -57,7 +58,7 @@ print_single_result (test_result : Test_Result) (config : Suite_Config) =
         "[" + times + "]"
 
     decorate_stack_trace = case config.use_ansi_colors && config.caller_project_root.is_nothing.not of
-        True -> decorate_stack_trace_text config.caller_project_root (maybe_highlighted_text _ config)
+        True -> Stack_Trace_Helpers.decorate_stack_trace_text config.caller_project_root (maybe_highlighted_text _ config)
         False -> (x->x)
 
     case test_result.spec_result of
@@ -156,21 +157,3 @@ print_group_report group_name test_results config builder =
 escape_xml : Text -> Text
 escape_xml input =
     input.replace '&' '&amp;' . replace '"' '&quot;' . replace "'" '&apos;' . replace '<' '&lt;' . replace '>' '&gt;'
-
-## PRIVATE
-decorate_stack_trace_text (project_root : File) (decorator : Text -> Text) (stack_trace_text : Text) -> Text =
-    ## This regex matches lines like:
-           at <enso> something(/path/to/file.enso:123:4-5)
-       and extracts the path `/path/to/file.enso`.
-    regex = Regex.compile "\s+at [^()]+\(([^()]*?):[\d:-]+\)"
-    normalized_root = project_root.absolute.normalize
-    stack_trace_text.lines
-        . map line->
-            is_line_from_current_project = case regex.match line . get 1 of
-                Nothing -> False
-                matched_path ->
-                    f = File.new matched_path . catch Any _->Nothing
-                    if f.is_nothing then False else
-                        f.absolute.normalize.is_descendant_of normalized_root
-            if is_line_from_current_project then decorator line else line
-        . join '\n'


### PR DESCRIPTION
### Pull Request Description

If ANSI coloring is enabled, stack trace entries corresponding to the currently running project will be highlighted in bold:
![image](https://github.com/enso-org/enso/assets/1436948/b02da409-b67c-421c-a6d0-07a6cbbaf5f8)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
