### PR TITLE
fix: escape docs text in documentation parser

### DIFF
--- a/lib/rust/parser/doc-parser/src/doc_sections.rs
+++ b/lib/rust/parser/doc-parser/src/doc_sections.rs
@@ -195,7 +195,7 @@ impl<L> TokenConsumer<L> for DocSectionCollector {
     }
 
     fn text(&mut self, text: Span<'_, L>) {
-        self.current_body.push_str(text.as_ref());
+        self.current_body.push_str(&escape(text.as_ref()));
     }
 
     fn start_list(&mut self) {
@@ -253,4 +253,23 @@ impl<L> TokenConsumer<L> for DocSectionCollector {
             ScopeType::Raw => self.current_body.push_str("</div>"),
         }
     }
+}
+
+// === HTML escaping ===
+
+/// Escape `<`, `>` and `&` characters to make them safe for embedding into HTML.
+///
+/// Note: we don’t need to escape single and double quotes, as we never produce them inside HTML
+/// tags.
+fn escape(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    for c in input.chars() {
+        match c {
+            '<' => result.push_str("&lt;"),
+            '>' => result.push_str("&gt;"),
+            '&' => result.push_str("&amp;"),
+            _ => result.push(c),
+        }
+    }
+    result
 }

--- a/lib/rust/parser/doc-parser/src/lib.rs
+++ b/lib/rust/parser/doc-parser/src/lib.rs
@@ -679,7 +679,7 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn test_list_parsing() {
+    fn test_doc_parsing() {
         use crate::doc_sections::Argument;
         use crate::DocSection::*;
         use crate::Mark::*;
@@ -688,13 +688,13 @@ mod tests {
         let docs = r#"
         ALIAS From Text
 
-        Parses a textual representation of an integer into an integer number, returning
+        Parses a textual <representation> of an integer into an integer number, returning
         a `Number_Parse_Error` if the text does not represent a valid integer.
 
         Arguments:
         - text: The text to parse into a integer.
         - radix: The number base to use for parsing (defaults to 10). `radix`
-            must be between 2 and 36 (inclusive)
+            must be between 2 and (&) 36 (inclusive)
         - arg argument without colon
         - argument_without_description
 
@@ -708,8 +708,8 @@ mod tests {
                 Integer.parse "20220216""#;
         let res = parse(docs);
         let expected = [
-            Tag { tag: Alias, body: "From Text".into() }, 
-            Paragraph { body: "Parses a textual representation of an integer into an integer number, \
+            Tag { tag: Alias, body: "From Text".into() },
+            Paragraph { body: "Parses a textual &lt;representation&gt; of an integer into an integer number, \
                 returning a <code>Number_Parse_Error</code> if the text does not represent a valid integer.".into() },
             Keyed { key: "Arguments".into(), body: "".into() },
             Arguments { args: [
@@ -719,7 +719,7 @@ mod tests {
                 Argument {
                     name: "radix".into(),
                     description: "The number base to use for parsing (defaults to 10). <code>radix</code> \
-                    must be between 2 and 36 (inclusive)".into()
+                    must be between 2 and (&amp;) 36 (inclusive)".into()
                 },
                 Argument {
                     name: "arg".into(),
@@ -733,7 +733,7 @@ mod tests {
             List { items: ["List item 1".into(), "List item 2".into(), "List item 3".into()].to_vec() },
             Marked {
                 mark: Example,
-                header: Some("Example".into()), 
+                header: Some("Example".into()),
                 body: "<p>Parse the text \"20220216\" into an integer number.<div class=\"example\">\nInteger.parse \"20220216\"</div>".into()
             }].to_vec();
         assert_eq!(res, expected);


### PR DESCRIPTION
### Pull Request Description

Fixes #9933 


<img width="679" alt="Screenshot 2024-05-17 at 2 27 18 PM" src="https://github.com/enso-org/enso/assets/6566674/261ea12c-1cb9-4a09-8e36-75dbc9e56c22">


### Important Notes


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
