### PR TITLE
Exposing just a single Persistance.Reference abstraction

### DIFF
--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Function.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Function.scala
@@ -46,7 +46,7 @@ object Function {
     */
   sealed case class Lambda(
     override val arguments: List[DefinitionArgument],
-    bodyReference: Persistance.InlineReference[Expression],
+    bodyReference: Persistance.Reference[Expression],
     location: Option[IdentifiedLocation],
     override val canBeTCO: Boolean,
     passData: MetadataStorage,
@@ -65,7 +65,7 @@ object Function {
     ) = {
       this(
         arguments,
-        Persistance.InlineReference.of(body),
+        Persistance.Reference.of(body, true),
         location,
         canBeTCO,
         passData,
@@ -73,7 +73,7 @@ object Function {
       )
     }
 
-    override lazy val body: Expression = bodyReference.get()
+    override lazy val body: Expression = bodyReference.get(classOf[Expression])
 
     /** Creates a copy of `this`.
       *
@@ -98,7 +98,7 @@ object Function {
       val res =
         Lambda(
           arguments,
-          Persistance.InlineReference.of(body),
+          Persistance.Reference.of(body, false),
           location,
           canBeTCO,
           passData,

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/module/scope/definition/Method.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/module/scope/definition/Method.scala
@@ -49,7 +49,7 @@ object Method {
     */
   sealed case class Explicit(
     override val methodReference: Name.MethodReference,
-    val bodyReference: Persistance.InlineReference[Expression],
+    val bodyReference: Persistance.Reference[Expression],
     val isStatic: Boolean,
     val isStaticWrapperForInstanceMethod: Boolean,
     override val location: Option[IdentifiedLocation],
@@ -67,7 +67,7 @@ object Method {
     ) = {
       this(
         methodReference,
-        Persistance.InlineReference.of(body),
+        Persistance.Reference.of(body, false),
         Explicit.computeIsStatic(body),
         Explicit.computeIsStaticWrapperForInstanceMethod(body),
         location,
@@ -76,7 +76,7 @@ object Method {
       );
     }
 
-    lazy val body: Expression = bodyReference.get()
+    lazy val body: Expression = bodyReference.get(classOf[Expression])
 
     /** Creates a copy of `this`.
       *
@@ -101,7 +101,7 @@ object Method {
     ): Explicit = {
       val res = Explicit(
         methodReference,
-        Persistance.InlineReference.of(body),
+        Persistance.Reference.of(body, false),
         isStatic,
         isStaticWrapperForInstanceMethod,
         location,

--- a/engine/runtime-parser/src/test/java/org/enso/compiler/core/IrPersistanceTest.java
+++ b/engine/runtime-parser/src/test/java/org/enso/compiler/core/IrPersistanceTest.java
@@ -332,14 +332,14 @@ public class IrPersistanceTest {
   @Test
   public void inlineReferenceIsLazy() throws Exception {
     var s1 = new LazyString("Hello");
-    var in = new InlineReferenceHolder(Persistance.InlineReference.of(s1));
+    var in = new InlineReferenceHolder(Persistance.Reference.of(s1, false));
 
     LazyString.forbidden = true;
     InlineReferenceHolder out = serde(InlineReferenceHolder.class, in, -1);
-    Persistance.InlineReference<CharSequence> ref = out.ref();
+    Persistance.Reference<CharSequence> ref = out.ref();
     LazyString.forbidden = false;
 
-    assertEquals(s1, ref.get());
+    assertEquals(s1, ref.get(Object.class));
   }
 
   @Test
@@ -560,5 +560,5 @@ public class IrPersistanceTest {
   }
 
   @Persistable(clazz = InlineReferenceHolder.class, id = 432437)
-  public record InlineReferenceHolder(Persistance.InlineReference<CharSequence> ref) {}
+  public record InlineReferenceHolder(Persistance.Reference<CharSequence> ref) {}
 }

--- a/lib/java/persistance-dsl/src/main/java/org/enso/persist/impl/PersistableProcessor.java
+++ b/lib/java/persistance-dsl/src/main/java/org/enso/persist/impl/PersistableProcessor.java
@@ -279,7 +279,7 @@ public class PersistableProcessor extends AbstractProcessor {
     var cnt = 0;
     for (var p : parameters) {
       var type = tu.asElement(tu.erasure(p.asType()));
-      if (type != null && type.getSimpleName().toString().equals("InlineReference")) {
+      if (type != null && type.getSimpleName().toString().equals("Reference")) {
         cnt++;
       }
     }

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerBufferReference.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerBufferReference.java
@@ -52,6 +52,11 @@ final class PerBufferReference<T> extends Persistance.Reference<T> {
     return obj;
   }
 
+  @Override
+  boolean isDeferredWrite() {
+    return true;
+  }
+
   static <V> Reference<V> from(Persistance<V> p, InputCache buffer, int offset) {
     return new PerBufferReference<>(p, buffer, offset, false);
   }

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerGenerator.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerGenerator.java
@@ -194,8 +194,12 @@ final class PerGenerator {
     return tableAt;
   }
 
-  private static final class ReferenceOutput extends DataOutputStream
-      implements Persistance.Output {
+  static int registerReference(Persistance.Output out, Persistance.Reference<?> ref) {
+    var g = ((ReferenceOutput) out).generator;
+    return g.registerReference(ref);
+  }
+
+  static final class ReferenceOutput extends DataOutputStream implements Persistance.Output {
     private final PerGenerator generator;
 
     ReferenceOutput(PerGenerator g, ByteArrayOutputStream out) {
@@ -205,15 +209,6 @@ final class PerGenerator {
 
     @Override
     public <T> void writeInline(Class<T> clazz, T t) throws IOException {
-      if (Persistance.Reference.class == clazz) {
-        Persistance.Reference<?> ref = (Persistance.Reference<?>) t;
-        if (ref.isDeferredWrite()) {
-          var id = this.generator.registerReference(ref);
-          writeInt(id);
-          return;
-        }
-        writeInt(INLINED_REFERENCE_ID);
-      }
       var obj = generator.writeReplace.apply(t);
       var p = generator.map.forType(clazz);
       p.writeInline(obj, this);

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerGenerator.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerGenerator.java
@@ -207,9 +207,12 @@ final class PerGenerator {
     public <T> void writeInline(Class<T> clazz, T t) throws IOException {
       if (Persistance.Reference.class == clazz) {
         Persistance.Reference<?> ref = (Persistance.Reference<?>) t;
-        var id = this.generator.registerReference(ref);
-        writeInt(id);
-        return;
+        if (ref.isDeferredWrite()) {
+          var id = this.generator.registerReference(ref);
+          writeInt(id);
+          return;
+        }
+        writeInt(INLINED_REFERENCE_ID);
       }
       var obj = generator.writeReplace.apply(t);
       var p = generator.map.forType(clazz);
@@ -255,5 +258,6 @@ final class PerGenerator {
     }
   }
 
+  static final int INLINED_REFERENCE_ID = -2;
   static final int NULL_REFERENCE_ID = -1;
 }

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerInputImpl.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerInputImpl.java
@@ -1,5 +1,6 @@
 package org.enso.persist;
 
+import static org.enso.persist.PerGenerator.INLINED_REFERENCE_ID;
 import static org.enso.persist.PerGenerator.NULL_REFERENCE_ID;
 import static org.enso.persist.PerUtils.raise;
 
@@ -43,7 +44,7 @@ final class PerInputImpl implements Input {
 
     var tableAt = buf.getInt(8);
     buf.position(tableAt);
-    InputCache.RawReferenceMap rawRefMap = InputCache.RawReferenceMap.readFromBuffer(buf);
+    var rawRefMap = InputCache.RawReferenceMap.readFromBuffer(buf);
     var cache = new InputCache(buf, readResolve, map, rawRefMap);
     return cache.getRef(0);
   }
@@ -56,9 +57,10 @@ final class PerInputImpl implements Input {
         var nullReference = Persistance.Reference.none();
         return clazz.cast(nullReference);
       }
-
-      var ref = cache.getRef(refId);
-      return clazz.cast(ref);
+      if (refId != INLINED_REFERENCE_ID) {
+        var ref = cache.getRef(refId);
+        return clazz.cast(ref);
+      }
     }
     Persistance<T> p = cache.map().forType(clazz);
     T res = p.readWith(this);
@@ -244,7 +246,7 @@ final class PerInputImpl implements Input {
       InputCache buffer, PerMap map, Input in, Class<T> clazz) throws IOException {
     var at = in.readInt();
     if (at < 0) {
-      return null;
+      return Reference.none();
     }
     var id = in.readInt();
     var p = map.forId(id);

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerInputImpl.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerInputImpl.java
@@ -49,19 +49,20 @@ final class PerInputImpl implements Input {
     return cache.getRef(0);
   }
 
+  static Persistance.Reference<?> findReference(Persistance.Input input, int refId) {
+    if (refId == NULL_REFERENCE_ID) {
+      return Persistance.Reference.none();
+    }
+    if (refId != INLINED_REFERENCE_ID) {
+      var impl = (PerInputImpl) input;
+      var ref = impl.cache.getRef(refId);
+      return ref;
+    }
+    return null;
+  }
+
   @Override
   public <T> T readInline(Class<T> clazz) throws IOException {
-    if (clazz == Persistance.Reference.class) {
-      var refId = readInt();
-      if (refId == NULL_REFERENCE_ID) {
-        var nullReference = Persistance.Reference.none();
-        return clazz.cast(nullReference);
-      }
-      if (refId != INLINED_REFERENCE_ID) {
-        var ref = cache.getRef(refId);
-        return clazz.cast(ref);
-      }
-    }
     Persistance<T> p = cache.map().forType(clazz);
     T res = p.readWith(this);
     var resolve = cache.resolveObject(res);

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerMap.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerMap.java
@@ -16,6 +16,7 @@ final class PerMap {
     var loader = PerMap.class.getClassLoader();
     var lookup = Lookups.metaInfServices(loader);
     var all = new ArrayList<Persistance>();
+    all.add(PerReferencePeristance.INSTANCE);
     all.addAll(lookup.lookupAll(Persistance.class));
     ALL = all;
   }

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerMemoryReference.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerMemoryReference.java
@@ -1,6 +1,7 @@
 package org.enso.persist;
 
-final class PerMemoryReference<T> extends Persistance.Reference<T> {
+sealed class PerMemoryReference<T> extends Persistance.Reference<T>
+    permits PerMemoryReference.Deferred {
   static final Persistance.Reference<?> NULL = new PerMemoryReference<>(null);
   private final T value;
 
@@ -10,5 +11,11 @@ final class PerMemoryReference<T> extends Persistance.Reference<T> {
 
   final T value() {
     return value;
+  }
+
+  static final class Deferred<T> extends PerMemoryReference<T> {
+    Deferred(T obj) {
+      super(obj);
+    }
   }
 }

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerMemoryReference.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerMemoryReference.java
@@ -13,6 +13,11 @@ sealed class PerMemoryReference<T> extends Persistance.Reference<T>
     return value;
   }
 
+  @Override
+  boolean isDeferredWrite() {
+    return Deferred.class == getClass();
+  }
+
   static final class Deferred<T> extends PerMemoryReference<T> {
     Deferred(T obj) {
       super(obj);

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerReferencePersistance.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerReferencePersistance.java
@@ -1,5 +1,7 @@
 package org.enso.persist;
 
+import static org.enso.persist.PerGenerator.INLINED_REFERENCE_ID;
+
 import java.io.IOException;
 import org.enso.persist.Persistance.Reference;
 
@@ -14,16 +16,24 @@ final class PerReferencePeristance extends Persistance<Reference> {
   @Override
   protected void writeObject(Reference ref, Output out) throws IOException {
     if (ref.isDeferredWrite()) {
-      throw new IOException("Write shall never be deferred");
+      var refId = PerGenerator.registerReference(out, ref);
+      out.writeInt(refId);
+    } else {
+      out.writeInt(INLINED_REFERENCE_ID);
+      var obj = ref.get(Object.class);
+      out.writeObject(obj);
     }
-    var obj = ref.get(Object.class);
-    out.writeObject(obj);
   }
 
   @SuppressWarnings("unchecked")
   @Override
   protected Reference readObject(Input in) throws IOException, ClassNotFoundException {
-    var ref = in.readReference(Object.class);
-    return ref;
+    var refId = in.readInt();
+    if (refId != INLINED_REFERENCE_ID) {
+      return PerInputImpl.findReference(in, refId);
+    } else {
+      var ref = in.readReference(Object.class);
+      return ref;
+    }
   }
 }

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerReferencePersistance.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerReferencePersistance.java
@@ -1,0 +1,29 @@
+package org.enso.persist;
+
+import java.io.IOException;
+import org.enso.persist.Persistance.Reference;
+
+final class PerReferencePeristance extends Persistance<Reference> {
+  static final Persistance<Reference> INSTANCE = new PerReferencePeristance();
+
+  private PerReferencePeristance() {
+    super(Reference.class, true, 4320);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  protected void writeObject(Reference ref, Output out) throws IOException {
+    if (ref.isDeferredWrite()) {
+      throw new IOException("Write shall never be deferred");
+    }
+    var obj = ref.get(Object.class);
+    out.writeObject(obj);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  protected Reference readObject(Input in) throws IOException, ClassNotFoundException {
+    var ref = in.readReference(Object.class);
+    return ref;
+  }
+}

--- a/lib/java/persistance/src/main/java/org/enso/persist/Persistance.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/Persistance.java
@@ -90,7 +90,7 @@ public abstract class Persistance<T> implements Cloneable {
   }
 
   /** Extended output interface for {@link #writeObject(Object)} method. */
-  public static interface Output extends DataOutput {
+  public static sealed interface Output extends DataOutput permits PerGenerator.ReferenceOutput {
     /**
      * Writes an object "inline" - as a value.
      *
@@ -112,7 +112,7 @@ public abstract class Persistance<T> implements Cloneable {
   }
 
   /** Extended input interface for the {@link #writeObject(T, Output)} method. */
-  public static interface Input extends DataInput {
+  public static sealed interface Input extends DataInput permits PerInputImpl {
     /**
      * Reads objects written down by {@link Output#writeInline}.
      *

--- a/lib/java/persistance/src/main/java/org/enso/persist/Persistance.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/Persistance.java
@@ -7,7 +7,6 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.function.Function;
-import org.openide.util.lookup.ServiceProvider;
 
 /**
  * Central persistance class. Use static {@link Persistance#write write} method to turn a graph of
@@ -253,82 +252,36 @@ public abstract class Persistance<T> implements Cloneable {
     }
 
     /**
-     * Creates a reference to existing object.
+     * Creates a reference to existing object. Behaves like {@link #of(V, boolean) of(obj, false)}
+     * when the {@code Reference} is being written into the stream.
      *
      * @param <V> the type of the object
      * @param obj the object to "reference"
      * @return reference pointing to the provided object
      */
     public static <V> Reference<V> of(V obj) {
-      return new PerMemoryReference<>(obj);
+      return of(obj, false);
     }
-  }
-
-  /**
-   * Reference to an object.
-   *
-   * <p>This is a sibling to {@link Reference} that has the same lazy behaviour upon read, but it is
-   * written eagerly. This class is not meant to be used when cycles in the structure are expected -
-   * use {@link Reference} instead. It should be used when we want to ensure that a part of a
-   * structure is only read lazily.
-   */
-  public abstract static sealed class InlineReference<T>
-      permits DirectInlineReference, IndirectInlineReference {
 
     /**
-     * Extract object from the reference.
+     * Creates a reference to existing object and specifies how to persist it. The {@code
+     * deferWrite} value controls the order of serialization:
      *
-     * @return the referenced object
+     * <ul>
+     *   <li>if {@code false} then the {@code obj} is stored in the stream immediatelly and only
+     *       then the {@link Persistance.Output#writeObject(Object)} returns - <b>more effective</b>
+     *   <li>if {@code true} then the {@link Persistance.Output#writeObject(Object)} makes <em>a
+     *       note</em> to persist also {@code obj}, but returns almost immediatelly - useful to deal
+     *       with <b>cycles in the references</b>
+     * </ul>
+     *
+     * @param <V> the type of the object
+     * @param obj the object to "reference"
+     * @param deferWrite {@code false} or {@code true} as described in the method description
+     * @return reference pointing to the provided object
      */
-    public abstract T get();
-
-    public static <T> InlineReference<T> of(T obj) {
-      return new DirectInlineReference<>(obj);
-    }
-  }
-
-  private static final class DirectInlineReference<T> extends InlineReference<T> {
-    private final T value;
-
-    public DirectInlineReference(T value) {
-      this.value = value;
-    }
-
-    @Override
-    public T get() {
-      return value;
-    }
-  }
-
-  private static final class IndirectInlineReference<T> extends InlineReference<T> {
-    private final Reference<T> ref;
-
-    public IndirectInlineReference(Reference<T> ref) {
-      this.ref = ref;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public T get() {
-      return (T) ref.get(Object.class);
-    }
-  }
-
-  @ServiceProvider(service = Persistance.class)
-  public static final class PersistInlineReference extends Persistance<InlineReference> {
-    public PersistInlineReference() {
-      super(InlineReference.class, true, 0);
-    }
-
-    @Override
-    protected void writeObject(InlineReference obj, Output out) throws IOException {
-      out.writeObject(obj.get());
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    protected InlineReference readObject(Input in) throws IOException, ClassNotFoundException {
-      return new IndirectInlineReference(in.readReference(Object.class));
+    public static <V> Reference<V> of(V obj, boolean deferWrite) {
+      return deferWrite ? new PerMemoryReference.Deferred<>(obj) : new PerMemoryReference<>(obj);
     }
   }
 }

--- a/lib/java/persistance/src/main/java/org/enso/persist/Persistance.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/Persistance.java
@@ -283,5 +283,7 @@ public abstract class Persistance<T> implements Cloneable {
     public static <V> Reference<V> of(V obj, boolean deferWrite) {
       return deferWrite ? new PerMemoryReference.Deferred<>(obj) : new PerMemoryReference<>(obj);
     }
+
+    abstract boolean isDeferredWrite();
   }
 }

--- a/lib/java/persistance/src/test/java/org/enso/persist/ReferenceAsInlineTest.java
+++ b/lib/java/persistance/src/test/java/org/enso/persist/ReferenceAsInlineTest.java
@@ -15,8 +15,12 @@ import org.openide.util.lookup.ServiceProvider;
  * chain <em>picks a number up</em>. As a result the {@link Chain#getNumber()} values are opposite
  * in each of the test. That demonstrates the difference between <em>inlined and deferred</em>
  * serialization of {@link Reference} objects.
+ *
+ * <p>This test is using {@link Persistance.Output#writeInline(Class<T>, T)} and {@link
+ * Persistance.Input#readInline(Class<T>)} methods to persist the reference. See {@link
+ * ReferenceAsObjectTest} for similar yet different test.
  */
-public class ReferenceTest {
+public class ReferenceAsInlineTest {
   private static Chain eagerChain(String id, int[] counter, Chain next) {
     Reference<Chain> ref = next == null ? Reference.none() : Reference.of(next, false);
     return new Chain(id, counter, ref);

--- a/lib/java/persistance/src/test/java/org/enso/persist/ReferenceAsObjectTest.java
+++ b/lib/java/persistance/src/test/java/org/enso/persist/ReferenceAsObjectTest.java
@@ -1,0 +1,132 @@
+package org.enso.persist;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
+import org.enso.persist.Persistance.Reference;
+import org.junit.Test;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * This test case verifies the order of writing references down. There are two tests. One creates
+ * {@code Chain} of objects with <em>deferred</em> references and one creates them with <em>inlined
+ * (eager)</em> references. There is a shared counter and during serialization each object from the
+ * chain <em>picks a number up</em>. As a result the {@link Chain#getNumber()} values are opposite
+ * in each of the test. That demonstrates the difference between <em>inlined and deferred</em>
+ * serialization of {@link Reference} objects.
+ *
+ * <p>This test is using {@link Persistance.Output#writeObject(Object)} and {@link
+ * Persistance.Input#readObject()} methods to persist the reference. See {@link
+ * ReferenceAsInlineTest} for similar yet different test.
+ */
+public final class ReferenceAsObjectTest {
+  private static Chain eagerChain(String id, int[] counter, Chain next) {
+    Reference<Chain> ref = next == null ? Reference.none() : Reference.of(next, false);
+    return new Chain(id, counter, ref);
+  }
+
+  private static Chain lazyChain(String id, int[] counter, Chain next) {
+    Reference<Chain> ref = next == null ? Reference.none() : Reference.of(next, true);
+    return new Chain(id, counter, ref);
+  }
+
+  @Test
+  public void persitChainEagerly() throws Exception {
+    var counter = new int[] {0};
+    var ch0 = eagerChain("ch0", counter, null);
+    var ch1 = eagerChain("ch1", counter, ch0);
+    var ch2 = eagerChain("ch2", counter, ch1);
+    var ch3 = eagerChain("ch3", counter, ch2);
+    var ch4 = eagerChain("ch4", counter, ch3);
+    var ch5 = eagerChain("ch5", counter, ch4);
+
+    var item = PersistanceTest.serde(Chain.class, ch5, -1);
+    for (var i = 0; i < 6; i++) {
+      var down = 5 - i;
+      assertEquals("ch" + down, item.id);
+      assertEquals("Also counting down", 6 - i, item.getNumber());
+      item = item.getNext();
+    }
+    assertNull("Six objects and no more", item);
+  }
+
+  @Test
+  public void persitChainLazily() throws Exception {
+    var counter = new int[] {0};
+    var ch0 = lazyChain("ch0", counter, null);
+    var ch1 = lazyChain("ch1", counter, ch0);
+    var ch2 = lazyChain("ch2", counter, ch1);
+    var ch3 = lazyChain("ch3", counter, ch2);
+    var ch4 = lazyChain("ch4", counter, ch3);
+    var ch5 = lazyChain("ch5", counter, ch4);
+
+    var item = PersistanceTest.serde(Chain.class, ch5, -1);
+    for (var i = 0; i < 6; i++) {
+      var down = 5 - i;
+      assertEquals("ch" + down, item.id);
+      assertEquals(i + 1, item.getNumber());
+      item = item.getNext();
+    }
+    assertNull("Six objects and no more", item);
+  }
+
+  public static final class Chain {
+    private final String id;
+    private final Reference<Chain> next;
+    private int[] counter;
+
+    Chain(String id, int[] counter, Reference<Chain> next) {
+      this.id = id;
+      this.counter = counter;
+      this.next = next;
+    }
+
+    int getNumber() {
+      return this.counter[0];
+    }
+
+    Chain getNext() {
+      return this.next.get(Chain.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    Chain(Persistance.Input in) throws IOException {
+      this.id = in.readUTF();
+      this.next = (Reference<Chain>) in.readObject();
+      this.counter = new int[] {in.readInt()};
+    }
+
+    final void write(Persistance.Output out) throws IOException {
+      // serialize own ID
+      out.writeUTF(id);
+      // serialize the reference then
+      out.writeObject(next);
+
+      // obtain a unique getNumber
+      this.counter[0]++;
+      // save it by cloning the counter for itself
+      this.counter = this.counter.clone();
+
+      out.writeInt(this.counter[0]);
+    }
+  }
+
+  @ServiceProvider(service = Persistance.class)
+  public static final class ChainPersistance extends Persistance<Chain> {
+
+    public ChainPersistance() {
+      super(Chain.class, true, 54288435);
+    }
+
+    @Override
+    protected void writeObject(Chain obj, Output out) throws IOException {
+      obj.write(out);
+    }
+
+    @Override
+    protected Chain readObject(Input in) throws IOException, ClassNotFoundException {
+      return new Chain(in);
+    }
+  }
+}

--- a/lib/java/persistance/src/test/java/org/enso/persist/ReferenceTest.java
+++ b/lib/java/persistance/src/test/java/org/enso/persist/ReferenceTest.java
@@ -1,0 +1,128 @@
+package org.enso.persist;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
+import org.enso.persist.Persistance.Reference;
+import org.junit.Test;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * This test case verifies the order of writing references down. There are two tests. One creates
+ * {@code Chain} of objects with <em>deferred</em> references and one creates them with <em>inlined
+ * (eager)</em> references. There is a shared counter and during serialization each object from the
+ * chain <em>picks a number up</em>. As a result the {@link Chain#getNumber()} values are opposite
+ * in each of the test. That demonstrates the difference between <em>inlined and deferred</em>
+ * serialization of {@link Reference} objects.
+ */
+public class ReferenceTest {
+  private static Chain eagerChain(String id, int[] counter, Chain next) {
+    Reference<Chain> ref = next == null ? Reference.none() : Reference.of(next, false);
+    return new Chain(id, counter, ref);
+  }
+
+  private static Chain lazyChain(String id, int[] counter, Chain next) {
+    Reference<Chain> ref = next == null ? Reference.none() : Reference.of(next, true);
+    return new Chain(id, counter, ref);
+  }
+
+  @Test
+  public void persitChainEagerly() throws Exception {
+    var counter = new int[] {0};
+    var ch0 = eagerChain("ch0", counter, null);
+    var ch1 = eagerChain("ch1", counter, ch0);
+    var ch2 = eagerChain("ch2", counter, ch1);
+    var ch3 = eagerChain("ch3", counter, ch2);
+    var ch4 = eagerChain("ch4", counter, ch3);
+    var ch5 = eagerChain("ch5", counter, ch4);
+
+    var item = PersistanceTest.serde(Chain.class, ch5, -1);
+    for (var i = 0; i < 6; i++) {
+      var down = 5 - i;
+      assertEquals("ch" + down, item.id);
+      assertEquals("Also counting down", 6 - i, item.getNumber());
+      item = item.getNext();
+    }
+    assertNull("Six objects and no more", item);
+  }
+
+  @Test
+  public void persitChainLazily() throws Exception {
+    var counter = new int[] {0};
+    var ch0 = lazyChain("ch0", counter, null);
+    var ch1 = lazyChain("ch1", counter, ch0);
+    var ch2 = lazyChain("ch2", counter, ch1);
+    var ch3 = lazyChain("ch3", counter, ch2);
+    var ch4 = lazyChain("ch4", counter, ch3);
+    var ch5 = lazyChain("ch5", counter, ch4);
+
+    var item = PersistanceTest.serde(Chain.class, ch5, -1);
+    for (var i = 0; i < 6; i++) {
+      var down = 5 - i;
+      assertEquals("ch" + down, item.id);
+      assertEquals(i + 1, item.getNumber());
+      item = item.getNext();
+    }
+    assertNull("Six objects and no more", item);
+  }
+
+  public static final class Chain {
+    private final String id;
+    private final Reference<Chain> next;
+    private int[] counter;
+
+    Chain(String id, int[] counter, Reference<Chain> next) {
+      this.id = id;
+      this.counter = counter;
+      this.next = next;
+    }
+
+    int getNumber() {
+      return this.counter[0];
+    }
+
+    Chain getNext() {
+      return this.next.get(Chain.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    Chain(Persistance.Input in) throws IOException {
+      this.id = in.readUTF();
+      this.next = in.readInline(Reference.class);
+      this.counter = new int[] {in.readInt()};
+    }
+
+    final void write(Persistance.Output out) throws IOException {
+      // serialize own ID
+      out.writeUTF(id);
+      // serialize the reference then
+      out.writeInline(Reference.class, next);
+
+      // obtain a unique getNumber
+      this.counter[0]++;
+      // save it by cloning the counter for itself
+      this.counter = this.counter.clone();
+
+      out.writeInt(this.counter[0]);
+    }
+  }
+
+  @ServiceProvider(service = Persistance.class)
+  public static final class ChainPersistance extends Persistance<Chain> {
+
+    public ChainPersistance() {
+      super(Chain.class, true, 54288453);
+    }
+
+    @Override
+    protected void writeObject(Chain obj, Output out) throws IOException {
+      obj.write(out);
+    }
+
+    @Override
+    protected Chain readObject(Input in) throws IOException, ClassNotFoundException {
+      return new Chain(in);
+    }
+  }
+}


### PR DESCRIPTION
Set of changes I'd like to make to @radeusgd PR:
- #10101
- Only the `Reference` abstraction
- Differentiated by `Reference.of(obj, deferWrite)`
- Two new `ReferenceAsXyzTest` showing two (times two) _"reverted"_ chains being written
- [Encapsulating Reference serde in PerReferencePeristance](https://github.com/enso-org/enso/pull/10117/commits/6a2409d61796557910a53ec4b0a15da6bf53af8b)