### PR TITLE
Fix Google Analytics tag injection

### DIFF
--- a/app/ide-desktop/lib/common/src/appConfig.js
+++ b/app/ide-desktop/lib/common/src/appConfig.js
@@ -97,6 +97,9 @@ export function getDefines(serverPort = 8080) {
         ),
         'process.env.ENSO_CLOUD_COGNITO_DOMAIN': stringify(process.env.ENSO_CLOUD_COGNITO_DOMAIN),
         'process.env.ENSO_CLOUD_COGNITO_REGION': stringify(process.env.ENSO_CLOUD_COGNITO_REGION),
+        'process.env.ENSO_CLOUD_GOOGLE_ANALYTICS_TAG': stringify(
+            process.env.ENSO_CLOUD_GOOGLE_ANALYTICS_TAG
+        ),
         /* eslint-enable @typescript-eslint/naming-convention */
     }
 }

--- a/app/ide-desktop/lib/common/src/gtag.ts
+++ b/app/ide-desktop/lib/common/src/gtag.ts
@@ -1,10 +1,10 @@
 /** @file Google Analytics tag. */
 import * as load from './load'
 
-if (process.env.ENSO_CLOUD_GOOGLE_ANALYTICS_TAG != null) {
-    void load.loadScript(
-        `https://www.googletagmanager.com/gtag/js?id=${process.env.ENSO_CLOUD_GOOGLE_ANALYTICS_TAG}`
-    )
+const GOOGLE_ANALYTICS_TAG = process.env.ENSO_CLOUD_GOOGLE_ANALYTICS_TAG
+
+if (GOOGLE_ANALYTICS_TAG != null) {
+    void load.loadScript(`https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_TAG}`)
 }
 
 // @ts-expect-error This is explicitly not given types as it is a mistake to acess this
@@ -29,5 +29,7 @@ export function event(name: string, params?: object) {
 gtag('js', new Date())
 // eslint-disable-next-line @typescript-eslint/naming-convention
 gtag('set', 'linker', { accept_incoming: true })
-gtag('config', 'G-CLTBJ37MDM')
-gtag('config', 'G-DH47F649JC')
+gtag('config', GOOGLE_ANALYTICS_TAG)
+if (GOOGLE_ANALYTICS_TAG === 'G-CLTBJ37MDM') {
+    gtag('config', 'G-DH47F649JC')
+}


### PR DESCRIPTION
### Pull Request Description
I missed injecting the Google Analytics tag from the environment at build time...

### Important Notes
None

### Testing instructions
- The main JS bundle will send the Google Analytics event "`open_app`". Find the file in which that string is defined, and check that `ENSO_CLOUD_GOOGLE_ANALYTICS_TAG` is *not* defined - it should have been replaced at build time with its actual value.
  - More detailed info on the file:
    - Should be called `index-<hash here>.js`
    - Should contain `googletagmanager` (the URL of the script that is loaded)
  - `ENSO_CLOUD_GOOGLE_ANALYTICS_TAG` MUST be manually set at build time (i.e. it must be present in the environment of the `./run` script). To set the tag to its value in production, use `ENSO_CLOUD_GOOGLE_ANALYTICS_TAG=G-CLTBJ37MDM`.
  - This should be checked on `./run ide build --skip-version-check --backend-source re
lease --backend-release nightly`, although checking on 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
