### PR TITLE
Make background clicks less flaky

### DIFF
--- a/app/gui2/e2e/actions.ts
+++ b/app/gui2/e2e/actions.ts
@@ -33,7 +33,7 @@ export async function expectNodePositionsInitialized(page: Page, yPos: number) {
 }
 
 export async function exitFunction(page: Page, x = 300, y = 300) {
-  await page.mouse.dblclick(x, y, { delay: 10 })
+  await locate.graphEditor(page).dblclick({ position: { x, y } })
 }
 
 // =================

--- a/app/gui2/e2e/componentBrowser.spec.ts
+++ b/app/gui2/e2e/componentBrowser.spec.ts
@@ -56,7 +56,7 @@ test('Different ways of opening Component Browser', async ({ page }) => {
   // Dragging out an edge
   const outputPort = await locate.outputPortCoordinates(locate.graphNodeByBinding(page, 'final'))
   await page.mouse.click(outputPort.x, outputPort.y)
-  await page.mouse.click(100, 500)
+  await locate.graphEditor(page).click({ position: { x: 100, y: 500 } })
   await expectAndCancelBrowser(page, '', 'final')
   // Double-clicking port
   // TODO[ao] Without timeout, even the first click would be treated as double due to previous
@@ -111,7 +111,7 @@ test('Graph Editor pans to Component Browser', async ({ page }) => {
   await expect(locate.graphNodeByBinding(page, 'five')).toBeInViewport()
   const outputPort = await locate.outputPortCoordinates(locate.graphNodeByBinding(page, 'final'))
   await page.mouse.click(outputPort.x, outputPort.y)
-  await page.mouse.click(100, 1700)
+  await locate.graphEditor(page).click({ position: { x: 100, y: 1700 } })
   await expect(locate.graphNodeByBinding(page, 'five')).not.toBeInViewport()
   await expectAndCancelBrowser(page, '', 'final')
 })

--- a/app/gui2/e2e/selectingNodes.spec.ts
+++ b/app/gui2/e2e/selectingNodes.spec.ts
@@ -37,7 +37,7 @@ test('Selecting nodes by click', async ({ page }) => {
   await expect(selectionMenu).not.toBeVisible()
 
   // Check that clicking the background deselects all nodes.
-  await page.mouse.click(600, 200)
+  await locate.graphEditor(page).click({ position: { x: 600, y: 200 } })
   await expect(node1).not.toBeSelected()
   await expect(node2).not.toBeSelected()
   await expect(selectionMenu).not.toBeVisible()


### PR DESCRIPTION
### Pull Request Description

We had some false test failures: https://github.com/enso-org/enso/actions/runs/9178969067/job/25240028635

The problem was the connection, which, while not being completely broken, still wasn't updated to proper position, thus taking clicks meant for the background. Now, I use proper locator click, so the test should wait for click spot being clear.

Also added locator-based clicks where I felt it's proper.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- ~~[ ] The documentation has been updated, if necessary.~~
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
