### PR TITLE
Allow file/read to return the contents of a collaborative buffer

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/protocol/json/JsonConnectionController.scala
@@ -538,7 +538,7 @@ class JsonConnectionController(
       WriteFile -> file.WriteTextualFileHandler
         .props(requestTimeout, fileManager),
       ReadFile -> file.ReadTextualFileHandler
-        .props(requestTimeout, fileManager),
+        .props(requestTimeout, bufferRegistry, fileManager),
       CreateFile -> file.CreateFileHandler.props(requestTimeout, fileManager),
       DeleteFile -> file.DeleteFileHandler.props(requestTimeout, fileManager),
       CopyFile   -> file.CopyFileHandler.props(requestTimeout, fileManager),

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/BufferRegistry.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/BufferRegistry.scala
@@ -38,6 +38,8 @@ import org.enso.languageserver.text.TextProtocol.{
   FileSaved,
   OpenBuffer,
   OpenFile,
+  ReadCollaborativeBuffer,
+  ReadCollaborativeBufferResult,
   SaveFailed,
   SaveFile
 }
@@ -154,6 +156,13 @@ class BufferRegistry(
         context.watch(bufferRef)
         bufferRef.forward(msg)
         context.become(running(registry + (path -> bufferRef)))
+      }
+
+    case msg @ ReadCollaborativeBuffer(path) =>
+      if (registry.contains(path)) {
+        registry(path).forward(msg)
+      } else {
+        sender() ! ReadCollaborativeBufferResult(None)
       }
 
     case Terminated(bufferRef) =>

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
@@ -357,6 +357,9 @@ class CollaborativeBuffer(
             failure
           )
       }
+
+    case ReadCollaborativeBuffer(_) =>
+      sender() ! ReadCollaborativeBufferResult(Some(buffer))
   }
 
   private def waitingOnReloadedContent(

--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/TextProtocol.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/TextProtocol.scala
@@ -202,4 +202,16 @@ object TextProtocol {
   /** Signals that the file is modified on disk. */
   case object SaveFailedFileModifiedOnDisk extends SaveFileResult
 
+  /** Read the contents of a collaborative buffer.
+    *
+    * @param path the file path
+    */
+  case class ReadCollaborativeBuffer(path: Path)
+
+  /** The data carried by a successful read operation.
+    *
+    * @param buffer file contents
+    */
+  case class ReadCollaborativeBufferResult(buffer: Option[Buffer])
+
 }

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/TextOperationsTest.scala
@@ -408,6 +408,126 @@ class TextOperationsTest
           }""")
     }
 
+    "allow file/read to read contents of a buffer" in {
+      val client = getInitialisedWsClient()
+      client.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "file/write",
+            "id": 0,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "file_read_test.txt" ]
+              },
+              "contents": "123456789"
+            }
+          }
+          """)
+      client.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 0,
+            "result": null
+          }
+          """)
+      client.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "text/openFile",
+            "id": 1,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "file_read_test.txt" ]
+              }
+            }
+          }
+          """)
+
+      receiveAndReplyToOpenFile("file_read_test.txt")
+
+      client.expectJson(json"""
+          {
+            "jsonrpc" : "2.0",
+            "id" : 1,
+            "result" : {
+              "writeCapability" : {
+                "method" : "text/canEdit",
+                "registerOptions" : {
+                  "path" : {
+                    "rootId" : $testContentRootId,
+                    "segments" : [
+                      "file_read_test.txt"
+                    ]
+                  }
+                }
+              },
+              "content" : "123456789",
+              "currentVersion" : "5795c3d628fd638c9835a4c79a55809f265068c88729a1a3fcdf8522"
+            }
+          }
+          """)
+
+      // apply edit
+      client.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "text/applyEdit",
+            "id": 2,
+            "params": {
+              "edit": {
+                "path": {
+                  "rootId": $testContentRootId,
+                  "segments": [ "file_read_test.txt" ]
+                },
+                "oldVersion": "5795c3d628fd638c9835a4c79a55809f265068c88729a1a3fcdf8522",
+                "newVersion": "ebe55342f9c8b86857402797dd723fb4a2174e0b56d6ace0a6929ec3",
+                "edits": [
+                  {
+                    "range": {
+                      "start": { "line": 0, "character": 0 },
+                      "end": { "line": 0, "character": 0 }
+                    },
+                    "text": "bar"
+                  },
+                  {
+                    "range": {
+                      "start": { "line": 0, "character": 12 },
+                      "end": { "line": 0, "character": 12 }
+                    },
+                    "text": "foo"
+                  }
+                ]
+              }
+            }
+          }
+          """)
+      client.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 2,
+            "result": null
+          }
+          """)
+
+      // file/read
+      client.send(json"""
+          { "jsonrpc": "2.0",
+            "method": "file/read",
+            "id": 3,
+            "params": {
+              "path": {
+                "rootId": $testContentRootId,
+                "segments": [ "file_read_test.txt" ]
+              }
+            }
+          }
+          """)
+      client.expectJson(json"""
+          { "jsonrpc": "2.0",
+            "id": 3,
+            "result": { "contents": "bar123456789foo" }
+          }
+          """)
+
+    }
+
   }
 
   "text/openFile" must {


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

part of #9960

Changelog:
- feat: file/read return contents of a collaborative buffer if they are available and fallback to reading the file from disk

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
