### PR TITLE
Support --module-path in VSCode extension

### DIFF
--- a/.github/workflows/enso4igv.yml
+++ b/.github/workflows/enso4igv.yml
@@ -30,7 +30,7 @@ jobs:
           # Why do we subtract a number? Read versioning policy!
           # https://github.com/enso-org/enso/pull/7861#discussion_r1333133490
           echo "POM_VERSION=`mvn -q -DforceStdout help:evaluate -Dexpression=project.version | cut -f1 -d -`" >> "$GITHUB_ENV"
-          echo "MICRO_VERSION=`expr $GITHUB_RUN_NUMBER - 2250`" >> "$GITHUB_ENV"
+          echo "MICRO_VERSION=`expr $GITHUB_RUN_NUMBER - 2930`" >> "$GITHUB_ENV"
 
       - name: Update project version
         working-directory: tools/enso4igv

--- a/tools/enso4igv/pom.xml
+++ b/tools/enso4igv/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>enso4igv</artifactId>
     <packaging>nbm</packaging>
     <name>Enso Language Support for NetBeans &amp; Ideal Graph Visualizer</name>
-    <version>1.33-SNAPSHOT</version>
+    <version>1.35-SNAPSHOT</version>
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
### Pull Request Description

While working on `engine/runtime-language-arrow` I have realized that the project isn't properly configured in our VSCode extension:

![Truffle Import Failures](https://github.com/enso-org/enso/assets/26887752/60a75759-660a-4e47-9bc7-bde1b68d43c3)

The problem was missing support for `--module-path` compiler option. This PR recognizes `--module-path` in `.enso-source*` files and properly reports that to the underlaying IDE support as `modules/compile` path.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Code was manually tested
