### PR TITLE
Directly allocate warnings asVectorEnsoObjects

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Array.enso
@@ -382,7 +382,7 @@ type Array
            `Map_Error`.
          - No_Wrap: The first error is thrown, and is not wrapped in
            `Map_Error`.
-         - Report_Warning: The result for that element is `Nothing`, 
+         - Report_Warning: The result for that element is `Nothing`,
            the error is attached as a warning. Currently unimplemented.
          - Ignore: The result is `Nothing`, and the error is
            ignored.
@@ -421,7 +421,7 @@ type Array
            `Map_Error`.
          - No_Wrap: The first error is thrown, and is not wrapped in
            `Map_Error`.
-         - Report_Warning: The result for that element is `Nothing`, 
+         - Report_Warning: The result for that element is `Nothing`,
            the error is attached as a warning. Currently unimplemented.
          - Ignore: The result is `Nothing`, and the error is
            ignored.
@@ -668,7 +668,7 @@ type Array
            `Map_Error`.
          - No_Wrap: The first error is thrown, and is not wrapped in
            `Map_Error`.
-         - Report_Warning: The result for that element is `Nothing`, 
+         - Report_Warning: The result for that element is `Nothing`,
            the error is attached as a warning. Currently unimplemented.
          - Ignore: The result is `Nothing`, and the error is
            ignored.
@@ -891,7 +891,7 @@ type Array
            `Map_Error`.
          - No_Wrap: The first error is thrown, and is not wrapped in
            `Map_Error`.
-         - Report_Warning: The result for that element is `Nothing`, 
+         - Report_Warning: The result for that element is `Nothing`,
            the error is attached as a warning. Currently unimplemented.
          - Ignore: The result is `Nothing`, and the error is
            ignored.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Vector.enso
@@ -679,7 +679,7 @@ type Vector a
            `Map_Error`.
          - No_Wrap: The first error is thrown, and is not wrapped in
            `Map_Error`.
-         - Report_Warning: The result for that element is `Nothing`, 
+         - Report_Warning: The result for that element is `Nothing`,
            the error is attached as a warning. Currently unimplemented.
          - Ignore: The result is `Nothing`, and the error is
            ignored.
@@ -718,7 +718,7 @@ type Vector a
            `Map_Error`.
          - No_Wrap: The first error is thrown, and is not wrapped in
            `Map_Error`.
-         - Report_Warning: The result for that element is `Nothing`, 
+         - Report_Warning: The result for that element is `Nothing`,
            the error is attached as a warning. Currently unimplemented.
          - Ignore: The result is `Nothing`, and the error is
            ignored.
@@ -772,7 +772,7 @@ type Vector a
            `Map_Error`.
          - No_Wrap: The first error is thrown, and is not wrapped in
            `Map_Error`.
-         - Report_Warning: The result for that element is `Nothing`, 
+         - Report_Warning: The result for that element is `Nothing`,
            the error is attached as a warning. Currently unimplemented.
          - Ignore: The result is `Nothing`, and the error is
            ignored.
@@ -1014,7 +1014,7 @@ type Vector a
            `Map_Error`.
          - No_Wrap: The first error is thrown, and is not wrapped in
            `Map_Error`.
-         - Report_Warning: The result for that element is `Nothing`, 
+         - Report_Warning: The result for that element is `Nothing`,
            the error is attached as a warning. Currently unimplemented.
          - Ignore: The result is `Nothing`, and the error is
            ignored.
@@ -1507,17 +1507,16 @@ type Builder
     ## GROUP Conversions
        ICON convert
        Clones the builder into a Vector.
-    to_vector : Vector Any
-    to_vector self =
+    to_vector self -> Vector =
         ## This creates a fresh copy of the builders storage, so any future
            changes to the builder will not affect the returned vector.
 
            This also reattaches any warnings that were attached to the added
            values. It attaches them to the whole array, not the individual
            values.
-        warnings_vector = Vector.from_polyglot_array self.warnings_java_builder.toArray
+        warnings_vector = self.warnings_java_builder.toArray
         Warning.attach_multiple warnings_vector <|
-            Vector.from_polyglot_array self.elements_java_builder.toArray
+            self.elements_java_builder.toArray
 
 ## PRIVATE
    Describes an error attached to a value within a `Vector`. The `index` field

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Warning.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Warning.enso
@@ -307,7 +307,7 @@ attach_with_stacktrace value warning origin = @Builtin_Method "Warning.attach_wi
 
    Builtin function that gets all the warnings attached to the given value.
 get_all_vector : Any -> Boolean -> Vector Warning
-get_all_vector value should_wrap = @Builtin_Method "Warning.get_all_array"
+get_all_vector value should_wrap = @Builtin_Method "Warning.get_all_vector"
 
 ## PRIVATE
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Warning.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Warning.enso
@@ -74,7 +74,7 @@ type Warning
        - wrap_errors: If true, warnings attached to elements in array-likes are
          wrapped in Map_Error.
     get_all : Any -> Boolean -> Vector Warning
-    get_all value wrap_errors:Boolean=False = Vector.from_polyglot_array (get_all_array value wrap_errors)
+    get_all value wrap_errors:Boolean=False = get_all_vector value wrap_errors
 
     ## PRIVATE
        ADVANCED
@@ -306,8 +306,8 @@ attach_with_stacktrace value warning origin = @Builtin_Method "Warning.attach_wi
 ## PRIVATE
 
    Builtin function that gets all the warnings attached to the given value.
-get_all_array : Any -> Boolean -> Array Warning
-get_all_array value should_wrap = @Builtin_Method "Warning.get_all_array"
+get_all_vector : Any -> Boolean -> Vector Warning
+get_all_vector value should_wrap = @Builtin_Method "Warning.get_all_array"
 
 ## PRIVATE
 

--- a/engine/runtime-benchmarks/src/main/java/org/enso/interpreter/bench/benchmarks/semantic/VectorBenchmarks.java
+++ b/engine/runtime-benchmarks/src/main/java/org/enso/interpreter/bench/benchmarks/semantic/VectorBenchmarks.java
@@ -38,10 +38,15 @@ public class VectorBenchmarks {
         import Standard.Base.Data.Vector.Builder
         import Standard.Base.Data.Vector.Vector
         import Standard.Base.Data.Array_Proxy.Array_Proxy
+        from Standard.Base.Data.Boolean import False
 
         avg arr =
-            sum acc i = if i == arr.length then acc else
-                @Tail_Call sum (acc + arr.at i) i+1
+            sum acc i =
+                stop = i == arr.length
+                if stop then acc else
+                    value = arr.at i
+                    both = acc + value
+                    @Tail_Call sum both i+1
             (sum 0 0) / arr.length
 
         fibarr size modulo =

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/builtin/Builtins.java
@@ -490,7 +490,11 @@ public final class Builtins {
     if (atomNodes == null) {
       return Optional.empty();
     }
-    LoadedBuiltinMethod builtin = atomNodes.get(methodName).get();
+    var supply = atomNodes.get(methodName);
+    if (supply == null) {
+      return Optional.empty();
+    }
+    LoadedBuiltinMethod builtin = supply.get();
     if (builtin == null) {
       return Optional.empty();
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/vector/ArrayLikeHelpers.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/vector/ArrayLikeHelpers.java
@@ -90,35 +90,14 @@ public final class ArrayLikeHelpers {
       @CachedLibrary(limit = "3") WarningsLibrary warnings) {
     var len = Math.toIntExact(length);
     var target = ArrayBuilder.newBuilder(len);
-    boolean nonTrivialEnsoValue = false;
     for (int i = 0; i < len; i++) {
       var value = invokeFunctionNode.execute(fun, frame, state, new Long[] {(long) i});
       if (value instanceof DataflowError) {
         return value;
       }
-      if (warnings.hasWarnings(value)) {
-        nonTrivialEnsoValue = true;
-      } else {
-        var isEnsoValue =
-            value instanceof EnsoObject || value instanceof Long || value instanceof Double;
-        if (!isEnsoValue) {
-          nonTrivialEnsoValue = true;
-        }
-      }
-      target.add(value);
+      target.add(value, warnings);
     }
-    var res = target.toArray();
-    if (res instanceof long[] longs) {
-      return Vector.fromLongArray(longs);
-    }
-    if (res instanceof double[] doubles) {
-      return Vector.fromDoubleArray(doubles);
-    }
-    if (nonTrivialEnsoValue) {
-      return Vector.fromInteropArray(Array.wrap((Object[]) res));
-    } else {
-      return Vector.fromEnsoOnlyArray((Object[]) res);
-    }
+    return target.asVector();
   }
 
   @Builtin.Method(

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/vector/ArrayLikeHelpers.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/vector/ArrayLikeHelpers.java
@@ -166,4 +166,12 @@ public final class ArrayLikeHelpers {
   public static EnsoObject asVectorFromArray(Object storage) {
     return Vector.fromInteropArray(storage);
   }
+
+  public static EnsoObject asVectorEnsoObjects(EnsoObject... arr) {
+    return Vector.fromEnsoOnlyArray(arr);
+  }
+
+  public static EnsoObject asVectorEmpty() {
+    return Vector.fromEnsoOnlyArray(null);
+  }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/vector/Vector.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/vector/Vector.java
@@ -24,6 +24,10 @@ import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 @ExportLibrary(TypesLibrary.class)
 @Builtin(pkg = "immutable", stdlibName = "Standard.Base.Data.Vector.Vector")
 abstract class Vector implements EnsoObject {
+  private static final Vector EMPTY_LONG = new Long(new long[0]);
+  private static final Vector EMPTY_DOUBLE = new Double(new double[0]);
+  private static final Vector EMPTY_VECTOR = new EnsoOnly(new Object[0]);
+
   @ExportMessage
   boolean hasArrayElements() {
     return true;
@@ -112,15 +116,27 @@ abstract class Vector implements EnsoObject {
   }
 
   static Vector fromLongArray(long[] arr) {
-    return new Long(arr);
+    if (arr == null || arr.length == 0) {
+      return EMPTY_LONG;
+    } else {
+      return new Long(arr);
+    }
   }
 
   static Vector fromDoubleArray(double[] arr) {
-    return new Double(arr);
+    if (arr == null || arr.length == 0) {
+      return EMPTY_DOUBLE;
+    } else {
+      return new Double(arr);
+    }
   }
 
-  static Object fromEnsoOnlyArray(Object[] arr) {
-    return new EnsoOnly(arr);
+  static Vector fromEnsoOnlyArray(Object[] arr) {
+    if (arr == null || arr.length == 0) {
+      return EMPTY_VECTOR;
+    } else {
+      return new EnsoOnly(arr);
+    }
   }
 
   @ExportLibrary(InteropLibrary.class)

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/Warning.java
@@ -88,7 +88,7 @@ public final class Warning implements EnsoObject {
   }
 
   @Builtin.Method(
-      name = "get_all_array",
+      name = "get_all_vector",
       description = "Gets all the warnings associated with the value.",
       autoRegister = false)
   @Builtin.Specialize
@@ -97,11 +97,11 @@ public final class Warning implements EnsoObject {
       WithWarnings value, boolean shouldWrap, WarningsLibrary warningsLib) {
     Warning[] warnings = value.getWarningsArray(warningsLib, shouldWrap);
     sortArray(warnings);
-    return ArrayLikeHelpers.wrapEnsoObjects(warnings);
+    return ArrayLikeHelpers.asVectorEnsoObjects(warnings);
   }
 
   @Builtin.Method(
-      name = "get_all_array",
+      name = "get_all_vector",
       description = "Gets all the warnings associated with the value.",
       autoRegister = false)
   @Builtin.Specialize(fallback = true)
@@ -110,12 +110,12 @@ public final class Warning implements EnsoObject {
       try {
         Warning[] warnings = warningsLib.getWarnings(value, null, shouldWrap);
         sortArray(warnings);
-        return ArrayLikeHelpers.wrapEnsoObjects(warnings);
+        return ArrayLikeHelpers.asVectorEnsoObjects(warnings);
       } catch (UnsupportedMessageException e) {
         throw EnsoContext.get(warningsLib).raiseAssertionPanic(warningsLib, null, e);
       }
     } else {
-      return ArrayLikeHelpers.empty();
+      return ArrayLikeHelpers.asVectorEmpty();
     }
   }
 


### PR DESCRIPTION
### Pull Request Description

Directly allocate a `Vector` via `asVectorEnsoObjects` to avoid overhead of a `Vector` delegating to an `Array`.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to pass
- [ ] Benchmarks are improved