### PR TITLE
Update test framework to default to only show failures

### DIFF
--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Suite.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Suite.enso
@@ -105,10 +105,12 @@ type Suite
         pending_groups = matching_specs.filter (p-> p.first.is_pending) . length
         case should_exit of
             True ->
+                IO.println ""
                 IO.println <| succ_tests.to_text + " tests succeeded."
                 IO.println <| failed_tests.to_text + " tests failed."
                 IO.println <| skipped_tests.to_text + " tests skipped."
                 IO.println <| pending_groups.to_text + " groups skipped."
+                IO.println ""
                 exit_code = if failed_tests > 0 then 1 else 0
                 System.exit exit_code
             False ->

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Suite_Config.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Suite_Config.enso
@@ -50,7 +50,7 @@ type Suite_Config
     ## Creates an Suite_Config based off environment and caller location
     from_environment : Suite_Config
     from_environment =
-        print_only_failures = Environment.get "REPORT_ONLY_FAILED" != Nothing
+        print_only_failures = Environment.get "REPORT_ALL_TESTS" . is_nothing
         junit_folder = Environment.get "ENSO_TEST_JUNIT_DIR"
         use_ansi_colors = Environment.get "ENSO_TEST_ANSI_COLORS" . is_nothing . not
         caller_script = find_caller_script Runtime.get_stack_trace

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Test_Reporter.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Test_Reporter.enso
@@ -76,15 +76,16 @@ print_single_result (test_result : Test_Result) (config : Suite_Config) =
                 txt = "    - " + test_result.spec_name + " " + times_suffix
                 IO.println (maybe_green_text txt config)
         Spec_Result.Failure msg details ->
+            IO.println ""
             txt = "    - [FAILED] " + test_result.spec_name + " " + times_suffix
             IO.println (maybe_red_text txt config)
             IO.println ("        Reason: " + msg)
             if details.is_nothing.not then
                 IO.println (decorate_stack_trace details)
+            IO.println ""
         Spec_Result.Pending reason ->
-            if config.print_only_failures.not then
-                IO.println (maybe_grey_text ("    - [PENDING] " + test_result.spec_name) config)
-                IO.println ("        Reason: " + reason)
+            IO.println (maybe_grey_text ("    - [PENDING] " + test_result.spec_name) config)
+            IO.println ("        Reason: " + reason)
 
 
 ## Prints all the results, optionally writing them to a jUnit XML output.
@@ -156,7 +157,7 @@ print_group_report group_name test_results config builder =
             builder.append '        </testcase>\n'
         builder.append '    </testsuite>\n'
 
-    should_print_behavior = config.print_only_failures.not || test_results.any (r -> r.is_fail)
+    should_print_behavior = config.print_only_failures.not || test_results.any (r -> r.is_fail) || test_results.any (r -> r.is_pending)
     if should_print_behavior then
         tests_succeeded = test_results.fold 0 acc-> res->
             if res.is_success then acc + 1 else acc

--- a/test/Base_Tests/src/Data/Ordering_Spec.enso
+++ b/test/Base_Tests/src/Data/Ordering_Spec.enso
@@ -77,7 +77,7 @@ add_specs suite_builder =
 
     suite_builder.group "Default comparator" group_builder->
         group_builder.specify "should support custom comparator" <|
-            Ordering.compare (Ord.Value 1) (Ord.Value 2) . should_equal Ordering.Less
+            Ordering.compare (Ord.Value 10) (Ord.Value 2) . should_equal Ordering.Less
             Ordering.compare (Ord.Value 1) (Ord.Value 1) . should_equal Ordering.Equal
             Ordering.compare (Ord.Value 20) (Ord.Value 1) . should_equal Ordering.Greater
             Ordering.compare (UPair.Value 1 2) (UPair.Value 2 1) . should_equal Ordering.Equal

--- a/test/Base_Tests/src/Data/Ordering_Spec.enso
+++ b/test/Base_Tests/src/Data/Ordering_Spec.enso
@@ -77,7 +77,7 @@ add_specs suite_builder =
 
     suite_builder.group "Default comparator" group_builder->
         group_builder.specify "should support custom comparator" <|
-            Ordering.compare (Ord.Value 10) (Ord.Value 2) . should_equal Ordering.Less
+            Ordering.compare (Ord.Value 1) (Ord.Value 2) . should_equal Ordering.Less
             Ordering.compare (Ord.Value 1) (Ord.Value 1) . should_equal Ordering.Equal
             Ordering.compare (Ord.Value 20) (Ord.Value 1) . should_equal Ordering.Greater
             Ordering.compare (UPair.Value 1 2) (UPair.Value 2 1) . should_equal Ordering.Equal


### PR DESCRIPTION
### Pull Request Description

This change removes the environment variable REPORT_ONLY_FAILED and makes that the default behavior. (With an additional change that pending tests are also always printed)
It adds a new environment variable REPORT_ALL_TESTS which when set gives you the old behaviour.

![image](https://github.com/enso-org/enso/assets/1720119/fc023fe5-1a7e-44eb-9d5c-d516334d8805)

Closes #9729 

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
