### PR TITLE
Fix adding nodes in collapsed functions

### DIFF
--- a/app/gui2/shared/ast/parse.ts
+++ b/app/gui2/shared/ast/parse.ts
@@ -507,11 +507,11 @@ export function printBlock(
 ): string {
   let blockIndent: string | undefined
   let code = ''
-  for (const line of block.fields.get('lines')) {
+  block.fields.get('lines').forEach((line, index) => {
     code += line.newline.whitespace ?? ''
     const newlineCode = block.module.getToken(line.newline.node).code()
     // Only print a newline if this isn't the first line in the output, or it's a comment.
-    if (offset || code || newlineCode.startsWith('#')) {
+    if (offset || index || newlineCode.startsWith('#')) {
       // If this isn't the first line in the output, but there is a concrete newline token:
       // if it's a zero-length newline, ignore it and print a normal newline.
       code += newlineCode || '\n'
@@ -533,7 +533,7 @@ export function printBlock(
       assertEqual(parentId(lineNode), block.id)
       code += lineNode.printSubtree(info, offset + code.length, blockIndent, verbatim)
     }
-  }
+  })
   const span = nodeKey(offset, code.length)
   map.setIfUndefined(info.nodes, span, (): Ast[] => []).unshift(block)
   return code

--- a/app/gui2/shared/ast/tree.ts
+++ b/app/gui2/shared/ast/tree.ts
@@ -137,6 +137,15 @@ export abstract class Ast {
     return this.wrappingExpression()?.documentingAncestor()
   }
 
+  get isBindingStatement(): boolean {
+    const inner = this.wrappedExpression()
+    if (inner) {
+      return inner.isBindingStatement
+    } else {
+      return false
+    }
+  }
+
   code(): string {
     return print(this).code
   }
@@ -1904,6 +1913,10 @@ export class Function extends Ast {
     }
   }
 
+  get isBindingStatement(): boolean {
+    return true
+  }
+
   *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
     const { name, argumentDefinitions, equals, body } = getAll(this.fields)
     yield name
@@ -1990,6 +2003,10 @@ export class Assignment extends Ast {
   }
   get expression(): Ast {
     return this.module.get(this.fields.get('expression').node)
+  }
+
+  get isBindingStatement(): boolean {
+    return true
   }
 
   *concreteChildren(verbatim?: boolean): IterableIterator<RawNodeChild> {

--- a/app/gui2/src/components/GraphEditor/GraphNodes.vue
+++ b/app/gui2/src/components/GraphEditor/GraphNodes.vue
@@ -48,7 +48,6 @@ const uploadingFiles = computed<[FileName, File][]>(() => {
     :node="node"
     :edited="id === graphStore.editedNodeInfo?.id"
     :graphNodeSelections="props.graphNodeSelections"
-    :data-node="id"
     @delete="graphStore.deleteNodes([id])"
     @dragging="nodeIsDragged(id, $event)"
     @draggingCommited="dragging.finishDrag()"

--- a/app/gui2/src/composables/__tests__/nodeCreation.test.ts
+++ b/app/gui2/src/composables/__tests__/nodeCreation.test.ts
@@ -1,0 +1,25 @@
+import { insertNodeStatements } from '@/composables/nodeCreation'
+import { Ast } from '@/util/ast'
+import { initializeFFI } from 'shared/ast/ffi'
+import { expect, test } from 'vitest'
+
+await initializeFFI()
+
+test.each([
+  ['node1 = 123', '*'],
+  ['node1 = 123', '*', 'node1'],
+  ['node1 = 123', '', '*', 'node1'],
+  ['*', 'node1'],
+  ['', '*', 'node1'],
+  ['*', '## Return value', 'node1'],
+  ['*', '## Return value', '', 'node1'],
+])('New node location in block', (...linesWithInsertionPoint: string[]) => {
+  const inputLines = linesWithInsertionPoint.filter((line) => line !== '*')
+  const bodyBlock = Ast.parseBlock(inputLines.join('\n'))
+  insertNodeStatements(bodyBlock, [Ast.parse('newNodePositionMarker')])
+  const lines = bodyBlock
+    .code()
+    .split('\n')
+    .map((line) => (line === 'newNodePositionMarker' ? '*' : line))
+  expect(lines).toEqual(linesWithInsertionPoint)
+})

--- a/app/gui2/src/composables/__tests__/nodeCreation.test.ts
+++ b/app/gui2/src/composables/__tests__/nodeCreation.test.ts
@@ -1,5 +1,6 @@
 import { insertNodeStatements } from '@/composables/nodeCreation'
 import { Ast } from '@/util/ast'
+import { identifier } from 'shared/ast'
 import { initializeFFI } from 'shared/ast/ffi'
 import { expect, test } from 'vitest'
 
@@ -13,6 +14,7 @@ test.each([
   ['', '*', 'node1'],
   ['*', '## Return value', 'node1'],
   ['*', '## Return value', '', 'node1'],
+  ['*', '## Block ends in documentation?!'],
 ])('New node location in block', (...linesWithInsertionPoint: string[]) => {
   const inputLines = linesWithInsertionPoint.filter((line) => line !== '*')
   const bodyBlock = Ast.parseBlock(inputLines.join('\n'))
@@ -22,4 +24,20 @@ test.each([
     .split('\n')
     .map((line) => (line === 'newNodePositionMarker' ? '*' : line))
   expect(lines).toEqual(linesWithInsertionPoint)
+})
+
+// This is a special case because when a block is empty, adding a line requires adding *two* linebreaks.
+test('Adding node to empty block', () => {
+  const module = Ast.MutableModule.Transient()
+  const func = Ast.Function.fromStatements(module, identifier('f')!, [], [])
+  const rootBlock = Ast.BodyBlock.new([], module)
+  rootBlock.push(func)
+  expect(rootBlock.code().trimEnd()).toBe('f =')
+  insertNodeStatements(func.bodyAsBlock(), [Ast.parse('newNode')])
+  expect(
+    rootBlock
+      .code()
+      .split('\n')
+      .map((line) => line.trimEnd()),
+  ).toEqual(['f =', '    newNode'])
 })

--- a/app/gui2/src/composables/selection.ts
+++ b/app/gui2/src/composables/selection.ts
@@ -179,7 +179,7 @@ export function useGraphHover(isPortEnabled: (port: PortId) => boolean) {
   const hoveredNode = computed<NodeId | undefined>(() => {
     const element = hoveredElement.value?.closest('.GraphNode')
     if (!element) return undefined
-    return dataAttribute<NodeId>(element, 'node')
+    return dataAttribute<NodeId>(element, 'node-id')
   })
 
   return { hoveredNode, hoveredPort }

--- a/app/gui2/src/util/ast/__tests__/abstract.test.ts
+++ b/app/gui2/src/util/ast/__tests__/abstract.test.ts
@@ -369,6 +369,10 @@ const cases = [
   ['value = foo', '    bar'].join('\n'),
   ['value = foo', '    +x', '    bar'].join('\n'),
   ['###', ' x'].join('\n'),
+  '\n',
+  '\n\n',
+  '\na',
+  '\n\na',
 ]
 test.each(cases)('parse/print round trip: %s', (code) => {
   // Get an AST.


### PR DESCRIPTION
### Pull Request Description

Insert new nodes before the block's terminal expression-statement, if present.

Fixes #9963.

### Important Notes

- Fix a bug that caused any empty lines at the beginning of a module not to be printed.
- Remove a redundant data-property from `GraphNode`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
