### PR TITLE
Implement `Vector.build`: implementation and some tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -650,6 +650,7 @@
 - [Added `Decimal.min` and `.max`.][9663]
 - [Added `Decimal.round`.][9672]
 - [Implemented write support for Enso Cloud files.][9686]
+- [Added `Vector.build`.][9725]
 
 [debug-shortcuts]:
   https://github.com/enso-org/enso/blob/develop/app/gui/docs/product/shortcuts.md#debug
@@ -950,6 +951,7 @@
 [9663]: https://github.com/enso-org/enso/pull/9663
 [9672]: https://github.com/enso-org/enso/pull/9672
 [9686]: https://github.com/enso-org/enso/pull/9686
+[9725]: https://github.com/enso-org/enso/pull/9725
 
 #### Enso Compiler
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -145,6 +145,7 @@ type Vector a
 
     ## PRIVATE
        ADVANCED
+       DEPRECATED
        Creates a new vector builder instance.
 
        A vector `Builder` is a mutable data structure, that allows for gathering

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -91,7 +91,7 @@ type Vector a
              Vector.collect (List.Cons 1 <| List.Cons 2 <| List.Nil) .x .xs stop_at=(_==List.Nil)
     collect : Any -> (Any -> Any) -> (Any -> Any) -> Integer | Nothing -> (Any -> Boolean) -> Vector Any
     collect seq element:(Any -> Any) next:(Any -> Any) limit:(Integer | Nothing)=Nothing stop_at:(Any -> Boolean)=(_==Nothing) =
-        Vector.build capacity=(if limit.is_nothing then 10 else limit) builder->
+        Vector.build initial_capacity=(if limit.is_nothing then 10 else limit) builder->
             iterate item remaining =
                 done = remaining == 0 || (stop_at item)
                 if done.not then

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -1255,8 +1255,15 @@ type Builder
        Appends a new element into this builder and returns it, propagating any
        errors that the provided element could have contained.
 
+       Returns the builder, unless `item` is a dataflow error, in which case the
+       error is propagated.
+
        Arguments:
        - item: The item to append to the vector builder.
+
+       ! Error Conditions
+
+         - If `item` is a dataflow error, the error is propagated.
 
        > Example
          Append two items.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -91,7 +91,7 @@ type Vector a
              Vector.collect (List.Cons 1 <| List.Cons 2 <| List.Nil) .x .xs stop_at=(_==List.Nil)
     collect : Any -> (Any -> Any) -> (Any -> Any) -> Integer | Nothing -> (Any -> Boolean) -> Vector Any
     collect seq element:(Any -> Any) next:(Any -> Any) limit:(Integer | Nothing)=Nothing stop_at:(Any -> Boolean)=(_==Nothing) =
-        Vector.build limit=(if limit.is_nothing then 10 else limit) builder->
+        Vector.build capacity=(if limit.is_nothing then 10 else limit) builder->
             iterate item remaining =
                 done = remaining == 0 || (stop_at item)
                 if done.not then
@@ -197,6 +197,7 @@ type Vector a
 
        Arguments:
        - function: a function taking a `Builder` and using it to add elements.
+       - capacity: Initial capacity of the Vector.Builder
 
        ! Error Conditions
 
@@ -212,8 +213,8 @@ type Vector a
                  builder.append 3
              # => [1, 2, 3]
     build : (Builder -> Any) -> Integer -> Vector
-    build (function : Builder -> Any) (limit : Integer = 10) -> Vector =
-        builder = Builder.new limit
+    build (function : Builder -> Any) (capacity : Integer = 10) -> Vector =
+        builder = Builder.new capacity
         result = function builder
         result.if_not_error builder.to_vector
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -147,12 +147,12 @@ type Vector a
        ADVANCED
        Creates a new vector builder instance.
 
-       A vector builder is a mutable data structure, that allows for gathering
+       A vector `Builder` is a mutable data structure, that allows for gathering
        a number of elements and then converting them into a vector. This is
        particularly useful when the number of elements is not known upfront.
 
-       A vector allows to store an arbitrary number of elements in linear memory. It
-       is the recommended data structure for most applications.
+       A vector allows to store an arbitrary number of elements in linear
+       memory. It is the recommended data structure for most applications.
 
        Arguments:
        - capacity: Initial capacity of the Vector.Builder
@@ -170,6 +170,47 @@ type Vector a
                   builder.to_vector
     new_builder : Integer -> Builder
     new_builder (capacity=10) = Builder.new capacity
+
+    ## PRIVATE
+       ADVANCED
+       Creates a new `Vector` by providing a `Builder` to the provided function.
+
+       A vector `Builder` is a mutable data structure, that allows for gathering
+       a number of elements and then converting them into a vector. This is
+       particularly useful when the number of elements is not known upfront.
+
+       `.build` creates a new `Builder`, passes it to the provided function, and
+       then closes the `Builder and returns the resulting `Vector`.
+
+       The provided function should call `.append` to add new elements to the
+       `Builder`. The return value of the provided function is not used, unless
+       it is a dataflow error, in which case the `Vector` is not built, and the
+       error is propagted instead.
+
+       A vector allows to store an arbitrary number of elements in linear
+       memory. It is the recommended data structure for most applications.
+
+       Arguments:
+       - function: a function taking a `Builder` and using it to add elements.
+
+       ! Error Conditions
+
+         - If the provided function throws a dataflow error, the `Vector` is not
+           built, and the error is propagted instead.
+
+       > Example
+         Construct a vector using a builder that contains the items 1 to 5.
+
+             Vector.build builder->
+                 builder.append 1
+                 builder.append 2
+                 builder.append 3
+             # => [1, 2, 3]
+    build : (Builder -> Any) -> Vector
+    build (function : Builder -> Any) -> Vector =
+        builder = Builder.new 10
+        result = function builder
+        result.if_not_error builder.to_vector
 
     ## PRIVATE
        ADVANCED

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -207,9 +207,9 @@ type Vector a
                  builder.append 2
                  builder.append 3
              # => [1, 2, 3]
-    build : (Builder -> Any) -> Vector
-    build (function : Builder -> Any) -> Vector =
-        builder = Builder.new 10
+    build : (Builder -> Any) -> Integer -> Vector
+    build (function : Builder -> Any) (limit : Integer = 10) -> Vector =
+        builder = Builder.new limit
         result = function builder
         result.if_not_error builder.to_vector
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -182,13 +182,15 @@ type Vector a
        a number of elements and then converting them into a vector. This is
        particularly useful when the number of elements is not known upfront.
 
-       `.build` creates a new `Builder`, passes it to the provided function, and
-       then closes the `Builder and returns the resulting `Vector`.
+       `.build` creates a new `Builder`, passes it to the provided function,
+       which can add elements using the `Builder`'s `.append` method. When the
+       function is done, `.build` then closes the `Builder and returns the
+       resulting `Vector`.
 
        The provided function should call `.append` to add new elements to the
        `Builder`. The return value of the provided function is not used, unless
        it is a dataflow error, in which case the `Vector` is not built, and the
-       error is propagted instead.
+       dataflow error is propagted instead.
 
        A vector allows to store an arbitrary number of elements in linear
        memory. It is the recommended data structure for most applications.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -91,11 +91,13 @@ type Vector a
              Vector.collect (List.Cons 1 <| List.Cons 2 <| List.Nil) .x .xs stop_at=(_==List.Nil)
     collect : Any -> (Any -> Any) -> (Any -> Any) -> Integer | Nothing -> (Any -> Boolean) -> Vector Any
     collect seq element:(Any -> Any) next:(Any -> Any) limit:(Integer | Nothing)=Nothing stop_at:(Any -> Boolean)=(_==Nothing) =
-        b = Vector.new_builder (if limit.is_nothing then 10 else limit)
-        iterate item remaining = if remaining == 0 || (stop_at item) then b.to_vector else
-            b.append <| element item
-            @Tail_Call iterate (next item) (if remaining.is_nothing then Nothing else remaining-1)
-        iterate seq limit
+        Vector.build limit=(if limit.is_nothing then 10 else limit) builder->
+            iterate item remaining =
+                done = remaining == 0 || (stop_at item)
+                if done.not then
+                    builder.append <| element item
+                    @Tail_Call iterate (next item) (if remaining.is_nothing then Nothing else remaining-1)
+            iterate seq limit
 
     ## PRIVATE
        ADVANCED

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -176,7 +176,7 @@ type Vector a
 
     ## PRIVATE
        ADVANCED
-       Creates a new `Vector` by providing a `Builder` to the provided function.
+       Creates a new `Vector` by passing a `Builder` to the provided function.
 
        A vector `Builder` is a mutable data structure, that allows for gathering
        a number of elements and then converting them into a vector. This is
@@ -197,7 +197,8 @@ type Vector a
 
        Arguments:
        - function: a function taking a `Builder` and using it to add elements.
-       - capacity: Initial capacity of the Vector.Builder
+       - initial_capacity: Initial capacity of the Vector.Builder; this is for
+         pre-allocation and does not affect the size of the resulting `Vector`.
 
        ! Error Conditions
 
@@ -213,8 +214,8 @@ type Vector a
                  builder.append 3
              # => [1, 2, 3]
     build : (Builder -> Any) -> Integer -> Vector
-    build (function : Builder -> Any) (capacity : Integer = 10) -> Vector =
-        builder = Builder.new capacity
+    build (function : Builder -> Any) (initial_capacity : Integer = 10) -> Vector =
+        builder = Builder.new initial_capacity
         result = function builder
         result.if_not_error builder.to_vector
 

--- a/test/Base_Tests/src/Data/Vector_Spec.enso
+++ b/test/Base_Tests/src/Data/Vector_Spec.enso
@@ -425,22 +425,20 @@ type_spec suite_builder name alter = suite_builder.group name group_builder->
         result . should_equal vec
 
     group_builder.specify "should accept changed elements" <|
-        vec_mut = Vector.new_builder
-        vec_mut.append 1
-        vec_mut.append 1.1
-        vec_mut.append Nothing
+        vec = alter <| Vector.build builder->
+            builder.append 1
+            builder.append 1.1
+            builder.append Nothing
 
-        vec = alter vec_mut.to_vector
         vec.length . should_equal 3
         vec.at 0 . should_equal 1
         vec.at 1 . should_equal 1.1
         vec.at 2 . should_equal Nothing
 
     group_builder.specify "should accept Nothing" <|
-        vec_mut = Vector.new_builder
-        vec_mut.append Nothing
+        vec = alter <| Vector.build builder->
+            builder.append Nothing
 
-        vec = alter vec_mut.to_vector
         vec.length . should_equal 1
         vec.at 0 . should_equal Nothing
 
@@ -778,21 +776,19 @@ type_spec suite_builder name alter = suite_builder.group name group_builder->
 
     group_builder.specify "should correctly propagate state through each" <|
         v = State.run Number 77 <|
-            b = Vector.new_builder
-            (alter ["A", "B"]).each x->
-                b.append x
-                b.append (State.get Number).to_text
-            b.to_vector
+            Vector.build builder->
+                (alter ["A", "B"]).each x->
+                    builder.append x
+                    builder.append (State.get Number).to_text
 
         v.should_equal ['A', '77', 'B', '77']
 
     group_builder.specify "should correctly propagate state through map" <|
         v = State.run Number 55 <|
-            b = Vector.new_builder
-            (alter ["X", "Y"]).map x->
-                b.append x
-                b.append (State.get Number).to_text
-            b.to_vector
+            Vector.build builder->
+                (alter ["X", "Y"]).map x->
+                    builder.append x
+                    builder.append (State.get Number).to_text
 
         v.should_equal ['X', '55', 'Y', '55']
 

--- a/test/Base_Tests/src/Data/Vector_Spec.enso
+++ b/test/Base_Tests/src/Data/Vector_Spec.enso
@@ -420,9 +420,9 @@ type_spec suite_builder name alter = suite_builder.group name group_builder->
 
     group_builder.specify "should allow applying a function to each element" <|
         vec = alter [1, 2, 3, 4]
-        vec_mut = Vector.new_builder
-        vec.each vec_mut.append
-        vec_mut.to_vector . should_equal vec
+        result = Vector.build builder->
+            vec.each builder.append
+        result . should_equal vec
 
     group_builder.specify "should accept changed elements" <|
         vec_mut = Vector.new_builder

--- a/test/Base_Tests/src/Data/Vector_Spec.enso
+++ b/test/Base_Tests/src/Data/Vector_Spec.enso
@@ -1034,6 +1034,26 @@ add_specs suite_builder =
             v = Vector.collect l .x .xs limit=30 stop_at=(_==List.Nil)
             v . should_equal [1, 2, 3]
 
+    suite_builder.group "Vector.build" group_builder->
+        group_builder.specify "Should be able to build a vector" <|
+            v = Vector.build builder->
+                builder.append 1
+                builder.append 2
+                builder.append Nothing
+                builder.append 3
+            v . should_equal [1, 2, Nothing, 3]
+
+            v2 = Vector.build builder->
+                _ = builder  # Do nothing
+            v2 . should_equal []
+
+        group_builder.specify "Should propagate dataflow errors" <|
+            v = Vector.build builder->
+                builder.append 1
+                builder.append 2
+                Error.throw (Illegal_Argument.Error "asdf")
+            v . should_fail_with (Illegal_Argument.Error "asdf")
+
     suite_builder.group "Vector/Array equality" group_builder->
         v1 = [1, 2, 3]
         a1 = v1.to_array

--- a/test/Base_Tests/src/Data/Vector_Spec.enso
+++ b/test/Base_Tests/src/Data/Vector_Spec.enso
@@ -1043,6 +1043,10 @@ add_specs suite_builder =
                 _ = builder  # Do nothing
             v2 . should_equal []
 
+            v3 = Vector.build initial_capacity=20 builder->
+                builder.append 1
+            v3 . should_equal [1]
+
         group_builder.specify "Should propagate dataflow errors" <|
             v = Vector.build builder->
                 builder.append 1


### PR DESCRIPTION
This PR implements `Vector.build` and converts uses of `.new_builder` to `.build` within Vector and Vector_Spec.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
