### PR TITLE
Add declarative api to invalidate queries in mutations

### DIFF
--- a/app/ide-desktop/eslint.config.js
+++ b/app/ide-desktop/eslint.config.js
@@ -453,11 +453,6 @@ export default [
                     selector: ':not(TSModuleDeclaration)[declare=true]',
                     message: 'No ambient declarations',
                 },
-                {
-                    selector: 'ExportDefaultDeclaration:has(Identifier.declaration)',
-                    message:
-                        'Use `export default` on the declaration, instead of as a separate statement',
-                },
             ],
             // This rule does not work with TypeScript, and TypeScript already does this.
             'no-undef': 'off',

--- a/app/ide-desktop/lib/dashboard/src/App.tsx
+++ b/app/ide-desktop/lib/dashboard/src/App.tsx
@@ -88,7 +88,6 @@ import * as object from '#/utilities/object'
 import * as authServiceModule from '#/authentication/service'
 
 import type * as types from '../../types/types'
-import * as reactQueryDevtools from './ReactQueryDevtools'
 
 // ============================
 // === Global configuration ===
@@ -173,12 +172,6 @@ export default function App(props: AppProps) {
     },
   })
 
-  const routerFuture: Partial<router.FutureConfig> = {
-    /* we want to use startTransition to enable concurrent rendering */
-    /* eslint-disable-next-line @typescript-eslint/naming-convention */
-    v7_startTransition: true,
-  }
-
   // Both `BackendProvider` and `InputBindingsProvider` depend on `LocalStorageProvider`.
   // Note that the `Router` must be the parent of the `AuthProvider`, because the `AuthProvider`
   // will redirect the user between the login/register pages and the dashboard.
@@ -193,15 +186,13 @@ export default function App(props: AppProps) {
         transition={toastify.Zoom}
         limit={3}
       />
-      <router.BrowserRouter basename={getMainPageUrl().pathname} future={routerFuture}>
+      <router.BrowserRouter basename={getMainPageUrl().pathname}>
         <LocalStorageProvider>
           <ModalProvider>
             <AppRouter {...props} projectManagerRootDirectory={rootDirectoryPath} />
           </ModalProvider>
         </LocalStorageProvider>
       </router.BrowserRouter>
-
-      <reactQueryDevtools.ReactQueryDevtools />
     </>
   )
 }

--- a/app/ide-desktop/lib/dashboard/src/index.tsx
+++ b/app/ide-desktop/lib/dashboard/src/index.tsx
@@ -19,6 +19,8 @@ import LoadingScreen from '#/pages/authentication/LoadingScreen'
 
 import * as errorBoundary from '#/components/ErrorBoundary'
 
+import * as reactQueryDevtools from './ReactQueryDevtools'
+
 // =================
 // === Constants ===
 // =================
@@ -101,13 +103,15 @@ function run(props: Omit<app.AppProps, 'portalRoot'>) {
                 {...props}
                 supportsDeepLinks={actuallySupportsDeepLinks}
                 portalRoot={portalRoot}
-              />
-            )}
-          </React.Suspense>
-        </errorBoundary.ErrorBoundary>
-      </reactQuery.QueryClientProvider>
-    </React.StrictMode>
-  )
+              />)}
+            </React.Suspense>
+          </errorBoundary.ErrorBoundary>
+
+          <reactQueryDevtools.ReactQueryDevtools />
+        </reactQuery.QueryClientProvider>
+      </React.StrictMode>
+    )
+
 }
 
 /** Global configuration for the {@link App} component. */

--- a/app/ide-desktop/lib/dashboard/src/index.tsx
+++ b/app/ide-desktop/lib/dashboard/src/index.tsx
@@ -103,15 +103,15 @@ function run(props: Omit<app.AppProps, 'portalRoot'>) {
                 {...props}
                 supportsDeepLinks={actuallySupportsDeepLinks}
                 portalRoot={portalRoot}
-              />)}
-            </React.Suspense>
-          </errorBoundary.ErrorBoundary>
+              />
+            )}
+          </React.Suspense>
+        </errorBoundary.ErrorBoundary>
 
-          <reactQueryDevtools.ReactQueryDevtools />
-        </reactQuery.QueryClientProvider>
-      </React.StrictMode>
-    )
-
+        <reactQueryDevtools.ReactQueryDevtools />
+      </reactQuery.QueryClientProvider>
+    </React.StrictMode>
+  )
 }
 
 /** Global configuration for the {@link App} component. */

--- a/app/ide-desktop/lib/dashboard/src/modals/SetOrganizationNameModal.tsx
+++ b/app/ide-desktop/lib/dashboard/src/modals/SetOrganizationNameModal.tsx
@@ -34,7 +34,6 @@ export function SetOrganizationNameModal() {
   const userPlan =
     session && 'user' in session && session.user?.plan != null ? session.user.plan : null
 
-  const queryClient = reactQuery.useQueryClient()
   const { data: organizationName } = reactQuery.useSuspenseQuery({
     queryKey: ['organization', userId],
     queryFn: () => {
@@ -51,7 +50,7 @@ export function SetOrganizationNameModal() {
   const submit = reactQuery.useMutation({
     mutationKey: ['organization', userId],
     mutationFn: (name: string) => backend.updateOrganization({ name }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['organization', userId] }),
+    meta: { invalidates: [['organization', userId]], awaitInvalidates: true },
   })
 
   const shouldShowModal =

--- a/app/ide-desktop/lib/dashboard/src/reactQueryClient.ts
+++ b/app/ide-desktop/lib/dashboard/src/reactQueryClient.ts
@@ -6,13 +6,77 @@
 
 import * as reactQuery from '@tanstack/react-query'
 
+declare module '@tanstack/react-query' {
+  /**
+   * Specifies the invalidation behavior of a mutation.
+   */
+  interface Register {
+    readonly mutationMeta: {
+      /**
+       * List of query keys to invalidate when the mutation succeeds.
+       */
+      readonly invalidates?: reactQuery.QueryKey[]
+      /**
+       * List of query keys to await invalidation before the mutation is considered successful.
+       *
+       * If `true`, all `invalidates` are awaited.
+       *
+       * If `false`, no invalidations are awaited.
+       *
+       * You can also provide an array of query keys to await.
+       *
+       * Queries that are not listed in invalidates will be ignored.
+       * @default false
+       */
+      readonly awaitInvalidates?: reactQuery.QueryKey[] | boolean
+    }
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+const DEFAULT_QUERY_STALE_TIME_MS = 2 * 60 * 1000
+
 /**
  * Create a new React Query client.
  */
 export function createReactQueryClient() {
-  return new reactQuery.QueryClient({
+  const queryClient: reactQuery.QueryClient = new reactQuery.QueryClient({
+    mutationCache: new reactQuery.MutationCache({
+      onSuccess: (_data, _variables, _context, mutation) => {
+        const shouldAwaitInvalidates = mutation.meta?.awaitInvalidates ?? false
+        const invalidates = mutation.meta?.invalidates ?? []
+        const invalidatesToAwait = (() => {
+          if (Array.isArray(shouldAwaitInvalidates)) {
+            return shouldAwaitInvalidates
+          } else {
+            return shouldAwaitInvalidates ? invalidates : []
+          }
+        })()
+        const invalidatesToIgnore = invalidates.filter(
+          queryKey => !invalidatesToAwait.includes(queryKey)
+        )
+
+        for (const queryKey of invalidatesToIgnore) {
+          void queryClient.invalidateQueries({
+            predicate: query => reactQuery.matchQuery({ queryKey }, query),
+          })
+        }
+
+        if (invalidatesToAwait.length > 0) {
+          // eslint-disable-next-line no-restricted-syntax
+          return Promise.all(
+            invalidatesToAwait.map(queryKey =>
+              queryClient.invalidateQueries({
+                predicate: query => reactQuery.matchQuery({ queryKey }, query),
+              })
+            )
+          )
+        }
+      },
+    }),
     defaultOptions: {
       queries: {
+        staleTime: DEFAULT_QUERY_STALE_TIME_MS,
         retry: (failureCount, error) => {
           // eslint-disable-next-line @typescript-eslint/no-magic-numbers
           const statusesToIgnore = [401, 403, 404]
@@ -28,4 +92,6 @@ export function createReactQueryClient() {
       },
     },
   })
+
+  return queryClient
 }

--- a/app/ide-desktop/lib/dashboard/src/reactQueryClient.ts
+++ b/app/ide-desktop/lib/dashboard/src/reactQueryClient.ts
@@ -11,6 +11,7 @@ declare module '@tanstack/react-query' {
    * Specifies the invalidation behavior of a mutation.
    */
   interface Register {
+    // eslint-disable-next-line no-restricted-syntax
     readonly mutationMeta: {
       /**
        * List of query keys to invalidate when the mutation succeeds.


### PR DESCRIPTION
### Pull Request Description

In this PR:

1. We added support to declaratively invalidate queries after making a mutation
2. We pull ReactQueryDevtools up in the component tree to make it available during dashboard loading

Also, this PR removes some rules in eslint

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
