### PR TITLE
Include milliseconds in the log output

### DIFF
--- a/lib/scala/logging-config/src/main/java/org/enso/logger/config/Appender.java
+++ b/lib/scala/logging-config/src/main/java/org/enso/logger/config/Appender.java
@@ -70,7 +70,7 @@ public abstract sealed class Appender
   }
 
   public static final String defaultPattern =
-      "[%level] [%d{yyyy-MM-dd'T'HH:mm:ssXXX}] [%logger] %msg%n";
+      "[%level] [%d{yyyy-MM-dd'T'HH:mm:ss.SSS}] [%logger] %msg%n";
   protected static final String patternKey = "pattern";
   private static final String nameKey = "name";
 }


### PR DESCRIPTION
### Pull Request Description

When analyzing performance it is important to see more detailed times of log messages than seconds. Including milliseconds by default. Needed when analyzing #9236. 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] No tests are broken
