### PR TITLE
Fix bundled engine after GraalVM upgrade

### DIFF
--- a/lib/scala/distribution-manager/src/main/scala/org/enso/distribution/DistributionManager.scala
+++ b/lib/scala/distribution-manager/src/main/scala/org/enso/distribution/DistributionManager.scala
@@ -75,13 +75,13 @@ case class DistributionPaths(
   /** Sequence of paths to search for engine installations, in order of
     * precedence.
     */
-  def engineSearchPaths: Seq[Path] = Seq(engines) ++ bundle.map(_.engines).toSeq
+  def engineSearchPaths: Seq[Path] = bundle.map(_.engines).toSeq ++ Seq(engines)
 
   /** Sequence of paths to search for runtime installations, in order of
     * precedence.
     */
   def runtimeSearchPaths: Seq[Path] =
-    Seq(runtimes) ++ bundle.map(_.runtimes).toSeq
+    bundle.map(_.runtimes).toSeq ++ Seq(runtimes)
 
   /** The directory for cached editions managed by us. */
   def cachedEditions: Path = dataRoot / DistributionManager.EDITIONS_DIRECTORY
@@ -93,8 +93,8 @@ case class DistributionPaths(
     * precedence.
     */
   def editionSearchPaths: Seq[Path] =
-    customEditions ++ Seq(cachedEditions) ++
-    bundledWithEngines(DistributionManager.EDITIONS_DIRECTORY)
+    bundledWithEngines(DistributionManager.EDITIONS_DIRECTORY) ++
+    customEditions ++ Seq(cachedEditions)
 
   /** Returns a sequence of paths to some subdirectory in all installed engines.
     */

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
@@ -183,15 +183,16 @@ class Runner(
       val commandLineOptions        = jvmSettings.jvmOptions.map(translateJVMOption)
       val shouldInvokeViaModulePath = engine.graalRuntimeVersion.isUnchained
 
+      val componentPath = engine.componentDirPath.toAbsolutePath.normalize
       val langHomeOption = Seq(
-        s"-Dorg.graalvm.language.enso.home=${engine.componentDirPath.toAbsolutePath.normalize.toString}"
+        s"-Dorg.graalvm.language.enso.home=$componentPath"
       )
       var jvmArguments =
         manifestOptions ++ environmentOptions ++ commandLineOptions ++ langHomeOption
       if (shouldInvokeViaModulePath) {
         jvmArguments = jvmArguments :++ Seq(
           "--module-path",
-          engine.componentDirPath.toAbsolutePath.normalize.toString,
+          componentPath.toString,
           "-m",
           "org.enso.runtime/org.enso.EngineRunnerBootLoader"
         )

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
@@ -183,8 +183,11 @@ class Runner(
       val commandLineOptions        = jvmSettings.jvmOptions.map(translateJVMOption)
       val shouldInvokeViaModulePath = engine.graalRuntimeVersion.isUnchained
 
+      val langHomeOption = Seq(
+        s"-Dorg.graalvm.language.enso.home=${engine.componentDirPath.toAbsolutePath.normalize.toString}"
+      )
       var jvmArguments =
-        manifestOptions ++ environmentOptions ++ commandLineOptions
+        manifestOptions ++ environmentOptions ++ commandLineOptions ++ langHomeOption
       if (shouldInvokeViaModulePath) {
         jvmArguments = jvmArguments :++ Seq(
           "--module-path",


### PR DESCRIPTION


### Pull Request Description

The change fixes the problem with suggestions loading by
1. Making sure that bundle is always the first on the search path for editions and engine
2. Passing language home to language server

Verified by building/running AppImage locally (previously would fail).

Closes #9728. Regressed in #9647.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

~~- [ ] The documentation has been updated, if necessary.~~
~~- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  ~~- [ ] Unit tests have been written where possible.~~
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
