### PR TITLE
Fix broken login flow

### DIFF
--- a/app/gui2/vite.config.ts
+++ b/app/gui2/vite.config.ts
@@ -12,7 +12,6 @@ import { defineConfig, type Plugin } from 'vite'
 // @ts-expect-error
 import * as tailwindConfig from 'enso-dashboard/tailwind.config'
 import { createGatewayServer } from './ydoc-server'
-const localServerPort = 8080
 const projectManagerUrl = 'ws://127.0.0.1:30535'
 
 const IS_CLOUD_BUILD = process.env.CLOUD_BUILD === 'true'
@@ -60,7 +59,7 @@ export default defineConfig({
     },
   },
   define: {
-    ...getDefines(localServerPort),
+    ...getDefines(),
     IS_CLOUD_BUILD: JSON.stringify(IS_CLOUD_BUILD),
     PROJECT_MANAGER_URL: JSON.stringify(projectManagerUrl),
     YDOC_SERVER_URL: IS_POLYGLOT_YDOC_SERVER ? JSON.stringify('defined') : undefined,

--- a/app/ide-desktop/.example.env
+++ b/app/ide-desktop/.example.env
@@ -1,4 +1,3 @@
-ENSO_CLOUD_REDIRECT=http://localhost:8080
 ENSO_CLOUD_ENVIRONMENT=production
 ENSO_CLOUD_API_URL=https://aaaaaaaaaa.execute-api.mars.amazonaws.com
 ENSO_CLOUD_CHAT_URL=wss://chat.example.com

--- a/app/ide-desktop/lib/client/src/bin/server.ts
+++ b/app/ide-desktop/lib/client/src/bin/server.ts
@@ -75,7 +75,7 @@ export class Config {
 /** Determine the initial available communication endpoint, starting from the specified port,
  * to provide file hosting services. */
 async function findPort(port: number): Promise<number> {
-    return await portfinder.getPortPromise({ port, startPort: port })
+    return await portfinder.getPortPromise({ port, startPort: port, stopPort: port + 4 })
 }
 
 // ==============

--- a/app/ide-desktop/lib/client/src/bin/server.ts
+++ b/app/ide-desktop/lib/client/src/bin/server.ts
@@ -74,31 +74,8 @@ export class Config {
 
 /** Determine the initial available communication endpoint, starting from the specified port,
  * to provide file hosting services. */
-async function findPort(port: number, stopPort: number): Promise<number> {
-    return await portfinder.getPortPromise({ port, startPort: port, stopPort })
-}
-
-// ================
-// === Port Use ===
-// ================
-
-/**
- * Check if a port is in use.
- */
-async function isPortInUse(port: number): Promise<boolean> {
-    // we need to check if the port is in use
-    // by finding the nearest port that is not in use
-    // we limit the search to the next port
-    // because we should check only the port provided
-    // and not the whole range
-    // if the port is in use, the function will throw
-    // and we will know that the port is in use
-    try {
-        await findPort(port, port)
-        return false
-    } catch (e) {
-        return true
-    }
+async function findPort(port: number): Promise<number> {
+    return await portfinder.getPortPromise({ port, startPort: port })
 }
 
 // ==============
@@ -121,20 +98,10 @@ export class Server {
     /** Server constructor. */
     static async create(config: Config): Promise<Server> {
         const localConfig = Object.assign({}, config)
-
-        if (await isPortInUse(localConfig.port)) {
-            logger.error(
-                `💥Port ${localConfig.port} is already in use. Please close the application using it and try again.`
-            )
-
-            return Promise.reject(
-                `💥Port ${localConfig.port} is already in use. Please close the application using it and try again.`
-            )
-        } else {
-            const server = new Server(localConfig)
-            await server.run()
-            return server
-        }
+        localConfig.port = await findPort(localConfig.port)
+        const server = new Server(localConfig)
+        await server.run()
+        return server
     }
 
     /** Start the server. */

--- a/app/ide-desktop/lib/common/src/appConfig.js
+++ b/app/ide-desktop/lib/common/src/appConfig.js
@@ -86,13 +86,13 @@ function stringify(value) {
  * - the unique identifier for the cloud environment, for use in Sentry logs
  * - Stripe, Sentry and Amplify public keys */
 // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-export function getDefines(serverPort = 8080) {
+export function getDefines() {
     return {
         /* eslint-disable @typescript-eslint/naming-convention */
         'process.env.ENSO_CLOUD_REDIRECT': stringify(
             // The actual environment variable does not necessarily exist.
             // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-            process.env.ENSO_CLOUD_REDIRECT ?? `http://localhost:${serverPort}`
+            process.env.ENSO_CLOUD_REDIRECT
         ),
         'process.env.ENSO_CLOUD_ENVIRONMENT': stringify(
             // The actual environment variable does not necessarily exist.
@@ -124,11 +124,9 @@ export function getDefines(serverPort = 8080) {
     }
 }
 
-const SERVER_PORT = 8080
 const DUMMY_DEFINES = {
     /* eslint-disable @typescript-eslint/naming-convention */
     'process.env.NODE_ENV': 'production',
-    'process.env.ENSO_CLOUD_REDIRECT': `http://localhost:${SERVER_PORT}`,
     'process.env.ENSO_CLOUD_ENVIRONMENT': 'production',
     'process.env.ENSO_CLOUD_API_URL': 'https://mock',
     'process.env.ENSO_CLOUD_SENTRY_DSN':

--- a/app/ide-desktop/lib/dashboard/src/authentication/service.ts
+++ b/app/ide-desktop/lib/dashboard/src/authentication/service.ts
@@ -167,10 +167,11 @@ function loadAmplifyConfig(
     // needs to be registered.
     setDeepLinkHandler(logger, navigate)
   }
+
+  const redirectUrl = process.env.ENSO_CLOUD_REDIRECT ?? window.location.origin
+
   /** Load the platform-specific Amplify configuration. */
-  const signInOutRedirect = supportsDeepLinks
-    ? `${common.DEEP_LINK_SCHEME}://auth`
-    : process.env.ENSO_CLOUD_REDIRECT
+  const signInOutRedirect = supportsDeepLinks ? `${common.DEEP_LINK_SCHEME}://auth` : redirectUrl
   return process.env.ENSO_CLOUD_COGNITO_USER_POOL_ID == null ||
     process.env.ENSO_CLOUD_COGNITO_USER_POOL_WEB_CLIENT_ID == null ||
     process.env.ENSO_CLOUD_COGNITO_DOMAIN == null ||

--- a/app/ide-desktop/lib/dashboard/vite.config.ts
+++ b/app/ide-desktop/lib/dashboard/vite.config.ts
@@ -45,7 +45,7 @@ export default vite.defineConfig({
     IS_VITE: JSON.stringify(true),
     // The sole hardcoded usage of `global` in aws-amplify.
     'global.TYPED_ARRAY_SUPPORT': JSON.stringify(true),
-    ...appConfig.getDefines(SERVER_PORT),
+    ...appConfig.getDefines(),
   },
 })
 

--- a/app/ide-desktop/lib/types/globals.d.ts
+++ b/app/ide-desktop/lib/types/globals.d.ts
@@ -147,7 +147,7 @@ declare global {
             // === Cloud environment variables ===
 
             // @ts-expect-error The index signature is intentional to disallow unknown env vars.
-            readonly ENSO_CLOUD_REDIRECT: string
+            readonly ENSO_CLOUD_REDIRECT?: string
             // When unset, the `.env` loader tries to load `.env` rather than `.<name>.env`.
             // Set to the empty string to load `.env`.
             // @ts-expect-error The index signature is intentional to disallow unknown env vars.


### PR DESCRIPTION
### Pull Request Description

#### Tl;dr 
Closes: enso-org/cloud-v2#1231
This PR makes the ENSO_CLOUD_REDIRECT env variable optional and uses window.location.origin as a redirect url by default

---

#### Context:
In the recent PR we have changed the server address where we start the electron app from 'http' to 'https'. This change was caused by the Stripe live mode that doesn't work in the HTTP environment. But now we have different origins based on where we launched the app. So we decided to make the ENSO_CLOUD_REDIRECT env variable optional and use window.location.origin as a redirect URL by default. Also, we found a bug if the electron server started on a different port, let's say 8081(this might happen if 8080 is already in use) and the server will be implicitly redirected from 8081 to 8080 after login. We decided to explicitly kill the app and show the error in the console. This is because we need to specify allowed redirect URLs in COGNITO explicitly to make the login flow work.


#### This Change:
1. Makes ENSO_CLOUD_REDIRECT optional
2. Uses window.location.origin as a defualt redirect URL
3. Throw an error if the port is in use when starting an electron app

#### Test Plan:
Go over how you plan to test it. Your test plan should be more thorough the riskier the change is. For major changes, I like to describe how I E2E tested it and will monitor the rollout.

---



### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
