### PR TITLE
Make Table.should_equal and Column.should_equal consider NaN equal

### DIFF
--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredBuilder.java
@@ -6,6 +6,7 @@ import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.List;
 import org.enso.base.polyglot.NumericConverter;
+import org.enso.base.polyglot.Polyglot_Utils;
 import org.enso.table.data.column.storage.Storage;
 import org.enso.table.data.column.storage.type.BigIntegerType;
 import org.enso.table.data.column.storage.type.BooleanType;
@@ -17,6 +18,7 @@ import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.data.column.storage.type.TextType;
 import org.enso.table.data.column.storage.type.TimeOfDayType;
 import org.enso.table.problems.ProblemAggregator;
+import org.graalvm.polyglot.Value;
 
 /**
  * A builder performing type inference on the appended elements, choosing the best possible storage.
@@ -61,6 +63,11 @@ public class InferredBuilder extends Builder {
 
   @Override
   public void append(Object o) {
+    if (o instanceof Value v) {
+      // ToDo: This a workaround for an issue with polyglot layer. #5590 is related.
+      o = Polyglot_Utils.convertPolyglotValue(v);
+    }
+
     if (currentBuilder == null) {
       if (o == null) {
         currentSize++;

--- a/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredBuilder.java
+++ b/std-bits/table/src/main/java/org/enso/table/data/column/builder/InferredBuilder.java
@@ -18,7 +18,6 @@ import org.enso.table.data.column.storage.type.StorageType;
 import org.enso.table.data.column.storage.type.TextType;
 import org.enso.table.data.column.storage.type.TimeOfDayType;
 import org.enso.table.problems.ProblemAggregator;
-import org.graalvm.polyglot.Value;
 
 /**
  * A builder performing type inference on the appended elements, choosing the best possible storage.
@@ -63,10 +62,8 @@ public class InferredBuilder extends Builder {
 
   @Override
   public void append(Object o) {
-    if (o instanceof Value v) {
-      // ToDo: This a workaround for an issue with polyglot layer. #5590 is related.
-      o = Polyglot_Utils.convertPolyglotValue(v);
-    }
+    // ToDo: This a workaround for an issue with polyglot layer. #5590 is related.
+    o = Polyglot_Utils.convertPolyglotValue(o);
 
     if (currentBuilder == null) {
       if (o == null) {

--- a/test/Table_Tests/src/In_Memory/Column_Format_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Column_Format_Spec.enso
@@ -298,7 +298,7 @@ add_specs suite_builder =
     suite_builder.group "Edge cases" group_builder->
         group_builder.specify "empty table is ok" <|
             input = Column.from_vector "values" [Date.new 2020 12 21, Date.new 2023 4 25] . take 0
-            expected = Column.from_vector "values" []
+            expected = Column.from_vector "values" [Date.new 2020 12 21, Date.new 2023 4 25] . take 0
             actual = input.format "yyyyMMdd"
             actual . should_equal expected
 

--- a/test/Table_Tests/src/In_Memory/Column_Format_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Column_Format_Spec.enso
@@ -298,7 +298,7 @@ add_specs suite_builder =
     suite_builder.group "Edge cases" group_builder->
         group_builder.specify "empty table is ok" <|
             input = Column.from_vector "values" [Date.new 2020 12 21, Date.new 2023 4 25] . take 0
-            expected = Column.from_vector "values" [Date.new 2020 12 21, Date.new 2023 4 25] . take 0
+            expected = Column.from_vector "values" [""] . take 0
             actual = input.format "yyyyMMdd"
             actual . should_equal expected
 

--- a/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
@@ -386,7 +386,7 @@ add_specs suite_builder =
 
         group_builder.specify "input with no matches, with named and unnamed regex groups" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "a", "y"]]
-            expected = Table.from_rows ["foo", "quux", "bar 1", "foo 1", "bar 2", "baz"] [["x", Nothing, Nothing, Nothing, Nothing, "y"]]
+            expected = Table.from_rows ["foo", "quux", "bar 1", "foo 1", "bar 2", "baz"] [["x", Nothing, Nothing, Nothing, Nothing, "y"], ["", "", "", "", "", ""]] . take 1
             actual = t.parse_to_columns "bar" "(?<quux>)(\d)(?<foo>\d)(\d)"
             actual.should_equal expected
 

--- a/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Split_Tokenize_Spec.enso
@@ -351,7 +351,7 @@ add_specs suite_builder =
 
         group_builder.specify "empty table" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "a", "y"]] . take 0
-            expected = Table.from_rows ["foo", "bar", "baz"] []
+            expected = Table.from_rows ["foo", "bar", "baz"] [["x", "a", "y"]] . take 0
             actual = t.parse_to_columns "bar" "\d+"
             actual.should_equal expected
 
@@ -380,7 +380,7 @@ add_specs suite_builder =
 
         group_builder.specify "input with no matches, with regex groups" <|
             t = Table.from_rows ["foo", "bar", "baz"] [["x", "a", "y"]]
-            expected = Table.from_rows ["foo", "bar 1", "bar 2", "baz"] [["x", Nothing, Nothing, "y"]]
+            expected = Table.from_rows ["foo", "bar 1", "bar 2", "baz"] [["x", Nothing, Nothing, "y"], ["", "", "", ""]] . take 1
             actual = t.parse_to_columns "bar" "(\d)(\d)"
             actual.should_equal expected
 

--- a/test/Table_Tests/src/Main.enso
+++ b/test/Table_Tests/src/Main.enso
@@ -7,6 +7,7 @@ import project.Formatting
 import project.Helpers
 import project.In_Memory
 import project.IO
+import project.Util_Spec
 
 main filter=Nothing =
     suite = Test.build suite_builder->

--- a/test/Table_Tests/src/Main.enso
+++ b/test/Table_Tests/src/Main.enso
@@ -15,5 +15,6 @@ main filter=Nothing =
         Formatting.Main.add_specs suite_builder
         Database.Main.add_specs suite_builder
         Helpers.Main.add_specs suite_builder
+        Util_Spec.add_specs suite_builder
 
     suite.run_with_filter filter

--- a/test/Table_Tests/src/Util.enso
+++ b/test/Table_Tests/src/Util.enso
@@ -11,6 +11,17 @@ polyglot java import org.enso.base_test_helpers.FileSystemHelper
 Table.should_equal : Any -> Integer -> Any
 Table.should_equal self expected frames_to_skip=0 =
     loc = Meta.get_source_location 1+frames_to_skip
+    Panic.catch Any (self.should_equal_impl expected loc) error->
+        Test.fail error.payload 
+
+Column.should_equal : Any -> Integer -> Any
+Column.should_equal self expected frames_to_skip=0 =
+    loc = Meta.get_source_location 1+frames_to_skip
+    Panic.catch Any (self.should_equal_impl expected loc) error->
+        Test.fail error.payload
+
+## PRIVATE
+Table.should_equal_impl self expected loc =
     case expected of
         _ : Table ->
             tables_equal t0 t1 =
@@ -20,14 +31,8 @@ Table.should_equal self expected frames_to_skip=0 =
             equal = tables_equal self expected
             if equal.not then
                 msg = 'Tables differ at '+loc+'.\nActual:\n' + self.display + '\nExpected:\n' + expected.display
-                Test.fail msg
-        _ -> Test.fail "Got a Table, but expected a "+expected.to_display_text+' (at '+loc+').'
-
-Column.should_equal : Any -> Integer -> Any
-Column.should_equal self expected frames_to_skip=0 =
-    loc = Meta.get_source_location 1+frames_to_skip
-    Panic.catch Any (self.should_equal_impl expected loc) error->
-        Test.fail error.payload
+                Panic.throw msg
+        _ -> Panic.throw "Got a Table, but expected a "+expected.to_display_text+' (at '+loc+').'
 
 ## PRIVATE
 Column.should_equal_impl self expected loc =

--- a/test/Table_Tests/src/Util.enso
+++ b/test/Table_Tests/src/Util.enso
@@ -20,6 +20,18 @@ Column.should_equal self expected frames_to_skip=0 =
     Panic.catch Any (self.should_equal_impl expected loc) error->
         Test.fail error.payload
 
+DB_Table.should_equal : DB_Table -> Integer -> Any
+DB_Table.should_equal self expected frames_to_skip=0 =
+    t0 = self.read
+    t1 = expected.read
+    t0 . should_equal t1 frames_to_skip
+
+DB_Column.should_equal : DB_Column -> Integer -> Any
+DB_Column.should_equal self expected frames_to_skip=0 =
+    t0 = self.read
+    t1 = expected.read
+    t0 . should_equal t1 frames_to_skip
+
 ## PRIVATE
 Table.should_equal_impl self expected loc =
     case expected of
@@ -30,6 +42,7 @@ Table.should_equal_impl self expected loc =
                 msg = 'Tables differ at '+loc+'.\nActual:\n'+self.display+'\nExpected:\n'+expected.display+'\n'+error.payload
                 Panic.throw msg
         _ -> Panic.throw "Got a Table, but expected a "+expected.to_display_text+(display_loc loc)+'.'
+
 ## PRIVATE
 Column.should_equal_impl self expected loc='' =
     case expected of
@@ -46,7 +59,7 @@ Column.should_equal_impl self expected loc='' =
                         self.report_fail expected loc
         _ -> Panic.throw "Got a Column, but expected a "+expected.to_display_text+(display_loc loc)+'.'
 
-
+## PRIVATE
 Column.report_fail self expected loc =
     indexed = self.zip (0.up_to self.length) a-> i-> Pair.new a i
     indexed.zip expected a-> e->
@@ -54,21 +67,10 @@ Column.report_fail self expected loc =
             if (a.first.is_a Number && e.is_a Number && a.first.is_nan && e.is_nan).not then
                 Panic.throw "Column: "+self.name+" differs at row "+a.second.to_text+'.\n\t  Actual  : '+a.first.to_text+'\n\t  Expected: '+e.to_text+'\n\t'+(display_loc loc)+'.'
 
+## PRIVATE
 display_loc loc:Text =
     if loc.is_empty then '' else
         ' (at '+loc+')'
-
-DB_Table.should_equal : DB_Table -> Integer -> Any
-DB_Table.should_equal self expected frames_to_skip=0 =
-    t0 = self.read
-    t1 = expected.read
-    t0 . should_equal t1 frames_to_skip
-
-DB_Column.should_equal : DB_Column -> Integer -> Any
-DB_Column.should_equal self expected frames_to_skip=0 =
-    t0 = self.read
-    t1 = expected.read
-    t0 . should_equal t1 frames_to_skip
 
 normalize_lines string line_separator=Line_Ending_Style.Unix.to_text newline_at_end=True =
     case newline_at_end of

--- a/test/Table_Tests/src/Util.enso
+++ b/test/Table_Tests/src/Util.enso
@@ -11,14 +11,14 @@ polyglot java import org.enso.base_test_helpers.FileSystemHelper
 Table.should_equal : Any -> Integer -> Any
 Table.should_equal self expected frames_to_skip=0 =
     loc = Meta.get_source_location 1+frames_to_skip
-    Panic.catch Any (self.should_equal_impl expected loc) error->
-        Test.fail error.payload 
+    Panic.catch Test_Failure_Error.Error (table_should_equal_impl self expected loc) error->
+        Test.fail error.payload.message 
 
 Column.should_equal : Any -> Integer -> Any
 Column.should_equal self expected frames_to_skip=0 =
     loc = Meta.get_source_location 1+frames_to_skip
-    Panic.catch Any (self.should_equal_impl expected loc) error->
-        Test.fail error.payload
+    Panic.catch Test_Failure_Error.Error (column_should_equal_impl self expected loc) error->
+        Test.fail error.payload.message
 
 DB_Table.should_equal : DB_Table -> Integer -> Any
 DB_Table.should_equal self expected frames_to_skip=0 =
@@ -32,40 +32,54 @@ DB_Column.should_equal self expected frames_to_skip=0 =
     t1 = expected.read
     t0 . should_equal t1 frames_to_skip
 
+type Test_Failure_Error
+    ## PRIVATE
+       The runtime representation of a test failure.
+
+       Arguments:
+       - message: A description of the test failure.
+    Error message
+
+    ## PRIVATE
+    to_display_text : Text
+    to_display_text self = "Test failure error: "+self.message
+
 ## PRIVATE
-Table.should_equal_impl self expected loc =
+table_should_equal_impl actual expected loc =
     case expected of
         _ : Table ->
-            if self.columns.length != expected.columns.length then
-                Panic.throw 'Tables differ at '+loc+'.\nActual:\n'+self.display+'\nExpected:\n'+expected.display+'\nExpected '+expected.columns.length.to_text+" columns, but got "+self.columns.length.to_text+'.'
-            Panic.catch Any (self.columns.zip expected.columns a-> e->(a.should_equal_impl e)) error->
-                msg = 'Tables differ at '+loc+'.\nActual:\n'+self.display+'\nExpected:\n'+expected.display+'\n'+error.payload
-                Panic.throw msg
-        _ -> Panic.throw "Got a Table, but expected a "+expected.to_display_text+(display_loc loc)+'.'
+            if actual.columns.length != expected.columns.length then
+                Panic.throw (Test_Failure_Error.Error 'Tables differ at '+loc+'.\nActual:\n'+actual.display+'\nExpected:\n'+expected.display+'\nExpected '+expected.columns.length.to_text+" columns, but got "+actual.columns.length.to_text+'.')
+            Panic.catch Test_Failure_Error.Error (actual.columns.zip expected.columns a-> e->(column_should_equal_impl a e)) error->
+                msg = 'Tables differ at '+loc+'.\nActual:\n'+actual.display+'\nExpected:\n'+expected.display+'\n'+error.payload.message
+                Panic.throw (Test_Failure_Error.Error msg)
+        _ -> Panic.throw (Test_Failure_Error.Error "Got a Table, but expected a "+expected.to_display_text+(display_loc loc)+'.')
 
 ## PRIVATE
-Column.should_equal_impl self expected loc='' =
+column_should_equal_impl actual expected loc='' =
     case expected of
         _ : Column ->
-            if self.name != expected.name then
-                Panic.throw "Expected column name "+expected.name+", but got "+self.name+(display_loc loc)+'.'
-            if self.length != expected.length then
-                Panic.throw "Expected column length "+expected.length.to_text+", but got "+self.length.to_text+(display_loc loc)+'.'
-            if self.value_type != expected.value_type then
-                Panic.throw "Expected column type "+expected.value_type.to_text+", but got "+self.value_type.to_text+(display_loc loc)+'.'
-            self.zip expected a-> e->
-                if a != e then
-                    if (a.is_a Number && e.is_a Number && a.is_nan && e.is_nan).not then
-                        self.report_fail expected loc
-        _ -> Panic.throw "Got a Column, but expected a "+expected.to_display_text+(display_loc loc)+'.'
+            if actual.name != expected.name then
+                Panic.throw (Test_Failure_Error.Error "Expected column name "+expected.name+", but got "+actual.name+(display_loc loc)+'.')
+            if actual.length != expected.length then
+                Panic.throw (Test_Failure_Error.Error "Expected column length "+expected.length.to_text+", but got "+actual.length.to_text+(display_loc loc)+'.')
+            if actual.value_type != expected.value_type then
+                Panic.throw (Test_Failure_Error.Error "Expected column type "+expected.value_type.to_text+", but got "+actual.value_type.to_text+(display_loc loc)+'.')
+            actual.zip expected a-> e->
+                if values_equal a e then
+                    report_fail actual expected loc
+        _ -> Panic.throw (Test_Failure_Error.Error "Got a Column, but expected a "+expected.to_display_text+(display_loc loc)+'.')
 
 ## PRIVATE
-Column.report_fail self expected loc =
-    indexed = self.zip (0.up_to self.length) a-> i-> Pair.new a i
+values_equal a e =
+    a != e && (a.is_a Number && e.is_a Number && a.is_nan && e.is_nan).not
+
+## PRIVATE
+report_fail actual expected loc =
+    indexed = actual.zip (0.up_to actual.length) a-> i-> Pair.new a i
     indexed.zip expected a-> e->
-        if a.first != e then
-            if (a.first.is_a Number && e.is_a Number && a.first.is_nan && e.is_nan).not then
-                Panic.throw "Column: "+self.name+" differs at row "+a.second.to_text+'.\n\t  Actual  : '+a.first.to_text+'\n\t  Expected: '+e.to_text+'\n\t'+(display_loc loc)+'.'
+        if values_equal a.first e then
+            Panic.throw (Test_Failure_Error.Error "Column: "+actual.name+" differs at row "+a.second.to_text+'.\n\t  Actual  : '+a.first.to_text+'\n\t  Expected: '+e.to_text+'\n\t'+(display_loc loc)+'.')
 
 ## PRIVATE
 display_loc loc:Text =

--- a/test/Table_Tests/src/Util.enso
+++ b/test/Table_Tests/src/Util.enso
@@ -11,13 +11,13 @@ polyglot java import org.enso.base_test_helpers.FileSystemHelper
 Table.should_equal : Any -> Integer -> Any
 Table.should_equal self expected frames_to_skip=0 =
     loc = Meta.get_source_location 1+frames_to_skip
-    Panic.catch Test_Failure_Error.Error (table_should_equal_impl self expected loc) error->
+    Panic.catch Test_Failure_Error (table_should_equal_impl self expected loc) error->
         Test.fail error.payload.message 
 
 Column.should_equal : Any -> Integer -> Any
 Column.should_equal self expected frames_to_skip=0 =
     loc = Meta.get_source_location 1+frames_to_skip
-    Panic.catch Test_Failure_Error.Error (column_should_equal_impl self expected loc) error->
+    Panic.catch Test_Failure_Error (column_should_equal_impl self expected loc) error->
         Test.fail error.payload.message
 
 DB_Table.should_equal : DB_Table -> Integer -> Any
@@ -50,7 +50,7 @@ table_should_equal_impl actual expected loc =
         _ : Table ->
             if actual.columns.length != expected.columns.length then
                 Panic.throw (Test_Failure_Error.Error 'Tables differ at '+loc+'.\nActual:\n'+actual.display+'\nExpected:\n'+expected.display+'\nExpected '+expected.columns.length.to_text+" columns, but got "+actual.columns.length.to_text+'.')
-            Panic.catch Test_Failure_Error.Error (actual.columns.zip expected.columns a-> e->(column_should_equal_impl a e)) error->
+            Panic.catch Test_Failure_Error (actual.columns.zip expected.columns a-> e->(column_should_equal_impl a e)) error->
                 msg = 'Tables differ at '+loc+'.\nActual:\n'+actual.display+'\nExpected:\n'+expected.display+'\n'+error.payload.message
                 Panic.throw (Test_Failure_Error.Error msg)
         _ -> Panic.throw (Test_Failure_Error.Error "Got a Table, but expected a "+expected.to_display_text+(display_loc loc)+'.')

--- a/test/Table_Tests/src/Util.enso
+++ b/test/Table_Tests/src/Util.enso
@@ -26,14 +26,32 @@ Table.should_equal self expected frames_to_skip=0 =
 Column.should_equal : Any -> Integer -> Any
 Column.should_equal self expected frames_to_skip=0 =
     loc = Meta.get_source_location 1+frames_to_skip
+    Panic.catch Any (self.should_equal_impl expected loc) error->
+        Test.fail error.payload
+
+## PRIVATE
+Column.should_equal_impl self expected loc =
     case expected of
         _ : Column ->
             if self.name != expected.name then
-                Test.fail "Expected column name "+expected.name+", but got "+self.name+" (at "+loc+")."
+                Panic.throw "Expected column name "+expected.name+", but got "+self.name+" (at "+loc+")."
             if self.length != expected.length then
-                Test.fail "Expected column length "+expected.length.to_text+", but got "+self.length.to_text+" (at "+loc+")."
-            self.to_vector.should_equal expected.to_vector 2+frames_to_skip
-        _ -> Test.fail "Got a Column, but expected a "+expected.to_display_text+' (at '+loc+').'
+                Panic.throw "Expected column length "+expected.length.to_text+", but got "+self.length.to_text+" (at "+loc+")."
+            if self.value_type != expected.value_type then
+                Panic.throw "Expected column type "+expected.value_type.to_text+", but got "+self.value_type.to_text+" (at "+loc+")."
+            self.zip expected a-> e->
+                if a != e then
+                    if (a.is_a Number && e.is_a Number && a.is_nan && e.is_nan).not then
+                        self.report_fail expected loc
+        _ -> Panic.throw "Got a Column, but expected a "+expected.to_display_text+' (at '+loc+').'
+
+
+Column.report_fail self expected loc =
+    indexed = self.zip (0.up_to self.length) a-> i-> Pair.new a i
+    indexed.zip expected a-> e->
+        if a.first != e then
+            if (a.first.is_a Number && e.is_a Number && a.first.is_nan && e.is_nan).not then
+                Panic.throw "Column: "+self.name+" differs at row "+a.second.to_text+". Actual: "+a.first.to_text+" Expected: "+e.to_text+' (at '+loc+').'
 
 DB_Table.should_equal : DB_Table -> Integer -> Any
 DB_Table.should_equal self expected frames_to_skip=0 =

--- a/test/Table_Tests/src/Util.enso
+++ b/test/Table_Tests/src/Util.enso
@@ -24,8 +24,10 @@ Column.should_equal self expected frames_to_skip=0 =
 Table.should_equal_impl self expected loc =
     case expected of
         _ : Table ->
+            if self.columns.length != expected.columns.length then
+                Panic.throw 'Tables differ at '+loc+'.\nActual:\n'+self.display+'\nExpected:\n'+expected.display+'\nExpected '+expected.columns.length.to_text+" columns, but got "+self.columns.length.to_text+'.'
             Panic.catch Any (self.columns.zip expected.columns a-> e->(a.should_equal_impl e)) error->
-                msg = 'Tables differ at '+loc+'.\nActual:\n' + self.display + '\nExpected:\n' + expected.display + '\n' + error.payload
+                msg = 'Tables differ at '+loc+'.\nActual:\n'+self.display+'\nExpected:\n'+expected.display+'\n'+error.payload
                 Panic.throw msg
         _ -> Panic.throw "Got a Table, but expected a "+expected.to_display_text+(display_loc loc)+'.'
 ## PRIVATE

--- a/test/Table_Tests/src/Util.enso
+++ b/test/Table_Tests/src/Util.enso
@@ -24,31 +24,25 @@ Column.should_equal self expected frames_to_skip=0 =
 Table.should_equal_impl self expected loc =
     case expected of
         _ : Table ->
-            tables_equal t0 t1 =
-                same_headers = (t0.columns.map .name) == (t1.columns.map .name)
-                same_columns = (t0.columns.map .to_vector) == (t1.columns.map .to_vector)
-                same_headers && same_columns
-            equal = tables_equal self expected
-            if equal.not then
-                msg = 'Tables differ at '+loc+'.\nActual:\n' + self.display + '\nExpected:\n' + expected.display
+            Panic.catch Any (self.columns.zip expected.columns a-> e->(a.should_equal_impl e)) error->
+                msg = 'Tables differ at '+loc+'.\nActual:\n' + self.display + '\nExpected:\n' + expected.display + '\n' + error.payload
                 Panic.throw msg
-        _ -> Panic.throw "Got a Table, but expected a "+expected.to_display_text+' (at '+loc+').'
-
+        _ -> Panic.throw "Got a Table, but expected a "+expected.to_display_text+(display_loc loc)+'.'
 ## PRIVATE
-Column.should_equal_impl self expected loc =
+Column.should_equal_impl self expected loc='' =
     case expected of
         _ : Column ->
             if self.name != expected.name then
-                Panic.throw "Expected column name "+expected.name+", but got "+self.name+" (at "+loc+")."
+                Panic.throw "Expected column name "+expected.name+", but got "+self.name+(display_loc loc)+'.'
             if self.length != expected.length then
-                Panic.throw "Expected column length "+expected.length.to_text+", but got "+self.length.to_text+" (at "+loc+")."
+                Panic.throw "Expected column length "+expected.length.to_text+", but got "+self.length.to_text+(display_loc loc)+'.'
             if self.value_type != expected.value_type then
-                Panic.throw "Expected column type "+expected.value_type.to_text+", but got "+self.value_type.to_text+" (at "+loc+")."
+                Panic.throw "Expected column type "+expected.value_type.to_text+", but got "+self.value_type.to_text+(display_loc loc)+'.'
             self.zip expected a-> e->
                 if a != e then
                     if (a.is_a Number && e.is_a Number && a.is_nan && e.is_nan).not then
                         self.report_fail expected loc
-        _ -> Panic.throw "Got a Column, but expected a "+expected.to_display_text+' (at '+loc+').'
+        _ -> Panic.throw "Got a Column, but expected a "+expected.to_display_text+(display_loc loc)+'.'
 
 
 Column.report_fail self expected loc =
@@ -56,7 +50,11 @@ Column.report_fail self expected loc =
     indexed.zip expected a-> e->
         if a.first != e then
             if (a.first.is_a Number && e.is_a Number && a.first.is_nan && e.is_nan).not then
-                Panic.throw "Column: "+self.name+" differs at row "+a.second.to_text+'.\n\t  Actual  : '+a.first.to_text+'\n\t  Expected: '+e.to_text+'\n\t(at '+loc+').'
+                Panic.throw "Column: "+self.name+" differs at row "+a.second.to_text+'.\n\t  Actual  : '+a.first.to_text+'\n\t  Expected: '+e.to_text+'\n\t'+(display_loc loc)+'.'
+
+display_loc loc:Text =
+    if loc.is_empty then '' else
+        ' (at '+loc+')'
 
 DB_Table.should_equal : DB_Table -> Integer -> Any
 DB_Table.should_equal self expected frames_to_skip=0 =

--- a/test/Table_Tests/src/Util.enso
+++ b/test/Table_Tests/src/Util.enso
@@ -56,7 +56,7 @@ Column.report_fail self expected loc =
     indexed.zip expected a-> e->
         if a.first != e then
             if (a.first.is_a Number && e.is_a Number && a.first.is_nan && e.is_nan).not then
-                Panic.throw "Column: "+self.name+" differs at row "+a.second.to_text+". Actual: "+a.first.to_text+" Expected: "+e.to_text+' (at '+loc+').'
+                Panic.throw "Column: "+self.name+" differs at row "+a.second.to_text+'.\n\t  Actual  : '+a.first.to_text+'\n\t  Expected: '+e.to_text+'\n\t(at '+loc+').'
 
 DB_Table.should_equal : DB_Table -> Integer -> Any
 DB_Table.should_equal self expected frames_to_skip=0 =

--- a/test/Table_Tests/src/Util_Spec.enso
+++ b/test/Table_Tests/src/Util_Spec.enso
@@ -1,0 +1,48 @@
+from Standard.Base import all
+from Standard.Table import Column, Table
+from project.Util import all
+from Standard.Test import all
+
+add_specs suite_builder =
+    suite_builder.group "Column should_equal" group_builder->
+        group_builder.specify "Two Columns Are Equal" <|
+            expected_column = Column.from_vector "Col" ["Quis", "custodiet", "ipsos", "custodes?"]
+            actual_column = Column.from_vector "Col" ["Quis", "custodiet", "ipsos", "custodes?"]
+            actual_column.should_equal expected_column
+        group_builder.specify "Two Columns With Different Name are Not Equal" <|
+            expected_column = Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"]
+            actual_column = Column.from_vector "Col2" ["Quis", "custodiet", "ipsos", "custodes?"]
+            res = Panic.recover Any (actual_column.should_equal_impl expected_column "LOCATION_PATH")
+            res.catch.should_equal "Expected column name Col1, but got Col2 (at LOCATION_PATH)."
+        group_builder.specify "Two Columns With Different Lengths are Not Equal" <|
+            expected_column = Column.from_vector "Col" ["Quis", "custodiet", "ipsos", "custodes?"]
+            actual_column = Column.from_vector "Col" ["Quis", "custodiet", "ipsos"]
+            res = Panic.recover Any (actual_column.should_equal_impl expected_column "LOCATION_PATH")
+            res.catch.should_equal "Expected column length 4, but got 3 (at LOCATION_PATH). "
+        group_builder.specify "Two Columns with different content Are Not Equal" <|
+            expected_column = Column.from_vector "Col" ["Quis", "custodiet", "ipsos", "custodes?"]
+            actual_column = Column.from_vector "Col" ["Who", "guards", "the", "guards?"]
+            res = Panic.recover Any (actual_column.should_equal_impl expected_column "LOCATION_PATH")
+            res.catch.should_equal "Column: Col differs at row 0. Actual: Who Expected: Quis (at LOCATION_PATH)."
+        group_builder.specify "Two Columns Are Not Equal in Row 3" <|
+            expected_column = Column.from_vector "My Column" ["Quis", "custodiet", "ipsos", "custodes?"]
+            actual_column = Column.from_vector "My Column" ["Quis", "custodiet", "ipsos", "guards?"]
+            res = Panic.recover Any (actual_column.should_equal_impl expected_column "LOCATION_PATH")
+            res.catch.should_equal "Column: My Column differs at row 3. Actual: guards? Expected: custodes? (at LOCATION_PATH)."
+        group_builder.specify "Two Columns with different types Are Not Equal" <|
+            expected_column = Column.from_vector "Col" ["1", "2", "3", "4"]
+            actual_column = Column.from_vector "Col" [1, 2, 3, 4]
+            res = Panic.recover Any (actual_column.should_equal_impl expected_column "LOCATION_PATH")
+            res.catch.should_equal "Expected column type (Char Nothing True), but got (Integer 64 bits) (at LOCATION_PATH)."
+        group_builder.specify "Two Columns Containg NaNs Are Equal" <|
+            # This is somewhat of a special case, as NaN != NaN but for the purposes of testing we consider them equal
+            expected_column = Column.from_vector "Col" [1.0, 2.0, Number.nan]
+            actual_column = Column.from_vector "Col" [1.0, 2.0, Number.nan]
+            actual_column.should_equal expected_column
+
+
+
+main filter=Nothing =
+    suite = Test.build suite_builder->
+        add_specs suite_builder
+    suite.run_with_filter filter

--- a/test/Table_Tests/src/Util_Spec.enso
+++ b/test/Table_Tests/src/Util_Spec.enso
@@ -18,7 +18,7 @@ add_specs suite_builder =
             expected_column = Column.from_vector "Col" ["Quis", "custodiet", "ipsos", "custodes?"]
             actual_column = Column.from_vector "Col" ["Quis", "custodiet", "ipsos"]
             res = Panic.recover Any (actual_column.should_equal_impl expected_column "LOCATION_PATH")
-            res.catch.should_equal "Expected column length 4, but got 3 (at LOCATION_PATH). "
+            res.catch.should_equal "Expected column length 4, but got 3 (at LOCATION_PATH)."
         group_builder.specify "Two Columns with different content Are Not Equal" <|
             expected_column = Column.from_vector "Col" ["Quis", "custodiet", "ipsos", "custodes?"]
             actual_column = Column.from_vector "Col" ["Who", "guards", "the", "guards?"]
@@ -34,6 +34,11 @@ add_specs suite_builder =
             actual_column = Column.from_vector "Col" [1, 2, 3, 4]
             res = Panic.recover Any (actual_column.should_equal_impl expected_column "LOCATION_PATH")
             res.catch.should_equal "Expected column type (Char Nothing True), but got (Integer 64 bits) (at LOCATION_PATH)."
+        group_builder.specify "Comparing a Column to non column" <|
+            expected_column = 42
+            actual_column = Column.from_vector "Col" [1, 2, 3, 4]
+            res = Panic.recover Any (actual_column.should_equal_impl expected_column "LOCATION_PATH")
+            res.catch.should_equal "Got a Column, but expected a 42 (at LOCATION_PATH)."
         group_builder.specify "Two Columns Containg NaNs Are Equal" <|
             # This is somewhat of a special case, as NaN != NaN but for the purposes of testing we consider them equal
             expected_column = Column.from_vector "Col" [1.0, 2.0, Number.nan]

--- a/test/Table_Tests/src/Util_Spec.enso
+++ b/test/Table_Tests/src/Util_Spec.enso
@@ -23,12 +23,12 @@ add_specs suite_builder =
             expected_column = Column.from_vector "Col" ["Quis", "custodiet", "ipsos", "custodes?"]
             actual_column = Column.from_vector "Col" ["Who", "guards", "the", "guards?"]
             res = Panic.recover Any (actual_column.should_equal_impl expected_column "LOCATION_PATH")
-            res.catch.should_equal 'Column: Col differs at row 0.\n\t  Actual  : Who\n\t  Expected: Quis\n\t(at LOCATION_PATH).'
+            res.catch.should_equal 'Column: Col differs at row 0.\n\t  Actual  : Who\n\t  Expected: Quis\n\t (at LOCATION_PATH).'
         group_builder.specify "Two Columns Are Not Equal in Row 3" <|
             expected_column = Column.from_vector "My Column" ["Quis", "custodiet", "ipsos", "custodes?"]
             actual_column = Column.from_vector "My Column" ["Quis", "custodiet", "ipsos", "guards?"]
             res = Panic.recover Any (actual_column.should_equal_impl expected_column "LOCATION_PATH")
-            res.catch.should_equal 'Column: My Column differs at row 3.\n\t  Actual  : guards?\n\t  Expected: custodes?\n\t(at LOCATION_PATH).'
+            res.catch.should_equal 'Column: My Column differs at row 3.\n\t  Actual  : guards?\n\t  Expected: custodes?\n\t (at LOCATION_PATH).'
         group_builder.specify "Two Columns with different types Are Not Equal" <|
             expected_column = Column.from_vector "Col" ["1", "2", "3", "4"]
             actual_column = Column.from_vector "Col" [1, 2, 3, 4]
@@ -44,6 +44,16 @@ add_specs suite_builder =
             expected_column = Column.from_vector "Col" [1.0, 2.0, Number.nan]
             actual_column = Column.from_vector "Col" [1.0, 2.0, Number.nan]
             actual_column.should_equal expected_column
+    suite_builder.group "Table should_equal" group_builder->
+        group_builder.specify "Two Tables Are Equal" <|
+            expected_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]
+            actual_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]
+            actual_table.should_equal expected_table
+        group_builder.specify "Tables With Mismatched Column names" <|
+            expected_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]
+            actual_table = Table.new [Column.from_vector "Col" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]
+            res = Panic.recover Any (actual_table.should_equal_impl expected_table "LOCATION_PATH")
+            res.catch.should_end_with "Expected column name Col1, but got Col."
 
 main filter=Nothing =
     suite = Test.build suite_builder->

--- a/test/Table_Tests/src/Util_Spec.enso
+++ b/test/Table_Tests/src/Util_Spec.enso
@@ -48,7 +48,12 @@ add_specs suite_builder =
         group_builder.specify "Two Tables Are Equal" <|
             expected_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]
             actual_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]
-            actual_table.should_equal expected_table
+            actual_table.should_equal expected_table    
+        group_builder.specify "Two Tables With Different Values" <|
+            expected_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]
+            actual_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "teh", "guards?"]]
+            res = Panic.recover Any (actual_table.should_equal_impl expected_table "LOCATION_PATH")
+            res.catch.should_end_with 'Column: Col2 differs at row 2.\n\t  Actual  : teh\n\t  Expected: the\n\t.'
         group_builder.specify "Tables different number of columns" <|
             expected_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"]]
             actual_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]

--- a/test/Table_Tests/src/Util_Spec.enso
+++ b/test/Table_Tests/src/Util_Spec.enso
@@ -12,33 +12,33 @@ add_specs suite_builder =
         group_builder.specify "Two Columns With Different Name are Not Equal" <|
             expected_column = Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"]
             actual_column = Column.from_vector "Col2" ["Quis", "custodiet", "ipsos", "custodes?"]
-            res = Panic.recover Any (actual_column.should_equal_impl expected_column "LOCATION_PATH")
-            res.catch.should_equal "Expected column name Col1, but got Col2 (at LOCATION_PATH)."
+            res = Panic.recover Test_Failure_Error (column_should_equal_impl actual_column expected_column "LOCATION_PATH")
+            res.catch.message.should_equal "Expected column name Col1, but got Col2 (at LOCATION_PATH)."
         group_builder.specify "Two Columns With Different Lengths are Not Equal" <|
             expected_column = Column.from_vector "Col" ["Quis", "custodiet", "ipsos", "custodes?"]
             actual_column = Column.from_vector "Col" ["Quis", "custodiet", "ipsos"]
-            res = Panic.recover Any (actual_column.should_equal_impl expected_column "LOCATION_PATH")
-            res.catch.should_equal "Expected column length 4, but got 3 (at LOCATION_PATH)."
+            res = Panic.recover Test_Failure_Error (column_should_equal_impl actual_column expected_column "LOCATION_PATH")
+            res.catch.message.should_equal "Expected column length 4, but got 3 (at LOCATION_PATH)."
         group_builder.specify "Two Columns with different content Are Not Equal" <|
             expected_column = Column.from_vector "Col" ["Quis", "custodiet", "ipsos", "custodes?"]
             actual_column = Column.from_vector "Col" ["Who", "guards", "the", "guards?"]
-            res = Panic.recover Any (actual_column.should_equal_impl expected_column "LOCATION_PATH")
-            res.catch.should_equal 'Column: Col differs at row 0.\n\t  Actual  : Who\n\t  Expected: Quis\n\t (at LOCATION_PATH).'
+            res = Panic.recover Test_Failure_Error (column_should_equal_impl actual_column expected_column "LOCATION_PATH")
+            res.catch.message.should_equal 'Column: Col differs at row 0.\n\t  Actual  : Who\n\t  Expected: Quis\n\t (at LOCATION_PATH).'
         group_builder.specify "Two Columns Are Not Equal in Row 3" <|
             expected_column = Column.from_vector "My Column" ["Quis", "custodiet", "ipsos", "custodes?"]
             actual_column = Column.from_vector "My Column" ["Quis", "custodiet", "ipsos", "guards?"]
-            res = Panic.recover Any (actual_column.should_equal_impl expected_column "LOCATION_PATH")
-            res.catch.should_equal 'Column: My Column differs at row 3.\n\t  Actual  : guards?\n\t  Expected: custodes?\n\t (at LOCATION_PATH).'
+            res = Panic.recover Test_Failure_Error (column_should_equal_impl actual_column expected_column "LOCATION_PATH")
+            res.catch.message.should_equal 'Column: My Column differs at row 3.\n\t  Actual  : guards?\n\t  Expected: custodes?\n\t (at LOCATION_PATH).'
         group_builder.specify "Two Columns with different types Are Not Equal" <|
             expected_column = Column.from_vector "Col" ["1", "2", "3", "4"]
             actual_column = Column.from_vector "Col" [1, 2, 3, 4]
-            res = Panic.recover Any (actual_column.should_equal_impl expected_column "LOCATION_PATH")
-            res.catch.should_equal "Expected column type (Char Nothing True), but got (Integer 64 bits) (at LOCATION_PATH)."
+            res = Panic.recover Test_Failure_Error (column_should_equal_impl actual_column expected_column "LOCATION_PATH")
+            res.catch.message.should_equal "Expected column type (Char Nothing True), but got (Integer 64 bits) (at LOCATION_PATH)."
         group_builder.specify "Comparing a Column to non column" <|
             expected_column = 42
             actual_column = Column.from_vector "Col" [1, 2, 3, 4]
-            res = Panic.recover Any (actual_column.should_equal_impl expected_column "LOCATION_PATH")
-            res.catch.should_equal "Got a Column, but expected a 42 (at LOCATION_PATH)."
+            res = Panic.recover Test_Failure_Error (column_should_equal_impl actual_column expected_column "LOCATION_PATH")
+            res.catch.message.should_equal "Got a Column, but expected a 42 (at LOCATION_PATH)."
         group_builder.specify "Two Columns Containg NaNs Are Equal" <|
             # This is somewhat of a special case, as NaN != NaN but for the purposes of testing we consider them equal
             expected_column = Column.from_vector "Col" [1.0, 2.0, Number.nan]
@@ -52,28 +52,28 @@ add_specs suite_builder =
         group_builder.specify "Two Tables With Different Values" <|
             expected_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]
             actual_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "teh", "guards?"]]
-            res = Panic.recover Any (actual_table.should_equal_impl expected_table "LOCATION_PATH")
-            res.catch.should_end_with 'Column: Col2 differs at row 2.\n\t  Actual  : teh\n\t  Expected: the\n\t.'
+            res = Panic.recover Test_Failure_Error (table_should_equal_impl actual_table expected_table "LOCATION_PATH")
+            res.catch.message.should_end_with 'Column: Col2 differs at row 2.\n\t  Actual  : teh\n\t  Expected: the\n\t.'
         group_builder.specify "Tables different number of columns" <|
             expected_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"]]
             actual_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]
-            res = Panic.recover Any (actual_table.should_equal_impl expected_table "LOCATION_PATH")
-            res.catch.should_end_with "Expected 1 columns, but got 2."
+            res = Panic.recover Test_Failure_Error (table_should_equal_impl actual_table expected_table "LOCATION_PATH")
+            res.catch.message.should_end_with "Expected 1 columns, but got 2."
         group_builder.specify "Tables different number of columns2" <|
             expected_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]
             actual_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"]]
-            res = Panic.recover Any (actual_table.should_equal_impl expected_table "LOCATION_PATH")
-            res.catch.should_end_with "Expected 2 columns, but got 1."
+            res = Panic.recover Test_Failure_Error (table_should_equal_impl actual_table expected_table "LOCATION_PATH")
+            res.catch.message.should_end_with "Expected 2 columns, but got 1."
         group_builder.specify "Tables With Mismatched Column names" <|
             expected_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]
             actual_table = Table.new [Column.from_vector "Col" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]
-            res = Panic.recover Any (actual_table.should_equal_impl expected_table "LOCATION_PATH")
-            res.catch.should_end_with "Expected column name Col1, but got Col."
+            res = Panic.recover Test_Failure_Error (table_should_equal_impl actual_table expected_table "LOCATION_PATH")
+            res.catch.message.should_end_with "Expected column name Col1, but got Col."
         group_builder.specify "Comparing a Table to non Table" <|
             expected_table = 42
             actual_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"]]
-            res = Panic.recover Any (actual_table.should_equal_impl expected_table "LOCATION_PATH")
-            res.catch.should_equal "Got a Table, but expected a 42 (at LOCATION_PATH)."
+            res = Panic.recover Test_Failure_Error (table_should_equal_impl actual_table expected_table "LOCATION_PATH")
+            res.catch.message.should_equal "Got a Table, but expected a 42 (at LOCATION_PATH)."
 
 main filter=Nothing =
     suite = Test.build suite_builder->

--- a/test/Table_Tests/src/Util_Spec.enso
+++ b/test/Table_Tests/src/Util_Spec.enso
@@ -49,11 +49,26 @@ add_specs suite_builder =
             expected_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]
             actual_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]
             actual_table.should_equal expected_table
+        group_builder.specify "Tables different number of columns" <|
+            expected_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"]]
+            actual_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]
+            res = Panic.recover Any (actual_table.should_equal_impl expected_table "LOCATION_PATH")
+            res.catch.should_end_with "Expected 1 columns, but got 2."
+        group_builder.specify "Tables different number of columns2" <|
+            expected_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]
+            actual_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"]]
+            res = Panic.recover Any (actual_table.should_equal_impl expected_table "LOCATION_PATH")
+            res.catch.should_end_with "Expected 2 columns, but got 1."
         group_builder.specify "Tables With Mismatched Column names" <|
             expected_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]
             actual_table = Table.new [Column.from_vector "Col" ["Quis", "custodiet", "ipsos", "custodes?"], Column.from_vector "Col2" ["Who", "guards", "the", "guards?"]]
             res = Panic.recover Any (actual_table.should_equal_impl expected_table "LOCATION_PATH")
             res.catch.should_end_with "Expected column name Col1, but got Col."
+        group_builder.specify "Comparing a Table to non Table" <|
+            expected_table = 42
+            actual_table = Table.new [Column.from_vector "Col1" ["Quis", "custodiet", "ipsos", "custodes?"]]
+            res = Panic.recover Any (actual_table.should_equal_impl expected_table "LOCATION_PATH")
+            res.catch.should_equal "Got a Table, but expected a 42 (at LOCATION_PATH)."
 
 main filter=Nothing =
     suite = Test.build suite_builder->

--- a/test/Table_Tests/src/Util_Spec.enso
+++ b/test/Table_Tests/src/Util_Spec.enso
@@ -23,12 +23,12 @@ add_specs suite_builder =
             expected_column = Column.from_vector "Col" ["Quis", "custodiet", "ipsos", "custodes?"]
             actual_column = Column.from_vector "Col" ["Who", "guards", "the", "guards?"]
             res = Panic.recover Any (actual_column.should_equal_impl expected_column "LOCATION_PATH")
-            res.catch.should_equal "Column: Col differs at row 0. Actual: Who Expected: Quis (at LOCATION_PATH)."
+            res.catch.should_equal 'Column: Col differs at row 0.\n\t  Actual  : Who\n\t  Expected: Quis\n\t(at LOCATION_PATH).'
         group_builder.specify "Two Columns Are Not Equal in Row 3" <|
             expected_column = Column.from_vector "My Column" ["Quis", "custodiet", "ipsos", "custodes?"]
             actual_column = Column.from_vector "My Column" ["Quis", "custodiet", "ipsos", "guards?"]
             res = Panic.recover Any (actual_column.should_equal_impl expected_column "LOCATION_PATH")
-            res.catch.should_equal "Column: My Column differs at row 3. Actual: guards? Expected: custodes? (at LOCATION_PATH)."
+            res.catch.should_equal 'Column: My Column differs at row 3.\n\t  Actual  : guards?\n\t  Expected: custodes?\n\t(at LOCATION_PATH).'
         group_builder.specify "Two Columns with different types Are Not Equal" <|
             expected_column = Column.from_vector "Col" ["1", "2", "3", "4"]
             actual_column = Column.from_vector "Col" [1, 2, 3, 4]
@@ -44,8 +44,6 @@ add_specs suite_builder =
             expected_column = Column.from_vector "Col" [1.0, 2.0, Number.nan]
             actual_column = Column.from_vector "Col" [1.0, 2.0, Number.nan]
             actual_column.should_equal expected_column
-
-
 
 main filter=Nothing =
     suite = Test.build suite_builder->


### PR DESCRIPTION
### Pull Request Description

For the purposes of testing the fact that NaN != NaN isn't useful. This change makes Table.should_equal and Column.should_equal consider NaN equal.

It also improves error reporting for when there is a difference in a Table/Column

![image](https://github.com/enso-org/enso/assets/1720119/8892f048-696f-4e4b-beae-30eaeb5d7be2)

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- All code has been tested:
  - [x] Unit tests have been written where possible.
  - [ ] If GUI codebase was changed, the GUI was tested when built using `./run ide build`.
