### PR TITLE
Quickfix for panic

### DIFF
--- a/build/build/src/changelog.rs
+++ b/build/build/src/changelog.rs
@@ -35,7 +35,7 @@ impl<'a> Changelog<'a> {
     pub fn top_release_notes(&self) -> Result<Entry> {
         let mut headers = self.iterate_headers();
         let first_header = headers.next().context("Failed to find a level one header.")?;
-        let file_end_pos = self.0.len() + 1;
+        let file_end_pos = self.0.len();
         let next_header_start = headers.next().map_or(file_end_pos, |h| h.pos.start);
         let contents = self.0[first_header.pos.end..next_header_start].trim();
         let entry =


### PR DESCRIPTION
### Pull Request Description

I have no idea why `+ 1` is there, but it presence causes panic when there's only one header.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
