### PR TITLE
Allow for profiling startup in dockerized setting

### DIFF
--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ExecutorWithUnlimitedPool.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/languageserver/ExecutorWithUnlimitedPool.scala
@@ -5,6 +5,7 @@ import com.typesafe.scalalogging.Logger
 import org.apache.commons.lang3.concurrent.BasicThreadFactory
 import org.enso.logger.masking.Masking
 import org.enso.logging.LoggingServiceManager
+import org.enso.projectmanager.boot.Cli.{PROFILING_PATH, PROFILING_TIME}
 import org.enso.projectmanager.service.versionmanagement.RuntimeVersionManagerFactory
 import org.enso.runtimeversionmanager.config.GlobalRunnerConfigurationManager
 import org.enso.runtimeversionmanager.runner.{LanguageServerOptions, Runner}
@@ -103,10 +104,10 @@ object ExecutorWithUnlimitedPool extends LanguageServerExecutor {
     )
     val profilingPathArguments =
       descriptor.profilingPath.toSeq
-        .flatMap(path => Seq("--profiling-path", path.toString))
+        .flatMap(path => Seq(s"--$PROFILING_PATH", path.toString))
     val profilingTimeArguments =
       descriptor.profilingTime.toSeq
-        .flatMap(time => Seq("--profiling-time", time.toSeconds.toString))
+        .flatMap(time => Seq(s"--$PROFILING_TIME", time.toSeconds.toString))
     val startupArgs =
       if (descriptor.skipGraalVMUpdater) Seq("--skip-graalvm-updater")
       else Seq()

--- a/tools/ci/docker/Dockerfile
+++ b/tools/ci/docker/Dockerfile
@@ -7,6 +7,8 @@ ARG RPC_PORT=30001
 ARG DATA_PORT=30002
 ARG PRINT_VERSION=0
 ARG JAVA_OPTS="-XX:MaxRAMPercentage=90.0 -XX:InitialRAMPercentage=90.0"
+ARG PROFILING_FILENAME
+ARG PROFILING_TIME
 
 RUN useradd -u 2000 -c 'Enso Developer' -U -m ensodev
 
@@ -27,6 +29,7 @@ ADD editions /opt/enso/editions
 
 RUN mkdir /opt/enso/work
 RUN mkdir /opt/enso/logs
+RUN mkdir /opt/enso/profiling
 
 ENV ENSO_DATA_DIRECTORY=/volumes/workspace/data_root
 ENV ENSO_CONFIG_DIRECTORY=/volumes/workspace/config
@@ -39,6 +42,7 @@ RUN chmod -R u=rX,g=rX /opt/enso
 RUN chmod a+x /opt/enso/bin/*
 RUN chmod a+rw /opt/enso/work
 RUN chmod a+rw /opt/enso/logs
+RUN chmod a+rw /opt/enso/profiling
 
 RUN mkdir -p /volumes
 RUN chown -hR ensodev:ensodev /volumes
@@ -59,5 +63,6 @@ ENV JAVA_OPTS=${JAVA_OPTS}
 
 EXPOSE ${RPC_PORT}
 EXPOSE ${DATA_PORT}
+
 
 CMD ["--server", "--daemon", "--path", "/volumes/workspace/project_root"]

--- a/tools/ci/docker/docker-entrypoint.sh
+++ b/tools/ci/docker/docker-entrypoint.sh
@@ -13,4 +13,9 @@ if [ "$INTERFACE" == "" ]; then
   INTERFACE="0.0.0.0"
 fi
 
-/opt/enso/bin/enso --log-level "$LOG_LEVEL" --rpc-port $RPC_PORT --data-port $DATA_PORT --root-id "$LS_ROOT_ID" --interface "$INTERFACE" "$@"
+PROFILING_OPTIONS=""
+if [ "$PROFILING_FILENAME" != "" ] && [ "$PROFILING_TIME" != "" ]; then
+  PROFILING_OPTIONS="--profiling-path /opt/enso/profiling/$PROFILING_FILENAME --profiling-time=$PROFILING_TIME"
+fi
+
+/opt/enso/bin/enso $PROFILING_OPTIONS --log-level "$LOG_LEVEL" --rpc-port $RPC_PORT --data-port $DATA_PORT --root-id "$LS_ROOT_ID" --interface "$INTERFACE" "$@"


### PR DESCRIPTION
### Pull Request Description

When `PROFILING_FILENAME` and `PROFILING_TIME` are set, language server will collect profiling data on startup and place it under `/opt/enso/profiling/$PROFILING_NAME` where it can be fetched from.

Needed to better analyze #9789.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
