### PR TITLE
Add icon to indicate value type in table

### DIFF
--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -402,8 +402,7 @@ watchEffect(() => {
       ('header' in data_ ? data_.header : [])?.map((v, i) => {
         const constructor = data_.value_type?.[i]?.constructor
         const valueType = constructor ? `${constructor}` : null
-        const displayVal = data_.value_type?.[i]?.display_text as string
-        const displayValue = displayVal ? `${displayVal}` : null
+        const displayValue = data_.value_type?.[i]?.display_text
         return toField(v, valueType, displayValue)
       }) ?? []
 

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -387,8 +387,8 @@ watchEffect(() => {
     )
     const dataHeader =
       ('header' in data_ ? data_.header : [])?.map((v, i) => {
-        const valueType =
-          data_.value_type && data_.value_type[i] ? (data_.value_type[i]?.constructor as any) : null
+        const constructor = data_.value_type?.[i]?.constructor
+        const valueType = constructor  ? `${constructor}` : null
         return toField(v, valueType)
       }) ?? []
 

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -282,7 +282,7 @@ function toField(name: string, valueType?: ValueType | null | undefined): ColDef
   let icon
   switch (valType) {
     case 'Char':
-      icon = 'text'
+      icon = 'text3'
       break
     case 'Boolean':
       icon = 'check'

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -397,7 +397,7 @@ watchEffect(() => {
       ('header' in data_ ? data_.header : [])?.map((v, i) => {
         const constructor = data_.value_type?.[i]?.constructor
         const valueType = constructor ? `${constructor}` : null
-        const displayVal = data_.value_type?.[i]?.display_type
+        const displayVal = data_.value_type?.[i]?.display_text
         const displayValue = displayVal ? `${displayVal}` : null
         return toField(v, valueType, displayValue)
       }) ?? []

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -271,7 +271,7 @@ function isMatrix(data: object): data is LegacyMatrix {
   return json.every((d) => d.length === firstLen)
 }
 
-function toField(name: string, valType?: string): ColDef {
+function toField(name: string, valType?: string | undefined | null): ColDef {
   let icon
   switch (valType) {
     case 'Char':
@@ -389,7 +389,7 @@ watchEffect(() => {
     const dataHeader =
       ('header' in data_ ? data_.header : [])?.map((v, i) => {
         const constructor = data_.value_type?.[i]?.constructor
-        const valueType = constructor  ? `${constructor}` : null
+        const valueType = constructor ? `${constructor}` : null
         return toField(v, valueType)
       }) ?? []
 

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import icons from '@/assets/icons.svg'
 import { useAutoBlur } from '@/util/autoBlur'
 import { VisualizationContainer } from '@/util/visualizationBuiltins'
 import '@ag-grid-community/styles/ag-grid.css'
@@ -289,7 +290,7 @@ function toField(name: string, valType?: string): ColDef {
     case 'Mixed':
       icon = 'mixed'
   }
-  const svgTemplate = `<svg viewBox="0 0 16 16" width="16" height="16"> <use xlink:href="src/assets/icons.svg#${icon}"/> </svg>`
+  const svgTemplate = `<svg viewBox="0 0 16 16" width="16" height="16"> <use xlink:href="${icons}#${icon}"/> </svg>`
   const template =
     icon ?
       `<div style="display:flex; flex-direction:row; justify-content:space-between; width:inherit;"> ${name} ${svgTemplate}</div>`

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -276,7 +276,9 @@ function isMatrix(data: object): data is LegacyMatrix {
   return json.every((d) => d.length === firstLen)
 }
 
-function toField(name: string, valType?: string | undefined | null, displayValue?: any): ColDef {
+function toField(name: string, valueType?: ValueType | null | undefined): ColDef {
+  const valType = valueType ? valueType.constructor : null
+  const displayValue = valueType ? valueType.display_text : null
   let icon
   switch (valType) {
     case 'Char':
@@ -400,10 +402,8 @@ watchEffect(() => {
     )
     const dataHeader =
       ('header' in data_ ? data_.header : [])?.map((v, i) => {
-        const constructor = data_.value_type?.[i]?.constructor
-        const valueType = constructor ? `${constructor}` : null
-        const displayValue = data_.value_type?.[i]?.display_text
-        return toField(v, valueType, displayValue)
+        const valueType = data_.value_type ? data_.value_type[i] : null
+        return toField(v, valueType)
       }) ?? []
 
     columnDefs = [...indicesHeader, ...dataHeader]

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -271,7 +271,7 @@ function isMatrix(data: object): data is LegacyMatrix {
   return json.every((d) => d.length === firstLen)
 }
 
-function toField(name: string, valType?: string | undefined | null): ColDef {
+function toField(name: string, valType?: string | undefined | null, displayValue?: any): ColDef {
   let icon
   switch (valType) {
     case 'Char':
@@ -282,10 +282,16 @@ function toField(name: string, valType?: string | undefined | null): ColDef {
       break
     case 'Integer':
     case 'Float':
+    case 'Decimal':
+    case 'Byte':
       icon = 'math'
       break
     case 'Date':
+    case 'Date_Time':
       icon = 'calendar'
+      break
+    case 'Time':
+      icon = 'time'
       break
     case 'Mixed':
       icon = 'mixed'
@@ -293,13 +299,14 @@ function toField(name: string, valType?: string | undefined | null): ColDef {
   const svgTemplate = `<svg viewBox="0 0 16 16" width="16" height="16"> <use xlink:href="${icons}#${icon}"/> </svg>`
   const template =
     icon ?
-      `<div style="display:flex; flex-direction:row; justify-content:space-between; width:inherit;"> ${name} ${svgTemplate}</div>`
+      `<div style='display:flex; flex-direction:row; justify-content:space-between; width:inherit;'> ${name} ${svgTemplate}</div>`
     : `<div>${name}</div>`
   return {
     field: name,
     headerComponentParams: {
       template,
     },
+    headerTooltip: displayValue ? displayValue : '',
   }
 }
 
@@ -390,7 +397,9 @@ watchEffect(() => {
       ('header' in data_ ? data_.header : [])?.map((v, i) => {
         const constructor = data_.value_type?.[i]?.constructor
         const valueType = constructor ? `${constructor}` : null
-        return toField(v, valueType)
+        const displayVal = data_.value_type?.[i]?.display_type
+        const displayValue = displayVal ? `${displayVal}` : null
+        return toField(v, valueType, displayValue)
       }) ?? []
 
     columnDefs = [...indicesHeader, ...dataHeader]

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -35,12 +35,17 @@ interface Error {
   all_rows_count?: undefined
 }
 
+interface ValueType {
+  constructor: string
+  display_text: string
+}
+
 interface Matrix {
   type: 'Matrix'
   column_count: number
   all_rows_count: number
   json: unknown[][]
-  value_type: object[]
+  value_type: ValueType[]
 }
 
 interface ObjectMatrix {
@@ -48,7 +53,7 @@ interface ObjectMatrix {
   column_count: number
   all_rows_count: number
   json: object[]
-  value_type: object[]
+  value_type: ValueType[]
 }
 
 interface LegacyMatrix {
@@ -56,7 +61,7 @@ interface LegacyMatrix {
   column_count: number
   all_rows_count: number
   json: unknown[][]
-  value_type: object[]
+  value_type: ValueType[]
 }
 
 interface LegacyObjectMatrix {
@@ -64,7 +69,7 @@ interface LegacyObjectMatrix {
   column_count: number
   all_rows_count: number
   json: object[]
-  value_type: object[]
+  value_type: ValueType[]
 }
 
 interface UnknownTable {
@@ -78,7 +83,7 @@ interface UnknownTable {
   indices_header?: string[]
   data: unknown[][] | undefined
   indices: unknown[][] | undefined
-  value_type: object[]
+  value_type: ValueType[]
 }
 
 declare module 'ag-grid-enterprise' {
@@ -397,7 +402,7 @@ watchEffect(() => {
       ('header' in data_ ? data_.header : [])?.map((v, i) => {
         const constructor = data_.value_type?.[i]?.constructor
         const valueType = constructor ? `${constructor}` : null
-        const displayVal = data_.value_type?.[i]?.display_text
+        const displayVal = data_.value_type?.[i]?.display_text as string
         const displayValue = displayVal ? `${displayVal}` : null
         return toField(v, valueType, displayValue)
       }) ?? []

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Value_Type.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Value_Type.enso
@@ -445,6 +445,7 @@ type Value_Type
     to_js_object : JS_Object
     to_js_object self =
         constructor_name = Meta.meta self . constructor . name
+        display_text = self . to_display_text
         additional_fields = case self of
             Value_Type.Integer size ->
                 [["bits", size.to_integer]]
@@ -460,7 +461,7 @@ type Value_Type
                 [["type_name", type_name]]
             _ -> []
         JS_Object.from_pairs <|
-            [["type", "Value_Type"], ["constructor", constructor_name]] + additional_fields
+            [["type", "Value_Type"], ["constructor", constructor_name], ["display_type", display_text]] + additional_fields
 
     ## GROUP Standard.Base.Metadata
        ICON metadata

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Value_Type.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Value_Type.enso
@@ -445,7 +445,7 @@ type Value_Type
     to_js_object : JS_Object
     to_js_object self =
         constructor_name = Meta.meta self . constructor . name
-        display_text = self . to_display_text
+        display_text_value = self . to_display_text
         additional_fields = case self of
             Value_Type.Integer size ->
                 [["bits", size.to_integer]]
@@ -461,7 +461,7 @@ type Value_Type
                 [["type_name", type_name]]
             _ -> []
         JS_Object.from_pairs <|
-            [["type", "Value_Type"], ["constructor", constructor_name], ["display_type", display_text]] + additional_fields
+            [["type", "Value_Type"], ["constructor", constructor_name], ["display_text", display_text_value]] + additional_fields
 
     ## GROUP Standard.Base.Metadata
        ICON metadata

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -155,11 +155,12 @@ make_json_for_table dataframe indices all_rows_count =
     get_vector c = Warning.set (c.to_vector.map v-> make_json_for_value v) []
     columns     = dataframe.columns
     header      = ["header", columns.map .name]
+    value_type  = ["value_type", columns.map .value_type]
     data        = ["data",   columns.map get_vector]
     all_rows    = ["all_rows_count", all_rows_count]
     ixes        = ["indices", indices.map get_vector]
     ixes_header = ["indices_header", indices.map .name]
-    pairs       = [header, data, all_rows, ixes, ixes_header, ["type", "Table"]]
+    pairs       = [header, value_type, data, all_rows, ixes, ixes_header, ["type", "Table"]]
     JS_Object.from_pairs pairs
 
 ## PRIVATE

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -38,13 +38,14 @@ type Foo
 
 
 add_specs suite_builder =
-    make_json header data all_rows ixes_header ixes =
+    make_json header data all_rows ixes_header ixes value_type=
         p_header      = ["header", header]
         p_data        = ["data",   data]
         p_all_rows    = ["all_rows_count", all_rows]
         p_ixes        = ["indices", ixes]
         p_ixes_header = ["indices_header", ixes_header]
-        pairs    = [p_header, p_data, p_all_rows, p_ixes, p_ixes_header, ["type", "Table"]]
+        p_value_type  = ["value_type", value_type]
+        pairs    = [p_header, p_value_type ,p_data, p_all_rows, p_ixes, p_ixes_header, ["type", "Table"]]
         JS_Object.from_pairs pairs . to_text
 
     suite_builder.group "Table Visualization" group_builder->
@@ -52,27 +53,33 @@ add_specs suite_builder =
 
         group_builder.specify "should visualize database tables" <|
             vis = Visualization.prepare_visualization data.t 1
-            json = make_json header=["A", "B", "C"] data=[['a'], [2], [3]] all_rows=3 ixes_header=[] ixes=[]
+            value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["bits", 64]]
+            value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["size", Nothing], ["variable_length", True]]
+            json = make_json header=["A", "B", "C"] data=[['a'], [2], [3]] all_rows=3 ixes_header=[] ixes=[] value_type=[value_type_char, value_type_int, value_type_int]
             vis . should_equal json
 
         group_builder.specify "should visualize database columns" <|
             vis = Visualization.prepare_visualization (data.t.at "A") 2
-            json = make_json header=["A"] data=[['a', 'a']] all_rows=3 ixes_header=[] ixes=[]
+            value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["size", Nothing], ["variable_length", True]]
+            value_type_float = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Float"], ["bits", 64]]
+            json = make_json header=["A"] data=[['a', 'a']] all_rows=3 ixes_header=[] ixes=[] value_type=[value_type_char]
             vis . should_equal json
 
             g = data.t.aggregate ["A", "B"] [Aggregate_Column.Average "C"] . at "Average C"
             vis2 = Visualization.prepare_visualization g 1
-            json2 = make_json header=["Average C"] data=[[4.0]] all_rows=2 ixes_header=[] ixes=[]
+            json2 = make_json header=["Average C"] data=[[4.0]] all_rows=2 ixes_header=[] ixes=[] value_type=[value_type_float]
             vis2 . should_equal json2
 
         group_builder.specify "should visualize dataframe tables" <|
             vis = Visualization.prepare_visualization data.t2 1
-            json = make_json header=["A", "B", "C"] data=[[1], [4], [7]] all_rows=3 ixes_header=["#"] ixes=[[0]]
+            value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["bits", 64]]
+            json = make_json header=["A", "B", "C"] data=[[1], [4], [7]] all_rows=3 ixes_header=["#"] ixes=[[0]] value_type=[value_type_int, value_type_int, value_type_int]
             vis . should_equal json
 
         group_builder.specify "should visualize dataframe columns" <|
             vis = Visualization.prepare_visualization (data.t2.at "A") 2
-            json = make_json header=["A"] data=[[1, 2]] all_rows=3 ixes_header=["#"] ixes=[[0, 1]]
+            value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["bits", 64]]
+            json = make_json header=["A"] data=[[1, 2]] all_rows=3 ixes_header=["#"] ixes=[[0, 1]] value_type=[value_type_int]
             vis . should_equal json
 
         group_builder.specify "should handle Vectors" <|

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -53,15 +53,15 @@ add_specs suite_builder =
 
         group_builder.specify "should visualize database tables" <|
             vis = Visualization.prepare_visualization data.t 1
-            value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["bits", 64]]
-            value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["size", Nothing], ["variable_length", True]]
+            value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
+            value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"], ["size", Nothing], ["variable_length", True]]
             json = make_json header=["A", "B", "C"] data=[['a'], [2], [3]] all_rows=3 ixes_header=[] ixes=[] value_type=[value_type_char, value_type_int, value_type_int]
             vis . should_equal json
 
         group_builder.specify "should visualize database columns" <|
             vis = Visualization.prepare_visualization (data.t.at "A") 2
-            value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["size", Nothing], ["variable_length", True]]
-            value_type_float = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Float"], ["bits", 64]]
+            value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"], ["size", Nothing], ["variable_length", True]]
+            value_type_float = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Float"], ["display_text", "Float (64 bits)"], ["bits", 64]]
             json = make_json header=["A"] data=[['a', 'a']] all_rows=3 ixes_header=[] ixes=[] value_type=[value_type_char]
             vis . should_equal json
 
@@ -72,13 +72,13 @@ add_specs suite_builder =
 
         group_builder.specify "should visualize dataframe tables" <|
             vis = Visualization.prepare_visualization data.t2 1
-            value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["bits", 64]]
+            value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
             json = make_json header=["A", "B", "C"] data=[[1], [4], [7]] all_rows=3 ixes_header=["#"] ixes=[[0]] value_type=[value_type_int, value_type_int, value_type_int]
             vis . should_equal json
 
         group_builder.specify "should visualize dataframe columns" <|
             vis = Visualization.prepare_visualization (data.t2.at "A") 2
-            value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["bits", 64]]
+            value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
             json = make_json header=["A"] data=[[1, 2]] all_rows=3 ixes_header=["#"] ixes=[[0, 1]] value_type=[value_type_int]
             vis . should_equal json
 

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -38,7 +38,7 @@ type Foo
 
 
 add_specs suite_builder =
-    make_json header data all_rows ixes_header ixes value_type=
+    make_json header data all_rows ixes_header ixes value_type =
         p_header      = ["header", header]
         p_data        = ["data",   data]
         p_all_rows    = ["all_rows_count", all_rows]


### PR DESCRIPTION
### Pull Request Description

closes #10018 

Sends the value type within the json for table visualisation
Header uses a html template to show it's value type to the right of the title 
Displays the value type also in a tooltip, this displays the types "display_text"

<img width="392" alt="image" src="https://github.com/enso-org/enso/assets/170310417/0828e6a2-b30f-4ac7-9a8f-46b4a9cfac91">


tooltip: 
<img width="498" alt="image" src="https://github.com/enso-org/enso/assets/170310417/f9964f90-9337-42d3-a0ef-3c58f6d74621">


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
