### PR TITLE
Allow a Table to be used to `rename_columns`.

### DIFF
--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -485,7 +485,8 @@ type DB_Table
          column names to apply by position. `Regex` objects can be used
          within the mapping to do pattern based renaming.
          Can also be supplied as a `Table` either with a single column of new
-         names or two columns with old and new names.
+         names or two columns with old (first column) and new names (second
+         column).
        - case_sensitivity: Controls whether to be case sensitive when matching
          column names.
        - error_on_missing_columns: Specifies if a missing input column should
@@ -541,17 +542,10 @@ type DB_Table
               table.rename_columns (Map.from_vector [["name=(.*)".to_regex, "key:$1"]])
     @column_map Widget_Helpers.make_rename_name_vector_selector
     rename_columns : Map (Text | Integer | Regex) Text | Vector Text | Vector Vector -> Case_Sensitivity -> Boolean -> Problem_Behavior -> DB_Table ! Missing_Input_Columns | Ambiguous_Column_Rename | Too_Many_Column_Names_Provided | Invalid_Column_Names | Duplicate_Output_Column_Names
-    rename_columns self (column_map:(DB_Table | Table | Map | Vector)=["Column"]) (case_sensitivity:Case_Sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=True) (on_problems:Problem_Behavior=Report_Warning) = case column_map of
-        _ : DB_Table -> Error.throw (Illegal_Argument.Error "column_map cannot be an in-database, use read to materialise.")
-        _ : Table -> case column_map.column_count of
-            1 ->
-                col = column_map.first_column
-                if col.value_type.is_text then self.rename_columns col.to_vector case_sensitivity error_on_missing_columns on_problems else
-                    Error.throw (Illegal_Argument.Error "Expected a table with one or two columns of text values.")
-            2 ->
-                if column_map.first_column.value_type.is_text && column_map.second_column.value_type.is_text then self.rename_columns (Map.from_vector column_map.rows) case_sensitivity error_on_missing_columns on_problems else
-                    Error.throw (Illegal_Argument.Error "Expected a table with one or two columns of text values.")
-            _ -> Error.throw (Illegal_Argument.Error "Expected a table with one or two columns of text values.")
+    rename_columns self (column_map:(Table | Map | Vector)=["Column"]) (case_sensitivity:Case_Sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=True) (on_problems:Problem_Behavior=Report_Warning) = case column_map of
+        _ : Table ->
+            resolved = Table_Helpers.read_name_map_from_table column_map
+            self.rename_columns resolved case_sensitivity error_on_missing_columns on_problems else
         _ ->
             new_names = Table_Helpers.rename_columns self.column_naming_helper self.internal_columns column_map case_sensitivity error_on_missing_columns on_problems
             Warning.with_suspended new_names names->
@@ -2967,7 +2961,7 @@ default_join_condition table join_kind = case join_kind of
 ## PRIVATE
 Table.from (that:DB_Table) =
     _ = [that]
-    Error.throw (Illegal_Argument.Error "Currently cross-backend operations are not supported. Materialize the table using `.read` before mixing it with an in-memory Table.")
+    Error.throw (Illegal_Argument.Error "This operation requires the data in-memory, materialize the table using `.read`.")
 
 ## PRIVATE
 DB_Table.from (that:Table) =

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -545,7 +545,7 @@ type DB_Table
     rename_columns self (column_map:(Table | Map | Vector)=["Column"]) (case_sensitivity:Case_Sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=True) (on_problems:Problem_Behavior=Report_Warning) = case column_map of
         _ : Table ->
             resolved = Table_Helpers.read_name_map_from_table column_map
-            self.rename_columns resolved case_sensitivity error_on_missing_columns on_problems else
+            self.rename_columns resolved case_sensitivity error_on_missing_columns on_problems
         _ ->
             new_names = Table_Helpers.rename_columns self.column_naming_helper self.internal_columns column_map case_sensitivity error_on_missing_columns on_problems
             Warning.with_suspended new_names names->

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -484,6 +484,8 @@ type DB_Table
        - column_map: Mapping from old column names to new or a vector of new
          column names to apply by position. `Regex` objects can be used
          within the mapping to do pattern based renaming.
+         Can also be supplied as a `Table` either with a single column of new
+         names or two columns with old and new names.
        - case_sensitivity: Controls whether to be case sensitive when matching
          column names.
        - error_on_missing_columns: Specifies if a missing input column should

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -539,10 +539,21 @@ type DB_Table
               table.rename_columns (Map.from_vector [["name=(.*)".to_regex, "key:$1"]])
     @column_map Widget_Helpers.make_rename_name_vector_selector
     rename_columns : Map (Text | Integer | Regex) Text | Vector Text | Vector Vector -> Case_Sensitivity -> Boolean -> Problem_Behavior -> DB_Table ! Missing_Input_Columns | Ambiguous_Column_Rename | Too_Many_Column_Names_Provided | Invalid_Column_Names | Duplicate_Output_Column_Names
-    rename_columns self (column_map:(Map | Vector)=["Column"]) (case_sensitivity:Case_Sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=True) (on_problems:Problem_Behavior=Report_Warning) =
-        new_names = Table_Helpers.rename_columns self.column_naming_helper self.internal_columns column_map case_sensitivity error_on_missing_columns on_problems
-        Warning.with_suspended new_names names->
-            self.updated_columns (self.internal_columns.map c-> c.rename (names.at c.name))
+    rename_columns self (column_map:(DB_Table | Table | Map | Vector)=["Column"]) (case_sensitivity:Case_Sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=True) (on_problems:Problem_Behavior=Report_Warning) = case column_map of
+        _ : DB_Table -> Error.throw (Illegal_Argument.Error "column_map cannot be an in-database, use read to materialise.")
+        _ : Table -> case column_map.column_count of
+            1 ->
+                col = column_map.first_column
+                if col.value_type.is_text then self.rename_columns col.to_vector case_sensitivity error_on_missing_columns on_problems else
+                    Error.throw (Illegal_Argument.Error "Expected a table with one or two columns of text values.")
+            2 ->
+                if column_map.first_column.value_type.is_text && column_map.second_column.value_type.is_text then self.rename_columns (Map.from_vector column_map.rows) case_sensitivity error_on_missing_columns on_problems else
+                    Error.throw (Illegal_Argument.Error "Expected a table with one or two columns of text values.")
+            _ -> Error.throw (Illegal_Argument.Error "Expected a table with one or two columns of text values.")
+        _ ->
+            new_names = Table_Helpers.rename_columns self.column_naming_helper self.internal_columns column_map case_sensitivity error_on_missing_columns on_problems
+            Warning.with_suspended new_names names->
+                self.updated_columns (self.internal_columns.map c-> c.rename (names.at c.name))
 
     ## GROUP Standard.Base.Metadata
        ICON table_edit

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -2961,7 +2961,7 @@ default_join_condition table join_kind = case join_kind of
 ## PRIVATE
 Table.from (that:DB_Table) =
     _ = [that]
-    Error.throw (Illegal_Argument.Error "This operation requires the data in-memory, materialize the table using `.read`.")
+    Error.throw (Illegal_Argument.Error "This operation requires the data to be in-memory, materialize the table using `.read`.")
 
 ## PRIVATE
 DB_Table.from (that:Table) =

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -284,6 +284,21 @@ type Table_Column_Helper
             Error.throw (No_Output_Columns.Error message)
 
 ## PRIVATE
+   A helper function which takes a Table like object and a Table for a name
+   mapping and returns a new Table with the columns renamed according to the
+   mapping.
+read_name_map_from_table : Table -> Vector | Map ! Illegal_Argument
+read_name_map_from_table column_map:Table = case column_map.column_count of
+    1 ->
+        col = column_map.first_column
+        if col.value_type.is_text then col.to_vector else
+            Error.throw (Illegal_Argument.Error "Expected a table with one or two columns of text values.")
+    2 ->
+        if column_map.first_column.value_type.is_text && column_map.second_column.value_type.is_text then Map.from_vector column_map.rows else
+            Error.throw (Illegal_Argument.Error "Expected a table with one or two columns of text values.")
+    _ -> Error.throw (Illegal_Argument.Error "Expected a table with one or two columns of text values.")
+
+## PRIVATE
    A helper function encapsulating shared code for `rename_columns`
    implementations of various Table variants. See the documentation for the
    Table type for details.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -673,10 +673,20 @@ type Table
               table.rename_columns (Map.from_vector [["name=(.*)".to_regex, "key:$1"]])
     @column_map Widget_Helpers.make_rename_name_vector_selector
     rename_columns : Map (Text | Integer | Regex) Text | Vector Text | Vector Vector -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Ambiguous_Column_Rename | Too_Many_Column_Names_Provided | Invalid_Column_Names | Duplicate_Output_Column_Names
-    rename_columns self (column_map:(Map | Vector)=["Column"]) (case_sensitivity:Case_Sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=True) (on_problems:Problem_Behavior=Report_Warning) =
-        new_names = Table_Helpers.rename_columns self.column_naming_helper self.columns column_map case_sensitivity error_on_missing_columns on_problems
-        Warning.with_suspended new_names names->
-            Table.new (self.columns.map c-> c.rename (names.at c.name))
+    rename_columns self (column_map:(Table | Map | Vector)=["Column"]) (case_sensitivity:Case_Sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=True) (on_problems:Problem_Behavior=Report_Warning) = case column_map of
+        _ : Table -> case column_map.column_count of
+            1 ->
+                col = column_map.first_column
+                if col.value_type.is_text then self.rename_columns col.to_vector case_sensitivity error_on_missing_columns on_problems else
+                    Error.throw (Illegal_Argument.Error "Expected a table with one or two columns of text values.")
+            2 ->
+                if column_map.first_column.value_type.is_text && column_map.second_column.value_type.is_text then self.rename_columns (Map.from_vector column_map.rows) case_sensitivity error_on_missing_columns on_problems else
+                    Error.throw (Illegal_Argument.Error "Expected a table with one or two columns of text values.")
+            _ -> Error.throw (Illegal_Argument.Error "Expected a table with one or two columns of text values.")
+        _ ->
+            new_names = Table_Helpers.rename_columns self.column_naming_helper self.columns column_map case_sensitivity error_on_missing_columns on_problems
+            Warning.with_suspended new_names names->
+                Table.new (self.columns.map c-> c.rename (names.at c.name))
 
     ## GROUP Standard.Base.Metadata
        ICON table_edit

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -619,7 +619,8 @@ type Table
          column names to apply by position. `Regex` objects can be used
          within the mapping to do pattern based renaming.
          Can also be supplied as a `Table` either with a single column of new
-         names or two columns with old and new names.
+         names or two columns with old (first column) and new names (second
+         column).
        - case_sensitivity: Controls whether to be case sensitive when matching
          column names.
        - error_on_missing_columns: Specifies if a missing input column should
@@ -676,15 +677,9 @@ type Table
     @column_map Widget_Helpers.make_rename_name_vector_selector
     rename_columns : Map (Text | Integer | Regex) Text | Vector Text | Vector Vector -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Ambiguous_Column_Rename | Too_Many_Column_Names_Provided | Invalid_Column_Names | Duplicate_Output_Column_Names
     rename_columns self (column_map:(Table | Map | Vector)=["Column"]) (case_sensitivity:Case_Sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=True) (on_problems:Problem_Behavior=Report_Warning) = case column_map of
-        _ : Table -> case column_map.column_count of
-            1 ->
-                col = column_map.first_column
-                if col.value_type.is_text then self.rename_columns col.to_vector case_sensitivity error_on_missing_columns on_problems else
-                    Error.throw (Illegal_Argument.Error "Expected a table with one or two columns of text values.")
-            2 ->
-                if column_map.first_column.value_type.is_text && column_map.second_column.value_type.is_text then self.rename_columns (Map.from_vector column_map.rows) case_sensitivity error_on_missing_columns on_problems else
-                    Error.throw (Illegal_Argument.Error "Expected a table with one or two columns of text values.")
-            _ -> Error.throw (Illegal_Argument.Error "Expected a table with one or two columns of text values.")
+        _ : Table ->
+            resolved = Table_Helpers.read_name_map_from_table column_map
+            self.rename_columns resolved case_sensitivity error_on_missing_columns on_problems else
         _ ->
             new_names = Table_Helpers.rename_columns self.column_naming_helper self.columns column_map case_sensitivity error_on_missing_columns on_problems
             Warning.with_suspended new_names names->

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -679,7 +679,7 @@ type Table
     rename_columns self (column_map:(Table | Map | Vector)=["Column"]) (case_sensitivity:Case_Sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=True) (on_problems:Problem_Behavior=Report_Warning) = case column_map of
         _ : Table ->
             resolved = Table_Helpers.read_name_map_from_table column_map
-            self.rename_columns resolved case_sensitivity error_on_missing_columns on_problems else
+            self.rename_columns resolved case_sensitivity error_on_missing_columns on_problems
         _ ->
             new_names = Table_Helpers.rename_columns self.column_naming_helper self.columns column_map case_sensitivity error_on_missing_columns on_problems
             Warning.with_suspended new_names names->

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -618,6 +618,8 @@ type Table
        - column_map: Mapping from old column names to new or a vector of new
          column names to apply by position. `Regex` objects can be used
          within the mapping to do pattern based renaming.
+         Can also be supplied as a `Table` either with a single column of new
+         names or two columns with old and new names.
        - case_sensitivity: Controls whether to be case sensitive when matching
          column names.
        - error_on_missing_columns: Specifies if a missing input column should

--- a/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
@@ -1,11 +1,10 @@
 from Standard.Base import all
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
-from Standard.Table import Position, Value_Type, Bits
+from Standard.Table import Position, Value_Type, Bits, Table
 from Standard.Table.Errors import all
 
 from Standard.Test import all
-
 
 from project.Common_Table_Operations.Util import expect_column_names, run_default_backend
 

--- a/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
@@ -489,6 +489,16 @@ add_specs suite_builder setup =
             expect_column_names ["FirstColumn", "beta", "gamma", "Another"] <|
                 data.table.rename_columns map
 
+        group_builder.specify "should work by single column Table of names" <|
+            vec = Table.new ["Name", ["one", "two", "three"]]
+            expect_column_names ["one", "two", "three", "delta"] <|
+                data.table.rename_columns vec
+
+        group_builder.specify "should work by two column Table of old name, new name" <|
+            vec = Table.from_rows ["Old", "New"] [["beta", "one"], ["delta", "two"], ["alpha", "three"]]
+            expect_column_names ["three", "one", "gamma", "two"] <|
+                data.table.rename_columns vec
+
         group_builder.specify "should work by name case-insensitively" <|
             map = Map.from_vector [["ALPHA", "FirstColumn"], ["DELTA", "Another"]]
             expect_column_names ["FirstColumn", "beta", "gamma", "Another"] <|

--- a/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
@@ -490,14 +490,30 @@ add_specs suite_builder setup =
                 data.table.rename_columns map
 
         group_builder.specify "should work by single column Table of names" <|
-            vec = Table.new ["Name", ["one", "two", "three"]]
+            table_1 = Table.new ["Name", ["one", "two", "three"]]
             expect_column_names ["one", "two", "three", "delta"] <|
-                data.table.rename_columns vec
+                data.table.rename_columns table_1
 
         group_builder.specify "should work by two column Table of old name, new name" <|
-            vec = Table.from_rows ["Old", "New"] [["beta", "one"], ["delta", "two"], ["alpha", "three"]]
+            table_2 = Table.from_rows ["Old", "New"] [["beta", "one"], ["delta", "two"], ["alpha", "three"]]
             expect_column_names ["three", "one", "gamma", "two"] <|
-                data.table.rename_columns vec
+                data.table.rename_columns table_2
+
+        group_builder.specify "should error if not correct table structure" <|
+            table_1 = Table.new [["Name", [1, 2, 3]]]
+            fail_1 = data.table.rename_columns table_1
+            fail_1 . should_fail_with Illegal_Argument
+            fail_1.catch.message.should_equal "Expected a table with one or two columns of text values."
+
+            table_2 = Table.new Table.from_rows ["Old", "New"] [["beta", 1], ["delta", 2], ["alpha", 3]]
+            fail_2 = data.table.rename_columns table_2
+            fail_2 . should_fail_with Illegal_Argument
+            fail_2.catch.message.should_equal "Expected a table with one or two columns of text values."
+
+            table_3 = Table.new [["Name", ["A", "B", "C"]], ["NewName", ["AA", "BB", "CC"]], ["Another", ["a", "b", "c"]]]
+            fail_3 = data.table.rename_columns table_3
+            fail_3 . should_fail_with Illegal_Argument
+            fail_3.catch.message.should_equal "Expected a table with one or two columns of text values."
 
         group_builder.specify "should work by name case-insensitively" <|
             map = Map.from_vector [["ALPHA", "FirstColumn"], ["DELTA", "Another"]]

--- a/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
@@ -489,7 +489,7 @@ add_specs suite_builder setup =
                 data.table.rename_columns map
 
         group_builder.specify "should work by single column Table of names" <|
-            table_1 = Table.new ["Name", ["one", "two", "three"]]
+            table_1 = Table.new [["Name", ["one", "two", "three"]]]
             expect_column_names ["one", "two", "three", "delta"] <|
                 data.table.rename_columns table_1
 
@@ -504,7 +504,7 @@ add_specs suite_builder setup =
             fail_1 . should_fail_with Illegal_Argument
             fail_1.catch.message.should_equal "Expected a table with one or two columns of text values."
 
-            table_2 = Table.new Table.from_rows ["Old", "New"] [["beta", 1], ["delta", 2], ["alpha", 3]]
+            table_2 = Table.from_rows ["Old", "New"] [["beta", 1], ["delta", 2], ["alpha", 3]]
             fail_2 = data.table.rename_columns table_2
             fail_2 . should_fail_with Illegal_Argument
             fail_2.catch.message.should_equal "Expected a table with one or two columns of text values."

--- a/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
@@ -514,6 +514,18 @@ add_specs suite_builder setup =
             fail_3 . should_fail_with Illegal_Argument
             fail_3.catch.message.should_equal "Expected a table with one or two columns of text values."
 
+        if setup.is_database then group_builder.specify "should error if renaming by Database table (it must be materialized)" <|
+            db_source_table = data.table
+            db_rename_table = data.table.select_columns [0, 1] . cast [0, 1] Value_Type.Char
+            fail_1 = db_source_table.rename_columns db_rename_table
+            fail_1.should_fail_with Illegal_Argument
+            fail_1.catch.message.should_contain "materialize"
+
+            # We also check that renaming an in-memory table with a database table as mapping also fails.
+            fail_2 = (Table.new [["X", [1, 2]]]).rename_columns db_rename_table
+            fail_2.should_fail_with Illegal_Argument
+            fail_2.catch.message.should_contain "materialize"
+
         group_builder.specify "should work by name case-insensitively" <|
             map = Map.from_vector [["ALPHA", "FirstColumn"], ["DELTA", "Another"]]
             expect_column_names ["FirstColumn", "beta", "gamma", "Another"] <|

--- a/test/Table_Tests/src/In_Memory/Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Spec.enso
@@ -903,7 +903,7 @@ add_specs suite_builder =
 
             r = t.join db_table
             r.should_fail_with Illegal_Argument
-            r.catch.message . contains "cross-backend" . should_be_true
+            r.catch.message . contains "materialize" . should_be_true
 
     suite_builder.group "[In-Memory-specific] Table.set" group_builder->
         group_builder.specify "should allow using vector and range for a new column" <|

--- a/test/Table_Tests/src/In_Memory/Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Spec.enso
@@ -903,7 +903,7 @@ add_specs suite_builder =
 
             r = t.join db_table
             r.should_fail_with Illegal_Argument
-            r.catch.message . contains "materialize" . should_be_true
+            r.catch.message . should_contain "materialize"
 
     suite_builder.group "[In-Memory-specific] Table.set" group_builder->
         group_builder.specify "should allow using vector and range for a new column" <|


### PR DESCRIPTION
### Pull Request Description

Following an example from Steve, adjusted `rename_column` to allow a `Table` to define the mapping.

- A single Text column table gives a list of new names.
- A two Text column table gives a map from old name to new name.
- If a `DB_Table` is passed errors and tells the user to materialize the table.

![image](https://github.com/enso-org/enso/assets/4699705/3ed98330-1fce-465e-bf96-4a86e0872dd3)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
