### PR TITLE
Color ring updates component colors continuously

### DIFF
--- a/app/gui2/src/components/CircularMenu.vue
+++ b/app/gui2/src/components/CircularMenu.vue
@@ -13,7 +13,7 @@ const props = defineProps<{
   isDocsVisible: boolean
   isVisualizationVisible: boolean
   isFullMenuVisible: boolean
-  visibleNodeColors: Set<string>
+  matchableNodeColors: Set<string>
 }>()
 const emit = defineEmits<{
   'update:isRecordingOverridden': [isRecordingOverridden: boolean]
@@ -84,7 +84,8 @@ const showColorPicker = ref(false)
     <div v-if="showColorPicker" class="circle">
       <ColorRing
         v-model="nodeColor"
-        :matchableColors="visibleNodeColors"
+        :matchableColors="matchableNodeColors"
+        :initialColorAngle="90"
         @close="showColorPicker = false"
       />
     </div>

--- a/app/gui2/src/components/ColorPickerMenu.vue
+++ b/app/gui2/src/components/ColorPickerMenu.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import ColorRing from '@/components/ColorRing.vue'
+import { injectNodeColors } from '@/providers/graphNodeColors'
+import { injectGraphSelection } from '@/providers/graphSelection'
+import { useGraphStore, type NodeId } from '@/stores/graph'
+import { filterDefined } from '@/util/data/iterable'
+import { tryGetSoleValue } from 'shared/util/data/iterable'
+import { computed, ref, watch } from 'vue'
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const { getNodeColor, getNodeColors } = injectNodeColors()
+const selection = injectGraphSelection()
+const graphStore = useGraphStore()
+
+const displayedColors = new Set<string>(
+  filterDefined(Array.from(selection.selected, (node) => getNodeColor(node))),
+)
+const currentColor = ref<string | undefined>(tryGetSoleValue(displayedColors.values()))
+
+const editedNodeInitialColors = new Map<NodeId, string | undefined>()
+
+function setColor(color: string | undefined) {
+  currentColor.value = color
+  graphStore.transact(() => {
+    if (color) {
+      for (const node of selection.selected) {
+        if (!editedNodeInitialColors.has(node))
+          editedNodeInitialColors.set(node, graphStore.getNodeColorOverride(node))
+        graphStore.overrideNodeColor(node, color)
+      }
+    } else {
+      for (const [node, color] of editedNodeInitialColors.entries())
+        graphStore.overrideNodeColor(node, color)
+    }
+  })
+}
+
+const matchableColors = computed(() => getNodeColors((node) => !selection.selected.has(node)))
+</script>
+
+<template>
+  <div class="ColorPickerMenu">
+    <ColorRing
+      :modelValue="currentColor"
+      :matchableColors="matchableColors"
+      :initialColorAngle="0"
+      @update:modelValue="setColor"
+      @close="emit('close')"
+    />
+  </div>
+</template>
+
+<style scoped>
+.ColorPickerMenu {
+  width: 240px;
+  height: 240px;
+  display: flex;
+  place-items: center;
+  padding: 36px;
+}
+</style>

--- a/app/gui2/src/components/ColorPickerMenu.vue
+++ b/app/gui2/src/components/ColorPickerMenu.vue
@@ -38,7 +38,7 @@ function setColor(color: string | undefined) {
   })
 }
 
-const matchableColors = computed(() => getNodeColors((node) => !selection.selected.has(node)))
+const matchableColors = getNodeColors((node) => !selection.selected.has(node))
 </script>
 
 <template>

--- a/app/gui2/src/components/ColorRing/__tests__/gradient.test.ts
+++ b/app/gui2/src/components/ColorRing/__tests__/gradient.test.ts
@@ -1,7 +1,8 @@
+import { normalizeHue } from '@/util/colors'
 import { fc, test as fcTest } from '@fast-check/vitest'
 import { expect } from 'vitest'
 import type { FixedRange, GradientPoint } from '../gradient'
-import { gradientPoints, normalizeHue, rangesForInputs } from '../gradient'
+import { gradientPoints, rangesForInputs } from '../gradient'
 
 /** Check value ranges and internal consistency. */
 function validateRange({ start, end }: FixedRange) {

--- a/app/gui2/src/components/ColorRing/gradient.ts
+++ b/app/gui2/src/components/ColorRing/gradient.ts
@@ -1,4 +1,4 @@
-import { ensoColor, formatCssColor } from '@/util/colors'
+import { ensoColor, formatCssColor, normalizeHue } from '@/util/colors'
 import { Resumable } from 'shared/util/data/iterable'
 
 export interface FixedRange {
@@ -19,10 +19,6 @@ function normalizeRangeInputs(inputs: Iterable<number>, radius: number) {
   sortedInputs.forEach((value) => normalizedInputs.add(value))
   if (firstInput != null && firstInput < radius) normalizedInputs.add(firstInput + 1)
   return normalizedInputs
-}
-
-export function normalizeHue(value: number) {
-  return ((value % 1) + 1) % 1
 }
 
 export function seminormalizeHue(value: number) {

--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -626,7 +626,6 @@ const groupColors = computed(() => {
       @zoomIn="graphNavigator.stepZoom(+1)"
       @zoomOut="graphNavigator.stepZoom(-1)"
       @collapseNodes="collapseNodes"
-      @setNodeColor="setSelectedNodesColor"
       @removeNodes="deleteSelected"
     />
     <PlusButton @click.stop="addNodeAuto()" />

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -444,7 +444,8 @@ function portGroupStyle(port: PortData) {
 
 const editingComment = ref(false)
 
-const { getNodeColor, visibleNodeColors } = injectNodeColors()
+const { getNodeColor, getNodeColors } = injectNodeColors()
+const matchableNodeColors = computed(() => getNodeColors((node) => node !== nodeId.value))
 </script>
 
 <template>
@@ -502,7 +503,7 @@ const { getNodeColor, visibleNodeColors } = injectNodeColors()
       :isVisualizationVisible="isVisualizationVisible"
       :isFullMenuVisible="menuVisible && menuFull"
       :nodeColor="getNodeColor(nodeId)"
-      :visibleNodeColors="visibleNodeColors"
+      :matchableNodeColors="matchableNodeColors"
       @update:isVisualizationVisible="emit('update:visualizationVisible', $event)"
       @startEditing="startEditingNode"
       @startEditingComment="editingComment = true"

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -445,7 +445,7 @@ function portGroupStyle(port: PortData) {
 const editingComment = ref(false)
 
 const { getNodeColor, getNodeColors } = injectNodeColors()
-const matchableNodeColors = computed(() => getNodeColors((node) => node !== nodeId.value))
+const matchableNodeColors = getNodeColors((node) => node !== nodeId.value)
 </script>
 
 <template>

--- a/app/gui2/src/components/SelectionMenu.vue
+++ b/app/gui2/src/components/SelectionMenu.vue
@@ -1,33 +1,14 @@
 <script setup lang="ts">
-import ColorRing from '@/components/ColorRing.vue'
+import ColorPickerMenu from '@/components/ColorPickerMenu.vue'
 import SvgIcon from '@/components/SvgIcon.vue'
 import ToggleIcon from '@/components/ToggleIcon.vue'
-import { injectNodeColors } from '@/providers/graphNodeColors'
-import { injectGraphSelection } from '@/providers/graphSelection'
-import { computed } from 'vue'
 
 const showColorPicker = defineModel<boolean>('showColorPicker', { required: true })
 const _props = defineProps<{ selectedComponents: number }>()
 const emit = defineEmits<{
   collapseNodes: []
-  setNodeColor: [color: string]
   removeNodes: []
 }>()
-
-const { getNodeColor, visibleNodeColors } = injectNodeColors()
-const selection = injectGraphSelection(true)
-const selectionColor = computed(() => {
-  if (!selection) return undefined
-  let color: string | undefined = undefined
-  for (const node of selection.selected) {
-    const nodeColor = getNodeColor(node)
-    if (nodeColor) {
-      if (color !== undefined && color !== nodeColor) return undefined
-      else color = nodeColor
-    }
-  }
-  return color
-})
 </script>
 
 <template>
@@ -60,14 +41,7 @@ const selectionColor = computed(() => {
       alt="Delete components"
       @click.stop="emit('removeNodes')"
     />
-    <div v-if="showColorPicker" class="colorPickerContainer">
-      <ColorRing
-        :modelValue="selectionColor"
-        :matchableColors="visibleNodeColors"
-        @close="showColorPicker = false"
-        @update:modelValue="emit('setNodeColor', $event)"
-      />
-    </div>
+    <ColorPickerMenu v-if="showColorPicker" class="submenu" @close="showColorPicker = false" />
   </div>
 </template>
 
@@ -86,18 +60,13 @@ const selectionColor = computed(() => {
   padding-bottom: 4px;
 }
 
-.colorPickerContainer {
+.submenu {
   position: absolute;
   top: 36px;
   left: 0;
-  width: 240px;
-  height: 240px;
-  display: flex;
   border-radius: var(--radius-default);
   background: var(--color-frame-bg);
   backdrop-filter: var(--blur-app-bg);
-  place-items: center;
-  padding: 36px;
 }
 
 .toggle {

--- a/app/gui2/src/components/TopBar.vue
+++ b/app/gui2/src/components/TopBar.vue
@@ -28,7 +28,6 @@ const emit = defineEmits<{
   zoomIn: []
   zoomOut: []
   collapseNodes: []
-  setNodeColor: [color: string]
   removeNodes: []
 }>()
 
@@ -66,7 +65,6 @@ const barStyle = computed(() => {
         :selectedComponents="componentsSelected"
         @collapseNodes="emit('collapseNodes')"
         @removeNodes="emit('removeNodes')"
-        @setNodeColor="emit('setNodeColor', $event)"
       />
     </Transition>
     <ExtendedMenu

--- a/app/gui2/src/composables/nodeColors.ts
+++ b/app/gui2/src/composables/nodeColors.ts
@@ -17,14 +17,16 @@ export function useNodeColors(getCssValue: (variable: string) => string) {
     }
   }
 
-  const visibleNodeColors = computed(() => {
+  function getNodeColors(filter?: (node: NodeId) => boolean) {
     const colors = new Set<string>()
     for (const node of graphStore.db.nodeIds()) {
-      const color = getNodeColor(node)
-      if (color) colors.add(color)
+      if (filter?.(node) !== false) {
+        const color = getNodeColor(node)
+        if (color) colors.add(color)
+      }
     }
     return colors
-  })
+  }
 
-  return { getNodeColor, visibleNodeColors }
+  return { getNodeColor, getNodeColors }
 }

--- a/app/gui2/src/composables/nodeColors.ts
+++ b/app/gui2/src/composables/nodeColors.ts
@@ -18,14 +18,16 @@ export function useNodeColors(getCssValue: (variable: string) => string) {
   }
 
   function getNodeColors(filter?: (node: NodeId) => boolean) {
-    const colors = new Set<string>()
-    for (const node of graphStore.db.nodeIds()) {
-      if (filter?.(node) !== false) {
-        const color = getNodeColor(node)
-        if (color) colors.add(color)
+    return computed(() => {
+      const colors = new Set<string>()
+      for (const node of graphStore.db.nodeIds()) {
+        if (filter?.(node) !== false) {
+          const color = getNodeColor(node)
+          if (color) colors.add(color)
+        }
       }
-    }
-    return colors
+      return colors
+    })
   }
 
   return { getNodeColor, getNodeColors }

--- a/app/gui2/src/stores/graph/index.ts
+++ b/app/gui2/src/stores/graph/index.ts
@@ -363,12 +363,16 @@ export const useGraphStore = defineStore('graph', () => {
     }
   }
 
-  function overrideNodeColor(nodeId: NodeId, color: string) {
+  function overrideNodeColor(nodeId: NodeId, color: string | undefined) {
     const nodeAst = syncModule.value?.tryGet(nodeId)
     if (!nodeAst) return
     editNodeMetadata(nodeAst, (metadata) => {
       metadata.set('colorOverride', color)
     })
+  }
+
+  function getNodeColorOverride(node: NodeId) {
+    return db.nodeIdToNode.get(node)?.colorOverride ?? undefined
   }
 
   function normalizeVisMetadata(
@@ -675,6 +679,7 @@ export const useGraphStore = defineStore('graph', () => {
     ensureCorrectNodeOrder,
     batchEdits,
     overrideNodeColor,
+    getNodeColorOverride,
     setNodeContent,
     setNodePosition,
     setNodeVisualization,

--- a/app/gui2/src/util/colors.ts
+++ b/app/gui2/src/util/colors.ts
@@ -27,8 +27,13 @@ export function ensoColor(hue: number): Oklch {
     mode: 'oklch',
     l: 0.545,
     c: 0.14,
-    h: hue * 360,
+    h: normalizeHue(hue) * 360,
   }
+}
+
+/* Normalize a value to the range 0-1, as used for hues. */
+export function normalizeHue(value: number) {
+  return ((value % 1) + 1) % 1
 }
 
 /** Format an OKLCH color in CSS. */


### PR DESCRIPTION
### Pull Request Description

Commit color ring selections to nodes live.

- To prevent opening the picker from immediately changing the color, gradient is rotated so that the initially-selected color is under the mouse when the picker is opened.
- Escape key reverts selection to initial color(s).

Closes #9936

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
