### PR TITLE
Make table default visualisation

### DIFF
--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Helpers.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Helpers.enso
@@ -10,9 +10,13 @@ import project.Table as Table_Visualization
 from project.Text import get_lazy_visualization_text_window
 
 ## PRIVATE
-   Specifies that the builtin JSON visualization should be used for any type,
+   Specifies that the builtin Table visualization should be used for any type,
    unless specified otherwise.
-Any.default_visualization self = Id.json
+Any.default_visualization self = Id.table
+
+## PRIVATE
+   Specifies that the builtin JSON visualization should be used for any JS_Objects
+JS_Object.default_visualization self = Id.json
 
 ## PRIVATE
    Returns a Text used to display this value in the IDE.

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -2027,7 +2027,7 @@ class RuntimeVisualizationsTest extends AnyFlatSpec with Matchers {
           data
       }
 
-      new String(data) shouldEqual "(Builtin 'JSON')"
+      new String(data) shouldEqual "(Builtin 'Table')"
 
       val loadedLibraries = attachVisualizationResponses
         .collect {

--- a/test/Visualization_Tests/src/Id_Spec.enso
+++ b/test/Visualization_Tests/src/Id_Spec.enso
@@ -32,10 +32,13 @@ add_specs suite_builder = suite_builder.group "Serializable Visualization Identi
         v_1.to_json.should_equal (expected "enso_dev.Visualization_Tests" "My Vis")
         v_2.to_json.should_equal (expected "Standard.Base" "Other Vis")
 
-    group_builder.specify "specifies default JSON visualization for any type" <|
-        My_Type.Value 30 . default_visualization . should_equal Visualization.Id.json
-        "foobar".default_visualization.should_equal Visualization.Id.json
-        True.default_visualization.should_equal Visualization.Id.json
+    group_builder.specify "specifies default Table visualization for any type" <|
+        My_Type.Value 30 . default_visualization . should_equal Visualization.Id.table
+        "foobar".default_visualization.should_equal Visualization.Id.table
+        True.default_visualization.should_equal Visualization.Id.table
+
+    group_builder.specify "specifies default json visualization JS_Object type" <|
+        (Json.parse '{"name":"John","age":25,"email":"john@example.com"}') . default_visualization . should_equal Visualization.Id.json
 
     group_builder.specify "specifies default Table visualization for Vector and Array type" <|
         [1,2,3].default_visualization.should_equal Visualization.Id.table


### PR DESCRIPTION
### Pull Request Description

Makes table the default vis type.

Before:
![image](https://github.com/enso-org/enso/assets/1720119/8a5d113a-ac06-4dd8-afdb-151cdbc149ab)

After:
![image](https://github.com/enso-org/enso/assets/1720119/d7c33cf7-355d-4517-8967-1963ff506f97)

Closes #10093 

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
