### PR TITLE
Ensure disable private check cmd line option disables runtime private access checks

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/TestBase.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/TestBase.java
@@ -30,6 +30,7 @@ import org.enso.pkg.QualifiedName;
 import org.enso.polyglot.PolyglotContext;
 import org.enso.polyglot.RuntimeOptions;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Context.Builder;
 import org.graalvm.polyglot.Language;
 import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
@@ -227,14 +228,16 @@ prefer-local-libraries: true
    * Tests running the project located in the given {@code projDir}. Is equal to running {@code enso
    * --run <projDir>}.
    *
+   * @param ctxBuilder A context builder that might be initialized with some specific options.
    * @param projDir Root directory of the project.
    * @param resultConsumer Any action that is to be evaluated on the result of running the {@code
    *     main} method
    */
-  protected void testProjectRun(Path projDir, Consumer<Value> resultConsumer) {
+  protected void testProjectRun(
+      Context.Builder ctxBuilder, Path projDir, Consumer<Value> resultConsumer) {
     assert projDir.toFile().exists() && projDir.toFile().isDirectory();
     try (var ctx =
-        defaultContextBuilder()
+        ctxBuilder
             .option(RuntimeOptions.PROJECT_ROOT, projDir.toAbsolutePath().toString())
             .option(RuntimeOptions.STRICT_ERRORS, "true")
             .option(RuntimeOptions.DISABLE_IR_CACHES, "true")
@@ -247,6 +250,17 @@ prefer-local-libraries: true
       var res = mainMethod.execute();
       resultConsumer.accept(res);
     }
+  }
+
+  /**
+   * Just a wrapper for {@link TestBase#testProjectRun(Builder, Path, Consumer)}.
+   *
+   * @param projDir Root directory of the project.
+   * @param resultConsumer Any action that is to be evaluated on the result of running the {@code
+   *     main} method
+   */
+  protected void testProjectRun(Path projDir, Consumer<Value> resultConsumer) {
+    testProjectRun(defaultContextBuilder(), projDir, resultConsumer);
   }
 
   /** A simple structure corresponding to an Enso module. */

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/privateaccess/PrivateAccessTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/privateaccess/PrivateAccessTest.java
@@ -48,20 +48,13 @@ public class PrivateAccessTest extends TestBase {
         main = My_Type.Cons 42
         """;
     var projDir = createProject("My_Project", mainSrc, tempFolder);
-    var mainSrcPath = projDir.resolve("src").resolve("Main.enso");
-    try (var ctx =
-        defaultContextBuilder()
-            .option(RuntimeOptions.PROJECT_ROOT, projDir.toAbsolutePath().toString())
-            .build()) {
-      var polyCtx = new PolyglotContext(ctx);
-      var mainMod = polyCtx.evalModule(mainSrcPath.toFile());
-      var assocType = mainMod.getAssociatedType();
-      var mainMethod = mainMod.getMethod(assocType, "main").get();
-      var res = mainMethod.execute();
-      assertThat(res.hasMember("data"), is(false));
-      assertThat(res.canInvokeMember("data"), is(false));
-      assertThat(res.getMember("data"), is(nullValue()));
-    }
+    testProjectRun(
+        projDir,
+        res -> {
+          assertThat(res.hasMember("data"), is(false));
+          assertThat(res.canInvokeMember("data"), is(false));
+          assertThat(res.getMember("data"), is(nullValue()));
+        });
   }
 
   @Test
@@ -128,19 +121,12 @@ public class PrivateAccessTest extends TestBase {
                 _ -> 0
         """;
     var projDir = createProject("My_Project", mainSrc, tempFolder);
-    var mainSrcPath = projDir.resolve("src").resolve("Main.enso");
-    try (var ctx =
-        defaultContextBuilder()
-            .option(RuntimeOptions.PROJECT_ROOT, projDir.toAbsolutePath().toString())
-            .build()) {
-      var polyCtx = new PolyglotContext(ctx);
-      var mainMod = polyCtx.evalModule(mainSrcPath.toFile());
-      var assocType = mainMod.getAssociatedType();
-      var mainMethod = mainMod.getMethod(assocType, "main").get();
-      var res = mainMethod.execute();
-      assertThat(res.isNumber(), is(true));
-      assertThat(res.asInt(), is(42));
-    }
+    testProjectRun(
+        projDir,
+        res -> {
+          assertThat(res.isNumber(), is(true));
+          assertThat(res.asInt(), is(42));
+        });
   }
 
   /** Tests that pattern matching on private constructors fails in compilation. */

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/privateaccess/PrivateAccessTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/privateaccess/PrivateAccessTest.java
@@ -1,4 +1,4 @@
-package org.enso.interpreter.test;
+package org.enso.interpreter.test.privateaccess;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -10,6 +10,7 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
+import org.enso.interpreter.test.TestBase;
 import org.enso.interpreter.util.ScalaConversions;
 import org.enso.polyglot.PolyglotContext;
 import org.enso.polyglot.RuntimeOptions;

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/privateaccess/PrivateCheckDisabledTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/privateaccess/PrivateCheckDisabledTest.java
@@ -1,0 +1,40 @@
+package org.enso.interpreter.test.privateaccess;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.IOException;
+import org.enso.interpreter.test.TestBase;
+import org.enso.polyglot.RuntimeOptions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class PrivateCheckDisabledTest extends TestBase {
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Test
+  public void privateCtorCanBeAccessedWhenPrivateCheckIsDisabled() throws IOException {
+    var libSrc = """
+        type T
+            private Cons data
+        """;
+    createProject("Lib", libSrc, tempFolder);
+    var mainSrc =
+        """
+        from local.Lib import T
+        main =
+            obj = T.Cons 42
+            obj.data
+        """;
+    var mainDir = createProject("Main", mainSrc, tempFolder);
+    var ctxBuilder = defaultContextBuilder().option(RuntimeOptions.DISABLE_PRIVATE_CHECK, "true");
+    testProjectRun(
+        ctxBuilder,
+        mainDir,
+        res -> {
+          assertThat(res.isNumber(), is(true));
+          assertThat(res.asInt(), is(42));
+        });
+  }
+}


### PR DESCRIPTION
Fixes #9882

### Pull Request Description

Ensure that `--disable-private-check` cmd line option disables the runtime private access checks as well. So far, only private constructor invocations are checked.

### Important Notes

Polyglot (foreign) code still cannot see private members of Enso objects, even when private checks are disabled. The `--disable-private-check` cmd line option shall work only for Enso code. Let's keep the private members of Enso objects hidden for the foreign polyglot code.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
