### PR TITLE
Fix input_number icons

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
@@ -88,7 +88,7 @@ type Decimal
     ## PRIVATE
     Value (big_decimal : BigDecimal)
 
-    ## ICON number_input
+    ## ICON input_number
        Construct a `Decimal` from a string or integer.
 
        Arguments:

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
@@ -767,7 +767,7 @@ type Float
         Locale.Value java_locale -> Panic.catch ParseException ((NumberFormat.getInstance java_locale).parse text) _->
             Error.throw (Number_Parse_Error.Error text)
 
-    ## ICON number_input
+    ## ICON input_number
 
        Maximum representable positive value, from the underlying Java double
        type.
@@ -775,7 +775,7 @@ type Float
        The absolute-value-largest representable negative value is `-max_value`.
     max_value = Double.MAX_VALUE
 
-    ## ICON number_input
+    ## ICON input_number
 
        Minimum representable positive value, from the underlying Java double
        type.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Range/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Range/Extensions.enso
@@ -6,7 +6,7 @@ from project.Data.Boolean import Boolean, False, True
 
 ## ALIAS range
    GROUP Input
-   ICON number_input
+   ICON input_number
 
    Creates an increasing range of integers from `self` to `n`.
 
@@ -34,7 +34,7 @@ Integer.up_to self n:Integer include_end:Boolean=False step:Integer=1 =
 
 ## ALIAS range
    GROUP Input
-   ICON number_input
+   ICON input_number
 
    Creates a decreasing right-exclusive range of integers from `self` to `n`.
 

--- a/distribution/lib/Standard/Searcher/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Searcher/0.0.0-dev/src/Main.enso
@@ -25,7 +25,7 @@ text_input = Unimplemented.throw "This function should not be called."
 
 ## ALIAS number input
    GROUP Standard.Base.Constants
-   ICON number_input
+   ICON input_number
 
    Creating a number in Enso is as simple as adding a node that contains the
    number that you would like to create.
@@ -41,7 +41,7 @@ text_input = Unimplemented.throw "This function should not be called."
      Creating a node containing the decimal 0.0.
 
          0.0
-number_input = Unimplemented.throw "This function should not be called."
+input_number = Unimplemented.throw "This function should not be called."
 
 ## ALIAS table input
    GROUP Standard.Base.Constants

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Faker.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Faker.enso
@@ -13,7 +13,7 @@ type Faker
        Set of lower case letters.
     lower_case_letters = "abcdefghijklmnopqrstuvwxyz".char_vector
 
-    ## ICON number_input
+    ## ICON input_number
        Set of numerical digits.
     numbers = "0123456789".char_vector
 


### PR DESCRIPTION
### Pull Request Description

icon is called input_number not number_input

![image](https://github.com/enso-org/enso/assets/1720119/c68790d3-05ad-4d17-8423-df3634fff29a)


### Important Notes


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
