### PR TITLE
Suspended arguments need one more child scope

### DIFF
--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
@@ -565,7 +565,7 @@ case object AliasAnalysis extends IRPass {
             name,
             _,
             value,
-            susp,
+            suspended,
             _,
             _,
             _
@@ -575,13 +575,11 @@ case object AliasAnalysis extends IRPass {
             name.name
           )
         if (!nameOccursInScope) {
-          val argScope = if (susp) {
-            scope.addChild()
-          } else {
-            scope
-          }
+          val argScope = if (suspended) scope.addChild() else scope
           val newDefault =
-            value.map((ir: Expression) => analyseExpression(ir, graph, argScope))
+            value.map((ir: Expression) =>
+              analyseExpression(ir, graph, argScope)
+            )
 
           val occurrenceId = graph.nextId()
           val definition = alias.Graph.Occurrence.Def(
@@ -589,7 +587,7 @@ case object AliasAnalysis extends IRPass {
             name.name,
             arg.getId(),
             arg.getExternalId,
-            susp
+            suspended
           )
           scope.add(definition)
           scope.addDefinition(definition)

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
@@ -575,8 +575,13 @@ case object AliasAnalysis extends IRPass {
             name.name
           )
         if (!nameOccursInScope) {
+          val argScope = if (susp) {
+            scope.addChild()
+          } else {
+            scope
+          }
           val newDefault =
-            value.map((ir: Expression) => analyseExpression(ir, graph, scope))
+            value.map((ir: Expression) => analyseExpression(ir, graph, argScope))
 
           val occurrenceId = graph.nextId()
           val definition = alias.Graph.Occurrence.Def(

--- a/test/Base_Tests/src/Main.enso
+++ b/test/Base_Tests/src/Main.enso
@@ -6,6 +6,7 @@ import project.Semantic.Any_Spec
 import project.Semantic.Case_Spec
 import project.Semantic.Conversion_Spec
 import project.Semantic.Deep_Export.Spec as Deep_Export_Spec
+import project.Semantic.Default_Args_Spec
 import project.Semantic.Error_Spec
 import project.Semantic.Import_Loop.Spec as Import_Loop_Spec
 import project.Semantic.Meta_Spec
@@ -103,6 +104,7 @@ main filter=Nothing =
         Function_Spec.add_specs suite_builder
         Case_Spec.add_specs suite_builder
         Conversion_Spec.add_specs suite_builder
+        Default_Args_Spec.add_specs suite_builder
         Deep_Export_Spec.add_specs suite_builder
         Error_Spec.add_specs suite_builder
         Environment_Spec.add_specs suite_builder

--- a/test/Base_Tests/src/Semantic/Default_Args_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Default_Args_Spec.enso
@@ -26,6 +26,14 @@ type F
 type G
     G a=4 b=Bar.B
 
+type H
+    H x y
+    eager self a=self b=self.y c=a.y =
+        [ self.x, a, b, c ]
+
+    lazy self ~a=self ~b=self.y ~c=a.y =
+        [ self.x, a, b, c ]
+
 local_fun a b=1 c=local_const = a + b + c
 local_const = 42
 
@@ -61,6 +69,22 @@ add_specs suite_builder =
     suite_builder.group "Functions" group_builder->
         group_builder.specify "should apply default arguments that involve local functions" <|
             local_fun 0 . should_equal 43
+
+        group_builder.specify "accessing default suspended self & args" <|
+            h = H.H 25 37
+
+            h.x . should_equal 25
+            h.y . should_equal 37
+
+            v1 = h.eager
+            v2 = h.lazy
+
+            v1 . should_equal v2
+
+            v1.at 0 . should_equal h.x
+            v1.at 1 . should_equal h
+            v1.at 2 . should_equal h.y
+            v1.at 3 . should_equal h.y
 
 main filter=Nothing =
     suite = Test.build suite_builder->

--- a/test/Base_Tests/src/Semantic/Default_Args_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Default_Args_Spec.enso
@@ -8,15 +8,23 @@ from project.Semantic.Default_Args_Spec.Box import all
 type Box
     Foo (v : Boolean = True)
 
-type Bar (a : Integer = 1) (b : Box = (Foo False)) (c : Boolean = b.v)
+type Bar
+    B (a : Integer = 1) (b : Box = (Foo False)) (c : Boolean = b.v)
 
-type A a=0 b=1
-type B a=2 b=(Foo True)
-type C a=3 b=Foo
-type D a=4 b=(Bar 1)
-type E a=5 b=a c=(b+1)
-type F a=6 b=(Foo False) c=(b.v)
-type G a=4 b=Bar
+type A
+    A a=0 b=1
+type B
+    B a=2 b=(Foo True)
+type C
+    C a=3 b=Foo
+type D
+    D a=4 b=(Bar.B 1)
+type E
+    E a=5 b=a c=(b+1)
+type F
+    F a=6 b=(Foo False) c=(b.v)
+type G
+    G a=4 b=Bar.B
 
 local_fun a b=1 c=local_const = a + b + c
 local_const = 42
@@ -24,31 +32,31 @@ local_const = 42
 add_specs suite_builder =
     suite_builder.group "Atom Constructors" group_builder->
         group_builder.specify "should be allowed to use primitive default arguments" <|
-            x = A 1
+            x = A.A 1
             x.b.should_equal 1
-            y = A 1
+            y = A.A 1
             y.b.should_equal 1
 
         group_builder.specify "should be allowed to use non-primitive default arguments" <|
-            a = B 1 (Foo False)
+            a = B.B 1 (Foo False)
             a.b.should_equal (Foo False)
-            b = B 1
+            b = B.B 1
             b.b.should_equal (Foo True)
-            c = C 1
+            c = C.C 1
             c.b.should_equal (Foo)
-            d = D 1
+            d = D.D 1
             d.b.b.should_equal (Foo False)
             d.b.c.should_equal False
 
         group_builder.specify "should be allowed to use default arguments that refer to previous parameters" <|
-            e = E 1
+            e = E.E 1
             e.b.should_equal 1
             e.c.should_equal 2
-            f = F 1
+            f = F.F 1
             f.c.should_equal False
 
         group_builder.specify "apply defaulted arguments that are themselves fully defaulted" <|
-            G.should_equal (G 4 (Bar 1 (Foo False) False))
+            G.G . should_equal (G.G 4 (Bar.B 1 (Foo False) False))
 
     suite_builder.group "Functions" group_builder->
         group_builder.specify "should apply default arguments that involve local functions" <|


### PR DESCRIPTION
### Pull Request Description

Fixes #8937. Suspended arguments are (unlike normal arguments) evaluated as _thunk_ in its own `VirtualFrame`. They access the other arguments via `MaterializedFrame` closure. That means they need one more _child scope_.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
