### PR TITLE
Compile-time `shapeless` in `runtime-compiler`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1962,7 +1962,7 @@ lazy val `runtime-compiler` =
       frgaalJavaCompilerSetting,
       (Test / fork) := true,
       libraryDependencies ++= Seq(
-        "com.chuusai"     %% "shapeless"               % shapelessVersion,
+        "com.chuusai"     %% "shapeless"               % shapelessVersion   % "provided",
         "junit"            % "junit"                   % junitVersion       % Test,
         "com.github.sbt"   % "junit-interface"         % junitIfVersion     % Test,
         "org.scalatest"   %% "scalatest"               % scalatestVersion   % Test,


### PR DESCRIPTION
### Pull Request Description

Marking the `shapeless` dependency as compile-time only.

### Important Notes

If we want to ditch the dependency completely then, if we want to keep the check in place, we would have to replace with its runtime equivalent:
```
--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/IRPass.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/IRPass.scala
@@ -148,6 +148,9 @@ object IRPass {
     def unsafeAs[T <: Metadata: ClassTag]: T = {
+      if (implicitly[ClassTag[T]].runtimeClass == Metadata.getClass) {
+        throw new InternalError("Type argument must be specified")
+      }
```
Not sure if we want to do it still after this change.

Note that `project-manager` uses that and some other definitions as well. 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
