### PR TITLE
Fix color-picker single-color-graph case

### DIFF
--- a/app/gui2/src/components/ColorRing.vue
+++ b/app/gui2/src/components/ColorRing.vue
@@ -121,7 +121,7 @@ const triangleHue = computed(() => {
 const cssGradient = computed(() => {
   const points = gradientPoints(
     fixedRanges.value,
-    browserSupportsOklchInterpolation ? 2 : NONNATIVE_OKLCH_INTERPOLATION_STEPS,
+    browserSupportsOklchInterpolation ? undefined : NONNATIVE_OKLCH_INTERPOLATION_STEPS,
   )
   const angularColorStopList = Array.from(points, cssAngularColorStop)
   const colorStops = angularColorStopList.join(',')

--- a/app/gui2/src/components/ColorRing/__tests__/gradient.test.ts
+++ b/app/gui2/src/components/ColorRing/__tests__/gradient.test.ts
@@ -34,8 +34,9 @@ interface AngularStop {
 function angularStops(points: Iterable<GradientPoint>) {
   const stops = new Array<AngularStop>()
   for (const { hue, angle, angle2 } of points) {
-    stops.push({ hue, angle })
-    if (angle2 != null) stops.push({ hue, angle: angle2 })
+    const normalized = normalizeHue(hue)
+    stops.push({ hue: normalized, angle })
+    if (angle2 != null) stops.push({ hue: normalized, angle: angle2 })
   }
   return stops
 }
@@ -46,11 +47,11 @@ function stopSpans(stops: Iterable<AngularStop>, radius: number) {
   for (const stop of stops) {
     if (prev && stop.angle !== prev.angle) {
       expect(stop.angle).toBeGreaterThanOrEqual(prev.angle)
-      expect(stop.hue).toBeGreaterThanOrEqual(prev.hue)
+      if (stop.hue !== 0) expect(stop.hue).toBeGreaterThanOrEqual(prev.hue)
       if (stop.hue === prev.hue) {
         spans.push({ start: prev.angle, end: stop.angle, hue: stop.hue })
       } else {
-        expect(stop.hue).toBe(stop.angle)
+        expect(stop.hue).toBe(normalizeHue(stop.angle))
         expect(prev.hue).toBe(prev.angle)
       }
     }
@@ -72,7 +73,7 @@ function testGradients({ hues, radius }: { hues: number[]; radius: number }) {
   const approximateHues = new Set(hues.map(approximate))
   const ranges = rangesForInputs(approximateHues, radius)
   ranges.forEach(validateRange)
-  const points = gradientPoints(ranges, 2)
+  const points = gradientPoints(ranges)
   points.forEach(validateGradientPoint)
   const stops = angularStops(points)
   expect(stops[0]?.angle).toBe(0)

--- a/app/gui2/src/components/ColorRing/gradient.ts
+++ b/app/gui2/src/components/ColorRing/gradient.ts
@@ -94,13 +94,14 @@ export function cssAngularColorStop({ hue, angle, angle2 }: GradientPoint) {
 
 export function gradientPoints(
   inputRanges: Iterable<FixedRange>,
-  minStops: number,
+  minStops?: number | undefined,
 ): GradientPoint[] {
   const points = new Array<GradientPoint>()
   const interpolationPoint = (angle: number) => ({ hue: angle, angle })
   const fixedRangeIter = new Resumable(inputRanges)
-  for (let i = 0; i < minStops; i++) {
-    const angle = i / (minStops - 1)
+  const min = Math.max(3, Math.round(minStops ?? 0))
+  for (let i = 0; i < min; i++) {
+    const angle = i / (min - 1)
     fixedRangeIter.advanceWhile((range) => range.end < angle)
     const nextFixedRange = fixedRangeIter.peek()
     if (!nextFixedRange || nextFixedRange.start > angle) points.push(interpolationPoint(angle))


### PR DESCRIPTION
### Pull Request Description

Fix rendering of the color picker wheel when there are no matchable colors, which occurs for the single-node picker when there is only one color in the graph.

- Increase minimum gradient points to fix bug.
- Update property tests to match browser interpretation of increasing-hue interpolation, and catch bugs of this type.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
