### PR TITLE
Display grab cursor 2

### DIFF
--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -246,13 +246,13 @@ const transform = computed(() => {
 })
 
 const startEpochMs = ref(0)
-let significantMove = false
+const significantMove = ref(false)
 
 const dragPointer = usePointer(
   (pos, event, type) => {
     if (type !== 'start') {
       if (
-        !significantMove &&
+        !significantMove.value &&
         (Number(new Date()) - startEpochMs.value >= MAXIMUM_CLICK_LENGTH_MS ||
           pos.relative.lengthSquared() >= MAXIMUM_CLICK_DISTANCE_SQ)
       ) {
@@ -260,7 +260,7 @@ const dragPointer = usePointer(
         // prevent `click` on widgets.
         if (event.currentTarget instanceof Element)
           event.currentTarget.setPointerCapture?.(event.pointerId)
-        significantMove = true
+        significantMove.value = true
       }
       const fullOffset = pos.relative
       emit('dragging', fullOffset)
@@ -268,7 +268,7 @@ const dragPointer = usePointer(
     switch (type) {
       case 'start':
         startEpochMs.value = Number(new Date())
-        significantMove = false
+        significantMove.value = false
         break
       case 'stop': {
         startEpochMs.value = 0
@@ -280,6 +280,7 @@ const dragPointer = usePointer(
   // is not going to be a node drag.
   { pointerCapturedBy: 'target' },
 )
+const isDragged = computed(() => dragPointer.dragging && significantMove)
 
 const isRecordingOverridden = computed({
   get() {
@@ -371,13 +372,13 @@ const handlePortClick = useDoubleClick(
 
 const handleNodeClick = useDoubleClick(
   (e: MouseEvent) => {
-    if (!significantMove) {
+    if (!significantMove.value) {
       nodeSelection?.handleSelectionOf(e, new Set([nodeId.value]))
       nodeEditHandler(e)
     }
   },
   () => {
-    if (!significantMove) emit('doubleClick')
+    if (!significantMove.value) emit('doubleClick')
   },
 ).handleClick
 
@@ -475,7 +476,7 @@ const matchableNodeColors = getNodeColors((node) => node !== nodeId.value)
     <Teleport :to="graphNodeSelections">
       <GraphNodeSelection
         v-if="navigator"
-        :class="dragPointer.dragging ? 'dragged' : 'draggable'"
+        :class="{ dragged: isDragged }"
         :nodePosition="props.node.position"
         :nodeSize="nodeSize"
         :selected
@@ -542,8 +543,7 @@ const matchableNodeColors = getNodeColors((node) => node !== nodeId.value)
     <GraphNodeComment v-model:editing="editingComment" :node="node" class="beforeNode" />
     <div
       ref="contentNode"
-      class="content"
-      :class="dragPointer.dragging ? 'dragged' : 'draggable'"
+      :class="{ content: true, dragged: isDragged }"
       v-on="dragPointer.events"
       @click="handleNodeClick"
     >

--- a/app/gui2/src/components/GraphEditor/GraphNode.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNode.vue
@@ -475,6 +475,7 @@ const matchableNodeColors = getNodeColors((node) => node !== nodeId.value)
     <Teleport :to="graphNodeSelections">
       <GraphNodeSelection
         v-if="navigator"
+        :class="dragPointer.dragging ? 'dragged' : 'draggable'"
         :nodePosition="props.node.position"
         :nodeSize="nodeSize"
         :selected
@@ -539,7 +540,13 @@ const matchableNodeColors = getNodeColors((node) => node !== nodeId.value)
       @createNodes="emit('createNodes', $event)"
     />
     <GraphNodeComment v-model:editing="editingComment" :node="node" class="beforeNode" />
-    <div ref="contentNode" class="content" v-on="dragPointer.events" @click="handleNodeClick">
+    <div
+      ref="contentNode"
+      class="content"
+      :class="dragPointer.dragging ? 'dragged' : 'draggable'"
+      v-on="dragPointer.events"
+      @click="handleNodeClick"
+    >
       <NodeWidgetTree
         :ast="props.node.innerExpr"
         :nodeId="nodeId"
@@ -801,5 +808,13 @@ const matchableNodeColors = getNodeColors((node) => node !== nodeId.value)
   height: 100%;
   right: 100%;
   margin-right: 4px;
+}
+
+.draggable {
+  cursor: grab;
+}
+
+.dragged {
+  cursor: grabbing;
 }
 </style>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetSelection.vue
@@ -406,6 +406,7 @@ declare module '@/providers/widgetRegistry' {
   align-items: center;
   position: relative;
   min-height: var(--node-port-height);
+  cursor: pointer;
 }
 
 .arrow {

--- a/app/gui2/src/components/widgets/AutoSizedInput.vue
+++ b/app/gui2/src/components/widgets/AutoSizedInput.vue
@@ -82,7 +82,6 @@ defineExpose({
   height: 24px;
   appearance: textfield;
   -moz-appearance: textfield;
-  cursor: default;
   user-select: all;
   box-sizing: content-box;
   &:focus {

--- a/app/gui2/src/components/widgets/ListWidget.vue
+++ b/app/gui2/src/components/widgets/ListWidget.vue
@@ -516,6 +516,7 @@ div {
     -2px 0 0 transparent;
   transition: box-shadow 0.2s ease;
   pointer-events: none;
+  cursor: grab;
 
   &:before {
     content: '';


### PR DESCRIPTION
### Pull Request Description

Fixes #9906, but the grab hand appears only when actually moving nodes.

Also changed cursor on some widgets.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
