### PR TITLE
Add By_Type option to more components

### DIFF
--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -2856,7 +2856,7 @@ type DB_Table
          Fill empty values in two columns with the value "hello".
 
              fill_empty = table.fill_empty ["col0", "col1"] "hello"
-    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True)
+    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @default (self -> Widget_Helpers.make_fill_default_value_selector column_source=self add_text=True)
     fill_empty : Vector (Integer | Text | Regex) | Text | Integer | Regex -> DB_Column | Column_Ref | Expression | Previous_Value | Any -> DB_Table
     fill_empty self (columns : Vector | Text | Integer | Regex) default =

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -2518,7 +2518,8 @@ type DB_Table
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     cast : Vector (Text | Integer | Regex | By_Type) | Text | Integer | Regex | By_Type -> Value_Type -> Boolean -> Problem_Behavior -> DB_Table ! Illegal_Argument | Inexact_Type_Coercion | Conversion_Failure
     cast self columns:(Vector (Text | Integer | Regex | By_Type) | Text | Integer | Regex | By_Type)=[0] value_type error_on_missing_columns=True on_problems=Problem_Behavior.Report_Warning =
-        selected = self.columns_helper.select_columns columns Case_Sensitivity.Default reorder=False error_on_missing_columns=error_on_missing_columns on_problems=on_problems error_on_empty=False . map self.make_column
+        helper = Table_Helpers.Table_Column_Helper.Value self.columns self.make_column self .read
+        selected = helper.select_columns columns Case_Sensitivity.Default reorder=False error_on_missing_columns=error_on_missing_columns on_problems=on_problems error_on_empty=False . map self.make_column
         selected.fold self table-> column_to_cast->
             new_column = column_to_cast.cast value_type on_problems
             table.set new_column as=column_to_cast.name set_mode=Set_Mode.Update

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -2529,7 +2529,7 @@ type DB_Table
        their contents.
 
        This operation is currently not available in the Database backend.
-    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True)
+    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     auto_value_types : Vector (Text | Integer | Regex) | Text | Integer | Regex -> Boolean -> Boolean -> Problem_Behavior -> DB_Table
     auto_value_types self columns=self.column_names shrink_types=False error_on_missing_columns=True on_problems=Problem_Behavior.Report_Warning =
         _ = [columns, shrink_types, error_on_missing_columns, on_problems]

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -467,8 +467,8 @@ type DB_Table
 
              table.reorder_columns [0] position=Position.After_Other_Columns
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
-    reorder_columns : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Position -> Case_Sensitivity -> Boolean -> Problem_Behavior -> DB_Table ! Missing_Input_Columns
-    reorder_columns self (columns : (Vector | Text | Integer | Regex) = [self.columns.first.name]) (position:Position=Position.Before_Other_Columns) (case_sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=False) (on_problems:Problem_Behavior=Report_Warning) =
+    reorder_columns : Vector (Integer | Text | Regex | By_Type) | Text | Integer | Regex | By_Type -> Position -> Case_Sensitivity -> Boolean -> Problem_Behavior -> DB_Table ! Missing_Input_Columns
+    reorder_columns self (columns : (Vector | Text | Integer | Regex | By_Type) = [self.columns.first.name]) (position:Position=Position.Before_Other_Columns) (case_sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=False) (on_problems:Problem_Behavior=Report_Warning) =
         new_columns = self.columns_helper.reorder_columns columns position case_sensitivity error_on_missing_columns on_problems
         self.updated_columns new_columns
 
@@ -1675,8 +1675,8 @@ type DB_Table
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @from_column Widget.Text_Input
     @to_column Widget.Text_Input
-    replace : (DB_Table | Map) -> (Text | Integer | Vector (Text | Integer)) -> (Text | Integer | Nothing) -> (Text | Integer | Nothing) -> Boolean -> Problem_Behavior -> DB_Table ! Missing_Input_Columns | Non_Unique_Key | Unmatched_Rows_In_Lookup
-    replace self lookup_table:(DB_Table | Map) columns:(Text | Integer | Vector (Text | Integer)) from_column:(Text | Integer | Nothing)=Nothing to_column:(Text | Integer | Nothing)=Nothing allow_unmatched_rows:Boolean=True on_problems:Problem_Behavior=Problem_Behavior.Report_Warning =
+    replace : (DB_Table | Map) -> Vector (Integer | Text | Regex | By_Type) | Text | Integer | Regex | By_Type -> (Text | Integer | Nothing) -> (Text | Integer | Nothing) -> Boolean -> Problem_Behavior -> DB_Table ! Missing_Input_Columns | Non_Unique_Key | Unmatched_Rows_In_Lookup
+    replace self lookup_table:(DB_Table | Map) columns:(Vector (Integer | Text | Regex | By_Type) | Text | Integer | Regex | By_Type) from_column:(Text | Integer | Nothing)=Nothing to_column:(Text | Integer | Nothing)=Nothing allow_unmatched_rows:Boolean=True on_problems:Problem_Behavior=Problem_Behavior.Report_Warning =
         Replace_Helpers.replace self lookup_table columns from_column to_column allow_unmatched_rows on_problems
 
     ## ALIAS join by row position
@@ -2280,8 +2280,8 @@ type DB_Table
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @locale Locale.default_widget
     @format (make_format_chooser include_number=True)
-    format : Vector (Text | Integer | Regex) | Text | Integer | Regex -> Text | Date_Time_Formatter | DB_Column -> Locale -> Boolean -> Problem_Behavior -> DB_Table ! Date_Time_Format_Parse_Error | Illegal_Argument
-    format self columns format:(Text | Date_Time_Formatter | DB_Column)="" locale=Locale.default error_on_missing_columns=True on_problems=Report_Warning =
+    format : Vector (Text | Integer | Regex | By_Type) | Text | Integer | Regex | By_Type -> Text | Date_Time_Formatter | DB_Column -> Locale -> Boolean -> Problem_Behavior -> DB_Table ! Date_Time_Format_Parse_Error | Illegal_Argument
+    format self columns:(Vector (Text | Integer | Regex | By_Type) | Text | Integer | Regex | By_Type) format:(Text | Date_Time_Formatter | DB_Column)="" locale=Locale.default error_on_missing_columns=True on_problems=Report_Warning =
         _ = [columns, format, locale, error_on_missing_columns, on_problems]
         Error.throw (Unsupported_Database_Operation.Error "DB_Table.format is not implemented yet for the Database backends.")
 
@@ -2516,8 +2516,8 @@ type DB_Table
          types. Due to this, a Mixed column containing values `[2, "3"]` will
          actually be converted into `[2, Nothing]` when casting to Integer type.
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
-    cast : Vector (Text | Integer | Regex) | Text | Integer | Regex -> Value_Type -> Boolean -> Problem_Behavior -> DB_Table ! Illegal_Argument | Inexact_Type_Coercion | Conversion_Failure
-    cast self columns=[0] value_type error_on_missing_columns=True on_problems=Problem_Behavior.Report_Warning =
+    cast : Vector (Text | Integer | Regex | By_Type) | Text | Integer | Regex | By_Type -> Value_Type -> Boolean -> Problem_Behavior -> DB_Table ! Illegal_Argument | Inexact_Type_Coercion | Conversion_Failure
+    cast self columns:(Vector (Text | Integer | Regex | By_Type) | Text | Integer | Regex | By_Type)=[0] value_type error_on_missing_columns=True on_problems=Problem_Behavior.Report_Warning =
         selected = self.columns_helper.select_columns columns Case_Sensitivity.Default reorder=False error_on_missing_columns=error_on_missing_columns on_problems=on_problems error_on_empty=False . map self.make_column
         selected.fold self table-> column_to_cast->
             new_column = column_to_cast.cast value_type on_problems
@@ -2530,8 +2530,8 @@ type DB_Table
 
        This operation is currently not available in the Database backend.
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
-    auto_value_types : Vector (Text | Integer | Regex) | Text | Integer | Regex -> Boolean -> Boolean -> Problem_Behavior -> DB_Table
-    auto_value_types self columns=self.column_names shrink_types=False error_on_missing_columns=True on_problems=Problem_Behavior.Report_Warning =
+    auto_value_types : Vector (Text | Integer | Regex | By_Type) | Text | Integer | Regex | By_Type -> Boolean -> Boolean -> Problem_Behavior -> DB_Table
+    auto_value_types self columns:(Vector (Text | Integer | Regex | By_Type) | Text | Integer | Regex | By_Type)=self.column_names shrink_types=False error_on_missing_columns=True on_problems=Problem_Behavior.Report_Warning =
         _ = [columns, shrink_types, error_on_missing_columns, on_problems]
         Error.throw (Unsupported_Database_Operation.Error "DB_Table.auto_value_types is not supported in the Database backends.")
 
@@ -2830,8 +2830,8 @@ type DB_Table
              fill_nothing = table.fill_nothing ["col0", "col1"] 20.5
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @default (self -> Widget_Helpers.make_fill_default_value_selector column_source=self add_text=True add_number=True add_boolean=True)
-    fill_nothing : Vector (Integer | Text | Regex) | Text | Integer | Regex -> DB_Column | Column_Ref | Expression | Previous_Value | Any -> DB_Table
-    fill_nothing self (columns : Vector | Text | Integer | Regex) default =
+    fill_nothing : Vector (Integer | Text | Regex | By_Type) | Text | Integer | Regex | By_Type -> DB_Column | Column_Ref | Expression | Previous_Value | Any -> DB_Table
+    fill_nothing self (columns : Vector | Text | Integer | Regex | By_Type) default =
         resolved_default = (self:Table_Ref).resolve default
         transformer col = col.fill_nothing resolved_default
         Table_Helpers.replace_columns_with_transformed_columns self columns transformer
@@ -2858,8 +2858,8 @@ type DB_Table
              fill_empty = table.fill_empty ["col0", "col1"] "hello"
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @default (self -> Widget_Helpers.make_fill_default_value_selector column_source=self add_text=True)
-    fill_empty : Vector (Integer | Text | Regex) | Text | Integer | Regex -> DB_Column | Column_Ref | Expression | Previous_Value | Any -> DB_Table
-    fill_empty self (columns : Vector | Text | Integer | Regex) default =
+    fill_empty : Vector (Integer | Text | Regex | By_Type) | Text | Integer | Regex | By_Type -> DB_Column | Column_Ref | Expression | Previous_Value | Any -> DB_Table
+    fill_empty self (columns : Vector | Text | Integer | Regex | By_Type) default =
         resolved_default = (self:Table_Ref).resolve default
         transformer col = col.fill_empty resolved_default
         Table_Helpers.replace_columns_with_transformed_columns self columns transformer
@@ -2899,8 +2899,8 @@ type DB_Table
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @term (Widget_Helpers.make_column_ref_by_name_selector add_regex=True add_text=True add_named_pattern=True)
     @new_text (Widget_Helpers.make_column_ref_by_name_selector add_text=True)
-    text_replace : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Text | DB_Column | Column_Ref | Expression | Regex -> Text | DB_Column | Column_Ref | Expression -> Case_Sensitivity -> Boolean -> DB_Column
-    text_replace self columns (term : Text | DB_Column | Column_Ref | Expression | Regex = "") (new_text : Text | DB_Column | Column_Ref | Expression = "") case_sensitivity=Case_Sensitivity.Sensitive only_first=False =
+    text_replace : Vector (Integer | Text | Regex | By_Type) | Text | Integer | Regex | By_Type -> Text | DB_Column | Column_Ref | Expression | Regex -> Text | DB_Column | Column_Ref | Expression -> Case_Sensitivity -> Boolean -> DB_Column
+    text_replace self columns:(Vector (Integer | Text | Regex | By_Type) | Text | Integer | Regex | By_Type) (term : Text | DB_Column | Column_Ref | Expression | Regex = "") (new_text : Text | DB_Column | Column_Ref | Expression = "") case_sensitivity=Case_Sensitivity.Sensitive only_first=False =
         table_ref = Table_Ref.from self
         resolved_term = table_ref.resolve term
         resolved_new_text = table_ref.resolve new_text
@@ -2935,8 +2935,8 @@ type DB_Table
              table.text_cleanse [..Leading_Whitespace, ..Trailing_Whitespace]
     @remove make_data_cleanse_vector_selector
     @from (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
-    text_cleanse : Vector Text_Cleanse -> Vector (Integer | Text | Regex) -> DB_Table
-    text_cleanse self remove from =
+    text_cleanse : Vector Text_Cleanse -> Vector (Integer | Text | Regex | By_Type) -> DB_Table
+    text_cleanse self remove from:(Vector (Integer | Text | Regex | By_Type)) =
         transformer col = col.text_cleanse remove
         Table_Helpers.replace_columns_with_transformed_columns self from transformer
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -2896,7 +2896,7 @@ type DB_Table
          Replace texts in quotes with parentheses.
 
              table.text_replace ["Input"] '"(.*?)"'.to_regex '($1)'
-    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True)
+    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @term (Widget_Helpers.make_column_ref_by_name_selector add_regex=True add_text=True add_named_pattern=True)
     @new_text (Widget_Helpers.make_column_ref_by_name_selector add_text=True)
     text_replace : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Text | DB_Column | Column_Ref | Expression | Regex -> Text | DB_Column | Column_Ref | Expression -> Case_Sensitivity -> Boolean -> DB_Column

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -2828,7 +2828,7 @@ type DB_Table
          Fill missing values in two columns with the value 20.5.
 
              fill_nothing = table.fill_nothing ["col0", "col1"] 20.5
-    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True)
+    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @default (self -> Widget_Helpers.make_fill_default_value_selector column_source=self add_text=True add_number=True add_boolean=True)
     fill_nothing : Vector (Integer | Text | Regex) | Text | Integer | Regex -> DB_Column | Column_Ref | Expression | Previous_Value | Any -> DB_Table
     fill_nothing self (columns : Vector | Text | Integer | Regex) default =

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -1672,7 +1672,7 @@ type DB_Table
              #    1 | 20 | b | f
              #    2 | 30 | c | g
              #    3 | 40 | d | h
-    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True)
+    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @from_column Widget.Text_Input
     @to_column Widget.Text_Input
     replace : (DB_Table | Map) -> (Text | Integer | Vector (Text | Integer)) -> (Text | Integer | Nothing) -> (Text | Integer | Nothing) -> Boolean -> Problem_Behavior -> DB_Table ! Missing_Input_Columns | Non_Unique_Key | Unmatched_Rows_In_Lookup

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -469,8 +469,9 @@ type DB_Table
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     reorder_columns : Vector (Integer | Text | Regex | By_Type) | Text | Integer | Regex | By_Type -> Position -> Case_Sensitivity -> Boolean -> Problem_Behavior -> DB_Table ! Missing_Input_Columns
     reorder_columns self (columns : (Vector | Text | Integer | Regex | By_Type) = [self.columns.first.name]) (position:Position=Position.Before_Other_Columns) (case_sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=False) (on_problems:Problem_Behavior=Report_Warning) =
-        new_columns = self.columns_helper.reorder_columns columns position case_sensitivity error_on_missing_columns on_problems
-        self.updated_columns new_columns
+        helper = Table_Helpers.Table_Column_Helper.Value self.columns self.make_column self .read
+        new_columns = helper.reorder_columns columns position case_sensitivity error_on_missing_columns on_problems
+        self.updated_columns (new_columns.map _.as_internal)
 
     ## GROUP Standard.Base.Selections
        ICON select_column

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -2277,7 +2277,7 @@ type DB_Table
          Format all columns in the table using the default formatter.
 
              table.format
-    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True)
+    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @locale Locale.default_widget
     @format (make_format_chooser include_number=True)
     format : Vector (Text | Integer | Regex) | Text | Integer | Regex -> Text | Date_Time_Formatter | DB_Column -> Locale -> Boolean -> Problem_Behavior -> DB_Table ! Date_Time_Format_Parse_Error | Illegal_Argument

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -261,8 +261,7 @@ type DB_Table
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     select_columns :  Vector (Integer | Text | Regex | By_Type) | Text | Integer | Regex | By_Type -> Boolean -> Case_Sensitivity -> Boolean -> Problem_Behavior -> DB_Table ! No_Output_Columns | Missing_Input_Columns
     select_columns self (columns : (Vector | Text | Integer | Regex | By_Type) = [self.columns.first.name]) (reorder:Boolean=False) (case_sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=True) (on_problems:Problem_Behavior=Report_Warning) =
-        helper = Table_Helpers.Table_Column_Helper.Value self.columns self.make_column self .read
-        new_columns = helper.select_columns columns case_sensitivity reorder error_on_missing_columns on_problems
+        new_columns = self.columns_helper.select_columns columns case_sensitivity reorder error_on_missing_columns on_problems
         self.updated_columns (new_columns.map _.as_internal)
 
     ## PRIVATE
@@ -280,8 +279,7 @@ type DB_Table
     @types Widget_Helpers.make_value_type_vector_selector
     select_columns_by_type : Vector Value_Type -> Boolean -> Table
     select_columns_by_type self types:Vector strict:Boolean=False =
-        helper = Table_Helpers.Table_Column_Helper.Value self.columns self.make_column self .read
-        new_columns = helper.select_by_type types strict
+        new_columns = self.columns_helper.select_by_type types strict
         result = self.updated_columns (new_columns.map _.as_internal)
         Warning.attach (Deprecated.Warning "Standard.Database.DB_Table.DB_Table" "select_columns_by_type" "Deprecated: use `select_columns` with a `By_Type` instead.") result
 
@@ -341,8 +339,7 @@ type DB_Table
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     remove_columns :  Vector (Integer | Text | Regex | By_Type) | Text | Integer | Regex | By_Type -> Case_Sensitivity -> Boolean -> Problem_Behavior -> DB_Table ! No_Output_Columns | Missing_Input_Columns
     remove_columns self (columns : (Vector | Text | Integer | Regex | By_Type) = [self.columns.first.name]) (case_sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=False) (on_problems:Problem_Behavior=Report_Warning) =
-        helper = Table_Helpers.Table_Column_Helper.Value self.columns self.make_column self .read
-        new_columns = helper.remove_columns columns case_sensitivity error_on_missing_columns=error_on_missing_columns on_problems=on_problems
+        new_columns = self.columns_helper.remove_columns columns case_sensitivity error_on_missing_columns=error_on_missing_columns on_problems=on_problems
         self.updated_columns (new_columns.map _.as_internal)
 
     ## PRIVATE
@@ -360,8 +357,7 @@ type DB_Table
     @types Widget_Helpers.make_value_type_vector_selector
     remove_columns_by_type : Vector Value_Type -> Boolean -> Table
     remove_columns_by_type self types:Vector strict:Boolean=False =
-        helper = Table_Helpers.Table_Column_Helper.Value self.columns self.make_column self .read
-        new_columns = helper.remove_by_type types strict
+        new_columns = self.columns_helper.remove_by_type types strict
         result = self.updated_columns (new_columns.map _.as_internal)
         Warning.attach (Deprecated.Warning "Standard.Database.DB_Table.DB_Table" "remove_columns_by_type" "Deprecated: use `remove_columns` with a `By_Type` instead.") result
 
@@ -469,8 +465,7 @@ type DB_Table
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     reorder_columns : Vector (Integer | Text | Regex | By_Type) | Text | Integer | Regex | By_Type -> Position -> Case_Sensitivity -> Boolean -> Problem_Behavior -> DB_Table ! Missing_Input_Columns
     reorder_columns self (columns : (Vector | Text | Integer | Regex | By_Type) = [self.columns.first.name]) (position:Position=Position.Before_Other_Columns) (case_sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=False) (on_problems:Problem_Behavior=Report_Warning) =
-        helper = Table_Helpers.Table_Column_Helper.Value self.columns self.make_column self .read
-        new_columns = helper.reorder_columns columns position case_sensitivity error_on_missing_columns on_problems
+        new_columns = self.columns_helper.reorder_columns columns position case_sensitivity error_on_missing_columns on_problems
         self.updated_columns (new_columns.map _.as_internal)
 
     ## GROUP Standard.Base.Selections
@@ -840,8 +835,7 @@ type DB_Table
     add_row_number self (name:Text="Row") (from:Integer=1) (step:Integer=1) (group_by:(Vector | Text | Integer | Regex)=[]) (order_by:(Vector | Text)=[]) (on_problems:Problem_Behavior=Problem_Behavior.Report_Warning) =
         problem_builder = Problem_Builder.new error_on_missing_columns=True
         grouping_columns = self.columns_helper.select_columns_helper group_by Case_Sensitivity.Default True problem_builder
-        grouping_columns.each internal_column->
-            column = self.make_column internal_column
+        grouping_columns.each column->
             if column.value_type.is_floating_point then
                 problem_builder.report_other_warning (Floating_Point_Equality.Error column.name)
         ordering = Table_Helpers.resolve_order_by self.columns order_by problem_builder
@@ -854,7 +848,7 @@ type DB_Table
                 True -> case self.default_ordering of
                     Nothing -> Error.throw (Illegal_Argument.Error "No `order_by` is specified and the table has no existing ordering (e.g. from an `order_by` operation or a primary key). Some ordering is required for `add_row_number` in Database tables.")
                     descriptors -> descriptors
-            grouping_expressions = grouping_columns.map .expression
+            grouping_expressions = (grouping_columns.map _.as_internal).map .expression
 
             # The SQL row_number() counts from 1, so we adjust the offset.
             offset = from - step
@@ -2519,8 +2513,7 @@ type DB_Table
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     cast : Vector (Text | Integer | Regex | By_Type) | Text | Integer | Regex | By_Type -> Value_Type -> Boolean -> Problem_Behavior -> DB_Table ! Illegal_Argument | Inexact_Type_Coercion | Conversion_Failure
     cast self columns:(Vector (Text | Integer | Regex | By_Type) | Text | Integer | Regex | By_Type)=[0] value_type error_on_missing_columns=True on_problems=Problem_Behavior.Report_Warning =
-        helper = Table_Helpers.Table_Column_Helper.Value self.columns self.make_column self .read
-        selected = helper.select_columns columns Case_Sensitivity.Default reorder=False error_on_missing_columns=error_on_missing_columns on_problems=on_problems error_on_empty=False . map self.make_column
+        selected = self.columns_helper.select_columns columns Case_Sensitivity.Default reorder=False error_on_missing_columns=error_on_missing_columns on_problems=on_problems error_on_empty=False . map self.make_column
         selected.fold self table-> column_to_cast->
             new_column = column_to_cast.cast value_type on_problems
             table.set new_column as=column_to_cast.name set_mode=Set_Mode.Update
@@ -2664,7 +2657,7 @@ type DB_Table
     ## PRIVATE
     columns_helper : Table_Column_Helper
     columns_helper self =
-        Table_Helpers.Table_Column_Helper.Value self.internal_columns self.make_column self .read
+        Table_Helpers.Table_Column_Helper.Value self.columns self.internal_columns self.make_column self .read
 
     ## PRIVATE
     column_naming_helper : Column_Naming_Helper

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -2515,7 +2515,7 @@ type DB_Table
          The `parse` method should be used to convert text values into other
          types. Due to this, a Mixed column containing values `[2, "3"]` will
          actually be converted into `[2, Nothing]` when casting to Integer type.
-    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True)
+    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     cast : Vector (Text | Integer | Regex) | Text | Integer | Regex -> Value_Type -> Boolean -> Problem_Behavior -> DB_Table ! Illegal_Argument | Inexact_Type_Coercion | Conversion_Failure
     cast self columns=[0] value_type error_on_missing_columns=True on_problems=Problem_Behavior.Report_Warning =
         selected = self.columns_helper.select_columns columns Case_Sensitivity.Default reorder=False error_on_missing_columns=error_on_missing_columns on_problems=on_problems error_on_empty=False . map self.make_column

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -423,7 +423,7 @@ type DB_Table
        either the start or the end in the specified order.
 
        Arguments:
-       - columns: Specifies columns by a name, index or regular expression to
+       - columns: Specifies columns by a name, type, index or regular expression to
          match names, or a Vector of these.
        - position: Specifies how to place the selected columns in relation to
          the remaining columns which were not matched by `columns` (if any).
@@ -466,7 +466,7 @@ type DB_Table
          Move the first column to back.
 
              table.reorder_columns [0] position=Position.After_Other_Columns
-    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True)
+    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     reorder_columns : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Position -> Case_Sensitivity -> Boolean -> Problem_Behavior -> DB_Table ! Missing_Input_Columns
     reorder_columns self (columns : (Vector | Text | Integer | Regex) = [self.columns.first.name]) (position:Position=Position.Before_Other_Columns) (case_sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=False) (on_problems:Problem_Behavior=Report_Warning) =
         new_columns = self.columns_helper.reorder_columns columns position case_sensitivity error_on_missing_columns on_problems

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -2934,7 +2934,7 @@ type DB_Table
 
              table.text_cleanse [..Leading_Whitespace, ..Trailing_Whitespace]
     @remove make_data_cleanse_vector_selector
-    @from (Widget_Helpers.make_column_name_multi_selector add_regex=True)
+    @from (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     text_cleanse : Vector Text_Cleanse -> Vector (Integer | Text | Regex) -> DB_Table
     text_cleanse self remove from =
         transformer col = col.text_cleanse remove

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Replace_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Replace_Helpers.enso
@@ -2,15 +2,21 @@ from Standard.Base import all
 import Standard.Base.Errors.Empty_Error.Empty_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 
+import project.Internal.Problem_Builder.Problem_Builder
+import project.Internal.Table_Helpers
 import project.Set_Mode.Set_Mode
 import project.Table.Table
+import project.Value_Type.By_Type
 from project.Errors import Missing_Input_Columns, No_Such_Column, Non_Unique_Key, Unmatched_Rows_In_Lookup
 
 ## PRIVATE
-replace : Table -> (Table | Map) -> (Text | Integer | Vector (Text | Integer)) -> (Text | Integer | Nothing) -> (Text | Integer | Nothing) -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Non_Unique_Key | Unmatched_Rows_In_Lookup
-replace base_table lookup_table columns:(Text | Integer | Vector (Text | Integer)) from_column:(Text | Integer | Nothing)=Nothing to_column:(Text | Integer | Nothing)=Nothing allow_unmatched_rows:Boolean=True on_problems:Problem_Behavior=Problem_Behavior.Report_Warning =
+replace : Table -> (Table | Map) -> (Text | Integer | By_Type | Vector (Text | Integer | By_Type)) -> (Text | Integer | Nothing) -> (Text | Integer | Nothing) -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Non_Unique_Key | Unmatched_Rows_In_Lookup
+replace base_table lookup_table columns:(Text | Integer | By_Type | Vector (Text | Integer | By_Type)) from_column:(Text | Integer | Nothing)=Nothing to_column:(Text | Integer | Nothing)=Nothing allow_unmatched_rows:Boolean=True on_problems:Problem_Behavior=Problem_Behavior.Report_Warning =
     case columns of
-        _ : Vector -> columns.fold base_table (base_table -> column-> replace base_table lookup_table column from_column to_column allow_unmatched_rows on_problems)
+        _ : Vector ->
+            problem_builder = Problem_Builder.new error_on_missing_columns=True
+            replace_columns = base_table.columns_helper.select_columns_helper columns Case_Sensitivity.Default False problem_builder
+            replace_columns.fold base_table (base_table -> column-> replace base_table lookup_table column.name from_column to_column allow_unmatched_rows on_problems)
         _ ->
             column = columns
             case lookup_table of

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -130,10 +130,8 @@ type Table_Column_Helper
          specified types will also be selected (i.e. ignore size, precision).
     remove_by_type : Vector Value_Type -> Boolean -> Vector
     remove_by_type self types:Vector strict:Boolean=False =
-        remaining_columns = if strict then self.columns.filter (c->(types.contains c.value_type).not) else
+        if strict then self.columns.filter (c->(types.contains c.value_type).not) else
             self.columns.filter c->(types.all (t->(c.value_type.is_same_type t . not)))
-        if remaining_columns.length == self.columns.length then Error.throw (No_Output_Columns.Error "No columns of the specified types were found.") else
-            remaining_columns
 
     ## PRIVATE
        A helper function encapsulating shared code for `reorder_columns`

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -132,8 +132,7 @@ type Table_Column_Helper
     remove_by_type self types:Vector strict:Boolean=False =
         remaining_columns = if strict then self.columns.filter (c->(types.contains c.value_type).not) else
             self.columns.filter c->(types.all (t->(c.value_type.is_same_type t . not)))
-        ## TODO below is defect
-        if remaining_columns.length == 0 then Error.throw (No_Output_Columns.Error "No columns of the specified types were found.") else
+        if remaining_columns.length == self.columns.length then Error.throw (No_Output_Columns.Error "No columns of the specified types were found.") else
             remaining_columns
 
     ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Table_Helpers.enso
@@ -26,13 +26,14 @@ type Table_Column_Helper
        Helps managing table columns.
 
        Arguments:
-       - internal_columns: A list of all columns in a table.
+       - columns: A list of columns in the table.
+       - internal_columns: A list of all columns in a table. (In_DB this is different from columns)
        - make_column: A function which takes the internal column and creates a
          fully fledged column from it.
        - table: A reference to the table.
        - materialize: A function which takes a table and materializes it to
          in-memory.
-    Value internal_columns make_column table materialize
+    Value columns internal_columns make_column table materialize
 
     ## PRIVATE
        A helper function encapsulating shared code for `select_columns`
@@ -82,10 +83,10 @@ type Table_Column_Helper
          specified types will also be selected (i.e. ignore size, precision).
     select_by_type : Vector Value_Type -> Boolean -> Vector
     select_by_type self types:Vector strict:Boolean=False =
-        columns = if strict then self.internal_columns.filter c-> types.contains c.value_type else
-            self.internal_columns.filter c-> types.any t-> c.value_type.is_same_type t
-        if columns.length == 0 then Error.throw (No_Output_Columns.Error "No columns of the specified types were found.") else
-            columns
+        selected_columns = if strict then self.columns.filter c-> types.contains c.value_type else
+            self.columns.filter c-> types.any t-> c.value_type.is_same_type t
+        if selected_columns.length == 0 then Error.throw (No_Output_Columns.Error "No columns of the specified types were found.") else
+            selected_columns
 
     ## PRIVATE
        A helper function encapsulating shared code for `remove_columns`
@@ -112,7 +113,7 @@ type Table_Column_Helper
         problem_builder = Problem_Builder.new error_on_missing_columns=error_on_missing_columns
         selection = self.select_columns_helper selectors case_sensitivity False problem_builder
         selected_names = Map.from_vector (selection.map column-> [column.name, True])
-        result = self.internal_columns.filter column->
+        result = self.columns.filter column->
             should_be_removed = selected_names.get column.name False
             should_be_removed.not
         if result.is_empty then Error.throw No_Output_Columns.Error else
@@ -129,10 +130,11 @@ type Table_Column_Helper
          specified types will also be selected (i.e. ignore size, precision).
     remove_by_type : Vector Value_Type -> Boolean -> Vector
     remove_by_type self types:Vector strict:Boolean=False =
-        columns = if strict then self.internal_columns.filter (c->(types.contains c.value_type).not) else
-            self.internal_columns.filter c->(types.all (t->(c.value_type.is_same_type t . not)))
-        if columns.length == 0 then Error.throw (No_Output_Columns.Error "No columns of the specified types were found.") else
-            columns
+        remaining_columns = if strict then self.columns.filter (c->(types.contains c.value_type).not) else
+            self.columns.filter c->(types.all (t->(c.value_type.is_same_type t . not)))
+        ## TODO below is defect
+        if remaining_columns.length == 0 then Error.throw (No_Output_Columns.Error "No columns of the specified types were found.") else
+            remaining_columns
 
     ## PRIVATE
        A helper function encapsulating shared code for `reorder_columns`
@@ -162,7 +164,7 @@ type Table_Column_Helper
         selection = self.select_columns_helper selectors case_sensitivity True problem_builder
         problem_builder.attach_problems_before on_problems <|
             selected_names = Map.from_vector (selection.map column-> [column.name, True])
-            other_columns = self.internal_columns.filter column->
+            other_columns = self.columns.filter column->
                 is_selected = selected_names.get column.name False
                 is_selected.not
             result = case position of
@@ -190,12 +192,12 @@ type Table_Column_Helper
     select_columns_helper self (selectors:(Text | Integer | Regex | By_Type | Vector)) (case_sensitivity:Case_Sensitivity) (reorder:Boolean) (problem_builder:Problem_Builder) =
         resolve_selector selector:(Text | Integer | Regex | By_Type) =
             case selector of
-                ix : Integer -> if is_index_valid self.internal_columns.length ix then [self.internal_columns.at ix] else
+                ix : Integer -> if is_index_valid self.columns.length ix then [self.columns.at ix] else
                     problem_builder.report_oob_indices [ix]
                     []
-                _ : By_Type -> self.internal_columns.filter column-> column.value_type.is_same_type selector.type
+                _ : By_Type -> self.columns.filter column-> column.value_type.is_same_type selector.type
                 _ ->
-                    matches = match_columns selector case_sensitivity self.internal_columns
+                    matches = match_columns selector case_sensitivity self.columns
                     if matches.is_empty then problem_builder.report_missing_input_columns [selector]
                     matches
 
@@ -205,7 +207,7 @@ type Table_Column_Helper
         selected_columns = vector.map resolve_selector . flatten
         if reorder then selected_columns.distinct on=_.name else
             map = Map.from_vector (selected_columns.map column-> [column.name, True]) error_on_duplicates=False
-            self.internal_columns.filter column-> map.contains_key column.name
+            self.columns.filter column-> map.contains_key column.name
 
     ## PRIVATE
        A helper function which selects a single column from the table.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -2832,7 +2832,7 @@ type Table
          Fill empty values in two columns with the value "hello".
 
              fill_empty = table.fill_empty ["col0", "col1"] "hello"
-    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True)
+    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @default (self -> Widget_Helpers.make_fill_default_value_selector column_source=self add_text=True)
     fill_empty : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Column | Column_Ref | Expression | Previous_Value | Any -> Table
     fill_empty self (columns : Vector | Text | Integer | Regex) default =

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -2781,7 +2781,7 @@ type Table
     ## PRIVATE
     columns_helper : Table_Column_Helper
     columns_helper self =
-        Table_Helpers.Table_Column_Helper.Value self.columns (x->x) self (x->x)
+        Table_Helpers.Table_Column_Helper.Value self.columns self.columns (x->x) self (x->x)
 
     ## ALIAS fill missing, if_nothing
        GROUP Standard.Base.Values

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -2804,7 +2804,7 @@ type Table
          Fill missing values in two columns with the value 20.5.
 
              fill_nothing = table.fill_nothing ["col0", "col1"] 20.5
-    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True)
+    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @default (self -> Widget_Helpers.make_fill_default_value_selector column_source=self add_text=True add_number=True add_boolean=True)
     fill_nothing : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Column | Column_Ref | Expression | Previous_Value | Any -> Table
     fill_nothing self (columns : Vector | Text | Integer | Regex) default =

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -598,8 +598,8 @@ type Table
 
              table.reorder_columns [0] position=Position.After_Other_Columns
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
-    reorder_columns : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Position -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns
-    reorder_columns self (columns : (Vector | Text | Integer | Regex) = [self.columns.first.name]) (position:Position=Position.Before_Other_Columns) (case_sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=False) (on_problems:Problem_Behavior=Report_Warning) =
+    reorder_columns : Vector (Integer | Text | Regex | By_Type) | Text | Integer | Regex | By_Type -> Position -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns
+    reorder_columns self (columns : (Vector | Text | Integer | Regex | By_Type) = [self.columns.first.name]) (position:Position=Position.Before_Other_Columns) (case_sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=False) (on_problems:Problem_Behavior=Report_Warning) =
         new_columns = self.columns_helper.reorder_columns columns position case_sensitivity error_on_missing_columns on_problems
         Table.new new_columns
 
@@ -1156,8 +1156,8 @@ type Table
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @locale Locale.default_widget
     @format (make_format_chooser include_number=True)
-    format : Vector (Text | Integer | Regex) | Text | Integer | Regex -> Text | Date_Time_Formatter | Column -> Locale -> Boolean -> Problem_Behavior -> Table ! Date_Time_Format_Parse_Error | Illegal_Argument
-    format self columns format:(Text | Date_Time_Formatter | Column)="" locale=Locale.default error_on_missing_columns=True on_problems=Report_Warning =
+    format : Vector (Text | Integer | Regex | By_Type) | Text | Integer | Regex | By_Type -> Text | Date_Time_Formatter | Column -> Locale -> Boolean -> Problem_Behavior -> Table ! Date_Time_Format_Parse_Error | Illegal_Argument
+    format self columns:(Vector (Text | Integer | Regex | By_Type) | Text | Integer | Regex | By_Type) format:(Text | Date_Time_Formatter | Column)="" locale=Locale.default error_on_missing_columns=True on_problems=Report_Warning =
         select_problem_builder = Problem_Builder.new error_on_missing_columns=error_on_missing_columns
         selected_columns = self.columns_helper.select_columns_helper columns Case_Sensitivity.Default True select_problem_builder
         select_problem_builder.attach_problems_before on_problems <|
@@ -1230,8 +1230,8 @@ type Table
          types. Due to this, a Mixed column containing values `[2, "3"]` will
          actually be converted into `[2, Nothing]` when casting to Integer type.
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
-    cast : Vector (Text | Integer | Regex) | Text | Integer | Regex -> Value_Type -> Boolean -> Problem_Behavior -> Table ! Illegal_Argument | Inexact_Type_Coercion | Conversion_Failure
-    cast self columns=[0] value_type error_on_missing_columns=True on_problems=Problem_Behavior.Report_Warning =
+    cast : Vector (Text | Integer | Regex | By_Type) | Text | Integer | Regex | By_Type -> Value_Type -> Boolean -> Problem_Behavior -> Table ! Illegal_Argument | Inexact_Type_Coercion | Conversion_Failure
+    cast self columns:(Vector (Text | Integer | Regex | By_Type) | Text | Integer | Regex | By_Type)=[0] value_type error_on_missing_columns=True on_problems=Problem_Behavior.Report_Warning =
         selected = self.columns_helper.select_columns columns Case_Sensitivity.Default reorder=False error_on_missing_columns=error_on_missing_columns on_problems=on_problems error_on_empty=False
         selected.fold self table-> column_to_cast->
             new_column = column_to_cast.cast value_type on_problems
@@ -1277,8 +1277,8 @@ type Table
              max length of 255. Otherwise, the column size limit will stay
              unchanged.
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
-    auto_value_types : Vector (Text | Integer | Regex) | Text | Integer | Regex -> Boolean -> Boolean -> Problem_Behavior -> Table
-    auto_value_types self columns=self.column_names shrink_types=False error_on_missing_columns=True on_problems=Problem_Behavior.Report_Warning =
+    auto_value_types : Vector (Text | Integer | Regex | By_Type) | Text | Integer | Regex | By_Type -> Boolean -> Boolean -> Problem_Behavior -> Table
+    auto_value_types self columns:(Vector (Text | Integer | Regex | By_Type) | Text | Integer | Regex | By_Type)=self.column_names shrink_types=False error_on_missing_columns=True on_problems=Problem_Behavior.Report_Warning =
         selected = self.columns_helper.select_columns columns Case_Sensitivity.Default reorder=False error_on_missing_columns=error_on_missing_columns on_problems=on_problems error_on_empty=False
         selected.fold self table-> column_to_cast->
             new_column = column_to_cast.auto_value_type shrink_types
@@ -2188,8 +2188,8 @@ type Table
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @from_column Widget.Text_Input
     @to_column Widget.Text_Input
-    replace : (Table | Map) -> (Text | Integer | Vector (Text | Integer)) -> (Text | Integer | Nothing) -> (Text | Integer | Nothing) -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Non_Unique_Key | Unmatched_Rows_In_Lookup
-    replace self lookup_table:(Table | Map) columns:(Text | Integer | Vector (Text | Integer)) from_column:(Text | Integer | Nothing)=Nothing to_column:(Text | Integer | Nothing)=Nothing allow_unmatched_rows:Boolean=True on_problems:Problem_Behavior=Problem_Behavior.Report_Warning =
+    replace : (Table | Map) -> (Text | Integer | Regex | By_Type | Vector (Text | Integer | Regex | By_Type)) -> (Text | Integer | Nothing) -> (Text | Integer | Nothing) -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Non_Unique_Key | Unmatched_Rows_In_Lookup
+    replace self lookup_table:(Table | Map) columns:(Text | Integer | Regex | By_Type | Vector (Text | Integer | Regex | By_Type)) from_column:(Text | Integer | Nothing)=Nothing to_column:(Text | Integer | Nothing)=Nothing allow_unmatched_rows:Boolean=True on_problems:Problem_Behavior=Problem_Behavior.Report_Warning =
         Replace_Helpers.replace self lookup_table columns from_column to_column allow_unmatched_rows on_problems
 
     ## ALIAS join by row position
@@ -2806,8 +2806,8 @@ type Table
              fill_nothing = table.fill_nothing ["col0", "col1"] 20.5
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @default (self -> Widget_Helpers.make_fill_default_value_selector column_source=self add_text=True add_number=True add_boolean=True)
-    fill_nothing : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Column | Column_Ref | Expression | Previous_Value | Any -> Table
-    fill_nothing self (columns : Vector | Text | Integer | Regex) default =
+    fill_nothing : Vector (Integer | Text | Regex | By_Type) | Text | Integer | Regex | By_Type -> Column | Column_Ref | Expression | Previous_Value | Any -> Table
+    fill_nothing self (columns : Vector | Text | Integer | Regex | By_Type) default =
         resolved_default = (self:Table_Ref).resolve default
         transformer col = col.fill_nothing resolved_default
         Table_Helpers.replace_columns_with_transformed_columns self columns transformer
@@ -2834,8 +2834,8 @@ type Table
              fill_empty = table.fill_empty ["col0", "col1"] "hello"
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @default (self -> Widget_Helpers.make_fill_default_value_selector column_source=self add_text=True)
-    fill_empty : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Column | Column_Ref | Expression | Previous_Value | Any -> Table
-    fill_empty self (columns : Vector | Text | Integer | Regex) default =
+    fill_empty : Vector (Integer | Text | Regex | By_Type) | Text | Integer | Regex | By_Type -> Column | Column_Ref | Expression | Previous_Value | Any -> Table
+    fill_empty self (columns : Vector | Text | Integer | Regex | By_Type) default =
         resolved_default = (self:Table_Ref).resolve default
         transformer col = col.fill_empty resolved_default
         Table_Helpers.replace_columns_with_transformed_columns self columns transformer
@@ -2875,8 +2875,8 @@ type Table
     @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @term (Widget_Helpers.make_column_ref_by_name_selector add_regex=True add_text=True add_named_pattern=True)
     @new_text (Widget_Helpers.make_column_ref_by_name_selector add_text=True)
-    text_replace : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Text | Column | Column_Ref | Expression | Regex -> Text | Column | Column_Ref | Expression -> Case_Sensitivity -> Boolean -> Column
-    text_replace self columns (term : Text | Column | Column_Ref | Expression | Regex = "") (new_text : Text | Column | Column_Ref | Expression = "") case_sensitivity=Case_Sensitivity.Sensitive only_first=False =
+    text_replace : Vector (Integer | Text | Regex | By_Type) | Text | Integer | Regex | By_Type -> Text | Column | Column_Ref | Expression | Regex -> Text | Column | Column_Ref | Expression -> Case_Sensitivity -> Boolean -> Column
+    text_replace self columns (term : Text | Column | Column_Ref | Expression | Regex | By_Type = "") (new_text : Text | Column | Column_Ref | Expression = "") case_sensitivity=Case_Sensitivity.Sensitive only_first=False =
         table_ref = Table_Ref.from self
         resolved_term = table_ref.resolve term
         resolved_new_text = table_ref.resolve new_text
@@ -2911,8 +2911,8 @@ type Table
              table.text_cleanse [..Leading_Whitespace, ..Trailing_Whitespace]
     @remove make_data_cleanse_vector_selector
     @from (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
-    text_cleanse : Vector Text_Cleanse -> Vector (Integer | Text | Regex) -> Table
-    text_cleanse self remove from =
+    text_cleanse : Vector Text_Cleanse -> Vector (Integer | Text | Regex | By_Type) -> Table
+    text_cleanse self remove from:(Vector (Integer | Text | Regex | By_Type)) =
         transformer col = col.text_cleanse remove
         Table_Helpers.replace_columns_with_transformed_columns self from transformer
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -2872,7 +2872,7 @@ type Table
          Replace texts in quotes with parentheses.
 
              table.text_replace ["Input"] '"(.*?)"'.to_regex '($1)'
-    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True)
+    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @term (Widget_Helpers.make_column_ref_by_name_selector add_regex=True add_text=True add_named_pattern=True)
     @new_text (Widget_Helpers.make_column_ref_by_name_selector add_text=True)
     text_replace : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Text | Column | Column_Ref | Expression | Regex -> Text | Column | Column_Ref | Expression -> Case_Sensitivity -> Boolean -> Column

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -2910,7 +2910,7 @@ type Table
 
              table.text_cleanse [..Leading_Whitespace, ..Trailing_Whitespace]
     @remove make_data_cleanse_vector_selector
-    @from (Widget_Helpers.make_column_name_multi_selector add_regex=True)
+    @from (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     text_cleanse : Vector Text_Cleanse -> Vector (Integer | Text | Regex) -> Table
     text_cleanse self remove from =
         transformer col = col.text_cleanse remove

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -554,7 +554,7 @@ type Table
        either the start or the end in the specified order.
 
        Arguments:
-       - columns: Specifies columns by a name, index or regular expression to
+       - columns: Specifies columns by a name, type, index or regular expression to
          match names, or a Vector of these.
        - position: Specifies how to place the selected columns in relation to
          the remaining columns which were not matched by `columns` (if any).
@@ -597,7 +597,7 @@ type Table
          Move the first column to back.
 
              table.reorder_columns [0] position=Position.After_Other_Columns
-    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True)
+    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     reorder_columns : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Position -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns
     reorder_columns self (columns : (Vector | Text | Integer | Regex) = [self.columns.first.name]) (position:Position=Position.Before_Other_Columns) (case_sensitivity=Case_Sensitivity.Default) (error_on_missing_columns:Boolean=False) (on_problems:Problem_Behavior=Report_Warning) =
         new_columns = self.columns_helper.reorder_columns columns position case_sensitivity error_on_missing_columns on_problems

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -1276,7 +1276,7 @@ type Table
              elements are no longer than 255 characters, the column will get a
              max length of 255. Otherwise, the column size limit will stay
              unchanged.
-    @columns (Widget_Helpers.make_column_name_multi_selector use_regex=True)
+    @columns (Widget_Helpers.make_column_name_multi_selector use_regex=True add_by_type=True)
     auto_value_types : Vector (Text | Integer | Regex) | Text | Integer | Regex -> Boolean -> Boolean -> Problem_Behavior -> Table
     auto_value_types self columns=self.column_names shrink_types=False error_on_missing_columns=True on_problems=Problem_Behavior.Report_Warning =
         selected = self.columns_helper.select_columns columns Case_Sensitivity.Default reorder=False error_on_missing_columns=error_on_missing_columns on_problems=on_problems error_on_empty=False

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -1229,7 +1229,7 @@ type Table
          The `parse` method should be used to convert text values into other
          types. Due to this, a Mixed column containing values `[2, "3"]` will
          actually be converted into `[2, Nothing]` when casting to Integer type.
-    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True)
+    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     cast : Vector (Text | Integer | Regex) | Text | Integer | Regex -> Value_Type -> Boolean -> Problem_Behavior -> Table ! Illegal_Argument | Inexact_Type_Coercion | Conversion_Failure
     cast self columns=[0] value_type error_on_missing_columns=True on_problems=Problem_Behavior.Report_Warning =
         selected = self.columns_helper.select_columns columns Case_Sensitivity.Default reorder=False error_on_missing_columns=error_on_missing_columns on_problems=on_problems error_on_empty=False

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -1153,7 +1153,7 @@ type Table
          Format all columns in the table using the default formatter.
 
              table.format
-    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True)
+    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @locale Locale.default_widget
     @format (make_format_chooser include_number=True)
     format : Vector (Text | Integer | Regex) | Text | Integer | Regex -> Text | Date_Time_Formatter | Column -> Locale -> Boolean -> Problem_Behavior -> Table ! Date_Time_Format_Parse_Error | Illegal_Argument

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -1276,7 +1276,7 @@ type Table
              elements are no longer than 255 characters, the column will get a
              max length of 255. Otherwise, the column size limit will stay
              unchanged.
-    @columns (Widget_Helpers.make_column_name_multi_selector use_regex=True add_by_type=True)
+    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     auto_value_types : Vector (Text | Integer | Regex) | Text | Integer | Regex -> Boolean -> Boolean -> Problem_Behavior -> Table
     auto_value_types self columns=self.column_names shrink_types=False error_on_missing_columns=True on_problems=Problem_Behavior.Report_Warning =
         selected = self.columns_helper.select_columns columns Case_Sensitivity.Default reorder=False error_on_missing_columns=error_on_missing_columns on_problems=on_problems error_on_empty=False
@@ -2185,7 +2185,7 @@ type Table
              #    1 | 20 | b | f
              #    2 | 30 | c | g
              #    3 | 40 | d | h
-    @columns (Widget_Helpers.make_column_name_multi_selector use_regex=True)
+    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True add_by_type=True)
     @from_column Widget.Text_Input
     @to_column Widget.Text_Input
     replace : (Table | Map) -> (Text | Integer | Vector (Text | Integer)) -> (Text | Integer | Nothing) -> (Text | Integer | Nothing) -> Boolean -> Problem_Behavior -> Table ! Missing_Input_Columns | Non_Unique_Key | Unmatched_Rows_In_Lookup
@@ -2872,7 +2872,7 @@ type Table
          Replace texts in quotes with parentheses.
 
              table.text_replace ["Input"] '"(.*?)"'.to_regex '($1)'
-    @columns (Widget_Helpers.make_column_name_multi_selector use_regex=True)
+    @columns (Widget_Helpers.make_column_name_multi_selector add_regex=True)
     @term (Widget_Helpers.make_column_ref_by_name_selector add_regex=True add_text=True add_named_pattern=True)
     @new_text (Widget_Helpers.make_column_ref_by_name_selector add_text=True)
     text_replace : Vector (Integer | Text | Regex) | Text | Integer | Regex -> Text | Column | Column_Ref | Expression | Regex -> Text | Column | Column_Ref | Expression -> Case_Sensitivity -> Boolean -> Column
@@ -2910,7 +2910,7 @@ type Table
 
              table.text_cleanse [..Leading_Whitespace, ..Trailing_Whitespace]
     @remove make_data_cleanse_vector_selector
-    @from (Widget_Helpers.make_column_name_multi_selector use_regex=True)
+    @from (Widget_Helpers.make_column_name_multi_selector add_regex=True)
     text_cleanse : Vector Text_Cleanse -> Vector (Integer | Text | Regex) -> Table
     text_cleanse self remove from =
         transformer col = col.text_cleanse remove

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -590,6 +590,24 @@ add_specs suite_builder setup =
             actual.at "col1" . to_vector . should_equal [1000, 200, 1000, 400, 500, 1000]
             actual.column_names . should_equal ["col0", "col_between", "col1", "def"]
 
+        group_builder.specify "fill_nothing should allow selection by regex" <|
+            t = table_builder [["col0", [0, Nothing, 4, 5, Nothing, Nothing]], ["col_between", [3, 4, 5, 6, 7, 8]], ["col1", [Nothing, 200, Nothing, 400, 500, Nothing]], ["def", [1, 2, 10, 20, Nothing, 30]]]
+            default = 1000
+            actual = t.fill_nothing [regex ("col.*")] default
+            actual.at "col0" . to_vector . should_equal [0, 1000, 4, 5, 1000, 1000]
+            actual.at "col_between" . to_vector . should_equal [3, 4, 5, 6, 7, 8]
+            actual.at "col1" . to_vector . should_equal [1000, 200, 1000, 400, 500, 1000]
+            actual.column_names . should_equal ["col0", "col_between", "col1", "def"]
+
+        group_builder.specify "fill_nothing should allow selection by type" <|
+            t = table_builder [["col0", [0, Nothing, 4, 5, Nothing, Nothing]], ["col_between", [3, 4, 5, 6, 7, 8]], ["col1", [Nothing, "200", Nothing, "400", "500", Nothing]], ["def", [1, 2, 10, 20, Nothing, 30]]]
+            default = 1000
+            actual = t.fill_nothing [..By_Type ..Integer] default
+            actual.at "col0" . to_vector . should_equal [0, 1000, 4, 5, 1000, 1000]
+            actual.at "col_between" . to_vector . should_equal [3, 4, 5, 6, 7, 8]
+            actual.at "col1" . to_vector . should_equal [Nothing, "200", Nothing, "400", "500", Nothing]
+            actual.column_names . should_equal ["col0", "col_between", "col1", "def"]
+
         group_builder.specify "fill_nothing should work with integer column selectors" <|
             t = table_builder [["col0", [0, Nothing, 4, 5, Nothing, Nothing]], ["col_between", [3, 4, 5, 6, 7, 8]], ["col1", [Nothing, 200, Nothing, 400, 500, Nothing]], ["def", [1, 2, 10, 20, Nothing, 30]]]
             default = 1000

--- a/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Column_Operations_Spec.enso
@@ -643,6 +643,20 @@ add_specs suite_builder setup =
                 actual = t.text_replace ["col0", "col1"] "ab" "xy"
                 actual.at "col0" . to_vector . should_equal ["xyc", "def", "ghi"]
                 actual.at "col1" . to_vector . should_equal ["nxyc", "ndef", "asdf"]
+        
+        group_builder.specify "should allow to replace values in a table selecting columns with regex" <|
+            with_mixed_columns_if_supported [["col0", ["abc", "def", "ghi"]], ["col1", ["nabc", "ndef", "asdf"]], ["zzz", ["nabc", "ndef", "asdf"]]] t->
+                actual = t.text_replace [(regex "col.*")] "ab" "xy"
+                actual.at "col0" . to_vector . should_equal ["xyc", "def", "ghi"]
+                actual.at "col1" . to_vector . should_equal ["nxyc", "ndef", "asdf"]
+                actual.at "zzz" . to_vector . should_equal ["nabc", "ndef", "asdf"]
+
+        group_builder.specify "should allow to replace values in a table selecting columns by type" <|
+            t = table_builder [["col0", ["abc", "def", "ghi"]], ["col1", ["nabc", "ndef", "asdf"]], ["zzz", [1, 2, 3]]]
+            actual = t.text_replace [..By_Type ..Char] "ab" "xy"
+            actual.at "col0" . to_vector . should_equal ["xyc", "def", "ghi"]
+            actual.at "col1" . to_vector . should_equal ["nxyc", "ndef", "asdf"]
+            actual.at "zzz" . to_vector . should_equal [1, 2, 3]
 
         group_builder.specify "should allow to replace values in a table with a regex" <|
             t = table_builder [["col0", ["abc", "def", "ghi"]], ["col1", ["nabc", "ndef", "asdf"]]]

--- a/test/Table_Tests/src/Common_Table_Operations/Conversion_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Conversion_Spec.enso
@@ -60,6 +60,14 @@ add_specs suite_builder setup =
             t2.at "Z" . to_vector . should_equal ["1.5", "0.125", "-2.5"]
             t2.at "W" . to_vector . should_equal ["a", "DEF", "a slightly longer text"]
 
+        group_builder.specify "should allow to cast columns selecting columns by type" <|
+            t = table_builder [["X", [1, 2, 3000]], ["Y", [True, False, True]], ["Z", [1.5, 0.125, -2.5]], ["W", ["a", "DEF", "a slightly longer text"]]]
+            t2 = t.cast [..By_Type ..Integer] Value_Type.Char
+            t2.at "X" . value_type . is_text . should_be_true
+            t2.at "Y" . value_type . is_text . should_be_false
+            t2.at "Z" . value_type . is_text . should_be_false
+            t2.at "W" . value_type . is_text . should_be_true
+
         if supports_dates then
             group_builder.specify "should allow to cast date/time columns to text" <|
                 t = table_builder [["X", [Date.new 2015 1 1, Date.new 2023 12 31]], ["Y", [Time_Of_Day.new 1 2 3, Time_Of_Day.new 23 57 59]], ["Z", [Date_Time.new 2015 1 1 1 2 3, Date_Time.new 2023 11 30 22 45 44]]]

--- a/test/Table_Tests/src/Common_Table_Operations/Conversion_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Conversion_Spec.enso
@@ -698,6 +698,15 @@ add_specs suite_builder setup =
             t4.at "ints" . value_type . should_equal Value_Type.Integer
             t4.at "floats" . value_type . should_equal Value_Type.Float
 
+        group_builder.specify "will only modify selected columns by type" <|
+            mixer = My_Type.Value 1
+            t0 = table_builder [["X", [1.0, 2.0, 3.0]], ["Y", [mixer, 2.5, 3.0]]]
+            t1 = t0.drop 1
+
+            t2 = t1.auto_value_types [..By_Type ..Float]
+            t2.at "X" . value_type . should_equal (Value_Type.Integer Bits.Bits_64)
+            t2.at "Y" . value_type . should_equal Value_Type.Mixed
+
         group_builder.specify "will convert a Float column to Integer if all values can be represented as long" <|
             t1 = table_builder [["X", [1.0, 2.0, 3.0]], ["Y", [1.0, 2.5, 3.0]], ["Z", [1.0, 2.0, (2.0^100)]]]
             t1.at "X" . value_type . should_equal Value_Type.Float

--- a/test/Table_Tests/src/Common_Table_Operations/Join/Replace_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Join/Replace_Spec.enso
@@ -68,6 +68,20 @@ add_specs suite_builder setup =
             result = table.replace lookup_table ['x', 'x2', 'x3'] 'x' 'z' . order_by ["x", "y"]
             result . should_equal expected
 
+        group_builder.specify "should be able to replace multiple columns selected by regex" <|
+            table = table_builder [['x', [1, 2, 3, 4, 2]], ['x2', [2, 1, 2, 1, 4]], ['x3', [3, 4, 1, 3, 4]], ['y', ['a', 'b', 'c', 'd', 'e']]]
+            lookup_table = table_builder [['d', [4, 5, 6, 7]], ['x', [2, 1, 4, 3]], ['d2', [5, 6, 7, 8]], ['z', [20, 10, 40, 30]]]
+            expected = table_builder [['x', [10, 20, 20, 30, 40]], ['x2', [20, 10, 40, 20, 10]], ['x3', [30, 40, 40, 10, 30]], ['y', ['a', 'b', 'e', 'c', 'd']]]
+            result = table.replace lookup_table [(regex 'x.*')] 'x' 'z' . order_by ["x", "y"]
+            result . should_equal expected
+        
+        group_builder.specify "should be able to replace multiple columns selected by type" <|
+            table = table_builder [['x', [1, 2, 3, 4, 2]], ['x2', [2, 1, 2, 1, 4]], ['x3', [3, 4, 1, 3, 4]], ['y', ['a', 'b', 'c', 'd', 'e']]]
+            lookup_table = table_builder [['d', [4, 5, 6, 7]], ['x', [2, 1, 4, 3]], ['d2', [5, 6, 7, 8]], ['z', [20, 10, 40, 30]]]
+            expected = table_builder [['x', [10, 20, 20, 30, 40]], ['x2', [20, 10, 40, 20, 10]], ['x3', [30, 40, 40, 10, 30]], ['y', ['a', 'b', 'e', 'c', 'd']]]
+            result = table.replace lookup_table [..By_Type ..Integer] 'x' 'z' . order_by ["x", "y"]
+            result . should_equal expected
+
         group_builder.specify "should fail with Missing_Input_Columns if the specified columns do not exist" <|
             table = table_builder [['x', [1, 2, 3, 4]], ['y', ['a', 'b', 'c', 'd']]]
             lookup_table = table_builder [['x', [2, 1, 4, 3]], ['z', [20, 10, 40, 30]]]

--- a/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Select_Columns_Spec.enso
@@ -433,6 +433,16 @@ add_specs suite_builder setup =
             err = data.table.reorder_columns selector Position.After_Other_Columns error_on_missing_columns=True
             err.should_fail_with Missing_Input_Columns
 
+    suite_builder.group prefix+"Table.reorder_columns by type" group_builder->
+        data = Mixed_Columns_Data.setup create_connection_fn table_builder
+
+        group_builder.teardown <|
+            data.teardown
+
+        group_builder.specify "should correctly handle By_Type matching" <|
+            expect_column_names ["float", "text", "bool", "int"] <| data.table.reorder_columns [..By_Type ..Integer] Position.After_Other_Columns
+            expect_column_names ["float", "text", "int", "bool"] <| data.table.reorder_columns [..By_Type ..Integer, ..By_Type ..Boolean] Position.After_Other_Columns
+
     suite_builder.group prefix+"Table.sort_columns" group_builder->
         data = Sort_Columns_Data.setup create_connection_fn table_builder
 

--- a/test/Table_Tests/src/In_Memory/Table_Format_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Format_Spec.enso
@@ -45,6 +45,15 @@ add_specs suite_builder =
             actual.at "datetimes" . should_equal expected_datetimes
             check_unchanged data.table actual ["times", "bools", "ints", "floats", "strings", "date_formats", "time_formats", "numeric_formats", "bool_formats"]
 
+        group_builder.specify "Date and Date_Time, with format string, selected by type" <|
+            expected_dates = Column.from_vector "dates" ["20201221", "20230425"]
+            expected_datetimes = Column.from_vector "datetimes" ["20200110", "20200808"]
+            actual = data.table.format [..By_Type ..Date_Time, ..By_Type ..Date] "yyyyMMdd"
+            actual.column_names . should_equal data.table.column_names
+            actual.at "dates" . should_equal expected_dates
+            actual.at "datetimes" . should_equal expected_datetimes
+            check_unchanged data.table actual ["times", "bools", "ints", "floats", "strings", "date_formats", "time_formats", "numeric_formats", "bool_formats"]
+
         group_builder.specify "Date_Time and Time_Of_Day, with format string" <|
             expected_datetimes = Column.from_vector "datetimes" ["03:04:05", "05:06:07"]
             expected_times = Column.from_vector "times" ["01:02:03", "10:30:35"]

--- a/test/Table_Tests/src/In_Memory/Table_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Table_Spec.enso
@@ -573,6 +573,30 @@ add_specs suite_builder =
             actual = t.fill_empty ["col0", "col1"] defaults
             actual.at "col0" . to_vector . should_equal ["0", "2", "4", "5", Nothing, "30"]
             actual.at "col1" . to_vector . should_equal ["1", "200", "10", "400", "500", "30"]
+        
+        group_builder.specify "fill_empty should allow selection by regex" <|
+            col0 = Column.from_vector "col0" ["0", Nothing, "4", "5", Nothing, Nothing]
+            col_between = Column.from_vector "col_between" [3, 4, 5, 6, 7, 8]
+            col1 = Column.from_vector "col1" [Nothing, "200", Nothing, "400", "500", Nothing]
+            t = Table.new [col0, col_between, col1]
+            default = "1000"
+            actual = t.fill_empty [regex ("col\d")] default
+            actual.at "col0" . to_vector . should_equal ["0", "1000", "4", "5", "1000", "1000"]
+            actual.at "col_between" . to_vector . should_equal [3, 4, 5, 6, 7, 8]
+            actual.at "col1" . to_vector . should_equal ["1000", "200", "1000", "400", "500", "1000"]
+            actual.column_names . should_equal ["col0", "col_between", "col1"]
+
+        group_builder.specify "fill_empty should allow selection by type" <|
+            col0 = Column.from_vector "col0" [0, Nothing, 4, 5, Nothing, Nothing]
+            col_between = Column.from_vector "col_between" [3, 4, 5, 6, 7, 8]
+            col1 = Column.from_vector "col1" [Nothing, "200", Nothing, "400", "500", Nothing]
+            t = Table.new [col0, col_between, col1]
+            default = "1000"
+            actual = t.fill_empty [..By_Type ..Char] default
+            actual.at "col0" . to_vector . should_equal [0, Nothing, 4, 5, Nothing, Nothing]
+            actual.at "col_between" . to_vector . should_equal [3, 4, 5, 6, 7, 8]
+            actual.at "col1" . to_vector . should_equal ["1000", "200", "1000", "400", "500", "1000"]
+            actual.column_names . should_equal ["col0", "col_between", "col1"]
 
         group_builder.specify "fill_nothing should leave other columns alone" <|
             col0 = Column.from_vector "col0" [0, Nothing, 4, 5, Nothing, Nothing]

--- a/test/Table_Tests/src/In_Memory/Text_Cleanse_Spec.enso
+++ b/test/Table_Tests/src/In_Memory/Text_Cleanse_Spec.enso
@@ -49,6 +49,22 @@ add_specs suite_builder setup =
             r = materialize res . rows . map .to_vector
             r.length . should_equal 5
             r.should_equal (expected_table . rows . map .to_vector)
+        group_builder.specify "can select columns with regex" <|
+            clean_flight = ["Flight", ["BA0123", "BA0123 ", "SG0456  ", "BA  0123", "S G 0 4 5 6 "]]
+            clean_passenger = ["Passenger", ["Albert Einstein", "Marie Curie   ", "Isaac Newton   ", "Stephen   Hawking", "A d a Lovelace "]]
+            expected_table = Table.new [clean_flight, clean_passenger, ticket_price]
+            res = table.text_cleanse [Named_Pattern.Leading_Whitespace] [(regex "Fl.*"), (regex "P.*")]
+            r = materialize res . rows . map .to_vector
+            r.length . should_equal 5
+            r.should_equal (expected_table . rows . map .to_vector)
+        group_builder.specify "can select columns by type" <|
+            clean_flight = ["Flight", ["BA0123", "BA0123 ", "SG0456  ", "BA  0123", "S G 0 4 5 6 "]]
+            clean_passenger = ["Passenger", ["Albert Einstein", "Marie Curie   ", "Isaac Newton   ", "Stephen   Hawking", "A d a Lovelace "]]
+            expected_table = Table.new [clean_flight, clean_passenger, ticket_price]
+            res = table.text_cleanse [Named_Pattern.Leading_Whitespace] [..By_Type ..Char]
+            r = materialize res . rows . map .to_vector
+            r.length . should_equal 5
+            r.should_equal (expected_table . rows . map .to_vector)
         group_builder.specify "should error if applied to non-text column" <|
             table.text_cleanse [Named_Pattern.Leading_Whitespace] ["Flight", "Passenger", "Ticket Price"] . should_fail_with Invalid_Value_Type
     suite_builder.group "Column Text Cleanse" group_builder->


### PR DESCRIPTION
### Pull Request Description

![image](https://github.com/enso-org/enso/assets/1720119/4fdefaa3-b27f-4965-a50d-cde50e24eaf7)

Adds the ability to choose fields by type to many of our components

![image](https://github.com/enso-org/enso/assets/1720119/71e1bd49-2ece-43d0-8f23-57bd318e5096)

![image](https://github.com/enso-org/enso/assets/1720119/fd7b9d30-97ae-44ed-bb13-5dfb552494be)

![image](https://github.com/enso-org/enso/assets/1720119/8d94a78b-1600-4449-ba33-fb91195c2534)

![image](https://github.com/enso-org/enso/assets/1720119/ddc0e442-8837-47f9-bd3d-9a732d5ad394)

![image](https://github.com/enso-org/enso/assets/1720119/d52d0185-3c22-4479-86a1-fe7a60b46238)

![image](https://github.com/enso-org/enso/assets/1720119/159bb633-b8a0-4800-a66b-a10cd12ad722)

![image](https://github.com/enso-org/enso/assets/1720119/9f3659a1-4b78-4869-b751-b481369f19f5)

![image](https://github.com/enso-org/enso/assets/1720119/b9ba0b1b-0444-40ae-8cef-658fa2aa7db6)

![image](https://github.com/enso-org/enso/assets/1720119/b0b60394-dfc5-4076-ae2e-dd3738f67ff2)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
