### PR TITLE
Move node type to visualization container

### DIFF
--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -371,7 +371,7 @@ const handleNodeClick = useDoubleClick(
 
 interface PortData {
   clipRange: [number, number]
-  label: string
+  label: string | undefined
   portId: AstId
 }
 
@@ -379,12 +379,9 @@ const outputPorts = computed((): PortData[] => {
   const ports = outputPortsSet.value
   const numPorts = ports.size
   return Array.from(ports, (portId, index): PortData => {
-    const labelIdent = numPorts > 1 ? graph.db.getOutputPortIdentifier(portId) + ': ' : ''
-    const labelType =
-      graph.db.getExpressionInfo(numPorts > 1 ? portId : nodeId.value)?.typename ?? 'Unknown'
     return {
       clipRange: [index / numPorts, (index + 1) / numPorts],
-      label: labelIdent + labelType,
+      label: numPorts > 1 ? graph.db.getOutputPortIdentifier(portId) : undefined,
       portId,
     }
   })

--- a/app/gui2/src/components/GraphEditor/GraphVisualization.vue
+++ b/app/gui2/src/components/GraphEditor/GraphVisualization.vue
@@ -293,6 +293,9 @@ provideVisualizationConfig({
   get icon() {
     return icon.value
   },
+  get nodeType() {
+    return props.typename
+  },
   hide: () => emit('update:visible', false),
   updateType: (id) => emit('update:id', id),
   createNodes: (...options) => emit('createNodes', options),

--- a/app/gui2/src/providers/visualizationConfig.ts
+++ b/app/gui2/src/providers/visualizationConfig.ts
@@ -16,6 +16,7 @@ export interface VisualizationConfig {
   readonly nodeSize: Vec2
   readonly scale: number
   readonly isFocused: boolean
+  readonly nodeType: string | undefined
   isBelowToolbar: boolean
   width: number | null
   height: number


### PR DESCRIPTION
### Pull Request Description

https://github.com/enso-org/enso/assets/1047859/25e52ca3-c527-4b4d-9858-dcf186707400

- When a visualization is shown, the node's type name is displayed, unqualified, at the right end of the visualization toolbar.
- When the unqualified type name is hovered, a tooltip shows the full type name.
- Hovering output ports no longer shows a type name.

Closes #9416.

### Important Notes

> Refinement note: Take care if the custom vis icons won't obscure the type label.

The node type is a child of the same flexbox as the custom toolbar, so there shouldn't be any problem.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
