### PR TITLE
Workaround slow responses with retries

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/CreateHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/CreateHandler.scala
@@ -38,7 +38,7 @@ class CreateHandler(
       ContextRegistryProtocol.CreateContextResponse,
       ContextRegistryProtocol.Failure,
       ContextRegistryProtocol.CreateContextRequest
-    ](contextRegistry, timeout, 10)
+    ](contextRegistry, timeout)
     with Actor
     with LazyLogging
     with UnhandledLogging {
@@ -59,7 +59,6 @@ class CreateHandler(
     ],
     msg: ContextRegistryProtocol.CreateContextResponse
   ): Unit = {
-    Thread.sleep(1000)
     val contextId       = msg.contextId
     val canModify       = CapabilityRegistration(CanModify(contextId))
     val receivesUpdates = CapabilityRegistration(ReceivesUpdates(contextId))

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/CreateHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/CreateHandler.scala
@@ -1,6 +1,6 @@
 package org.enso.languageserver.requesthandler.executioncontext
 
-import akka.actor.{Actor, ActorRef, Cancellable, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import com.typesafe.scalalogging.LazyLogging
 import org.enso.jsonrpc._
 import org.enso.languageserver.data.{
@@ -8,15 +8,19 @@ import org.enso.languageserver.data.{
   CapabilityRegistration,
   ReceivesUpdates
 }
-import org.enso.languageserver.requesthandler.RequestTimeout
 import org.enso.languageserver.runtime.ExecutionApi._
 import org.enso.languageserver.runtime.{
   ContextRegistryProtocol,
+  ExecutionApi,
   RuntimeFailureMapper
 }
 import org.enso.languageserver.session.JsonSession
-import org.enso.languageserver.util.UnhandledLogging
+import org.enso.languageserver.util.{
+  RequestHandlerWithRetries,
+  UnhandledLogging
+}
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 /** A request handler for `executionContext/create` commands.
@@ -29,51 +33,53 @@ class CreateHandler(
   timeout: FiniteDuration,
   contextRegistry: ActorRef,
   session: JsonSession
-) extends Actor
+) extends RequestHandlerWithRetries[
+      Request[ExecutionContextCreate.type, ExecutionContextCreate.Params],
+      ContextRegistryProtocol.CreateContextResponse,
+      ContextRegistryProtocol.Failure,
+      ContextRegistryProtocol.CreateContextRequest
+    ](contextRegistry, timeout, 10)
+    with Actor
     with LazyLogging
     with UnhandledLogging {
 
-  import ContextRegistryProtocol._
-  import context.dispatcher
+  override protected def request(
+    msg: Request[
+      ExecutionApi.ExecutionContextCreate.type,
+      ExecutionContextCreate.Params
+    ]
+  ): ContextRegistryProtocol.CreateContextRequest =
+    ContextRegistryProtocol.CreateContextRequest(session, msg.params.contextId)
 
-  override def receive: Receive = requestStage
-
-  private def requestStage: Receive = {
-    case Request(
-          ExecutionContextCreate,
-          id,
-          params: ExecutionContextCreate.Params
-        ) =>
-      contextRegistry ! CreateContextRequest(session, params.contextId)
-      val cancellable =
-        context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
-      context.become(responseStage(id, sender(), cancellable))
-  }
-
-  private def responseStage(
-    id: Id,
+  protected def positiveResponse(
     replyTo: ActorRef,
-    cancellable: Cancellable
-  ): Receive = {
-    case RequestTimeout =>
-      logger.error("Request [{}] timed out.", id)
-      replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
-      context.stop(self)
-
-    case CreateContextResponse(contextId) =>
-      val canModify       = CapabilityRegistration(CanModify(contextId))
-      val receivesUpdates = CapabilityRegistration(ReceivesUpdates(contextId))
-      val result =
-        ExecutionContextCreate.Result(contextId, canModify, receivesUpdates)
-      replyTo ! ResponseResult(ExecutionContextCreate, id, result)
-      cancellable.cancel()
-      context.stop(self)
-
-    case error: ContextRegistryProtocol.Failure =>
-      replyTo ! ResponseError(Some(id), RuntimeFailureMapper.mapFailure(error))
-      cancellable.cancel()
-      context.stop(self)
+    initialMsg: Request[
+      ExecutionApi.ExecutionContextCreate.type,
+      ExecutionContextCreate.Params
+    ],
+    msg: ContextRegistryProtocol.CreateContextResponse
+  ): Unit = {
+    Thread.sleep(1000)
+    val contextId       = msg.contextId
+    val canModify       = CapabilityRegistration(CanModify(contextId))
+    val receivesUpdates = CapabilityRegistration(ReceivesUpdates(contextId))
+    val result =
+      ExecutionContextCreate.Result(contextId, canModify, receivesUpdates)
+    replyTo ! ResponseResult(ExecutionContextCreate, initialMsg.id, result)
   }
+
+  override protected def negativeResponse(
+    replyTo: ActorRef,
+    initialMsg: Request[
+      ExecutionApi.ExecutionContextCreate.type,
+      ExecutionContextCreate.Params
+    ],
+    error: ContextRegistryProtocol.Failure
+  )(implicit ec: ExecutionContext): Unit =
+    replyTo ! ResponseError(
+      Some(initialMsg.id),
+      RuntimeFailureMapper.mapFailure(error)
+    )
 }
 
 object CreateHandler {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/DestroyHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/DestroyHandler.scala
@@ -33,7 +33,7 @@ class DestroyHandler(
       ContextRegistryProtocol.DestroyContextResponse,
       ContextRegistryProtocol.Failure,
       ContextRegistryProtocol.DestroyContextRequest
-    ](contextRegistry, timeout, 10)
+    ](contextRegistry, timeout)
     with Actor
     with LazyLogging
     with UnhandledLogging {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/DestroyHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/DestroyHandler.scala
@@ -1,17 +1,21 @@
 package org.enso.languageserver.requesthandler.executioncontext
 
-import akka.actor.{Actor, ActorRef, Cancellable, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import com.typesafe.scalalogging.LazyLogging
 import org.enso.jsonrpc._
-import org.enso.languageserver.requesthandler.RequestTimeout
 import org.enso.languageserver.runtime.ExecutionApi._
 import org.enso.languageserver.runtime.{
   ContextRegistryProtocol,
+  ExecutionApi,
   RuntimeFailureMapper
 }
 import org.enso.languageserver.session.JsonSession
-import org.enso.languageserver.util.UnhandledLogging
+import org.enso.languageserver.util.{
+  RequestHandlerWithRetries,
+  UnhandledLogging
+}
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 /** A request handler for `executionContext/destroy` commands.
@@ -24,47 +28,46 @@ class DestroyHandler(
   timeout: FiniteDuration,
   contextRegistry: ActorRef,
   session: JsonSession
-) extends Actor
+) extends RequestHandlerWithRetries[
+      Request[ExecutionContextDestroy.type, ExecutionContextDestroy.Params],
+      ContextRegistryProtocol.DestroyContextResponse,
+      ContextRegistryProtocol.Failure,
+      ContextRegistryProtocol.DestroyContextRequest
+    ](contextRegistry, timeout, 10)
+    with Actor
     with LazyLogging
     with UnhandledLogging {
 
-  import ContextRegistryProtocol._
-  import context.dispatcher
+  override protected def request(
+    msg: Request[
+      ExecutionApi.ExecutionContextDestroy.type,
+      ExecutionContextDestroy.Params
+    ]
+  ): ContextRegistryProtocol.DestroyContextRequest =
+    ContextRegistryProtocol.DestroyContextRequest(session, msg.params.contextId)
 
-  override def receive: Receive = requestStage
-
-  private def requestStage: Receive = {
-    case Request(
-          ExecutionContextDestroy,
-          id,
-          params: ExecutionContextDestroy.Params
-        ) =>
-      contextRegistry ! DestroyContextRequest(session, params.contextId)
-      val cancellable =
-        context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
-      context.become(responseStage(id, sender(), cancellable))
-  }
-
-  private def responseStage(
-    id: Id,
+  override protected def positiveResponse(
     replyTo: ActorRef,
-    cancellable: Cancellable
-  ): Receive = {
-    case RequestTimeout =>
-      logger.error("Request [{}] timed out.", id)
-      replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
-      context.stop(self)
+    initialMsg: Request[
+      ExecutionApi.ExecutionContextDestroy.type,
+      ExecutionContextDestroy.Params
+    ],
+    msg: ContextRegistryProtocol.DestroyContextResponse
+  ): Unit =
+    replyTo ! ResponseResult(ExecutionContextDestroy, initialMsg.id, Unused)
 
-    case DestroyContextResponse(_) =>
-      replyTo ! ResponseResult(ExecutionContextDestroy, id, Unused)
-      cancellable.cancel()
-      context.stop(self)
-
-    case error: ContextRegistryProtocol.Failure =>
-      replyTo ! ResponseError(Some(id), RuntimeFailureMapper.mapFailure(error))
-      cancellable.cancel()
-      context.stop(self)
-  }
+  override protected def negativeResponse(
+    replyTo: ActorRef,
+    initialMsg: Request[
+      ExecutionApi.ExecutionContextDestroy.type,
+      ExecutionContextDestroy.Params
+    ],
+    error: ContextRegistryProtocol.Failure
+  )(implicit ec: ExecutionContext): Unit =
+    replyTo ! ResponseError(
+      Some(initialMsg.id),
+      RuntimeFailureMapper.mapFailure(error)
+    )
 }
 
 object DestroyHandler {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/GetComponentGroupsHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/GetComponentGroupsHandler.scala
@@ -36,7 +36,7 @@ class GetComponentGroupsHandler(
       ContextRegistryProtocol.GetComponentGroupsResponse,
       ContextRegistryProtocol.Failure,
       ContextRegistryProtocol.GetComponentGroupsRequest
-    ](contextRegistry, timeout, 10)
+    ](contextRegistry, timeout)
     with Actor
     with LazyLogging
     with UnhandledLogging {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/InterruptHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/InterruptHandler.scala
@@ -1,17 +1,21 @@
 package org.enso.languageserver.requesthandler.executioncontext
 
-import akka.actor.{Actor, ActorRef, Cancellable, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import com.typesafe.scalalogging.LazyLogging
 import org.enso.jsonrpc._
-import org.enso.languageserver.requesthandler.RequestTimeout
 import org.enso.languageserver.runtime.ExecutionApi._
 import org.enso.languageserver.runtime.{
   ContextRegistryProtocol,
+  ExecutionApi,
   RuntimeFailureMapper
 }
 import org.enso.languageserver.session.JsonSession
-import org.enso.languageserver.util.UnhandledLogging
+import org.enso.languageserver.util.{
+  RequestHandlerWithRetries,
+  UnhandledLogging
+}
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 /** A request handler for `executionContext/interrupt` commands.
@@ -24,49 +28,49 @@ class InterruptHandler(
   timeout: FiniteDuration,
   contextRegistry: ActorRef,
   session: JsonSession
-) extends Actor
+) extends RequestHandlerWithRetries[
+      Request[ExecutionContextInterrupt.type, ExecutionContextInterrupt.Params],
+      ContextRegistryProtocol.InterruptContextResponse,
+      ContextRegistryProtocol.Failure,
+      ContextRegistryProtocol.InterruptContextRequest
+    ](contextRegistry, timeout, 10)
+    with Actor
     with LazyLogging
     with UnhandledLogging {
 
-  import context.dispatcher
+  override protected def request(
+    msg: Request[
+      ExecutionApi.ExecutionContextInterrupt.type,
+      ExecutionContextInterrupt.Params
+    ]
+  ): ContextRegistryProtocol.InterruptContextRequest =
+    ContextRegistryProtocol.InterruptContextRequest(
+      session,
+      msg.params.contextId
+    )
 
-  override def receive: Receive = requestStage
-
-  private def requestStage: Receive = {
-    case Request(
-          ExecutionContextInterrupt,
-          id,
-          params: ExecutionContextInterrupt.Params
-        ) =>
-      contextRegistry ! ContextRegistryProtocol.InterruptContextRequest(
-        session,
-        params.contextId
-      )
-      val cancellable =
-        context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
-      context.become(responseStage(id, sender(), cancellable))
-  }
-
-  private def responseStage(
-    id: Id,
+  override protected def positiveResponse(
     replyTo: ActorRef,
-    cancellable: Cancellable
-  ): Receive = {
-    case RequestTimeout =>
-      logger.error("Request [{}] timed out.", id)
-      replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
-      context.stop(self)
+    initialMsg: Request[
+      ExecutionApi.ExecutionContextInterrupt.type,
+      ExecutionContextInterrupt.Params
+    ],
+    msg: ContextRegistryProtocol.InterruptContextResponse
+  ): Unit =
+    replyTo ! ResponseResult(ExecutionContextInterrupt, initialMsg.id, Unused)
 
-    case ContextRegistryProtocol.InterruptContextResponse(_) =>
-      replyTo ! ResponseResult(ExecutionContextInterrupt, id, Unused)
-      cancellable.cancel()
-      context.stop(self)
-
-    case error: ContextRegistryProtocol.Failure =>
-      replyTo ! ResponseError(Some(id), RuntimeFailureMapper.mapFailure(error))
-      cancellable.cancel()
-      context.stop(self)
-  }
+  override protected def negativeResponse(
+    replyTo: ActorRef,
+    initialMsg: Request[
+      ExecutionApi.ExecutionContextInterrupt.type,
+      ExecutionContextInterrupt.Params
+    ],
+    error: ContextRegistryProtocol.Failure
+  )(implicit ec: ExecutionContext): Unit =
+    replyTo ! ResponseError(
+      Some(initialMsg.id),
+      RuntimeFailureMapper.mapFailure(error)
+    )
 }
 
 object InterruptHandler {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/InterruptHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/InterruptHandler.scala
@@ -33,7 +33,7 @@ class InterruptHandler(
       ContextRegistryProtocol.InterruptContextResponse,
       ContextRegistryProtocol.Failure,
       ContextRegistryProtocol.InterruptContextRequest
-    ](contextRegistry, timeout, 10)
+    ](contextRegistry, timeout)
     with Actor
     with LazyLogging
     with UnhandledLogging {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/PopHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/PopHandler.scala
@@ -33,7 +33,7 @@ class PopHandler(
       ContextRegistryProtocol.PopContextResponse,
       ContextRegistryProtocol.Failure,
       ContextRegistryProtocol.PopContextRequest
-    ](contextRegistry, timeout, 10)
+    ](contextRegistry, timeout)
     with Actor
     with LazyLogging
     with UnhandledLogging {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/PopHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/PopHandler.scala
@@ -1,17 +1,21 @@
 package org.enso.languageserver.requesthandler.executioncontext
 
-import akka.actor.{Actor, ActorRef, Cancellable, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import com.typesafe.scalalogging.LazyLogging
 import org.enso.jsonrpc._
-import org.enso.languageserver.requesthandler.RequestTimeout
 import org.enso.languageserver.runtime.ExecutionApi._
 import org.enso.languageserver.runtime.{
   ContextRegistryProtocol,
+  ExecutionApi,
   RuntimeFailureMapper
 }
 import org.enso.languageserver.session.JsonSession
-import org.enso.languageserver.util.UnhandledLogging
+import org.enso.languageserver.util.{
+  RequestHandlerWithRetries,
+  UnhandledLogging
+}
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 /** A request handler for `executionContext/push` commands.
@@ -24,43 +28,46 @@ class PopHandler(
   timeout: FiniteDuration,
   contextRegistry: ActorRef,
   session: JsonSession
-) extends Actor
+) extends RequestHandlerWithRetries[
+      Request[ExecutionContextPop.type, ExecutionContextPop.Params],
+      ContextRegistryProtocol.PopContextResponse,
+      ContextRegistryProtocol.Failure,
+      ContextRegistryProtocol.PopContextRequest
+    ](contextRegistry, timeout, 10)
+    with Actor
     with LazyLogging
     with UnhandledLogging {
 
-  import ContextRegistryProtocol._
-  import context.dispatcher
+  override protected def request(
+    msg: Request[
+      ExecutionApi.ExecutionContextPop.type,
+      ExecutionContextPop.Params
+    ]
+  ): ContextRegistryProtocol.PopContextRequest =
+    ContextRegistryProtocol.PopContextRequest(session, msg.params.contextId)
 
-  override def receive: Receive = requestStage
-
-  private def requestStage: Receive = {
-    case Request(ExecutionContextPop, id, params: ExecutionContextPop.Params) =>
-      contextRegistry ! PopContextRequest(session, params.contextId)
-      val cancellable =
-        context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
-      context.become(responseStage(id, sender(), cancellable))
-  }
-
-  private def responseStage(
-    id: Id,
+  override protected def positiveResponse(
     replyTo: ActorRef,
-    cancellable: Cancellable
-  ): Receive = {
-    case RequestTimeout =>
-      logger.error("Request [{}] timed out.", id)
-      replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
-      context.stop(self)
+    initialMsg: Request[
+      ExecutionApi.ExecutionContextPop.type,
+      ExecutionContextPop.Params
+    ],
+    msg: ContextRegistryProtocol.PopContextResponse
+  ): Unit =
+    replyTo ! ResponseResult(ExecutionContextPop, initialMsg.id, Unused)
 
-    case PopContextResponse(_) =>
-      replyTo ! ResponseResult(ExecutionContextPop, id, Unused)
-      cancellable.cancel()
-      context.stop(self)
-
-    case error: ContextRegistryProtocol.Failure =>
-      replyTo ! ResponseError(Some(id), RuntimeFailureMapper.mapFailure(error))
-      cancellable.cancel()
-      context.stop(self)
-  }
+  override protected def negativeResponse(
+    replyTo: ActorRef,
+    initialMsg: Request[
+      ExecutionApi.ExecutionContextPop.type,
+      ExecutionContextPop.Params
+    ],
+    error: ContextRegistryProtocol.Failure
+  )(implicit ec: ExecutionContext): Unit =
+    replyTo ! ResponseError(
+      Some(initialMsg.id),
+      RuntimeFailureMapper.mapFailure(error)
+    )
 }
 
 object PopHandler {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/PushHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/PushHandler.scala
@@ -1,17 +1,21 @@
 package org.enso.languageserver.requesthandler.executioncontext
 
-import akka.actor.{Actor, ActorRef, Cancellable, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import com.typesafe.scalalogging.LazyLogging
 import org.enso.jsonrpc._
-import org.enso.languageserver.requesthandler.RequestTimeout
 import org.enso.languageserver.runtime.ExecutionApi._
 import org.enso.languageserver.runtime.{
   ContextRegistryProtocol,
+  ExecutionApi,
   RuntimeFailureMapper
 }
 import org.enso.languageserver.session.JsonSession
-import org.enso.languageserver.util.UnhandledLogging
+import org.enso.languageserver.util.{
+  RequestHandlerWithRetries,
+  UnhandledLogging
+}
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 /** A request handler for `executionContext/push` commands.
@@ -24,51 +28,50 @@ class PushHandler(
   timeout: FiniteDuration,
   contextRegistry: ActorRef,
   session: JsonSession
-) extends Actor
+) extends RequestHandlerWithRetries[
+      Request[ExecutionContextPush.type, ExecutionContextPush.Params],
+      ContextRegistryProtocol.PushContextResponse,
+      ContextRegistryProtocol.Failure,
+      ContextRegistryProtocol.PushContextRequest
+    ](contextRegistry, timeout, 5)
+    with Actor
     with LazyLogging
     with UnhandledLogging {
 
-  import ContextRegistryProtocol._
-  import context.dispatcher
+  override protected def request(
+    msg: Request[
+      ExecutionApi.ExecutionContextPush.type,
+      ExecutionContextPush.Params
+    ]
+  ): ContextRegistryProtocol.PushContextRequest =
+    ContextRegistryProtocol.PushContextRequest(
+      session,
+      msg.params.contextId,
+      msg.params.stackItem
+    )
 
-  override def receive: Receive = requestStage
-
-  private def requestStage: Receive = {
-    case Request(
-          ExecutionContextPush,
-          id,
-          params: ExecutionContextPush.Params
-        ) =>
-      contextRegistry ! PushContextRequest(
-        session,
-        params.contextId,
-        params.stackItem
-      )
-      val cancellable =
-        context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
-      context.become(responseStage(id, sender(), cancellable))
-  }
-
-  private def responseStage(
-    id: Id,
+  override protected def positiveResponse(
     replyTo: ActorRef,
-    cancellable: Cancellable
-  ): Receive = {
-    case RequestTimeout =>
-      logger.error("Request [{}] timed out.", id)
-      replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
-      context.stop(self)
+    initialMsg: Request[
+      ExecutionApi.ExecutionContextPush.type,
+      ExecutionContextPush.Params
+    ],
+    msg: ContextRegistryProtocol.PushContextResponse
+  ): Unit =
+    replyTo ! ResponseResult(ExecutionContextPush, initialMsg.id, Unused)
 
-    case PushContextResponse(_) =>
-      replyTo ! ResponseResult(ExecutionContextPush, id, Unused)
-      cancellable.cancel()
-      context.stop(self)
-
-    case error: ContextRegistryProtocol.Failure =>
-      replyTo ! ResponseError(Some(id), RuntimeFailureMapper.mapFailure(error))
-      cancellable.cancel()
-      context.stop(self)
-  }
+  override protected def negativeResponse(
+    replyTo: ActorRef,
+    initialMsg: Request[
+      ExecutionApi.ExecutionContextPush.type,
+      ExecutionContextPush.Params
+    ],
+    error: ContextRegistryProtocol.Failure
+  )(implicit ec: ExecutionContext): Unit =
+    replyTo ! ResponseError(
+      Some(initialMsg.id),
+      RuntimeFailureMapper.mapFailure(error)
+    )
 }
 
 object PushHandler {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/PushHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/PushHandler.scala
@@ -33,7 +33,7 @@ class PushHandler(
       ContextRegistryProtocol.PushContextResponse,
       ContextRegistryProtocol.Failure,
       ContextRegistryProtocol.PushContextRequest
-    ](contextRegistry, timeout, 5)
+    ](contextRegistry, timeout)
     with Actor
     with LazyLogging
     with UnhandledLogging {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/RecomputeHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/RecomputeHandler.scala
@@ -1,17 +1,21 @@
 package org.enso.languageserver.requesthandler.executioncontext
 
-import akka.actor.{Actor, ActorRef, Cancellable, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import com.typesafe.scalalogging.LazyLogging
 import org.enso.jsonrpc._
-import org.enso.languageserver.requesthandler.RequestTimeout
 import org.enso.languageserver.runtime.ExecutionApi._
 import org.enso.languageserver.runtime.{
   ContextRegistryProtocol,
+  ExecutionApi,
   RuntimeFailureMapper
 }
 import org.enso.languageserver.session.JsonSession
-import org.enso.languageserver.util.UnhandledLogging
+import org.enso.languageserver.util.{
+  RequestHandlerWithRetries,
+  UnhandledLogging
+}
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 /** A request handler for `executionContext/recompute` commands.
@@ -24,52 +28,51 @@ class RecomputeHandler(
   timeout: FiniteDuration,
   contextRegistry: ActorRef,
   session: JsonSession
-) extends Actor
+) extends RequestHandlerWithRetries[
+      Request[ExecutionContextRecompute.type, ExecutionContextRecompute.Params],
+      ContextRegistryProtocol.RecomputeContextResponse,
+      ContextRegistryProtocol.Failure,
+      ContextRegistryProtocol.RecomputeContextRequest
+    ](contextRegistry, timeout, 5)
+    with Actor
     with LazyLogging
     with UnhandledLogging {
 
-  import ContextRegistryProtocol._
-  import context.dispatcher
+  override protected def request(
+    msg: Request[
+      ExecutionApi.ExecutionContextRecompute.type,
+      ExecutionContextRecompute.Params
+    ]
+  ): ContextRegistryProtocol.RecomputeContextRequest =
+    ContextRegistryProtocol.RecomputeContextRequest(
+      session,
+      msg.params.contextId,
+      msg.params.invalidatedExpressions,
+      msg.params.executionEnvironment
+    )
 
-  override def receive: Receive = requestStage
-
-  private def requestStage: Receive = {
-    case Request(
-          ExecutionContextRecompute,
-          id,
-          params: ExecutionContextRecompute.Params
-        ) =>
-      contextRegistry ! RecomputeContextRequest(
-        session,
-        params.contextId,
-        params.invalidatedExpressions,
-        params.executionEnvironment
-      )
-      val cancellable =
-        context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
-      context.become(responseStage(id, sender(), cancellable))
-  }
-
-  private def responseStage(
-    id: Id,
+  override protected def positiveResponse(
     replyTo: ActorRef,
-    cancellable: Cancellable
-  ): Receive = {
-    case RequestTimeout =>
-      logger.error("Request [{}] timed out.", id)
-      replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
-      context.stop(self)
+    initialMsg: Request[
+      ExecutionApi.ExecutionContextRecompute.type,
+      ExecutionContextRecompute.Params
+    ],
+    msg: ContextRegistryProtocol.RecomputeContextResponse
+  ): Unit =
+    replyTo ! ResponseResult(ExecutionContextRecompute, initialMsg.id, Unused)
 
-    case RecomputeContextResponse(_) =>
-      replyTo ! ResponseResult(ExecutionContextRecompute, id, Unused)
-      cancellable.cancel()
-      context.stop(self)
-
-    case error: ContextRegistryProtocol.Failure =>
-      replyTo ! ResponseError(Some(id), RuntimeFailureMapper.mapFailure(error))
-      cancellable.cancel()
-      context.stop(self)
-  }
+  override protected def negativeResponse(
+    replyTo: ActorRef,
+    initialMsg: Request[
+      ExecutionApi.ExecutionContextRecompute.type,
+      ExecutionContextRecompute.Params
+    ],
+    error: ContextRegistryProtocol.Failure
+  )(implicit ec: ExecutionContext): Unit =
+    replyTo ! ResponseError(
+      Some(initialMsg.id),
+      RuntimeFailureMapper.mapFailure(error)
+    )
 }
 
 object RecomputeHandler {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/RecomputeHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/RecomputeHandler.scala
@@ -33,7 +33,7 @@ class RecomputeHandler(
       ContextRegistryProtocol.RecomputeContextResponse,
       ContextRegistryProtocol.Failure,
       ContextRegistryProtocol.RecomputeContextRequest
-    ](contextRegistry, timeout, 5)
+    ](contextRegistry, timeout)
     with Actor
     with LazyLogging
     with UnhandledLogging {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/SetExecutionEnvironmentHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/SetExecutionEnvironmentHandler.scala
@@ -1,17 +1,21 @@
 package org.enso.languageserver.requesthandler.executioncontext
 
-import akka.actor.{Actor, ActorRef, Cancellable, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import com.typesafe.scalalogging.LazyLogging
 import org.enso.jsonrpc._
-import org.enso.languageserver.requesthandler.RequestTimeout
 import org.enso.languageserver.runtime.ExecutionApi._
 import org.enso.languageserver.runtime.{
   ContextRegistryProtocol,
+  ExecutionApi,
   RuntimeFailureMapper
 }
 import org.enso.languageserver.session.JsonSession
-import org.enso.languageserver.util.UnhandledLogging
+import org.enso.languageserver.util.{
+  RequestHandlerWithRetries,
+  UnhandledLogging
+}
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 /** A request handler for `executionContext/setExecutionEnvironment` commands.
@@ -24,51 +28,53 @@ class SetExecutionEnvironmentHandler(
   timeout: FiniteDuration,
   contextRegistry: ActorRef,
   session: JsonSession
-) extends Actor
+) extends RequestHandlerWithRetries[
+      Request[
+        ExecutionContextRecompute.type,
+        ExecutionContextSetExecutionEnvironment.Params
+      ],
+      ContextRegistryProtocol.SetExecutionEnvironmentResponse,
+      ContextRegistryProtocol.Failure,
+      ContextRegistryProtocol.SetExecutionEnvironmentRequest
+    ](contextRegistry, timeout, 5)
+    with Actor
     with LazyLogging
     with UnhandledLogging {
 
-  import ContextRegistryProtocol._
-  import context.dispatcher
+  override protected def request(
+    msg: Request[
+      ExecutionApi.ExecutionContextRecompute.type,
+      ExecutionContextSetExecutionEnvironment.Params
+    ]
+  ): ContextRegistryProtocol.SetExecutionEnvironmentRequest =
+    ContextRegistryProtocol.SetExecutionEnvironmentRequest(
+      session,
+      msg.params.contextId,
+      msg.params.executionEnvironment
+    )
 
-  override def receive: Receive = requestStage
-
-  private def requestStage: Receive = {
-    case Request(
-          ExecutionContextSetExecutionEnvironment,
-          id,
-          params: ExecutionContextSetExecutionEnvironment.Params
-        ) =>
-      contextRegistry ! SetExecutionEnvironmentRequest(
-        session,
-        params.contextId,
-        params.executionEnvironment
-      )
-      val cancellable =
-        context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
-      context.become(responseStage(id, sender(), cancellable))
-  }
-
-  private def responseStage(
-    id: Id,
+  override protected def positiveResponse(
     replyTo: ActorRef,
-    cancellable: Cancellable
-  ): Receive = {
-    case RequestTimeout =>
-      logger.error("Request [{}] timed out.", id)
-      replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
-      context.stop(self)
+    initialMsg: Request[
+      ExecutionApi.ExecutionContextRecompute.type,
+      ExecutionContextSetExecutionEnvironment.Params
+    ],
+    msg: ContextRegistryProtocol.SetExecutionEnvironmentResponse
+  ): Unit =
+    replyTo ! ResponseResult(ExecutionContextRecompute, initialMsg.id, Unused)
 
-    case SetExecutionEnvironmentResponse(_) =>
-      replyTo ! ResponseResult(ExecutionContextRecompute, id, Unused)
-      cancellable.cancel()
-      context.stop(self)
-
-    case error: ContextRegistryProtocol.Failure =>
-      replyTo ! ResponseError(Some(id), RuntimeFailureMapper.mapFailure(error))
-      cancellable.cancel()
-      context.stop(self)
-  }
+  override protected def negativeResponse(
+    replyTo: ActorRef,
+    initialMsg: Request[
+      ExecutionApi.ExecutionContextRecompute.type,
+      ExecutionContextSetExecutionEnvironment.Params
+    ],
+    error: ContextRegistryProtocol.Failure
+  )(implicit ec: ExecutionContext): Unit =
+    replyTo ! ResponseError(
+      Some(initialMsg.id),
+      RuntimeFailureMapper.mapFailure(error)
+    )
 }
 
 object SetExecutionEnvironmentHandler {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/SetExecutionEnvironmentHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/executioncontext/SetExecutionEnvironmentHandler.scala
@@ -36,7 +36,7 @@ class SetExecutionEnvironmentHandler(
       ContextRegistryProtocol.SetExecutionEnvironmentResponse,
       ContextRegistryProtocol.Failure,
       ContextRegistryProtocol.SetExecutionEnvironmentRequest
-    ](contextRegistry, timeout, 5)
+    ](contextRegistry, timeout)
     with Actor
     with LazyLogging
     with UnhandledLogging {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/refactoring/RenameProjectHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/refactoring/RenameProjectHandler.scala
@@ -24,7 +24,7 @@ class RenameProjectHandler(timeout: FiniteDuration, target: ActorRef)
     extends ApiHandlerWithRetries[
       Request[RenameProject.type, RenameProject.Params],
       Api.ProjectRenamed
-    ](target, timeout, 10)
+    ](target, timeout)
     with Actor
     with LazyLogging
     with UnhandledLogging {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/refactoring/RenameSymbolHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/refactoring/RenameSymbolHandler.scala
@@ -24,7 +24,7 @@ class RenameSymbolHandler(
 ) extends ApiHandlerWithRetries[
       Request[RenameSymbol.type, RenameSymbol.Params],
       Api.SymbolRenamed
-    ](runtime, timeout, 10)
+    ](runtime, timeout)
     with Actor
     with LazyLogging
     with UnhandledLogging {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/refactoring/RenameSymbolHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/refactoring/RenameSymbolHandler.scala
@@ -1,84 +1,78 @@
 package org.enso.languageserver.requesthandler.refactoring
 
-import akka.actor.{Actor, ActorRef, Cancellable, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import com.typesafe.scalalogging.LazyLogging
 import org.enso.jsonrpc._
 import org.enso.languageserver.refactoring.RefactoringApi.RenameSymbol
-import org.enso.languageserver.refactoring.RenameFailureMapper
-import org.enso.languageserver.requesthandler.RequestTimeout
+import org.enso.languageserver.refactoring.{RefactoringApi, RenameFailureMapper}
 import org.enso.languageserver.runtime.ExecutionApi
-import org.enso.languageserver.util.UnhandledLogging
+import org.enso.languageserver.util.{ApiHandlerWithRetries, UnhandledLogging}
 import org.enso.polyglot.runtime.Runtime.Api
 
 import java.util.UUID
-
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 /** A request handler for `refactoring/renameSymbol` commands.
   *
   * @param timeout a request timeout
-  * @param runtimeConnector a reference to the runtime connector
+  * @param runtime a reference to the runtime connector
   */
 class RenameSymbolHandler(
   timeout: FiniteDuration,
-  runtimeConnector: ActorRef
-) extends Actor
+  runtime: ActorRef
+) extends ApiHandlerWithRetries[
+      Request[RenameSymbol.type, RenameSymbol.Params],
+      Api.SymbolRenamed
+    ](runtime, timeout, 10)
+    with Actor
     with LazyLogging
     with UnhandledLogging {
 
-  import context.dispatcher
+  var id: Id = null
 
-  override def receive: Receive = requestStage
-
-  private def requestStage: Receive = {
-    case Request(RenameSymbol, id, params: RenameSymbol.Params) =>
-      val payload =
-        Api.RenameSymbol(params.module, params.expressionId, params.newName)
-      runtimeConnector ! Api.Request(UUID.randomUUID(), payload)
-      val cancellable =
-        context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
-      context.become(
-        responseStage(
-          id,
-          sender(),
-          cancellable
-        )
-      )
+  override protected def request(
+    msg: Request[RefactoringApi.RenameSymbol.type, RenameSymbol.Params]
+  ): Api.Request = {
+    val Request(RenameSymbol, _, params: RenameSymbol.Params) = msg
+    val payload =
+      Api.RenameSymbol(params.module, params.expressionId, params.newName)
+    id = msg.id
+    Api.Request(UUID.randomUUID(), payload)
   }
 
-  private def responseStage(
-    id: Id,
+  override protected def positiveResponse(
     replyTo: ActorRef,
-    cancellable: Cancellable
-  ): Receive = {
-    case RequestTimeout =>
-      logger.error("Request [{}] timed out.", id)
-      replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
-      context.stop(self)
-
-    case Api.Response(_, Api.SymbolRenamed(newName)) =>
-      replyTo ! ResponseResult(
-        RenameSymbol,
-        id,
-        RenameSymbol.Result(newName)
-      )
-      cancellable.cancel()
-      context.stop(self)
-
-    case Api.Response(_, Api.ModuleNotFound(moduleName)) =>
-      replyTo ! ResponseError(
-        Some(id),
-        ExecutionApi.ModuleNotFoundError(moduleName)
-      )
-      cancellable.cancel()
-      context.stop(self)
-
-    case Api.Response(_, Api.SymbolRenameFailed(error)) =>
-      replyTo ! ResponseError(Some(id), RenameFailureMapper.mapFailure(error))
-      cancellable.cancel()
-      context.stop(self)
+    msg: Api.SymbolRenamed
+  ): Unit = {
+    replyTo ! ResponseResult(
+      RenameSymbol,
+      id,
+      RenameSymbol.Result(msg.newName)
+    )
   }
 
+  override protected def negativeResponse(
+    replyTo: ActorRef,
+    error: Api.Error
+  )(implicit
+    ec: ExecutionContext
+  ): Unit = {
+    error match {
+      case Api.ModuleNotFound(moduleName) =>
+        replyTo ! ResponseError(
+          Some(id),
+          ExecutionApi.ModuleNotFoundError(moduleName)
+        )
+      case Api.SymbolRenameFailed(error) =>
+        replyTo ! ResponseError(
+          Some(id),
+          RenameFailureMapper.mapFailure(error)
+        )
+      case _ =>
+        logger.error(s"unexpected error response $error")
+    }
+  }
 }
 
 object RenameSymbolHandler {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/CreateContextHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/CreateContextHandler.scala
@@ -7,7 +7,7 @@ import org.enso.languageserver.runtime.{
   ContextRegistryProtocol,
   RuntimeFailureMapper
 }
-import org.enso.languageserver.util.{HandlerWithRetries, UnhandledLogging}
+import org.enso.languageserver.util.{ApiHandlerWithRetries, UnhandledLogging}
 import org.enso.polyglot.runtime.Runtime.Api
 
 import java.util.UUID
@@ -18,16 +18,16 @@ import scala.concurrent.duration.FiniteDuration
   *
   * @param runtimeFailureMapper mapper for runtime failures
   * @param timeout request timeout
-  * @param runtime reference to the runtime connector
+  * @param target reference to the runtime connector
   */
 final class CreateContextHandler(
   runtimeFailureMapper: RuntimeFailureMapper,
   timeout: FiniteDuration,
-  runtime: ActorRef
-) extends HandlerWithRetries[
+  target: ActorRef
+) extends ApiHandlerWithRetries[
       Api.CreateContextRequest,
       Api.CreateContextResponse
-    ](runtime, timeout, 10)
+    ](target, timeout, 10)
     with Actor
     with LazyLogging
     with UnhandledLogging {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/CreateContextHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/CreateContextHandler.scala
@@ -27,7 +27,7 @@ final class CreateContextHandler(
 ) extends ApiHandlerWithRetries[
       Api.CreateContextRequest,
       Api.CreateContextResponse
-    ](target, timeout, 10)
+    ](target, timeout)
     with Actor
     with LazyLogging
     with UnhandledLogging {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/DestroyContextHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/DestroyContextHandler.scala
@@ -7,7 +7,7 @@ import org.enso.languageserver.runtime.{
   ContextRegistryProtocol,
   RuntimeFailureMapper
 }
-import org.enso.languageserver.util.{HandlerWithRetries, UnhandledLogging}
+import org.enso.languageserver.util.{ApiHandlerWithRetries, UnhandledLogging}
 import org.enso.polyglot.runtime.Runtime.Api
 
 import java.util.UUID
@@ -24,7 +24,7 @@ final class DestroyContextHandler(
   runtimeFailureMapper: RuntimeFailureMapper,
   timeout: FiniteDuration,
   runtime: ActorRef
-) extends HandlerWithRetries[
+) extends ApiHandlerWithRetries[
       Api.DestroyContextRequest,
       Api.DestroyContextResponse
     ](runtime, timeout, 10)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/DestroyContextHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/DestroyContextHandler.scala
@@ -1,17 +1,17 @@
 package org.enso.languageserver.runtime.handler
 
-import akka.actor.{Actor, ActorRef, Cancellable, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import akka.pattern.pipe
 import com.typesafe.scalalogging.LazyLogging
-import org.enso.languageserver.requesthandler.RequestTimeout
 import org.enso.languageserver.runtime.{
   ContextRegistryProtocol,
   RuntimeFailureMapper
 }
-import org.enso.languageserver.util.UnhandledLogging
+import org.enso.languageserver.util.{HandlerWithRetries, UnhandledLogging}
 import org.enso.polyglot.runtime.Runtime.Api
 
 import java.util.UUID
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 /** A request handler for destroy context commands.
@@ -24,40 +24,27 @@ final class DestroyContextHandler(
   runtimeFailureMapper: RuntimeFailureMapper,
   timeout: FiniteDuration,
   runtime: ActorRef
-) extends Actor
+) extends HandlerWithRetries[
+      Api.DestroyContextRequest,
+      Api.DestroyContextResponse
+    ](runtime, timeout, 10)
+    with Actor
     with LazyLogging
     with UnhandledLogging {
 
-  import ContextRegistryProtocol._
-  import context.dispatcher
+  override protected def request(msg: Api.DestroyContextRequest): Api.Request =
+    Api.Request(UUID.randomUUID(), msg)
 
-  override def receive: Receive = requestStage
-
-  private def requestStage: Receive = { case msg: Api.DestroyContextRequest =>
-    runtime ! Api.Request(UUID.randomUUID(), msg)
-    val cancellable =
-      context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
-    context.become(responseStage(sender(), cancellable))
-  }
-
-  private def responseStage(
+  override protected def positiveResponse(
     replyTo: ActorRef,
-    cancellable: Cancellable
-  ): Receive = {
-    case RequestTimeout =>
-      replyTo ! RequestTimeout
-      context.stop(self)
+    msg: Api.DestroyContextResponse
+  ): Unit =
+    replyTo ! ContextRegistryProtocol.DestroyContextResponse(msg.contextId)
 
-    case Api.Response(_, Api.DestroyContextResponse(contextId)) =>
-      replyTo ! DestroyContextResponse(contextId)
-      cancellable.cancel()
-      context.stop(self)
-
-    case Api.Response(_, error: Api.Error) =>
-      runtimeFailureMapper.mapApiError(error).pipeTo(replyTo)
-      cancellable.cancel()
-      context.stop(self)
-  }
+  override protected def negativeResponse(replyTo: ActorRef, error: Api.Error)(
+    implicit ec: ExecutionContext
+  ): Unit =
+    runtimeFailureMapper.mapApiError(error).pipeTo(replyTo)
 }
 
 object DestroyContextHandler {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/DestroyContextHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/DestroyContextHandler.scala
@@ -27,7 +27,7 @@ final class DestroyContextHandler(
 ) extends ApiHandlerWithRetries[
       Api.DestroyContextRequest,
       Api.DestroyContextResponse
-    ](runtime, timeout, 10)
+    ](runtime, timeout)
     with Actor
     with LazyLogging
     with UnhandledLogging {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PopContextHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PopContextHandler.scala
@@ -27,11 +27,7 @@ final class PopContextHandler(
 ) extends ApiHandlerWithRetries[
       Api.PopContextRequest,
       Api.PopContextResponse
-    ](
-      runtime,
-      timeout,
-      5
-    )
+    ](runtime, timeout)
     with Actor
     with LazyLogging
     with UnhandledLogging {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PopContextHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PopContextHandler.scala
@@ -1,17 +1,17 @@
 package org.enso.languageserver.runtime.handler
 
-import akka.actor.{Actor, ActorRef, Cancellable, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import akka.pattern.pipe
 import com.typesafe.scalalogging.LazyLogging
-import org.enso.languageserver.requesthandler.RequestTimeout
 import org.enso.languageserver.runtime.{
   ContextRegistryProtocol,
   RuntimeFailureMapper
 }
-import org.enso.languageserver.util.UnhandledLogging
+import org.enso.languageserver.util.{HandlerWithRetries, UnhandledLogging}
 import org.enso.polyglot.runtime.Runtime.Api
 
 import java.util.UUID
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 /** A request handler for push commands.
@@ -24,39 +24,28 @@ final class PopContextHandler(
   runtimeFailureMapper: RuntimeFailureMapper,
   timeout: FiniteDuration,
   runtime: ActorRef
-) extends Actor
+) extends HandlerWithRetries[Api.PopContextRequest, Api.PopContextResponse](
+      runtime,
+      timeout,
+      5
+    )
+    with Actor
     with LazyLogging
     with UnhandledLogging {
 
-  import context.dispatcher
+  override protected def request(msg: Api.PopContextRequest): Api.Request =
+    Api.Request(UUID.randomUUID(), msg)
 
-  override def receive: Receive = requestStage
-
-  private def requestStage: Receive = { case msg: Api.PopContextRequest =>
-    runtime ! Api.Request(UUID.randomUUID(), msg)
-    val cancellable =
-      context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
-    context.become(responseStage(sender(), cancellable))
-  }
-
-  private def responseStage(
+  override protected def positiveResponse(
     replyTo: ActorRef,
-    cancellable: Cancellable
-  ): Receive = {
-    case RequestTimeout =>
-      replyTo ! RequestTimeout
-      context.stop(self)
+    msg: Api.PopContextResponse
+  ): Unit =
+    replyTo ! ContextRegistryProtocol.PopContextResponse(msg.contextId)
 
-    case Api.Response(_, Api.PopContextResponse(contextId)) =>
-      replyTo ! ContextRegistryProtocol.PopContextResponse(contextId)
-      cancellable.cancel()
-      context.stop(self)
-
-    case Api.Response(_, error: Api.Error) =>
-      runtimeFailureMapper.mapApiError(error).pipeTo(replyTo)
-      cancellable.cancel()
-      context.stop(self)
-  }
+  override protected def negativeResponse(replyTo: ActorRef, error: Api.Error)(
+    implicit ec: ExecutionContext
+  ): Unit =
+    runtimeFailureMapper.mapApiError(error).pipeTo(replyTo)
 }
 
 object PopContextHandler {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PopContextHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PopContextHandler.scala
@@ -7,7 +7,7 @@ import org.enso.languageserver.runtime.{
   ContextRegistryProtocol,
   RuntimeFailureMapper
 }
-import org.enso.languageserver.util.{HandlerWithRetries, UnhandledLogging}
+import org.enso.languageserver.util.{ApiHandlerWithRetries, UnhandledLogging}
 import org.enso.polyglot.runtime.Runtime.Api
 
 import java.util.UUID
@@ -24,7 +24,10 @@ final class PopContextHandler(
   runtimeFailureMapper: RuntimeFailureMapper,
   timeout: FiniteDuration,
   runtime: ActorRef
-) extends HandlerWithRetries[Api.PopContextRequest, Api.PopContextResponse](
+) extends ApiHandlerWithRetries[
+      Api.PopContextRequest,
+      Api.PopContextResponse
+    ](
       runtime,
       timeout,
       5

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PushContextHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PushContextHandler.scala
@@ -27,11 +27,7 @@ final class PushContextHandler(
 ) extends ApiHandlerWithRetries[
       Api.PushContextRequest,
       Api.PushContextResponse
-    ](
-      runtime,
-      timeout,
-      5
-    )
+    ](runtime, timeout)
     with Actor
     with LazyLogging
     with UnhandledLogging {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PushContextHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PushContextHandler.scala
@@ -7,7 +7,7 @@ import org.enso.languageserver.runtime.{
   ContextRegistryProtocol,
   RuntimeFailureMapper
 }
-import org.enso.languageserver.util.{HandlerWithRetries, UnhandledLogging}
+import org.enso.languageserver.util.{ApiHandlerWithRetries, UnhandledLogging}
 import org.enso.polyglot.runtime.Runtime.Api
 
 import java.util.UUID
@@ -24,7 +24,10 @@ final class PushContextHandler(
   runtimeFailureMapper: RuntimeFailureMapper,
   timeout: FiniteDuration,
   runtime: ActorRef
-) extends HandlerWithRetries[Api.PushContextRequest, Api.PushContextResponse](
+) extends ApiHandlerWithRetries[
+      Api.PushContextRequest,
+      Api.PushContextResponse
+    ](
       runtime,
       timeout,
       5

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PushContextHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/PushContextHandler.scala
@@ -1,17 +1,17 @@
 package org.enso.languageserver.runtime.handler
 
-import akka.actor.{Actor, ActorRef, Cancellable, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import akka.pattern.pipe
 import com.typesafe.scalalogging.LazyLogging
-import org.enso.languageserver.requesthandler.RequestTimeout
 import org.enso.languageserver.runtime.{
   ContextRegistryProtocol,
   RuntimeFailureMapper
 }
-import org.enso.languageserver.util.UnhandledLogging
+import org.enso.languageserver.util.{HandlerWithRetries, UnhandledLogging}
 import org.enso.polyglot.runtime.Runtime.Api
 
 import java.util.UUID
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 /** A request handler for push commands.
@@ -24,39 +24,28 @@ final class PushContextHandler(
   runtimeFailureMapper: RuntimeFailureMapper,
   timeout: FiniteDuration,
   runtime: ActorRef
-) extends Actor
+) extends HandlerWithRetries[Api.PushContextRequest, Api.PushContextResponse](
+      runtime,
+      timeout,
+      5
+    )
+    with Actor
     with LazyLogging
     with UnhandledLogging {
 
-  import context.dispatcher
+  override protected def request(msg: Api.PushContextRequest): Api.Request =
+    Api.Request(UUID.randomUUID(), msg)
 
-  override def receive: Receive = requestStage
-
-  private def requestStage: Receive = { case msg: Api.PushContextRequest =>
-    runtime ! Api.Request(UUID.randomUUID(), msg)
-    val cancellable =
-      context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
-    context.become(responseStage(sender(), cancellable))
-  }
-
-  private def responseStage(
+  override protected def positiveResponse(
     replyTo: ActorRef,
-    cancellable: Cancellable
-  ): Receive = {
-    case RequestTimeout =>
-      replyTo ! RequestTimeout
-      context.stop(self)
+    msg: Api.PushContextResponse
+  ): Unit =
+    replyTo ! ContextRegistryProtocol.PushContextResponse(msg.contextId)
 
-    case Api.Response(_, Api.PushContextResponse(contextId)) =>
-      replyTo ! ContextRegistryProtocol.PushContextResponse(contextId)
-      cancellable.cancel()
-      context.stop(self)
-
-    case Api.Response(_, error: Api.Error) =>
-      runtimeFailureMapper.mapApiError(error).pipeTo(replyTo)
-      cancellable.cancel()
-      context.stop(self)
-  }
+  override protected def negativeResponse(replyTo: ActorRef, error: Api.Error)(
+    implicit ec: ExecutionContext
+  ): Unit =
+    runtimeFailureMapper.mapApiError(error).pipeTo(replyTo)
 }
 
 object PushContextHandler {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/RecomputeContextHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/RecomputeContextHandler.scala
@@ -7,7 +7,7 @@ import org.enso.languageserver.runtime.{
   ContextRegistryProtocol,
   RuntimeFailureMapper
 }
-import org.enso.languageserver.util.{HandlerWithRetries, UnhandledLogging}
+import org.enso.languageserver.util.{ApiHandlerWithRetries, UnhandledLogging}
 import org.enso.polyglot.runtime.Runtime.Api
 
 import java.util.UUID
@@ -24,7 +24,7 @@ final class RecomputeContextHandler(
   runtimeFailureMapper: RuntimeFailureMapper,
   timeout: FiniteDuration,
   runtime: ActorRef
-) extends HandlerWithRetries[
+) extends ApiHandlerWithRetries[
       Api.RecomputeContextRequest,
       Api.RecomputeContextResponse
     ](runtime, timeout, 10)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/RecomputeContextHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/RecomputeContextHandler.scala
@@ -27,7 +27,7 @@ final class RecomputeContextHandler(
 ) extends ApiHandlerWithRetries[
       Api.RecomputeContextRequest,
       Api.RecomputeContextResponse
-    ](runtime, timeout, 10)
+    ](runtime, timeout)
     with Actor
     with LazyLogging
     with UnhandledLogging {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/RecomputeContextHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/RecomputeContextHandler.scala
@@ -1,17 +1,17 @@
 package org.enso.languageserver.runtime.handler
 
-import akka.actor.{Actor, ActorRef, Cancellable, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import akka.pattern.pipe
 import com.typesafe.scalalogging.LazyLogging
-import org.enso.languageserver.requesthandler.RequestTimeout
 import org.enso.languageserver.runtime.{
   ContextRegistryProtocol,
   RuntimeFailureMapper
 }
-import org.enso.languageserver.util.UnhandledLogging
+import org.enso.languageserver.util.{HandlerWithRetries, UnhandledLogging}
 import org.enso.polyglot.runtime.Runtime.Api
 
 import java.util.UUID
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 /** A request handler for recompute commands.
@@ -24,40 +24,29 @@ final class RecomputeContextHandler(
   runtimeFailureMapper: RuntimeFailureMapper,
   timeout: FiniteDuration,
   runtime: ActorRef
-) extends Actor
+) extends HandlerWithRetries[
+      Api.RecomputeContextRequest,
+      Api.RecomputeContextResponse
+    ](runtime, timeout, 10)
+    with Actor
     with LazyLogging
     with UnhandledLogging {
 
-  import ContextRegistryProtocol._
-  import context.dispatcher
+  override protected def request(
+    msg: Api.RecomputeContextRequest
+  ): Api.Request =
+    Api.Request(UUID.randomUUID(), msg)
 
-  override def receive: Receive = requestStage
-
-  private def requestStage: Receive = { case msg: Api.RecomputeContextRequest =>
-    runtime ! Api.Request(UUID.randomUUID(), msg)
-    val cancellable =
-      context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
-    context.become(responseStage(sender(), cancellable))
-  }
-
-  private def responseStage(
+  override protected def positiveResponse(
     replyTo: ActorRef,
-    cancellable: Cancellable
-  ): Receive = {
-    case RequestTimeout =>
-      replyTo ! RequestTimeout
-      context.stop(self)
+    msg: Api.RecomputeContextResponse
+  ): Unit =
+    replyTo ! ContextRegistryProtocol.RecomputeContextResponse(msg.contextId)
 
-    case Api.Response(_, Api.RecomputeContextResponse(contextId)) =>
-      replyTo ! RecomputeContextResponse(contextId)
-      cancellable.cancel()
-      context.stop(self)
-
-    case Api.Response(_, error: Api.Error) =>
-      runtimeFailureMapper.mapApiError(error).pipeTo(replyTo)
-      cancellable.cancel()
-      context.stop(self)
-  }
+  override protected def negativeResponse(replyTo: ActorRef, error: Api.Error)(
+    implicit ec: ExecutionContext
+  ): Unit =
+    runtimeFailureMapper.mapApiError(error).pipeTo(replyTo)
 }
 
 object RecomputeContextHandler {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/SetExecutionContextEnvironmentHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/SetExecutionContextEnvironmentHandler.scala
@@ -7,7 +7,7 @@ import org.enso.languageserver.runtime.{
   ContextRegistryProtocol,
   RuntimeFailureMapper
 }
-import org.enso.languageserver.util.{HandlerWithRetries, UnhandledLogging}
+import org.enso.languageserver.util.{ApiHandlerWithRetries, UnhandledLogging}
 import org.enso.polyglot.runtime.Runtime.Api
 
 import java.util.UUID
@@ -24,7 +24,7 @@ final class SetExecutionContextEnvironmentHandler(
   runtimeFailureMapper: RuntimeFailureMapper,
   timeout: FiniteDuration,
   runtime: ActorRef
-) extends HandlerWithRetries[
+) extends ApiHandlerWithRetries[
       Api.SetExecutionEnvironmentRequest,
       Api.SetExecutionEnvironmentResponse
     ](runtime, timeout, 10)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/SetExecutionContextEnvironmentHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/runtime/handler/SetExecutionContextEnvironmentHandler.scala
@@ -27,7 +27,7 @@ final class SetExecutionContextEnvironmentHandler(
 ) extends ApiHandlerWithRetries[
       Api.SetExecutionEnvironmentRequest,
       Api.SetExecutionEnvironmentResponse
-    ](runtime, timeout, 10)
+    ](runtime, timeout)
     with Actor
     with LazyLogging
     with UnhandledLogging {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/search/SuggestionsHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/search/SuggestionsHandler.scala
@@ -197,7 +197,7 @@ final class SuggestionsHandler(
 
     case msg: Api.SuggestionsDatabaseSuggestionsLoadedNotification =>
       logger.debug(
-        "Starting loading suggestions for library [{0}].",
+        "Starting loading suggestions for library [{}].",
         msg.libraryName
       )
       context.become(
@@ -212,7 +212,7 @@ final class SuggestionsHandler(
         .onComplete {
           case Success(notification) =>
             logger.debug(
-              "Complete loading suggestions for library [{0}]. Has updates: {1}",
+              "Complete loading suggestions for library [{}]. Has updates: {}",
               msg.libraryName,
               notification.updates.nonEmpty
             )
@@ -224,7 +224,7 @@ final class SuggestionsHandler(
             self ! SuggestionsHandler.SuggestionLoadingCompleted
           case Failure(ex) =>
             logger.error(
-              "Error applying suggestion updates for loaded library [{0}].",
+              "Error applying suggestion updates for loaded library [{}].",
               msg.libraryName,
               ex
             )

--- a/engine/language-server/src/main/scala/org/enso/languageserver/search/handler/InvalidateModulesIndexHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/search/handler/InvalidateModulesIndexHandler.scala
@@ -5,7 +5,7 @@ import akka.pattern.pipe
 import com.typesafe.scalalogging.LazyLogging
 import org.enso.languageserver.runtime.RuntimeFailureMapper
 import org.enso.languageserver.search.SearchProtocol
-import org.enso.languageserver.util.{HandlerWithRetries, UnhandledLogging}
+import org.enso.languageserver.util.{ApiHandlerWithRetries, UnhandledLogging}
 import org.enso.polyglot.runtime.Runtime.Api
 
 import java.util.UUID
@@ -24,7 +24,7 @@ final class InvalidateModulesIndexHandler(
   runtime: ActorRef,
   suggestionsHandler: ActorRef,
   timeout: FiniteDuration
-) extends HandlerWithRetries[
+) extends ApiHandlerWithRetries[
       SearchProtocol.InvalidateModulesIndex.type,
       Api.InvalidateModulesIndexResponse
     ](runtime, timeout, 10)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/search/handler/InvalidateModulesIndexHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/search/handler/InvalidateModulesIndexHandler.scala
@@ -27,7 +27,7 @@ final class InvalidateModulesIndexHandler(
 ) extends ApiHandlerWithRetries[
       SearchProtocol.InvalidateModulesIndex.type,
       Api.InvalidateModulesIndexResponse
-    ](runtime, timeout, 10)
+    ](runtime, timeout)
     with Actor
     with LazyLogging
     with UnhandledLogging {

--- a/engine/language-server/src/main/scala/org/enso/languageserver/util/HandlerWithRetries.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/util/HandlerWithRetries.scala
@@ -9,10 +9,46 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
 
+/** Handler base class with retries support.
+  *
+  * @tparam RequestType type of the message being handled
+  * @tparam ResponseType type of the message expected when message is successfully handled
+  * @tparam ErrorType type of the message expected when message has failed to be handled
+  * @tparam ForwardedPayloadType type of the message forwarded to `target`
+  */
 abstract class HandlerWithRetries[
+  RequestType,
+  ResponseType,
+  ErrorType,
+  ForwardedPayloadType
+] {
+  a: Actor with LazyLogging =>
+
+  override def receive: Receive = requestStage
+
+  protected def request(msg: RequestType): ForwardedPayloadType
+
+  protected def requestStage: Receive
+}
+
+/** API handler base class with retries support.
+  *
+  * @param target target actor which will handle a message
+  * @param timeout timeout for serving a message
+  * @param retries number of retries attempted on timeout before aborting
+  * @tparam RequestType type of the message being handled
+  * @tparam ResponseType type of the message expected when message is successfully handled
+  */
+abstract class ApiHandlerWithRetries[
   RequestType: ClassTag,
   ResponseType: ClassTag
-](runtime: ActorRef, timeout: FiniteDuration, retries: Int) {
+](target: ActorRef, timeout: FiniteDuration, retries: Int)
+    extends HandlerWithRetries[
+      RequestType,
+      ResponseType,
+      Api.Error,
+      Api.Request
+    ] {
   a: Actor with LazyLogging =>
 
   def this(runtime: ActorRef, timeout: FiniteDuration) = {
@@ -27,7 +63,7 @@ abstract class HandlerWithRetries[
 
   protected def requestStage: Receive = { case msg: RequestType =>
     val req = request(msg)
-    runtime ! req
+    target ! req
     val cancellable =
       context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
     context.become(responseStage(sender(), req, cancellable, retries))
@@ -35,21 +71,31 @@ abstract class HandlerWithRetries[
 
   private def responseStage(
     replyTo: ActorRef,
-    request: Api.Request,
+    forwardedRequest: Api.Request,
     cancellable: Cancellable,
     retries: Int
   ): Receive = {
     case RequestTimeout =>
-      logger.warn(
-        "Failed to receive a [{}] response in [{}]. Retrying.",
-        request,
-        timeout
-      )
-      val newCancellable =
-        context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
-      context.become(
-        responseStage(replyTo, request, newCancellable, retries - 1)
-      )
+      if (retries > 0) {
+        logger.warn(
+          "Failed to receive a [{}] response in [{}]. Retrying.",
+          forwardedRequest,
+          timeout
+        )
+        val newCancellable =
+          context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
+        context.become(
+          responseStage(
+            replyTo,
+            forwardedRequest,
+            newCancellable,
+            retries - 1
+          )
+        )
+      } else {
+        replyTo ! RequestTimeout
+        context.stop(self)
+      }
 
     case Api.Response(_, msg: ResponseType) =>
       positiveResponse(replyTo, msg)
@@ -60,10 +106,112 @@ abstract class HandlerWithRetries[
       negativeResponse(replyTo, error)
       cancellable.cancel()
       context.stop(self)
+
   }
 
   protected def positiveResponse(replyTo: ActorRef, msg: ResponseType): Unit
+
   protected def negativeResponse(replyTo: ActorRef, error: Api.Error)(implicit
+    ec: ExecutionContext
+  ): Unit
+
+}
+
+/** Request handler base class with retries support.
+  *
+  * @param target target actor which will handle a message
+  * @param timeout timeout for serving a message
+  * @param retries number of retries attempted on timeout before aborting
+  * @tparam RequestType type of the message being handled
+  * @tparam ResponseType type of the message expected when message is successfully handled
+  * @tparam ErrorType type of the message expected when message has failed to be handled
+  * @tparam ForwardedPayloadType type of the message forwarded to `target`
+  */
+abstract class RequestHandlerWithRetries[
+  RequestType: ClassTag,
+  ResponseType: ClassTag,
+  ErrorType: ClassTag,
+  ForwardedPayloadType
+](target: ActorRef, timeout: FiniteDuration, retries: Int)
+    extends HandlerWithRetries[
+      RequestType,
+      ResponseType,
+      ErrorType,
+      ForwardedPayloadType
+    ] {
+  a: Actor with LazyLogging =>
+
+  def this(runtime: ActorRef, timeout: FiniteDuration) = {
+    this(runtime, timeout, 10)
+  }
+
+  import context.dispatcher
+
+  override def receive: Receive = requestStage
+
+  protected def request(msg: RequestType): ForwardedPayloadType
+
+  protected def requestStage: Receive = { case msg: RequestType =>
+    val req = request(msg)
+    target ! req
+    val cancellable =
+      context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
+    context.become(responseStage(sender(), msg, req, cancellable, retries))
+  }
+
+  private def responseStage(
+    replyTo: ActorRef,
+    initialMsg: RequestType,
+    forwardedRequest: ForwardedPayloadType,
+    cancellable: Cancellable,
+    retries: Int
+  ): Receive = {
+    case RequestTimeout =>
+      if (retries > 0) {
+        logger.warn(
+          "Failed to receive a [{}] response in [{}]. Retrying.",
+          forwardedRequest,
+          timeout
+        )
+        val newCancellable =
+          context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
+        context.become(
+          responseStage(
+            replyTo,
+            initialMsg,
+            forwardedRequest,
+            newCancellable,
+            retries - 1
+          )
+        )
+      } else {
+        replyTo ! RequestTimeout
+        context.stop(self)
+      }
+
+    case msg: ResponseType =>
+      positiveResponse(replyTo, initialMsg, msg)
+      cancellable.cancel()
+      context.stop(self)
+
+    case error: ErrorType =>
+      negativeResponse(replyTo, initialMsg, error)
+      cancellable.cancel()
+      context.stop(self)
+
+  }
+
+  protected def positiveResponse(
+    replyTo: ActorRef,
+    initialMsg: RequestType,
+    msg: ResponseType
+  ): Unit
+
+  protected def negativeResponse(
+    replyTo: ActorRef,
+    initialMsg: RequestType,
+    error: ErrorType
+  )(implicit
     ec: ExecutionContext
   ): Unit
 

--- a/engine/language-server/src/main/scala/org/enso/languageserver/util/HandlerWithRetries.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/util/HandlerWithRetries.scala
@@ -216,3 +216,103 @@ abstract class RequestHandlerWithRetries[
   ): Unit
 
 }
+
+/** Request handler base class with retries support. Handler forwards messages directly to runtime.
+  *
+  * @param target target actor which will handle a message
+  * @param timeout timeout for serving a message
+  * @param retries number of retries attempted on timeout before aborting
+  * @tparam RequestType type of the message being handled
+  * @tparam ResponseType type of the message expected when message is successfully handled
+  * @tparam ErrorType type of the message expected when message has failed to be handled
+  * @tparam ForwardedPayloadType type of the message forwarded to `target`
+  */
+abstract class RequestToApiHandlerWithRetries[
+  RequestType: ClassTag,
+  ResponseType: ClassTag,
+  ErrorType: ClassTag,
+  ForwardedPayloadType
+](target: ActorRef, timeout: FiniteDuration, retries: Int)
+    extends HandlerWithRetries[
+      RequestType,
+      ResponseType,
+      ErrorType,
+      ForwardedPayloadType
+    ] {
+  a: Actor with LazyLogging =>
+
+  def this(runtime: ActorRef, timeout: FiniteDuration) = {
+    this(runtime, timeout, 10)
+  }
+
+  import context.dispatcher
+
+  override def receive: Receive = requestStage
+
+  protected def request(msg: RequestType): ForwardedPayloadType
+
+  protected def requestStage: Receive = { case msg: RequestType =>
+    val req = request(msg)
+    target ! req
+    val cancellable =
+      context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
+    context.become(responseStage(sender(), msg, req, cancellable, retries))
+  }
+
+  private def responseStage(
+    replyTo: ActorRef,
+    initialMsg: RequestType,
+    forwardedRequest: ForwardedPayloadType,
+    cancellable: Cancellable,
+    retries: Int
+  ): Receive = {
+    case RequestTimeout =>
+      if (retries > 0) {
+        logger.warn(
+          "Failed to receive a [{}] response in [{}]. Retrying.",
+          forwardedRequest,
+          timeout
+        )
+        val newCancellable =
+          context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
+        context.become(
+          responseStage(
+            replyTo,
+            initialMsg,
+            forwardedRequest,
+            newCancellable,
+            retries - 1
+          )
+        )
+      } else {
+        replyTo ! RequestTimeout
+        context.stop(self)
+      }
+
+    case Api.Response(_, msg: ResponseType) =>
+      positiveResponse(replyTo, initialMsg, msg)
+      cancellable.cancel()
+      context.stop(self)
+
+    case Api.Response(_, error: ErrorType) =>
+      negativeResponse(replyTo, initialMsg, error)
+      cancellable.cancel()
+      context.stop(self)
+
+  }
+
+  protected def positiveResponse(
+    replyTo: ActorRef,
+    initialMsg: RequestType,
+    msg: ResponseType
+  ): Unit
+
+  protected def negativeResponse(
+    replyTo: ActorRef,
+    initialMsg: RequestType,
+    error: ErrorType
+  )(implicit
+    ec: ExecutionContext
+  ): Unit
+
+}

--- a/engine/language-server/src/main/scala/org/enso/languageserver/util/HandlerWithRetries.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/util/HandlerWithRetries.scala
@@ -1,0 +1,70 @@
+package org.enso.languageserver.util
+
+import akka.actor.{Actor, ActorRef, Cancellable}
+import com.typesafe.scalalogging.LazyLogging
+import org.enso.languageserver.requesthandler.RequestTimeout
+import org.enso.polyglot.runtime.Runtime.Api
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
+import scala.reflect.ClassTag
+
+abstract class HandlerWithRetries[
+  RequestType: ClassTag,
+  ResponseType: ClassTag
+](runtime: ActorRef, timeout: FiniteDuration, retries: Int) {
+  a: Actor with LazyLogging =>
+
+  def this(runtime: ActorRef, timeout: FiniteDuration) = {
+    this(runtime, timeout, 10)
+  }
+
+  import context.dispatcher
+
+  override def receive: Receive = requestStage
+
+  protected def request(msg: RequestType): Api.Request
+
+  protected def requestStage: Receive = { case msg: RequestType =>
+    val req = request(msg)
+    runtime ! req
+    val cancellable =
+      context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
+    context.become(responseStage(sender(), req, cancellable, retries))
+  }
+
+  private def responseStage(
+    replyTo: ActorRef,
+    request: Api.Request,
+    cancellable: Cancellable,
+    retries: Int
+  ): Receive = {
+    case RequestTimeout =>
+      logger.warn(
+        "Failed to receive a [{}] response in [{}]. Retrying.",
+        request,
+        timeout
+      )
+      val newCancellable =
+        context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
+      context.become(
+        responseStage(replyTo, request, newCancellable, retries - 1)
+      )
+
+    case Api.Response(_, msg: ResponseType) =>
+      positiveResponse(replyTo, msg)
+      cancellable.cancel()
+      context.stop(self)
+
+    case Api.Response(_, error: Api.Error) =>
+      negativeResponse(replyTo, error)
+      cancellable.cancel()
+      context.stop(self)
+  }
+
+  protected def positiveResponse(replyTo: ActorRef, msg: ResponseType): Unit
+  protected def negativeResponse(replyTo: ActorRef, error: Api.Error)(implicit
+    ec: ExecutionContext
+  ): Unit
+
+}

--- a/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
+++ b/engine/polyglot-api/src/main/scala/org/enso/polyglot/runtime/Runtime.scala
@@ -1679,13 +1679,13 @@ object Runtime {
       newName: String
     ) extends ApiResponse
 
-    /** Signals that project has been renamed.
+    /** Signals that project has failed to be renamed.
       *
       * @param oldName the old name of the project
       * @param newName the new name of the project
       */
     final case class ProjectRenameFailed(oldName: String, newName: String)
-        extends ApiResponse
+        extends Error
 
     /** A request for symbol renaming.
       *
@@ -1710,7 +1710,7 @@ object Runtime {
       * @param error the error that happened
       */
     final case class SymbolRenameFailed(error: SymbolRenameFailed.Error)
-        extends ApiResponse
+        extends Error
 
     object SymbolRenameFailed {
 


### PR DESCRIPTION
### Pull Request Description

Follow up to #9558, this time to `SetExecutionContextEnvironmentHandler` that was timing out in #9789.
Added a base classes that handles the repeatable logic.

Maybe it will close #9789.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
