### PR TITLE
Publish Persistance API+Javadoc to local m2 repository

### DIFF
--- a/.github/workflows/enso4igv.yml
+++ b/.github/workflows/enso4igv.yml
@@ -25,6 +25,11 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: maven
 
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '21'
+          distribution: 'graalvm-community'
+
       - name: Publish to Maven Repository
         run: sbt publishM2
 

--- a/.github/workflows/enso4igv.yml
+++ b/.github/workflows/enso4igv.yml
@@ -27,8 +27,8 @@ jobs:
 
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '21'
-          distribution: 'graalvm-community'
+          java-version: "21"
+          distribution: "graalvm-community"
 
       - name: Publish to Maven Repository
         run: sbt publishM2

--- a/.github/workflows/enso4igv.yml
+++ b/.github/workflows/enso4igv.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [develop]
     paths:
+      - ".github/workflows/enso4igv.yml"
       - "tools/enso4igv/**/*"
 
 jobs:
@@ -23,6 +24,9 @@ jobs:
           distribution: "zulu"
           java-version: ${{ matrix.java }}
           cache: maven
+
+      - name: Publish to Maven Repository
+        run: sbt publishM2
 
       - name: Find out pom & micro versions
         working-directory: tools/enso4igv

--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,7 @@ val currentEdition = sys.env.getOrElse(
 // Note [Stdlib Version]
 val stdLibVersion       = defaultDevEnsoVersion
 val targetStdlibVersion = ensoVersion
+val persistanceVersion  = "0.2-SNAPSHOT"
 
 // Inspired by https://www.scala-sbt.org/1.x/docs/Howto-Startup.html#How+to+take+an+action+on+startup
 lazy val startupStateTransition: State => State = { s: State =>
@@ -1305,7 +1306,6 @@ lazy val `ydoc-server` = project
   .dependsOn(`logging-service-logback`)
   .dependsOn(`profiling-utils`)
 
-lazy val persistanceVersion = "0.2-SNAPSHOT"
 lazy val `persistance` = (project in file("lib/java/persistance"))
   .settings(
     version := persistanceVersion,

--- a/lib/java/persistance/src/main/java/org/enso/persist/Persistable.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/Persistable.java
@@ -39,9 +39,9 @@ public @interface Persistable {
   int id();
 
   /**
-   * Should the generated code use {@link Persistance.Output#writeInline(Class<T>, T)} or not. By
-   * default all {@code final} or <em>sealed</em> classes are inlined. Inlining is however not very
-   * helpful when a single object is shared between multiple other objects.
+   * Should the generated code use {@link Persistance.Output#writeInline} or not. By default all
+   * {@code final} or <em>sealed</em> classes are inlined. Inlining is however not very helpful when
+   * a single object is shared between multiple other objects.
    *
    * @return
    */

--- a/lib/java/persistance/src/main/java/org/enso/persist/package-info.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/package-info.java
@@ -4,33 +4,33 @@
  *
  * <p>{@snippet file="org/enso/persist/PersistanceTest.java" region="write"}
  *
- * <p>Use sibling static {@link Persistance#read readO} method to read the byte buffer back into
+ * <p>Use sibling static {@link Persistance#read read} method to read the byte buffer back into
  * their memory representation.
  *
  * <p>{@snippet file="org/enso/persist/PersistanceTest.java" region="read"}
  *
  * <h2>Laziness</h2>
  *
- * The major benefit of this framework is the ability to read only the part of the stored graph that
+ * The major benefit of this framework is the ability to read only a part of the stored graph that
  * is actually needed. One may {@linkplain Persistance.Input#readReference obtain a reference} to an
  * object and turn that {@link Persistance.Reference} into actual object <b>later</b>, when needed.
  *
  * <h2>Manual Persistance</h2>
  *
  * Unlike typical Java serialization (which tries to make things automatic), this framework requires
- * one to implement the persistance manually. For each class that one wants to support, one has to
- * implement subclass {@link Persistance} and implement its {@link Persistance#writeObject} and
- * {@link Persistance#readObject} method.
+ * one to implement the persistance manually. For each class one wants to serde, one has to
+ * implement a subclass of {@link Persistance} and implement its {@link Persistance#writeObject} and
+ * {@link Persistance#readObject} methods.
  *
  * <p>{@snippet file="org/enso/persist/PersistanceTest.java" region="manual"}
  *
  * <h2>Semi-automatic Persistance</h2>
  *
  * Writing serialization and deserialization implementation manually is a boring, tedious and
- * errorprone process. That's why there is a {@link Persistable} annotation and associated
- * annotation processor that generates the necessary {@link Persistance} subclass based on the
- * "richest" constructor in the class to be persisted. This approach seems to work well for Java
- * records and Scala case classes.
+ * errorprone process. That's why there is a {@link Persistable @Persistable} annotation and
+ * associated annotation processor that generates the necessary {@link Persistance} subclass based
+ * on the "richest" constructor in the class to be persisted. This approach seems to work well for
+ * Java records and Scala case classes.
  *
  * <p>{@snippet file="org/enso/persist/PersistanceTest.java" region="annotation"}
  */


### PR DESCRIPTION
### Pull Request Description

One of the biggest issues that is holding #7054 back is an effective ability to reuse parts of Enso engine code base in the Maven build assembling VSCode and IGV extension. This PR adds a simple command to **publish such artifacts**:
```bash
sbt publishM2
```
that puts artifacts of selected projects (currently only `persistance` and `persistance-dsl` - more to come) into local Maven repository (e.g. `~/.m2/repository`) where they can be located by the Maven build then.

Essential part of Maven repository is **Javadoc** - as such this PR also needed to come up with a way to build Javadoc for the projects that publish their artifacts. Use 
```bash
sbt persistance/doc
```
to build Javadoc for the `persitance` API.

### Important Notes

Running `sbt publishM2` publishes following artifacts:
```bash
$ sbt publishM2
published persistance-dsl to ~/.m2/repository/org/enso/persistance-dsl/0.2-SNAPSHOT/persistance-dsl-0.2-SNAPSHOT.pom
published persistance-dsl to ~/.m2/repository/org/enso/persistance-dsl/0.2-SNAPSHOT/persistance-dsl-0.2-SNAPSHOT.jar
published persistance-dsl to ~/.m2/repository/org/enso/persistance-dsl/0.2-SNAPSHOT/persistance-dsl-0.2-SNAPSHOT-sources.jar
published persistance-dsl to ~/.m2/repository/org/enso/persistance-dsl/0.2-SNAPSHOT/persistance-dsl-0.2-SNAPSHOT-javadoc.jar

published persistance to ~/.m2/repository/org/enso/persistance/0.2-SNAPSHOT/persistance-0.2-SNAPSHOT.pom
published persistance to ~/.m2/repository/org/enso/persistance/0.2-SNAPSHOT/persistance-0.2-SNAPSHOT.jar
published persistance to ~/.m2/repository/org/enso/persistance/0.2-SNAPSHOT/persistance-0.2-SNAPSHOT-sources.jar
published persistance to ~/.m2/repository/org/enso/persistance/0.2-SNAPSHOT/persistance-0.2-SNAPSHOT-javadoc.jar
```

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides. 
- [x] CI tests have been written where possible.
