### PR TITLE
Run engine benchmarks with increased stack size

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1919,6 +1919,7 @@ lazy val `runtime-benchmarks` =
         )
       },
       javaOptions ++= benchOnlyOptions,
+      javaOptions += "-Xss16M",
       run / fork := true,
       run / connectInput := true,
       bench := Def


### PR DESCRIPTION
Fixes #9645

### Pull Request Description

In the previous old benchmarking configuration, we used to start all the benchmarks with `-Xss16M`. This PR re-introduces this cmdline option to the new configuration. This "fixes" the recursion benchmark mentioned in the issue description so that it no longer fails on `StackOverflowError`.

### Important Notes



### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
