### PR TITLE
Language server needs java.desktop and java.se modules

### DIFF
--- a/engine/runtime-fat-jar/src/main/java/module-info.java
+++ b/engine/runtime-fat-jar/src/main/java/module-info.java
@@ -18,4 +18,13 @@ open module org.enso.runtime {
     org.enso.interpreter.instrument.ReplDebuggerInstrumentProvider,
     org.enso.interpreter.instrument.RuntimeServerInstrumentProvider,
     org.enso.interpreter.instrument.IdExecutionInstrumentProvider;
+
+
+  // java.beans.Transient needed by Jackson jackson.databind.ext.Java7SupportImpl
+  requires java.desktop;
+  // also needed by Jackson to avoid
+  // com.fasterxml.jackson.databind.exc.InvalidTypeIdException:
+  //   Could not resolve type id 'org.enso.polyglot.data.Tree$Node' as a subtype of
+  //   `org.enso.polyglot.data.Tree$Node<org.enso.polyglot.runtime.Runtime$Api$SuggestionUpdate>`: Not a subtype
+  requires java.se;
 }


### PR DESCRIPTION
### Pull Request Description

Fixes regression introduced by #9868 - language server still needs dependency on `java.desktop` and `java.se`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Manually tested IDE integration.
