### PR TITLE
Remove legacy  matrix and legacy objects from table visualization and remove the index column

### DIFF
--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -198,10 +198,8 @@ function cellRenderer(params: ICellRendererParams) {
   else if (params.value === undefined) return ''
   else if (params.value === '') return '<span style="color:grey; font-style: italic;">Empty</span>'
   else if (typeof params.value === 'number') return formatNumber(params)
-  else if (Array.isArray(params.value)) {
-    const content = params.value
-    return `[Vector ${content.length} items]`
-  } else if (typeof params.value === 'object') {
+  else if (Array.isArray(params.value)) return `[Vector ${params.value.length} items]`
+  else if (typeof params.value === 'object') {
     const valueType = params.value?.type
     if (valueType === 'BigInt') return formatNumber(params)
     else if (valueType === 'Float')
@@ -334,12 +332,12 @@ watchEffect(() => {
         return toField(v, valueType)
       }) ?? []
 
-    const columnDefs = data_.has_index_col ? [indexField(), ...dataHeader] : [...dataHeader]
+    columnDefs = data_.has_index_col ? [indexField(), ...dataHeader] : [...dataHeader]
     const rows = data_.data && data_.data.length > 0 ? data_.data[0]?.length ?? 0 : 0
     rowData = Array.from({ length: rows }, (_, i) => {
       return Object.fromEntries(
         columnDefs.map((h, j) => {
-          return [h.field, toRender(h.field === INDEX_FIELD_NAME ? i : data_.data?.[j]?.[i])]
+          return [h.field, toRender(h.field === INDEX_FIELD_NAME ? i : data_.data?.[j - 1]?.[i])]
         }),
       )
     })

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -332,7 +332,7 @@ watchEffect(() => {
         return toField(v, valueType)
       }) ?? []
 
-    columnDefs = data_.has_index_col ? [indexField(), ...dataHeader] : [...dataHeader]
+    columnDefs = data_.has_index_col ? [indexField(), ...dataHeader] : dataHeader
     const rows = data_.data && data_.data.length > 0 ? data_.data[0]?.length ?? 0 : 0
     rowData = Array.from({ length: rows }, (_, i) => {
       const shift = data_.has_index_col ? 1 : 0

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -66,7 +66,7 @@ interface UnknownTable {
   header: string[] | undefined
   data: unknown[][] | undefined
   value_type: ValueType[]
-  has_index_col: boolean
+  has_index_col: boolean | undefined
 }
 
 declare module 'ag-grid-enterprise' {
@@ -279,6 +279,7 @@ watchEffect(() => {
         data: undefined,
         // eslint-disable-next-line camelcase
         value_type: undefined,
+        // eslint-disable-next-line camelcase
         has_index_col: false,
       }
   const options = agGridOptions.value

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -64,10 +64,9 @@ interface UnknownTable {
   json: unknown
   all_rows_count?: number
   header: string[] | undefined
-  indices_header?: string[]
   data: unknown[][] | undefined
-  indices: unknown[][] | undefined
   value_type: ValueType[]
+  has_index_col: boolean
 }
 
 declare module 'ag-grid-enterprise' {
@@ -278,9 +277,9 @@ watchEffect(() => {
         // eslint-disable-next-line camelcase
         all_rows_count: 1,
         data: undefined,
-        indices: undefined,
         // eslint-disable-next-line camelcase
         value_type: undefined,
+        has_index_col: false,
       }
   const options = agGridOptions.value
   if (options.api == null) {
@@ -334,7 +333,7 @@ watchEffect(() => {
         return toField(v, valueType)
       }) ?? []
 
-    columnDefs = [indexField(), ...dataHeader]
+    const columnDefs = data_.has_index_col ? [indexField(), ...dataHeader] : [...dataHeader]
     const rows = data_.data && data_.data.length > 0 ? data_.data[0]?.length ?? 0 : 0
     rowData = Array.from({ length: rows }, (_, i) => {
       return Object.fromEntries(
@@ -343,7 +342,6 @@ watchEffect(() => {
         }),
       )
     })
-    console.log({ rowData })
     isTruncated.value = data_.all_rows_count !== rowData.length
   }
 

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -201,13 +201,7 @@ function cellRenderer(params: ICellRendererParams) {
   else if (typeof params.value === 'number') return formatNumber(params)
   else if (Array.isArray(params.value)) {
     const content = params.value
-    // if (isMatrix({ json: content })) {
-    //   return `[Vector ${content.length} rows x ${content[0].length} cols]`
-    // } else if (isObjectMatrix({ json: content })) {
-    //   return `[Table ${content.length} rows x ${Object.keys(content[0]).length} cols]`
-    // } else {
     return `[Vector ${content.length} items]`
-    // }
   } else if (typeof params.value === 'object') {
     const valueType = params.value?.type
     if (valueType === 'BigInt') return formatNumber(params)
@@ -222,43 +216,6 @@ function cellRenderer(params: ICellRendererParams) {
 function addRowIndex(data: object[]): object[] {
   return data.map((row, i) => ({ [INDEX_FIELD_NAME]: i, ...row }))
 }
-
-// function hasExactlyKeys(keys: string[], obj: object) {
-//   return (
-//     Object.keys(obj).length === keys.length &&
-//     keys.every((k) => Object.prototype.hasOwnProperty.call(obj, k))
-//   )
-// }
-
-// function isObjectMatrix(data: object): data is LegacyObjectMatrix {
-//   if (!('json' in data)) {
-//     return false
-//   }
-//   const json = data.json
-//   const isList = Array.isArray(json) && json[0] != null
-//   if (!isList || !(typeof json[0] === 'object')) {
-//     return false
-//   }
-//   const firstKeys = Object.keys(json[0])
-//   return json.every((obj) => hasExactlyKeys(firstKeys, obj))
-// }
-
-// function isMatrix(data: object): data is LegacyMatrix {
-//   if (!('json' in data)) {
-//     return false
-//   }
-//   const json = data.json
-//   const isList = Array.isArray(json) && json[0] != null
-//   if (!isList) {
-//     return false
-//   }
-//   const firstIsArray = Array.isArray(json[0])
-//   if (!firstIsArray) {
-//     return false
-//   }
-//   const firstLen = json[0].length
-//   return json.every((d) => d.length === firstLen)
-// }
 
 function toField(name: string, valueType?: ValueType | null | undefined): ColDef {
   const valType = valueType ? valueType.constructor : null
@@ -363,16 +320,6 @@ watchEffect(() => {
     }
     rowData = addRowIndex(data_.json)
     isTruncated.value = data_.all_rows_count !== data_.json.length
-    // } else if (isMatrix(data_)) {
-    //   // Kept to allow visualization from older versions of the backend.
-    //   columnDefs = [indexField(), ...data_.json[0]!.map((_, i) => toField(i.toString()))]
-    //   rowData = addRowIndex(data_.json)
-    //   isTruncated.value = data_.all_rows_count !== data_.json.length
-    // } else if (isObjectMatrix(data_)) {
-    //   // Kept to allow visualization from older versions of the backend.
-    //   columnDefs = [INDEX_FIELD_NAME, ...Object.keys(data_.json[0]!)].map(toField)
-    //   rowData = addRowIndex(data_.json)
-    //   isTruncated.value = data_.all_rows_count !== data_.json.length
   } else if (Array.isArray(data_.json)) {
     columnDefs = [indexField(), toField('Value')]
     rowData = data_.json.map((row, i) => ({ [INDEX_FIELD_NAME]: i, Value: toRender(row) }))

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -335,9 +335,13 @@ watchEffect(() => {
     columnDefs = data_.has_index_col ? [indexField(), ...dataHeader] : [...dataHeader]
     const rows = data_.data && data_.data.length > 0 ? data_.data[0]?.length ?? 0 : 0
     rowData = Array.from({ length: rows }, (_, i) => {
+      const shift = data_.has_index_col ? 1 : 0
       return Object.fromEntries(
         columnDefs.map((h, j) => {
-          return [h.field, toRender(h.field === INDEX_FIELD_NAME ? i : data_.data?.[j - 1]?.[i])]
+          return [
+            h.field,
+            toRender(h.field === INDEX_FIELD_NAME ? i : data_.data?.[j - shift]?.[i]),
+          ]
         }),
       )
     })

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -147,14 +147,14 @@ make_json_for_js_object js_object max_items =
    - all_rows_count: the number of all rows in the underlying data, useful if
      only a fragment is displayed.
 make_json_for_table : Table -> Integer -> Boolean -> JS_Object
-make_json_for_table dataframe all_rows_count index_col =
+make_json_for_table dataframe all_rows_count include_index_col =
     get_vector c = Warning.set (c.to_vector.map v-> make_json_for_value v) []
     columns     = dataframe.columns
     header      = ["header", columns.map .name]
     value_type  = ["value_type", columns.map .value_type]
     data        = ["data",   columns.map get_vector]
     all_rows    = ["all_rows_count", all_rows_count]
-    has_index_col = ["has_index_col", index_col]
+    has_index_col = ["has_index_col", include_index_col]
     pairs       = [header, value_type, data, all_rows, has_index_col, ["type", "Table"]]
     JS_Object.from_pairs pairs
 

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -34,13 +34,12 @@ prepare_visualization y max_rows=1000 =
         _ : Table ->
             dataframe = x.take max_rows
             all_rows_count = x.row_count
-            index = Column.from_vector "#" (Vector.new dataframe.row_count i->i)
-            make_json_for_table dataframe [index] all_rows_count
+            make_json_for_table dataframe all_rows_count
         _ : DB_Column -> prepare_visualization x.to_table max_rows
         _ : DB_Table ->
             dataframe = x.read (..First max_rows)
             all_rows_count = x.row_count
-            make_json_for_table dataframe [] all_rows_count
+            make_json_for_table dataframe all_rows_count
         _ : Function ->
             pairs = [['_display_text_', '[Function '+x.to_text+']']]
             value = JS_Object.from_pairs pairs
@@ -145,22 +144,17 @@ make_json_for_js_object js_object max_items =
    Arguments:
    - dataframe: the dataframe containing (possibly just a fragment of) the data
      to display.
-   - indices: a vector of dataframe columns that should be displayed as indices;
-     it can be empty, they should have the same amount of rows as the
-     `dataframe`.
    - all_rows_count: the number of all rows in the underlying data, useful if
      only a fragment is displayed.
-make_json_for_table : Table -> Vector Column -> Integer -> JS_Object
-make_json_for_table dataframe indices all_rows_count =
+make_json_for_table : Table -> Integer -> JS_Object
+make_json_for_table dataframe all_rows_count =
     get_vector c = Warning.set (c.to_vector.map v-> make_json_for_value v) []
     columns     = dataframe.columns
     header      = ["header", columns.map .name]
     value_type  = ["value_type", columns.map .value_type]
     data        = ["data",   columns.map get_vector]
     all_rows    = ["all_rows_count", all_rows_count]
-    ixes        = ["indices", indices.map get_vector]
-    ixes_header = ["indices_header", indices.map .name]
-    pairs       = [header, value_type, data, all_rows, ixes, ixes_header, ["type", "Table"]]
+    pairs       = [header, value_type, data, all_rows, ["type", "Table"]]
     JS_Object.from_pairs pairs
 
 ## PRIVATE

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -146,7 +146,7 @@ make_json_for_js_object js_object max_items =
      to display.
    - all_rows_count: the number of all rows in the underlying data, useful if
      only a fragment is displayed.
-make_json_for_table : Table -> Integer -> JS_Object
+make_json_for_table : Table -> Integer -> Boolean -> JS_Object
 make_json_for_table dataframe all_rows_count index_col =
     get_vector c = Warning.set (c.to_vector.map v-> make_json_for_value v) []
     columns     = dataframe.columns

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -34,12 +34,12 @@ prepare_visualization y max_rows=1000 =
         _ : Table ->
             dataframe = x.take max_rows
             all_rows_count = x.row_count
-            make_json_for_table dataframe all_rows_count
+            make_json_for_table dataframe all_rows_count True
         _ : DB_Column -> prepare_visualization x.to_table max_rows
         _ : DB_Table ->
             dataframe = x.read (..First max_rows)
             all_rows_count = x.row_count
-            make_json_for_table dataframe all_rows_count
+            make_json_for_table dataframe all_rows_count True
         _ : Function ->
             pairs = [['_display_text_', '[Function '+x.to_text+']']]
             value = JS_Object.from_pairs pairs
@@ -147,14 +147,15 @@ make_json_for_js_object js_object max_items =
    - all_rows_count: the number of all rows in the underlying data, useful if
      only a fragment is displayed.
 make_json_for_table : Table -> Integer -> JS_Object
-make_json_for_table dataframe all_rows_count =
+make_json_for_table dataframe all_rows_count index_col =
     get_vector c = Warning.set (c.to_vector.map v-> make_json_for_value v) []
     columns     = dataframe.columns
     header      = ["header", columns.map .name]
     value_type  = ["value_type", columns.map .value_type]
     data        = ["data",   columns.map get_vector]
     all_rows    = ["all_rows_count", all_rows_count]
-    pairs       = [header, value_type, data, all_rows, ["type", "Table"]]
+    has_index_col = ["has_index_col", index_col]
+    pairs       = [header, value_type, data, all_rows, has_index_col, ["type", "Table"]]
     JS_Object.from_pairs pairs
 
 ## PRIVATE

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -38,14 +38,12 @@ type Foo
 
 
 add_specs suite_builder =
-    make_json header data all_rows ixes_header ixes value_type =
+    make_json header data all_rows =
         p_header      = ["header", header]
         p_data        = ["data",   data]
         p_all_rows    = ["all_rows_count", all_rows]
-        p_ixes        = ["indices", ixes]
-        p_ixes_header = ["indices_header", ixes_header]
         p_value_type  = ["value_type", value_type]
-        pairs    = [p_header, p_value_type ,p_data, p_all_rows, p_ixes, p_ixes_header, ["type", "Table"]]
+        pairs    = [p_header, p_value_type, p_data, p_all_rows, ["type", "Table"]]
         JS_Object.from_pairs pairs . to_text
 
     suite_builder.group "Table Visualization" group_builder->
@@ -55,31 +53,31 @@ add_specs suite_builder =
             vis = Visualization.prepare_visualization data.t 1
             value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
             value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"], ["size", Nothing], ["variable_length", True]]
-            json = make_json header=["A", "B", "C"] data=[['a'], [2], [3]] all_rows=3 ixes_header=[] ixes=[] value_type=[value_type_char, value_type_int, value_type_int]
+            json = make_json header=["A", "B", "C"] data=[['a'], [2], [3]] all_rows=3 value_type=[value_type_char, value_type_int, value_type_int]
             vis . should_equal json
 
         group_builder.specify "should visualize database columns" <|
             vis = Visualization.prepare_visualization (data.t.at "A") 2
             value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"], ["size", Nothing], ["variable_length", True]]
             value_type_float = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Float"], ["display_text", "Float (64 bits)"], ["bits", 64]]
-            json = make_json header=["A"] data=[['a', 'a']] all_rows=3 ixes_header=[] ixes=[] value_type=[value_type_char]
+            json = make_json header=["A"] data=[['a', 'a']] all_rows=3 value_type=[value_type_char]
             vis . should_equal json
 
             g = data.t.aggregate ["A", "B"] [Aggregate_Column.Average "C"] . at "Average C"
             vis2 = Visualization.prepare_visualization g 1
-            json2 = make_json header=["Average C"] data=[[4.0]] all_rows=2 ixes_header=[] ixes=[] value_type=[value_type_float]
+            json2 = make_json header=["Average C"] data=[[4.0]] all_rows=2 value_type=[value_type_float]
             vis2 . should_equal json2
 
         group_builder.specify "should visualize dataframe tables" <|
             vis = Visualization.prepare_visualization data.t2 1
             value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
-            json = make_json header=["A", "B", "C"] data=[[1], [4], [7]] all_rows=3 ixes_header=["#"] ixes=[[0]] value_type=[value_type_int, value_type_int, value_type_int]
+            json = make_json header=["A", "B", "C"] data=[[1], [4], [7]] all_rows=3 value_type=[value_type_int, value_type_int, value_type_int]
             vis . should_equal json
 
         group_builder.specify "should visualize dataframe columns" <|
             vis = Visualization.prepare_visualization (data.t2.at "A") 2
             value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
-            json = make_json header=["A"] data=[[1, 2]] all_rows=3 ixes_header=["#"] ixes=[[0, 1]] value_type=[value_type_int]
+            json = make_json header=["A"] data=[[1, 2]] all_rows=3 value_type=[value_type_int]
             vis . should_equal json
 
         group_builder.specify "should handle Vectors" <|

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -38,12 +38,13 @@ type Foo
 
 
 add_specs suite_builder =
-    make_json header data all_rows =
+    make_json header data all_rows value_type has_index_col =
         p_header      = ["header", header]
         p_data        = ["data",   data]
         p_all_rows    = ["all_rows_count", all_rows]
         p_value_type  = ["value_type", value_type]
-        pairs    = [p_header, p_value_type, p_data, p_all_rows, ["type", "Table"]]
+        p_has_index_col = ["has_index_col", has_index_col]
+        pairs    = [p_header, p_value_type, p_data, p_all_rows, p_has_index_col, ["type", "Table"]]
         JS_Object.from_pairs pairs . to_text
 
     suite_builder.group "Table Visualization" group_builder->
@@ -53,31 +54,31 @@ add_specs suite_builder =
             vis = Visualization.prepare_visualization data.t 1
             value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
             value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"], ["size", Nothing], ["variable_length", True]]
-            json = make_json header=["A", "B", "C"] data=[['a'], [2], [3]] all_rows=3 value_type=[value_type_char, value_type_int, value_type_int]
+            json = make_json header=["A", "B", "C"] data=[['a'], [2], [3]] all_rows=3 value_type=[value_type_char, value_type_int, value_type_int] has_index_col=True
             vis . should_equal json
 
         group_builder.specify "should visualize database columns" <|
             vis = Visualization.prepare_visualization (data.t.at "A") 2
             value_type_char = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Char"], ["display_text", "Char (variable length, max_size=unlimited)"], ["size", Nothing], ["variable_length", True]]
             value_type_float = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Float"], ["display_text", "Float (64 bits)"], ["bits", 64]]
-            json = make_json header=["A"] data=[['a', 'a']] all_rows=3 value_type=[value_type_char]
+            json = make_json header=["A"] data=[['a', 'a']] all_rows=3 value_type=[value_type_char] has_index_col=True
             vis . should_equal json
 
             g = data.t.aggregate ["A", "B"] [Aggregate_Column.Average "C"] . at "Average C"
             vis2 = Visualization.prepare_visualization g 1
-            json2 = make_json header=["Average C"] data=[[4.0]] all_rows=2 value_type=[value_type_float]
+            json2 = make_json header=["Average C"] data=[[4.0]] all_rows=2 value_type=[value_type_float] has_index_col=True
             vis2 . should_equal json2
 
         group_builder.specify "should visualize dataframe tables" <|
             vis = Visualization.prepare_visualization data.t2 1
             value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
-            json = make_json header=["A", "B", "C"] data=[[1], [4], [7]] all_rows=3 value_type=[value_type_int, value_type_int, value_type_int]
+            json = make_json header=["A", "B", "C"] data=[[1], [4], [7]] all_rows=3 value_type=[value_type_int, value_type_int, value_type_int] has_index_col=True
             vis . should_equal json
 
         group_builder.specify "should visualize dataframe columns" <|
             vis = Visualization.prepare_visualization (data.t2.at "A") 2
             value_type_int = JS_Object.from_pairs [["type", "Value_Type"], ["constructor", "Integer"], ["display_text", "Integer (64 bits)"], ["bits", 64]]
-            json = make_json header=["A"] data=[[1, 2]] all_rows=3 value_type=[value_type_int]
+            json = make_json header=["A"] data=[[1, 2]] all_rows=3 value_type=[value_type_int] has_index_col=True
             vis . should_equal json
 
         group_builder.specify "should handle Vectors" <|


### PR DESCRIPTION
- closes #10245 

### Pull Request Description

- remove legacy matrix and object types from vue component and any further code relating to those 
- remove the index and index header being sent in the json for tables 
- add has_index_col flag for json hat previously sent 'indicies_header' and 'indicies' so that index/# column is still rendered where required 

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] 