### PR TITLE
Heading levels

### DIFF
--- a/app/gui2/src/components/PlainTextEditor.vue
+++ b/app/gui2/src/components/PlainTextEditor.vue
@@ -22,7 +22,7 @@ const textSync: LexicalPlugin = {
   },
 }
 
-useLexical(contentElement, 'PlainTextEditor', [plainText, textSync])
+useLexical(contentElement, 'PlainTextEditor', {}, [plainText, textSync])
 </script>
 
 <template>

--- a/app/gui2/src/components/lexical/MarkdownEditorImpl.vue
+++ b/app/gui2/src/components/lexical/MarkdownEditorImpl.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useLexical, type LexicalPlugin } from '@/components/lexical'
+import { lexicalTheme, useLexical, type LexicalPlugin } from '@/components/lexical'
 import FloatingSelectionMenu from '@/components/lexical/FloatingSelectionMenu.vue'
 import LexicalContent from '@/components/lexical/LexicalContent.vue'
 import SelectionFormattingToolbar from '@/components/lexical/SelectionFormattingToolbar.vue'
@@ -18,7 +18,7 @@ import {
 import { HeadingNode, QuoteNode, registerRichText } from '@lexical/rich-text'
 import { TableCellNode, TableNode, TableRowNode } from '@lexical/table'
 import { syncRef } from '@vueuse/core'
-import { shallowRef, type ComponentInstance } from 'vue'
+import { shallowRef, useCssModule, type ComponentInstance } from 'vue'
 
 const markdown = defineModel<string>({ required: true })
 
@@ -56,7 +56,8 @@ const markdownSyncPlugin: LexicalPlugin = {
   },
 }
 
-const { editor } = useLexical(contentElement, 'MarkdownEditor', [
+const theme = lexicalTheme(useCssModule('lexicalTheme'))
+const { editor } = useLexical(contentElement, 'MarkdownEditor', theme, [
   listPlugin,
   markdownPlugin,
   markdownSyncPlugin,
@@ -77,43 +78,6 @@ const formatting = useFormatting(editor)
 .fullHeight {
   height: 100%;
 }
-
-.LexicalContent :deep(h1) {
-  font-weight: 700;
-  font-size: 16px;
-  line-height: 1.75;
-}
-
-.LexicalContent :deep(h2, h3, h4, h5, h6) {
-  font-size: 14px;
-  line-height: 2;
-}
-
-.LexicalContent :deep(p + p) {
-  margin-bottom: 4px;
-}
-
-.LexicalContent :deep(ol) {
-  list-style-type: decimal;
-  list-style-position: outside;
-  padding-left: 1.6em;
-}
-
-.LexicalContent :deep(ul) {
-  list-style-type: disc;
-  list-style-position: outside;
-  padding-left: 1.6em;
-}
-
-.LexicalContent :deep(strong) {
-  font-weight: bold;
-}
-
-.LexicalContent :deep(.lexical-strikethrough) {
-  text-decoration: line-through;
-}
-
-.LexicalContent :deep(.lexical-italic) {
-  font-style: italic;
-}
 </style>
+
+<style module="lexicalTheme" src="@/components/lexical/theme.css" />

--- a/app/gui2/src/components/lexical/index.ts
+++ b/app/gui2/src/components/lexical/index.ts
@@ -1,6 +1,7 @@
 import { unrefElement, type MaybeElement } from '@vueuse/core'
 import {
   createEditor,
+  type EditorThemeClasses,
   type KlassConstructor,
   type LexicalEditor,
   type LexicalNode,
@@ -15,9 +16,36 @@ export interface LexicalPlugin {
   register: (editor: LexicalEditor) => void
 }
 
+export function lexicalTheme(theme: Record<string, string>): EditorThemeClasses {
+  function getTheme(className: string) {
+    if (!(className in theme))
+      console.warn(`Referenced class ${className} not found in lexical theme.`, theme)
+    return theme[className]!
+  }
+  return {
+    text: {
+      strikethrough: getTheme('strikethrough'),
+      italic: getTheme('italic'),
+      bold: getTheme('bold'),
+    },
+    quote: getTheme('quote'),
+    heading: {
+      h1: getTheme('h1'),
+      h2: getTheme('h2'),
+      h3: getTheme('h3'),
+    },
+    paragraph: getTheme('paragraph'),
+    list: {
+      ol: getTheme('ol'),
+      ul: getTheme('ul'),
+    },
+  }
+}
+
 export function useLexical(
   contentElement: Ref<MaybeElement>,
   namespace: string,
+  theme: EditorThemeClasses,
   plugins: LexicalPlugin[],
 ) {
   const nodes = new Set<NodeDefinition>()
@@ -27,12 +55,7 @@ export function useLexical(
     createEditor({
       editable: true,
       namespace,
-      theme: {
-        text: {
-          strikethrough: 'lexical-strikethrough',
-          italic: 'lexical-italic',
-        },
-      },
+      theme,
       nodes: [...nodes],
       onError: console.error,
     }),

--- a/app/gui2/src/components/lexical/theme.css
+++ b/app/gui2/src/components/lexical/theme.css
@@ -1,47 +1,51 @@
-.h1 {
+/*
+Lexical theme. Class names are derived from the `LexicalThemeClasses` type from `lexical`, with the hierarchy flattened
+using `_` to separate levels. See the `lexicalTheme` function in `lexical/formatting.ts`.
+*/
+
+.heading_h1 {
   font-weight: 700;
   font-size: 20px;
   line-height: 1.75;
 }
-.h2 {
+.heading_h2 {
   font-weight: 700;
   font-size: 16px;
   line-height: 1.75;
 }
-.h3 {
+.heading_h3,
+.heading_h4,
+.heading_h5,
+.heading_h6 {
   font-size: 14px;
   line-height: 2;
 }
 
-.strikethrough {
+.text_strikethrough {
   text-decoration: line-through;
 }
-
-.italic {
+.text_italic {
   font-style: italic;
 }
-
-.quote {
+.text_quote {
   margin-left: 0.2em;
   border-left: 0.3em solid #ccc;
   padding-left: 1.6em;
+}
+.text_bold {
+  font-weight: bold;
 }
 
 .paragraph {
   margin-bottom: 0.5em;
 }
 
-.bold {
-  font-weight: bold;
-}
-
-.ol {
+.list_ol {
   list-style-type: decimal;
   list-style-position: outside;
   padding-left: 1.6em;
 }
-
-.ul {
+.list_ul {
   list-style-type: disc;
   list-style-position: outside;
   padding-left: 1.6em;

--- a/app/gui2/src/components/lexical/theme.css
+++ b/app/gui2/src/components/lexical/theme.css
@@ -1,0 +1,48 @@
+.h1 {
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 1.75;
+}
+.h2 {
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1.75;
+}
+.h3 {
+  font-size: 14px;
+  line-height: 2;
+}
+
+.strikethrough {
+  text-decoration: line-through;
+}
+
+.italic {
+  font-style: italic;
+}
+
+.quote {
+  margin-left: 0.2em;
+  border-left: 0.3em solid #ccc;
+  padding-left: 1.6em;
+}
+
+.paragraph {
+  margin-bottom: 0.5em;
+}
+
+.bold {
+  font-weight: bold;
+}
+
+.ol {
+  list-style-type: decimal;
+  list-style-position: outside;
+  padding-left: 1.6em;
+}
+
+.ul {
+  list-style-type: disc;
+  list-style-position: outside;
+  padding-left: 1.6em;
+}


### PR DESCRIPTION
### Pull Request Description

Larger h1 to enable three levels of headings.

<img width="508" alt="Screenshot 2024-05-24 at 07 38 31" src="https://github.com/enso-org/enso/assets/1047859/53e77040-30c2-4ed0-bfb5-81d4a703a565">

Fixes #10051.

### Important Notes

Refactored Lexical styling.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
