### PR TITLE
Fetch EULA in background if a user accepted it before

### DIFF
--- a/app/ide-desktop/lib/dashboard/src/modals/TermsOfServiceModal.tsx
+++ b/app/ide-desktop/lib/dashboard/src/modals/TermsOfServiceModal.tsx
@@ -62,10 +62,19 @@ export function TermsOfServiceModal() {
   const checkboxId = React.useId()
   const { session } = authProvider.useAuth()
 
-  const eula = reactQuery.useSuspenseQuery(latestTermsOfService)
-
-  const latestVersionHash = eula.data.hash
   const localVersionHash = localStorage.get('termsOfService')?.versionHash
+  const { data: latestVersionHash } = reactQuery.useSuspenseQuery({
+    ...latestTermsOfService,
+    // If the user has already accepted EULA, we don't need to
+    // block user interaction with the app while we fetch the latest version.
+    // We can use the local version hash as the initial data.
+    // and refetch in the background to check for updates.
+    ...(localVersionHash != null && {
+      initialData: { hash: localVersionHash },
+      initialDataUpdatedAt: 0,
+    }),
+    select: data => data.hash,
+  })
 
   const isLatest = latestVersionHash === localVersionHash
   const isAccepted = localVersionHash != null


### PR DESCRIPTION
### Pull Request Description

This PR improves the behavior of fetching EULA: if a user has already accepted the terms of service, we no longer block the UI until we fetch the EULA, now it happens in the background. This behavior doesn't affect users who have not accepted EULA yet(we block the interactions with the dashboard)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
