### PR TITLE
Lower the size of the parser library in VSCode

### DIFF
--- a/.github/workflows/enso4igv.yml
+++ b/.github/workflows/enso4igv.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: List Binaries
         run: |
-          find . | grep -i enso.parser
+          find . | grep -i enso.parser | xargs ls -ld
 
       - name: Set up Rustup
         run: rustup show

--- a/.github/workflows/enso4igv.yml
+++ b/.github/workflows/enso4igv.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           RUSTFLAGS: "-C target-feature=-crt-static"
         run: |
-          cargo build -p enso-parser-jni -Z unstable-options --target x86_64-unknown-linux-musl --out-dir target/lib/
+          cargo build --release -p enso-parser-jni -Z unstable-options --target x86_64-unknown-linux-musl --out-dir target/lib/
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
@@ -49,7 +49,7 @@ jobs:
         env:
           RUSTFLAGS: "-C target-feature=-crt-static"
         run: |
-          cargo build -p enso-parser-jni -Z unstable-options --out-dir target/lib/x86_64
+          cargo build --release -p enso-parser-jni -Z unstable-options --out-dir target/lib/x86_64
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
@@ -69,7 +69,7 @@ jobs:
         env:
           RUSTFLAGS: "-C target-feature=-crt-static"
         run: |
-          cargo build -p enso-parser-jni -Z unstable-options --out-dir target/lib/aarch64/
+          cargo build --release -p enso-parser-jni -Z unstable-options --out-dir target/lib/aarch64/
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
@@ -89,7 +89,7 @@ jobs:
         env:
           RUSTFLAGS: "-C target-feature=-crt-static"
         run: |
-          cargo build -p enso-parser-jni -Z unstable-options --out-dir target/lib/
+          cargo build --release -p enso-parser-jni -Z unstable-options --out-dir target/lib/
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Pull Request Description

Uses `--release` when building the `enso_parser` libraries to make the code smaller:
-  parser_linux **1020 KB**
- parser_mac_arm **599 KB**
- parser_mac_intel **604 KB**
- parser_windows **438 KB**

when compressed.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. 
- [x] Existing tests are passing OK
