### PR TITLE
Fix visualization z-indexes

### DIFF
--- a/app/gui2/src/components/GraphEditor/GraphVisualization.vue
+++ b/app/gui2/src/components/GraphEditor/GraphVisualization.vue
@@ -381,3 +381,10 @@ watch(
     </Suspense>
   </div>
 </template>
+
+<style scoped>
+.GraphVisualization {
+  /** Prevent drawing on top of other UI elements (e.g. dropdown widgets). */
+  isolation: isolate;
+}
+</style>


### PR DESCRIPTION
### Pull Request Description

Prevent visualizations (such as table) and visualization container (including toolbar) from drawing above widgets (such as dropdown).

<img width="245" alt="image" src="https://github.com/enso-org/enso/assets/1047859/51b86256-1d6d-4cf1-9e88-3b36d13f39b8">

Dropdown now covers visualization toolbars.

<img width="245" alt="image" src="https://github.com/enso-org/enso/assets/1047859/b7fe9e47-4121-47a5-9b8a-335449d25734">

Dropdown now covers table column resize handle.

Fixes #9783.

### Important Notes

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
