### PR TITLE
Remove old GUI1 ICONs and mapping function

### DIFF
--- a/app/gui2/src/util/getIconName.ts
+++ b/app/gui2/src/util/getIconName.ts
@@ -6,28 +6,6 @@ import {
 import type { Icon } from '@/util/iconName'
 import type { MethodPointer } from 'shared/languageServerTypes'
 
-const oldIconNameToNewIconNameLookup: Record<string, Icon> = {
-  /* eslint-disable camelcase */
-  dataframe_clean: 'table_clean',
-  dataframe_map_row: 'map_row',
-  dataframe_map_column: 'column_add',
-  dataframes_join: 'join2-1',
-  dataframes_union: 'union',
-  sigma: 'transform4',
-  io: 'in_out',
-  date_and_time: 'time',
-  spatial: 'location',
-  predictive: 'predict',
-  machine_learning: 'robot',
-  split_text: 'split',
-  /* eslint-enable camelcase */
-}
-
-export function mapOldIconName(oldIconName: string): Icon {
-  const mappedName = oldIconNameToNewIconNameLookup[oldIconName] ?? oldIconName
-  return mappedName as Icon
-}
-
 const typeNameToIconLookup: Record<string, Icon> = {
   'Standard.Base.Data.Text.Text': 'text_input',
   'Standard.Base.Data.Numbers.Integer': 'input_number',
@@ -46,7 +24,7 @@ export function typeNameToIcon(typeName: string): Icon {
 }
 
 export function suggestionEntryToIcon(entry: SuggestionEntry) {
-  if (entry.iconName) return mapOldIconName(entry.iconName)
+  if (entry.iconName) return entry.iconName
   if (entry.kind === SuggestionKind.Local) return 'local_scope2'
   if (entry.kind === SuggestionKind.Module) return 'collection'
   return DEFAULT_ICON

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Any.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Any.enso
@@ -376,7 +376,7 @@ type Any
     catch_primitive : (Error -> Any) -> Any
     catch_primitive self handler = @Builtin_Method "Any.catch_primitive"
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Transforms an error.
 
        Arguments:
@@ -432,7 +432,7 @@ type Any
     if_not_error : Any -> Any
     if_not_error self ~other = other
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Applies the provided function to `self` unless `self` is `Nothing`, which is
        returned unchanged.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
@@ -362,7 +362,7 @@ type Array
     duplicates self (on = x->x) =
         Array_Like_Helpers.duplicates self on
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Applies a function to each element of the array, returning the `Vector` of
        results.
 
@@ -401,7 +401,7 @@ type Array
     map self function on_problems=Problem_Behavior.Report_Error =
         Array_Like_Helpers.map self function on_problems
 
-    ## ICON dataframes_union
+    ## ICON union
        Applies a function to each element of the array, returning the `Vector`
        that contains all results concatenated.
 
@@ -460,7 +460,7 @@ type Array
     filter self (filter : Filter_Condition | (Any -> Boolean)) = Array_Like_Helpers.filter self filter
 
     ## GROUP Calculations
-       ICON dataframes_union
+       ICON union
        Transforms an array of arrays into a `Vector` of inner elements - removes
        one layer of nesting from a stack of nested arrays.
 
@@ -477,7 +477,7 @@ type Array
     short_display_text self max_entries=10 =
         Array_Like_Helpers.short_display_text self max_entries
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Combines all the elements of the array, by iteratively applying the
        passed function with the next element of the array. After each step the
        value is stored resulting in a new array of the same size as self.
@@ -494,7 +494,7 @@ type Array
     running_fold self init function =
         Array_Like_Helpers.running_fold self init function
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Combines all the elements of the array, by iteratively applying the
        passed function with next elements of the array.
 
@@ -515,7 +515,7 @@ type Array
     fold self init function =
         Array_Like_Helpers.fold self init function
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Combines all the elements of the array, by iteratively applying the
        passed function with next elements of the array.
 
@@ -533,7 +533,7 @@ type Array
         Array_Like_Helpers.fold_with_index self init function
 
     ## GROUP Calculations
-       ICON dataframes_union
+       ICON union
        Extend `self` array to the length of `n` appending elements `elem` to
        the end.
 
@@ -557,7 +557,7 @@ type Array
     pad self n elem = Array_Like_Helpers.pad self n elem
 
     ## GROUP Selections
-       ICON split_text
+       ICON split
        Partitions the array into `Vector`s of elements which satisfy a given
        condition and ones that do not.
 
@@ -610,7 +610,7 @@ type Array
         Array_Like_Helpers.partition_with_index self predicate
 
     ## GROUP Selections
-       ICON dataframe_map_row
+       ICON map_row
        Swaps the rows and columns of a matrix represented by an array of arrays.
 
        ! Error Conditions
@@ -645,7 +645,7 @@ type Array
     transpose self =
         Array_Like_Helpers.transpose self
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Applies a function to each element of the array, returning the `Vector`
        of results.
 
@@ -792,7 +792,7 @@ type Array
     to_display_text : Text
     to_display_text self = self.short_display_text max_entries=40
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Combines all the elements of a non-empty array using a binary operation.
        If the array is empty, it returns `if_empty`.
 
@@ -866,7 +866,7 @@ type Array
 
     ## ALIAS combine, join by row position, merge
        GROUP Calculations
-       ICON dataframes_join
+       ICON join2-1
        Performs a pair-wise operation passed in `function` on consecutive
        elements of `self` and `that`.
 
@@ -975,7 +975,7 @@ type Array
 
     ## ALIAS append, concatenate, union
        GROUP Operators
-       ICON dataframes_union
+       ICON union
        Concatenates two arrays, resulting in a new `Vector`, containing all the
        elements of `self`, followed by all the elements of `that`.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Decimal.enso
@@ -708,7 +708,7 @@ type Decimal
     signum self -> Integer = self.big_decimal.signum
 
     ## GROUP Math
-       ICON sigma
+       ICON transform4
        Returns the smaller value of `self` and `that`.
 
        Arguments:
@@ -723,7 +723,7 @@ type Decimal
     min self (that : Decimal) -> Decimal = if self < that then self else that
 
     ## GROUP Math
-       ICON sigma
+       ICON transform4
        Returns the larger value of `self` and `that`.
 
        Arguments:

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Interval.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Interval.enso
@@ -49,7 +49,7 @@ type Interval_Type
 ## A type representing an interval over real numbers.
 type Interval
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Creates an interval.
 
        Arguments:

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json.enso
@@ -217,7 +217,7 @@ type JS_Object
     field_names : Vector
     field_names self = self.field_array
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Maps a function over each value in this object
 
        Arguments:
@@ -228,7 +228,7 @@ type JS_Object
         kv_func = _ -> function
         self.map_with_key kv_func
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Maps a function over each field-value pair in the object.
 
        Arguments:

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/List.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/List.enso
@@ -108,7 +108,7 @@ type List
                     @Tail_Call loop xs (0.max count-1) new_lagged
             loop self -index self
 
-    ## ICON sigma
+    ## ICON transform4
        Combines all the elements of the list, by iteratively applying the
        passed function with next elements of the list.
 
@@ -322,7 +322,7 @@ type List
                 True  -> Pair.new (Cons elem acc.first) acc.second
                 False -> Pair.new acc.first (Cons elem acc.second)
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Applies a function to each element of the list, returning the list of
        results.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Map.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Map.enso
@@ -237,7 +237,7 @@ type Map key value
     values : Vector Any
     values self = self.to_vector.map pair-> pair.at 1
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Maps a function over each value in this map.
 
        Arguments:
@@ -256,7 +256,7 @@ type Map key value
         kv_func = _ -> function
         self.map_with_key kv_func
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Maps a function over each key-value pair in the map, transforming the
        value.
 
@@ -279,7 +279,7 @@ type Map key value
             value = pair.last
             [key, (function key value)]
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Maps a function over each key in this map.
 
        Arguments:
@@ -298,7 +298,7 @@ type Map key value
         trans_function = k -> v -> [function k, v]
         self.transform trans_function
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Transforms the map's keys and values to create a new map.
 
        Arguments:
@@ -329,7 +329,7 @@ type Map key value
                     Error.throw (Illegal_Argument.Error new_message error.cause)
                 False -> new_map
 
-    ## ICON sigma
+    ## ICON transform4
        Combines the values in the map.
 
        Arguments:
@@ -346,7 +346,7 @@ type Map key value
     fold : Any -> (Any -> Any -> Any) -> Any
     fold self init function = self.values.fold init function
 
-    ## ICON sigma
+    ## ICON transform4
        Combines the key-value pairs in the map.
 
        Arguments:

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
@@ -1129,7 +1129,7 @@ type Integer
 
        The bitwise compliment negates the value of each bit in the operand.
 
-       ? Example
+       > Example
          Bitwise negation of 2_0110.
 
              2_0110.bit_not

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Numbers.enso
@@ -346,7 +346,7 @@ type Number
         (self == that) || ((self - that).abs <= epsilon)
 
     ## GROUP Math
-       ICON sigma
+       ICON transform4
        Returns the smaller value of `self` and `that`.
 
        Arguments:
@@ -365,7 +365,7 @@ type Number
     min self that = if self < that then self else that
 
     ## GROUP Math
-       ICON sigma
+       ICON transform4
        Returns the larger value of `self` and `that`.
 
        Arguments:

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Pair.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Pair.enso
@@ -40,7 +40,7 @@ type Pair
     last : Any
     last self = self.second
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Applies the provided function to both elements of the pair.
 
        > Example
@@ -211,7 +211,7 @@ type Pair
             if used_start>=0 && predicate self.first then 0 else
                 Nothing
 
-    ## ICON sigma
+    ## ICON transform4
        Combines all the elements of the pair, by iteratively applying the
        passed function with next elements of the pair.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Range.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Range.enso
@@ -164,7 +164,7 @@ type Range
     not_empty : Boolean
     not_empty self = self.is_empty.not
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Applies a function to each element in the range, producing a vector of
        results.
 
@@ -301,7 +301,7 @@ type Range
                     @Tail_Call go ix+1 current+self.step
             go 0 self.start
 
-    ## ICON sigma
+    ## ICON transform4
        Combines all the elements of the range, by iteratively applying the
        passed function with next elements of the range.
 
@@ -330,7 +330,7 @@ type Range
                     @Tail_Call go new_acc current+self.step
             go init self.start
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Combines all the elements of the range, by iteratively applying the
        passed function with the next element of the range. After each step the
        value is stored resulting in a new Vector of the same size as self.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Regression.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Regression.enso
@@ -51,7 +51,7 @@ type Model
             if x <= 0 then Panic.throw (Illegal_Argument.Error (series_name + " must be positive.")) else x.ln
         Panic.recover Illegal_Argument <| xs.map ln_with_panic
 
-## ICON machine_learning
+## ICON robot
    Use Least Squares to fit a line to the data.
 fit_least_squares : Vector -> Vector -> Model -> Fitted_Model ! Illegal_Argument | Fit_Error
 fit_least_squares known_xs known_ys model=Model.Linear =
@@ -105,7 +105,7 @@ type Fitted_Model
         Fitted_Model.Power a b _ -> a.to_text + " * X ^ " + b.to_text
 
     ## GROUP Calculations
-       ICON machine_learning
+       ICON robot
        Use the model to predict a value.
     predict : Number -> Number
     predict self x = case self of

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Set.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Set.enso
@@ -109,7 +109,7 @@ type Set
         Set.Value new_map
 
     ## GROUP Calculations
-       ICON dataframes_union
+       ICON union
        Creates a union of the two sets.
     union : Set -> Set
     union self (other : Set) =

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Statistics.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Statistics.enso
@@ -45,7 +45,7 @@ type Rank_Method
     Ordinal
 
     ## GROUP Statistics
-       ICON sigma
+       ICON transform4
        Assigns a rank to each value of data, dealing with equal values according to the method.
 
        Arguments:
@@ -323,7 +323,7 @@ calculate_correlation_statistics_matrix data =
     Vector.new stats_array.length i->(Vector.from_polyglot_array (stats_array.at i))
 
 ## GROUP Statistics
-   ICON sigma
+   ICON transform4
    Compute a single statistic on the vector (ignoring Nothing and NaN values).
 
    Arguments:
@@ -332,7 +332,7 @@ Vector.compute : Statistic -> Any
 Vector.compute self statistic=Statistic.Count =
     self.compute_bulk [statistic] . first
 
-## ICON dataframe_map_column
+## ICON column_add
    Compute statistics on the vector (ignoring Nothing and NaN values).
 
    Arguments:
@@ -363,7 +363,7 @@ Vector.running_bulk self statistics=[Statistic.Count, Statistic.Sum] =
     Statistic.running_bulk self statistics
 
 ## GROUP Statistics
-   ICON dataframe_map_column
+   ICON column_add
    Assigns a rank to each value of data, dealing with equal values according to
    the method.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -108,7 +108,7 @@ Text.each self function =
 
 ## ALIAS get character
    GROUP Selections
-   ICON split_text
+   ICON split
 
    Returns a character from the text at the specified index (0-based).
 
@@ -133,7 +133,7 @@ Text.at self index =
     self.get index (Error.throw (Index_Out_Of_Bounds.Error index self.length))
 
 ## ALIAS get character
-   ICON split_text
+   ICON split
 
    Returns a character from the text at the specified index (0-based).
    If the index is invalid then `if_missing` is returned.
@@ -167,7 +167,7 @@ Text.get self index ~if_missing=Nothing =
             Text_Utils.substring self first next
 
 ## GROUP Selections
-   ICON split_text
+   ICON split
    Returns the first character from the text.
 
    ! What is a Character?
@@ -183,7 +183,7 @@ Text.first : Text ! Index_Out_Of_Bounds
 Text.first self = self.at 0
 
 ## GROUP Selections
-   ICON split_text
+   ICON split
    Returns the second character from the text.
 
    ! What is a Character?
@@ -199,7 +199,7 @@ Text.second : Text ! Index_Out_Of_Bounds
 Text.second self = self.at 1
 
 ## GROUP Selections
-   ICON split_text
+   ICON split
    Returns the last character from the text.
 
    ! What is a Character?
@@ -345,7 +345,7 @@ Text.to_regex self case_insensitive=False = Regex.compile self case_insensitive
 
 ## ALIAS split text
    GROUP Conversions
-   ICON split_text
+   ICON split
 
    Takes a delimiter and returns the vector that results from splitting `self`
    on each of its occurrences.
@@ -411,7 +411,7 @@ Text.split self delimiter="," case_sensitivity=Case_Sensitivity.Sensitive use_re
 
 ## ADVANCED
    GROUP Conversions
-   ICON split_text
+   ICON split
    Takes an input string and and a pattern and returns all the matches as a
    `Vector Text`. If the pattern contains marked groups, the values are
    concatenated together; otherwise the whole match is returned.
@@ -1011,7 +1011,7 @@ Text.repeat self count=1 =
 
 ## ALIAS first, head, last, left, limit, mid, right, slice, substring, tail, top, keep
    GROUP Selections
-   ICON split_text
+   ICON split
    Creates a new Text by selecting the specified range of the input.
 
    This can select a section of text from the beginning, end, or middle of the
@@ -1060,7 +1060,7 @@ Text.take self range=(Index_Sub_Range.First 1) =
 
 ## ALIAS remove, skip
    GROUP Selections
-   ICON split_text
+   ICON split
    Creates a new Text by removing the specified range of the input.
 
    This can select a section of text from the beginning, end, or middle of the
@@ -1879,7 +1879,7 @@ Text.parse_time_zone self = Time_Zone.parse self
 
 ## ALIAS mid, slice, substring
    GROUP Selections
-   ICON split_text
+   ICON split
    Creates a new Text by selecting the specified range of the input.
 
    Arguments:

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -45,10 +45,10 @@ polyglot java import com.ibm.icu.text.BreakIterator
 polyglot java import java.lang.StringBuilder
 polyglot java import org.enso.base.Encoding_Utils
 polyglot java import org.enso.base.Regex_Utils
-polyglot java import org.enso.base.Text_Utils
-polyglot java import org.enso.base.text.Utf16Span
 polyglot java import org.enso.base.text.GraphemeSpan
 polyglot java import org.enso.base.text.ResultWithWarnings
+polyglot java import org.enso.base.text.Utf16Span
+polyglot java import org.enso.base.Text_Utils
 
 ## GROUP Text
    ICON text
@@ -1009,7 +1009,7 @@ Text.repeat : Integer -> Text
 Text.repeat self count=1 =
     0.up_to count . fold "" acc-> _-> acc + self
 
-## ALIAS first, head, last, left, limit, mid, right, slice, substring, tail, top, keep
+## ALIAS first, head, keep, last, left, limit, mid, right, slice, substring, tail, top
    GROUP Selections
    ICON split
    Creates a new Text by selecting the specified range of the input.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -927,7 +927,9 @@ Text.ends_with self suffix case_sensitivity=Case_Sensitivity.Sensitive = case ca
    ICON preparation
 
    Checks whether `self` contains `sequence` as its substring.
-   Returns: `True` if term is found within `self`. `False` otherwise.
+
+   Returns:
+   `True` if term is found within `self`. `False` otherwise.
 
    Arguments:
    - term: The term to find.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
@@ -311,7 +311,8 @@ type Regex
        Arguments:
        - id: The name or number of the group that was asked for.
 
-       Returns: a group number.
+       Returns:
+       A group number.
 
        A group number is invalid if it is outside the range of groups
        that were in the original pattern.
@@ -333,7 +334,6 @@ type Regex
        In this case, the group id for "(d)", which is 3, is a valid group id and
        (Regex.lookup_group 3) will return 3. If the caller tries to get group 3,
        Match.group will return Nothing.
-
     lookup_group : Integer | Text -> Integer ! No_Such_Group
     lookup_group self id =
         case id of

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
@@ -157,7 +157,7 @@ type Regex
        self.match_all input . map match_to_group_maybe
 
     ## GROUP Conversions
-       ICON split_text
+       ICON split
        Splits the `input` text based on the pattern described by `self`.
 
        Arguments:
@@ -201,7 +201,7 @@ type Regex
             go it.next
 
     ## GROUP Conversions
-       ICON split_text
+       ICON split
        Takes an input string and returns all the matches as a `Vector Text`.
        If the pattern contains marked groups, the values are concatenated
        together; otherwise the whole match is returned. Non-participating

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Match.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex/Match.enso
@@ -291,7 +291,7 @@ type Match
         Map.from_vector <|
             pattern_named_groups.map name-> [name, self.text name default=default]
 
-    ## ICON split_text
+    ## ICON split
        Gets the grapheme span matched by the group with the provided index, or
        a default value if the group did not participate in the match.
        If the identifier is invalid then `if_missing` is returned.
@@ -304,7 +304,7 @@ type Match
         self.text index . catch No_Such_Group (_-> if_missing)
 
     ## GROUP Selections
-       ICON split_text
+       ICON split
        Gets the grapheme span matched by the group with the provided index, or
        a default value if the group did not participate in the match.
        If the identifier is invalid then Index_Out_Of_Bounds is thrown.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Text_Sub_Range.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Text_Sub_Range.enso
@@ -167,6 +167,7 @@ type Codepoint_Ranges
 
 ## PRIVATE
    Utility function to find char indices for Text_Sub_Range.
+
    Arguments:
    - text: Text to search
    - predicate: Function to test each character, receives:
@@ -174,8 +175,9 @@ type Codepoint_Ranges
      - start: index the char array to start of grapheme cluster
      - end: index the char array to start of next grapheme cluster
      If the predicate returns True for a given character, the loop will exit.
-   Returns: either a Pair of char indices for current grapheme cluster or
-     Pair Nothing (char array length) if not found.
+
+   Returns:
+   Either a Pair of char indices for current grapheme cluster or Pair Nothing (char array length) if not found.
 find_sub_range_end text predicate =
     iterator = BreakIterator.getCharacterInstance
     iterator.setText text

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
@@ -60,7 +60,7 @@ new_builtin year month day = @Builtin_Method "Date.new_builtin"
 type Date
     ## ALIAS current date, now
        GROUP DateTime
-       ICON date_and_time
+       ICON time
 
        Obtains the current date from the system clock in the system timezone.
 
@@ -72,7 +72,7 @@ type Date
     today = @Builtin_Method "Date.today"
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Constructs a new Date from a year, month, and day.
 
        Arguments:
@@ -310,19 +310,19 @@ type Date
             Day_Of_Week.from (Time_Utils.get_field_as_localdate self ChronoField.DAY_OF_WEEK) Day_Of_Week.Monday
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Returns the first date within the `Date_Period` containing self.
     start_of : Date_Period -> Date
     start_of self period=Date_Period.Month = period.adjust_start self
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Returns the last date within the `Date_Period` containing self.
     end_of : Date_Period -> Date
     end_of self period=Date_Period.Month = period.adjust_end self
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Returns the next date adding the `Date_Period` to self.
 
        Produces a warning for a Date that is before epoch start.
@@ -334,7 +334,7 @@ type Date
     next self period=Date_Period.Day = self + period.to_period
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Returns the previous date subtracting the `Date_Period` from self.
 
        Produces a warning for a Date that is before epoch start.
@@ -346,7 +346,7 @@ type Date
     previous self period=Date_Period.Day = self - period.to_period
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Creates a `Period` between self and the provided end date.
 
        Produces a warning for a Date that is before epoch start.
@@ -360,7 +360,7 @@ type Date
             Period.between self end
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Counts the days between self (inclusive) and the provided end date
        (exclusive, or inclusive if include_end_date=True).
 
@@ -378,7 +378,7 @@ type Date
                 (Time_Utils.days_between self end) + if include_end_date then 1 else 0
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Returns a requested date part as integer.
 
        Produces a warning for a Date that is before epoch start.
@@ -393,7 +393,7 @@ type Date
             Date_Period.Day     -> self.day
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Computes a time difference between the two dates.
 
        It returns an integer expressing how many periods fit between the two
@@ -412,7 +412,7 @@ type Date
         Time_Utils.unit_date_difference period.to_java_unit self end
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Shifts the date by a specified period.
 
        Produces a warning for a Date that is before epoch start.
@@ -426,7 +426,7 @@ type Date
         Time_Utils.unit_date_add period.to_java_unit self amount
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Counts workdays between self (inclusive) and the provided end date
        (exclusive).
 
@@ -494,7 +494,7 @@ type Date
 
     ## ALIAS add period
        GROUP Operators
-       ICON date_and_time
+       ICON time
        Add the specified amount of time to this instant to get another date.
 
        Arguments:
@@ -524,7 +524,7 @@ type Date
 
     ## ALIAS date range
        GROUP Input
-       ICON date_and_time
+       ICON time
        Creates an increasing range of dates from `self` to `end`.
 
        Arguments:
@@ -551,7 +551,7 @@ type Date
 
     ## ALIAS date range
        GROUP Input
-       ICON date_and_time
+       ICON time
        Creates a decreasing range of dates from `self` to `end`.
 
        Arguments:
@@ -575,7 +575,7 @@ type Date
         if step == Date_Period.Day then day_range else day_range.with_step step
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Shift the date by the specified amount of business days.
 
        For the purpose of this method, the business days are defined to be
@@ -700,7 +700,7 @@ type Date
 
     ## ALIAS subtract period
        GROUP Operators
-       ICON date_and_time
+       ICON time
        Subtract the specified amount of time from this instant to get another
        date.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Range.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Range.enso
@@ -29,7 +29,7 @@ type Date_Range
        allow to verify invariants and may lead to unexpected behavior.
     Internal_Constructor (start : Date) (end : Date) (step : Period) (increasing : Boolean) (cached_length : Integer)
 
-    ## ICON date_and_time
+    ## ICON time
        Create a representation of a right-exclusive range of dates.
 
        The range is increasing or decreasing, depending on if the start date is
@@ -54,7 +54,7 @@ type Date_Range
         Date_Range.Internal_Constructor start end one_day increasing base_length . with_step step
 
     ## GROUP Calculations
-       ICON date_and_time
+       ICON time
        Creates a copy of this range with a changed step.
 
        Arguments:
@@ -188,7 +188,7 @@ type Date_Range
     internal_at self i =
         nth_element_of_range self.start self.step self.increasing i
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Applies a function to each element in the range, producing a vector of
        results.
 
@@ -336,7 +336,7 @@ type Date_Range
         (0.up_to self.length).each_with_index ix->
             function ix (self.internal_at ix)
 
-    ## ICON sigma
+    ## ICON transform4
        Combines all the elements of the range, by iteratively applying the
        passed function with next elements of the range.
 
@@ -356,7 +356,7 @@ type Date_Range
         (0.up_to self.length).fold init acc-> ix->
             function acc (self.internal_at ix)
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Combines all the elements of the range, by iteratively applying the
        passed function with the next element of the range. After each step the
        value is stored resulting in a new Vector of the same size as self.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date_Time.enso
@@ -84,7 +84,7 @@ new_builtin year month day hour minute second nanosecond zone = @Builtin_Method 
    the Europe/Paris timezone" can be stored as `Time`.
 @Builtin_Type
 type Date_Time
-    ## ICON date_and_time
+    ## ICON time
        Obtains the start of the epoch for Enso.
 
        ? Start of the epoch
@@ -102,7 +102,7 @@ type Date_Time
 
     ## ALIAS current time
        GROUP DateTime
-       ICON date_and_time
+       ICON time
 
        Obtains the current date-time from the system clock in the system timezone.
 
@@ -116,7 +116,7 @@ type Date_Time
     now = @Builtin_Method "Date_Time.now"
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Obtains an instance of `Date_Time` from a year, month, day, hour, minute,
        second, nanosecond and timezone.
 
@@ -586,7 +586,7 @@ type Date_Time
             Day_Of_Week.from (Time_Utils.get_field_as_zoneddatetime self ChronoField.DAY_OF_WEEK) Day_Of_Week.Monday
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Returns the first date within the `Time_Period` or `Date_Period`
        containing self.
     start_of : (Date_Period|Time_Period) -> Date_Time
@@ -597,7 +597,7 @@ type Date_Time
             _ : Time_Period -> adjusted
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Returns the last date within the `Time_Period` or `Date_Period`
        containing self.
     end_of : (Date_Period|Time_Period) -> Date_Time
@@ -625,7 +625,7 @@ type Date_Time
 
     ## ALIAS change time zone
        GROUP DateTime
-       ICON date_and_time
+       ICON time
 
        Convert the time instant to the same instant in the provided time zone.
 
@@ -643,7 +643,7 @@ type Date_Time
         Time_Utils.with_zone_same_instant self zone
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Returns a requested date-time part as integer.
 
        Produces a warning for a Date_Time that is before epoch start.
@@ -665,7 +665,7 @@ type Date_Time
             Time_Period.Nanosecond  -> self.nanosecond
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Computes a time difference between the two date-times.
 
        It returns an integer expressing how many periods fit between the two
@@ -684,7 +684,7 @@ type Date_Time
         Time_Utils.unit_datetime_difference period.to_java_unit self end
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Shifts the date-time by a specified period.
 
        Produces a warning for a Date_Time that is before epoch start.
@@ -700,7 +700,7 @@ type Date_Time
 
     ## ALIAS add duration, add period
        GROUP Operators
-       ICON date_and_time
+       ICON time
        Add the specified amount of time to this instant to produce a new instant.
 
        Arguments:
@@ -734,7 +734,7 @@ type Date_Time
                 self + date_period.to_period
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Shift the date by the specified amount of business days.
 
        For the purpose of this method, the business days are defined to be
@@ -778,7 +778,7 @@ type Date_Time
 
     ## ALIAS subtract duration, subtract period
        GROUP Operators
-       ICON date_and_time
+       ICON time
        Subtract the specified amount of time from this instant to get a new
        instant.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Duration.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Duration.enso
@@ -65,7 +65,7 @@ ensure_duration object ~action =
 ## Represents the amount of time between two points in time.
 @Builtin_Type
 type Duration
-    ## ICON date_and_time
+    ## ICON time
        Create an interval representing the duration between two points in time.
 
        Arguments:
@@ -86,7 +86,7 @@ type Duration
         between_builtin start_inclusive end_exclusive timezone_aware
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Create a duration from time units.
 
        Arguments:
@@ -106,7 +106,7 @@ type Duration
     new (hours : Integer = 0) (minutes : Integer = 0) (seconds : Integer = 0) (milliseconds : Integer = 0) (nanoseconds : Integer = 0) =
         new_builtin hours minutes seconds milliseconds nanoseconds
 
-    ## ICON date_and_time
+    ## ICON time
        Create a zero (empty) duration.
        > Example
          Folding a vector of durations.
@@ -119,7 +119,7 @@ type Duration
     zero = Duration.new
 
     ## ADVANCED
-       ICON date_and_time
+       ICON time
 
        Time the evaluation of a function, return a Pair of Duration and Result
 
@@ -135,7 +135,7 @@ type Duration
 
     ## ALIAS add duration
        GROUP Operators
-       ICON date_and_time
+       ICON time
        Add the specified amount of time to this duration.
 
        Arguments:
@@ -162,7 +162,7 @@ type Duration
 
     ## ALIAS subtract duration
        GROUP Operators
-       ICON date_and_time
+       ICON time
        Subtract the specified amount of time from this duration.
 
        Arguments:

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Period.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Period.enso
@@ -39,7 +39,7 @@ ensure_period object ~action error_msg="Cannot use Duration as a parameter" =
    daylight saving time. This means that a Period of 1 day does not necessarily
    have to be 24 hours of Duration.
 type Period
-    ## ICON date_and_time
+    ## ICON time
        Create a Period representing the time interval between two dates.
 
        Arguments:
@@ -57,7 +57,7 @@ type Period
         Period.Value (Java_Period.between start_date_inclusive end_date_exclusive)
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Create a new Period from years, months and days.
 
        Arguments:
@@ -83,33 +83,33 @@ type Period
     Value (internal_period : Java_Period)
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Get the portion of the period expressed in years.
     years : Integer
     years self = self.internal_period.getYears
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Get the portion of the period expressed in months.
     months : Integer
     months self = self.internal_period.getMonths
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Get the portion of the period coming from months and years as months
        (every year is translated to 12 months).
     total_months : Integer
     total_months self = self.internal_period.toTotalMonths
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Get the portion of the period expressed in days.
     days : Integer
     days self = self.internal_period.getDays
 
     ## ALIAS add period
        GROUP Operators
-       ICON date_and_time
+       ICON time
        Add the specified amount of time to this period.
 
        Arguments:
@@ -130,7 +130,7 @@ type Period
 
     ## ALIAS subtract period
        GROUP Operators
-       ICON date_and_time
+       ICON time
        Subtract a specified amount of time from this period.
 
        Arguments:
@@ -152,7 +152,7 @@ type Period
 
     ## ALIAS multiply, times
        GROUP Operators
-       ICON date_and_time
+       ICON time
        Multiply the amount of time in this period by the specified scalar.
 
        Arguments:

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Of_Day.enso
@@ -52,7 +52,7 @@ new_builtin hour minute second nanosecond = @Builtin_Method "Time_Of_Day.new_bui
 @Builtin_Type
 type Time_Of_Day
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Obtains the current time from the system clock in the default time-zone.
 
        > Example
@@ -65,7 +65,7 @@ type Time_Of_Day
     now = @Builtin_Method "Time_Of_Day.now"
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Obtains an instance of `Time_Of_Day` from an hour, minute, second
        and nanosecond.
 
@@ -262,13 +262,13 @@ type Time_Of_Day
         self.nanosecond_builtin include_milliseconds
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Returns the first time within the `Time_Period` containing self.
     start_of : Time_Period -> Time_Of_Day
     start_of self period=Time_Period.Day = period.adjust_start self
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Returns the last time within the `Time_Period` containing self.
     end_of : Time_Period -> Time_Of_Day
     end_of self period=Time_Period.Day = period.adjust_end self
@@ -306,7 +306,7 @@ type Time_Of_Day
 
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Returns a requested time part as integer.
     date_part : Time_Period -> Integer
     date_part self (period : Time_Period) =
@@ -320,7 +320,7 @@ type Time_Of_Day
             Time_Period.Nanosecond  -> self.nanosecond
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Computes a time difference between the two times of day.
 
        It returns an integer expressing how many periods fit between the two
@@ -339,7 +339,7 @@ type Time_Of_Day
             Time_Utils.unit_time_difference period.to_java_unit self end
 
     ## GROUP DateTime
-       ICON date_and_time
+       ICON time
        Shifts the time of day by a specified period.
 
        Arguments:
@@ -354,7 +354,7 @@ type Time_Of_Day
 
     ## ALIAS add duration
        GROUP Operators
-       ICON date_and_time
+       ICON time
        Add the specified amount of time to this instant to get a new instant.
 
        Arguments:
@@ -383,7 +383,7 @@ type Time_Of_Day
 
     ## ALIAS subtract duration
        GROUP Operators
-       ICON date_and_time
+       ICON time
        Subtract the  specified amount of time from this instant to get a new
        instant.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Zone.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Time_Zone.enso
@@ -50,7 +50,7 @@ parse_builtin text = @Builtin_Method "Time_Zone.parse_builtin"
    "Europe/Paris".
 @Builtin_Type
 type Time_Zone
-    ## ICON date_and_time
+    ## ICON time
        The system default timezone.
 
        > Example
@@ -63,7 +63,7 @@ type Time_Zone
     system = @Builtin_Method "Time_Zone.system"
 
     ## ALIAS current time zone
-       ICON date_and_time
+       ICON time
 
        The system's local timezone.
 
@@ -77,7 +77,7 @@ type Time_Zone
     local = Time_Zone.system
 
     ## ALIAS utc time zone
-       ICON date_and_time
+       ICON time
 
        The UTC timezone.
 
@@ -90,7 +90,7 @@ type Time_Zone
     utc : Time_Zone
     utc = Time_Zone.parse "UTC"
 
-    ## ICON date_and_time
+    ## ICON time
        Obtains an instance of `Time_Zone` using an offset in hours, minutes and seconds
        from the UTC zone.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -310,7 +310,7 @@ type Vector a
     get self index ~if_missing=Nothing =
         Array_Like_Helpers.get self index if_missing
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Combines all the elements of the vector, by iteratively applying the
        passed function with next elements of the vector.
 
@@ -331,7 +331,7 @@ type Vector a
     fold self init function =
         Array_Like_Helpers.fold self init function
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Combines all the elements of the vector, by iteratively applying the
        passed function with next elements of the vector.
 
@@ -348,7 +348,7 @@ type Vector a
     fold_with_index self init function =
         Array_Like_Helpers.fold_with_index self init function
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Combines all the elements of the vector, by iteratively applying the
        passed function with the next element of the vector. After each step the
        value is stored resulting in a new vector of the same size as self.
@@ -365,7 +365,7 @@ type Vector a
     running_fold self init function =
         Array_Like_Helpers.running_fold self init function
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Combines all the elements of a non-empty vector using a binary operation.
        If the vector is empty, it returns `if_empty`.
 
@@ -570,7 +570,7 @@ type Vector a
         Array_Like_Helpers.filter_with_index self predicate
 
     ## GROUP Selections
-       ICON split_text
+       ICON split
        Partitions the vector into `Vector`s of elements which satisfy a given
        condition and ones that do not.
 
@@ -623,7 +623,7 @@ type Vector a
         Array_Like_Helpers.partition_with_index self predicate
 
     ## GROUP Selections
-       ICON dataframe_map_row
+       ICON map_row
        Swaps the rows and columns of a matrix represented by a vector of vectors.
 
        ! Error Conditions
@@ -658,7 +658,7 @@ type Vector a
     transpose self =
         Array_Like_Helpers.transpose self
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Applies a function to each element of the vector, returning the `Vector` of
        results.
 
@@ -697,7 +697,7 @@ type Vector a
     map self function on_problems=Problem_Behavior.Report_Error =
         Array_Like_Helpers.map self function on_problems
 
-    ## ICON dataframes_union
+    ## ICON union
        Applies a function to each element of the vector, returning the `Vector`
        that contains all results concatenated.
 
@@ -737,7 +737,7 @@ type Vector a
         Array_Like_Helpers.flat_map self function on_problems
 
     ## GROUP Calculations
-       ICON dataframes_union
+       ICON union
        Transforms a vector of vectors into a `Vector` of inner elements - removes
        one layer of nesting from a stack of nested vectors.
 
@@ -748,7 +748,7 @@ type Vector a
     flatten : Vector Any
     flatten self = Array_Like_Helpers.flatten self
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Applies a function to each element of the vector, returning the `Vector`
        of results.
 
@@ -875,7 +875,7 @@ type Vector a
 
     ## ALIAS append, concatenate, union
        GROUP Operators
-       ICON dataframes_union
+       ICON union
        Concatenates two vectors, resulting in a new `Vector`, containing all the
        elements of `self`, followed by all the elements of `that`.
 
@@ -989,7 +989,7 @@ type Vector a
 
     ## ALIAS combine, join by row position, merge
        GROUP Calculations
-       ICON dataframes_join
+       ICON join2-1
        Performs a pair-wise operation passed in `function` on consecutive
        elements of `self` and `that`.
 
@@ -1040,7 +1040,7 @@ type Vector a
         Array_Like_Helpers.vector_from_function len (i-> function (self.at i) (that.at i)) on_problems
 
     ## GROUP Calculations
-       ICON dataframes_union
+       ICON union
        Extend `self` vector to the length of `n` appending elements `elem` to
        the end.
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Error.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Error.enso
@@ -151,7 +151,7 @@ type Error
             wrapped_error = Wrapped_Error.from error_value
             @Tail_Call Error.unwrap wrapped_error.inner_error
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Transforms an error.
 
        Arguments:

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_By_Line.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_By_Line.enso
@@ -113,7 +113,7 @@ type File_By_Line
         end_at = if self.limit_lines.is_nothing then Nothing else self.limit_lines-1
         for_each_lines self 0 end_at function
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Transforms each line in the file and returns the result as a vector.
 
        Arguments:
@@ -124,7 +124,7 @@ type File_By_Line
             wrapped_action _ t = builder.append (action t)
             self.each_with_index wrapped_action
 
-    ## ICON dataframe_map_column
+    ## ICON column_add
        Transforms each line in the file and returns the result as a vector.
 
        Arguments:

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Column.enso
@@ -252,14 +252,14 @@ type DB_Column
     length self = self.to_table.row_count
 
     ## GROUP Standard.Base.Metadata
-       ICON sigma
+       ICON transform4
        Returns the number of missing items in this column.
     count_nothing : Integer
     count_nothing self =
         self.to_table.filter 0 Filter_Condition.Is_Nothing . row_count
 
     ## GROUP Standard.Base.Metadata
-       ICON sigma
+       ICON transform4
        Returns the number of non-null items in this column.
     count : Integer
     count self =
@@ -983,7 +983,7 @@ type DB_Column
             adapt_unified_column op_result common_type
 
     ## GROUP Standard.Base.Math
-       ICON sigma
+       ICON transform4
        Returns a column of minimum on each row of `self` and `values`.
 
        Arguments:
@@ -1004,7 +1004,7 @@ type DB_Column
             self.make_op "ROW_MIN" args new_name
 
     ## GROUP Standard.Base.Math
-       ICON sigma
+       ICON transform4
        Returns a column of maximum on each row of `self` and `values`.
 
        Arguments:
@@ -1100,7 +1100,7 @@ type DB_Column
 
     ## ALIAS fill missing, if_nothing
        GROUP Standard.Base.Values
-       ICON dataframe_map_column
+       ICON column_add
 
        Returns a new column where missing values have been replaced with the
        provided default.
@@ -1130,7 +1130,7 @@ type DB_Column
 
     ## ALIAS fill empty, if_empty
        GROUP Standard.Base.Values
-       ICON dataframe_map_column
+       ICON column_add
 
        Returns a new column where empty Text values have been replaced with the
        provided default.
@@ -1384,7 +1384,7 @@ type DB_Column
                     Error.throw (Unsupported_Database_Operation.Error ("`DB_Column.trim "+where.to_text+"` is not supported by this connection."))
 
     ## GROUP Standard.Base.Text
-       ICON dataframe_map_column
+       ICON column_add
        Replaces the first, or all occurrences of `term` with `new_text` in each
        row. If `term` is empty, the function returns the table unchanged.
 
@@ -1460,7 +1460,7 @@ type DB_Column
                 self.make_op "REPLACE" [raw_term, new_text] new_name [term, params]
 
     ## GROUP Standard.Base.Text
-       ICON dataframe_map_column
+       ICON column_add
        Applies the specified cleansings to the text in each row.
 
        Arguments:
@@ -1490,7 +1490,7 @@ type DB_Column
       remove.fold self (current-> tc-> tc.apply current)
 
     ## GROUP Standard.Base.DateTime
-       ICON date_and_time
+       ICON time
        Gets the year as a number from the date stored in the column.
 
        Applies only to columns that hold the `Date` or `Date_Time` types.
@@ -1500,7 +1500,7 @@ type DB_Column
         self.make_unary_op "year"
 
     ## GROUP Standard.Base.DateTime
-       ICON date_and_time
+       ICON time
        Gets the month as a number (1-12) from the date stored in the column.
 
        Applies only to columns that hold the `Date` or `Date_Time` types.
@@ -1510,7 +1510,7 @@ type DB_Column
         self.make_unary_op "month"
 
     ## GROUP Standard.Base.DateTime
-       ICON date_and_time
+       ICON time
        Gets the day of the month as a number (1-31) from the date stored in the
        column.
 
@@ -1521,7 +1521,7 @@ type DB_Column
         self.make_unary_op "day"
 
     ## GROUP Standard.Base.DateTime
-       ICON date_and_time
+       ICON time
        Gets the hour as a number (0-23) from the time stored in the column.
 
        Applies only to columns that hold the `Time_Of_Day` or `Date_Time` types.
@@ -1531,7 +1531,7 @@ type DB_Column
         self.make_unary_op "hour"
 
     ## GROUP Standard.Base.DateTime
-       ICON date_and_time
+       ICON time
        Gets the minute as a number (0-59) from the time stored in the column.
 
        Applies only to columns that hold the `Time_Of_Day` or `Date_Time` types.
@@ -1541,7 +1541,7 @@ type DB_Column
         self.make_unary_op "minute"
 
     ## GROUP Standard.Base.DateTime
-       ICON date_and_time
+       ICON time
        Gets the second as an integer (0-60) from the time stored in the column.
 
        Applies only to columns that hold the `Time_Of_Day` or `Date_Time` types.
@@ -1551,7 +1551,7 @@ type DB_Column
         self.make_unary_op "second"
 
     ## GROUP Standard.Base.DateTime
-       ICON date_and_time
+       ICON time
        Gets the date part of the date/time value.
 
        Returns a column of `Integer` type.
@@ -1561,7 +1561,7 @@ type DB_Column
         Date_Time_Helpers.make_date_part_function self period (column->op_name-> column.make_unary_op op_name) self.naming_helper
 
     ## GROUP Standard.Base.DateTime
-       ICON date_and_time
+       ICON time
        Computes a time difference between the two dates.
 
        It returns a column of integers expressing how many periods fit between
@@ -1596,7 +1596,7 @@ type DB_Column
                     self.make_op "date_diff" [end] new_name metadata
 
     ## GROUP Standard.Base.DateTime
-       ICON date_and_time
+       ICON time
        Shifts the date/time by a specified period, returning a new date/time
        column of the same type.
 
@@ -1806,7 +1806,7 @@ type DB_Column
             DB_Column.Value new_column.name self.connection new_column.sql_type_reference new_column.expression self.context
 
     ## ALIAS transform column
-       ICON dataframe_map_column
+       ICON column_add
 
        Applies `function` to each item in this column and returns the column
        of results.
@@ -1840,7 +1840,7 @@ type DB_Column
         Error.throw <| Unsupported_Database_Operation.Error "`DB_Column.map` is not supported in the Database backends."
 
     ## ALIAS combine, join by row position, merge
-       ICON dataframes_join
+       ICON join2-1
 
        Applies `function` to consecutive pairs of elements of `self` and `that`
        and returns a column of results.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -784,7 +784,7 @@ type DB_Table
 
     ## ALIAS add index column, rank, record id
        GROUP Standard.Base.Values
-       ICON dataframe_map_column
+       ICON column_add
        Adds a new column to the table enumerating the rows.
 
        Arguments:
@@ -895,7 +895,7 @@ type DB_Table
 
     ## ALIAS add column, expression, formula, new column, update column
        GROUP Standard.Base.Values
-       ICON dataframe_map_column
+       ICON column_add
        Sets the column value at the given name.
 
        Arguments:
@@ -1580,7 +1580,7 @@ type DB_Table
 
     ## ALIAS find replace
        GROUP Standard.Base.Text
-       ICON dataframe_map_column
+       ICON column_add
        Replaces values in the columns using `lookup_table` to specify a mapping
        from old to new values.
 
@@ -1662,7 +1662,7 @@ type DB_Table
 
     ## ALIAS join by row position
        GROUP Standard.Base.Calculations
-       ICON dataframes_join
+       ICON join2-1
        Joins two tables by zipping rows from both tables table together - the
        first row of the left table is correlated with the first one of the right
        one etc.
@@ -1714,7 +1714,7 @@ type DB_Table
 
     ## ALIAS append, concat
        GROUP Standard.Base.Calculations
-       ICON dataframes_union
+       ICON union
        Appends records from other table(s) to this table.
 
        Arguments:
@@ -1875,7 +1875,7 @@ type DB_Table
 
     ## ALIAS group by, summarize
        GROUP Standard.Base.Calculations
-       ICON sigma
+       ICON transform4
 
        Aggregates the rows in a table using `group_by` columns.
        The columns argument specifies which additional aggregations to perform
@@ -2002,7 +2002,7 @@ type DB_Table
 
     ## ALIAS pivot, unpivot
        GROUP Standard.Base.Calculations
-       ICON dataframe_map_row
+       ICON map_row
        Returns a new table with a chosen subset of columns left unchanged and
        the other columns pivoted to rows with a single name field and a single
        value field.
@@ -2060,7 +2060,7 @@ type DB_Table
 
     ## ALIAS pivot, unpivot
        GROUP Standard.Base.Calculations
-       ICON dataframe_map_column
+       ICON column_add
        Returns a new table using a chosen field as the column header and then
        aggregating the rows within each value as specified. Optionally, a set of
        fields can be used to group the rows.
@@ -2265,7 +2265,7 @@ type DB_Table
         Error.throw (Unsupported_Database_Operation.Error "DB_Table.format is not implemented yet for the Database backends.")
 
     ## GROUP Standard.Base.Conversions
-       ICON split_text
+       ICON split
        Splits a column of text into a set of new columns.
        The original column will be removed from the table.
        The new columns will be named with the name of the input column with a
@@ -2289,7 +2289,7 @@ type DB_Table
         Error.throw (Unsupported_Database_Operation.Error "DB_Table.split_to_columns is not implemented yet for the Database backends.")
 
     ## GROUP Standard.Base.Conversions
-       ICON split_text
+       ICON split
        Splits a column of text into a set of new rows.
        The values of other columns are repeated for the new rows.
 
@@ -2304,7 +2304,7 @@ type DB_Table
         Error.throw (Unsupported_Database_Operation.Error "DB_Table.split_to_rows is not implemented yet for the Database backends.")
 
     ## GROUP Standard.Base.Conversions
-       ICON split_text
+       ICON split
        Tokenizes a column of text into a set of new columns using a regular
        expression.
        If the pattern contains marked groups, the values are concatenated
@@ -2332,7 +2332,7 @@ type DB_Table
         Error.throw (Unsupported_Database_Operation.Error "DB_Table.tokenize_to_columns is not implemented yet for the Database backends.")
 
     ## GROUP Standard.Base.Conversions
-       ICON split_text
+       ICON split
        Tokenizes a column of text into a set of new rows using a regular
        expression.
        If the pattern contains marked groups, the values are concatenated
@@ -2354,7 +2354,7 @@ type DB_Table
         Error.throw (Unsupported_Database_Operation.Error "DB_Table.tokenize_to_rows is not implemented yet for the Database backends.")
 
     ## GROUP Standard.Base.Conversions
-       ICON split_text
+       ICON split
        Converts a Text column into new columns using a regular expression
        pattern.
 
@@ -2387,7 +2387,7 @@ type DB_Table
         Error.throw (Unsupported_Database_Operation.Error "DB_Table.parse_to_columns is not implemented yet for the Database backends.")
 
     ## GROUP Standard.Base.Calculations
-       ICON split_text
+       ICON split
        Expand a column of objects to a new set of columns.
 
        Arguments:
@@ -2402,7 +2402,7 @@ type DB_Table
             Error.throw (Unsupported_Database_Operation.Error "DB_Table.expand_column is currently not implemented for the Database backend. You may download the table to memory using `.read` to use this feature.")
 
     ## GROUP Standard.Base.Calculations
-       ICON split_text
+       ICON split
        Expand aggregate values in a column to separate rows.
 
        For each value in the specified column, if it is an aggregate (`Vector`,
@@ -2787,7 +2787,7 @@ type DB_Table
 
     ## ALIAS fill missing, if_nothing
        GROUP Standard.Base.Values
-       ICON dataframe_clean
+       ICON table_clean
 
        Returns a new table where missing values in the specified columns have
        been replaced with the provided default(s).
@@ -2816,7 +2816,7 @@ type DB_Table
 
     ## ALIAS fill empty, if_empty
        GROUP Standard.Base.Values
-       ICON dataframe_clean
+       ICON table_clean
 
        Returns a new column where empty Text values have been replaced with the
        provided default.
@@ -2843,7 +2843,7 @@ type DB_Table
         Table_Helpers.replace_columns_with_transformed_columns self columns transformer
 
     ## GROUP Standard.Base.Text
-       ICON dataframe_map_column
+       ICON column_add
        Replaces the first, or all occurrences of `term` with `new_text` in each
        row of the specified column. If `term` is empty, the function returns the
        table unchanged.
@@ -2886,7 +2886,7 @@ type DB_Table
         Table_Helpers.replace_columns_with_transformed_columns self columns transformer
 
     ## GROUP Standard.Base.Text
-       ICON dataframe_map_column
+       ICON column_add
        Applies the specified cleansings to the text in each row of the specified columns
 
        Arguments:

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -1790,7 +1790,7 @@ type DB_Table
          the order they appear in the input.
     @tables (Widget.Vector_Editor item_editor=Widget.Code_Input item_default='_' display=Display.Always)
     @columns_to_keep Columns_To_Keep.default_widget
-    union : (DB_Table | Vector DB_Table) -> Match_Columns -> Columns_To_Keep -> Problem_Behavior -> DB_Table
+    union : (DB_Table | Vector DB_Table) -> Columns_To_Keep -> Match_Columns -> Problem_Behavior -> DB_Table
     union self tables:(DB_Table | Vector) (columns_to_keep : Columns_To_Keep = ..In_Any_Warn_On_Missing) (match_columns : Match_Columns = Match_Columns.By_Name) (on_problems : Problem_Behavior = Report_Warning) =
         all_tables = case tables of
             v : Vector -> [self] + (v.map t-> DB_Table.from t)

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -2032,7 +2032,8 @@ type DB_Table
            `Duplicate_Output_Column_Names` is reported according to the
            `on_problems` setting.
 
-       ? Example Transpose Operation
+       > Example
+         Transpose Operation
 
          Input Table `table`:
 
@@ -2096,7 +2097,8 @@ type DB_Table
            - If there are more than 10 issues with a single column,
              an `Additional_Warnings`.
 
-       ? Example Cross Tab Operation
+       > Example
+         Cross Tab Operation
 
          Input Table `table`:
 

--- a/distribution/lib/Standard/Geo/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Geo/0.0.0-dev/src/Main.enso
@@ -5,7 +5,7 @@ from Standard.Table import Table
 from project.Geo_Json export geo_json_to_table
 
 ## UNSTABLE
-   ICON spatial
+   ICON location
 
    Create a `Table` representing a geographic point with the specified latitude,
    longitude, and elevation.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
@@ -987,7 +987,7 @@ type Column
         run_vectorized_many_op self "coalesce" fallback values
 
     ## GROUP Standard.Base.Math
-       ICON sigma
+       ICON transform4
        Returns a column of minimum on each row of `self` and `values`.
 
        Arguments:
@@ -1009,7 +1009,7 @@ type Column
             run_vectorized_many_op self "min" fallback values
 
     ## GROUP Standard.Base.Math
-       ICON sigma
+       ICON transform4
        Returns a column of maximum on each row of `self` and `values`.
 
        Arguments:
@@ -1133,7 +1133,7 @@ type Column
 
     ## ALIAS fill missing, if_nothing
        GROUP Standard.Base.Values
-       ICON dataframe_map_column
+       ICON column_add
 
        Returns a new column where missing values have been replaced with the
        provided default.
@@ -1171,7 +1171,7 @@ type Column
 
     ## ALIAS fill empty, if_empty
        GROUP Standard.Base.Values
-       ICON dataframe_map_column
+       ICON column_add
 
        Returns a new column where empty Text values have been replaced with the
        provided default.
@@ -1407,7 +1407,7 @@ type Column
             Column.from_vector new_name mapped
 
     ## GROUP Standard.Base.Text
-       ICON dataframe_map_column
+       ICON column_add
        Replaces the first, or all occurrences of `term` with `new_text` in each
        row. If `term` is empty, the function returns the column unchanged.
 
@@ -1463,7 +1463,7 @@ type Column
                 Column.from_storage new_name builder.seal
 
     ## GROUP Standard.Base.Text
-       ICON dataframe_map_column
+       ICON column_add
        Applies the specified cleansings to the text in each row.
 
        Arguments:
@@ -1493,7 +1493,7 @@ type Column
       remove.fold self (current-> tc-> tc.apply current)
 
     ## GROUP Standard.Base.DateTime
-       ICON date_and_time
+       ICON time
        Gets the year as a number from the date stored in the column.
 
        Applies only to columns that hold the `Date` or `Date_Time` types.
@@ -1503,7 +1503,7 @@ type Column
         apply_unary_operation self DatePartOperation.YEAR_INSTANCE
 
     ## GROUP Standard.Base.DateTime
-       ICON date_and_time
+       ICON time
        Gets the month as a number (1-12) from the date stored in the column.
 
        Applies only to columns that hold the `Date` or `Date_Time` types.
@@ -1513,7 +1513,7 @@ type Column
         apply_unary_operation self DatePartOperation.MONTH_INSTANCE
 
     ## GROUP Standard.Base.DateTime
-       ICON date_and_time
+       ICON time
        Gets the day of the month as a number (1-31) from the date stored in the
        column.
 
@@ -1524,7 +1524,7 @@ type Column
         apply_unary_operation self DatePartOperation.DAY_INSTANCE
 
     ## GROUP Standard.Base.DateTime
-       ICON date_and_time
+       ICON time
        Gets the hour as a number (0-23) from the time stored in the column.
 
        Applies only to columns that hold the `Time_Of_Day` or `Date_Time` types.
@@ -1534,7 +1534,7 @@ type Column
         apply_unary_operation self DatePartOperation.HOUR_INSTANCE
 
     ## GROUP Standard.Base.DateTime
-       ICON date_and_time
+       ICON time
        Gets the minute as a number (0-59) from the time stored in the column.
 
        Applies only to columns that hold the `Time_Of_Day` or `Date_Time` types.
@@ -1544,7 +1544,7 @@ type Column
         apply_unary_operation self DatePartOperation.MINUTE_INSTANCE
 
     ## GROUP Standard.Base.DateTime
-       ICON date_and_time
+       ICON time
        Gets the second as an integer (0-60) from the time stored in the column.
 
        Applies only to columns that hold the `Time_Of_Day` or `Date_Time` types.
@@ -1554,7 +1554,7 @@ type Column
         apply_unary_operation self DatePartOperation.SECOND_INSTANCE
 
     ## GROUP Standard.Base.DateTime
-       ICON date_and_time
+       ICON time
        Gets the date part of the date/time value.
 
        Returns a column of `Integer` type.
@@ -1578,7 +1578,7 @@ type Column
         Date_Time_Helpers.make_date_part_function self period date_part_operation naming_helper
 
     ## GROUP Standard.Base.DateTime
-       ICON date_and_time
+       ICON time
        Computes a time difference between the two dates.
 
        It returns a column of integers expressing how many periods fit between
@@ -1621,7 +1621,7 @@ type Column
 
 
     ## GROUP Standard.Base.DateTime
-       ICON date_and_time
+       ICON time
        Shifts the date/time by a specified period, returning a new date/time
        column of the same type.
 
@@ -1969,7 +1969,7 @@ type Column
         self.cast new_value_type on_problems=Problem_Behavior.Report_Error
 
     ## ALIAS transform column
-       ICON dataframe_map_column
+       ICON column_add
 
        Applies `function` to each item in this column and returns the column
        of results.
@@ -2004,7 +2004,7 @@ type Column
         Column.from_vector self.name new_st value_type=expected_value_type
 
     ## ALIAS combine, join by row position, merge
-       ICON dataframes_join
+       ICON join2-1
 
        Applies `function` to consecutive pairs of elements of `self` and `that`
        and returns a column of results.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Columns_To_Keep.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Columns_To_Keep.enso
@@ -1,4 +1,4 @@
-from Standard.Base import Vector, Text
+from Standard.Base import Text, Vector
 from Standard.Base.Metadata import make_single_choice, Widget
 
 ## Specifies which columns to keep in a union operation.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Errors.enso
@@ -865,6 +865,7 @@ type Mixing_Date_Time_Types
     ## PRIVATE
     Implicit_Time_Zone (related_column_name : Text | Nothing)
 
+    ## PRIVATE
     to_display_text self -> Text =
         location = if self.related_column_name.is_nothing then "" else " (in column ["+self.related_column_name+"])"
         case self of

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Expression.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Expression.enso
@@ -4,7 +4,7 @@ polyglot java import java.lang.IllegalArgumentException
 polyglot java import java.lang.UnsupportedOperationException
 polyglot java import org.enso.table.expressions.ExpressionVisitorImpl
 
-## ICON dataframe_map_column
+## ICON column_add
    Create an expression from a Text value.
 
    Arguments:

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Column_Vector_Extensions.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Column_Vector_Extensions.enso
@@ -35,7 +35,7 @@ Date_Range.to_column self name="Date_Range" =
 
 ## ALIAS count, kurtosis, maximum, mean, median, minimum, mode, skew, standard_deviation, statistic, sum, variance
    GROUP Standard.Base.Statistics
-   ICON sigma
+   ICON transform4
    Compute a single statistic on the column.
 
    Arguments:
@@ -45,7 +45,7 @@ Column.compute self statistic=Statistic.Count =
     Statistic.compute_bulk self.to_vector [statistic] . first
 
 ## ALIAS count, kurtosis, maximum, mean, median, minimum, mode, skew, standard_deviation, statistic, sum, variance
-   ICON sigma
+   ICON transform4
    Compute statistics on the column.
 
    Arguments:
@@ -58,7 +58,7 @@ Column.compute_bulk self statistics=[Statistic.Count, Statistic.Sum] =
 
 ## ALIAS count, kurtosis, maximum, mean, median, minimum, mode, skew, standard_deviation, statistic, sum, variance
    GROUP Standard.Base.Statistics
-   ICON sigma
+   ICON transform4
    Compute a single running statistic on the column.
 
    Arguments:

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -2424,7 +2424,8 @@ type Table
            `Duplicate_Output_Column_Names` is reported according to the
            `on_problems` setting.
 
-       ? Example Transpose Operation
+       > Example
+         Transpose Operation
 
          Input Table `table`:
 
@@ -2503,7 +2504,8 @@ type Table
            - If there are more than 10 issues with a single column,
              an `Additional_Warnings`.
 
-       ? Example Cross Tab Operation
+       > Example
+         Cross Tab Operation
 
          Input Table `table`:
 
@@ -2713,7 +2715,8 @@ type Table
            `attribute_columns` or `value_column`, a `Unexpected_Extra_Columns`
            is reported according to the `on_problems` setting.
 
-       ? Example to_xml Operation
+       > Example
+         to_xml Operation
 
          Input Table `table`:
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -722,7 +722,7 @@ type Table
 
     ## ALIAS group by, summarize
        GROUP Standard.Base.Calculations
-       ICON sigma
+       ICON transform4
 
        Aggregates the rows in a table using `group_by` columns.
        The columns argument specifies which additional aggregations to perform
@@ -1266,7 +1266,7 @@ type Table
             table.set new_column as=column_to_cast.name set_mode=Set_Mode.Update
 
     ## GROUP Standard.Base.Conversions
-       ICON split_text
+       ICON split
        Splits a column of text into a set of new columns.
        The original column will be removed from the table.
        The new columns will be named with the name of the input column with a
@@ -1289,7 +1289,7 @@ type Table
         Split_Tokenize.split_to_columns self column delimiter column_count on_problems
 
     ## GROUP Standard.Base.Conversions
-       ICON split_text
+       ICON split
        Splits a column of text into a set of new rows.
        The values of other columns are repeated for the new rows.
 
@@ -1303,7 +1303,7 @@ type Table
         Split_Tokenize.split_to_rows self column delimiter
 
     ## GROUP Standard.Base.Conversions
-       ICON split_text
+       ICON split
        Tokenizes a column of text into a set of new columns using a regular
        expression.
        If the pattern contains marked groups, the values are concatenated
@@ -1330,7 +1330,7 @@ type Table
         Split_Tokenize.tokenize_to_columns self column pattern case_sensitivity column_count on_problems
 
     ## GROUP Standard.Base.Conversions
-       ICON split_text
+       ICON split
        Tokenizes a column of text into a set of new rows using a regular
        expression.
        If the pattern contains marked groups, the values are concatenated
@@ -1351,7 +1351,7 @@ type Table
         Split_Tokenize.tokenize_to_rows self column pattern case_sensitivity at_least_one_row
 
     ## GROUP Standard.Base.Conversions
-       ICON split_text
+       ICON split
        Converts a Text column into new columns using a regular expression
        pattern.
 
@@ -1383,7 +1383,7 @@ type Table
         Split_Tokenize.parse_to_columns self column pattern case_sensitivity parse_values on_problems
 
     ## GROUP Standard.Base.Calculations
-       ICON split_text
+       ICON split
        Expand a column of objects to a new set of columns.
 
        Arguments:
@@ -1397,7 +1397,7 @@ type Table
         Expand_Objects_Helpers.expand_column self column fields prefix
 
     ## GROUP Standard.Base.Calculations
-       ICON split_text
+       ICON split
        Expand aggregate values in a column to separate rows.
 
        For each value in the specified column, if it is an aggregate (`Vector`,
@@ -1612,7 +1612,7 @@ type Table
 
     ## ALIAS add index column, rank, record id
        GROUP Standard.Base.Values
-       ICON dataframe_map_column
+       ICON column_add
        Adds a new column to the table enumerating the rows.
 
        Arguments:
@@ -1650,7 +1650,7 @@ type Table
 
     ## ALIAS add column, expression, formula, new column, update column
        GROUP Standard.Base.Values
-       ICON dataframe_map_column
+       ICON column_add
        Sets the column value at the given name.
 
        Arguments:
@@ -2092,7 +2092,7 @@ type Table
 
     ## ALIAS find replace
        GROUP Standard.Base.Text
-       ICON dataframe_map_column
+       ICON column_add
        Replaces values in the columns using `lookup_table` to specify a mapping
        from old to new values.
 
@@ -2174,7 +2174,7 @@ type Table
 
     ## ALIAS join by row position
        GROUP Standard.Base.Calculations
-       ICON dataframes_join
+       ICON join2-1
        Joins two tables by zipping rows from both tables table together - the
        first row of the left table is correlated with the first one of the right
        one etc.
@@ -2241,7 +2241,7 @@ type Table
 
     ## ALIAS append, concat
        GROUP Standard.Base.Calculations
-       ICON dataframes_union
+       ICON union
        Appends records from other table(s) to this table.
 
        Arguments:
@@ -2394,7 +2394,7 @@ type Table
 
     ## ALIAS pivot, unpivot
        GROUP Standard.Base.Calculations
-       ICON dataframe_map_row
+       ICON map_row
        Returns a new table with a chosen subset of columns left unchanged and
        the other columns pivoted to rows with a single name field and a single
        value field.
@@ -2467,7 +2467,7 @@ type Table
 
     ## ALIAS pivot, unpivot
        GROUP Standard.Base.Calculations
-       ICON dataframe_map_column
+       ICON column_add
        Returns a new table using a chosen field as the column header and then
        aggregating the rows within each value as specified. Optionally, a set of
        fields can be used to group the rows.
@@ -2762,7 +2762,7 @@ type Table
 
     ## ALIAS fill missing, if_nothing
        GROUP Standard.Base.Values
-       ICON dataframe_clean
+       ICON table_clean
 
        Returns a new table where missing values in the specified columns have
        been replaced with the provided default(s).
@@ -2791,7 +2791,7 @@ type Table
 
     ## ALIAS fill empty, if_empty
        GROUP Standard.Base.Values
-       ICON dataframe_clean
+       ICON table_clean
 
        Returns a new column where empty Text values have been replaced with the
        provided default(s).
@@ -2818,7 +2818,7 @@ type Table
         Table_Helpers.replace_columns_with_transformed_columns self columns transformer
 
     ## GROUP Standard.Base.Text
-       ICON dataframe_map_column
+       ICON column_add
        Replaces the first, or all occurrences of `term` with `new_text` in each
        row of the specified column. If `term` is empty, the function returns the
        table unchanged.
@@ -2861,7 +2861,7 @@ type Table
         Table_Helpers.replace_columns_with_transformed_columns self columns transformer
 
     ## GROUP Standard.Base.Text
-       ICON dataframe_map_column
+       ICON column_add
        Applies the specified cleansings to the text in each row of the specified columns.
 
        Arguments:
@@ -2895,7 +2895,7 @@ type Table
 
     ## ALIAS cumulative
        GROUP Standard.Base.Values
-       ICON dataframe_map_column
+       ICON column_add
        Adds a new column to the table with a running calculation.
 
        Arguments:

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Suite.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Suite.enso
@@ -58,7 +58,8 @@ type Suite
        - should_exit: If true, executes `System.exit` at the end, so the method does not return.
          If false, return boolean from the method indicating whether some tests failed.
 
-       Returns: Boolean if `should_exit` is False, otherwise exits the process.
+       Returns:
+       Boolean if `should_exit` is False, otherwise exits the process.
     run_with_filter self (filter : (Text | Nothing) = Nothing) (should_exit : Boolean = True) -> (Boolean | Nothing) =
         config = Suite_Config.from_environment
 


### PR DESCRIPTION
### Pull Request Description

Updates all the ICONs using GUI1 names to GUI2 names.
Removes the mapping function.

- `dataframe_clean` -> `table_clean`
- `dataframe_map_row` -> `map_row`
- `dataframe_map_column` -> `column_add`
- `dataframes_join` -> `join2-1`
- `dataframes_union` -> `union`
- `sigma` -> `transform4`
- `io` -> `in_out`
- `date_and_time` -> `time`
- `spatial` -> `location`
- `predictive` -> `predict`
- `machine_learning` -> `robot`
- `split_text` -> `split`

Sort out a few `? Example` and `Returns:` lines in doc comments.
Linter fixes.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
