### PR TITLE
Special treatment for ..True and ..False

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedConstructor.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/UnresolvedConstructor.java
@@ -241,6 +241,13 @@ public final class UnresolvedConstructor implements EnsoObject {
         UnresolvedConstructor unresolved,
         State state,
         DirectCallNode callNode) {
+      var builtins = EnsoContext.get(callNode).getBuiltins();
+      if (c == builtins.bool().getTrue()) {
+        return true;
+      }
+      if (c == builtins.bool().getFalse()) {
+        return false;
+      }
       var fn = c.getConstructorFunction();
       var args = new Object[prototype.descs.length + 1];
       System.arraycopy(unresolved.args, 0, args, 1, prototype.descs.length);

--- a/test/Base_Tests/src/Semantic/Conversion_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Conversion_Spec.enso
@@ -439,6 +439,13 @@ add_specs suite_builder =
             foo = v:Foo
             Foo.Value 10 . should_equal foo
 
+        group_builder.specify "..False can be autoscoped" <|
+
+            bool b:Boolean = b
+
+            f = bool ..False
+            f.not . should_be_true
+
         group_builder.specify "Autoscope to two different values" <|
 
             v = ..Value 10


### PR DESCRIPTION
### Pull Request Description

Addresses interpreter crash described by #9765 by providing special treatment to `..True` and `..False` to avoid `ClassCastException`.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- All code has been tested:
  - [x] Unit tests have been written where possible.
