### PR TITLE
[Do not merge yet] Revert temporary workaround that allowed both old and new Path Resolver API

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Existing_Enso_Asset.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Existing_Enso_Asset.enso
@@ -11,7 +11,6 @@ import project.Enso_Cloud.Cloud_Caching_Settings
 import project.Enso_Cloud.Enso_File.Enso_Asset_Type
 import project.Enso_Cloud.Enso_File.Enso_File
 import project.Enso_Cloud.Enso_User.Enso_User
-import project.Enso_Cloud.Errors.Enso_Cloud_Error
 import project.Enso_Cloud.Internal.Utils
 import project.Error.Error
 import project.Errors.Common.Not_Found
@@ -85,16 +84,7 @@ type Existing_Enso_Asset
         error_handlers = Map.from_vector [["resource_missing", handle_not_found]]
 
         uri = ((URI.from Utils.cloud_root_uri) / "path/resolve") . add_query_argument "path" path
-        r = Utils.http_request_as_json HTTP_Method.Get uri error_handlers=error_handlers
-        ## Workaround to keep compatibility with old cloud API
-           TODO remove it after https://github.com/enso-org/cloud-v2/pull/1236 has been deployed
-        response = r.catch Enso_Cloud_Error error-> case error of
-            Enso_Cloud_Error.Unexpected_Service_Error status _ ->
-                if status.code != 404 then r else
-                    old_uri = (URI.from Utils.cloud_root_uri) / "path/resolve"
-                    old_payload = JS_Object.from_pairs [["path", path]]
-                    Context.Output.with_enabled <| Utils.http_request_as_json HTTP_Method.Post old_uri old_payload error_handlers=error_handlers
-            _ -> r
+        response = Utils.http_request_as_json HTTP_Method.Get uri error_handlers=error_handlers
         Existing_Enso_Asset.from_json response
 
     ## PRIVATE


### PR DESCRIPTION


### Pull Request Description

- Followup of #9958 
- This reverts commit d8460d0d063216ec2d53101c7d865da3199f2173.
- It should be merged after https://github.com/enso-org/cloud-v2/pull/1236 has been deployed

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
