### PR TITLE
Fix build of stdlib benchmarks after ydoc PR

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2751,19 +2751,17 @@ lazy val `std-benchmarks` = (project in file("std-bits/benchmarks"))
       "-J-Dpolyglot.engine.WarnInterpreterOnly=false"
     ),
     modulePath := {
-      val requiredModIds = GraalVM.modules ++ GraalVM.langsPkgs ++ Seq(
-        "org.slf4j" % "slf4j-api" % slf4jVersion,
+      val allRuntimeMods = componentModulesPaths.value
+      val otherModIds = Seq(
         "org.slf4j" % "slf4j-nop" % slf4jVersion
       )
       val requiredMods = JPMSUtils.filterModulesFromUpdate(
         (Compile / update).value,
-        requiredModIds,
+        otherModIds,
         streams.value.log,
         shouldContainAll = true
       )
-      val runtimeMod =
-        (`runtime-fat-jar` / assembly / assemblyOutputPath).value
-      requiredMods ++ Seq(runtimeMod)
+      allRuntimeMods ++ requiredMods
     },
     addModules := {
       val runtimeModuleName = (`runtime-fat-jar` / javaModuleName).value


### PR DESCRIPTION
### Pull Request Description

A quickfix for a broken build of `std-benchmarks`. A recent error is, e.g., in https://github.com/enso-org/enso/actions/runs/9294745663/job/25580483426#step:7:1343. io.helidon modules are missed on the module-path when invoking std lib benchmarks. This PR adds them via dependency on `componentModulesPath`.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
