### PR TITLE
Another follow up to parser library loading issue

### DIFF
--- a/lib/rust/parser/generate-java/java/org/enso/syntax2/Parser.java
+++ b/lib/rust/parser/generate-java/java/org/enso/syntax2/Parser.java
@@ -7,7 +7,7 @@ import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 
 public final class Parser implements AutoCloseable {
-  private static void initializeLibraries() {
+  static {
     String os = System.getProperty("os.name");
     String name;
     if (os.startsWith("Mac")) {
@@ -87,7 +87,6 @@ public final class Parser implements AutoCloseable {
   static native long getUuidLow(long metadata, long codeOffset, long codeLength);
 
   public static Parser create() {
-    initializeLibraries();
     var state = allocState();
     return new Parser(state);
   }


### PR DESCRIPTION
### Pull Request Description

Parser is present in both `runtime.jar` and `runner.jar` jars, leading to shared library loading issues:
```
Caused by: java.lang.UnsatisfiedLinkError: Native Library <...>/component/libenso_parser.so already loaded in another classloader
    at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:167)
    at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:139)
    at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2418)
    at java.base/java.lang.Runtime.load0(Runtime.java:852)
    at java.base/java.lang.System.load(System.java:2025)
    at org.enso.runtime/org.enso.syntax2.Parser.initializeLibraries(Parser.java:36)
    ... 43 common frames omitted
Caused by: java.lang.UnsatisfiedLinkError: Can't load library: <...>/target/rust/debug/libenso_parser.so
    at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2422)
```

This change ensures that library is only loaded once.

### Important Notes

Follow up to https://github.com/enso-org/enso/pull/10123
