### PR TITLE
Removing last node from main graph makes execution error

### DIFF
--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/optimise/LambdaConsolidate.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/optimise/LambdaConsolidate.scala
@@ -131,7 +131,7 @@ case object LambdaConsolidate extends IRPass {
     * @return the optimised version of `function`, with any directly chained
     *         lambdas collapsed
     */
-  def collapseFunction(
+  private def collapseFunction(
     function: Function,
     inlineContext: InlineContext,
     freshNameSupply: FreshNameSupply
@@ -209,7 +209,7 @@ case object LambdaConsolidate extends IRPass {
     * @return the list of arguments, some with attached warnings, along with
     *         whether or not they are shadowed
     */
-  def attachShadowingWarnings(
+  private def attachShadowingWarnings(
     argsWithShadowed: List[(DefinitionArgument, Boolean)]
   ): List[(DefinitionArgument, Boolean)] = {
     val args = argsWithShadowed.map(_._1)

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/ErrorCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/ErrorCompilerTest.java
@@ -3,9 +3,11 @@ package org.enso.compiler;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.enso.compiler.core.ir.Empty;
 import org.enso.compiler.core.ir.Location;
 import org.enso.compiler.core.ir.Module;
 import org.enso.compiler.core.ir.expression.errors.Syntax;
+import org.enso.compiler.core.ir.module.scope.definition.Method;
 import org.junit.Test;
 import scala.collection.immutable.List;
 
@@ -500,10 +502,10 @@ public class ErrorCompilerTest extends CompilerTest {
          42
     """);
     var errors = ir.preorder().filter(Syntax.class::isInstance).map(Syntax.class::cast);
-    assertEquals("Two errors", 2, errors.size());
-    assertTrue(errors.head().reason() instanceof Syntax.UnsupportedSyntax);
-    assertEquals(errors.head().location().get().start(), 0);
-    assertEquals(errors.head().location().get().length(), 6);
+    assertEquals("One error", 1, errors.size());
+    assertEquals(Syntax.UnexpectedExpression$.MODULE$, errors.head().reason());
+    assertEquals(7, errors.head().location().get().start());
+    assertEquals(16, errors.head().location().get().length());
   }
 
   @Test
@@ -553,6 +555,16 @@ public class ErrorCompilerTest extends CompilerTest {
     """);
     assertSingleSyntaxError(
         ir, Syntax.UnexpectedExpression$.MODULE$, "Unexpected expression", 0, 6);
+  }
+
+  @Test
+  public void testEmptyBody() throws Exception {
+    var ir = parse("""
+    main =
+    """);
+
+    var method = (Method) ir.bindings().apply(0);
+    assertTrue(method.body() instanceof Empty);
   }
 
   private void assertSingleSyntaxError(

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/ExecStrictCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/ExecStrictCompilerTest.java
@@ -51,12 +51,12 @@ public class ExecStrictCompilerTest {
   }
 
   @AfterClass
-  public static void closeEnsoContext() throws Exception {
+  public static void closeEnsoContext() {
     ctx.close();
   }
 
   @Test
-  public void redefinedArgument() throws Exception {
+  public void redefinedArgument() {
     try {
       var module = ctx.eval("enso", """
       type My_Type

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
@@ -37,9 +37,7 @@ import org.enso.syntax2.Line;
 import org.enso.syntax2.TextElement;
 import org.enso.syntax2.Token;
 import org.enso.syntax2.Tree;
-
 import org.enso.syntax2.Tree.Invalid;
-
 import org.enso.syntax2.Tree.Private;
 
 import scala.Option;
@@ -246,8 +244,11 @@ final class TreeToIr {
         var loc = getIdentifiedLocation(inputAst, 0, 0, null);
         var returnSignature = resolveReturnTypeSignature(fn);
         if (body == null) {
-            var error = translateSyntaxError(inputAst, new Syntax.UnsupportedSyntax("Block without body"));
-            yield join(error, appendTo);
+            var emptyLocation = methodRef.location().map(identifiedLocation -> {
+              var location = new Location(identifiedLocation.end(), identifiedLocation.end());
+              return new IdentifiedLocation(location, identifiedLocation.uuid());
+            });
+            body = new Empty(emptyLocation, meta(), diag());
         }
 
         String functionName = fn.getName().codeRepr();

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Empty.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Empty.scala
@@ -17,7 +17,6 @@ sealed case class Empty(
   diagnostics: DiagnosticStorage = DiagnosticStorage()
 ) extends IR
     with Expression
-    with Diagnostic
     with IRKind.Primitive
     with LazyId {
 
@@ -78,13 +77,6 @@ sealed case class Empty(
 
   /** @inheritdoc */
   override def children: List[IR] = List()
-
-  /** @inheritdoc */
-  override def message(source: (IdentifiedLocation => String)): String =
-    "Empty IR: Please report this as a compiler bug."
-
-  /** @inheritdoc */
-  override def diagnosticKeys(): Array[Any] = Array()
 
   /** @inheritdoc */
   override def showCode(indent: Int): String = "IR.Empty"

--- a/engine/runtime-parser/src/test/java/org/enso/compiler/core/EnsoParserTest.java
+++ b/engine/runtime-parser/src/test/java/org/enso/compiler/core/EnsoParserTest.java
@@ -1434,8 +1434,7 @@ public class EnsoParserTest {
 
   @Test
   public void testEmptyBody() {
-    parseTest(
-        """
+    parseTest("""
     main =
     """);
   }

--- a/engine/runtime-parser/src/test/java/org/enso/compiler/core/EnsoParserTest.java
+++ b/engine/runtime-parser/src/test/java/org/enso/compiler/core/EnsoParserTest.java
@@ -1432,13 +1432,20 @@ public class EnsoParserTest {
     """);
   }
 
-  private static void parseTest(String code) throws IOException {
+  @Test
+  public void testEmptyBody() throws IOException {
+    parseTest(
+        """
+    main =
+    """);
+  }
+
+  private static void parseTest(String code) {
     parseTest(code, true, true, true);
   }
 
   @SuppressWarnings("unchecked")
-  private static void parseTest(String code, boolean noIds, boolean noLocations, boolean lessDocs)
-      throws IOException {
+  private static void parseTest(String code, boolean noIds, boolean noLocations, boolean lessDocs) {
     var ir = compile(code);
     assertNotNull(ir);
   }

--- a/engine/runtime-parser/src/test/java/org/enso/compiler/core/EnsoParserTest.java
+++ b/engine/runtime-parser/src/test/java/org/enso/compiler/core/EnsoParserTest.java
@@ -33,28 +33,28 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testParseMain7Foo() throws Exception {
+  public void testParseMain7Foo() {
     parseTest("""
     main = 7.foo
     """);
   }
 
   @Test
-  public void testLocationsSimpleArithmeticExpression() throws Exception {
+  public void testLocationsSimpleArithmeticExpression() {
     parseTest("""
     main = 2 + 45 * 20
     """, true, true, true);
   }
 
   @Test
-  public void testLocationsApplicationsAndMethodCalls() throws Exception {
+  public void testLocationsApplicationsAndMethodCalls() {
     parseTest("""
     main = (2-2 == 0).if_then_else (List.Cons 5 6) 0
     """, true, true, true);
   }
 
   @Test
-  public void testLocationsCorrectAssignmentOfVariableReads() throws Exception {
+  public void testLocationsCorrectAssignmentOfVariableReads() {
     parseTest(
         """
     main =
@@ -68,7 +68,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testLocationsMethodWithComplexBody() throws Exception {
+  public void testLocationsMethodWithComplexBody() {
     parseTest(
         """
     foo a b =
@@ -83,7 +83,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testLocationsBuildFunctionSimple() throws Exception {
+  public void testLocationsBuildFunctionSimple() {
     parseTest("""
     main =
         foo a = a + 1
@@ -92,14 +92,14 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testListWithATrailingComma() throws Exception {
+  public void testListWithATrailingComma() {
     parseTest("""
     main = ["a", ]
     """, true, true, true);
   }
 
   @Test
-  public void testLocationsDeeplyNestedFunctions() throws Exception {
+  public void testLocationsDeeplyNestedFunctions() {
     parseTest("""
         foo = a -> b ->
             IO.println a
@@ -107,7 +107,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testLocationsDeeplyNestedFunctionsNoBlock() throws Exception {
+  public void testLocationsDeeplyNestedFunctionsNoBlock() {
     parseTest(
         """
     Nothing.method =
@@ -121,7 +121,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testSpacesAtTheEndOfFile() throws Exception {
+  public void testSpacesAtTheEndOfFile() {
     var fourSpaces = "    ";
     parseTest("""
     main = add_ten 5
@@ -129,7 +129,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testCase() throws Exception {
+  public void testCase() {
     parseTest(
         """
     type Msg
@@ -144,7 +144,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testTypeMethodWithSignature() throws Exception {
+  public void testTypeMethodWithSignature() {
     parseTest(
         """
     @Builtin_Type
@@ -155,7 +155,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testImport() throws Exception {
+  public void testImport() {
     parseTest(
         """
     import Standard.Base.Any.Any
@@ -170,7 +170,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testImportAll() throws Exception {
+  public void testImportAll() {
     parseTest(
         """
     ## TODO Dubious constructor export
@@ -180,14 +180,14 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testImportTrue() throws Exception {
+  public void testImportTrue() {
     parseTest("""
     from Standard.Base import True
     """);
   }
 
   @Test
-  public void testMeaningOfWorld() throws Exception {
+  public void testMeaningOfWorld() {
     parseTest("""
     import Standard.Base.IO
 
@@ -196,42 +196,42 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testMinusOne() throws Exception {
+  public void testMinusOne() {
     parseTest("""
     minus n = n-1
     """);
   }
 
   @Test
-  public void testIfNothingSelf() throws Exception {
+  public void testIfNothingSelf() {
     parseTest("""
     if_nothing self ~_ = self
     """);
   }
 
   @Test
-  public void testIfSomethingSelf() throws Exception {
+  public void testIfSomethingSelf() {
     parseTest("""
     if_nothing self ~ignore = self
     """);
   }
 
   @Test
-  public void testMinusRec() throws Exception {
+  public void testMinusRec() {
     parseTest("""
     minus n = minus n-1
     """);
   }
 
   @Test
-  public void testFactorial() throws Exception {
+  public void testFactorial() {
     parseTest("""
     fac n = if n == 1 then 1 else n * fac n-1
     """);
   }
 
   @Test
-  public void testIsDigitWithSpaces() throws Exception {
+  public void testIsDigitWithSpaces() {
     parseTest("""
     compare =
         is_digit = character -> 42
@@ -239,14 +239,14 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testComments() throws Exception {
+  public void testComments() {
     parseTest("""
     # a b c
     """);
   }
 
   @Test
-  public void testCaseTypeOf() throws Exception {
+  public void testCaseTypeOf() {
     parseTest("""
     cmp self = case self of
         v:Vector_2d -> x
@@ -255,7 +255,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testCaseTypeOf2() throws Exception {
+  public void testCaseTypeOf2() {
     parseTest("""
     cmp self = case self of
         v:My_Type -> x
@@ -263,7 +263,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testCaseTypeOfWithSpace() throws Exception {
+  public void testCaseTypeOfWithSpace() {
     parseTest("""
     filter self filter = case filter of
         _ : Filter -> 42
@@ -271,28 +271,28 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testAnnotation0() throws Exception {
+  public void testAnnotation0() {
     parseTest("""
     dont_stop = @Tail_Call dont_stop
     """);
   }
 
   @Test
-  public void testAnnotation1() throws Exception {
+  public void testAnnotation1() {
     parseTest("""
     go t = @Tail_Call go t-1
     """);
   }
 
   @Test
-  public void testAnnotation2() throws Exception {
+  public void testAnnotation2() {
     parseTest("""
     go t x = @Tail_Call go t-1 x
     """);
   }
 
   @Test
-  public void testAnnotationBlock() throws Exception {
+  public void testAnnotationBlock() {
     parseTest("""
     go a b = @Tail_Call go
         a
@@ -301,7 +301,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testBuiltinTypeAnnotation() throws Exception {
+  public void testBuiltinTypeAnnotation() {
     parseTest("""
     @Builtin_Type
     type Date
@@ -309,7 +309,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testBoolean() throws Exception {
+  public void testBoolean() {
     parseTest(
         """
     @Builtin_Type
@@ -338,14 +338,14 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testBuiltinMethodAnnotation() throws Exception {
+  public void testBuiltinMethodAnnotation() {
     parseTest("""
     normalize x = @Builtin_Method "File.normalize"
     """);
   }
 
   @Test
-  public void testTextOrNothing() throws Exception {
+  public void testTextOrNothing() {
     parseTest("""
     type Locale
         language : Text | Nothing
@@ -353,7 +353,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testInterval() throws Exception {
+  public void testInterval() {
     parseTest("""
     type Interval
         Interval_Data (start : Bound.Bound)
@@ -361,7 +361,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testAtEq() throws Exception {
+  public void testAtEq() {
     parseTest(
         """
     type Array
@@ -374,7 +374,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testNestedBlocks() throws Exception {
+  public void testNestedBlocks() {
     parseTest(
         """
     type Array
@@ -385,14 +385,14 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testSelf1() throws Exception {
+  public void testSelf1() {
     parseTest("""
     contains self elem = self.contains Nothing
     """);
   }
 
   @Test
-  public void testPanic_184119084() throws Exception {
+  public void testPanic_184119084() {
     parseTest("""
     type Foo
         type Bar
@@ -402,7 +402,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testMetadataRaw() throws Exception {
+  public void testMetadataRaw() {
     parseTest(
         """
     main =
@@ -416,7 +416,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testDocumentationComment() throws Exception {
+  public void testDocumentationComment() {
     parseTest("""
     ## A type representing computations that may fail.
     type Maybe
@@ -424,7 +424,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testColumnSelector() throws Exception {
+  public void testColumnSelector() {
     parseTest(
         """
     ## Specifies a selection of columns from the table on which an operation is
@@ -436,7 +436,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testAssignments() throws Exception {
+  public void testAssignments() {
     parseTest(
         """
       from_java_set java_set =
@@ -447,7 +447,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testNumberTimes() throws Exception {
+  public void testNumberTimes() {
     parseTest(
         """
     Standard.Base.Number.times : List Any
@@ -457,7 +457,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testIfThenBlock() throws Exception {
+  public void testIfThenBlock() {
     parseTest(
         """
       from_java_set java_set =
@@ -469,7 +469,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testInvokeFilePermissions() throws Exception {
+  public void testInvokeFilePermissions() {
     parseTest(
         """
       from_java_set java_set =
@@ -478,64 +478,64 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testSignature1() throws Exception {
+  public void testSignature1() {
     parseTest("val : Bool");
   }
 
   @Test
-  public void testSignature2() throws Exception {
+  public void testSignature2() {
     parseTest("val : List Int");
   }
 
   @Test
-  public void testSignature3() throws Exception {
+  public void testSignature3() {
     parseTest("val = 123 : Int");
   }
 
   @Test
-  public void testSignature4() throws Exception {
+  public void testSignature4() {
     parseTest("val = foo (123 : Int)");
   }
 
   @Test
-  public void testSignature5() throws Exception {
+  public void testSignature5() {
     parseTest("val : List Int -> Int");
   }
 
   @Test
-  public void testExport1() throws Exception {
+  public void testExport1() {
     parseTest("export prj.Data.Foo");
   }
 
   @Test
-  public void testExportAs() throws Exception {
+  public void testExportAs() {
     parseTest("export prj.Data.Foo as Bar");
   }
 
   @Test
-  public void testExportFrom() throws Exception {
+  public void testExportFrom() {
     parseTest("from prj.Data.Foo export Bar, Baz");
   }
 
   @Test
-  public void testExportFromTen() throws Exception {
+  public void testExportFromTen() {
     parseTest("from prj.Data.Foo export One, Two, Three, Four, Five, Six, Seven, Eight, Nine, Ten");
   }
 
   @Test
-  public void testExportFromAllHiding() throws Exception {
+  public void testExportFromAllHiding() {
     parseTest("from prj.Data.Foo export all hiding Bar, Baz");
   }
 
   @Test
-  public void testTextLiteral() throws Exception {
+  public void testTextLiteral() {
     parseTest("""
     main = "I'm an inline raw text!"
     """);
   }
 
   @Test
-  public void testTextLiteralWithEscape() throws Exception {
+  public void testTextLiteralWithEscape() {
     parseTest(
         """
     wrap_junit_testsuites = '<?xml version="1.0"\\tencoding="UTF-8"?>\\n'
@@ -543,7 +543,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testRawBlockLiteral() throws Exception {
+  public void testRawBlockLiteral() {
     // mimics TextTest
     parseTest("""
     x = \"\"\"
@@ -554,21 +554,21 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testVariousKindsOfUnicodeWhitespace() throws Exception {
+  public void testVariousKindsOfUnicodeWhitespace() {
     parseTest("""
     t = '\\v\\f\\u{200a}\\u{202f}\\u{205F}\\u{3000}'.trim
     """);
   }
 
   @Test
-  public void testLambda() throws Exception {
+  public void testLambda() {
     parseTest("""
     f = map _->alphabet
     """);
   }
 
   @Test
-  public void testMultiParameterFunction() throws Exception {
+  public void testMultiParameterFunction() {
     parseTest(
         """
     from Standard.Base import all
@@ -581,7 +581,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testTestGroup() throws Exception {
+  public void testTestGroup() {
     parseTest(
         """
     type Test
@@ -606,7 +606,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testEmptyGroup() throws Exception {
+  public void testEmptyGroup() {
     parseTest(
         """
     main =
@@ -618,7 +618,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testEmptyGroup2() throws Exception {
+  public void testEmptyGroup2() {
     parseTest("""
     main =
         x = ()
@@ -627,7 +627,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testTestGroupSimple() throws Exception {
+  public void testTestGroupSimple() {
     parseTest(
         """
     group1 : Text -> Any -> (Text | Nothing) -> Nothing
@@ -638,7 +638,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testWildcardLeftHandSide() throws Exception {
+  public void testWildcardLeftHandSide() {
     parseTest(
         """
     Any.should_succeed self frames_to_skip=0 =
@@ -647,7 +647,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testReverseListType() throws Exception {
+  public void testReverseListType() {
     parseTest("""
     reverse_list : List Any -> List
     reverse_list list = List.Nil
@@ -655,7 +655,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testReverseList() throws Exception {
+  public void testReverseList() {
     parseTest(
         """
     reverse_list list =
@@ -670,7 +670,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testProblemHandling() throws Exception {
+  public void testProblemHandling() {
     parseTest(
         """
     test_problem_handling : (Problem_Behavior -> Any) -> Vector Any -> (Any -> Nothing) -> Nothing
@@ -680,7 +680,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testProblemHandling2() throws Exception {
+  public void testProblemHandling2() {
     parseTest(
         """
     test_problem_handling action expected_problems result_checker =
@@ -692,42 +692,42 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testNamedArgument() throws Exception {
+  public void testNamedArgument() {
     parseTest("""
     fn = get_all frames_to_skip=1
     """);
   }
 
   @Test
-  public void testVectorLiteralEmpty() throws Exception {
+  public void testVectorLiteralEmpty() {
     parseTest("""
     fn = []
     """);
   }
 
   @Test
-  public void testVectorLiteralOne() throws Exception {
+  public void testVectorLiteralOne() {
     parseTest("""
     fn = [ 1 ]
     """);
   }
 
   @Test
-  public void testVectorLiteralMany() throws Exception {
+  public void testVectorLiteralMany() {
     parseTest("""
     fn = [ 1, 2, 3 ]
     """);
   }
 
   @Test
-  public void testInvokeMethod() throws Exception {
+  public void testInvokeMethod() {
     parseTest("""
     fn = result_ignoring . should_equal
     """);
   }
 
   @Test
-  public void testTableDataArgumentInCase() throws Exception {
+  public void testTableDataArgumentInCase() {
     parseTest(
         """
     process_to_json_text value =
@@ -738,7 +738,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testVisualizationCaseOf() throws Exception {
+  public void testVisualizationCaseOf() {
     parseTest(
         """
     prepare_visualization : Any -> Integer -> Json
@@ -753,7 +753,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testAggregateColumnGroupByTrue() throws Exception {
+  public void testAggregateColumnGroupByTrue() {
     parseTest(
         """
     prepare_aggregate_columns : [Aggregate_Column] -> Table -> Problem_Behavior -> Resolved_Aggregate_Columns
@@ -766,28 +766,28 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testUnaryDot() throws Exception {
+  public void testUnaryDot() {
     parseTest("""
     write_file = ExcelWriter.setEnsoToTextCallbackIfUnset (.to_text)
       """);
   }
 
   @Test
-  public void testUnaryMinus() throws Exception {
+  public void testUnaryMinus() {
     parseTest("""
     meaning = -42
       """);
   }
 
   @Test
-  public void testExtensionMethod() throws Exception {
+  public void testExtensionMethod() {
     parseTest("""
     Any.meaning = -42
       """);
   }
 
   @Test
-  public void testExtensionOperator() throws Exception {
+  public void testExtensionOperator() {
     parseTest("""
     Text.* : Integer -> Text
     Text.* self = 42
@@ -795,7 +795,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testTypeSignature() throws Exception {
+  public void testTypeSignature() {
     parseTest(
         """
     resolve_aggregate table problem_builder aggregate_column =
@@ -807,7 +807,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testTypeSignature2() throws Exception {
+  public void testTypeSignature2() {
     parseTest("""
     type Baz
         resolve : Integer -> Column
@@ -815,7 +815,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testTypeSignatureQualified() throws Exception {
+  public void testTypeSignatureQualified() {
     parseTest("""
     type Baz
         Foo.resolve : Integer -> Column
@@ -823,7 +823,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testMethodDef() throws Exception {
+  public void testMethodDef() {
     parseTest("""
     type Foo
         id x = x
@@ -831,7 +831,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testSelfTypeKeyword() throws Exception {
+  public void testSelfTypeKeyword() {
     parseTest(
         """
     type My_Type
@@ -857,7 +857,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testCaseOnTextLiteral() throws Exception {
+  public void testCaseOnTextLiteral() {
     parseTest("""
     choose ch = case ch of
         "yes" -> True
@@ -866,7 +866,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testCaseWithUnderscore() throws Exception {
+  public void testCaseWithUnderscore() {
     parseTest("""
     choose ch = case ch of
         0 -> _.name
@@ -875,7 +875,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testCaseWithLowerCaseA() throws Exception {
+  public void testCaseWithLowerCaseA() {
     parseTest("""
     map_nothing self = case self of
         a -> f a
@@ -883,7 +883,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testBalanceUpperCase() throws Exception {
+  public void testBalanceUpperCase() {
     parseTest("""
     balance_left k x l r = case r of
         Bin _ lk lx Tip -> 42
@@ -891,7 +891,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testBalanceLowerCase() throws Exception {
+  public void testBalanceLowerCase() {
     parseTest("""
     balance_left k x l r = case r of
         Bin _ lk lx tip -> 42
@@ -899,7 +899,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testVectorVectorSimple() throws Exception {
+  public void testVectorVectorSimple() {
     parseTest("""
     type Vector
         build : Matrix Any Float
@@ -907,7 +907,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testVectorVectorAny() throws Exception {
+  public void testVectorVectorAny() {
     parseTest(
         """
     type Vector
@@ -916,7 +916,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testCaseOfVector() throws Exception {
+  public void testCaseOfVector() {
     parseTest("""
         m other = case other of
             _:Vector.Vector -> 0
@@ -924,7 +924,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testOperatorSectionRight() throws Exception {
+  public void testOperatorSectionRight() {
     parseTest(
         """
     type Filter_Condition
@@ -934,7 +934,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testSuspendedDefaultArguments() throws Exception {
+  public void testSuspendedDefaultArguments() {
     parseTest("""
     fn that_meta =
         c_2 = that_meta.constructor ...
@@ -942,7 +942,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testSuspendedDefaultArguments2() throws Exception {
+  public void testSuspendedDefaultArguments2() {
     parseTest("""
     fn1 = fn ...
     fn2 = fn 1 ...
@@ -950,14 +950,14 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testForcedTerms() throws Exception {
+  public void testForcedTerms() {
     parseTest("""
     ifTest = c -> (~ifT) -> ~ifF -> if c == 0 then ifT else ifF
     """);
   }
 
   @Test
-  public void testTextArrayType() throws Exception {
+  public void testTextArrayType() {
     parseTest("""
     type Connection
         table_types : [Text]
@@ -965,7 +965,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testListBody() throws Exception {
+  public void testListBody() {
     parseTest(
         """
           list directory name_filter=Nothing recursive=False =
@@ -974,7 +974,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testLambdaBody() throws Exception {
+  public void testLambdaBody() {
     parseTest("""
     list =
         all_files.filter file->
@@ -983,7 +983,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testCaseWithComment() throws Exception {
+  public void testCaseWithComment() {
     parseTest(
         """
     ansi_bold : Boolean -> Text -> Text
@@ -996,7 +996,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testAlternationTypes() throws Exception {
+  public void testAlternationTypes() {
     parseTest("""
     foo : [Integer | Text] -> (Integer | Text)
     foo v = v.at 0
@@ -1004,7 +1004,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testGroupOfPatterns() throws Exception {
+  public void testGroupOfPatterns() {
     parseTest(
         """
     sum self = case self of
@@ -1013,28 +1013,28 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testNameAsMethodApp() throws Exception {
+  public void testNameAsMethodApp() {
     parseTest("""
     f = foo x=A.B
     """);
   }
 
   @Test
-  public void testIsMethodWithSpaces() throws Exception {
+  public void testIsMethodWithSpaces() {
     parseTest("""
     f = 0.up_to . all f
     """);
   }
 
   @Test
-  public void testIsMethodWithoutSpaces() throws Exception {
+  public void testIsMethodWithoutSpaces() {
     parseTest("""
     f = 0.up_to.all f
     """);
   }
 
   @Test
-  public void testHandleRequestError() throws Exception {
+  public void testHandleRequestError() {
     parseTest("""
     request self req =
         handle_request_error =
@@ -1043,7 +1043,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testWriteFlag() throws Exception {
+  public void testWriteFlag() {
     parseTest("""
     type Write_Flag
         JPEG_Quality val:Integer=95
@@ -1051,28 +1051,28 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testHasDefaultsSuspended() throws Exception {
+  public void testHasDefaultsSuspended() {
     parseTest("""
     Atom.constructor self = get_atom_constructor self.value ...
     """);
   }
 
   @Test
-  public void testVectorVector() throws Exception {
+  public void testVectorVector() {
     parseTest("""
     get_stack_trace : Vector.Vector Stack_Trace_Element
     """);
   }
 
   @Test
-  public void testSidesPlus() throws Exception {
+  public void testSidesPlus() {
     parseTest("""
     result = reduce (+)
     """);
   }
 
   @Test
-  public void testConstructorMultipleNamedArgs1() throws Exception {
+  public void testConstructorMultipleNamedArgs1() {
     parseTest(
         """
     x = Regex_Matcher.Regex_Matcher_Data case_sensitivity=Case_Sensitivity.Sensitive dot_matches_newline=True
@@ -1080,7 +1080,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testDocAtEndOfBlock() throws Exception {
+  public void testDocAtEndOfBlock() {
     parseTest("""
     x =
       23
@@ -1089,21 +1089,21 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testMethodSections() throws Exception {
+  public void testMethodSections() {
     parseTest("""
     x = .from self=Foo
     """);
   }
 
   @Test
-  public void testGroupArgument() throws Exception {
+  public void testGroupArgument() {
     parseTest("""
     foo = x -> (y = bar x) -> x + y
     """);
   }
 
   @Test
-  public void testRuntimeServerTestCode() throws Exception {
+  public void testRuntimeServerTestCode() {
     parseTest(
         """
     from Standard.Base.Data.Numbers import Number
@@ -1125,14 +1125,14 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testResolveExecutionContext() throws Exception {
+  public void testResolveExecutionContext() {
     parseTest("""
     foo : A -> B -> C in Input
     """);
   }
 
   @Test
-  public void testSugaredFunctionDefinition() throws Exception {
+  public void testSugaredFunctionDefinition() {
     parseTest("""
     main =
         f a b = a - b
@@ -1141,7 +1141,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testAtomBenchmarks1() throws Exception {
+  public void testAtomBenchmarks1() {
     parseTest(
         """
     import Standard.Base.Data.List.List
@@ -1154,7 +1154,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testAtomBenchmarks3() throws Exception {
+  public void testAtomBenchmarks3() {
     parseTest(
         """
     import Standard.Base.Data.List.List
@@ -1173,7 +1173,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testShouldQuoteValuesContainingTheCommentSymbol() throws Exception {
+  public void testShouldQuoteValuesContainingTheCommentSymbol() {
     parseTest(
         """
     suite =
@@ -1195,7 +1195,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testEmptyValueBetweenComments() throws Exception {
+  public void testEmptyValueBetweenComments() {
     parseTest(
         """
     expected_text = normalize_lines <| \"""
@@ -1210,7 +1210,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testQuotedValues() throws Exception {
+  public void testQuotedValues() {
     parseTest(
         """
     expected_text = normalize_lines <| \"""
@@ -1222,7 +1222,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testSimpleTripleQuote() throws Exception {
+  public void testSimpleTripleQuote() {
     parseTest(
         """
     expected_response = Json.parse <| '''
@@ -1252,7 +1252,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testInThePresenceOfComments() throws Exception {
+  public void testInThePresenceOfComments() {
     parseTest(
         """
     # this is a comment
@@ -1267,26 +1267,26 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testNPE183892665() throws Exception {
+  public void testNPE183892665() {
     parseTest("""
     foo : Integer ->
     """);
   }
 
   @Test
-  public void testNamedDefaultedArguments183953473() throws Exception {
+  public void testNamedDefaultedArguments183953473() {
     parseTest("""
     main = @Tail_Call summator (current = 0) (acc = 1)
     """);
   }
 
   @Test
-  public void testDotPrecedence() throws Exception {
+  public void testDotPrecedence() throws IOException {
     equivalenceTest("x = -1.up_to 100", "x = (-1).up_to 100");
   }
 
   @Test
-  public void testFreeze() throws Exception {
+  public void testFreeze() throws IOException {
     equivalenceTest("a = x", "a = FREEZE x");
     equivalenceTest("a = x+1", "a = FREEZE x+1");
     equivalenceTest("a = x + 1", "a = FREEZE x + 1");
@@ -1294,7 +1294,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testSkip() throws Exception {
+  public void testSkip() throws IOException {
     equivalenceTest("a = x", "a = SKIP x");
     equivalenceTest("a = x", "a = SKIP x+1");
     equivalenceTest("a = x", "a = SKIP x + 1");
@@ -1312,7 +1312,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testBlockSyntax() throws Exception {
+  public void testBlockSyntax() throws IOException {
     equivalenceTest(
         """
     nums v fm ff n = v . map fm . filter ff . take n
@@ -1326,7 +1326,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testBlockSyntaxOperators() throws Exception {
+  public void testBlockSyntaxOperators() throws IOException {
     equivalenceTest(
         """
     value = nums * each random + constant
@@ -1339,7 +1339,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testBlockSyntaxOperators2() throws Exception {
+  public void testBlockSyntaxOperators2() throws IOException {
     equivalenceTest(
         """
     value = (nums + each random) * constant
@@ -1352,7 +1352,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testBlockSyntaxOperators3() throws Exception {
+  public void testBlockSyntaxOperators3() throws IOException {
     equivalenceTest(
         """
     v = (rect1 . width) . center
@@ -1365,7 +1365,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testBlockSyntaxOperators4() throws Exception {
+  public void testBlockSyntaxOperators4() throws IOException {
     equivalenceTest(
         """
     v = (rect1 . width 4) . center 3 2
@@ -1378,7 +1378,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testPrivateModules() throws Exception {
+  public void testPrivateModules() throws IOException {
     List<String> moduleCodes =
         List.of(
             "private",
@@ -1401,7 +1401,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testPrivateConstructor() throws Exception {
+  public void testPrivateConstructor() {
     parseTest(
         """
             type My_Type
@@ -1419,7 +1419,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void ise_184219679() throws IOException {
+  public void ise_184219679() {
     parseTest(
         """
     from Standard.Base import all
@@ -1433,7 +1433,7 @@ public class EnsoParserTest {
   }
 
   @Test
-  public void testEmptyBody() throws IOException {
+  public void testEmptyBody() {
     parseTest(
         """
     main =

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -1082,9 +1082,7 @@ class IrToTruffle(
           processCase(caseExpr, subjectToInstrumentation)
         case typ: Tpe => processType(typ)
         case _: Empty =>
-          throw new CompilerError(
-            "Empty IR nodes should not exist during code generation."
-          )
+          processEmpty()
         case _: Comment =>
           throw new CompilerError(
             "Comments should not be present during codegen."
@@ -1814,7 +1812,7 @@ class IrToTruffle(
       * @return the truffle nodes corresponding to `literal`
       */
     @throws[CompilerError]
-    def processLiteral(literal: Literal): RuntimeExpression =
+    private def processLiteral(literal: Literal): RuntimeExpression =
       literal match {
         case lit @ Literal.Number(_, _, location, _, _) =>
           val node = lit.numericValue match {
@@ -1841,7 +1839,7 @@ class IrToTruffle(
       * @param error the IR representing a compile error.
       * @return a runtime node representing the error.
       */
-    def processError(error: Error): RuntimeExpression = {
+    private def processError(error: Error): RuntimeExpression = {
       val payload: Atom = error match {
         case Error.InvalidIR(_, _, _) =>
           throw new CompilerError("Unexpected Invalid IR during codegen.")
@@ -1899,6 +1897,14 @@ class IrToTruffle(
           )
       }
       setLocation(ErrorNode.build(payload), error.location)
+    }
+
+    /** Processes an empty expression.
+      *
+      * @return the Nothing builtin
+      */
+    private def processEmpty(): RuntimeExpression = {
+      ConstantObjectNode.build(context.getBuiltins.nothing())
     }
 
     /** Processes function arguments, generates arguments reads and creates


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #9172

Changelog:
- update: insert `Empty` IR node for the empty method definition bodies
- update: generate node resulting in `Nothing` for `Empty` IR nodes
- refactor: remove redundant checked exceptions in `EnsoParserTest`

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
