### PR TITLE
Small fixes to Postgres integration

### DIFF
--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Credentials.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Credentials.enso
@@ -1,4 +1,8 @@
 from Standard.Base import all
+import Standard.Base.Metadata.Display
+import Standard.Base.Metadata.Widget
+from Standard.Base.Metadata.Choice import Option
+from Standard.Base.Metadata.Widget import Single_Choice
 from Standard.Base.Widget_Helpers import make_text_secret_selector
 
 type Credentials
@@ -11,3 +15,12 @@ type Credentials
        Override `to_text` to mask the password field.
     to_text : Text
     to_text self = 'Credentials ' + self.username + ' *****'
+
+    ## PRIVATE
+    to_display_text self -> Text = self.to_text.to_display_text
+
+    ## PRIVATE
+    default_widget (include_nothing : Boolean = True) -> Widget =
+        fqn = Meta.get_qualified_type_name Credentials
+        values = [Option "Username_And_Password" fqn+".Username_And_Password"] + if include_nothing then [Option "No credentials" "Nothing"] else []
+        Single_Choice values=values display=Display.When_Modified

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Details.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres_Details.enso
@@ -27,6 +27,7 @@ type Postgres_Details
          No Authentication or the PGPass file).
        - use_ssl: Whether to use SSL (defaults to `SSL_Mode.Prefer`).
        - client_cert: The client certificate to use or `Nothing` if not needed.
+    @credentials Credentials.default_widget
     Postgres (host:Text=default_postgres_host) (port:Integer=default_postgres_port) (database:Text=default_postgres_database) (schema:Text="") (credentials:(Credentials|Nothing)=Nothing) (use_ssl:SSL_Mode=SSL_Mode.Prefer) (client_cert:(Client_Certificate|Nothing)=Nothing)
 
     ## PRIVATE

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Data_Link_Setup.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Data_Link_Setup.enso
@@ -4,6 +4,7 @@ from Standard.Base import all
 import Standard.Base.Enso_Cloud.Data_Link.Data_Link
 import Standard.Base.Errors.File_Error.File_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
+import Standard.Base.Runtime.Context
 from Standard.Base.Enso_Cloud.Data_Link_Helpers import data_link_extension, secure_value_to_json
 
 import project.Connection.Credentials.Credentials
@@ -20,7 +21,7 @@ type Postgres_Data_Link_Setup
 
     ## PRIVATE
     save_as_data_link self destination on_existing_file:Existing_File_Behavior = case self of
-        Postgres_Data_Link_Setup.Available details ->
+        Postgres_Data_Link_Setup.Available details -> Context.Output.if_enabled disabled_message="Saving a connection to data link requires the Output context." panic=False <|
             case destination of
                 _ : Enso_File ->
                     replace_existing = case on_existing_file of

--- a/std-bits/database/src/main/java/org/enso/database/postgres/PostgresConnectionDetailsSPI.java
+++ b/std-bits/database/src/main/java/org/enso/database/postgres/PostgresConnectionDetailsSPI.java
@@ -16,7 +16,7 @@ public class PostgresConnectionDetailsSPI extends DatabaseConnectionDetailsSPI {
 
   @Override
   protected String getCodeForDefaultConstructor() {
-    return "(Postgres)";
+    return "(Postgres 'localhost' 5432)";
   }
 
   @Override


### PR DESCRIPTION
### Pull Request Description

- Better message when saving datalink in disabled Output context:
![image](https://github.com/enso-org/enso/assets/1436948/540d615b-79ff-4811-8262-a0475a7b6923)
Before it was:
![image](https://github.com/enso-org/enso/assets/1436948/51198bf1-1e50-41bc-a56b-f829bc32d09a)

- Hack to get Postgres widget to display connection options:
![image](https://github.com/enso-org/enso/assets/1436948/39f3db39-1163-4815-b59f-c629d812e2ab)
Before the `Postgres` constructor was created without any parameters and it was not showing any parameters for modification.


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
