### PR TITLE
Hotfix for finding parser library

### DIFF
--- a/lib/rust/parser/generate-java/java/org/enso/syntax2/Parser.java
+++ b/lib/rust/parser/generate-java/java/org/enso/syntax2/Parser.java
@@ -21,7 +21,7 @@ public final class Parser implements AutoCloseable {
     File parser = null;
     try {
       var whereAmI = Parser.class.getProtectionDomain().getCodeSource().getLocation();
-      File dir = new File(whereAmI.toURI()).getParentFile();
+      File dir = new File(whereAmI.toURI()).getParentFile().getParentFile();
       parser = new File(dir, name);
       System.load(parser.getAbsolutePath());
     } catch (URISyntaxException | LinkageError e) {

--- a/lib/rust/parser/generate-java/java/org/enso/syntax2/Parser.java
+++ b/lib/rust/parser/generate-java/java/org/enso/syntax2/Parser.java
@@ -29,7 +29,7 @@ public final class Parser implements AutoCloseable {
         d = d.getParentFile();
       }
       if (d == null) {
-        throw new IllegalStateException(
+        throw new LinkageError(
             "Cannot find parser in " + new File(whereAmI.toURI()).getParentFile());
       }
       parser = path;

--- a/lib/rust/parser/generate-java/java/org/enso/syntax2/Parser.java
+++ b/lib/rust/parser/generate-java/java/org/enso/syntax2/Parser.java
@@ -21,8 +21,18 @@ public final class Parser implements AutoCloseable {
     File parser = null;
     try {
       var whereAmI = Parser.class.getProtectionDomain().getCodeSource().getLocation();
-      File dir = new File(whereAmI.toURI()).getParentFile().getParentFile();
-      parser = new File(dir, name);
+      var d = new File(whereAmI.toURI()).getParentFile();
+      File path = null;
+      while (d != null) {
+        path = new File(d, name);
+        if (path.exists()) break;
+        d = d.getParentFile();
+      }
+      if (d == null) {
+        throw new IllegalStateException(
+            "Cannot find parser in " + new File(whereAmI.toURI()).getParentFile());
+      }
+      parser = path;
       System.load(parser.getAbsolutePath());
     } catch (URISyntaxException | LinkageError e) {
       File root = new File(".").getAbsoluteFile();


### PR DESCRIPTION
Since ydoc is now started by language server, parser is initialized differently and attempts to find `libenso_parser.so` in `component/runner` rather than `component` directory.

Related to #9862.  Unbreaks nightlies.