### PR TITLE
Use macos-13 for x64 and macos-latest for arm64

### DIFF
--- a/.github/workflows/engine-nightly.yml
+++ b/.github/workflows/engine-nightly.yml
@@ -61,9 +61,7 @@ jobs:
   enso-build-ci-gen-job-ci-check-backend-graal-vm-ce-macos-aarch64:
     name: Engine (GraalVM CE) (macos, aarch64)
     runs-on:
-      - self-hosted
-      - macOS
-      - ARM64
+      - macos-latest
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -107,7 +105,7 @@ jobs:
   enso-build-ci-gen-job-ci-check-backend-graal-vm-ce-macos-x86_64:
     name: Engine (GraalVM CE) (macos, x86_64)
     runs-on:
-      - macos-latest
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -297,9 +295,7 @@ jobs:
   enso-build-ci-gen-job-jvm-tests-graal-vm-ce-macos-aarch64:
     name: JVM Tests (GraalVM CE) (macos, aarch64)
     runs-on:
-      - self-hosted
-      - macOS
-      - ARM64
+      - macos-latest
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -354,7 +350,7 @@ jobs:
   enso-build-ci-gen-job-jvm-tests-graal-vm-ce-macos-x86_64:
     name: JVM Tests (GraalVM CE) (macos, x86_64)
     runs-on:
-      - macos-latest
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -580,9 +576,7 @@ jobs:
   enso-build-ci-gen-job-standard-library-tests-graal-vm-ce-macos-aarch64:
     name: Standard Library Tests (GraalVM CE) (macos, aarch64)
     runs-on:
-      - self-hosted
-      - macOS
-      - ARM64
+      - macos-latest
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -640,7 +634,7 @@ jobs:
   enso-build-ci-gen-job-standard-library-tests-graal-vm-ce-macos-x86_64:
     name: Standard Library Tests (GraalVM CE) (macos, x86_64)
     runs-on:
-      - macos-latest
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -61,7 +61,7 @@ jobs:
   enso-build-ci-gen-job-build-backend-macos-x86_64:
     name: Build Backend (macos, x86_64)
     runs-on:
-      - macos-latest
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -214,7 +214,7 @@ jobs:
   enso-build-ci-gen-job-new-gui-build-macos-x86_64:
     name: GUI build (macos, x86_64)
     runs-on:
-      - macos-latest
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -385,7 +385,7 @@ jobs:
     needs:
       - enso-build-ci-gen-job-build-backend-macos-x86_64
     runs-on:
-      - macos-latest
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,9 +153,7 @@ jobs:
     needs:
       - enso-build-ci-gen-draft-release-linux-x86_64
     runs-on:
-      - self-hosted
-      - macOS
-      - ARM64
+      - macos-latest
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -202,7 +200,7 @@ jobs:
     needs:
       - enso-build-ci-gen-draft-release-linux-x86_64
     runs-on:
-      - macos-latest
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -416,9 +414,7 @@ jobs:
       - enso-build-ci-gen-draft-release-linux-x86_64
       - enso-build-ci-gen-job-upload-backend-macos-aarch64
     runs-on:
-      - self-hosted
-      - macOS
-      - ARM64
+      - macos-latest
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -492,7 +488,7 @@ jobs:
       - enso-build-ci-gen-draft-release-linux-x86_64
       - enso-build-ci-gen-job-upload-backend-macos-x86_64
     runs-on:
-      - macos-latest
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack

--- a/.github/workflows/scala-new.yml
+++ b/.github/workflows/scala-new.yml
@@ -75,7 +75,7 @@ jobs:
   enso-build-ci-gen-job-ci-check-backend-graal-vm-ce-macos-x86_64:
     name: Engine (GraalVM CE) (macos, x86_64)
     runs-on:
-      - macos-latest
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -220,7 +220,7 @@ jobs:
   enso-build-ci-gen-job-jvm-tests-graal-vm-ce-macos-x86_64:
     name: JVM Tests (GraalVM CE) (macos, x86_64)
     runs-on:
-      - macos-latest
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -390,7 +390,7 @@ jobs:
   enso-build-ci-gen-job-standard-library-tests-graal-vm-ce-macos-x86_64:
     name: Standard Library Tests (GraalVM CE) (macos, x86_64)
     runs-on:
-      - macos-latest
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -66,6 +66,7 @@ impl RunsOn for RunnerLabel {
             RunnerLabel::MacOS => Some("MacOS".to_string()),
             RunnerLabel::Linux => Some("Linux".to_string()),
             RunnerLabel::Windows => Some("Windows".to_string()),
+            RunnerLabel::MacOS13 => Some("MacOS13".to_string()),
             RunnerLabel::MacOSLatest => Some("MacOSLatest".to_string()),
             RunnerLabel::LinuxLatest => Some("LinuxLatest".to_string()),
             RunnerLabel::WindowsLatest => Some("WindowsLatest".to_string()),
@@ -93,13 +94,9 @@ impl RunsOn for OS {
 impl RunsOn for (OS, Arch) {
     fn runs_on(&self) -> Vec<RunnerLabel> {
         match self {
-            (OS::MacOS, Arch::X86_64) => runs_on(OS::MacOS, RunnerType::GitHubHosted),
+            (OS::MacOS, Arch::X86_64) => vec![RunnerLabel::MacOS13],
             (os, Arch::X86_64) => runs_on(*os, RunnerType::SelfHosted),
-            (OS::MacOS, Arch::AArch64) => {
-                let mut ret = runs_on(OS::MacOS, RunnerType::SelfHosted);
-                ret.push(RunnerLabel::Arm64);
-                ret
-            }
+            (OS::MacOS, Arch::AArch64) => vec![RunnerLabel::MacOSLatest],
             _ => panic!("Unsupported OS/arch combination: {self:?}"),
         }
     }

--- a/build/ci_utils/src/actions/workflow/definition.rs
+++ b/build/ci_utils/src/actions/workflow/definition.rs
@@ -1014,6 +1014,9 @@ pub enum RunnerLabel {
     Windows,
     #[serde(rename = "engine")]
     Engine,
+    /// macos-13 is the last x64 version of the GitHub-hosted macOS runner.
+    #[serde(rename = "macos-13")]
+    MacOS13,
     #[serde(rename = "macos-latest")]
     MacOSLatest,
     #[serde(rename = "ubuntu-latest")]


### PR DESCRIPTION
### Pull Request Description
GitHub made arm64 runners generally available and changed `macos-latest` label to point to them.
The runner architecture is coupled with GH-hosted runners OS version: macos-13 is the last one to run on x64.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [ ] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
