### PR TITLE
Reduce probability of non-determinism test randomly failing.

### DIFF
--- a/test/Base_Tests/src/Data/Vector_Spec.enso
+++ b/test/Base_Tests/src/Data/Vector_Spec.enso
@@ -672,14 +672,13 @@ type_spec suite_builder name alter = suite_builder.group name group_builder->
         alter ["a", "a", "a"] . drop (Sample 100) . should_equal []
 
     suite_builder.group "take/drop Sample non-determinism" group_builder->
-        v = 0.up_to 20 . to_vector
+        v = 0.up_to 60 . to_vector
 
         group_builder.specify "sampling should be deterministic when a seed is supplied" <|
-            v.take (Sample 3 seed=4200000) . should_equal (v.take (Sample 3 seed=4200000))
+            v.take (Sample 5 seed=4200000) . should_equal (v.take (Sample 5 seed=4200000))
 
         group_builder.specify "sampling should be non-deterministic when a seed is not supplied" <|
-            0.up_to 3 . map _->
-                v.take (Sample 3) . should_not_equal (v.take (Sample 3))
+            v.take (Sample 5) . should_not_equal (v.take (Sample 5))
 
     group_builder.specify "take/drop should gracefully handle missing constructor arguments" <|
         Test.expect_panic Type_Error <| [].take "FOO"


### PR DESCRIPTION
### Pull Request Description

The standard library vector sampling test happened to fail by random chance of two consecutive samplings being equal.

![image](https://github.com/enso-org/enso/assets/919491/3c9c73a8-51da-468c-a42d-88a99d30ecbf)

To prevent that from happening again, the sampled vector and number of samples was increased. Also, the non-determinism test for some reason was actually performed 3 times, giving 3 opportunities for samplings to accidentaly match and fail the test. Removed that outer loop, since one non-equality is plenty enough to pass the test.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
