### PR TITLE
Remove invalid JVM parameters

### DIFF
--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Runner.scala
@@ -221,12 +221,9 @@ class Runner(
           forceLoggerConnectionArguments()
         else Seq()
 
-      val command = Seq(javaCommand.executableName) ++
-        Seq(
-          "-XX:ActiveProcessorCount=2",
-          "-Xmx8192m"
-          //"-agentlib:jdwp=transport=dt_socket,server=y,address=localhost:5005,suspend=y"
-        ) ++ jvmArguments ++ loggingConnectionArguments ++ runSettings.runnerArguments
+      val command = Seq(
+        javaCommand.executableName
+      ) ++ jvmArguments ++ loggingConnectionArguments ++ runSettings.runnerArguments
 
       val distributionSettings =
         distributionManager.getEnvironmentToInheritSettings


### PR DESCRIPTION
Those JVM options were only used for testing and should have never entered the main branch, apologies.

Accidentally committed in https://github.com/enso-org/enso/pull/9967