### PR TITLE
Abort jobs as early as possible

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
@@ -130,6 +130,7 @@ class CollaborativeBuffer(
       stop(Map.empty)
 
     case IOTimeout =>
+      logger.warn("Timeout reached when awaiting file's content")
       replyTo ! OpenFileResponse(Left(OperationTimeout))
       stop(Map.empty)
 
@@ -155,6 +156,7 @@ class CollaborativeBuffer(
     timeout: Cancellable
   ): Receive = {
     case ServerConfirmationTimeout =>
+      logger.warn("Timeout reached when awaiting response from the server")
       replyTo ! OpenFileResponse(Left(OperationTimeout))
       stop(Map.empty)
     case Api.Response(Some(id), Api.OpenFileResponse) if id == requestId =>
@@ -432,6 +434,7 @@ class CollaborativeBuffer(
       stop(Map.empty)
 
     case IOTimeout =>
+      logger.warn("Timeout reached when awaiting file's content reloading")
       replyTo ! ReloadBufferFailed(path, "io timeout")
       context.become(
         collaborativeEditing(
@@ -455,6 +458,9 @@ class CollaborativeBuffer(
     timeoutCancellable: Cancellable
   ): Receive = {
     case IOTimeout =>
+      logger.warn(
+        "Timeout reached when awaiting confirmation of buffer's saving"
+      )
       replyTo.foreach(_ ! SaveFailed(OperationTimeout))
       unstashAll()
       onClose match {

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/SetExecutionEnvironmentCommand.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/SetExecutionEnvironmentCommand.java
@@ -42,12 +42,12 @@ public class SetExecutionEnvironmentCommand extends AsynchronousCommand {
   private void setExecutionEnvironment(
       Runtime$Api$ExecutionEnvironment executionEnvironment, UUID contextId, RuntimeContext ctx) {
     var logger = ctx.executionService().getLogger();
+    ctx.jobControlPlane().abortJobs(contextId);
     var contextLockTimestamp = ctx.locking().acquireContextLock(contextId);
     try {
       var writeLockTimestamp = ctx.locking().acquireWriteCompilationLock();
       try {
         Stack<InstrumentFrame> stack = ctx.contextManager().getStack(contextId);
-        ctx.jobControlPlane().abortJobs(contextId);
         ctx.executionService()
             .getContext()
             .setExecutionEnvironment(ExecutionEnvironment.forName(executionEnvironment.name()));

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/JVMSettings.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/JVMSettings.scala
@@ -42,10 +42,24 @@ object JVMSettings {
   /** Creates a default instance of [[JVMSettings]] that just use the default
     * JVM with no options overrides.
     */
-  def default: JVMSettings =
+  def default: JVMSettings = {
+    val jvmOptions = Seq.newBuilder[(String, String)]
+    val concurrencyConfigs = Seq(
+      "scala.concurrent.context.minThreads",
+      "scala.concurrent.context.numThreads",
+      "scala.concurrent.context.maxThreads"
+    )
+    concurrencyConfigs.flatMap(jvmOptionIfSet).foreach(jvmOptions.addOne)
     JVMSettings(
       useSystemJVM = false,
-      jvmOptions   = Seq(),
+      jvmOptions   = jvmOptions.result(),
       extraOptions = Seq(nioOpen)
     )
+  }
+
+  private def jvmOptionIfSet(name: String): Option[(String, String)] = {
+    val propertyValue = System.getProperty(name)
+    Option(propertyValue).map((name, _))
+  }
+
 }


### PR DESCRIPTION

### Pull Request Description

We don't seem to run `abortJobs` under a lock, and especially not under the write compilation lock, in other scenarios. This is causing some major slowdown when there is a long running execution or compilation, as currently experienced in the cloud.

This should reduce chances of a timeout.

Also added an option to override the global executor. Currently it would always default to the runtime number of available process which may be suboptimal.

### Important Notes

Pending testing on the impact it will have.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
