### PR TITLE
Handle UTF BOM when decoding text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 #### Enso Standard Library
 
 - [Added Statistic.Product][10122]
+- [Added Encoding.Default that tries to detect UTF-8 or UTF-16 encoding based on
+  BOM][10130]
 
 [debug-shortcuts]:
 
 [10122]: https://github.com/enso-org/enso/pull/10122
+[10130]: https://github.com/enso-org/enso/pull/10130
 
 <br/>![Release Notes](/docs/assets/tags/release_notes.svg)
 

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/S3/S3_File.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/S3/S3_File.enso
@@ -193,7 +193,7 @@ type S3_File
          If set to `Ignore`, the operation proceeds without errors or warnings.
     @encoding Encoding.default_widget
     read_text : Encoding -> Problem_Behavior -> Text ! File_Error
-    read_text self (encoding=Encoding.Default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
+    read_text self (encoding=Encoding.default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
         self.read (Plain_Text encoding) on_problems
 
     ## ICON data_output

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/S3/S3_File.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/S3/S3_File.enso
@@ -163,7 +163,7 @@ type S3_File
          If set to `Ignore`, the operation proceeds without errors or warnings.
     @format File_Format.default_widget
     read : File_Format -> Problem_Behavior -> Any ! S3_Error
-    read self format=Auto_Detect (on_problems=Problem_Behavior.Report_Warning) =
+    read self format=Auto_Detect (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
         if Data_Link.is_data_link self then Data_Link_Helpers.read_data_link self format on_problems else
             File_Format.handle_format_missing_arguments format <| case format of
                 Auto_Detect -> if self.is_directory then format.read self on_problems else
@@ -193,7 +193,7 @@ type S3_File
          If set to `Ignore`, the operation proceeds without errors or warnings.
     @encoding Encoding.default_widget
     read_text : Encoding -> Problem_Behavior -> Text ! File_Error
-    read_text self (encoding=Encoding.Default) (on_problems=Problem_Behavior.Report_Warning) =
+    read_text self (encoding=Encoding.Default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
         self.read (Plain_Text encoding) on_problems
 
     ## ICON data_output

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/S3/S3_File.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/S3/S3_File.enso
@@ -193,7 +193,7 @@ type S3_File
          If set to `Ignore`, the operation proceeds without errors or warnings.
     @encoding Encoding.default_widget
     read_text : Encoding -> Problem_Behavior -> Text ! File_Error
-    read_text self (encoding=Encoding.utf_8) (on_problems=Problem_Behavior.Report_Warning) =
+    read_text self (encoding=Encoding.Default) (on_problems=Problem_Behavior.Report_Warning) =
         self.read (Plain_Text encoding) on_problems
 
     ## ICON data_output

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/S3/S3_File.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/S3/S3_File.enso
@@ -193,7 +193,7 @@ type S3_File
          If set to `Ignore`, the operation proceeds without errors or warnings.
     @encoding Encoding.default_widget
     read_text : Encoding -> Problem_Behavior -> Text ! File_Error
-    read_text self (encoding=Encoding.default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
+    read_text self (encoding : Encoding = Encoding.default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
         self.read (Plain_Text encoding) on_problems
 
     ## ICON data_output

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
@@ -100,7 +100,7 @@ read path format=Auto_Detect (on_problems=Problem_Behavior.Report_Warning) = cas
 @path Text_Input
 @encoding Encoding.default_widget
 read_text : (Text | File) -> Encoding -> Problem_Behavior -> Text
-read_text path (encoding=Encoding.utf_8) (on_problems=Problem_Behavior.Report_Warning) =
+read_text path (encoding=Encoding.Default) (on_problems=Problem_Behavior.Report_Warning) =
     File.new path . read_text encoding on_problems
 
 ## GROUP Input

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
@@ -68,7 +68,7 @@ from project.System.File_Format import Auto_Detect, File_Format
 @path Text_Input
 @format File_Format.default_widget
 read : Text | File -> File_Format -> Problem_Behavior -> Any ! File_Error
-read path format=Auto_Detect (on_problems=Problem_Behavior.Report_Warning) = case path of
+read path format=Auto_Detect (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) = case path of
     _ : Text -> if Data_Read_Helpers.looks_like_uri path then Data_Read_Helpers.fetch_following_data_links path format=format else
         read (File.new path) format on_problems
     uri : URI -> Data_Read_Helpers.fetch_following_data_links uri format=format
@@ -100,7 +100,7 @@ read path format=Auto_Detect (on_problems=Problem_Behavior.Report_Warning) = cas
 @path Text_Input
 @encoding Encoding.default_widget
 read_text : (Text | File) -> Encoding -> Problem_Behavior -> Text
-read_text path (encoding=Encoding.Default) (on_problems=Problem_Behavior.Report_Warning) =
+read_text path (encoding=Encoding.Default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
     File.new path . read_text encoding on_problems
 
 ## GROUP Input

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
@@ -100,7 +100,7 @@ read path format=Auto_Detect (on_problems : Problem_Behavior = Problem_Behavior.
 @path Text_Input
 @encoding Encoding.default_widget
 read_text : (Text | File) -> Encoding -> Problem_Behavior -> Text
-read_text path (encoding=Encoding.Default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
+read_text path (encoding=Encoding.default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
     File.new path . read_text encoding on_problems
 
 ## GROUP Input

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
@@ -100,7 +100,7 @@ read path format=Auto_Detect (on_problems : Problem_Behavior = Problem_Behavior.
 @path Text_Input
 @encoding Encoding.default_widget
 read_text : (Text | File) -> Encoding -> Problem_Behavior -> Text
-read_text path (encoding=Encoding.default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
+read_text path (encoding : Encoding = Encoding.default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
     File.new path . read_text encoding on_problems
 
 ## GROUP Input

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Encoding.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Encoding.enso
@@ -48,19 +48,42 @@ type Encoding
             charset = Charset.forName name
             Encoding.Value charset.name
 
+    ## ICON convert
+       A default encoding that will try to guess the encoding based on some
+       heuristics.
+
+       If a BOM is present, it will be used to determine UTF-8 or UTF-16
+       encoding. Otherwise, the input is decoded using UTF-8 unless it contains
+       invalid UTF-8 sequences, in which case Windows-1252 is used as a fallback.
+
+       When used for encoding, it will always encode using UTF-8.
+       This encoding cannot be passed to some functions that require a Java
+       Charset.
+    Default
+
     ## PRIVATE
-       Create a new Encoding object.
+       An encoding identified by its Java name.
 
        Arguments:
        - character_set: java.nio.charset name.
-    Value (character_set:Text)
+    Value (internal_character_set:Text)
 
     ## PRIVATE
        Convert an Encoding to it's corresponding Java Charset
-    to_java_charset : Charset
-    to_java_charset self =
-        Panic.catch UnsupportedCharsetException (Charset.forName self.character_set) _->
-            Error.throw (Illegal_Argument.Error ("Unknown Character Set: " + self.character_set))
+    to_java_charset : Charset ! Illegal_Argument
+    to_java_charset self = case self of
+        Encoding.Value charset_name ->
+            Panic.catch UnsupportedCharsetException (Charset.forName charset_name) _->
+                Error.throw (Illegal_Argument.Error ("Unknown Character Set: " + charset_name))
+        Encoding.Default ->
+            Error.throw (Illegal_Argument.Error "The Default encoding cannot be converted to a Java Charset. Please select a specific encoding for this operation.")
+
+    ## ICON metadata
+       Get the name of the character set.
+    character_set_name self -> Text ! Illegal_Argument = case self of
+        Encoding.Value charset_name -> charset_name
+        Encoding.Default ->
+            Error.throw (Illegal_Argument.Error "The Default encoding does not have a character set name. Please select a specific encoding.")
 
     ## ICON convert
        Encoding for ASCII.
@@ -142,4 +165,6 @@ type Encoding
     ## PRIVATE
        Convert Encoding to a friendly string.
     to_display_text : Text
-    to_display_text self = self.character_set
+    to_display_text self = case self of
+        Encoding.Value charset_name -> charset_name
+        Encoding.Default -> "Default Encoding"

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Encoding.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Encoding.enso
@@ -8,6 +8,7 @@ import project.Metadata.Display
 import project.Metadata.Widget
 import project.Nothing.Nothing
 import project.Panic.Panic
+import project.Warning.Warning
 from project.Metadata.Choice import Option
 from project.Metadata.Widget import Single_Choice
 
@@ -87,7 +88,8 @@ type Encoding
        Default encoding. In such places, usage of Default encoding will be forbidden.
     to_java_charset self -> Charset ! Illegal_Argument =
         self.to_java_charset_or_null.if_nothing <|
-            Error.throw (Illegal_Argument.Error "The Default encoding cannot be converted to a Java Charset. Please select a specific encoding for this operation.")
+            warning = Illegal_Argument.Error "The Default encoding has been used in an unexpected place (e.g. Write operation). It will be replaced with UTF-8. Please specify the desired encoding explicitly)"
+            Warning.attach warning (Encoding.utf_8.to_java_charset)
 
     ## PRIVATE
        Convert an Encoding to it's corresponding Java Charset or null if it is the Default encoding.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Encoding.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Encoding.enso
@@ -64,14 +64,22 @@ type Encoding
        When used for encoding, it will always encode using UTF-8.
        This encoding cannot be passed to some functions that require a Java
        Charset.
-    Default
+    default -> Encoding =
+        # This factory method is used to publicly expose the `Default` constructor.
+        # The constructor itself has to be private, because we want to make `Value` constructor private, but all constructors must have the same privacy.
+        Encoding.Default
+
+    ## PRIVATE
+       A default encoding that will try to guess the encoding based on some heuristics.
+       See `Encoding.default`.
+    private Default
 
     ## PRIVATE
        An encoding identified by its Java name.
 
        Arguments:
        - character_set: java.nio.charset name.
-    Value (internal_character_set:Text)
+    private Value (internal_character_set:Text)
 
     ## PRIVATE
        Convert an Encoding to it's corresponding Java Charset, if applicable.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Encoding.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Encoding.enso
@@ -49,6 +49,10 @@ type Encoding
             charset = Charset.forName name
             Encoding.Value charset.name
 
+    ## PRIVATE
+    from_java_charset (charset : Charset) -> Encoding =
+        Encoding.Value charset.name
+
     ## ICON convert
        A default encoding that will try to guess the encoding based on some
        heuristics.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Encoding.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Encoding.enso
@@ -6,6 +6,7 @@ import project.Errors.Illegal_Argument.Illegal_Argument
 import project.Meta
 import project.Metadata.Display
 import project.Metadata.Widget
+import project.Nothing.Nothing
 import project.Panic.Panic
 from project.Metadata.Choice import Option
 from project.Metadata.Widget import Single_Choice
@@ -69,14 +70,21 @@ type Encoding
     Value (internal_character_set:Text)
 
     ## PRIVATE
-       Convert an Encoding to it's corresponding Java Charset
-    to_java_charset : Charset ! Illegal_Argument
-    to_java_charset self = case self of
+       Convert an Encoding to it's corresponding Java Charset, if applicable.
+       This method should be used in places not aware of special logic for the
+       Default encoding. In such places, usage of Default encoding will be forbidden.
+    to_java_charset self -> Charset ! Illegal_Argument =
+        self.to_java_charset_or_null.if_nothing <|
+            Error.throw (Illegal_Argument.Error "The Default encoding cannot be converted to a Java Charset. Please select a specific encoding for this operation.")
+
+    ## PRIVATE
+       Convert an Encoding to it's corresponding Java Charset or null if it is the Default encoding.
+       This method should only be used in places where a null Charset is expected - i.e. places aware of the Default encoding.
+    to_java_charset_or_null self -> Charset ! Illegal_Argument = case self of
         Encoding.Value charset_name ->
             Panic.catch UnsupportedCharsetException (Charset.forName charset_name) _->
                 Error.throw (Illegal_Argument.Error ("Unknown Character Set: " + charset_name))
-        Encoding.Default ->
-            Error.throw (Illegal_Argument.Error "The Default encoding cannot be converted to a Java Charset. Please select a specific encoding for this operation.")
+        Encoding.Default -> Nothing
 
     ## ICON metadata
        Get the name of the character set.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -739,7 +739,7 @@ Text.is_whitespace self =
          "Hello".bytes (Encoding.ascii)
 @encoding Encoding.default_widget
 Text.bytes : Encoding -> Problem_Behavior -> Vector Integer
-Text.bytes self encoding (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
+Text.bytes self (encoding : Encoding = Encoding.utf_8) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
     result = Encoding_Utils.get_bytes self (encoding . to_java_charset)
     vector = Vector.from_polyglot_array result.result
     if result.warnings.is_nothing then vector else
@@ -761,7 +761,7 @@ Text.bytes self encoding (on_problems : Problem_Behavior = Problem_Behavior.Repo
          Text.from_bytes [72, 101, 108, 108, 111] (Encoding.ascii)
 @encoding Encoding.default_widget
 Text.from_bytes : Vector Integer -> Encoding -> Problem_Behavior -> Text
-Text.from_bytes bytes encoding (on_problems : Problem_Behavior = Problem_Behavior.Report_Error) =
+Text.from_bytes bytes (encoding : Encoding = Encoding.default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Error) =
     result = Encoding_Utils.from_bytes bytes encoding.to_java_charset_or_null : WithProblems
     if result.problems.is_empty then result.result else
         problems = result.problems.map decoding_problem->

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -45,6 +45,7 @@ polyglot java import com.ibm.icu.lang.UCharacter
 polyglot java import com.ibm.icu.text.BreakIterator
 polyglot java import java.lang.StringBuilder
 polyglot java import org.enso.base.encoding.Encoding_Utils
+polyglot java import org.enso.base.text.ResultWithWarnings
 polyglot java import org.enso.base.Text_Utils
 polyglot java import org.enso.base.Regex_Utils
 polyglot java import org.enso.base.WithProblems
@@ -740,7 +741,7 @@ Text.is_whitespace self =
 @encoding Encoding.default_widget
 Text.bytes : Encoding -> Problem_Behavior -> Vector Integer
 Text.bytes self (encoding : Encoding = Encoding.utf_8) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
-    result = Encoding_Utils.get_bytes self (encoding . to_java_charset)
+    result = Encoding_Utils.get_bytes self encoding.to_java_charset : ResultWithWarnings
     vector = Vector.from_polyglot_array result.result
     if result.warnings.is_nothing then vector else
         on_problems.attach_problems_after vector [Encoding_Error.Error result.warnings]

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -44,7 +44,7 @@ from project.Widget_Helpers import make_data_cleanse_vector_selector, make_date_
 polyglot java import com.ibm.icu.lang.UCharacter
 polyglot java import com.ibm.icu.text.BreakIterator
 polyglot java import java.lang.StringBuilder
-polyglot java import org.enso.base.Encoding_Utils
+polyglot java import org.enso.base.encoding.Encoding_Utils
 polyglot java import org.enso.base.Regex_Utils
 polyglot java import org.enso.base.text.GraphemeSpan
 polyglot java import org.enso.base.text.ResultWithWarnings

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -45,11 +45,11 @@ polyglot java import com.ibm.icu.lang.UCharacter
 polyglot java import com.ibm.icu.text.BreakIterator
 polyglot java import java.lang.StringBuilder
 polyglot java import org.enso.base.encoding.Encoding_Utils
-polyglot java import org.enso.base.Regex_Utils
-polyglot java import org.enso.base.text.GraphemeSpan
-polyglot java import org.enso.base.text.ResultWithWarnings
-polyglot java import org.enso.base.text.Utf16Span
 polyglot java import org.enso.base.Text_Utils
+polyglot java import org.enso.base.Regex_Utils
+polyglot java import org.enso.base.WithProblems
+polyglot java import org.enso.base.text.GraphemeSpan
+polyglot java import org.enso.base.text.Utf16Span
 
 ## GROUP Text
    ICON text
@@ -762,9 +762,11 @@ Text.bytes self encoding on_problems=Problem_Behavior.Report_Warning =
 @encoding Encoding.default_widget
 Text.from_bytes : Vector Integer -> Encoding -> Problem_Behavior -> Text
 Text.from_bytes bytes encoding on_problems=Problem_Behavior.Report_Error =
-    result = Encoding_Utils.from_bytes bytes (encoding . to_java_charset) : ResultWithWarnings
-    if result.warnings.is_nothing then result.result else
-        on_problems.attach_problems_after result.result [Encoding_Error.Error result.warnings]
+    result = Encoding_Utils.from_bytes bytes (encoding . to_java_charset) : WithProblems
+    if result.problems.is_empty then result.result else
+        problems = result.problems.map decoding_problem->
+            Encoding_Error.Error decoding_problem.getMessage
+        on_problems.attach_problems_after result.result problems
 
 ## ICON convert
    Returns a vector containing bytes representing the UTF-8 encoding of the

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -765,7 +765,7 @@ Text.from_bytes bytes encoding on_problems=Problem_Behavior.Report_Error =
     result = Encoding_Utils.from_bytes bytes encoding.to_java_charset_or_null : WithProblems
     if result.problems.is_empty then result.result else
         problems = result.problems.map decoding_problem->
-            Encoding_Error.Error decoding_problem.getMessage
+            Encoding_Error.Error decoding_problem.message
         on_problems.attach_problems_after result.result problems
 
 ## ICON convert

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -756,9 +756,9 @@ Text.bytes self encoding on_problems=Problem_Behavior.Report_Warning =
      function. By default, a dataflow error is raised.
 
    > Example
-     Get the ASCII bytes of the text "Hello".
+     Decode a sequence of ASCII bytes into Text.
 
-         "Hello".bytes (Encoding.ascii)
+         Text.from_bytes [72, 101, 108, 108, 111] (Encoding.ascii)
 @encoding Encoding.default_widget
 Text.from_bytes : Vector Integer -> Encoding -> Problem_Behavior -> Text
 Text.from_bytes bytes encoding on_problems=Problem_Behavior.Report_Error =

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -739,7 +739,7 @@ Text.is_whitespace self =
          "Hello".bytes (Encoding.ascii)
 @encoding Encoding.default_widget
 Text.bytes : Encoding -> Problem_Behavior -> Vector Integer
-Text.bytes self encoding on_problems=Problem_Behavior.Report_Warning =
+Text.bytes self encoding (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
     result = Encoding_Utils.get_bytes self (encoding . to_java_charset)
     vector = Vector.from_polyglot_array result.result
     if result.warnings.is_nothing then vector else
@@ -761,7 +761,7 @@ Text.bytes self encoding on_problems=Problem_Behavior.Report_Warning =
          Text.from_bytes [72, 101, 108, 108, 111] (Encoding.ascii)
 @encoding Encoding.default_widget
 Text.from_bytes : Vector Integer -> Encoding -> Problem_Behavior -> Text
-Text.from_bytes bytes encoding on_problems=Problem_Behavior.Report_Error =
+Text.from_bytes bytes encoding (on_problems : Problem_Behavior = Problem_Behavior.Report_Error) =
     result = Encoding_Utils.from_bytes bytes encoding.to_java_charset_or_null : WithProblems
     if result.problems.is_empty then result.result else
         problems = result.problems.map decoding_problem->
@@ -787,7 +787,7 @@ Text.from_bytes bytes encoding on_problems=Problem_Behavior.Report_Error =
 
          "Hello".utf_8
 Text.utf_8 : Problem_Behavior -> Vector Integer
-Text.utf_8 self on_problems=Problem_Behavior.Report_Warning =
+Text.utf_8 self (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
     self.bytes Encoding.utf_8 on_problems
 
 ## ICON convert
@@ -806,7 +806,7 @@ Text.utf_8 self on_problems=Problem_Behavior.Report_Warning =
 
          Text.from_utf_8 [-32, -92, -107, -32, -91, -115, -32, -92, -73, -32, -92, -65]
 Text.from_utf_8 : Vector Integer -> Problem_Behavior -> Text
-Text.from_utf_8 bytes on_problems=Problem_Behavior.Report_Error =
+Text.from_utf_8 bytes (on_problems : Problem_Behavior = Problem_Behavior.Report_Error) =
     Text.from_bytes bytes Encoding.utf_8 on_problems
 
 ## ICON convert

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -762,7 +762,7 @@ Text.bytes self encoding on_problems=Problem_Behavior.Report_Warning =
 @encoding Encoding.default_widget
 Text.from_bytes : Vector Integer -> Encoding -> Problem_Behavior -> Text
 Text.from_bytes bytes encoding on_problems=Problem_Behavior.Report_Error =
-    result = Encoding_Utils.from_bytes bytes (encoding . to_java_charset) : WithProblems
+    result = Encoding_Utils.from_bytes bytes encoding.to_java_charset_or_null : WithProblems
     if result.problems.is_empty then result.result else
         problems = result.problems.map decoding_problem->
             Encoding_Error.Error decoding_problem.getMessage

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/XML.enso
@@ -761,6 +761,6 @@ child_selector node:(XML_Element | XML_Document) =
 ## PRIVATE
    write an XML document or element to a file.
 write_impl node:Node path:Writable_File (encoding : Encoding = Encoding.utf_8) (on_existing_file : Existing_File_Behavior = Existing_File_Behavior.Backup) (include_xml_declaration : Boolean = Boolean.True) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
-    declaration = if include_xml_declaration then '<?xml version=\"1.0\" encoding=\"' + encoding.character_set + '\"?>\n' else ""
+    declaration = if include_xml_declaration then '<?xml version=\"1.0\" encoding=\"' + encoding.character_set_name + '\"?>\n' else ""
     XML_Error.handle_java_exceptions <|
         (declaration + XML_Utils.outerXML node True).write path encoding on_existing_file on_problems

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
@@ -290,7 +290,7 @@ type Enso_File
          If set to `Ignore`, the operation proceeds without errors or warnings.
     @encoding Encoding.default_widget
     read_text : Encoding -> Problem_Behavior -> Text ! File_Error
-    read_text self (encoding=Encoding.utf_8) (on_problems=Problem_Behavior.Report_Warning) =
+    read_text self (encoding=Encoding.Default) (on_problems=Problem_Behavior.Report_Warning) =
         self.read (Plain_Text_Format.Plain_Text encoding) on_problems
 
     ## GROUP Metadata

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
@@ -290,7 +290,7 @@ type Enso_File
          If set to `Ignore`, the operation proceeds without errors or warnings.
     @encoding Encoding.default_widget
     read_text : Encoding -> Problem_Behavior -> Text ! File_Error
-    read_text self (encoding=Encoding.default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
+    read_text self (encoding : Encoding = Encoding.default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
         self.read (Plain_Text_Format.Plain_Text encoding) on_problems
 
     ## GROUP Metadata

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
@@ -290,7 +290,7 @@ type Enso_File
          If set to `Ignore`, the operation proceeds without errors or warnings.
     @encoding Encoding.default_widget
     read_text : Encoding -> Problem_Behavior -> Text ! File_Error
-    read_text self (encoding=Encoding.Default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
+    read_text self (encoding=Encoding.default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
         self.read (Plain_Text_Format.Plain_Text encoding) on_problems
 
     ## GROUP Metadata

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
@@ -250,7 +250,7 @@ type Enso_File
          If set to `Ignore`, the operation proceeds without errors or warnings.
     @format File_Format.default_widget
     read : File_Format -> Problem_Behavior -> Any ! Illegal_Argument | File_Error
-    read self format=Auto_Detect (on_problems=Problem_Behavior.Report_Warning) =
+    read self format=Auto_Detect (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
         asset = Existing_Enso_Asset.get_asset_reference_for self
         case asset.asset_type of
             Enso_Asset_Type.Project -> Error.throw (Illegal_Argument.Error "Projects cannot be read within Enso code. Open using the IDE.")
@@ -290,7 +290,7 @@ type Enso_File
          If set to `Ignore`, the operation proceeds without errors or warnings.
     @encoding Encoding.default_widget
     read_text : Encoding -> Problem_Behavior -> Text ! File_Error
-    read_text self (encoding=Encoding.Default) (on_problems=Problem_Behavior.Report_Warning) =
+    read_text self (encoding=Encoding.Default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
         self.read (Plain_Text_Format.Plain_Text encoding) on_problems
 
     ## GROUP Metadata

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/Header.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/Header.enso
@@ -129,7 +129,7 @@ type Header
              example_content_type = Header.content_type "my_type"
     content_type : Text -> Encoding | Nothing -> Header
     content_type value:Text encoding:(Encoding | Nothing)=Nothing =
-        charset = if encoding.is_nothing then "" else "; charset="+encoding.character_set
+        charset = if encoding.is_nothing then "" else "; charset="+encoding.character_set_name
         Header.Value Header.content_type_header_name value+charset
 
     ## ICON text_input

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -333,7 +333,7 @@ type File
              example_read = Examples.csv.read
     @encoding Encoding.default_widget
     read_text : Encoding -> Problem_Behavior -> Text ! File_Error
-    read_text self (encoding=Encoding.default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
+    read_text self (encoding : Encoding = Encoding.default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
         bytes = self.read_bytes
         Text.from_bytes bytes encoding on_problems
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -333,7 +333,7 @@ type File
              example_read = Examples.csv.read
     @encoding Encoding.default_widget
     read_text : Encoding -> Problem_Behavior -> Text ! File_Error
-    read_text self (encoding=Encoding.Default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
+    read_text self (encoding=Encoding.default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
         bytes = self.read_bytes
         Text.from_bytes bytes encoding on_problems
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -333,7 +333,7 @@ type File
              example_read = Examples.csv.read
     @encoding Encoding.default_widget
     read_text : Encoding -> Problem_Behavior -> Text ! File_Error
-    read_text self (encoding=Encoding.Default) (on_problems=Problem_Behavior.Report_Warning) =
+    read_text self (encoding=Encoding.Default) (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
         bytes = self.read_bytes
         Text.from_bytes bytes encoding on_problems
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -333,7 +333,7 @@ type File
              example_read = Examples.csv.read
     @encoding Encoding.default_widget
     read_text : Encoding -> Problem_Behavior -> Text ! File_Error
-    read_text self (encoding=Encoding.utf_8) (on_problems=Problem_Behavior.Report_Warning) =
+    read_text self (encoding=Encoding.Default) (on_problems=Problem_Behavior.Report_Warning) =
         bytes = self.read_bytes
         Text.from_bytes bytes encoding on_problems
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -292,7 +292,7 @@ type File
              example_xls_to_table = Examples.xls.read (Excel_Format.Sheet 'Dates')
     @format File_Format.default_widget
     read : File_Format -> Problem_Behavior -> Any ! File_Error
-    read self format=Auto_Detect (on_problems=Problem_Behavior.Report_Warning) =
+    read self format=Auto_Detect (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
         if self.exists.not then Error.throw (File_Error.Not_Found self) else
             if Data_Link.is_data_link self then Data_Link_Helpers.read_data_link self format on_problems else
                 File_Format.handle_format_missing_arguments format <|

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_By_Line.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_By_Line.enso
@@ -30,6 +30,7 @@ type File_By_Line
        - offset: The position within the file to read from (defaults to first byte).
     new : File -> Encoding -> Integer -> File_By_Line
     new file:File encoding:Encoding=Encoding.utf_8 offset:Integer=0 =
+        # TODO we might want to support Encoding.Default here, but that requires modifying the FileLineReader a bit
         create_row_map =
             row_map = LongArrayList.new
             row_map.add offset

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_By_Line.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_By_Line.enso
@@ -30,7 +30,7 @@ type File_By_Line
        - offset: The position within the file to read from (defaults to first byte).
     new : File -> Encoding -> Integer -> File_By_Line
     new file:File encoding:Encoding=Encoding.utf_8 offset:Integer=0 =
-        # TODO we might want to support Encoding.Default here, but that requires modifying the FileLineReader a bit
+        # TODO we might want to support Encoding.default here, but that requires modifying the FileLineReader a bit
         create_row_map =
             row_map = LongArrayList.new
             row_map.add offset

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
@@ -140,12 +140,12 @@ type Plain_Text_Format
         from_content_type = content_type.if_not_nothing <|
             case content_type.base_type of
                 "text/plain" ->
-                    effective_encoding = content_type.encoding.if_nothing Encoding.Default
+                    effective_encoding = content_type.encoding.if_nothing Encoding.default
                     Plain_Text_Format.Plain_Text effective_encoding
                 _ -> Nothing
         from_content_type.if_nothing <| case file.guess_extension of
-            ".txt" -> Plain_Text_Format.Plain_Text Encoding.Default
-            ".log" -> Plain_Text_Format.Plain_Text Encoding.Default
+            ".txt" -> Plain_Text_Format.Plain_Text Encoding.default
+            ".log" -> Plain_Text_Format.Plain_Text Encoding.default
             _ -> Nothing
 
     ## PRIVATE
@@ -175,7 +175,7 @@ type Plain_Text_Format
         if self.encoding != Infer then self.encoding else
             content_type = metadata.interpret_content_type
             resolved_encoding = content_type.if_not_nothing <| content_type.encoding
-            resolved_encoding.if_nothing Encoding.Default
+            resolved_encoding.if_nothing Encoding.default
 
 ## A file format for reading or writing files as a sequence of bytes.
 type Bytes

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
@@ -130,7 +130,7 @@ type Plain_Text_Format
          Windows-1252 fallback). For writing, UTF-8 is used as default, unless
          overridden.
     @encoding Encoding.default_widget
-    Plain_Text (encoding:Encoding = Encoding.Default)
+    Plain_Text (encoding : Encoding | Infer = Infer)
 
     ## PRIVATE
        If the File_Format supports reading from the file, return a configured instance.
@@ -144,8 +144,8 @@ type Plain_Text_Format
                     Plain_Text_Format.Plain_Text effective_encoding
                 _ -> Nothing
         from_content_type.if_nothing <| case file.guess_extension of
-            ".txt" -> Plain_Text_Format.Plain_Text
-            ".log" -> Plain_Text_Format.Plain_Text
+            ".txt" -> Plain_Text_Format.Plain_Text Encoding.Default
+            ".log" -> Plain_Text_Format.Plain_Text Encoding.Default
             _ -> Nothing
 
     ## PRIVATE
@@ -172,7 +172,7 @@ type Plain_Text_Format
     ## PRIVATE
     resolve_encoding : File_Format_Metadata -> Encoding
     resolve_encoding self (metadata : File_Format_Metadata) =
-        if self.encoding != Encoding.Default then self.encoding else
+        if self.encoding != Infer then self.encoding else
             content_type = metadata.interpret_content_type
             resolved_encoding = content_type.if_not_nothing <| content_type.encoding
             resolved_encoding.if_nothing Encoding.Default

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
@@ -126,10 +126,11 @@ type Plain_Text_Format
        Arguments:
        - encoding: The encoding to use.
          If the encoding is set to `Infer`, it will be inferred from metadata if
-         available, falling back to UTF-8. For writing, `Infer` will also imply
-         the UTF-8 encoding as the default.
+         available, falling back to the default encoding (UTF-8 with
+         Windows-1252 fallback). For writing, UTF-8 is used as default, unless
+         overridden.
     @encoding Encoding.default_widget
-    Plain_Text (encoding:Encoding|Infer = Infer)
+    Plain_Text (encoding:Encoding = Encoding.Default)
 
     ## PRIVATE
        If the File_Format supports reading from the file, return a configured instance.
@@ -139,7 +140,7 @@ type Plain_Text_Format
         from_content_type = content_type.if_not_nothing <|
             case content_type.base_type of
                 "text/plain" ->
-                    effective_encoding = content_type.encoding.if_nothing Encoding.utf_8
+                    effective_encoding = content_type.encoding.if_nothing Encoding.Default
                     Plain_Text_Format.Plain_Text effective_encoding
                 _ -> Nothing
         from_content_type.if_nothing <| case file.guess_extension of
@@ -171,10 +172,10 @@ type Plain_Text_Format
     ## PRIVATE
     resolve_encoding : File_Format_Metadata -> Encoding
     resolve_encoding self (metadata : File_Format_Metadata) =
-        if self.encoding != Infer then self.encoding else
+        if self.encoding != Encoding.Default then self.encoding else
             content_type = metadata.interpret_content_type
             resolved_encoding = content_type.if_not_nothing <| content_type.encoding
-            resolved_encoding.if_nothing Encoding.utf_8
+            resolved_encoding.if_nothing Encoding.Default
 
 ## A file format for reading or writing files as a sequence of bytes.
 type Bytes

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/Input_Stream.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/Input_Stream.enso
@@ -13,7 +13,7 @@ import project.System.File.Generic.Writable_File.Writable_File
 
 polyglot java import java.io.InputStream as Java_Input_Stream
 polyglot java import org.enso.base.encoding.ReportingStreamDecoder
-polyglot java import org.enso.base.Encoding_Utils
+polyglot java import org.enso.base.encoding.Encoding_Utils
 
 ## PRIVATE
    An input stream, allowing for interactive reading of contents.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/Input_Stream.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/Input_Stream.enso
@@ -102,7 +102,8 @@ type Input_Stream
     with_stream_decoder self encoding on_problems action = self.stream_resource . with java_stream->
         java_charset = encoding.to_java_charset
         results = Encoding_Utils.with_stream_decoder java_stream java_charset action
-        problems = Vector.from_polyglot_array results.problems . map Encoding_Error.Error
+        problems = Vector.from_polyglot_array results.problems . map decoding_problem->
+            Encoding_Error.Error decoding_problem.getMessage
         on_problems.attach_problems_after results.result problems
 
     ## PRIVATE

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/Input_Stream.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/Input_Stream.enso
@@ -103,7 +103,7 @@ type Input_Stream
         java_charset = encoding.to_java_charset
         results = Encoding_Utils.with_stream_decoder java_stream java_charset action
         problems = Vector.from_polyglot_array results.problems . map decoding_problem->
-            Encoding_Error.Error decoding_problem.getMessage
+            Encoding_Error.Error decoding_problem.message
         on_problems.attach_problems_after results.result problems
 
     ## PRIVATE

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/Input_Stream.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/Input_Stream.enso
@@ -100,8 +100,7 @@ type Input_Stream
        input stream with the specified encoding.
     with_stream_decoder : Encoding -> Problem_Behavior -> (ReportingStreamDecoder -> Any) -> Any
     with_stream_decoder self encoding on_problems action = self.stream_resource . with java_stream->
-        java_charset = encoding.to_java_charset
-        results = Encoding_Utils.with_stream_decoder java_stream java_charset action
+        results = Encoding_Utils.with_stream_decoder java_stream encoding.to_java_charset_or_null action
         problems = Vector.from_polyglot_array results.problems . map decoding_problem->
             Encoding_Error.Error decoding_problem.message
         on_problems.attach_problems_after results.result problems

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/Output_Stream.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/Output_Stream.enso
@@ -15,7 +15,7 @@ from project.System.Input_Stream import close_stream
 polyglot java import java.io.ByteArrayOutputStream
 polyglot java import java.io.OutputStream as Java_Output_Stream
 polyglot java import org.enso.base.encoding.ReportingStreamEncoder
-polyglot java import org.enso.base.Encoding_Utils
+polyglot java import org.enso.base.encoding.Encoding_Utils
 
 ## PRIVATE
    An output stream, allowing for interactive writing of contents.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Delimited/Delimited_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Delimited/Delimited_Format.enso
@@ -112,10 +112,9 @@ type Delimited_Format
 
     ## PRIVATE
        Clone the instance with some properties overridden.
-       Note: This function is internal until such time as Atom cloning with modification is built into Enso.
     clone : Quote_Style -> Headers -> (Data_Formatter|Nothing) -> Boolean -> (Text|Nothing) -> (Text|Nothing) -> Delimited_Format
-    clone self (quote_style=self.quote_style) (headers:Headers=self.headers) (value_formatter=self.value_formatter) (keep_invalid_rows=self.keep_invalid_rows) (line_endings=self.line_endings) (comment_character=self.comment_character) =
-        Delimited_Format.Delimited self.delimiter self.encoding self.skip_rows self.row_limit quote_style headers value_formatter keep_invalid_rows line_endings comment_character
+    clone self (encoding:Encoding = self.encoding) (quote_style=self.quote_style) (headers:Headers=self.headers) (value_formatter=self.value_formatter) (keep_invalid_rows=self.keep_invalid_rows) (line_endings=self.line_endings) (comment_character=self.comment_character) =
+        Delimited_Format.Delimited self.delimiter encoding self.skip_rows self.row_limit quote_style headers value_formatter keep_invalid_rows line_endings comment_character
 
     ## ICON data_input
        Create a clone of this with specified quoting settings.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Delimited/Delimited_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Delimited/Delimited_Format.enso
@@ -59,7 +59,7 @@ type Delimited_Format
     @delimiter make_file_read_delimiter_selector
     @encoding Encoding.default_widget
     @row_limit Rows_To_Read.default_widget
-    Delimited (delimiter:Text=',') (encoding:Encoding=Encoding.Default) (skip_rows:Integer=0) (row_limit:Rows_To_Read=..All_Rows) (quote_style:Quote_Style=Quote_Style.With_Quotes) (headers:Headers=Headers.Detect_Headers) (value_formatter:Data_Formatter|Nothing=Data_Formatter.Value) (keep_invalid_rows:Boolean=True) (line_endings:Line_Ending_Style|Infer=Infer) (comment_character:Text|Nothing=Nothing)
+    Delimited (delimiter:Text=',') (encoding:Encoding=Encoding.default) (skip_rows:Integer=0) (row_limit:Rows_To_Read=..All_Rows) (quote_style:Quote_Style=Quote_Style.With_Quotes) (headers:Headers=Headers.Detect_Headers) (value_formatter:Data_Formatter|Nothing=Data_Formatter.Value) (keep_invalid_rows:Boolean=True) (line_endings:Line_Ending_Style|Infer=Infer) (comment_character:Text|Nothing=Nothing)
 
     ## PRIVATE
        ADVANCED
@@ -68,7 +68,7 @@ type Delimited_Format
     for_read file:File_Format_Metadata =
         content_type = file.interpret_content_type
         from_content_type = content_type.if_not_nothing <|
-            encoding = content_type.encoding.if_nothing Encoding.Default
+            encoding = content_type.encoding.if_nothing Encoding.default
             case content_type.base_type of
                 "text/csv" -> Delimited_Format.Delimited ',' encoding
                 "text/tab-separated-values" -> Delimited_Format.Delimited '\t' encoding
@@ -178,7 +178,7 @@ Delimited_Format.from (that : JS_Object) =
     encoding_name = that.get "encoding"
     encoding = encoding_name
         . if_not_nothing (Encoding.from_name encoding_name)
-        . if_nothing Encoding.Default
+        . if_nothing Encoding.default
     headers = that.get "headers" |> parse_boolean_with_infer "headers"
     skip_rows = that.get "skip_rows" . if_nothing 0
     row_limit = that.get "row_limit"

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Delimited/Delimited_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Delimited/Delimited_Format.enso
@@ -59,7 +59,7 @@ type Delimited_Format
     @delimiter make_file_read_delimiter_selector
     @encoding Encoding.default_widget
     @row_limit Rows_To_Read.default_widget
-    Delimited (delimiter:Text=',') (encoding:Encoding=Encoding.utf_8) (skip_rows:Integer=0) (row_limit:Rows_To_Read=..All_Rows) (quote_style:Quote_Style=Quote_Style.With_Quotes) (headers:Headers=Headers.Detect_Headers) (value_formatter:Data_Formatter|Nothing=Data_Formatter.Value) (keep_invalid_rows:Boolean=True) (line_endings:Line_Ending_Style|Infer=Infer) (comment_character:Text|Nothing=Nothing)
+    Delimited (delimiter:Text=',') (encoding:Encoding=Encoding.Default) (skip_rows:Integer=0) (row_limit:Rows_To_Read=..All_Rows) (quote_style:Quote_Style=Quote_Style.With_Quotes) (headers:Headers=Headers.Detect_Headers) (value_formatter:Data_Formatter|Nothing=Data_Formatter.Value) (keep_invalid_rows:Boolean=True) (line_endings:Line_Ending_Style|Infer=Infer) (comment_character:Text|Nothing=Nothing)
 
     ## PRIVATE
        ADVANCED
@@ -68,7 +68,7 @@ type Delimited_Format
     for_read file:File_Format_Metadata =
         content_type = file.interpret_content_type
         from_content_type = content_type.if_not_nothing <|
-            encoding = content_type.encoding.if_nothing Encoding.utf_8
+            encoding = content_type.encoding.if_nothing Encoding.Default
             case content_type.base_type of
                 "text/csv" -> Delimited_Format.Delimited ',' encoding
                 "text/tab-separated-values" -> Delimited_Format.Delimited '\t' encoding
@@ -179,7 +179,7 @@ Delimited_Format.from (that : JS_Object) =
     encoding_name = that.get "encoding"
     encoding = encoding_name
         . if_not_nothing (Encoding.from_name encoding_name)
-        . if_nothing Encoding.utf_8
+        . if_nothing Encoding.Default
     headers = that.get "headers" |> parse_boolean_with_infer "headers"
     skip_rows = that.get "skip_rows" . if_nothing 0
     row_limit = that.get "row_limit"

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Delimited_Reader.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Delimited_Reader.enso
@@ -147,7 +147,11 @@ type Detected_File_Metadata
        - ends_with_newline: specifies if the last line ends with a line
          separator that is consistent with the detected one.
        - has_any_content: specifies if the file contains any content.
-    Value (headers : Detected_Headers | Nothing) (line_separator : Text|Nothing) (ends_with_newline : Boolean) (has_any_content : Boolean)
+       - detected_encoding: the encoding that would be used if reading the file.
+         If a specific encoding was set in the configuration, it will be passed
+         unchanged. However, if `Encoding.Default` was used, this will contain
+         the detected encoding that was chosen.
+    Value (headers : Detected_Headers | Nothing) (line_separator : Text|Nothing) (ends_with_newline : Boolean) (has_any_content : Boolean) (detected_encoding : Encoding)
 
 ## PRIVATE
    Reads the beginning of the file to detect the existing headers and column
@@ -156,13 +160,14 @@ detect_metadata : File -> Delimited_Format -> Detected_File_Metadata
 detect_metadata file format =
     on_problems = Problem_Behavior.Ignore
     result = handle_io_exception file <| Illegal_Argument.handle_java_exception <| handle_parsing_failure <| handle_parsing_exception <|
-        trailing_line_separator = newline_at_eof file format.encoding
-        has_trailing_line_separator = trailing_line_separator.is_nothing.not
         file.with_input_stream [File_Access.Read] stream->
-            stream.with_stream_decoder format.encoding on_problems java_reader->
+            stream.with_stream_decoder format.encoding on_problems stream_decoder->
+                detected_encoding = Encoding.from_java_charset stream_decoder.getCharset
+                trailing_line_separator = newline_at_eof file detected_encoding
+                has_trailing_line_separator = trailing_line_separator.is_nothing.not
                 ## We don't need to close this one, as closing the parent stream
                    will suffice.
-                newline_detecting_reader = NewlineDetector.new java_reader
+                newline_detecting_reader = NewlineDetector.new stream_decoder
                 ## We use the default `max_columns` setting. If we want to be able to
                    read files with unlimited column limits (risking OutOfMemory
                    exceptions), we can catch the exception indicating the limit has been
@@ -188,9 +193,11 @@ detect_metadata file format =
                     True -> line_separator_from_parser
                     False -> trailing_line_separator
                 has_any_content = metadata.hasAnyContent
-                Detected_File_Metadata.Value headers effective_line_separator has_trailing_line_separator has_any_content
+                Detected_File_Metadata.Value headers effective_line_separator has_trailing_line_separator has_any_content detected_encoding
     result.catch File_Error error-> case error of
-        File_Error.Not_Found _ -> Detected_File_Metadata.Value Nothing Nothing False False
+        File_Error.Not_Found _ ->
+            default_encoding = if format.encoding == Encoding.Default then Encoding.utf_8 else format.encoding
+            Detected_File_Metadata.Value Nothing Nothing False False default_encoding
         _ -> Error.throw error
 
 ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Delimited_Reader.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Delimited_Reader.enso
@@ -149,7 +149,7 @@ type Detected_File_Metadata
        - has_any_content: specifies if the file contains any content.
        - detected_encoding: the encoding that would be used if reading the file.
          If a specific encoding was set in the configuration, it will be passed
-         unchanged. However, if `Encoding.Default` was used, this will contain
+         unchanged. However, if `Encoding.default` was used, this will contain
          the detected encoding that was chosen.
     Value (headers : Detected_Headers | Nothing) (line_separator : Text|Nothing) (ends_with_newline : Boolean) (has_any_content : Boolean) (detected_encoding : Encoding)
 
@@ -196,7 +196,7 @@ detect_metadata file format =
                 Detected_File_Metadata.Value headers effective_line_separator has_trailing_line_separator has_any_content detected_encoding
     result.catch File_Error error-> case error of
         File_Error.Not_Found _ ->
-            default_encoding = if format.encoding == Encoding.Default then Encoding.utf_8 else format.encoding
+            default_encoding = if format.encoding == Encoding.default then Encoding.utf_8 else format.encoding
             Detected_File_Metadata.Value Nothing Nothing False False default_encoding
         _ -> Error.throw error
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Delimited_Writer.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Delimited_Writer.enso
@@ -40,10 +40,14 @@ write_file : Table -> Delimited_Format -> Writable_File -> Existing_File_Behavio
 write_file table format (file : Writable_File) on_existing_file match_columns on_problems =
     case on_existing_file of
         Existing_File_Behavior.Append ->
+            # The default encoding may be used for detecting the effective encoding in append mode.
             append_to_file table format file match_columns on_problems
         _ ->
+            # Override Encoding.Default to be just UTF-8 for writing a new file.
+            amended_format = if format.encoding != Encoding.Default then format else
+                format.clone encoding=Encoding.utf_8
             file.write_handling_dry_run on_existing_file effective_file-> stream->
-                r = write_to_stream table format stream on_problems related_file=effective_file
+                r = write_to_stream table amended_format stream on_problems related_file=effective_file
                 r.if_not_error effective_file
 
 ## PRIVATE
@@ -92,13 +96,14 @@ append_to_local_file table format (file : File) match_columns on_problems =
                     ColumnMapper.mapColumnsByPosition table.java_table column_count
         reordered_table = Table.Value reordered_java_table
         writing_new_file = preexisting_headers == Nothing
-        amended_format = case writing_new_file && (should_write_headers format.headers) of
+        amended_format_1 = case writing_new_file && (should_write_headers format.headers) of
             True -> format.with_headers
             False -> format.without_headers
+        amended_format_2 = amended_format_1.clone encoding=metadata.detected_encoding
         needs_leading_newline =
             metadata.has_any_content && metadata.ends_with_newline.not
         (file : Writable_File).write_handling_dry_run Existing_File_Behavior.Append effective_file-> stream->
-            r = write_to_stream reordered_table amended_format stream on_problems related_file=effective_file separator_override=effective_line_separator needs_leading_newline=needs_leading_newline
+            r = write_to_stream reordered_table amended_format_2 stream on_problems related_file=effective_file separator_override=effective_line_separator needs_leading_newline=needs_leading_newline
             r.if_not_error effective_file
 
 ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Delimited_Writer.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Delimited_Writer.enso
@@ -43,8 +43,8 @@ write_file table format (file : Writable_File) on_existing_file match_columns on
             # The default encoding may be used for detecting the effective encoding in append mode.
             append_to_file table format file match_columns on_problems
         _ ->
-            # Override Encoding.Default to be just UTF-8 for writing a new file.
-            amended_format = if format.encoding != Encoding.Default then format else
+            # Override Encoding.default to be just UTF-8 for writing a new file.
+            amended_format = if format.encoding != Encoding.default then format else
                 format.clone encoding=Encoding.utf_8
             file.write_handling_dry_run on_existing_file effective_file-> stream->
                 r = write_to_stream table amended_format stream on_problems related_file=effective_file

--- a/std-bits/base/src/main/java/org/enso/base/encoding/DecodingProblem.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/DecodingProblem.java
@@ -1,6 +1,3 @@
 package org.enso.base.encoding;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 public record DecodingProblem(String message) {}

--- a/std-bits/base/src/main/java/org/enso/base/encoding/DecodingProblem.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/DecodingProblem.java
@@ -7,6 +7,6 @@ public record DecodingProblem(int count, List<Integer> examplePositions) {
   public String getMessage() {
     String positions = examplePositions.stream().map(Object::toString).collect(Collectors.joining(", "));
     String suffix = count > examplePositions.size() ? ", ..." : "";
-    return "Failed to decode " + count + " code units (at positions " + positions + suffix + ").";
+    return "Failed to decode " + count + " code units (at positions: " + positions + suffix + ").";
   }
 }

--- a/std-bits/base/src/main/java/org/enso/base/encoding/DecodingProblem.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/DecodingProblem.java
@@ -1,0 +1,12 @@
+package org.enso.base.encoding;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record DecodingProblem(int count, List<Integer> examplePositions) {
+  public String getMessage() {
+    String positions = examplePositions.stream().map(Object::toString).collect(Collectors.joining(", "));
+    String suffix = count > examplePositions.size() ? ", ..." : "";
+    return "Failed to decode " + count + " code units (at positions " + positions + suffix + ").";
+  }
+}

--- a/std-bits/base/src/main/java/org/enso/base/encoding/DecodingProblem.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/DecodingProblem.java
@@ -3,10 +3,4 @@ package org.enso.base.encoding;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public record DecodingProblem(int count, List<Integer> examplePositions) {
-  public String getMessage() {
-    String positions = examplePositions.stream().map(Object::toString).collect(Collectors.joining(", "));
-    String suffix = count > examplePositions.size() ? ", ..." : "";
-    return "Failed to decode " + count + " code units (at positions: " + positions + suffix + ").";
-  }
-}
+public record DecodingProblem(String message) {}

--- a/std-bits/base/src/main/java/org/enso/base/encoding/DecodingProblemAggregator.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/DecodingProblemAggregator.java
@@ -15,9 +15,10 @@ public class DecodingProblemAggregator {
     baseProblems.add(new DecodingProblem(message));
   }
 
-  /** Sets message prefix for the problem indicating characters that could not be decoded.
-   * <p>
-   * This prefix can be used to provide additional context for the problem.
+  /**
+   * Sets message prefix for the problem indicating characters that could not be decoded.
+   *
+   * <p>This prefix can be used to provide additional context for the problem.
    */
   public void setInvalidCharacterErrorPrefix(String prefix) {
     invalidCharacterErrorPrefix = prefix;
@@ -35,9 +36,19 @@ public class DecodingProblemAggregator {
       return null;
     }
 
-    String positions = invalidUnitExamplePositions.stream().map(Object::toString).collect(Collectors.joining(", "));
+    String positions =
+        invalidUnitExamplePositions.stream()
+            .map(Object::toString)
+            .collect(Collectors.joining(", "));
     String suffix = invalidUnitCount > invalidUnitExamplePositions.size() ? ", ..." : "";
-    return new DecodingProblem(invalidCharacterErrorPrefix + "Failed to decode " + invalidUnitCount + " code units (at positions: " + positions + suffix + ").");
+    return new DecodingProblem(
+        invalidCharacterErrorPrefix
+            + "Failed to decode "
+            + invalidUnitCount
+            + " code units (at positions: "
+            + positions
+            + suffix
+            + ").");
   }
 
   public List<DecodingProblem> summarize() {

--- a/std-bits/base/src/main/java/org/enso/base/encoding/DecodingProblemAggregator.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/DecodingProblemAggregator.java
@@ -1,0 +1,51 @@
+package org.enso.base.encoding;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DecodingProblemAggregator {
+  private final List<DecodingProblem> baseProblems = new ArrayList<>();
+  private int invalidUnitCount = 0;
+  private String invalidCharacterErrorPrefix = "";
+  private final List<Integer> invalidUnitExamplePositions = new ArrayList<>();
+  private static final int MAX_ENCODING_ISSUE_EXAMPLES = 3;
+
+  public void reportOtherProblem(String message) {
+    baseProblems.add(new DecodingProblem(message));
+  }
+
+  /** Sets message prefix for the problem indicating characters that could not be decoded.
+   * <p>
+   * This prefix can be used to provide additional context for the problem.
+   */
+  public void setInvalidCharacterErrorPrefix(String prefix) {
+    invalidCharacterErrorPrefix = prefix;
+  }
+
+  public void reportInvalidCharacterProblem(int position) {
+    invalidUnitCount++;
+    if (invalidUnitExamplePositions.size() < MAX_ENCODING_ISSUE_EXAMPLES) {
+      invalidUnitExamplePositions.add(position);
+    }
+  }
+
+  private DecodingProblem summarizeInvalidCharacterProblems() {
+    if (invalidUnitCount == 0) {
+      return null;
+    }
+
+    String positions = invalidUnitExamplePositions.stream().map(Object::toString).collect(Collectors.joining(", "));
+    String suffix = invalidUnitCount > invalidUnitExamplePositions.size() ? ", ..." : "";
+    return new DecodingProblem(invalidCharacterErrorPrefix + "Failed to decode " + invalidUnitCount + " code units (at positions: " + positions + suffix + ").");
+  }
+
+  public List<DecodingProblem> summarize() {
+    var problems = new ArrayList<>(baseProblems);
+    var invalidCharacterProblem = summarizeInvalidCharacterProblems();
+    if (invalidCharacterProblem != null) {
+      problems.add(invalidCharacterProblem);
+    }
+    return problems;
+  }
+}

--- a/std-bits/base/src/main/java/org/enso/base/encoding/EncodingRepresentation.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/EncodingRepresentation.java
@@ -7,9 +7,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 public abstract sealed class EncodingRepresentation {
-  private static final byte[] UTF_8_BOM = new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
-  private static final byte[] UTF_16_BE_BOM = new byte[]{(byte) 0xFE, (byte) 0xFF};
-  private static final byte[] UTF_16_LE_BOM = new byte[]{(byte) 0xFF, (byte) 0xFE};
+  private static final byte[] UTF_8_BOM = new byte[] {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
+  private static final byte[] UTF_16_BE_BOM = new byte[] {(byte) 0xFE, (byte) 0xFF};
+  private static final byte[] UTF_16_LE_BOM = new byte[] {(byte) 0xFF, (byte) 0xFE};
 
   private static byte[] peekStream(BufferedInputStream stream, int n) throws IOException {
     byte[] buffer = new byte[n];
@@ -60,15 +60,22 @@ public abstract sealed class EncodingRepresentation {
   /**
    * Detects the effective charset based on initial data present in the stream.
    *
-   * @param stream the stream to detect the charset for. Initial BOM header may be deliberately consumed by this method, so that it is ignored for further processing. No other data is consumed (we only peek).
-   * @param problemAggregator an aggregator to report any warnings about detected encoding, or report context metadata to be used in future errors reported by other components.
+   * @param stream the stream to detect the charset for. Initial BOM header may be deliberately
+   *     consumed by this method, so that it is ignored for further processing. No other data is
+   *     consumed (we only peek).
+   * @param problemAggregator an aggregator to report any warnings about detected encoding, or
+   *     report context metadata to be used in future errors reported by other components.
    */
-  public abstract Charset detectCharset(BufferedInputStream stream, DecodingProblemAggregator problemAggregator) throws IOException;
+  public abstract Charset detectCharset(
+      BufferedInputStream stream, DecodingProblemAggregator problemAggregator) throws IOException;
 
   private static final class Default extends EncodingRepresentation {
-    // Note: the Windows-1252 fallback is not implemented as part of this detection - it only allows to distinguish UTF BOMs.
+    // Note: the Windows-1252 fallback is not implemented as part of this detection - it only allows
+    // to distinguish UTF BOMs.
     @Override
-    public Charset detectCharset(BufferedInputStream stream, DecodingProblemAggregator problemAggregator) throws IOException {
+    public Charset detectCharset(
+        BufferedInputStream stream, DecodingProblemAggregator problemAggregator)
+        throws IOException {
       byte[] beginning = peekStream(stream, 3);
       if (startsWith(beginning, UTF_8_BOM)) {
         skipStream(stream, UTF_8_BOM.length);
@@ -94,7 +101,9 @@ public abstract sealed class EncodingRepresentation {
     }
 
     @Override
-    public Charset detectCharset(BufferedInputStream stream, DecodingProblemAggregator problemAggregator) throws IOException {
+    public Charset detectCharset(
+        BufferedInputStream stream, DecodingProblemAggregator problemAggregator)
+        throws IOException {
       // We ignore the stream as we just use the provided encoding as-is.
       return charset;
     }
@@ -103,6 +112,7 @@ public abstract sealed class EncodingRepresentation {
   private static final class UnicodeHandlingBOM extends EncodingRepresentation {
     private final Charset charset;
     private final byte[] expectedBOM;
+
     // TODO unexpected BOM
 
     private UnicodeHandlingBOM(Charset charset, byte[] expectedBOM) {
@@ -111,7 +121,9 @@ public abstract sealed class EncodingRepresentation {
     }
 
     private static boolean isSupported(Charset charset) {
-      return charset.equals(StandardCharsets.UTF_8) || charset.equals(StandardCharsets.UTF_16BE) || charset.equals(StandardCharsets.UTF_16LE);
+      return charset.equals(StandardCharsets.UTF_8)
+          || charset.equals(StandardCharsets.UTF_16BE)
+          || charset.equals(StandardCharsets.UTF_16LE);
     }
 
     private static UnicodeHandlingBOM fromUnicodeCharset(Charset charset) {
@@ -127,7 +139,9 @@ public abstract sealed class EncodingRepresentation {
     }
 
     @Override
-    public Charset detectCharset(BufferedInputStream stream, DecodingProblemAggregator problemAggregator) throws IOException {
+    public Charset detectCharset(
+        BufferedInputStream stream, DecodingProblemAggregator problemAggregator)
+        throws IOException {
       byte[] beginning = peekStream(stream, expectedBOM.length);
       if (startsWith(beginning, expectedBOM)) {
         skipStream(stream, expectedBOM.length);

--- a/std-bits/base/src/main/java/org/enso/base/encoding/EncodingRepresentation.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/EncodingRepresentation.java
@@ -1,0 +1,117 @@
+package org.enso.base.encoding;
+
+import java.io.BufferedInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+public abstract sealed class EncodingRepresentation {
+  private static final byte[] UTF_8_BOM = new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
+  private static final byte[] UTF_16_BE_BOM = new byte[]{(byte) 0xFE, (byte) 0xFF};
+  private static final byte[] UTF_16_LE_BOM = new byte[]{(byte) 0xFF, (byte) 0xFE};
+
+  private static byte[] peekStream(BufferedInputStream stream, int n) throws IOException {
+    byte[] buffer = new byte[n];
+    stream.mark(n + 1);
+    int offset = 0;
+    while (offset < n) {
+      int read = stream.read(buffer, offset, n - offset);
+      if (read == -1) {
+        break;
+      }
+      offset += read;
+    }
+    stream.reset();
+    return buffer;
+  }
+
+  private static void skipStream(BufferedInputStream stream, int n) throws IOException {
+    try {
+      stream.skipNBytes(n);
+    } catch (EOFException eofException) {
+      // ignore early EOF
+    }
+  }
+
+  private static boolean startsWith(byte[] buffer, byte[] prefix) {
+    if (buffer.length < prefix.length) {
+      return false;
+    }
+
+    for (int i = 0; i < prefix.length; i++) {
+      if (buffer[i] != prefix[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public static EncodingRepresentation fromCharset(Charset charset) {
+    if (charset == null) {
+      return new Default();
+    } else if (charset.equals(StandardCharsets.UTF_8) || charset.equals(StandardCharsets.UTF_16BE) || charset.equals(StandardCharsets.UTF_16LE)) {
+      return new UnicodeHandlingBOM(charset);
+    } else {
+      return new Other(charset);
+    }
+  }
+
+  /**
+   * Detects the effective charset based on initial data present in the stream.
+   * <p>
+   * Initial BOM header may be consumed by this method, so that it is ignored for further processing.
+   */
+  public abstract Charset detectCharset(BufferedInputStream stream) throws IOException;
+
+  private static final class Default extends EncodingRepresentation {
+    // Note: the Windows-1252 fallback is not implemented as part of this detection - it only allows to distinguish UTF BOMs.
+    @Override
+    public Charset detectCharset(BufferedInputStream stream) throws IOException {
+      byte[] beginning = peekStream(stream, 3);
+      if (startsWith(beginning, UTF_8_BOM)) {
+        skipStream(stream, UTF_8_BOM.length);
+        return StandardCharsets.UTF_8;
+      } else if (startsWith(beginning, UTF_16_BE_BOM)) {
+        skipStream(stream, UTF_16_BE_BOM.length);
+        return StandardCharsets.UTF_16BE;
+      } else if (startsWith(beginning, UTF_16_LE_BOM)) {
+        skipStream(stream, UTF_16_LE_BOM.length);
+        return StandardCharsets.UTF_16LE;
+      } else {
+        // If no BOM we fallback to UTF-8.
+        return StandardCharsets.UTF_8;
+      }
+    }
+  }
+
+  private static final class Other extends EncodingRepresentation {
+    private final Charset charset;
+
+    public Other(Charset charset) {
+      this.charset = charset;
+    }
+
+    @Override
+    public Charset detectCharset(BufferedInputStream stream) throws IOException {
+      // We ignore the stream as we just use the provided encoding as-is.
+      return charset;
+    }
+  }
+
+  private static final class UnicodeHandlingBOM extends EncodingRepresentation {
+    private Charset charset;
+    // TODO BOM
+
+    private UnicodeHandlingBOM(Charset charset) {
+      this.charset = charset;
+    }
+
+
+    @Override
+    public Charset detectCharset(BufferedInputStream stream) throws IOException {
+      // TODO check BOM match and report problems
+      return charset;
+    }
+  }
+}

--- a/std-bits/base/src/main/java/org/enso/base/encoding/EncodingRepresentation.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/EncodingRepresentation.java
@@ -79,17 +79,25 @@ public abstract sealed class EncodingRepresentation {
       byte[] beginning = peekStream(stream, 3);
       if (startsWith(beginning, UTF_8_BOM)) {
         skipStream(stream, UTF_8_BOM.length);
+        notifyContextAboutAssumedEncoding(problemAggregator, "UTF-8");
         return StandardCharsets.UTF_8;
       } else if (startsWith(beginning, UTF_16_BE_BOM)) {
         skipStream(stream, UTF_16_BE_BOM.length);
+        notifyContextAboutAssumedEncoding(problemAggregator, "UTF-16 BE");
         return StandardCharsets.UTF_16BE;
       } else if (startsWith(beginning, UTF_16_LE_BOM)) {
         skipStream(stream, UTF_16_LE_BOM.length);
+        notifyContextAboutAssumedEncoding(problemAggregator, "UTF-16 LE");
         return StandardCharsets.UTF_16LE;
       } else {
         // If no BOM we fallback to UTF-8.
         return StandardCharsets.UTF_8;
       }
+    }
+
+    private static void notifyContextAboutAssumedEncoding(DecodingProblemAggregator problemAggregator, String encodingName) {
+      String prefix = "An " + encodingName + " BOM was detected, so " + encodingName + " encoding has been assumed, but some characters seem invalid: ";
+      problemAggregator.setInvalidCharacterErrorPrefix(prefix);
     }
   }
 

--- a/std-bits/base/src/main/java/org/enso/base/encoding/EncodingRepresentation.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/EncodingRepresentation.java
@@ -59,15 +59,16 @@ public abstract sealed class EncodingRepresentation {
 
   /**
    * Detects the effective charset based on initial data present in the stream.
-   * <p>
-   * Initial BOM header may be consumed by this method, so that it is ignored for further processing.
+   *
+   * @param stream the stream to detect the charset for. Initial BOM header may be deliberately consumed by this method, so that it is ignored for further processing. No other data is consumed (we only peek).
+   * @param problemAggregator an aggregator to report any warnings about detected encoding, or report context metadata to be used in future errors reported by other components.
    */
-  public abstract Charset detectCharset(BufferedInputStream stream) throws IOException;
+  public abstract Charset detectCharset(BufferedInputStream stream, DecodingProblemAggregator problemAggregator) throws IOException;
 
   private static final class Default extends EncodingRepresentation {
     // Note: the Windows-1252 fallback is not implemented as part of this detection - it only allows to distinguish UTF BOMs.
     @Override
-    public Charset detectCharset(BufferedInputStream stream) throws IOException {
+    public Charset detectCharset(BufferedInputStream stream, DecodingProblemAggregator problemAggregator) throws IOException {
       byte[] beginning = peekStream(stream, 3);
       if (startsWith(beginning, UTF_8_BOM)) {
         skipStream(stream, UTF_8_BOM.length);
@@ -93,7 +94,7 @@ public abstract sealed class EncodingRepresentation {
     }
 
     @Override
-    public Charset detectCharset(BufferedInputStream stream) throws IOException {
+    public Charset detectCharset(BufferedInputStream stream, DecodingProblemAggregator problemAggregator) throws IOException {
       // We ignore the stream as we just use the provided encoding as-is.
       return charset;
     }
@@ -126,7 +127,7 @@ public abstract sealed class EncodingRepresentation {
     }
 
     @Override
-    public Charset detectCharset(BufferedInputStream stream) throws IOException {
+    public Charset detectCharset(BufferedInputStream stream, DecodingProblemAggregator problemAggregator) throws IOException {
       byte[] beginning = peekStream(stream, expectedBOM.length);
       if (startsWith(beginning, expectedBOM)) {
         skipStream(stream, expectedBOM.length);

--- a/std-bits/base/src/main/java/org/enso/base/encoding/Encoding_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/Encoding_Utils.java
@@ -9,7 +9,6 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
-import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
@@ -155,13 +154,8 @@ public class Encoding_Utils {
     EncodingRepresentation representation = EncodingRepresentation.fromCharset(charset);
     // This may also advance the stream past the BOM
     Charset detectedCharset = representation.detectCharset(bufferedStream, problemAggregator);
-    CharsetDecoder decoder =
-        detectedCharset
-            .newDecoder()
-            .onMalformedInput(CodingErrorAction.REPORT)
-            .onUnmappableCharacter(CodingErrorAction.REPORT)
-            .reset();
-    return new ReportingStreamDecoder(bufferedStream, decoder, problemAggregator, pollSafepoints);
+    return new ReportingStreamDecoder(
+        bufferedStream, detectedCharset, problemAggregator, pollSafepoints);
   }
 
   /**

--- a/std-bits/base/src/main/java/org/enso/base/encoding/Encoding_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/Encoding_Utils.java
@@ -128,7 +128,7 @@ public class Encoding_Utils {
         }
         // read is already polling safepoints so we don't have to
         n = decoder.read(out);
-      } while (n > 0);
+      } while (n >= 0);
     } catch (IOException e) {
       throw new IllegalStateException("Unexpected exception: " + e.getMessage(), e);
     }

--- a/std-bits/base/src/main/java/org/enso/base/encoding/Encoding_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/Encoding_Utils.java
@@ -1,4 +1,4 @@
-package org.enso.base;
+package org.enso.base.encoding;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -15,8 +15,8 @@ import java.util.Arrays;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
-import org.enso.base.encoding.ReportingStreamDecoder;
-import org.enso.base.encoding.ReportingStreamEncoder;
+
+import org.enso.base.WithProblems;
 import org.enso.base.text.ResultWithWarnings;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;

--- a/std-bits/base/src/main/java/org/enso/base/encoding/Encoding_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/Encoding_Utils.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
-
 import org.enso.base.WithProblems;
 import org.enso.base.text.ResultWithWarnings;
 import org.graalvm.polyglot.Context;
@@ -116,7 +115,8 @@ public class Encoding_Utils {
     try {
       decoder = create_stream_decoder(inputStream, charset, problemAggregator, true);
     } catch (IOException e) {
-      throw new IllegalStateException("Unexpected IO exception in internal code: " + e.getMessage(), e);
+      throw new IllegalStateException(
+          "Unexpected IO exception in internal code: " + e.getMessage(), e);
     }
 
     CharBuffer out = CharBuffer.allocate((int) (bytes.length * decoder.averageCharsPerByte()));
@@ -137,14 +137,20 @@ public class Encoding_Utils {
     return new WithProblems<>(out.toString(), problemAggregator.summarize());
   }
 
-  /** Creates a new instance of {@code ReportingStreamDecoder} decoding a given charset.
+  /**
+   * Creates a new instance of {@code ReportingStreamDecoder} decoding a given charset.
    *
    * @param stream the input stream to decode
    * @param charset the character set to use for decoding, use {@code null} to try auto-detection
-   * @param pollSafepoints whether to poll for safepoints during decoding.
-   *                       This should be true if the decoding will run on the main thread, and false otherwise.
+   * @param pollSafepoints whether to poll for safepoints during decoding. This should be true if
+   *     the decoding will run on the main thread, and false otherwise.
    */
-  private static ReportingStreamDecoder create_stream_decoder(InputStream stream, Charset charset, DecodingProblemAggregator problemAggregator, boolean pollSafepoints) throws IOException {
+  private static ReportingStreamDecoder create_stream_decoder(
+      InputStream stream,
+      Charset charset,
+      DecodingProblemAggregator problemAggregator,
+      boolean pollSafepoints)
+      throws IOException {
     BufferedInputStream bufferedStream = new BufferedInputStream(stream);
     EncodingRepresentation representation = EncodingRepresentation.fromCharset(charset);
     // This may also advance the stream past the BOM
@@ -169,7 +175,8 @@ public class Encoding_Utils {
       throws IOException {
     DecodingProblemAggregator problemAggregator = new DecodingProblemAggregator();
     Value result;
-    ReportingStreamDecoder decoder = create_stream_decoder(stream, charset, problemAggregator, false);
+    ReportingStreamDecoder decoder =
+        create_stream_decoder(stream, charset, problemAggregator, false);
     try (decoder) {
       result = action.apply(decoder);
     }

--- a/std-bits/base/src/main/java/org/enso/base/encoding/Encoding_Utils.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/Encoding_Utils.java
@@ -169,6 +169,11 @@ public class Encoding_Utils {
    *
    * <p>It returns the result returned from the executed action and any encoding problems that
    * occurred when processing it.
+   *
+   * @param stream the input stream to decode
+   * @param charset the character set to use for decoding, use {@code null} to try auto-detection
+   * @param action the action to run with the created decoder
+   * @return the result of the action and any problems that occurred during decoding
    */
   public static WithProblems<Value, DecodingProblem> with_stream_decoder(
       InputStream stream, Charset charset, Function<ReportingStreamDecoder, Value> action)

--- a/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamDecoder.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamDecoder.java
@@ -9,17 +9,17 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
+
 import org.graalvm.polyglot.Context;
 
 /**
- * A {@code Reader} which takes an {@code InputStream} and decodes it using a provided {@code
- * CharsetDecoder}.
+ * A {@code Reader} which takes an {@code InputStream} and decodes it using a provided {@code CharsetDecoder}.
  *
  * <p>Functionally, it should be equivalent to {@code java.io.InputStreamReader}. The major
- * difference is that this class allows more granular reporting of decoding issues - instead of just
- * replacing malformed characters with a replacement or failing at the first error, it allows to
- * both perform the replacements but also remember the positions at which the problems occurred and
- * then return a bulk report of places where the issues have been encountered.
+ * difference is that this class allows more granular reporting of decoding issues - instead of just replacing malformed
+ * characters with a replacement or failing at the first error, it allows to both perform the replacements but also
+ * remember the positions at which the problems occurred and then return a bulk report of places where the issues have
+ * been encountered.
  */
 public class ReportingStreamDecoder extends Reader {
   private final DecodingProblemAggregator problemAggregator;
@@ -43,18 +43,16 @@ public class ReportingStreamDecoder extends Reader {
   }
 
   /**
-   * Currently there is no easy way to check if a Context is available in the current thread and we
-   * can use safepoints or not. The issue tracking this feature can be found at: <a
-   * href="https://github.com/oracle/graal/issues/6931">oracle/graal#6931</a>. For the time being we
-   * just manually let the user consciously choose if safepoints shall be enabled or not, based on
-   * the user's knowledge if the thread running the decoding will run on the main thread or in the
-   * background.
+   * Currently there is no easy way to check if a Context is available in the current thread and we can use safepoints
+   * or not. The issue tracking this feature can be found at: <a
+   * href="https://github.com/oracle/graal/issues/6931">oracle/graal#6931</a>. For the time being we just manually let
+   * the user consciously choose if safepoints shall be enabled or not, based on the user's knowledge if the thread
+   * running the decoding will run on the main thread or in the background.
    */
   private final boolean pollSafepoints;
 
   /**
-   * The buffer keeping any characters that have already been decoded, but not consumed by the user
-   * yet.
+   * The buffer keeping any characters that have already been decoded, but not consumed by the user yet.
    *
    * <p>Between the calls to read, it satisfies the invariant that it is in 'reading' mode.
    */
@@ -72,14 +70,13 @@ public class ReportingStreamDecoder extends Reader {
    * Indicates the amount of bytes consumed before the start of the current input buffer.
    *
    * <p>The input buffer is reset many times and so its position will only indicate the bytes that
-   * were consumed in some current iteration, this counter allows us to compute the overall amount
-   * of bytes.
+   * were consumed in some current iteration, this counter allows us to compute the overall amount of bytes.
    */
   private int inputBytesConsumedBeforeCurrentBuffer = 0;
 
   /**
-   * We re-use the work array between calls to read, to avoid re-allocating it on each call. It is
-   * only re-allocated if it needs to be bigger than before.
+   * We re-use the work array between calls to read, to avoid re-allocating it on each call. It is only re-allocated if
+   * it needs to be bigger than before.
    */
   private byte[] workArray = null;
 
@@ -92,16 +89,15 @@ public class ReportingStreamDecoder extends Reader {
   private boolean eof = false;
 
   /**
-   * Specifies if the last {@code decoder.decode} call with the {@code endOfInput = true} argument
-   * has been made.
+   * Specifies if the last {@code decoder.decode} call with the {@code endOfInput = true} argument has been made.
    */
   private boolean hadEofDecodeCall = false;
 
   /**
    * Our read method tries to read as many characters as requested by the user.
    *
-   * <p>It will never return 0 - it will either return a positive number of characters read, or -1
-   * if EOF was reached.
+   * <p>Unless user specifically asks for `len == 0`, it will never return 0 otherwise - it will either return a
+   * positive number of characters read, or -1 if EOF was reached.
    */
   @Override
   public int read(char[] cbuf, int off, int len) throws IOException {
@@ -183,7 +179,7 @@ public class ReportingStreamDecoder extends Reader {
       len -= toTransfer;
       assert (len == 0 || !outputBuffer.hasRemaining())
           : "if we did not yet satisfy the request, the output buffer should have been completely"
-              + " emptied";
+          + " emptied";
 
       // No safepoint is needed here, because the inner loop of `runDecoderOnInputBuffer` already
       // polls.
@@ -202,12 +198,11 @@ public class ReportingStreamDecoder extends Reader {
   }
 
   /**
-   * Ensures that the output buffer is allocated and has enough space to fit as many characters as
-   * we expect to read.
+   * Ensures that the output buffer is allocated and has enough space to fit as many characters as we expect to read.
    *
    * <p>When this method is called, the output buffer should not have any remaining cached
-   * characters and should be in read mode. After the method returns, the output buffer is empty and
-   * left in write mode.
+   * characters and should be in read mode. After the method returns, the output buffer is empty and left in write
+   * mode.
    */
   private void prepareOutputBuffer(int expectedCharactersCount) {
     assert outputBuffer == null || !outputBuffer.hasRemaining();
@@ -247,7 +242,9 @@ public class ReportingStreamDecoder extends Reader {
     inputBuffer.flip();
   }
 
-  /** Allocates or grows the work array so that it can fit the amount of bytes we want to read. */
+  /**
+   * Allocates or grows the work array so that it can fit the amount of bytes we want to read.
+   */
   private void ensureWorkArraySize(int bytesToRead) {
     if (workArray == null || workArray.length < bytesToRead) {
       workArray = new byte[bytesToRead];
@@ -255,12 +252,12 @@ public class ReportingStreamDecoder extends Reader {
   }
 
   /**
-   * Runs the decoder on the input buffer, transferring any decoded characters to the output buffer
-   * and growing it as needed.
+   * Runs the decoder on the input buffer, transferring any decoded characters to the output buffer and growing it as
+   * needed.
    *
    * <p>Even if the input buffer does not contain any remaining data, but end-of-input has been
-   * encountered, one decoding step is performed to satisfy the contract of the decoder (it requires
-   * one final call to the decode method signifying end of input).
+   * encountered, one decoding step is performed to satisfy the contract of the decoder (it requires one final call to
+   * the decode method signifying end of input).
    *
    * <p>After this call, the output buffer is in reading mode. If EOF on the input was encountered,
    * all buffered input has been consumed after this method finishes.
@@ -307,15 +304,16 @@ public class ReportingStreamDecoder extends Reader {
     outputBuffer.flip();
   }
 
-  /** Returns the amount of bytes that have already been consumed by the decoder. */
+  /**
+   * Returns the amount of bytes that have already been consumed by the decoder.
+   */
   private int getCurrentInputPosition() {
     if (inputBuffer == null) return 0;
     return inputBytesConsumedBeforeCurrentBuffer + inputBuffer.position();
   }
 
   /**
-   * Flushes the decoder, growing the buffer as needed to ensure that any additional output from the
-   * decoder fits.
+   * Flushes the decoder, growing the buffer as needed to ensure that any additional output from the decoder fits.
    */
   private void flushDecoder() {
     while (decoder.flush(outputBuffer) == CoderResult.OVERFLOW) {
@@ -324,8 +322,7 @@ public class ReportingStreamDecoder extends Reader {
   }
 
   /**
-   * Ensures that the input buffer has enough free space to hold the number of bytes that we want to
-   * read.
+   * Ensures that the input buffer has enough free space to hold the number of bytes that we want to read.
    *
    * <p>If necessary, the buffer is allocated or grown, preserving any existing content.
    *

--- a/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamDecoder.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamDecoder.java
@@ -9,17 +9,17 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
-
 import org.graalvm.polyglot.Context;
 
 /**
- * A {@code Reader} which takes an {@code InputStream} and decodes it using a provided {@code CharsetDecoder}.
+ * A {@code Reader} which takes an {@code InputStream} and decodes it using a provided {@code
+ * CharsetDecoder}.
  *
  * <p>Functionally, it should be equivalent to {@code java.io.InputStreamReader}. The major
- * difference is that this class allows more granular reporting of decoding issues - instead of just replacing malformed
- * characters with a replacement or failing at the first error, it allows to both perform the replacements but also
- * remember the positions at which the problems occurred and then return a bulk report of places where the issues have
- * been encountered.
+ * difference is that this class allows more granular reporting of decoding issues - instead of just
+ * replacing malformed characters with a replacement or failing at the first error, it allows to
+ * both perform the replacements but also remember the positions at which the problems occurred and
+ * then return a bulk report of places where the issues have been encountered.
  */
 public class ReportingStreamDecoder extends Reader {
   private final DecodingProblemAggregator problemAggregator;
@@ -43,16 +43,18 @@ public class ReportingStreamDecoder extends Reader {
   }
 
   /**
-   * Currently there is no easy way to check if a Context is available in the current thread and we can use safepoints
-   * or not. The issue tracking this feature can be found at: <a
-   * href="https://github.com/oracle/graal/issues/6931">oracle/graal#6931</a>. For the time being we just manually let
-   * the user consciously choose if safepoints shall be enabled or not, based on the user's knowledge if the thread
-   * running the decoding will run on the main thread or in the background.
+   * Currently there is no easy way to check if a Context is available in the current thread and we
+   * can use safepoints or not. The issue tracking this feature can be found at: <a
+   * href="https://github.com/oracle/graal/issues/6931">oracle/graal#6931</a>. For the time being we
+   * just manually let the user consciously choose if safepoints shall be enabled or not, based on
+   * the user's knowledge if the thread running the decoding will run on the main thread or in the
+   * background.
    */
   private final boolean pollSafepoints;
 
   /**
-   * The buffer keeping any characters that have already been decoded, but not consumed by the user yet.
+   * The buffer keeping any characters that have already been decoded, but not consumed by the user
+   * yet.
    *
    * <p>Between the calls to read, it satisfies the invariant that it is in 'reading' mode.
    */
@@ -70,13 +72,14 @@ public class ReportingStreamDecoder extends Reader {
    * Indicates the amount of bytes consumed before the start of the current input buffer.
    *
    * <p>The input buffer is reset many times and so its position will only indicate the bytes that
-   * were consumed in some current iteration, this counter allows us to compute the overall amount of bytes.
+   * were consumed in some current iteration, this counter allows us to compute the overall amount
+   * of bytes.
    */
   private int inputBytesConsumedBeforeCurrentBuffer = 0;
 
   /**
-   * We re-use the work array between calls to read, to avoid re-allocating it on each call. It is only re-allocated if
-   * it needs to be bigger than before.
+   * We re-use the work array between calls to read, to avoid re-allocating it on each call. It is
+   * only re-allocated if it needs to be bigger than before.
    */
   private byte[] workArray = null;
 
@@ -89,15 +92,16 @@ public class ReportingStreamDecoder extends Reader {
   private boolean eof = false;
 
   /**
-   * Specifies if the last {@code decoder.decode} call with the {@code endOfInput = true} argument has been made.
+   * Specifies if the last {@code decoder.decode} call with the {@code endOfInput = true} argument
+   * has been made.
    */
   private boolean hadEofDecodeCall = false;
 
   /**
    * Our read method tries to read as many characters as requested by the user.
    *
-   * <p>Unless user specifically asks for `len == 0`, it will never return 0 otherwise - it will either return a
-   * positive number of characters read, or -1 if EOF was reached.
+   * <p>Unless user specifically asks for `len == 0`, it will never return 0 otherwise - it will
+   * either return a positive number of characters read, or -1 if EOF was reached.
    */
   @Override
   public int read(char[] cbuf, int off, int len) throws IOException {
@@ -179,7 +183,7 @@ public class ReportingStreamDecoder extends Reader {
       len -= toTransfer;
       assert (len == 0 || !outputBuffer.hasRemaining())
           : "if we did not yet satisfy the request, the output buffer should have been completely"
-          + " emptied";
+              + " emptied";
 
       // No safepoint is needed here, because the inner loop of `runDecoderOnInputBuffer` already
       // polls.
@@ -198,11 +202,12 @@ public class ReportingStreamDecoder extends Reader {
   }
 
   /**
-   * Ensures that the output buffer is allocated and has enough space to fit as many characters as we expect to read.
+   * Ensures that the output buffer is allocated and has enough space to fit as many characters as
+   * we expect to read.
    *
    * <p>When this method is called, the output buffer should not have any remaining cached
-   * characters and should be in read mode. After the method returns, the output buffer is empty and left in write
-   * mode.
+   * characters and should be in read mode. After the method returns, the output buffer is empty and
+   * left in write mode.
    */
   private void prepareOutputBuffer(int expectedCharactersCount) {
     assert outputBuffer == null || !outputBuffer.hasRemaining();
@@ -242,9 +247,7 @@ public class ReportingStreamDecoder extends Reader {
     inputBuffer.flip();
   }
 
-  /**
-   * Allocates or grows the work array so that it can fit the amount of bytes we want to read.
-   */
+  /** Allocates or grows the work array so that it can fit the amount of bytes we want to read. */
   private void ensureWorkArraySize(int bytesToRead) {
     if (workArray == null || workArray.length < bytesToRead) {
       workArray = new byte[bytesToRead];
@@ -252,12 +255,12 @@ public class ReportingStreamDecoder extends Reader {
   }
 
   /**
-   * Runs the decoder on the input buffer, transferring any decoded characters to the output buffer and growing it as
-   * needed.
+   * Runs the decoder on the input buffer, transferring any decoded characters to the output buffer
+   * and growing it as needed.
    *
    * <p>Even if the input buffer does not contain any remaining data, but end-of-input has been
-   * encountered, one decoding step is performed to satisfy the contract of the decoder (it requires one final call to
-   * the decode method signifying end of input).
+   * encountered, one decoding step is performed to satisfy the contract of the decoder (it requires
+   * one final call to the decode method signifying end of input).
    *
    * <p>After this call, the output buffer is in reading mode. If EOF on the input was encountered,
    * all buffered input has been consumed after this method finishes.
@@ -304,16 +307,15 @@ public class ReportingStreamDecoder extends Reader {
     outputBuffer.flip();
   }
 
-  /**
-   * Returns the amount of bytes that have already been consumed by the decoder.
-   */
+  /** Returns the amount of bytes that have already been consumed by the decoder. */
   private int getCurrentInputPosition() {
     if (inputBuffer == null) return 0;
     return inputBytesConsumedBeforeCurrentBuffer + inputBuffer.position();
   }
 
   /**
-   * Flushes the decoder, growing the buffer as needed to ensure that any additional output from the decoder fits.
+   * Flushes the decoder, growing the buffer as needed to ensure that any additional output from the
+   * decoder fits.
    */
   private void flushDecoder() {
     while (decoder.flush(outputBuffer) == CoderResult.OVERFLOW) {
@@ -322,7 +324,8 @@ public class ReportingStreamDecoder extends Reader {
   }
 
   /**
-   * Ensures that the input buffer has enough free space to hold the number of bytes that we want to read.
+   * Ensures that the input buffer has enough free space to hold the number of bytes that we want to
+   * read.
    *
    * <p>If necessary, the buffer is allocated or grown, preserving any existing content.
    *

--- a/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamDecoder.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamDecoder.java
@@ -32,6 +32,10 @@ public class ReportingStreamDecoder extends Reader {
     this.pollSafepoints = pollSafepoints;
   }
 
+  float averageCharsPerByte() {
+    return decoder.averageCharsPerByte();
+  }
+
   private final BufferedInputStream bufferedInputStream;
   private final CharsetDecoder decoder;
 
@@ -140,7 +144,7 @@ public class ReportingStreamDecoder extends Reader {
     outputBuffer.get(cbuf, off, toTransfer);
     readBytes += toTransfer;
 
-    // If we did not read any new bytes in the call that reachedn EOF, we return EOF immediately
+    // If we did not read any new bytes in the call that reached EOF, we return EOF immediately
     // instead of postponing to the next call. Returning 0 at the end was causing division by zero
     // in the CSV parser.
     return (eof && readBytes <= 0) ? -1 : readBytes;

--- a/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamDecoder.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamDecoder.java
@@ -1,6 +1,6 @@
 package org.enso.base.encoding;
 
-import static org.enso.base.Encoding_Utils.INVALID_CHARACTER;
+import static org.enso.base.encoding.Encoding_Utils.INVALID_CHARACTER;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -13,7 +13,6 @@ import java.nio.charset.CoderResult;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.enso.base.Encoding_Utils;
 
 /**
  * A {@code Reader} which takes an {@code InputStream} and decodes it using a provided {@code

--- a/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamDecoder.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamDecoder.java
@@ -26,8 +26,8 @@ import org.graalvm.polyglot.Context;
  * then return a bulk report of places where the issues have been encountered.
  */
 public class ReportingStreamDecoder extends Reader {
-  public ReportingStreamDecoder(InputStream stream, CharsetDecoder decoder, boolean pollSafepoints) {
-    bufferedInputStream = new BufferedInputStream(stream);
+  public ReportingStreamDecoder(BufferedInputStream stream, CharsetDecoder decoder, boolean pollSafepoints) {
+    bufferedInputStream = stream;
     this.decoder = decoder;
     this.pollSafepoints = pollSafepoints;
   }

--- a/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamDecoder.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamDecoder.java
@@ -1,6 +1,6 @@
 package org.enso.base.encoding;
 
-import org.graalvm.polyglot.Context;
+import static org.enso.base.encoding.Encoding_Utils.INVALID_CHARACTER;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -9,8 +9,7 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
-
-import static org.enso.base.encoding.Encoding_Utils.INVALID_CHARACTER;
+import org.graalvm.polyglot.Context;
 
 /**
  * A {@code Reader} which takes an {@code InputStream} and decodes it using a provided {@code
@@ -31,19 +30,25 @@ public class ReportingStreamDecoder extends Reader {
 
   private final BufferedInputStream bufferedInputStream;
   private final CharsetDecoder decoder;
-  public ReportingStreamDecoder(BufferedInputStream stream, CharsetDecoder decoder, DecodingProblemAggregator problemAggregator, boolean pollSafepoints) {
+
+  public ReportingStreamDecoder(
+      BufferedInputStream stream,
+      CharsetDecoder decoder,
+      DecodingProblemAggregator problemAggregator,
+      boolean pollSafepoints) {
     bufferedInputStream = stream;
     this.decoder = decoder;
     this.problemAggregator = problemAggregator;
     this.pollSafepoints = pollSafepoints;
   }
 
-
   /**
-   * Currently there is no easy way to check if a Context is available in the current thread and we can use safepoints or not.
-   * The issue tracking this feature can be found at: <a href="https://github.com/oracle/graal/issues/6931">oracle/graal#6931</a>.
-   * For the time being we just manually let the user consciously choose if safepoints shall be enabled or not, based on
-   * the user's knowledge if the thread running the decoding will run on the main thread or in the background.
+   * Currently there is no easy way to check if a Context is available in the current thread and we
+   * can use safepoints or not. The issue tracking this feature can be found at: <a
+   * href="https://github.com/oracle/graal/issues/6931">oracle/graal#6931</a>. For the time being we
+   * just manually let the user consciously choose if safepoints shall be enabled or not, based on
+   * the user's knowledge if the thread running the decoding will run on the main thread or in the
+   * background.
    */
   private final boolean pollSafepoints;
 

--- a/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamDecoder.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamDecoder.java
@@ -125,7 +125,8 @@ public class ReportingStreamDecoder extends Reader {
       return readBytes;
     }
 
-    // If we are at EOF and no cached characters were available, we return -1 indicating that there will be no more data.
+    // If we are at EOF and no cached characters were available, we return -1 indicating that there
+    // will be no more data.
     if (eof && readBytes == 0) {
       // If the previous invocation of read set the EOF flag, it must have finished the decoding
       // process and flushed the decoder, so the input buffer must have been consumed in whole.
@@ -153,7 +154,8 @@ public class ReportingStreamDecoder extends Reader {
     // instead of postponing to the next call. Returning 0 at the end was causing division by zero
     // in the CSV parser.
     int returnValue = (eof && readBytes <= 0) ? -1 : readBytes;
-    assert (returnValue >= 0 || hadEofDecodeCall) : "decoding should have been finalized before returning EOF";
+    assert (returnValue >= 0 || hadEofDecodeCall)
+        : "decoding should have been finalized before returning EOF";
     return returnValue;
   }
 

--- a/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamDecoder.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamDecoder.java
@@ -7,8 +7,10 @@ import java.io.IOException;
 import java.io.Reader;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
+import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
 import org.graalvm.polyglot.Context;
 
 /**
@@ -30,14 +32,25 @@ public class ReportingStreamDecoder extends Reader {
 
   private final BufferedInputStream bufferedInputStream;
   private final CharsetDecoder decoder;
+  private final Charset charset;
+
+  public Charset getCharset() {
+    return charset;
+  }
 
   public ReportingStreamDecoder(
       BufferedInputStream stream,
-      CharsetDecoder decoder,
+      Charset charset,
       DecodingProblemAggregator problemAggregator,
       boolean pollSafepoints) {
     bufferedInputStream = stream;
-    this.decoder = decoder;
+    this.charset = charset;
+    this.decoder =
+        charset
+            .newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT)
+            .reset();
     this.problemAggregator = problemAggregator;
     this.pollSafepoints = pollSafepoints;
   }

--- a/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamEncoder.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamEncoder.java
@@ -11,7 +11,7 @@ import java.nio.charset.CoderResult;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.enso.base.Encoding_Utils;
+
 import org.graalvm.polyglot.Context;
 
 /**

--- a/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamEncoder.java
+++ b/std-bits/base/src/main/java/org/enso/base/encoding/ReportingStreamEncoder.java
@@ -11,7 +11,6 @@ import java.nio.charset.CoderResult;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.graalvm.polyglot.Context;
 
 /**

--- a/test/Base_Tests/src/Data/Json_Spec.enso
+++ b/test/Base_Tests/src/Data/Json_Spec.enso
@@ -117,6 +117,12 @@ add_specs suite_builder =
             '{"type":"Date_Time","constructor":"new","year":2023,"month":9,"day":29,"hour":11,"second":52}'.should_parse_as (JS_Object.from_pairs [["type", "Date_Time"], ["constructor", "new"], ["year", 2023], ["month", 9], ["day", 29], ["hour", 11], ["second", 52]])
             '{"type":"Date_Time","constructor":"new","year":2023,"month":9,"day":29,"hour":11,"minute":52,"nanosecond":572104300}'.should_parse_as (JS_Object.from_pairs [["type", "Date_Time"], ["constructor", "new"], ["year", 2023], ["month", 9], ["day", 29], ["hour", 11], ["minute", 52], ["nanosecond", 572104300]])
 
+        group_builder.specify "should be able to read a JSON file with a BOM indicating UTF-16 encoding" <|
+            bytes = [-1, -2] + ("{}".bytes Encoding.utf_16_le)
+            f = File.create_temporary_file "json-with-bom" ".json"
+            bytes.write_bytes f . should_succeed
+            f.read . should_be_a JS_Object
+
     suite_builder.group "JSON Serialization" group_builder->
         group_builder.specify "should print JSON structures to valid json" <|
             "0".should_render_itself

--- a/test/Base_Tests/src/Data/Json_Spec.enso
+++ b/test/Base_Tests/src/Data/Json_Spec.enso
@@ -118,7 +118,8 @@ add_specs suite_builder =
             '{"type":"Date_Time","constructor":"new","year":2023,"month":9,"day":29,"hour":11,"minute":52,"nanosecond":572104300}'.should_parse_as (JS_Object.from_pairs [["type", "Date_Time"], ["constructor", "new"], ["year", 2023], ["month", 9], ["day", 29], ["hour", 11], ["minute", 52], ["nanosecond", 572104300]])
 
         group_builder.specify "should be able to read a JSON file with a BOM indicating UTF-16 encoding" <|
-            bytes = [-1, -2] + ("{}".bytes Encoding.utf_16_le)
+            utf_16_le_bom = [-1, -2]
+            bytes = utf_16_le_bom + ("{}".bytes Encoding.utf_16_le)
             f = File.create_temporary_file "json-with-bom" ".json"
             bytes.write_bytes f . should_succeed
             f.read . should_be_a JS_Object

--- a/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
+++ b/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
@@ -288,7 +288,7 @@ add_specs suite_builder =
 
             txt = Text.from_bytes [-1] Encoding.utf_16_be Problem_Behavior.Report_Warning
             w = Problems.expect_only_warning Encoding_Error txt
-            w.to_display_text . should_equal "Failed to decode 1 code units (at positions: 0)."
+            w.to_display_text . should_contain "Failed to decode 1 code units (at positions: 0)."
 
     suite_builder.group "UTF_16 LittleEndian" group_builder->
         kshi = '\u0915\u094D\u0937\u093F'
@@ -324,7 +324,7 @@ add_specs suite_builder =
 
             txt = Text.from_bytes [-1] Encoding.utf_16_le Problem_Behavior.Report_Warning
             w = Problems.expect_only_warning Encoding_Error txt
-            w.to_display_text . should_equal "Failed to decode 1 code units (at positions: 0)."
+            w.to_display_text . should_contain "Failed to decode 1 code units (at positions: 0)."
 
     suite_builder.group "codepoints" group_builder->
         facepalm = '\u{1F926}\u{1F3FC}\u200D\u2642\uFE0F'

--- a/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
+++ b/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
@@ -204,7 +204,7 @@ add_specs suite_builder =
         group_builder.specify "Invalid UTF-8 should raise a problem when decoding via encoding" <|
             action = Text.from_bytes invalid_utf_8 Encoding.utf_8 on_problems=_
             tester result = result . should_equal invalid
-            problems = [Encoding_Error.Error "Encoding issues at 19."]
+            problems = [Encoding_Error.Error "Failed to decode 1 code units (at positions: 19)."]
             Problems.test_problem_handling action problems tester
 
         group_builder.specify "Invalid UTF-8 should raise a problem when decoding (error by default)" <|

--- a/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
+++ b/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
@@ -69,6 +69,7 @@ add_specs suite_builder =
             Problems.get_attached_warnings default_warning . should_contain_the_same_elements_as problems
 
     suite_builder.group "Default Encoding" group_builder->
+        pending_fallback = "Fallback to Windows-1252 is not implemented yet."
         group_builder.specify "should try reading as UTF-8 by default" <|
             bytes = [65, -60, -123, -60, -103]
             #        A   ą          ę
@@ -112,7 +113,7 @@ add_specs suite_builder =
             bytes.length . should_equal 4*2
             txt.length . should_equal 3
 
-        group_builder.specify "falls back to Windows-1252 if invalid Unicode is detected and no BOM" <|
+        group_builder.specify "falls back to Windows-1252 if invalid Unicode is detected and no BOM" pending=pending_fallback <|
             # These are not valid bytes for UTF-8
             bytes = [-30, -55, -1]
             Text.from_bytes bytes Encoding.utf_8 . should_fail_with Encoding_Error
@@ -147,6 +148,7 @@ add_specs suite_builder =
             empty.should_equal ""
             Problems.assume_no_problems empty
 
+        group_builder.specify "should work on 0 or 1 byte input (TODO merge with above)" pending=pending_fallback <|
             txt = Text.from_bytes [-1] Encoding.Default Problem_Behavior.Report_Warning
             txt.should_equal 'ÿ'
             # No problems, as falling back to Windows-1252.
@@ -161,11 +163,13 @@ add_specs suite_builder =
             f.read . should_equal "Aąę"
 
             # UTF-16 LE BOM
-            ([-1, -2] + [65, 0, 5, 1, 25, 1]).write f Existing_File_Behavior.Overwrite . should_succeed
+            ([-1, -2] + [65, 0, 5, 1, 25, 1]).write_bytes f Existing_File_Behavior.Overwrite . should_succeed
             f.read . should_equal "Aąę"
 
+        group_builder.specify "Default Encoding heuristics also work in File.read (TODO merge with above)" pending=pending_fallback <|
+            f = File.create_temporary_file "utf-heuristics" ".txt"
             # Fallback to Windows-1252
-            ([-30, -55, -1]).write f Existing_File_Behavior.Overwrite . should_succeed
+            ([-30, -55, -1]).write_bytes f Existing_File_Behavior.Overwrite . should_succeed
             f.read . should_equal "âÉÿ"
 
         group_builder.specify "cannot be used in Write operations" <|

--- a/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
+++ b/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
@@ -68,6 +68,18 @@ add_specs suite_builder =
             default_warning.should_equal invalid_ascii_out
             Problems.get_attached_warnings default_warning . should_contain_the_same_elements_as problems
 
+    suite_builder.group "Default Encoding" group_builder->
+        group_builder.specify "should try reading as UTF-8 by default" <|
+            Error.throw "TODO"
+        group_builder.specify "does not keep the UTF-8 BOM within the decoded contents" <|
+            Error.throw "TODO"
+        group_builder.specify "switches to UTF-16 if BOM is detected" <|
+            Error.throw "TODO"
+        group_builder.specify "falls back to Windows-1252 if invalid Unicode is detected and no BOM" <|
+            Error.throw "TODO"
+        group_builder.specify "reports failed characters if invalid Unicode but a BOM was present" <|
+            Error.throw "TODO"
+
     suite_builder.group "UTF_8" group_builder->
         kshi = '\u0915\u094D\u0937\u093F'
         kshi_utf_8 = [-32, -92, -107, -32, -91, -115, -32, -92, -73, -32, -92, -65]
@@ -195,4 +207,3 @@ main filter=Nothing =
     suite = Test.build suite_builder->
         add_specs suite_builder
     suite.run_with_filter filter
-

--- a/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
+++ b/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
@@ -72,13 +72,13 @@ add_specs suite_builder =
         group_builder.specify "should try reading as UTF-8 by default" <|
             bytes = [65, -60, -123, -60, -103]
             #        A   ą          ę
-            Text.from_bytes bytes Encoding.Default . should_equal 'Aąę'
+            Text.from_bytes bytes Encoding.Default . should_equal "Aąę"
 
         group_builder.specify "does not keep the UTF-8 BOM within the decoded contents" <|
             bytes = [-17, -69, -65] + [65, -60, -123, -60, -103]
             #       BOM                A   ą          ę
             txt = Text.from_bytes bytes Encoding.Default
-            txt.should_equal 'Aąę'
+            txt.should_equal "Aąę"
             # The BOM is lost:
             txt.utf_8 . should_equal [65, -60, -123, -60, -103]
 
@@ -92,11 +92,11 @@ add_specs suite_builder =
         group_builder.specify "switches to UTF-16 if BOM is detected" <|
             bytes_le = [-1, -2] + [65, 0, 5, 1, 25, 1]
             #           BOM        A      ą     ę
-            Text.from_bytes bytes_le Encoding.Default . should_equal 'Aąę'
+            Text.from_bytes bytes_le Encoding.Default . should_equal "Aąę"
 
             bytes_be = [-2, -1] + [0, 65, 1, 5, 1, 25]
             #           BOM        A      ą     ę
-            Text.from_bytes bytes_be Encoding.Default . should_equal 'Aąę'
+            Text.from_bytes bytes_be Encoding.Default . should_equal "Aąę"
 
             # If there is no BOM the bytes are interpreted as UTF-8 and the result is no longer the expected text:
             bytes_without_bom = [65, 0, 5, 1, 25, 1]
@@ -121,11 +121,45 @@ add_specs suite_builder =
             Text.from_bytes bytes Encoding.Default . should_equal 'âÉÿ'
 
         group_builder.specify "reports failed characters if invalid Unicode but a BOM was present" <|
-            Error.throw "TODO"
+            ## Without a BOM this would fallback, but as we see the BOM it seems most likely this is a Unicode stream,
+               but it contains some errors.
+               This is based on assumption that it is very unlikely for a valid Windows-1252 encoded file to start with
+               characters `ï»¿` or `ÿþ` (the Win-1252 representations of UTF-8 and UTF-16 BOMs).
+            bytes1 = [-17, -69, -65] + [-30, -55, -1]
+            r1 = Text.from_bytes bytes_8 Encoding.Default Problem_Behavior.Report_Warning
+            r1.should_equal "���"
+            # We've got 3 characters that failed to decode. The BOM is stripped, so it is not counted.
+            r1.length . should_equal 3
+            # TODO maybe some other type instead of Encoding_Error should be used for these?
+            w1 = Problems.expect_only_warning Encoding_Error r1
+            w1.to_display_text . should_contain "BOM"
 
-        group_builder.specify "also works in File.read" <|
-            # TODO also include a test for Delimited somewhere
-            Error.throw "TODO"
+            bytes2 = [-2, -1] + [0, 65, -1]
+            r2 = Text.from_bytes bytes_16_le Encoding.Default Problem_Behavior.Report_Warning
+            r2.should_equal "A�"
+            # We have 1 correct character (A), one invalid character (odd number of bytes). The BOM is not counted.
+            r2.length . should_equal 2
+            w2 = Problems.expect_only_warning Encoding_Error r2
+            w2.to_display_text . should_contain "BOM"
+
+        group_builder.specify "Default Encoding heuristics also work in File.read" <|
+            f = File.create_temporary_file "utf-heuristics" ".txt"
+
+            # UTF-8 BOM
+            ([-17, -69, -65] + [65, -60, -123, -60, -103]).write_bytes f Existing_File_Behavior.Overwrite . should_succeed
+            f.read Encoding.Default . should_equal "Aąę"
+
+            # UTF-16 LE BOM
+            ([-1, -2] + [65, 0, 5, 1, 25, 1]).write f Existing_File_Behavior.Overwrite . should_succeed
+            f.read Encoding.Default . should_equal "Aąę"
+
+            # Fallback to Windows-1252
+            ([-30, -55, -1]).write f Existing_File_Behavior.Overwrite . should_succeed
+            f.read Encoding.Default . should_equal "âÉÿ"
+
+        group_builder.specify "cannot be used in Write operations" <|
+            r = "foo".write (enso_project.data / "transient" / "my-file.txt") Encoding.Default
+            r.should_fail_with Illegal_Argument
 
     suite_builder.group "UTF_8" group_builder->
         kshi = '\u0915\u094D\u0937\u093F'
@@ -191,6 +225,7 @@ add_specs suite_builder =
         group_builder.specify "should report a clearer error when UTF-16 BOM is encountered" <|
             bytes = [-2, -1] + [0, 65, 1, 5, 1, 25]
             as_utf = Text.from_bytes bytes Encoding.utf_8 Problem_Behavior.Report_Warning
+            # TODO maybe some other type instead of Encoding_Error should be used for these?
             w = Problems.expect_only_warning Encoding_Error as_utf
             w.to_display_text . should_contain "BOM"
             w.to_display_text . should_contain "UTF-16"

--- a/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
+++ b/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
@@ -51,12 +51,12 @@ add_specs suite_builder =
         group_builder.specify "Invalid ASCII should raise a problem when decoding (error by default)" <|
             action = Text.from_bytes invalid_ascii Encoding.ascii on_problems=_
             tester result = result . should_equal invalid
-            problems = [Encoding_Error.Error "Encoding issues at 12."]
+            problems = [Encoding_Error.Error "Failed to decode 1 code units (at positions: 12)."]
             Problems.test_problem_handling action problems tester
 
             default_error = Text.from_bytes invalid_ascii Encoding.ascii
             default_error.should_fail_with Encoding_Error
-            default_error.catch.message . should_equal "Encoding issues at 12."
+            default_error.catch.message . should_equal "Failed to decode 1 code units (at positions: 12)."
 
         group_builder.specify "Invalid ASCII should raise a problem when encoding (warning by default)" <|
             action = invalid.bytes Encoding.ascii on_problems=_
@@ -210,12 +210,12 @@ add_specs suite_builder =
         group_builder.specify "Invalid UTF-8 should raise a problem when decoding (error by default)" <|
             action = Text.from_utf_8 invalid_utf_8 on_problems=_
             tester result = result . should_equal invalid
-            problems = [Encoding_Error.Error "Encoding issues at 19."]
+            problems = [Encoding_Error.Error "Failed to decode 1 code units (at positions: 19)."]
             Problems.test_problem_handling action problems tester
 
             default_error = Text.from_utf_8 invalid_utf_8
             default_error.should_fail_with Encoding_Error
-            default_error.catch.message . should_equal "Encoding issues at 19."
+            default_error.catch.message . should_equal "Failed to decode 1 code units (at positions: 19)."
 
         group_builder.specify "should strip the initial BOM, but not subsequent repetitions of it" <|
             bytes = [-17, -69, -65] + [-17, -69, -65] + [65] + [-17, -69, -65]
@@ -314,7 +314,7 @@ add_specs suite_builder =
         group_builder.specify "Invalid Windows-1252 should raise a problem when decoding" <|
             action = Text.from_bytes invalid_windows Encoding.windows_1252 on_problems=_
             tester result = result . should_equal invalid
-            problems = [Encoding_Error.Error "Encoding issues at 16."]
+            problems = [Encoding_Error.Error "Failed to decode 1 code units (at positions: 16)."]
             Problems.test_problem_handling action problems tester
 
         group_builder.specify "Invalid Windows-1252 should raise a problem when encoding" <|

--- a/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
+++ b/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
@@ -142,6 +142,16 @@ add_specs suite_builder =
             w2 = Problems.expect_only_warning Encoding_Error r2
             w2.to_display_text . should_contain "BOM"
 
+        group_builder.specify "should work on 0 or 1 byte input" <|
+            empty = Text.from_bytes [] Encoding.Default
+            empty.should_equal ""
+            Problems.assume_no_problems empty
+
+            txt = Text.from_bytes [-1] Encoding.Default Problem_Behavior.Report_Warning
+            txt.should_equal 'ÿ'
+            # No problems, as falling back to Windows-1252.
+            Problems.assume_no_problems txt
+
         group_builder.specify "Default Encoding heuristics also work in File.read" <|
             f = File.create_temporary_file "utf-heuristics" ".txt"
 
@@ -223,6 +233,7 @@ add_specs suite_builder =
             txt.should_equal '\ufeffA\ufeff'
             Problems.assume_no_problems txt
 
+        ## A UTF-16 BOM representation does not make sense in UTF-8, so we can detect that situation and report it.
         group_builder.specify "should report a clearer error when UTF-16 BOM is encountered" <|
             bytes = [-2, -1] + [0, 65, 1, 5, 1, 25]
             as_utf = Text.from_bytes bytes Encoding.utf_8 Problem_Behavior.Report_Warning
@@ -230,6 +241,16 @@ add_specs suite_builder =
             w = Problems.expect_only_warning Encoding_Error as_utf
             w.to_display_text . should_contain "BOM"
             w.to_display_text . should_contain "UTF-16"
+
+        group_builder.specify "should work on 0 or 1 byte input" <|
+            empty = Text.from_bytes [] Encoding.utf_8
+            empty.should_equal ""
+            Problems.assume_no_problems empty
+
+            txt = Text.from_bytes [-1] Encoding.utf_8 Problem_Behavior.Report_Warning
+            txt.should_equal '\ufffd'
+            w = Problems.expect_only_warning Encoding_Error txt
+            w.to_display_text . should_equal "Failed to decode 1 code units (at positions: 0)."
 
     suite_builder.group "UTF_16 BigEndian" group_builder->
         kshi = '\u0915\u094D\u0937\u093F'
@@ -256,6 +277,16 @@ add_specs suite_builder =
             txt.should_equal "￾A䄀"
             w = Problems.expect_only_warning Encoding_Error txt
             w.to_display_text . should_contain "BOM"
+
+        group_builder.specify "should work on 0 or 1 byte input" <|
+            empty = Text.from_bytes [] Encoding.utf_16_be
+            empty.should_equal ""
+            Problems.assume_no_problems empty
+
+            txt = Text.from_bytes [-1] Encoding.utf_16_be Problem_Behavior.Report_Warning
+            txt.should_equal '\ufffd'
+            w = Problems.expect_only_warning Encoding_Error txt
+            w.to_display_text . should_equal "Failed to decode 1 code units (at positions: 0)."
 
     suite_builder.group "UTF_16 LittleEndian" group_builder->
         kshi = '\u0915\u094D\u0937\u093F'

--- a/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
+++ b/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
@@ -10,15 +10,15 @@ polyglot java import java.lang.String as Java_String
 add_specs suite_builder =
     suite_builder.group "Encoding object" group_builder->
         group_builder.specify "Can get standard UTF encodings" <|
-            Encoding.utf_8 . should_equal (Encoding.Value "UTF-8")
-            Encoding.utf_16_le . should_equal (Encoding.Value "UTF-16LE")
-            Encoding.utf_16_be . should_equal (Encoding.Value "UTF-16BE")
-            Encoding.utf_32_le . should_equal (Encoding.Value "UTF-32LE")
-            Encoding.utf_32_be . should_equal (Encoding.Value "UTF-32BE")
+            Encoding.utf_8.character_set_name . should_equal "UTF-8"
+            Encoding.utf_16_le.character_set_name . should_equal "UTF-16LE"
+            Encoding.utf_16_be.character_set_name . should_equal "UTF-16BE"
+            Encoding.utf_32_le.character_set_name . should_equal "UTF-32LE"
+            Encoding.utf_32_be.character_set_name . should_equal "UTF-32BE"
 
         group_builder.specify "Catches invalid character sets" <|
-            invalid = Encoding.Value "NotAValidCharacterSet"
-            invalid.to_java_charset . should_fail_with Illegal_Argument
+            invalid = Encoding.from_name "NotAValidCharacterSet"
+            invalid.should_fail_with Illegal_Argument
 
         group_builder.specify "Can get full set of character sets" <|
             character_sets = Encoding.all_character_sets
@@ -73,19 +73,19 @@ add_specs suite_builder =
         group_builder.specify "should try reading as UTF-8 by default" <|
             bytes = [65, -60, -123, -60, -103]
             #        A   ą          ę
-            Text.from_bytes bytes Encoding.Default . should_equal "Aąę"
+            Text.from_bytes bytes Encoding.default . should_equal "Aąę"
 
         group_builder.specify "does not keep the UTF-8 BOM within the decoded contents" <|
             bytes = [-17, -69, -65] + [65, -60, -123, -60, -103]
             #       BOM                A   ą          ę
-            txt = Text.from_bytes bytes Encoding.Default
+            txt = Text.from_bytes bytes Encoding.default
             txt.should_equal "Aąę"
             # The BOM is lost:
             txt.utf_8 . should_equal [65, -60, -123, -60, -103]
 
         group_builder.specify "keeps the \ufeff BOM (UTF-8 variant) character if it appeared later on in the stream" <|
             bytes = [-17, -69, -65] + [-17, -69, -65]
-            txt = Text.from_bytes bytes Encoding.Default
+            txt = Text.from_bytes bytes Encoding.default
             # First BOM is stripped, the second one is kept as ZERO WIDTH NO-BREAK SPACE
             txt.should_equal '\ufeff'
             txt.length . should_equal 1
@@ -93,21 +93,21 @@ add_specs suite_builder =
         group_builder.specify "switches to UTF-16 if BOM is detected" <|
             bytes_le = [-1, -2] + [65, 0, 5, 1, 25, 1]
             #           BOM        A      ą     ę
-            Text.from_bytes bytes_le Encoding.Default . should_equal "Aąę"
+            Text.from_bytes bytes_le Encoding.default . should_equal "Aąę"
 
             bytes_be = [-2, -1] + [0, 65, 1, 5, 1, 25]
             #           BOM        A      ą     ę
-            Text.from_bytes bytes_be Encoding.Default . should_equal "Aąę"
+            Text.from_bytes bytes_be Encoding.default . should_equal "Aąę"
 
             # If there is no BOM the bytes are interpreted as UTF-8 and the result is no longer the expected text:
             bytes_without_bom = [65, 0, 5, 1, 25, 1]
-            bad_text = Text.from_bytes bytes_without_bom Encoding.Default
+            bad_text = Text.from_bytes bytes_without_bom Encoding.default
             bad_text.should_start_with 'A'
             bad_text.length . should_equal 6
 
         group_builder.specify "keeps the \ufeff BOM (UTF-16 variant) character if it appeared later on in the stream" <|
             bytes = [-1, -2] + [-1, -2] + [65, 0] + [-1, -2]
-            txt = Text.from_bytes bytes Encoding.Default
+            txt = Text.from_bytes bytes Encoding.default
             # First BOM is stripped, the second one is kept as ZERO WIDTH NO-BREAK SPACE
             txt.should_equal '\ufeffA\ufeff'
             bytes.length . should_equal 4*2
@@ -119,7 +119,7 @@ add_specs suite_builder =
             Text.from_bytes bytes Encoding.utf_8 . should_fail_with Encoding_Error
 
             # But our default encoding will just fall back to Windows-1252 and return something:
-            Text.from_bytes bytes Encoding.Default . should_equal 'âÉÿ'
+            Text.from_bytes bytes Encoding.default . should_equal 'âÉÿ'
 
         group_builder.specify "reports failed characters if invalid Unicode but a BOM was present" <|
             ## Without a BOM this would fallback, but as we see the BOM it seems most likely this is a Unicode stream,
@@ -127,7 +127,7 @@ add_specs suite_builder =
                This is based on assumption that it is very unlikely for a valid Windows-1252 encoded file to start with
                characters `ï»¿` or `ÿþ` (the Win-1252 representations of UTF-8 and UTF-16 BOMs).
             bytes1 = [-17, -69, -65] + [-30, -55, -1]
-            r1 = Text.from_bytes bytes1 Encoding.Default Problem_Behavior.Report_Warning
+            r1 = Text.from_bytes bytes1 Encoding.default Problem_Behavior.Report_Warning
             r1.should_equal "���"
             # We've got 3 characters that failed to decode. The BOM is stripped, so it is not counted.
             r1.length . should_equal 3
@@ -136,7 +136,7 @@ add_specs suite_builder =
             w1.to_display_text . should_contain "BOM"
 
             bytes2 = [-2, -1] + [0, 65, -1]
-            r2 = Text.from_bytes bytes2 Encoding.Default Problem_Behavior.Report_Warning
+            r2 = Text.from_bytes bytes2 Encoding.default Problem_Behavior.Report_Warning
             r2.should_equal "A�"
             # We have 1 correct character (A), one invalid character (odd number of bytes). The BOM is not counted.
             r2.length . should_equal 2
@@ -144,12 +144,12 @@ add_specs suite_builder =
             w2.to_display_text . should_contain "BOM"
 
         group_builder.specify "should work on 0 or 1 byte input" <|
-            empty = Text.from_bytes [] Encoding.Default
+            empty = Text.from_bytes [] Encoding.default
             empty.should_equal ""
             Problems.assume_no_problems empty
 
         group_builder.specify "should work on 0 or 1 byte input (TODO merge with above)" pending=pending_fallback <|
-            txt = Text.from_bytes [-1] Encoding.Default Problem_Behavior.Report_Warning
+            txt = Text.from_bytes [-1] Encoding.default Problem_Behavior.Report_Warning
             txt.should_equal 'ÿ'
             # No problems, as falling back to Windows-1252.
             Problems.assume_no_problems txt
@@ -159,7 +159,7 @@ add_specs suite_builder =
 
             # UTF-8 BOM
             ([-17, -69, -65] + [65, -60, -123, -60, -103]).write_bytes f Existing_File_Behavior.Overwrite . should_succeed
-            # The Encoding.Default does not have to be provided, as it should be the default
+            # The Encoding.default does not have to be provided, as it should be the default
             f.read . should_equal "Aąę"
 
             # UTF-16 LE BOM
@@ -173,7 +173,7 @@ add_specs suite_builder =
             f.read . should_equal "âÉÿ"
 
         group_builder.specify "cannot be used in Write operations" <|
-            r = "foo".write (enso_project.data / "transient" / "my-file.txt") Encoding.Default
+            r = "foo".write (enso_project.data / "transient" / "my-file.txt") Encoding.default
             r.should_fail_with Illegal_Argument
 
     suite_builder.group "UTF_8" group_builder->

--- a/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
+++ b/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
@@ -172,9 +172,9 @@ add_specs suite_builder =
             ([-30, -55, -1]).write_bytes f Existing_File_Behavior.Overwrite . should_succeed
             f.read . should_equal "âÉÿ"
 
-        group_builder.specify "cannot be used in Write operations" <|
+        group_builder.specify "should not be used in Write operations" <|
             r = "foo".write (enso_project.data / "transient" / "my-file.txt") Encoding.default
-            r.should_fail_with Illegal_Argument
+            Problems.expect_only_warning Illegal_Argument r
 
     suite_builder.group "UTF_8" group_builder->
         kshi = '\u0915\u094D\u0937\u093F'

--- a/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
+++ b/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
@@ -241,10 +241,9 @@ add_specs suite_builder =
         group_builder.specify "should report a clearer error when UTF-16 BOM is encountered" <|
             bytes = [-2, -1] + [0, 65, 1, 5, 1, 25]
             as_utf = Text.from_bytes bytes Encoding.utf_8 Problem_Behavior.Report_Warning
-            # TODO maybe some other type instead of Encoding_Error should be used for these?
-            w = Problems.expect_only_warning Encoding_Error as_utf
-            w.to_display_text . should_contain "BOM"
-            w.to_display_text . should_contain "UTF-16"
+
+            warnings = Problems.get_attached_warnings as_utf . map .to_display_text
+            warnings.find (t-> t.contains "BOM") . should_succeed
 
         group_builder.specify "should work on 0 or 1 byte input" <|
             empty = Text.from_bytes [] Encoding.utf_8
@@ -288,7 +287,6 @@ add_specs suite_builder =
             Problems.assume_no_problems empty
 
             txt = Text.from_bytes [-1] Encoding.utf_16_be Problem_Behavior.Report_Warning
-            txt.should_equal '\ufffd'
             w = Problems.expect_only_warning Encoding_Error txt
             w.to_display_text . should_equal "Failed to decode 1 code units (at positions: 0)."
 
@@ -318,6 +316,15 @@ add_specs suite_builder =
             txt.should_equal "￾䄀ԁᤁ"
             w = Problems.expect_only_warning Encoding_Error txt
             w.to_display_text . should_contain "BOM"
+
+        group_builder.specify "should work on 0 or 1 byte input" <|
+            empty = Text.from_bytes [] Encoding.utf_16_le
+            empty.should_equal ""
+            Problems.assume_no_problems empty
+
+            txt = Text.from_bytes [-1] Encoding.utf_16_le Problem_Behavior.Report_Warning
+            w = Problems.expect_only_warning Encoding_Error txt
+            w.to_display_text . should_equal "Failed to decode 1 code units (at positions: 0)."
 
     suite_builder.group "codepoints" group_builder->
         facepalm = '\u{1F926}\u{1F3FC}\u200D\u2642\uFE0F'

--- a/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
+++ b/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
@@ -311,6 +311,7 @@ add_specs suite_builder =
             txt = Text.from_bytes bytes Encoding.utf_16_le
             txt.should_equal '\ufeffA\ufeff'
 
+        # We cannot warn on UTF-8 BOM because it actually represents valid text: [-17, -69, -65] + [65] decoded as UTF-16 LE is "믯䆿".
         group_builder.specify "should warn if an inverted BOM is encountered" <|
             bytes = [-2, -1] + [0, 65, 1, 5, 1, 25]
             txt = Text.from_bytes bytes Encoding.utf_16_le Problem_Behavior.Report_Warning

--- a/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
+++ b/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
@@ -254,7 +254,7 @@ add_specs suite_builder =
             txt = Text.from_bytes [-1] Encoding.utf_8 Problem_Behavior.Report_Warning
             txt.should_equal '\ufffd'
             w = Problems.expect_only_warning Encoding_Error txt
-            w.to_display_text . should_equal "Failed to decode 1 code units (at positions: 0)."
+            w.to_display_text . should_contain "Failed to decode 1 code units (at positions: 0)."
 
     suite_builder.group "UTF_16 BigEndian" group_builder->
         kshi = '\u0915\u094D\u0937\u093F'
@@ -278,7 +278,7 @@ add_specs suite_builder =
         group_builder.specify "should warn if an inverted BOM is encountered" <|
             bytes = [-1, -2] + [0, 65, 1, 5, 1, 25]
             txt = Text.from_bytes bytes Encoding.utf_16_be Problem_Behavior.Report_Warning
-            txt.should_equal "￾A䄀"
+            txt.should_equal "￾Aąę"
             w = Problems.expect_only_warning Encoding_Error txt
             w.to_display_text . should_contain "BOM"
 
@@ -314,7 +314,7 @@ add_specs suite_builder =
         group_builder.specify "should warn if an inverted BOM is encountered" <|
             bytes = [-2, -1] + [0, 65, 1, 5, 1, 25]
             txt = Text.from_bytes bytes Encoding.utf_16_le Problem_Behavior.Report_Warning
-            txt.should_equal "￾䄀A"
+            txt.should_equal "￾䄀ԁᤁ"
             w = Problems.expect_only_warning Encoding_Error txt
             w.to_display_text . should_contain "BOM"
 

--- a/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
+++ b/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
@@ -126,7 +126,7 @@ add_specs suite_builder =
                This is based on assumption that it is very unlikely for a valid Windows-1252 encoded file to start with
                characters `ï»¿` or `ÿþ` (the Win-1252 representations of UTF-8 and UTF-16 BOMs).
             bytes1 = [-17, -69, -65] + [-30, -55, -1]
-            r1 = Text.from_bytes bytes_8 Encoding.Default Problem_Behavior.Report_Warning
+            r1 = Text.from_bytes bytes1 Encoding.Default Problem_Behavior.Report_Warning
             r1.should_equal "���"
             # We've got 3 characters that failed to decode. The BOM is stripped, so it is not counted.
             r1.length . should_equal 3
@@ -135,7 +135,7 @@ add_specs suite_builder =
             w1.to_display_text . should_contain "BOM"
 
             bytes2 = [-2, -1] + [0, 65, -1]
-            r2 = Text.from_bytes bytes_16_le Encoding.Default Problem_Behavior.Report_Warning
+            r2 = Text.from_bytes bytes2 Encoding.Default Problem_Behavior.Report_Warning
             r2.should_equal "A�"
             # We have 1 correct character (A), one invalid character (odd number of bytes). The BOM is not counted.
             r2.length . should_equal 2
@@ -147,15 +147,16 @@ add_specs suite_builder =
 
             # UTF-8 BOM
             ([-17, -69, -65] + [65, -60, -123, -60, -103]).write_bytes f Existing_File_Behavior.Overwrite . should_succeed
-            f.read Encoding.Default . should_equal "Aąę"
+            # The Encoding.Default does not have to be provided, as it should be the default
+            f.read . should_equal "Aąę"
 
             # UTF-16 LE BOM
             ([-1, -2] + [65, 0, 5, 1, 25, 1]).write f Existing_File_Behavior.Overwrite . should_succeed
-            f.read Encoding.Default . should_equal "Aąę"
+            f.read . should_equal "Aąę"
 
             # Fallback to Windows-1252
             ([-30, -55, -1]).write f Existing_File_Behavior.Overwrite . should_succeed
-            f.read Encoding.Default . should_equal "âÉÿ"
+            f.read . should_equal "âÉÿ"
 
         group_builder.specify "cannot be used in Write operations" <|
             r = "foo".write (enso_project.data / "transient" / "my-file.txt") Encoding.Default

--- a/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
+++ b/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
@@ -255,6 +255,15 @@ add_specs suite_builder =
             w = Problems.expect_only_warning Encoding_Error txt
             w.to_display_text . should_contain "Failed to decode 1 code units (at positions: 0)."
 
+        group_builder.specify "should report only a few example positions if many errors are encountered" <|
+            bytes = Vector.fill 10000 -1
+            txt = Text.from_bytes bytes Encoding.utf_8 Problem_Behavior.Report_Warning
+            txt.length . should_equal 10000
+            w = Problems.expect_only_warning Encoding_Error txt
+            w.to_display_text . should_contain "Failed to decode 10000 code units"
+            w.to_display_text . should_contain "..."
+            (w.to_display_text.length < 300).should_be_true
+
     suite_builder.group "UTF_16 BigEndian" group_builder->
         kshi = '\u0915\u094D\u0937\u093F'
         kshi_utf_16 = [9, 21, 9, 77, 9, 55, 9, 63]

--- a/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
+++ b/test/Base_Tests/src/Data/Text/Encoding_Spec.enso
@@ -70,14 +70,61 @@ add_specs suite_builder =
 
     suite_builder.group "Default Encoding" group_builder->
         group_builder.specify "should try reading as UTF-8 by default" <|
-            Error.throw "TODO"
+            bytes = [65, -60, -123, -60, -103]
+            #        A   ą          ę
+            Text.from_bytes bytes Encoding.Default . should_equal 'Aąę'
+
         group_builder.specify "does not keep the UTF-8 BOM within the decoded contents" <|
-            Error.throw "TODO"
+            bytes = [-17, -69, -65] + [65, -60, -123, -60, -103]
+            #       BOM                A   ą          ę
+            txt = Text.from_bytes bytes Encoding.Default
+            txt.should_equal 'Aąę'
+            # The BOM is lost:
+            txt.utf_8 . should_equal [65, -60, -123, -60, -103]
+
+        group_builder.specify "keeps the \ufeff BOM (UTF-8 variant) character if it appeared later on in the stream" <|
+            bytes = [-17, -69, -65] + [-17, -69, -65]
+            txt = Text.from_bytes bytes Encoding.Default
+            # First BOM is stripped, the second one is kept as ZERO WIDTH NO-BREAK SPACE
+            txt.should_equal '\ufeff'
+            txt.length . should_equal 1
+
         group_builder.specify "switches to UTF-16 if BOM is detected" <|
-            Error.throw "TODO"
+            bytes_le = [-1, -2] + [65, 0, 5, 1, 25, 1]
+            #           BOM        A      ą     ę
+            Text.from_bytes bytes_le Encoding.Default . should_equal 'Aąę'
+
+            bytes_be = [-2, -1] + [0, 65, 1, 5, 1, 25]
+            #           BOM        A      ą     ę
+            Text.from_bytes bytes_be Encoding.Default . should_equal 'Aąę'
+
+            # If there is no BOM the bytes are interpreted as UTF-8 and the result is no longer the expected text:
+            bytes_without_bom = [65, 0, 5, 1, 25, 1]
+            bad_text = Text.from_bytes bytes_without_bom Encoding.Default
+            bad_text.should_start_with 'A'
+            bad_text.length . should_equal 6
+
+        group_builder.specify "keeps the \ufeff BOM (UTF-16 variant) character if it appeared later on in the stream" <|
+            bytes = [-1, -2] + [-1, -2] + [65, 0] + [-1, -2]
+            txt = Text.from_bytes bytes Encoding.Default
+            # First BOM is stripped, the second one is kept as ZERO WIDTH NO-BREAK SPACE
+            txt.should_equal '\ufeffA\ufeff'
+            bytes.length . should_equal 4*2
+            txt.length . should_equal 3
+
         group_builder.specify "falls back to Windows-1252 if invalid Unicode is detected and no BOM" <|
-            Error.throw "TODO"
+            # These are not valid bytes for UTF-8
+            bytes = [-30, -55, -1]
+            Text.from_bytes bytes Encoding.utf_8 . should_fail_with Encoding_Error
+
+            # But our default encoding will just fall back to Windows-1252 and return something:
+            Text.from_bytes bytes Encoding.Default . should_equal 'âÉÿ'
+
         group_builder.specify "reports failed characters if invalid Unicode but a BOM was present" <|
+            Error.throw "TODO"
+
+        group_builder.specify "also works in File.read" <|
+            # TODO also include a test for Delimited somewhere
             Error.throw "TODO"
 
     suite_builder.group "UTF_8" group_builder->
@@ -135,6 +182,19 @@ add_specs suite_builder =
             default_error.should_fail_with Encoding_Error
             default_error.catch.message . should_equal "Encoding issues at 19."
 
+        group_builder.specify "should strip the initial BOM, but not subsequent repetitions of it" <|
+            bytes = [-17, -69, -65] + [-17, -69, -65] + [65] + [-17, -69, -65]
+            txt = Text.from_bytes bytes Encoding.utf_8
+            txt.should_equal '\ufeffA\ufeff'
+            Problems.assume_no_problems txt
+
+        group_builder.specify "should report a clearer error when UTF-16 BOM is encountered" <|
+            bytes = [-2, -1] + [0, 65, 1, 5, 1, 25]
+            as_utf = Text.from_bytes bytes Encoding.utf_8 Problem_Behavior.Report_Warning
+            w = Problems.expect_only_warning Encoding_Error as_utf
+            w.to_display_text . should_contain "BOM"
+            w.to_display_text . should_contain "UTF-16"
+
     suite_builder.group "UTF_16 BigEndian" group_builder->
         kshi = '\u0915\u094D\u0937\u093F'
         kshi_utf_16 = [9, 21, 9, 77, 9, 55, 9, 63]
@@ -149,6 +209,18 @@ add_specs suite_builder =
             Test.assert_no_problems result
             result . should_equal kshi
 
+        group_builder.specify "should strip the initial BOM, but not subsequent repetitions of it" <|
+            bytes = [-2, -1, -2, -1, 0, 65, -2, -1]
+            txt = Text.from_bytes bytes Encoding.utf_16_be
+            txt.should_equal '\ufeffA\ufeff'
+
+        group_builder.specify "should warn if an inverted BOM is encountered" <|
+            bytes = [-1, -2] + [0, 65, 1, 5, 1, 25]
+            txt = Text.from_bytes bytes Encoding.utf_16_be Problem_Behavior.Report_Warning
+            txt.should_equal "￾A䄀"
+            w = Problems.expect_only_warning Encoding_Error txt
+            w.to_display_text . should_contain "BOM"
+
     suite_builder.group "UTF_16 LittleEndian" group_builder->
         kshi = '\u0915\u094D\u0937\u093F'
         kshi_utf_16 = [21, 9, 77, 9, 55, 9, 63, 9]
@@ -162,6 +234,18 @@ add_specs suite_builder =
             result = Text.from_bytes kshi_utf_16 Encoding.utf_16_le
             Test.assert_no_problems result
             result . should_equal kshi
+
+        group_builder.specify "should strip the initial BOM, but not subsequent repetitions of it" <|
+            bytes = [-1, -2, -1, -2, 65, 0, -1, -2]
+            txt = Text.from_bytes bytes Encoding.utf_16_le
+            txt.should_equal '\ufeffA\ufeff'
+
+        group_builder.specify "should warn if an inverted BOM is encountered" <|
+            bytes = [-2, -1] + [0, 65, 1, 5, 1, 25]
+            txt = Text.from_bytes bytes Encoding.utf_16_le Problem_Behavior.Report_Warning
+            txt.should_equal "￾䄀A"
+            w = Problems.expect_only_warning Encoding_Error txt
+            w.to_display_text . should_contain "BOM"
 
     suite_builder.group "codepoints" group_builder->
         facepalm = '\u{1F926}\u{1F3FC}\u200D\u2642\uFE0F'

--- a/test/Base_Tests/src/System/File_Read_Spec.enso
+++ b/test/Base_Tests/src/System/File_Read_Spec.enso
@@ -51,7 +51,7 @@ add_specs suite_builder =
         group_builder.specify "should raise a warning when invalid encoding in a Text file" <|
             action = windows_log.read (Plain_Text Encoding.ascii) on_problems=_
             tester result = result . should_equal 'Hello World! $\uFFFD\uFFFD\uFFFD'
-            problems = [Encoding_Error.Error "Encoding issues at 14, 15, 16."]
+            problems = [Encoding_Error.Error "Failed to decode 3 code units (at positions: 14, 15, 16)."]
             Problems.test_problem_handling action problems tester
 
             # Check that it defaults to warning.

--- a/test/Base_Tests/src/System/File_Spec.enso
+++ b/test/Base_Tests/src/System/File_Spec.enso
@@ -369,7 +369,7 @@ add_specs suite_builder =
         group_builder.specify "should raise warnings when reading invalid characters" <|
             action = windows_file.read_text Encoding.ascii on_problems=_
             tester result = result.should_equal 'Hello World! $\uFFFD\uFFFD\uFFFD'
-            problems = [Encoding_Error.Error "Encoding issues at 14, 15, 16."]
+            problems = [Encoding_Error.Error "Failed to decode 3 code units (at positions: 14, 15, 16)."]
             Problems.test_problem_handling action problems tester
 
             # Check that it defaults to warning.

--- a/test/Base_Tests/src/System/Reporting_Stream_Decoder_Spec.enso
+++ b/test/Base_Tests/src/System/Reporting_Stream_Decoder_Spec.enso
@@ -28,7 +28,7 @@ add_specs suite_builder =
         group_builder.specify "should work correctly when reading chunks of varying sizes" <|
             f = enso_project.data / "transient" / "varying_chunks.txt"
             fragment = 'Hello 😎🚀🚧!'
-            contents = 1.up_to 1000 . map _->fragment . join '\n'
+            contents = 1.up_to 10000 . map _->fragment . join '\n'
             contents.write f . should_succeed
             all_codepoints = Builder.new
             read_chars decoder n =
@@ -39,37 +39,36 @@ add_specs suite_builder =
                         chars
 
             result = f.with_input_stream [File_Access.Read] stream->
-                stream.with_stream_decoder Encoding.utf_8 Problem_Behavior.Report_Error decoder->
-                    read_chars decoder 1 . should_equal "H".codepoints
-                    read_chars decoder 2 . should_equal "el".codepoints
-                    read_chars decoder 3 . should_equal "lo ".codepoints
-                    v1 = read_chars decoder 6
-                    Text.from_codepoints v1 . should_equal '😎🚀🚧'
+                available_bytes_counts = Vector.build available_bytes_counter->
+                    stream.with_stream_decoder Encoding.utf_8 Problem_Behavior.Report_Error decoder->
+                        read_chars decoder 1 . should_equal "H".codepoints
+                        read_chars decoder 2 . should_equal "el".codepoints
+                        read_chars decoder 3 . should_equal "lo ".codepoints
+                        v1 = read_chars decoder 6
+                        Text.from_codepoints v1 . should_equal '😎🚀🚧'
 
-                    v2 = read_chars decoder 200
-                    ## Here we show that while the decoder is trying to read
-                       200 codepoints, some codepoints require more than one
-                       byte in UTF-8 to represent, so the actual result
-                       should be slightly smaller.
-                    (v2.length < 200) . should_be_true
+                        available_bytes_counter.append (stream.with_java_stream .available)
 
-                    ## Now we read increasingly larger amounts, to trigger
-                       and test all paths of the input buffer resizing
-                       mechanism.
-                    read_chars decoder 40
-                    read_chars decoder 500
-                    read_chars decoder 1000
-                    read_chars decoder 1
-                    read_chars decoder 2
-                    read_chars decoder 10
+                        ## Now we read increasingly larger amounts, to trigger
+                           and test all paths of the input buffer resizing
+                           mechanism.
+                        read_chars decoder 40
+                        read_chars decoder 500
+                        read_chars decoder 1000
+                        read_chars decoder 1
+                        read_chars decoder 2
+                        read_chars decoder 10
 
-                    ## Finally read all the remaining contents of the file
-                       to verify they were decoded correctly as a whole.
-                    read_rest _ =
-                        case read_chars decoder 100 of
-                            Nothing -> Nothing
-                            _ -> @Tail_Call read_rest Nothing
-                    read_rest Nothing
+                        ## Finally read all the remaining contents of the file
+                           to verify they were decoded correctly as a whole.
+                        read_rest _ =
+                            available_bytes_counter.append (stream.with_java_stream .available)
+                            case read_chars decoder 1000 of
+                                Nothing -> Nothing
+                                _ -> @Tail_Call read_rest Nothing
+                        read_rest Nothing
+                # We now check that not all bytes were read in one go on the first read, instead the file should have been read incrementally as needed:
+                available_bytes_counts.any (x-> x != available_bytes_counts.first) . should_be_true
             Text.from_codepoints all_codepoints.to_vector . should_equal contents
             result.should_succeed
             f.delete

--- a/test/Base_Tests/src/System/Reporting_Stream_Decoder_Spec.enso
+++ b/test/Base_Tests/src/System/Reporting_Stream_Decoder_Spec.enso
@@ -91,7 +91,7 @@ add_specs suite_builder =
         group_builder.specify "should raise warnings when reading invalid characters" <|
             encoding = Encoding.ascii
             expected_contents = 'Hello World! $\uFFFD\uFFFD\uFFFD'
-            expected_problems = [Encoding_Error.Error "Encoding issues at bytes 14, 15, 16."]
+            expected_problems = [Encoding_Error.Error "Failed to decode 3 code units (at positions 14, 15, 16)."]
             contents_1 = read_file_one_by_one windows_file encoding expected_contents.length on_problems=Problem_Behavior.Report_Warning
             contents_1.should_equal expected_contents
             Problems.get_attached_warnings contents_1 . should_equal expected_problems
@@ -138,4 +138,3 @@ main filter=Nothing =
     suite = Test.build suite_builder->
         add_specs suite_builder
     suite.run_with_filter filter
-

--- a/test/Base_Tests/src/System/Reporting_Stream_Decoder_Spec.enso
+++ b/test/Base_Tests/src/System/Reporting_Stream_Decoder_Spec.enso
@@ -77,10 +77,12 @@ add_specs suite_builder =
         group_builder.specify "should allow reading a UTF-8 file" <|
             f = enso_project.data / "transient" / "utf8.txt"
             encoding = Encoding.utf_8
-            ((0.up_to 100).map _->'Hello World!' . join '\n').write f . should_succeed
-            expected_contents = f.read_text
+            expected_contents = ((0.up_to 100).map _->'Hello World!' . join '\n')
+            expected_contents.write f . should_succeed
             contents = read_file_one_by_one f encoding expected_contents.length
             contents.should_equal expected_contents
+            # The regular read_text should also provide aligned results.
+            f.read_text . should_equal expected_contents
 
         group_builder.specify "should allow reading a Windows file" <|
             encoding = Encoding.windows_1252
@@ -91,7 +93,7 @@ add_specs suite_builder =
         group_builder.specify "should raise warnings when reading invalid characters" <|
             encoding = Encoding.ascii
             expected_contents = 'Hello World! $\uFFFD\uFFFD\uFFFD'
-            expected_problems = [Encoding_Error.Error "Failed to decode 3 code units (at positions 14, 15, 16)."]
+            expected_problems = [Encoding_Error.Error "Failed to decode 3 code units (at positions: 14, 15, 16)."]
             contents_1 = read_file_one_by_one windows_file encoding expected_contents.length on_problems=Problem_Behavior.Report_Warning
             contents_1.should_equal expected_contents
             Problems.get_attached_warnings contents_1 . should_equal expected_problems

--- a/test/Base_Tests/src/System/Reporting_Stream_Encoder_Spec.enso
+++ b/test/Base_Tests/src/System/Reporting_Stream_Encoder_Spec.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base.Errors.Encoding_Error.Encoding_Error
 import Standard.Base.Errors.Illegal_State.Illegal_State
 
-polyglot java import org.enso.base.Encoding_Utils
+polyglot java import org.enso.base.encoding.Encoding_Utils
 polyglot java import java.nio.CharBuffer
 
 from Standard.Test import all
@@ -133,4 +133,3 @@ main filter=Nothing =
     suite = Test.build suite_builder->
         add_specs suite_builder
     suite.run_with_filter filter
-

--- a/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
+++ b/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
@@ -510,6 +510,14 @@ add_specs suite_builder =
             r2.column_names . should_equal ["愀Ⰰ戀਀㄀Ⰰ㈀"]
             r2.first_column.to_vector . should_equal []
 
+        group_builder.specify "should gracefully handle malformed data edge cases: 1 byte file with multi-byte encoding (UTF-8)" <|
+            f = File.create_temporary_file "delimited-malformed-utf-16" ".csv"
+            [-1].write_bytes f . should_succeed
+            r = f.read (Delimited_Format.Delimited "," encoding=Encoding.utf_16_be)
+            IO.println r
+            # TODO clarify what error should happen here?
+            r.should_fail_with File_Error
+
 main filter=Nothing =
     suite = Test.build suite_builder->
         add_specs suite_builder

--- a/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
+++ b/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
@@ -473,8 +473,44 @@ add_specs suite_builder =
             Delimited_Format.Delimited ',' comment_character='#' . without_comments . should_equal (Delimited_Format.Delimited ',' comment_character=Nothing)
             Delimited_Format.Delimited ',' . with_line_endings Line_Ending_Style.Unix . should_equal (Delimited_Format.Delimited ',' line_endings=Line_Ending_Style.Unix)
 
+        utf_16_le_bom = [-1, -2]
+        group_builder.specify "(in default mode) should detect UTF-16 encoding if BOM is present" <|
+            bytes = utf_16_le_bom + ('a,b\n1,2'.bytes Encoding.utf_16_le)
+            f = File.create_temporary_file "delimited-utf-16-bom" ".csv"
+            bytes.write_bytes f . should_succeed
+            table = f.read
+            table.column_names.should_equal ["a", "b"]
+            table.at "a" . to_vector . should_equal ["1"]
+            # No hidden BOM in the column name
+            table.column_names.first.utf_8 . should_equal [97]
+
+        group_builder.specify "(in default mode) should skip UTF-8 BOM if it was present" <|
+            utf_8_bom = [-17, -69, -65]
+            bytes = utf_8_bom + ('a,b\n1,2'.bytes Encoding.utf_8)
+            f = File.create_temporary_file "delimited-utf-8-bom" ".csv"
+            bytes.write_bytes f . should_succeed
+            table = f.read
+            table.column_names.should_equal ["a", "b"]
+            # No hidden BOM in the column name
+            table.column_names.first.utf_8 . should_equal [97]
+
+        group_builder.specify "if UTF-16 encoding was selected but an inverted BOM is detected, a warning is issued" <|
+            bytes = utf_16_le_bom + ('a,b\n1,2'.bytes Encoding.utf_16_be)
+            f = File.create_temporary_file "delimited-utf-16-inverted-bom" ".csv"
+            bytes.write_bytes f . should_succeed
+            # We choose the correct encoding for the rest of the file, only BOM is bad
+            r = f.read (Delimited_Format.Delimited "," encoding=Encoding.utf_16_be)
+            w = Problems.expect_only_warning Encoding_Error r
+            w.to_display_text . should_contain "BOM"
+            # The first column name now contains this invalid character, because it wasn't a BOM
+            r.column_names.first . should_equal "￾a"
+
+            # If we read without specifying the encoding, we will infer UTF-16 LE encoding because of the BOM and get garbage:
+            r2 = f.read
+            r2.column_names . should_equal ["愀Ⰰ戀਀㄀Ⰰ㈀"]
+            r2.first_column.to_vector . should_equal []
+
 main filter=Nothing =
     suite = Test.build suite_builder->
         add_specs suite_builder
     suite.run_with_filter filter
-

--- a/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
+++ b/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
@@ -513,10 +513,14 @@ add_specs suite_builder =
         group_builder.specify "should gracefully handle malformed data edge cases: 1 byte file with multi-byte encoding (UTF-8)" <|
             f = File.create_temporary_file "delimited-malformed-utf-16" ".csv"
             [-1].write_bytes f . should_succeed
+            error = f.read (Delimited_Format.Delimited "," encoding=Encoding.utf_16_be) on_problems=..Report_Error
+            error.should_fail_with Encoding_Error
+
             r = f.read (Delimited_Format.Delimited "," encoding=Encoding.utf_16_be)
-            IO.println r
-            # TODO clarify what error should happen here?
-            r.should_fail_with File_Error
+            r.should_be_a Table
+            r.column_names . should_equal ["Column 1"]
+            r.first_column.to_vector . should_equal ['\uFFFD']
+            Problems.expect_only_warning Encoding_Error r
 
 main filter=Nothing =
     suite = Test.build suite_builder->

--- a/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
+++ b/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
@@ -179,7 +179,7 @@ add_specs suite_builder =
                 table.at 'a' . to_vector . should_equal ['ą']
                 table.at 'b' . to_vector . should_equal ['\uFFFF']
                 table.at 'c' . to_vector . should_equal ['\uFFFD(\uFFFD(']
-            problems_1 = [Encoding_Error.Error "Encoding issues at bytes 13, 15."]
+            problems_1 = [Encoding_Error.Error "Failed to decode 2 code units (at positions: 13, 15)."]
             Problems.test_problem_handling action_1 problems_1 tester_1
             utf8_file.delete
 
@@ -192,7 +192,7 @@ add_specs suite_builder =
                 table.at 'b' . to_vector . should_equal ['\uFFFF']
                 # However, this column will raise a problem as the '\uFFFD' comes from replacing an invalid codepoint.
                 table.at 'c' . to_vector . should_equal ['\uFFFD']
-            problems_2 = [Encoding_Error.Error "Encoding issues at byte 22."]
+            problems_2 = [Encoding_Error.Error "Failed to decode 1 code units (at positions: 20)."]
             Problems.test_problem_handling action_2 problems_2 tester_2
 
         group_builder.specify "should handle duplicated columns" <|
@@ -480,7 +480,7 @@ add_specs suite_builder =
             bytes.write_bytes f . should_succeed
             table = f.read
             table.column_names.should_equal ["a", "b"]
-            table.at "a" . to_vector . should_equal ["1"]
+            table.at "a" . to_vector . should_equal [1]
             # No hidden BOM in the column name
             table.column_names.first.utf_8 . should_equal [97]
 
@@ -507,8 +507,8 @@ add_specs suite_builder =
 
             # If we read without specifying the encoding, we will infer UTF-16 LE encoding because of the BOM and get garbage:
             r2 = f.read
-            r2.column_names . should_equal ["愀Ⰰ戀਀㄀Ⰰ㈀"]
-            r2.first_column.to_vector . should_equal []
+            r2.column_names . should_equal ["Column 1"]
+            r2.first_column.to_vector . should_equal ["愀Ⰰ戀਀㄀Ⰰ㈀"]
 
         group_builder.specify "should gracefully handle malformed data edge cases: 1 byte file with multi-byte encoding (UTF-8)" <|
             f = File.create_temporary_file "delimited-malformed-utf-16" ".csv"

--- a/test/Table_Tests/src/IO/Delimited_Write_Spec.enso
+++ b/test/Table_Tests/src/IO/Delimited_Write_Spec.enso
@@ -554,8 +554,9 @@ add_specs suite_builder =
             bytes = flipped_bom + ('A,B\n1,2'.bytes Encoding.utf_16_le)
             bytes.write_bytes f . should_succeed
             r = f.read format
-            r.column_names . should_equal ["A", "B"]
-            w = Problems.expect_only_warning Encoding_Error
+            # The flipped BOM is not a valid BOM so it is retained in the data and will be contained in column name:
+            r.column_names . should_equal [(Text.from_codepoints [65534]) + "A", "B"]
+            w = Problems.expect_only_warning Encoding_Error r
             w.to_display_text . should_contain "BOM"
 
         ## If the Delimited config has Encoding.default, the encoding for read will be determined by BOM and Win-1252 fallback heuristics.
@@ -567,14 +568,14 @@ add_specs suite_builder =
                 initial_bytes = bom + ('A,B\n1,ąęćś\n2,💯'.bytes Encoding.utf_16_le)
                 initial_bytes.write_bytes f on_existing_file=Existing_File_Behavior.Overwrite . should_succeed
 
-                (Table.new [["A", [3, 4]], ["B", ["żółw", "🐢"]]]).write f . should_succeed
+                (Table.new [["A", [3, 4]], ["B", ["żółw", "🐢"]]]).write f on_existing_file=Existing_File_Behavior.Append . should_succeed
 
                 # Now we read in auto mode, the part appended to the table should have been correctly written in UTF-16
                 t = f.read
                 t.should_be_a Table
                 t.column_names . should_equal ["A", "B"]
-                t.at "A" . should_equal [1, 2, 3, 4]
-                t.at "B" . should_equal ["ąęćś", "💯", "żółw", "🐢"]
+                t.at "A" . to_vector . should_equal [1, 2, 3, 4]
+                t.at "B" . to_vector . should_equal ["ąęćś", "💯", "żółw", "🐢"]
 
         group_builder.specify "should fail if the target file is read-only" <|
             f = enso_project.data / "transient" / "permission.csv"

--- a/test/Table_Tests/src/IO/Delimited_Write_Spec.enso
+++ b/test/Table_Tests/src/IO/Delimited_Write_Spec.enso
@@ -547,6 +547,35 @@ add_specs suite_builder =
             result.catch.message . should_equal "The explicitly provided line endings ('\n') do not match the line endings in the file ('\r')."
             file.delete
 
+        group_builder.specify "should report flipped BOM when reading with specified UTF-16 encoding" <|
+            f = File.create_temporary_file "flipped-bom" ".csv"
+            format = Delimited_Format.Delimited ',' encoding=Encoding.utf_16_le
+            flipped_bom = [-2, -1]
+            bytes = flipped_bom + ('A,B\n1,2'.bytes Encoding.utf_16_le)
+            bytes.write_bytes f . should_succeed
+            r = f.read format
+            r.column_names . should_equal ["A", "B"]
+            w = Problems.expect_only_warning Encoding_Error
+            w.to_display_text . should_contain "BOM"
+
+        ## If the Delimited config has Encoding.Default, the encoding for read will be determined by BOM and Win-1252 fallback heuristics.
+           The same encoding should be used for writing, to ensure that when the resulting file is read, all content is correctly decoded.
+        group_builder.specify "should use the same effective encoding for writing as the one that would be used for reading" <|
+            f = File.create_temporary_file "append-detect" ".csv"
+            Test.with_clue "UTF-16 detected by BOM: " <|
+                bom = [-1, -2]
+                initial_bytes = bom + ('A,B\n1,ąęćś\n2,💯'.bytes Encoding.utf_16_le)
+                initial_bytes.write_bytes f on_existing_file=Existing_File_Behavior.Overwrite . should_succeed
+
+                (Table.new [["A", [3, 4]], ["B", ["żółw", "🐢"]]]).write f . should_succeed
+
+                # Now we read in auto mode, the part appended to the table should have been correctly written in UTF-16
+                t = f.read
+                t.should_be_a Table
+                t.column_names . should_equal ["A", "B"]
+                t.at "A" . should_equal [1, 2, 3, 4]
+                t.at "B" . should_equal ["ąęćś", "💯", "żółw", "🐢"]
+
         group_builder.specify "should fail if the target file is read-only" <|
             f = enso_project.data / "transient" / "permission.csv"
             f.delete_if_exists

--- a/test/Table_Tests/src/IO/Delimited_Write_Spec.enso
+++ b/test/Table_Tests/src/IO/Delimited_Write_Spec.enso
@@ -558,7 +558,7 @@ add_specs suite_builder =
             w = Problems.expect_only_warning Encoding_Error
             w.to_display_text . should_contain "BOM"
 
-        ## If the Delimited config has Encoding.Default, the encoding for read will be determined by BOM and Win-1252 fallback heuristics.
+        ## If the Delimited config has Encoding.default, the encoding for read will be determined by BOM and Win-1252 fallback heuristics.
            The same encoding should be used for writing, to ensure that when the resulting file is read, all content is correctly decoded.
         group_builder.specify "should use the same effective encoding for writing as the one that would be used for reading" <|
             f = File.create_temporary_file "append-detect" ".csv"


### PR DESCRIPTION
### Pull Request Description

- Improve BOM handling: detect and skip the BOM character, Default encoding that detects encoding based on BOM if present, warnings if unexpected BOM is encountered.
- Closes #9849 
- Windows-1252 fallback will be done as a separate PR as it has additional complexity. Tracked in ticket #10148.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
