### PR TITLE
Pretending WithWarnings isException

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/BinaryDispatchTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/BinaryDispatchTest.java
@@ -292,9 +292,13 @@ public class BinaryDispatchTest extends TestBase {
   }
 
   static void assertContains(String expected, String actual) {
-    if (actual.contains(expected)) {
+    assertContains("Expecting", expected, actual);
+  }
+
+  static void assertContains(String msg, String expected, String actual) {
+    if (actual != null && actual.contains(expected)) {
       return;
     }
-    fail("Expecting " + expected + " in " + actual);
+    fail(msg + " " + expected + " in " + actual);
   }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/BinaryDispatchTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/BinaryDispatchTest.java
@@ -291,7 +291,7 @@ public class BinaryDispatchTest extends TestBase {
     }
   }
 
-  private static void assertContains(String expected, String actual) {
+  static void assertContains(String expected, String actual) {
     if (actual.contains(expected)) {
       return;
     }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/MetaIsATest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/MetaIsATest.java
@@ -288,7 +288,8 @@ public class MetaIsATest extends TestBase {
     if (test.isException()) {
       // if a generated value isException (from interop point of view)
       // then it is either DataflowError or Warning
-      if (g.typeError() == v.getMetaObject()) {
+      var vMeta = v.getMetaObject();
+      if (g.typeError().equals(vMeta)) {
         assertEquals("DataFlowError in", g.typeError(), v.getMetaObject());
         assertEquals("DataFlowError out", g.typeError(), test.getMetaObject());
         // end the test here as DataflowError doesn't represent a value
@@ -297,10 +298,6 @@ public class MetaIsATest extends TestBase {
         // check if Warning.has_warnings is true
         var wv = warningCheck.execute(v);
         var wTest = warningCheck.execute(test);
-        if (wv.isException()) {
-          assertTrue(wTest.isException());
-          return;
-        }
         assertTrue("Warning in", wv.asBoolean());
         assertTrue("Warning out", wTest.asBoolean());
         // but continue with the rest of the test, as Warning still represents a value

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/WarningsTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/WarningsTest.java
@@ -1,5 +1,6 @@
 package org.enso.interpreter.test;
 
+import static org.enso.interpreter.test.BinaryDispatchTest.assertContains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -112,7 +113,8 @@ public class WarningsTest extends TestBase {
       warningMulti.throwException();
       fail("Shouldn't reach here");
     } catch (PolyglotException ex) {
-      assertEquals("warn:1 warn:3", ex.getMessage());
+      assertContains("warn:1", ex.getMessage());
+      assertContains("warn:3", ex.getMessage());
     }
   }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/WarningsTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/WarningsTest.java
@@ -100,5 +100,19 @@ public class WarningsTest extends TestBase {
     } catch (PolyglotException ex) {
       assertEquals("warn:1", ex.getMessage());
     }
+
+    var warningMulti = wrap.execute("warn:3", warning42);
+    assertTrue("multi value is a number", warningMulti.isNumber());
+    assertTrue("multi value is Int", warningMulti.fitsInInt());
+    assertEquals(42, warningMulti.asInt());
+
+    assertTrue("multi vlaue with warning is also an exception", warningMulti.isException());
+
+    try {
+      warningMulti.throwException();
+      fail("Shouldn't reach here");
+    } catch (PolyglotException ex) {
+      assertEquals("warn:1 warn:3", ex.getMessage());
+    }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InteropMethodCallNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/callable/InteropMethodCallNode.java
@@ -32,6 +32,10 @@ public abstract class InteropMethodCallNode extends Node {
     return InteropMethodCallNodeGen.create();
   }
 
+  public static InteropMethodCallNode getUncached() {
+    return InteropMethodCallNodeGen.getUncached();
+  }
+
   /**
    * Calls the method with given state and arguments.
    *

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/text/Text.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/text/Text.java
@@ -27,6 +27,7 @@ import org.enso.polyglot.common_utils.Core_Text_Utils;
 @ExportLibrary(TypesLibrary.class)
 public final class Text implements EnsoObject {
   private static final Lock LOCK = new ReentrantLock();
+  private static final Text EMPTY = new Text("");
   private volatile Object contents;
   private volatile int length = -1;
   private volatile FcdNormalized fcdNormalized = FcdNormalized.UNKNOWN;
@@ -96,6 +97,10 @@ public final class Text implements EnsoObject {
       }
     }
     return false;
+  }
+
+  public static Text empty() {
+    return EMPTY;
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -83,9 +83,7 @@ public final class PanicException extends AbstractTruffleException implements En
     InteropLibrary library = InteropLibrary.getUncached();
     try {
       msg = library.asString(library.getExceptionMessage(this));
-      new Exception(msg).printStackTrace();
     } catch (AssertionError | UnsupportedMessageException e) {
-      e.printStackTrace();
       msg = TypeToDisplayTextNode.getUncached().execute(payload);
     }
     cacheMessage = msg;
@@ -113,16 +111,17 @@ public final class PanicException extends AbstractTruffleException implements En
   }
 
   @NeverDefault
-  static UnresolvedSymbol toText(IndirectInvokeMethodNode payloads) {
+  static UnresolvedSymbol toDisplayText(IndirectInvokeMethodNode payloads) {
     var ctx = EnsoContext.get(payloads);
     var scope = ctx.getBuiltins().panic().getDefinitionScope();
-    return UnresolvedSymbol.build("to_text", scope);
+    return UnresolvedSymbol.build("to_display_text", scope);
   }
 
   @ExportMessage
   Object getExceptionMessage(
       @Cached IndirectInvokeMethodNode payloads,
-      @Cached(value = "toText(payloads)", allowUncached = true) UnresolvedSymbol toText,
+      @Cached(value = "toDisplayText(payloads)", allowUncached = true)
+          UnresolvedSymbol toDisplayText,
       @CachedLibrary(limit = "3") InteropLibrary strings,
       @Cached TypeToDisplayTextNode typeToDisplayTextNode) {
     var ctx = EnsoContext.get(payloads);
@@ -130,7 +129,7 @@ public final class PanicException extends AbstractTruffleException implements En
         payloads.execute(
             null,
             State.create(ctx),
-            toText,
+            toDisplayText,
             payload,
             new Object[] {payload},
             new CallArgumentInfo[] {new CallArgumentInfo("self")},

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -83,7 +83,9 @@ public final class PanicException extends AbstractTruffleException implements En
     InteropLibrary library = InteropLibrary.getUncached();
     try {
       msg = library.asString(library.getExceptionMessage(this));
+      new Exception(msg).printStackTrace();
     } catch (AssertionError | UnsupportedMessageException e) {
+      e.printStackTrace();
       msg = TypeToDisplayTextNode.getUncached().execute(payload);
     }
     cacheMessage = msg;
@@ -111,17 +113,16 @@ public final class PanicException extends AbstractTruffleException implements En
   }
 
   @NeverDefault
-  static UnresolvedSymbol toDisplayText(IndirectInvokeMethodNode payloads) {
+  static UnresolvedSymbol toText(IndirectInvokeMethodNode payloads) {
     var ctx = EnsoContext.get(payloads);
     var scope = ctx.getBuiltins().panic().getDefinitionScope();
-    return UnresolvedSymbol.build("to_display_text", scope);
+    return UnresolvedSymbol.build("to_text", scope);
   }
 
   @ExportMessage
   Object getExceptionMessage(
       @Cached IndirectInvokeMethodNode payloads,
-      @Cached(value = "toDisplayText(payloads)", allowUncached = true)
-          UnresolvedSymbol toDisplayText,
+      @Cached(value = "toText(payloads)", allowUncached = true) UnresolvedSymbol toText,
       @CachedLibrary(limit = "3") InteropLibrary strings,
       @Cached TypeToDisplayTextNode typeToDisplayTextNode) {
     var ctx = EnsoContext.get(payloads);
@@ -129,7 +130,7 @@ public final class PanicException extends AbstractTruffleException implements En
         payloads.execute(
             null,
             State.create(ctx),
-            toDisplayText,
+            toText,
             payload,
             new Object[] {payload},
             new CallArgumentInfo[] {new CallArgumentInfo("self")},

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/WithWarnings.java
@@ -25,6 +25,24 @@ import org.enso.interpreter.runtime.state.State;
 import org.graalvm.collections.EconomicSet;
 import org.graalvm.collections.Equivalence;
 
+/**
+ * Represents a typical Enso <em>value with warnings</em>. As much of care as possible is taken to
+ * delegate all operations to the underlaying {@code value}. Warnings are considered {@link
+ * InteropLibrary#isException exceptional values} - e.g. one can check for them in Java polyglot
+ * code as:
+ *
+ * <pre>
+ *  Value value = ...;
+ *  if (value.fitsInLong() && value.isException()) {
+ *    // probably an Integer with a warning
+ *    try {
+ *      warningMulti.throwException();
+ *    } catch (PolyglotException ex) {
+ *      System.out.println("Warnings attached to " + value.asLong() + " are " + ex.getMessage());
+ *    }
+ *  }
+ * </pre>
+ */
 @ExportLibrary(TypesLibrary.class)
 @ExportLibrary(WarningsLibrary.class)
 @ExportLibrary(ReflectionLibrary.class)


### PR DESCRIPTION
### Pull Request Description

Addresses another puzzle of #9749 - how to recognize a _value has an attached warning_ from a polyglot code? One of the problems of the [GraalVM Insight](https://www.graalvm.org/jdk21/tools/graalvm-insight/) is the need to mix Enso and JavaScript. One way to avoid that is to make sure `Warning` can be recognized via a polyglot boundary - e.g. it exposes itself via the `InteropLibrary` in a _recognizable way_.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated in [235c043](https://github.com/enso-org/enso/pull/9840/commits/235c0437b4309b188da8251461e228c63a0a54fb)
- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
