### PR TITLE
Make test framework list out failed tests to use in filter

### DIFF
--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Suite.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Suite.enso
@@ -102,21 +102,25 @@ type Suite
 
         all_results = all_results_bldr.to_vector
         succ_tests = all_results.filter (r-> r.is_success) . length
-        failed_tests = all_results.filter (r-> r.is_fail) . length
+        failed_tests = all_results.filter (r-> r.is_fail)
+        failed_tests_number = failed_tests.length
+        failed_tests_names = failed_tests.map (t-> t.spec_name) . distinct . fold "" (a -> b -> a+b+"|") . trim ..End "|"
         skipped_tests = all_results.filter (r-> r.is_pending) . length
         pending_groups = matching_specs.filter (p-> p.first.is_pending) . length
         case should_exit of
             True ->
                 IO.println ""
                 IO.println <| succ_tests.to_text + " tests succeeded."
-                IO.println <| failed_tests.to_text + " tests failed."
+                IO.println <| failed_tests_number.to_text + " tests failed."
                 IO.println <| skipped_tests.to_text + " tests skipped."
                 IO.println <| pending_groups.to_text + " groups skipped."
                 IO.println ""
-                exit_code = if failed_tests > 0 then 1 else 0
+                IO.println <| "Failed tests: '" + failed_tests_names + "'"
+                IO.println ""
+                exit_code = if failed_tests_number > 0 then 1 else 0
                 System.exit exit_code
             False ->
-                failed_tests == 0
+                failed_tests_number == 0
 
     ## Gets the names of all the groups in this suite.
     group_names self =

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Suite.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Suite.enso
@@ -104,7 +104,7 @@ type Suite
         succ_tests = all_results.filter (r-> r.is_success) . length
         failed_tests = all_results.filter (r-> r.is_fail)
         failed_tests_number = failed_tests.length
-        failed_tests_names = failed_tests.map (t-> t.spec_name) . distinct . fold "" (a -> b -> a+b+"|") . trim ..End "|"
+        failed_tests_names = failed_tests.map (t-> t.spec_name) . distinct . take 10 . join "|"
         skipped_tests = all_results.filter (r-> r.is_pending) . length
         pending_groups = matching_specs.filter (p-> p.first.is_pending) . length
         case should_exit of
@@ -116,6 +116,7 @@ type Suite
                 IO.println <| pending_groups.to_text + " groups skipped."
                 IO.println ""
                 IO.println <| "Failed tests: '" + failed_tests_names + "'"
+                if failed_tests_number > 10 then IO.println "(Displaying only first 10 failed tests)"
                 IO.println ""
                 exit_code = if failed_tests_number > 0 then 1 else 0
                 System.exit exit_code


### PR DESCRIPTION
### Pull Request Description

If I run a series of tests

![image](https://github.com/enso-org/enso/assets/1720119/c581f6ef-ee87-4bf9-ac20-2b7c877515ea)

this PR now summarises the failing tests at the end

![image](https://github.com/enso-org/enso/assets/1720119/87695329-da3e-446f-94fe-8bb600fb102a)

Which I can then copy and paste to only re-run the failing tests

![image](https://github.com/enso-org/enso/assets/1720119/70522e12-6d59-4e0b-a27b-fa642a17551e)

![image](https://github.com/enso-org/enso/assets/1720119/357079a8-6897-4bb7-b5c0-2c1422754d1a)

Allowing for faster iterations on fixing failing tests

It will only list the first 10 failures to avoid overloading the log in the case when all the tests fail :)

![image](https://github.com/enso-org/enso/assets/1720119/1008ba58-ff46-4a24-9f23-0eb15b79e893)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
