### PR TITLE
What's the name of my method?

### DIFF
--- a/distribution/bin/enso
+++ b/distribution/bin/enso
@@ -3,7 +3,7 @@ COMP_PATH=$(dirname "$0")/../component
 EXTRA_OPTS="-Dgraal.PrintGraph=Network"
 for opt in "$@"; do
   if [ "$opt" = "--dump-graphs" ]; then
-    EXTRA_OPTS="$EXTRA_OPTS -Dgraal.Dump=:1"
+    EXTRA_OPTS="$EXTRA_OPTS -Dgraal.Dump=Truffle:1"
   fi
 done
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/InsightForEnsoTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/InsightForEnsoTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.ByteArrayOutputStream;
 import java.util.Map;
 import java.util.function.Function;
+import org.enso.common.MethodNames;
 import org.enso.test.utils.ContextUtils;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Language;
@@ -79,7 +80,7 @@ public class InsightForEnsoTest {
             .build();
 
     var m = ctx.eval(code);
-    var fac = m.invokeMember("eval_expression", "fac");
+    var fac = m.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "fac");
     var res = fac.execute(5);
     assertEquals(120, res.asInt());
 
@@ -135,10 +136,10 @@ public class InsightForEnsoTest {
             .build();
 
     var m = ctx.eval(code);
-    var alloc1 = m.invokeMember("eval_expression", "alloc1");
-    var alloc2 = m.invokeMember("eval_expression", "alloc2");
-    var alloc3 = m.invokeMember("eval_expression", "alloc3");
-    var alloc4 = m.invokeMember("eval_expression", "alloc4");
+    var alloc1 = m.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "alloc1");
+    var alloc2 = m.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "alloc2");
+    var alloc3 = m.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "alloc3");
+    var alloc4 = m.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "alloc4");
 
     var useAlloc = useAutoscoping ? (lazy ? alloc4 : alloc2) : (lazy ? alloc3 : alloc1);
     var res = useAlloc.execute(3, 4);

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/RootNamesTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/RootNamesTest.java
@@ -1,0 +1,139 @@
+package org.enso.interpreter.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.enso.common.MethodNames;
+import org.enso.test.utils.ContextUtils;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Language;
+import org.graalvm.polyglot.Source;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RootNamesTest {
+  private Context ctx;
+  private AutoCloseable insightHandle;
+  private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+  @Before
+  public void initContext() throws Exception {
+    this.ctx = ContextUtils.defaultContextBuilder().out(out).build();
+
+    var engine = ctx.getEngine();
+    Map<String, Language> langs = engine.getLanguages();
+    assertNotNull("Enso found: " + langs, langs.get("enso"));
+
+    @SuppressWarnings("unchecked")
+    var fn =
+        (Function<Source, AutoCloseable>)
+            engine.getInstruments().get("insight").lookup(Function.class);
+    assertNotNull(fn);
+
+    var insightScript =
+        Source.newBuilder(
+                "js",
+                """
+        insight.on('enter', (ctx, frame) => {
+            print(`ENTER: ${ctx.name}`);
+        }, {
+            roots : true
+        });
+        """,
+                "trace.js")
+            .build();
+    this.insightHandle = fn.apply(insightScript);
+  }
+
+  @After
+  public void disposeContext() throws Exception {
+    this.insightHandle.close();
+    this.ctx.close();
+  }
+
+  @Test
+  public void computeFactorial() throws Exception {
+    var code =
+        Source.newBuilder(
+                "enso",
+                """
+                import Standard.Base.Data.Numbers
+                fac n =
+                    acc n v = if n <= 1 then v else
+                        @Tail_Call acc n-1 n*v
+
+                    acc n 1
+                """,
+                "factorial.enso")
+            .build();
+
+    var m = ctx.eval(code);
+    var fac = m.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "fac");
+    var res = fac.execute(3);
+    assertEquals(6, res.asInt());
+
+    var msgs = out.toString();
+    var closures =
+        msgs.lines()
+            .filter(l -> l.startsWith("ENTER: "))
+            .map(l -> l.substring(7))
+            .collect(Collectors.toSet());
+
+    assertEquals("Few closures: " + closures, 3, closures.size());
+    assertTrue(
+        "Fully qualified name for method: " + closures,
+        closures.contains("factorial::factorial::fac"));
+    assertTrue(
+        "Name with dots for local method: " + closures, closures.contains("factorial.fac.acc"));
+    assertTrue(
+        "Prefixed with dot name for argument thunk: " + closures,
+        closures.contains("factorial.fac.acc<arg-2>"));
+  }
+
+  @Test
+  public void useNameOfPreviousBinding() throws Exception {
+    var code =
+        Source.newBuilder(
+                "enso",
+                """
+                import Standard.Base.Data.Numbers
+
+                compute a b =
+                  plus = x-> y-> x+y
+                  mul = x-> y-> x*y
+
+                  mul (plus a b) (plus b a)
+                """,
+                "bindings_test.enso")
+            .build();
+
+    var m = ctx.eval(code);
+    var compute = m.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "compute");
+    var powerOfEight = compute.execute(3, 5);
+    assertEquals(64, powerOfEight.asInt());
+
+    var msgs = out.toString();
+    var closures =
+        msgs.lines()
+            .filter(l -> l.startsWith("ENTER: "))
+            .map(l -> l.substring(7))
+            .collect(Collectors.toSet());
+
+    assertEquals("Few closures: " + closures, 3, closures.size());
+    assertTrue(
+        "Fully qualified name for method: " + closures,
+        closures.contains("bindings_test::bindings_test::compute"));
+    assertTrue(
+        "Name taken from previous binding plus: " + closures,
+        closures.contains("bindings_test.compute.plus"));
+    assertTrue(
+        "Name taken from previous binding mul: " + closures,
+        closures.contains("bindings_test.compute.mul"));
+  }
+}

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -2211,7 +2211,7 @@ class RuntimeVisualizationsTest extends AnyFlatSpec with Matchers {
                 None,
                 Vector(
                   Api.StackTraceElement(
-                    "<anonymous>",
+                    "<inline_source>.Enso_Test.Test.Main",
                     None,
                     Some(
                       model.Range(model.Position(0, 5), model.Position(0, 19))

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -1029,6 +1029,7 @@ class IrToTruffle(
     *
     * @param scope     the scope in which the code generation is occurring
     * @param scopeName the name of `scope`
+    * @param initialName suggested name for a first closure
     */
   sealed private class ExpressionProcessor(
     val scope: LocalScope,
@@ -1044,6 +1045,7 @@ class IrToTruffle(
       * scope.
       *
       * @param scopeName the name to attribute to the default local scope.
+      * @param initialName suggested name for a first closure
       */
     def this(
       scopeName: String,
@@ -1063,6 +1065,7 @@ class IrToTruffle(
       * scope of `this`.
       *
       * @param name the name of the child scope
+      * @param initialName suggested name for a first closure
       * @return an expression processor operating on a child scope
       */
     def createChild(
@@ -1943,6 +1946,7 @@ class IrToTruffle(
       *
       * @param arguments the argument definitions
       * @param body      the body definition
+      * @param initialName suggested name for a first closure
       * @return a node for the final shape of function body and pre-processed
       *         argument definitions.
       */
@@ -2199,6 +2203,7 @@ class IrToTruffle(
     *
     * @param scope     the scope in which the function call exists
     * @param scopeName the name of `scope`
+    * @param initialName suggested name for a first closure
     */
   sealed private class CallArgumentProcessor(
     val scope: LocalScope,
@@ -2305,6 +2310,7 @@ class IrToTruffle(
     *
     * @param scope     the scope in which the function is defined
     * @param scopeName the name of `scope`
+    * @param initialName suggested name for a first closure
     */
   sealed private class DefinitionArgumentProcessor(
     val scopeName: String = "<root>",


### PR DESCRIPTION
### Pull Request Description

While working on #10056 I realized the names of method and closure nodes are incomprehensible to anyone. This PR replaces the infamous `<anonymous>` with a name hinting where the method actually is.

### Important Notes

I assume this change will be visible not only in IGV, but also in _stacktraces_ and we may need to adjust few tests.

### Checklist

![nicer names](https://github.com/enso-org/enso/assets/26887752/0a28cc67-8dce-4e3c-bd5a-289f192c1cc1)

- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests were updated: [fixed](https://github.com/enso-org/enso/pull/10164#issuecomment-2149058296)
- [x] [RootNamesTest](https://github.com/enso-org/enso/pull/10164/commits/965310551e8a95a4d7a84f35517fc7058154b659) was written
