### PR TITLE
Allow picking non-existing files in write component

### DIFF
--- a/app/gui2/env.d.ts
+++ b/app/gui2/env.d.ts
@@ -23,8 +23,11 @@ interface Window {
  * interface.
  */
 interface FileBrowserApi {
-  /** Select path for local file or directory using the system file browser. */
+  /**
+   * Select path for local file or directory using the system file browser.
+   * 'filePath' is same as 'file', but allows picking non-existing files.
+   */
   readonly openFileBrowser: (
-    kind: 'file' | 'directory' | 'default',
+    kind: 'file' | 'directory' | 'default' | 'filePath',
   ) => Promise<string[] | undefined>
 }

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetFunctionName.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetFunctionName.vue
@@ -2,12 +2,11 @@
 import AutoSizedInput from '@/components/widgets/AutoSizedInput.vue'
 import { Score, WidgetInput, defineWidget, widgetProps } from '@/providers/widgetRegistry'
 import { useProjectStore } from '@/stores/project'
-import type { SuggestionEntry } from '@/stores/suggestionDatabase/entry'
 import { Ast } from '@/util/ast'
 import { Err, Ok, type Result } from '@/util/data/result'
 import { useToast } from '@/util/toast'
 import { PropertyAccess } from 'shared/ast'
-import type { ExpressionId, MethodPointer } from 'shared/languageServerTypes'
+import type { ExpressionId } from 'shared/languageServerTypes'
 import { computed, ref, watchEffect } from 'vue'
 import NodeWidget from '../NodeWidget.vue'
 

--- a/app/gui2/src/providers/widgetRegistry/configuration.ts
+++ b/app/gui2/src/providers/widgetRegistry/configuration.ts
@@ -106,6 +106,7 @@ export interface FolderBrowse {
 
 export interface FileBrowse {
   kind: 'File_Browse'
+  existing_only?: boolean | undefined
 }
 
 export interface SingleChoice {
@@ -143,6 +144,7 @@ export const widgetConfigurationSchema: z.ZodType<
   z.ZodTypeDef,
   any
 > = withKindSchema.pipe(
+  /* eslint-disable camelcase */
   z.discriminatedUnion('kind', [
     z
       .object({
@@ -154,10 +156,8 @@ export const widgetConfigurationSchema: z.ZodType<
     z
       .object({
         kind: z.literal('Vector_Editor'),
-        /* eslint-disable camelcase */
         item_editor: z.lazy(() => widgetConfigurationSchema),
         item_default: z.string(),
-        /* eslint-enable camelcase */
       })
       .merge(withDisplay),
     z
@@ -178,7 +178,10 @@ export const widgetConfigurationSchema: z.ZodType<
       .merge(withDisplay),
     z.object({ kind: z.literal('Text_Input') }).merge(withDisplay),
     z.object({ kind: z.literal('Folder_Browse') }).merge(withDisplay),
-    z.object({ kind: z.literal('File_Browse') }).merge(withDisplay),
+    z
+      .object({ kind: z.literal('File_Browse'), existing_only: z.boolean().optional() })
+      .merge(withDisplay),
+    /* eslint-enable camelcase */
   ]),
 )
 

--- a/app/ide-desktop/lib/client/src/index.ts
+++ b/app/ide-desktop/lib/client/src/index.ts
@@ -447,12 +447,15 @@ class App {
             ipc.Channel.openFileBrowser,
             async (_event, kind: 'default' | 'directory' | 'file' | 'filePath') => {
                 logger.log('Request for opening browser for ', kind)
+                let retval = null
                 if (kind === 'filePath') {
                     // "Accept", as the file won't be created immediately.
                     const { canceled, filePath } = await electron.dialog.showSaveDialog({
                         buttonLabel: 'Accept',
                     })
-                    if (!canceled) return [filePath]
+                    if (!canceled) {
+                        retval = [filePath]
+                    }
                 } else {
                     /** Helper for `showOpenDialog`, which has weird types by default. */
                     type Properties = ('openDirectory' | 'openFile')[]
@@ -467,9 +470,11 @@ class App {
                     const { canceled, filePaths } = await electron.dialog.showOpenDialog({
                         properties,
                     })
-                    if (!canceled) return filePaths
+                    if (!canceled) {
+                        retval = filePaths
+                    }
                 }
-                return null
+                return retval
             }
         )
 

--- a/app/ide-desktop/lib/client/src/index.ts
+++ b/app/ide-desktop/lib/client/src/index.ts
@@ -445,24 +445,31 @@ class App {
         )
         electron.ipcMain.handle(
             ipc.Channel.openFileBrowser,
-            async (_event, kind: 'default' | 'directory' | 'file') => {
+            async (_event, kind: 'default' | 'directory' | 'file' | 'filePath') => {
                 logger.log('Request for opening browser for ', kind)
-                /** Helper for `showOpenDialog`, which has weird types by default. */
-                type Properties = ('openDirectory' | 'openFile')[]
-                const properties: Properties =
-                    kind === 'file'
-                        ? ['openFile']
-                        : kind === 'directory'
-                          ? ['openDirectory']
-                          : process.platform === 'darwin'
-                            ? ['openFile', 'openDirectory']
-                            : ['openFile']
-                const { canceled, filePaths } = await electron.dialog.showOpenDialog({ properties })
-                if (!canceled) {
-                    return filePaths
+                if (kind === 'filePath') {
+                    // "Accept", as the file won't be created immediately.
+                    const { canceled, filePath } = await electron.dialog.showSaveDialog({
+                        buttonLabel: 'Accept',
+                    })
+                    if (!canceled) return [filePath]
                 } else {
-                    return null
+                    /** Helper for `showOpenDialog`, which has weird types by default. */
+                    type Properties = ('openDirectory' | 'openFile')[]
+                    const properties: Properties =
+                        kind === 'file'
+                            ? ['openFile']
+                            : kind === 'directory'
+                              ? ['openDirectory']
+                              : process.platform === 'darwin'
+                                ? ['openFile', 'openDirectory']
+                                : ['openFile']
+                    const { canceled, filePaths } = await electron.dialog.showOpenDialog({
+                        properties,
+                    })
+                    if (!canceled) return filePaths
                 }
+                return null
             }
         )
 

--- a/app/ide-desktop/lib/client/src/preload.ts
+++ b/app/ide-desktop/lib/client/src/preload.ts
@@ -173,7 +173,7 @@ const AUTHENTICATION_API = {
 electron.contextBridge.exposeInMainWorld(AUTHENTICATION_API_KEY, AUTHENTICATION_API)
 
 const FILE_BROWSER_API = {
-    openFileBrowser: (kind: 'any' | 'directory' | 'file') =>
+    openFileBrowser: (kind: 'any' | 'directory' | 'file' | 'filePath') =>
         electron.ipcRenderer.invoke(ipc.Channel.openFileBrowser, kind),
 }
 electron.contextBridge.exposeInMainWorld(FILE_BROWSER_API_KEY, FILE_BROWSER_API)

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
@@ -76,7 +76,7 @@ type Widget
     Folder_Browse label:(Nothing | Text)=Nothing display:Display=Display.When_Modified
 
     ## Describes a file chooser.
-    File_Browse label:(Nothing | Text)=Nothing display:Display=Display.When_Modified action:File_Action=File_Action.Open file_types:(Vector Pair)=[Pair.new "All Files" "*.*"]
+    File_Browse existing_only:Boolean=True label:(Nothing | Text)=Nothing display:Display=Display.When_Modified action:File_Action=File_Action.Open file_types:(Vector Pair)=[Pair.new "All Files" "*.*"]
 
 ## PRIVATE
 make_single_choice : Vector -> Display -> Widget

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -2670,7 +2670,7 @@ type Table
              from Standard.Table import all
 
              example_to_xlsx = Examples.inventory_table.write (enso_project.data / "example_xlsx_output.xlsx") (Excel_Format.Sheet "MySheetName")
-    @path (Widget.File_Browse display=Display.Always)
+    @path (Widget.File_Browse existing_only=False display=Display.Always)
     @format Widget_Helpers.write_table_selector
     write : Writable_File -> File_Format -> Existing_File_Behavior -> Match_Columns -> Problem_Behavior -> File ! Column_Count_Mismatch | Illegal_Argument | File_Error
     write self path:Writable_File format=Auto_Detect on_existing_file=Existing_File_Behavior.Backup match_columns=Match_Columns.By_Name on_problems=Report_Warning =


### PR DESCRIPTION
### Pull Request Description

Fixes #9984 

Added a flag to `File_Browse` widget configuration specifying if we require an existing file. Also, the FileBrowserWidget will match against all "Writable_File", also displaying Save dialog.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
