### PR TITLE
Remove spurious warnings from zinc compiler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1207,6 +1207,7 @@ lazy val searcher = project
   .configs(Test)
   .settings(
     frgaalJavaCompilerSetting,
+    annotationProcSetting,
     libraryDependencies ++= jmh ++ Seq(
       "org.scalatest" %% "scalatest" % scalatestVersion % Test
     ) ++ logbackTest
@@ -1308,6 +1309,7 @@ lazy val `persistance` = (project in file("lib/java/persistance"))
     Test / fork := true,
     commands += WithDebugCommand.withDebug,
     frgaalJavaCompilerSetting,
+    annotationProcSetting,
     Compile / javacOptions := ((Compile / javacOptions).value),
     libraryDependencies ++= Seq(
       "org.slf4j"        % "slf4j-api"               % slf4jVersion,
@@ -2619,6 +2621,7 @@ lazy val `test-utils` =
   (project in file("lib/java/test-utils"))
     .settings(
       frgaalJavaCompilerSetting,
+      annotationProcSetting,
       libraryDependencies ++= GraalVM.modules,
       libraryDependencies ++= Seq(
         "org.graalvm.truffle" % "truffle-api"           % graalMavenPackagesVersion % "provided",

--- a/build.sbt
+++ b/build.sbt
@@ -749,7 +749,6 @@ lazy val `syntax-rust-definition` = project
   .enablePlugins(JPMSPlugin)
   .configs(Test)
   .settings(
-    javaModuleName := "org.enso.syntax",
     Compile / sourceGenerators += generateParserJavaSources,
     Compile / resourceGenerators += generateRustParserLib,
     Compile / javaSource := baseDirectory.value / "generate-java" / "java"

--- a/build.sbt
+++ b/build.sbt
@@ -1359,19 +1359,11 @@ lazy val `interpreter-dsl-test` =
     .settings(
       version := "0.1",
       frgaalJavaCompilerSetting,
+      annotationProcSetting,
       Test / fork := true,
       Test / javaOptions ++= Seq(
         "-Dpolyglotimpl.DisableClassPathIsolation=true"
       ),
-      Test / javacOptions ++= Seq(
-        "-s",
-        (Test / sourceManaged).value.getAbsolutePath
-      ),
-      Compile / logManager :=
-        sbt.internal.util.CustomLogManager.excludeMsg(
-          "Could not determine source for class ",
-          Level.Warn
-        ),
       commands += WithDebugCommand.withDebug,
       libraryDependencies ++= Seq(
         "org.graalvm.truffle" % "truffle-api"           % graalMavenPackagesVersion % "provided",
@@ -1652,6 +1644,30 @@ lazy val truffleDslSuppressWarnsSetting = Seq(
   )
 )
 
+/** Common settings for projects whose sources are processed by some annotation
+  * processors. These settings ensure that the generated sources are placed under
+  * `(Compile/sourceManaged)` directory, usually pointing to `target/classes/src_managed`.
+  */
+lazy val annotationProcSetting = Seq(
+  Compile / javacOptions ++= Seq(
+    "-s",
+    (Compile / sourceManaged).value.getAbsolutePath,
+    "-Xlint:unchecked"
+  ),
+  Compile / compile := (Compile / compile)
+    .dependsOn(Def.task { (Compile / sourceManaged).value.mkdirs })
+    .value,
+  // zinc cannot see who is generating the java files so it adds some
+  // spurious warning messages. The following setting filters out such
+  // spurious warnings.
+  // See https://stackoverflow.com/questions/55558849/how-do-i-build-a-mixed-java-scala-project-which-uses-java-annotation-code-genera
+  Compile / logManager :=
+    sbt.internal.util.CustomLogManager.excludeMsg(
+      "Could not determine source for class ",
+      Level.Warn
+    )
+)
+
 /** A setting to replace javac with Frgaal compiler, allowing to use latest Java features in the code
   * and still compile down to JDK 17
   */
@@ -1676,27 +1692,20 @@ def customFrgaalJavaCompilerSettings(targetJdk: String) = Seq(
   )
 )
 
-lazy val instrumentationSettings = frgaalJavaCompilerSetting ++ Seq(
-  version := ensoVersion,
-  commands += WithDebugCommand.withDebug,
-  Compile / logManager :=
-    sbt.internal.util.CustomLogManager
-      .excludeMsg("Could not determine source for class ", Level.Warn),
-  Compile / javacOptions --= Seq(
-    "-source",
-    frgaalSourceLevel,
-    "--enable-preview"
-  ),
-  libraryDependencies ++= Seq(
-    "org.graalvm.truffle" % "truffle-api"           % graalMavenPackagesVersion % "provided",
-    "org.graalvm.truffle" % "truffle-dsl-processor" % graalMavenPackagesVersion % "provided"
-  ),
-  (Compile / javacOptions) ++= Seq(
-    "-s",
-    (Compile / sourceManaged).value.getAbsolutePath,
-    "-Xlint:unchecked"
+lazy val instrumentationSettings =
+  frgaalJavaCompilerSetting ++ annotationProcSetting ++ Seq(
+    version := ensoVersion,
+    commands += WithDebugCommand.withDebug,
+    Compile / javacOptions --= Seq(
+      "-source",
+      frgaalSourceLevel,
+      "--enable-preview"
+    ),
+    libraryDependencies ++= Seq(
+      "org.graalvm.truffle" % "truffle-api"           % graalMavenPackagesVersion % "provided",
+      "org.graalvm.truffle" % "truffle-dsl-processor" % graalMavenPackagesVersion % "provided"
+    )
   )
-)
 
 lazy val `runtime-language-epb` =
   (project in file("engine/runtime-language-epb"))
@@ -1800,12 +1809,8 @@ lazy val runtime = (project in file("engine/runtime"))
   .enablePlugins(JPMSPlugin)
   .settings(
     frgaalJavaCompilerSetting,
+    annotationProcSetting,
     truffleDslSuppressWarnsSetting,
-    Compile / logManager :=
-      sbt.internal.util.CustomLogManager.excludeMsg(
-        "Could not determine source for class ",
-        Level.Warn
-      ),
     version := ensoVersion,
     commands += WithDebugCommand.withDebug,
     inConfig(Compile)(truffleRunOptionsSettings),
@@ -1837,18 +1842,6 @@ lazy val runtime = (project in file("engine/runtime"))
         GraalVM.toolsPkgs.map(_.withConfigurations(Some(Runtime.name)))
       necessaryModules ++ langs ++ tools
     }
-  )
-  .settings(
-    (Compile / javacOptions) ++= Seq(
-      "-s",
-      (Compile / sourceManaged).value.getAbsolutePath,
-      "-Xlint:unchecked"
-    )
-  )
-  .settings(
-    (Compile / compile) := (Compile / compile)
-      .dependsOn(Def.task { (Compile / sourceManaged).value.mkdirs })
-      .value
   )
   .settings(
     (Runtime / compile) := (Runtime / compile)
@@ -1886,11 +1879,7 @@ lazy val `runtime-integration-tests` =
     .enablePlugins(JPMSPlugin)
     .settings(
       frgaalJavaCompilerSetting,
-      Compile / logManager :=
-        sbt.internal.util.CustomLogManager.excludeMsg(
-          "Could not determine source for class ",
-          Level.Warn
-        ),
+      annotationProcSetting,
       commands += WithDebugCommand.withDebug,
       libraryDependencies ++= GraalVM.modules ++ GraalVM.langsPkgs ++ GraalVM.insightPkgs ++ logbackPkg ++ helidon ++ Seq(
         "org.graalvm.polyglot" % "polyglot"              % graalMavenPackagesVersion % "provided",
@@ -1908,13 +1897,7 @@ lazy val `runtime-integration-tests` =
         "org.hamcrest"         % "hamcrest-all"          % hamcrestVersion           % Test,
         "org.slf4j"            % "slf4j-api"             % slf4jVersion              % Test
       ),
-      Test / javacOptions ++= Seq(
-        "-s",
-        (Compile / sourceManaged).value.getAbsolutePath,
-        "-Xlint:unchecked"
-      ),
       Test / compile := (Test / compile)
-        .dependsOn(Def.task { (Compile / sourceManaged).value.mkdirs })
         .dependsOn(`runtime-fat-jar` / Compile / compileModuleInfo)
         .value,
       Test / fork := true,
@@ -2034,6 +2017,7 @@ lazy val `runtime-benchmarks` =
     .enablePlugins(JPMSPlugin)
     .settings(
       frgaalJavaCompilerSetting,
+      annotationProcSetting,
       // Note that withDebug command only makes sense if you use `@Fork(0)` in your benchmarks.
       commands += WithDebugCommand.withDebug,
       libraryDependencies ++= GraalVM.modules ++ GraalVM.langsPkgs ++ GraalVM.toolsPkgs ++ helidon ++ Seq(
@@ -2048,24 +2032,13 @@ lazy val `runtime-benchmarks` =
       ),
       mainClass :=
         Some("org.enso.interpreter.bench.benchmarks.RuntimeBenchmarksRunner"),
-      Compile / logManager :=
-        sbt.internal.util.CustomLogManager.excludeMsg(
-          "Could not determine source for class ",
-          Level.Warn
-        ),
       javacOptions --= Seq(
         "-source",
         frgaalSourceLevel,
         "--enable-preview"
       ),
-      javacOptions ++= Seq(
-        "-s",
-        (Compile / sourceManaged).value.getAbsolutePath,
-        "-Xlint:unchecked"
-      ),
       Compile / compile := (Compile / compile)
         .dependsOn(`runtime-fat-jar` / assembly)
-        .dependsOn(Def.task { (Compile / sourceManaged).value.mkdirs })
         .value,
       parallelExecution := false,
       modulePath := {
@@ -2127,6 +2100,7 @@ lazy val `runtime-parser` =
   (project in file("engine/runtime-parser"))
     .settings(
       frgaalJavaCompilerSetting,
+      annotationProcSetting,
       commands += WithDebugCommand.withDebug,
       fork := true,
       Test / javaOptions ++= Seq(
@@ -2138,12 +2112,7 @@ lazy val `runtime-parser` =
         "com.github.sbt"   % "junit-interface"         % junitIfVersion     % Test,
         "org.scalatest"   %% "scalatest"               % scalatestVersion   % Test,
         "org.netbeans.api" % "org-openide-util-lookup" % netbeansApiVersion % "provided"
-      ),
-      (Compile / logManager) :=
-        sbt.internal.util.CustomLogManager.excludeMsg(
-          "Could not determine source for class ",
-          Level.Warn
-        )
+      )
     )
     .dependsOn(syntax)
     .dependsOn(`syntax-rust-definition`)
@@ -2154,6 +2123,7 @@ lazy val `runtime-compiler` =
   (project in file("engine/runtime-compiler"))
     .settings(
       frgaalJavaCompilerSetting,
+      annotationProcSetting,
       (Test / fork) := true,
       libraryDependencies ++= Seq(
         "com.chuusai"     %% "shapeless"               % shapelessVersion   % "provided",
@@ -2720,6 +2690,7 @@ lazy val `std-benchmarks` = (project in file("std-bits/benchmarks"))
   .enablePlugins(JPMSPlugin)
   .settings(
     frgaalJavaCompilerSetting,
+    annotationProcSetting,
     libraryDependencies ++= GraalVM.modules ++ GraalVM.langsPkgs ++ Seq(
       "org.openjdk.jmh"      % "jmh-core"                 % jmhVersion,
       "org.openjdk.jmh"      % "jmh-generator-annprocess" % jmhVersion,
@@ -2727,12 +2698,7 @@ lazy val `std-benchmarks` = (project in file("std-bits/benchmarks"))
       "org.slf4j"            % "slf4j-api"                % slf4jVersion,
       "org.slf4j"            % "slf4j-nop"                % slf4jVersion
     ),
-    commands += WithDebugCommand.withDebug,
-    (Compile / logManager) :=
-      sbt.internal.util.CustomLogManager.excludeMsg(
-        "Could not determine source for class ",
-        Level.Warn
-      )
+    commands += WithDebugCommand.withDebug
   )
   .settings(
     parallelExecution := false,
@@ -2744,8 +2710,6 @@ lazy val `std-benchmarks` = (project in file("std-bits/benchmarks"))
       .dependsOn(`runtime-fat-jar` / assembly)
       .value,
     Compile / javacOptions ++= Seq(
-      "-s",
-      (Compile / sourceManaged).value.getAbsolutePath,
       "-Xlint:unchecked",
       "-J-Dpolyglotimpl.DisableClassPathIsolation=true",
       "-J-Dpolyglot.engine.WarnInterpreterOnly=false"


### PR DESCRIPTION
### Pull Request Description

sbt projects processed with annotation processors that generate new sources tend to echo a spurious warning of form
```
[warn] Could not determine source class for ...
```
That is because `zinc` compiler does not work correctly with Java annotation processors.
This PR removes this warning from logs and ensures that a `target/src_managed` directory is created and used for such generated sources for all relevant projects.

### Important Notes

- Improve setting of sbt projects with annotation processors.
- Remove unused `syntax-rust-definition/javaModuleName` setting key.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] Ensure there are no warnings on the CI during project build
