### PR TITLE
Use `group` icon for components created by grouping.

### DIFF
--- a/app/gui2/src/components/GraphEditor/collapsing.ts
+++ b/app/gui2/src/components/GraphEditor/collapsing.ts
@@ -214,7 +214,8 @@ export function performCollapse(
   }
   const argNames = info.extracted.inputs
   const collapsedFunction = Ast.Function.fromStatements(edit, collapsedName, argNames, collapsed)
-  topLevel.insert(posToInsert, collapsedFunction, undefined)
+  const collapsedFunctionWithIcon  = Ast.Documented.new("ICON group", collapsedFunction)
+  topLevel.insert(posToInsert, collapsedFunctionWithIcon, undefined)
   return { refactoredNodeId, collapsedNodeIds, outputNodeId }
 }
 

--- a/app/gui2/src/components/GraphEditor/collapsing.ts
+++ b/app/gui2/src/components/GraphEditor/collapsing.ts
@@ -214,7 +214,7 @@ export function performCollapse(
   }
   const argNames = info.extracted.inputs
   const collapsedFunction = Ast.Function.fromStatements(edit, collapsedName, argNames, collapsed)
-  const collapsedFunctionWithIcon  = Ast.Documented.new("ICON group", collapsedFunction)
+  const collapsedFunctionWithIcon = Ast.Documented.new('ICON group', collapsedFunction)
   topLevel.insert(posToInsert, collapsedFunctionWithIcon, undefined)
   return { refactoredNodeId, collapsedNodeIds, outputNodeId }
 }

--- a/app/gui2/src/components/SelectionMenu.vue
+++ b/app/gui2/src/components/SelectionMenu.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import ColorPickerMenu from '@/components/ColorPickerMenu.vue'
-import SvgIcon from '@/components/SvgIcon.vue'
 import ToggleIcon from '@/components/ToggleIcon.vue'
 import SvgButton from './SvgButton.vue'
 

--- a/app/gui2/src/components/ToggleIcon.vue
+++ b/app/gui2/src/components/ToggleIcon.vue
@@ -9,7 +9,7 @@
 import SvgButton from '@/components/SvgButton.vue'
 import type { Icon } from '@/util/iconName'
 
-const props = withDefaults(defineProps<{ icon: Icon; modelValue?: boolean }>(), {
+const _props = withDefaults(defineProps<{ icon: Icon; modelValue?: boolean }>(), {
   modelValue: false,
 })
 const emit = defineEmits<{


### PR DESCRIPTION
### Pull Request Description

Use `group` icon for components created by grouping.

https://github.com/enso-org/enso/assets/1047859/50a0dbb6-d36e-4fcb-9f39-b6493b8cca86

See: #9831.

### Important Notes

- This PR always sets the icon, but it is not always shown due to missing updates from the backend; this issue is currently being investigated.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
