### PR TITLE
Should not use auto-scoping for atom types

### DIFF
--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/context/SuggestionBuilderTest.scala
@@ -941,7 +941,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
                   false,
                   false,
                   None,
-                  Some(Seq("..A", "..B", "..Auto"))
+                  Some(Seq("..A", "..B", "Unnamed.Test.Auto"))
                 )
               ),
               selfType      = "Unnamed.Test",
@@ -1033,7 +1033,7 @@ class SuggestionBuilderTest extends AnyWordSpecLike with Matchers {
                   false,
                   false,
                   None,
-                  Some(Seq("..A", "..B", "..Auto"))
+                  Some(Seq("..A", "..B", "Unnamed.Test.Auto"))
                 )
               ),
               selfType      = "Unnamed.Test",


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #9738

Do now use autoscope syntax for type definitions without constructors.

### Important Notes


https://github.com/enso-org/enso/assets/357683/5147b9a6-f5f4-4e5e-8b3a-3d2fa3eab2d5


https://github.com/enso-org/enso/assets/357683/db1beff8-53de-4ea1-a087-b84e571904e8



<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [x] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
