### PR TITLE
Log timings of FS operations

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -123,7 +123,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
   private val zioExec = effect.ZioExec(zioRuntime)
   log.trace("Created ZIO executor [{}].", zioExec)
 
-  private val fileSystem: FileSystem = new FileSystem
+  private val fileSystem: FileSystem = new FileSystem(log)
   log.trace("Created file system [{}].", fileSystem)
 
   val git = Git.withEmptyUserConfig(

--- a/engine/language-server/src/test/scala/org/enso/languageserver/filemanager/FileSystemSpec.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/filemanager/FileSystemSpec.scala
@@ -13,6 +13,7 @@ import java.security.MessageDigest
 import scala.collection.mutable.ArrayBuffer
 import scala.io.Source
 import scala.jdk.CollectionConverters._
+import org.slf4j.LoggerFactory
 
 class FileSystemSpec
     extends AnyWordSpecLike
@@ -1020,7 +1021,9 @@ class FileSystemSpec
     val testDirPath = Files.createTempDirectory(null)
     sys.addShutdownHook(FileUtils.deleteQuietly(testDirPath.toFile))
 
-    val objectUnderTest = new FileSystem
+    val objectUnderTest = new FileSystem(
+      LoggerFactory.getLogger(classOf[FileSystemSpec])
+    )
 
   }
 

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/binary/BaseBinaryServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/binary/BaseBinaryServerTest.scala
@@ -36,6 +36,7 @@ import org.enso.languageserver.websocket.binary.factory.{
 import java.util.concurrent.{ExecutorService, Executors}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
+import org.slf4j.LoggerFactory
 
 abstract class BaseBinaryServerTest extends BinaryServerTestKit {
 
@@ -89,7 +90,9 @@ abstract class BaseBinaryServerTest extends BinaryServerTestKit {
           FileManager.props(
             config.fileManager,
             contentRootManagerWrapper,
-            new FileSystem,
+            new FileSystem(
+              LoggerFactory.getLogger(classOf[BaseBinaryServerTest])
+            ),
             zioExec
           )
         )

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
@@ -73,6 +73,7 @@ import java.util.concurrent.{Executors, ThreadFactory}
 import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
+import org.slf4j.LoggerFactory
 
 abstract class BaseServerTest
     extends JsonRpcServerTestKit
@@ -235,7 +236,7 @@ abstract class BaseServerTest
       FileManager.props(
         config.fileManager,
         contentRootManagerWrapper,
-        new FileSystem,
+        new FileSystem(LoggerFactory.getLogger(classOf[BaseServerTest])),
         zioExec
       ),
       s"file-manager-${UUID.randomUUID()}"
@@ -273,7 +274,7 @@ abstract class BaseServerTest
         config,
         contentRootManagerWrapper,
         watcherFactory,
-        new FileSystem,
+        new FileSystem(LoggerFactory.getLogger(classOf[BaseServerTest])),
         zioExec
       ),
       s"fileevent-registry-${UUID.randomUUID()}"


### PR DESCRIPTION
### Pull Request Description

I'm seeing occasional IO timeouts, especially on startup operations, for cloud projects. Adding some logging to make an informed decision if there are some problems there.

Related to https://github.com/enso-org/enso/issues/9789

### Important Notes

Also added retries when closing the file as I saw a number of times:
```
Session release failed.
 LsRpcError: Language server request 'text/closeFile' failed.
    at LanguageServer.request (/tmp/.mount_enso-leMqqdS/resources/app.asar/index.cjs:58291:15)
    at async Promise.all (index 0)
    at async _LanguageServerSession.release (/tmp/.mount_enso-leMqqdS/resources/app.asar/index.cjs:59165:5)
    at async /tmp/.mount_enso-leMqqdS/resources/app.asar/index.cjs:59670:7 {
  cause: JSONRPCError2: Request timeout request took longer than 15000 ms to resolve
      at new JSONRPCError2 (/tmp/.mount_enso-leMqqdS/resources/app.asar/index.cjs:26822:30)
      at Timeout._onTimeout (/tmp/.mount_enso-leMqqdS/resources/app.asar/index.cjs:26985:20)
      at listOnTimeout (node:internal/timers:569:17)
      at process.processTimers (node:internal/timers:512:7) {
    code: 7777,
    data: undefined
  },
  request: 'text/closeFile',
  params: {
    path: {
      rootId: '00000000-0000-0000-0000-000000000001',
      segments: [Array]
    }
  }
}
```
### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
