### PR TITLE
Compile parser using musl

### DIFF
--- a/project/Cargo.scala
+++ b/project/Cargo.scala
@@ -7,6 +7,7 @@ import scala.sys.process._
 /** A wrapper for executing the command `cargo`. */
 object Cargo {
   private val cargoCmd            = "cargo"
+  private val rustUpCmd           = "rustup"
   private var wasCargoOk: Boolean = false
 
   /** Executes the command `cargo $args`. */
@@ -38,13 +39,32 @@ object Cargo {
       try Process(cmd, None, extraEnv: _*).!
       catch {
         case _: RuntimeException =>
-          throw new RuntimeException("Cargo command failed to run.")
+          throw new RuntimeException(s"`$cargoCmd` command failed to run.")
       }
     if (exitCode != 0) {
       throw new RuntimeException(
-        s"Cargo command returned a non-zero exit code: $exitCode."
+        s"`$cargoCmd` command returned a non-zero exit code: $exitCode."
       )
     }
+  }
+
+  def rustUp(target: String, log: ManagedLogger): Unit = {
+    val cmd: Seq[String] = Seq(rustUpCmd) ++ Seq("target", "add", target)
+
+    log.info(cmd.toString())
+
+    val exitCode =
+      try Process(cmd, None).!
+      catch {
+        case _: RuntimeException =>
+          throw new RuntimeException(s"`$rustUpCmd` command failed to run.")
+      }
+    if (exitCode != 0) {
+      throw new RuntimeException(
+        s"`$rustUpCmd` command returned a non-zero exit code: $exitCode."
+      )
+    }
+
   }
 
   /** Checks that cargo is installed. Logs an error and returns false if not. */


### PR DESCRIPTION
### Pull Request Description

To workaround problems with `glibc` we need to build parser in the backend with C stdlib statically linked using musl. Uses the arguments presented in #9521.

### Important Notes

No problems in tests so far.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
