### PR TITLE
Refactor drag handlers

### DIFF
--- a/app/gui2/src/bindings.ts
+++ b/app/gui2/src/bindings.ts
@@ -20,7 +20,6 @@ export const componentBrowserBindings = defineKeybinds('component-browser', {
 export const graphBindings = defineKeybinds('graph-editor', {
   undo: ['Mod+Z'],
   redo: ['Mod+Y', 'Mod+Shift+Z'],
-  dragScene: ['PointerAux', 'Mod+PointerMain'],
   openComponentBrowser: ['Enter'],
   toggleVisualization: ['Space'],
   deleteSelected: ['OsDelete'],

--- a/app/gui2/src/components/CircularMenu.vue
+++ b/app/gui2/src/components/CircularMenu.vue
@@ -30,7 +30,7 @@ const showColorPicker = ref(false)
 </script>
 
 <template>
-  <div class="CircularMenu" @pointerdown.stop @pointerup.stop @click.stop>
+  <div class="CircularMenu">
     <div
       v-if="!showColorPicker"
       class="circle menu"

--- a/app/gui2/src/components/CodeEditor.vue
+++ b/app/gui2/src/components/CodeEditor.vue
@@ -335,9 +335,6 @@ const editorStyle = computed(() => {
     @keydown.backspace.stop
     @keydown.delete.stop
     @wheel.stop.passive
-    @pointerdown.stop
-    @pointerup.stop
-    @click.stop
     @contextmenu.stop
   >
     <div class="resize-handle" v-on="resize.events" @dblclick="resetSize">

--- a/app/gui2/src/components/ColorRing.vue
+++ b/app/gui2/src/components/ColorRing.vue
@@ -148,8 +148,6 @@ const cssTriangleColor = computed(() =>
       @pointerleave="mouseSelectedAngle = undefined"
       @pointermove="ringHover"
       @click.stop="ringClick"
-      @pointerdown.stop
-      @pointerup.stop
     />
   </div>
 </template>

--- a/app/gui2/src/components/ExtendedMenu.vue
+++ b/app/gui2/src/components/ExtendedMenu.vue
@@ -13,22 +13,11 @@ const toggleCodeEditorShortcut = codeEditorBindings.bindings.toggle.humanReadabl
 </script>
 
 <template>
-  <div
-    class="ExtendedMenu"
-    @pointerdown.stop
-    @pointerup.stop
-    @click.stop="isDropdownOpen = !isDropdownOpen"
-  >
+  <div class="ExtendedMenu" @click.stop="isDropdownOpen = !isDropdownOpen">
     <SvgIcon name="3_dot_menu" class="moreIcon" />
   </div>
   <Transition name="dropdown">
-    <div
-      v-show="isDropdownOpen"
-      class="ExtendedMenuPane"
-      @pointerdown.stop
-      @pointerup.stop
-      @click.stop
-    >
+    <div v-show="isDropdownOpen" class="ExtendedMenuPane">
       <div class="row">
         <div class="label">Zoom</div>
         <div class="zoomControl">

--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -246,11 +246,11 @@ const graphBindingsHandler = graphBindings.handler({
 
 const { handleClick } = useDoubleClick(
   (e: MouseEvent) => {
-    if (e.target !== viewportNode.value) return false
+    if (e.target !== e.currentTarget) return false
     clearFocus()
   },
   (e: MouseEvent) => {
-    if (e.target !== viewportNode.value) return false
+    if (e.target !== e.currentTarget) return false
     stackNavigator.exitNode()
   },
 )

--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -246,10 +246,11 @@ const graphBindingsHandler = graphBindings.handler({
 
 const { handleClick } = useDoubleClick(
   (e: MouseEvent) => {
-    graphBindingsHandler(e)
+    if (e.target !== viewportNode.value) return false
     clearFocus()
   },
-  () => {
+  (e: MouseEvent) => {
+    if (e.target !== viewportNode.value) return false
     stackNavigator.exitNode()
   },
 )
@@ -574,7 +575,7 @@ const groupColors = computed(() => {
       @setNodeColor="setSelectedNodesColor"
       @removeNodes="deleteSelected"
     />
-    <PlusButton @pointerdown.stop @click.stop="addNodeAuto()" @pointerup.stop />
+    <PlusButton @click.stop="addNodeAuto()" />
     <Transition>
       <Suspense ref="codeEditorArea">
         <CodeEditor v-if="showCodeEditor" @close="showCodeEditor = false" />

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -244,7 +244,6 @@ const transform = computed(() => {
 })
 
 const startEpochMs = ref(0)
-let draggedElement: Element | undefined
 let significantMove = false
 
 const dragPointer = usePointer(
@@ -252,13 +251,13 @@ const dragPointer = usePointer(
     if (type !== 'start') {
       if (
         !significantMove &&
-        draggedElement &&
         (Number(new Date()) - startEpochMs.value >= MAXIMUM_CLICK_LENGTH_MS ||
           pos.relative.lengthSquared() >= MAXIMUM_CLICK_DISTANCE_SQ)
       ) {
         // If this is clearly a drag (not a click), the node itself capture pointer events to
         // prevent `click` on widgets.
-        draggedElement.setPointerCapture?.(event.pointerId)
+        if (event.currentTarget instanceof Element)
+          event.currentTarget.setPointerCapture?.(event.pointerId)
         significantMove = true
       }
       const fullOffset = pos.relative
@@ -267,11 +266,9 @@ const dragPointer = usePointer(
     switch (type) {
       case 'start':
         startEpochMs.value = Number(new Date())
-        if (event.currentTarget instanceof Element) draggedElement = event.currentTarget
         significantMove = false
         break
       case 'stop': {
-        draggedElement = undefined
         startEpochMs.value = 0
         emit('draggingCommited')
       }

--- a/app/gui2/src/components/GraphEditor/GraphNodeComment.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNodeComment.vue
@@ -113,8 +113,6 @@ export function cookedTextToRaw(cooked: string) {
     @keydown.delete.stop
     @wheel.stop.passive
     @focusout="finishEdit"
-    @pointerdown.stop
-    @pointerup.stop
     @click.stop="startEdit"
     @contextmenu.stop
   ></div>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetCheckbox.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetCheckbox.vue
@@ -101,12 +101,7 @@ export const widgetDefinition = defineWidget(
 <template>
   <div class="CheckboxContainer r-24" :class="{ primary }">
     <span v-if="argumentName" class="name" v-text="argumentName" />
-    <CheckboxWidget
-      v-model="value"
-      class="WidgetCheckbox"
-      contenteditable="false"
-      @beforeinput.stop
-    />
+    <CheckboxWidget v-model="value" class="WidgetCheckbox" contenteditable="false" />
   </div>
 </template>
 

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetCheckbox.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetCheckbox.vue
@@ -101,14 +101,11 @@ export const widgetDefinition = defineWidget(
 <template>
   <div class="CheckboxContainer r-24" :class="{ primary }">
     <span v-if="argumentName" class="name" v-text="argumentName" />
-    <!-- See comment in GraphNode next to dragPointer definition about stopping pointerdown and pointerup -->
     <CheckboxWidget
       v-model="value"
       class="WidgetCheckbox"
       contenteditable="false"
       @beforeinput.stop
-      @pointerdown.stop
-      @pointerup.stop
     />
   </div>
 </template>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetNumber.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetNumber.vue
@@ -67,9 +67,6 @@ export const widgetDefinition = defineWidget(
     v-model="value"
     class="WidgetNumber r-24"
     :limits="limits"
-    @pointerdown.stop
-    @pointerup.stop
-    @click.stop
     @focus="editHandler.start()"
     @blur="editHandler.end()"
     @input="editHandler.edit($event)"

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetNumber.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetNumber.vue
@@ -67,6 +67,7 @@ export const widgetDefinition = defineWidget(
     v-model="value"
     class="WidgetNumber r-24"
     :limits="limits"
+    @click.stop
     @focus="editHandler.start()"
     @blur="editHandler.end()"
     @input="editHandler.edit($event)"

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetNumber.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetNumber.vue
@@ -62,7 +62,6 @@ export const widgetDefinition = defineWidget(
 </script>
 
 <template>
-  <!-- See comment in GraphNode next to dragPointer definition about stopping pointerdown and pointerup -->
   <NumericInputWidget
     ref="inputComponent"
     v-model="value"
@@ -70,6 +69,7 @@ export const widgetDefinition = defineWidget(
     :limits="limits"
     @pointerdown.stop
     @pointerup.stop
+    @click.stop
     @focus="editHandler.start()"
     @blur="editHandler.end()"
     @input="editHandler.edit($event)"

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
@@ -342,13 +342,10 @@ declare module '@/providers/widgetRegistry' {
 </script>
 
 <template>
-  <!-- See comment in GraphNode next to dragPointer definition about stopping pointerdown and pointerup -->
   <div
     ref="widgetRoot"
     class="WidgetSelection"
     :class="{ multiSelect: isMulti }"
-    @pointerdown.stop
-    @pointerup.stop
     @click.stop="toggleDropdownWidget"
     @pointerover="isHovered = true"
     @pointerout="isHovered = false"

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
@@ -99,9 +99,6 @@ export const widgetDefinition = defineWidget(
       ref="input"
       v-model="editedContents"
       autoSelect
-      @pointerdown.stop
-      @pointerup.stop
-      @click.stop
       @keydown.enter.stop="accepted"
       @focusin="editing.start()"
       @input="editing.edit(makeLiteralFromUserInput($event ?? ''))"

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
@@ -99,6 +99,8 @@ export const widgetDefinition = defineWidget(
       ref="input"
       v-model="editedContents"
       autoSelect
+      @pointerdown.stop
+      @click.stop
       @keydown.enter.stop="accepted"
       @focusin="editing.start()"
       @input="editing.edit(makeLiteralFromUserInput($event ?? ''))"

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
@@ -93,7 +93,7 @@ export const widgetDefinition = defineWidget(
 </script>
 
 <template>
-  <label ref="widgetRoot" class="WidgetText r-24" @pointerdown.stop>
+  <label ref="widgetRoot" class="WidgetText r-24">
     <NodeWidget v-if="shownLiteral.open" :input="WidgetInput.FromAst(shownLiteral.open)" />
     <AutoSizedInput
       ref="input"

--- a/app/gui2/src/components/NavBar.vue
+++ b/app/gui2/src/components/NavBar.vue
@@ -11,7 +11,7 @@ const emit = defineEmits<{ back: []; forward: []; breadcrumbClick: [index: numbe
 </script>
 
 <template>
-  <div class="NavBar" @pointerdown.stop @pointerup.stop @click.stop>
+  <div class="NavBar">
     <SvgIcon name="graph_editor" draggable="false" class="icon" />
     <div class="breadcrumbs-controls">
       <SvgIcon

--- a/app/gui2/src/components/RecordControl.vue
+++ b/app/gui2/src/components/RecordControl.vue
@@ -7,7 +7,7 @@ const emit = defineEmits<{ recordOnce: []; 'update:recordMode': [enabled: boolea
 </script>
 
 <template>
-  <div class="RecordControl" @pointerdown.stop @pointerup.stop @click.stop>
+  <div class="RecordControl">
     <div class="control left-end" @click.stop="() => emit('update:recordMode', !props.recordMode)">
       <ToggleIcon
         icon="record"

--- a/app/gui2/src/components/ScrollBar.vue
+++ b/app/gui2/src/components/ScrollBar.vue
@@ -121,11 +121,11 @@ export type ScrollbarEvent =
 </script>
 
 <template>
-  <div ref="element" class="ScrollBar" @click.stop @pointerdown.stop @pointerup.stop>
-    <div class="track vertical" @pointerdown="clickTrack.y">
+  <div ref="element" class="ScrollBar">
+    <div class="track vertical" @pointerdown.stop="clickTrack.y">
       <div class="bar vertical" v-on.stop="dragSlider.y" />
     </div>
-    <div class="track horizontal" @pointerdown="clickTrack.x">
+    <div class="track horizontal" @pointerdown.stop="clickTrack.x">
       <div class="bar horizontal" v-on.stop="dragSlider.x" />
     </div>
   </div>

--- a/app/gui2/src/components/SelectionMenu.vue
+++ b/app/gui2/src/components/SelectionMenu.vue
@@ -31,7 +31,7 @@ const selectionColor = computed(() => {
 </script>
 
 <template>
-  <div class="SelectionMenu" @pointerdown.stop @pointerup.stop @click.stop>
+  <div class="SelectionMenu">
     <span
       v-text="`${selectedComponents} component${selectedComponents === 1 ? '' : 's'} selected`"
     />

--- a/app/gui2/src/components/SmallPlusButton.vue
+++ b/app/gui2/src/components/SmallPlusButton.vue
@@ -12,12 +12,7 @@ function addNode() {
 </script>
 
 <template>
-  <div
-    class="SmallPlusButton add-node button"
-    @click.stop="addNode"
-    @pointerdown.stop
-    @pointerup.stop
-  >
+  <div class="SmallPlusButton add-node button" @click.stop="addNode">
     <SvgIcon name="add" class="icon" />
   </div>
 </template>

--- a/app/gui2/src/components/VisualizationContainer.vue
+++ b/app/gui2/src/components/VisualizationContainer.vue
@@ -2,12 +2,7 @@
 import SmallPlusButton from '@/components/SmallPlusButton.vue'
 import SvgIcon from '@/components/SvgIcon.vue'
 import VisualizationSelector from '@/components/VisualizationSelector.vue'
-import {
-  PointerButtonMask,
-  isTriggeredByKeyboard,
-  usePointer,
-  useResizeObserver,
-} from '@/composables/events'
+import { isTriggeredByKeyboard, usePointer, useResizeObserver } from '@/composables/events'
 import { useVisualizationConfig } from '@/providers/visualizationConfig'
 import { Vec2 } from '@/util/data/vec2'
 import { isQualifiedName, qnLastSegment } from '@/util/qualifiedName'

--- a/app/gui2/src/components/VisualizationContainer.vue
+++ b/app/gui2/src/components/VisualizationContainer.vue
@@ -134,9 +134,6 @@ const nodeShortType = computed(() =>
         '--color-visualization-bg': config.background,
         '--node-height': `${config.nodeSize.y}px`,
       }"
-      @pointerdown.stop
-      @pointerup.stop
-      @click.stop
     >
       <SmallPlusButton
         v-if="config.isCircularMenuVisible"
@@ -174,9 +171,6 @@ const nodeShortType = computed(() =>
             invisible: config.isCircularMenuVisible,
             hidden: config.fullscreen,
           }"
-          @pointerdown.stop
-          @pointerup.stop
-          @click.stop
         >
           <button class="image-button active" @click.stop="config.hide()">
             <SvgIcon class="icon" name="eye" alt="Hide visualization" />

--- a/app/gui2/src/components/VisualizationContainer.vue
+++ b/app/gui2/src/components/VisualizationContainer.vue
@@ -94,7 +94,7 @@ function resizeHandler(resizeX: 'left' | 'right' | false, resizeY: boolean) {
         leftDragging = false
         break
     }
-  }, PointerButtonMask.Main)
+  })
 }
 
 const resizeRight = resizeHandler('right', false)

--- a/app/gui2/src/components/VisualizationSelector.vue
+++ b/app/gui2/src/components/VisualizationSelector.vue
@@ -40,9 +40,6 @@ onMounted(() => setTimeout(() => rootNode.value?.querySelector('button')?.focus(
     ref="rootNode"
     class="VisualizationSelector"
     @focusout="$event.relatedTarget == null && emit('hide')"
-    @pointerdown.stop
-    @pointerup.stop
-    @click.stop
   >
     <div class="background"></div>
     <ul>

--- a/app/gui2/src/components/visualizations/JSONVisualization/JsonArrayWidget.vue
+++ b/app/gui2/src/components/visualizations/JSONVisualization/JsonArrayWidget.vue
@@ -26,8 +26,6 @@ function entryTitle(index: number) {
       :key="index"
       :title="entryTitle(index)"
       class="button element"
-      @pointerdown.stop
-      @pointerup.stop
       @click.stop="emit('createProjection', [$event.shiftKey ? [...props.data.keys()] : [index]])"
     >
       <JsonValueWidget

--- a/app/gui2/src/components/visualizations/JSONVisualization/JsonObjectWidget.vue
+++ b/app/gui2/src/components/visualizations/JSONVisualization/JsonObjectWidget.vue
@@ -30,8 +30,6 @@ function entryTitle(key: string) {
       :key="key"
       :title="entryTitle(key)"
       class="button field"
-      @pointerdown.stop
-      @pointerup.stop
       @click.stop="emit('createProjection', [$event.shiftKey ? Object.keys(props.data) : [key]])"
     >
       <span class="key" v-text="JSON.stringify(key)" />:

--- a/app/gui2/src/components/widgets/DropdownWidget.vue
+++ b/app/gui2/src/components/widgets/DropdownWidget.vue
@@ -61,13 +61,7 @@ export interface DropdownEntry {
 </script>
 
 <template>
-  <div
-    class="DropdownWidget"
-    :style="{ '--dropdown-bg': color }"
-    @pointerdown.stop
-    @pointerup.stop
-    @click.stop
-  >
+  <div class="DropdownWidget" :style="{ '--dropdown-bg': color }">
     <ul class="list scrollable" @wheel.stop>
       <template v-for="entry in sortedValues" :key="entry.value">
         <li v-if="entry.selected">

--- a/app/gui2/src/components/widgets/NumericInputWidget.vue
+++ b/app/gui2/src/components/widgets/NumericInputWidget.vue
@@ -35,10 +35,7 @@ const dragPointer = usePointer(
       return
     }
 
-    if (eventType === 'start') {
-      event.stopImmediatePropagation()
-      return
-    }
+    if (eventType === 'start') return
 
     if (inputFieldActive.value || props.limits == null) return false
 
@@ -120,6 +117,7 @@ defineExpose({
       autoSelect
       :style="inputStyle"
       v-on="dragPointer.events"
+      @click.stop
       @blur="blurred"
       @focus="focused"
       @input="emit('input', editedValue)"

--- a/app/gui2/src/components/widgets/NumericInputWidget.vue
+++ b/app/gui2/src/components/widgets/NumericInputWidget.vue
@@ -121,7 +121,6 @@ defineExpose({
       autoSelect
       :style="inputStyle"
       v-on="dragPointer.events"
-      @click.stop
       @blur="blurred"
       @focus="focused"
       @input="emit('input', editedValue)"

--- a/app/gui2/src/components/widgets/NumericInputWidget.vue
+++ b/app/gui2/src/components/widgets/NumericInputWidget.vue
@@ -50,8 +50,7 @@ const dragPointer = usePointer(
     editedValue.value = `${newValue}`
     if (eventType === 'stop') emitUpdate()
   },
-  PointerButtonMask.Main,
-  (event) => !event.ctrlKey && !event.altKey && !event.shiftKey && !event.metaKey,
+  { predicate: (event) => !event.ctrlKey && !event.altKey && !event.shiftKey && !event.metaKey },
 )
 
 const sliderWidth = computed(() => {

--- a/app/gui2/src/composables/__tests__/selection.test.ts
+++ b/app/gui2/src/composables/__tests__/selection.test.ts
@@ -82,36 +82,43 @@ test.each`
   ${'top'}    | ${bindingInvert}  | ${[]}
   ${'bottom'} | ${bindingInvert}  | ${[1, 2, 3, 4]}
   ${'all'}    | ${bindingInvert}  | ${[3, 4]}
-`('Selection by dragging $area area with $modifiers', ({ areaId, binding, expected }) => {
-  const area = areas[areaId]!
-  const dragCase = (start: Vec2, stop: Vec2) => {
-    const mousePos = ref(start)
-    const selection = selectionWithMockData(mousePos)
+`(
+  'Selection by dragging $areaId area with $binding.humanReadable',
+  ({ areaId, binding, expected }) => {
+    const area = areas[areaId]!
+    const dragCase = (start: Vec2, stop: Vec2) => {
+      const mousePos = ref(start)
+      const selection = selectionWithMockData(mousePos)
 
-    selection.events.pointerdown(mockPointerEvent('pointerdown', mousePos.value, binding))
-    selection.events.pointermove(mockPointerEvent('pointermove', mousePos.value, binding))
-    mousePos.value = stop
-    selection.events.pointermove(mockPointerEvent('pointermove', mousePos.value, binding))
-    expect(selection.selected).toEqual(new Set(expected))
-    selection.events.pointerdown(mockPointerEvent('pointerup', mousePos.value, binding))
-    expect(selection.selected).toEqual(new Set(expected))
-  }
+      selection.events.pointerdown(mockPointerEvent('pointerdown', mousePos.value, binding))
+      selection.events.pointermove(mockPointerEvent('pointermove', mousePos.value, binding))
+      mousePos.value = stop
+      selection.events.pointermove(mockPointerEvent('pointermove', mousePos.value, binding))
+      expect(selection.selected).toEqual(new Set(expected))
+      selection.events.pointerdown(mockPointerEvent('pointerup', mousePos.value, binding))
+      expect(selection.selected).toEqual(new Set(expected))
+    }
 
-  // We should select same set of nodes, regardless of drag direction
-  dragCase(new Vec2(area.left, area.top), new Vec2(area.right, area.bottom))
-  dragCase(new Vec2(area.right, area.bottom), new Vec2(area.left, area.top))
-  dragCase(new Vec2(area.left, area.bottom), new Vec2(area.right, area.top))
-  dragCase(new Vec2(area.right, area.top), new Vec2(area.left, area.bottom))
-})
+    // We should select same set of nodes, regardless of drag direction
+    dragCase(new Vec2(area.left, area.top), new Vec2(area.right, area.bottom))
+    dragCase(new Vec2(area.right, area.bottom), new Vec2(area.left, area.top))
+    dragCase(new Vec2(area.left, area.bottom), new Vec2(area.right, area.top))
+    dragCase(new Vec2(area.right, area.top), new Vec2(area.left, area.bottom))
+  },
+)
 
 // See https://github.com/thymikee/jest-preset-angular/issues/245#issuecomment-576296325
 class MockPointerEvent extends MouseEvent {
   readonly pointerId: number
-  constructor(type: string, options: MouseEventInit & { currentTarget?: Element | undefined }) {
+  constructor(
+    type: string,
+    options: MouseEventInit & { target?: Element | undefined; currentTarget?: Element | undefined },
+  ) {
     super(type, options)
     vi.spyOn<MouseEvent, 'currentTarget'>(this, 'currentTarget', 'get').mockReturnValue(
       options.currentTarget ?? null,
     )
+    vi.spyOn<MouseEvent, 'target'>(this, 'target', 'get').mockReturnValue(options.target ?? null)
     this.pointerId = 4
   }
 }
@@ -120,6 +127,7 @@ beforeAll(() => {
   ;(window as any).PointerEvent = MockPointerEvent
 })
 
+const graphRootMock = document.createElement('div')
 function mockPointerEvent(type: string, pos: Vec2, binding: BindingInfo): PointerEvent {
   const modifiersSet = new Set(binding.modifiers)
   assert(isPointer(binding.key))
@@ -133,7 +141,8 @@ function mockPointerEvent(type: string, pos: Vec2, binding: BindingInfo): Pointe
     clientY: pos.y,
     button,
     buttons,
-    currentTarget: document.createElement('div'),
+    target: graphRootMock,
+    currentTarget: graphRootMock,
   }) as PointerEvent
   return event
 }

--- a/app/gui2/src/composables/events.ts
+++ b/app/gui2/src/composables/events.ts
@@ -345,7 +345,7 @@ export function usePointer(
     },
     pointerup(e: PointerEvent) {
       if (trackedPointer.value !== e.pointerId) {
-        return
+        return false
       }
       doStop(e)
     },

--- a/app/gui2/src/composables/events.ts
+++ b/app/gui2/src/composables/events.ts
@@ -345,7 +345,7 @@ export function usePointer(
     },
     pointerup(e: PointerEvent) {
       if (trackedPointer.value !== e.pointerId) {
-        return false
+        return
       }
       doStop(e)
     },

--- a/app/gui2/src/composables/navigator.ts
+++ b/app/gui2/src/composables/navigator.ts
@@ -33,9 +33,13 @@ export function useNavigator(viewportNode: Ref<Element | undefined>, keyboard: K
 
   const targetScale = shallowRef(1)
   const scale = useApproach(targetScale)
-  const panPointer = usePointer((pos) => {
-    scrollTo(center.value.addScaled(pos.delta, -1 / scale.value))
-  }, PointerButtonMask.Auxiliary)
+  const panPointer = usePointer(
+    (pos) => {
+      scrollTo(center.value.addScaled(pos.delta, -1 / scale.value))
+    },
+    PointerButtonMask.Auxiliary,
+    (e) => e.target === viewportNode.value,
+  )
 
   function eventScreenPos(e: { clientX: number; clientY: number }): Vec2 {
     return new Vec2(e.clientX, e.clientY)
@@ -113,20 +117,24 @@ export function useNavigator(viewportNode: Ref<Element | undefined>, keyboard: K
   }
 
   let zoomPivot = Vec2.Zero
-  const zoomPointer = usePointer((pos, _event, ty) => {
-    if (ty === 'start') {
-      zoomPivot = clientToScenePos(pos.initial)
-    }
+  const zoomPointer = usePointer(
+    (pos, _event, ty) => {
+      if (ty === 'start') {
+        zoomPivot = clientToScenePos(pos.initial)
+      }
 
-    const prevScale = scale.value
-    updateScale((oldValue) => oldValue * Math.exp(-pos.delta.y / 100))
-    scrollTo(
-      center.value
-        .sub(zoomPivot)
-        .scale(prevScale / scale.value)
-        .add(zoomPivot),
-    )
-  }, PointerButtonMask.Secondary)
+      const prevScale = scale.value
+      updateScale((oldValue) => oldValue * Math.exp(-pos.delta.y / 100))
+      scrollTo(
+        center.value
+          .sub(zoomPivot)
+          .scale(prevScale / scale.value)
+          .add(zoomPivot),
+      )
+    },
+    PointerButtonMask.Secondary,
+    (e) => e.target === viewportNode.value,
+  )
 
   const viewport = computed(() => {
     const nodeSize = size.value

--- a/app/gui2/src/composables/navigator.ts
+++ b/app/gui2/src/composables/navigator.ts
@@ -38,7 +38,7 @@ export function useNavigator(viewportNode: Ref<Element | undefined>, keyboard: K
       scrollTo(center.value.addScaled(pos.delta, -1 / scale.value))
     },
     PointerButtonMask.Auxiliary,
-    (e) => e.target === viewportNode.value,
+    (e) => e.target === e.currentTarget,
   )
 
   function eventScreenPos(e: { clientX: number; clientY: number }): Vec2 {
@@ -133,7 +133,7 @@ export function useNavigator(viewportNode: Ref<Element | undefined>, keyboard: K
       )
     },
     PointerButtonMask.Secondary,
-    (e) => e.target === viewportNode.value,
+    (e) => e.target === e.currentTarget,
   )
 
   const viewport = computed(() => {

--- a/app/gui2/src/composables/navigator.ts
+++ b/app/gui2/src/composables/navigator.ts
@@ -37,8 +37,10 @@ export function useNavigator(viewportNode: Ref<Element | undefined>, keyboard: K
     (pos) => {
       scrollTo(center.value.addScaled(pos.delta, -1 / scale.value))
     },
-    PointerButtonMask.Auxiliary,
-    (e) => e.target === e.currentTarget,
+    {
+      requiredButtonMask: PointerButtonMask.Auxiliary,
+      predicate: (e) => e.target === e.currentTarget,
+    },
   )
 
   function eventScreenPos(e: { clientX: number; clientY: number }): Vec2 {
@@ -132,8 +134,10 @@ export function useNavigator(viewportNode: Ref<Element | undefined>, keyboard: K
           .add(zoomPivot),
       )
     },
-    PointerButtonMask.Secondary,
-    (e) => e.target === e.currentTarget,
+    {
+      requiredButtonMask: PointerButtonMask.Secondary,
+      predicate: (e) => e.target === e.currentTarget,
+    },
   )
 
   const viewport = computed(() => {

--- a/app/gui2/src/composables/selection.ts
+++ b/app/gui2/src/composables/selection.ts
@@ -1,12 +1,12 @@
 /** @file A Vue composable for keeping track of selected DOM elements. */
 import { selectionMouseBindings } from '@/bindings'
-import { PointerButtonMask, useEvent, usePointer } from '@/composables/events'
+import { useEvent, usePointer } from '@/composables/events'
 import type { PortId } from '@/providers/portInfo.ts'
 import { type NodeId } from '@/stores/graph'
 import type { Rect } from '@/util/data/rect'
 import { intersectionSize } from '@/util/data/set'
 import type { Vec2 } from '@/util/data/vec2'
-import { computed, proxyRefs, ref, shallowReactive, shallowRef, type Ref } from 'vue'
+import { computed, proxyRefs, ref, shallowReactive, shallowRef } from 'vue'
 
 export type SelectionComposable<T> = ReturnType<typeof useSelection<T>>
 export function useSelection<T>(

--- a/app/gui2/src/composables/selection.ts
+++ b/app/gui2/src/composables/selection.ts
@@ -166,8 +166,7 @@ export function useSelection<T>(
         selectionEventHandler(event)
       }
     },
-    PointerButtonMask.Main,
-    (e) => e.target === e.currentTarget,
+    { predicate: (e) => e.target === e.currentTarget },
   )
 
   return proxyRefs({


### PR DESCRIPTION
### Pull Request Description

Fixes #9780 

Before all drag handlers set pointer capture on their `currentTarget`, preventing click events on the actual click target, and to prevent that we stopped `pointerdown` (and more) on every "panel-like" element. Now it's ok to stop only actually handled events.

Navigator and selection handlers just ignore `pointerdown` events not targeted to actual Graph Editor background.

Node dragging is more complex, as we want to allow dragging the node by grabbing just any of its part (including widgets). So the handler takes pointer capture from widget only after a significant move (long enough in time _or_ space). **This allows user to drag nodes by many interactive widgets (before they stopped `pointerdown` disabling node drag).

[Screencast from 2024-05-08 10-45-33.webm](https://github.com/enso-org/enso/assets/3919101/d521b7a4-96c5-4e2c-a8a6-84388a18d041)


### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
