### PR TITLE
Some formatting issues and a few tweaks

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/List.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/List.enso
@@ -120,7 +120,7 @@ type List
        - f: The binary function used to combine elements of the list.
 
        In general, the result of
-           (Cons l0 <| Cons l1 <| ... <| Cons ln) . fold init f
+           (Cons l0 &lt;| Cons l1 &lt;| ... &lt;| Cons ln) . fold init f
        is the same as
            f (...(f (f init l0) l1)...) ln
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Statistics.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Statistics.enso
@@ -18,6 +18,7 @@ import project.Runtime.Ref.Ref
 from project.Data.Boolean import Boolean, False, True
 from project.Data.Range.Extensions import all
 from project.Errors.Common import Unsupported_Argument_Types
+from project.Metadata import Choice, Widget
 
 polyglot java import java.lang.NullPointerException
 polyglot java import org.enso.base.CompareException
@@ -131,6 +132,14 @@ type Statistic
     R_Squared (predicted:Vector)
 
     ## PRIVATE
+       Bulk widget for Statistic.
+    bulk_widget : Widget
+    bulk_widget =
+        options = ["Count", "Minimum", "Maximum", "Sum", "Product", "Mean", "Variance", "Standard_Deviation", "Skew", "Kurtosis", "Covariance", "Pearson", "Spearman", "R_Squared"].map n-> Choice.Option n ".."+n
+        items = Widget.Single_Choice options
+        Widget.Vector_Editor items "..Count"
+
+    ## PRIVATE
        Gets the order needed to compute a statistic for a moment based statistic.
     order : Integer | Nothing
     order self = case self of
@@ -169,7 +178,7 @@ type Statistic
        - data: Vector like object which has a `to_array` method.
        - statistic: Statistic to calculate.
     compute : Vector -> Statistic -> Any
-    compute data statistic=Statistic.Count =
+    compute data statistic:Statistic=..Count =
         Statistic.compute_bulk data [statistic] . first
 
     ## PRIVATE
@@ -179,10 +188,11 @@ type Statistic
        - data: Vector like object which has a `to_array` method.
        - statistics: Set of statistics to calculate.
     compute_bulk : Vector -> Vector Statistic -> Vector Any
-    compute_bulk data statistics=[Statistic.Count, Statistic.Sum] =
-        moment_order = statistics.map on_problems=No_Wrap .order
-        has_min_max = statistics.any (s-> s == Statistic.Minimum || s == Statistic.Maximum)
-        has_product = statistics.any (s-> s == Statistic.Product)
+    compute_bulk data statistics:Vector=[Statistic.Count, Statistic.Sum] =
+        resolved_stats = statistics.map (r-> r:Statistic)
+        moment_order = resolved_stats.map on_problems=No_Wrap .order
+        has_min_max = resolved_stats.any (s-> s == Statistic.Minimum || s == Statistic.Maximum)
+        has_product = resolved_stats.any (s-> s == Statistic.Product)
         max_moment_order = moment_order.filter (v-> v != Nothing) . fold 0 .max
         counter = data.fold (Accumulator.new has_min_max max_moment_order has_product) current-> value-> compute_fold current value
 
@@ -191,8 +201,8 @@ type Statistic
             stat = stats.at first
             Error.throw (Illegal_Argument.Error ("Can only compute " + stat.to_text + " on numerical data sets."))
 
-        if max_moment_order > 0 && counter.moments.is_nothing then report_error statistics else
-            statistics.map on_problems=No_Wrap statistic-> case statistic of
+        if max_moment_order > 0 && counter.moments.is_nothing then report_error resolved_stats else
+            resolved_stats.map on_problems=No_Wrap statistic-> case statistic of
                 Statistic.Covariance series -> check_if_empty counter.count <| calculate_correlation_statistics data series . covariance
                 Statistic.Pearson series -> check_if_empty counter.count <| calculate_correlation_statistics data series . pearsonCorrelation
                 Statistic.R_Squared series -> check_if_empty counter.count <| calculate_correlation_statistics data series . rSquared
@@ -206,7 +216,7 @@ type Statistic
        - data: Vector like object which has a `to_array` method.
        - statistics: Set of statistics to calculate.
     running : Vector -> Statistic -> Vector Any
-    running data statistic=Statistic.Sum =
+    running data statistic:Statistic=..Sum =
         Statistic.running_bulk data [statistic] . map .first
 
     ## PRIVATE
@@ -217,10 +227,11 @@ type Statistic
        - statistics: Set of statistics to calculate.
     running_bulk : Vector -> Vector Statistic -> Vector Any
     running_bulk data statistics=[Statistic.Count, Statistic.Sum] =
-        check_running_support statistics <|
-            moment_order = statistics.map on_problems=No_Wrap .order
-            has_min_max = statistics.any (s-> s == Statistic.Minimum || s == Statistic.Maximum)
-            has_product = statistics.any (s-> s == Statistic.Product)
+        resolved_stats = statistics.map (r-> r:Statistic)
+        check_running_support resolved_stats <|
+            moment_order = resolved_stats.map on_problems=No_Wrap .order
+            has_min_max = resolved_stats.any (s-> s == Statistic.Minimum || s == Statistic.Maximum)
+            has_product = resolved_stats.any (s-> s == Statistic.Product)
             max_moment_order = moment_order.filter (v-> v != Nothing) . fold 0 .max
 
             Panic.handle_wrapped_dataflow_error <|
@@ -230,7 +241,7 @@ type Statistic
                     data.fold counter current->value->
                         result = compute_fold current value
 
-                        row = Panic.rethrow_wrapped_if_error <| statistics.map on_problems=No_Wrap s-> case s of
+                        row = Panic.rethrow_wrapped_if_error <| resolved_stats.map on_problems=No_Wrap s-> case s of
                             Statistic.Maximum -> if result.count == 0 then Nothing else result.maximum
                             Statistic.Minimum -> if result.count == 0 then Nothing else result.minimum
                             _ -> result.compute s
@@ -327,57 +338,6 @@ calculate_correlation_statistics_matrix data =
     data_array = Vector.new data.length i->(data.at i).to_array
     stats_array = wrap_java_call <| CorrelationStatistics.computeMatrix data_array
     Vector.new stats_array.length i->(Vector.from_polyglot_array (stats_array.at i))
-
-## GROUP Statistics
-   ICON transform4
-   Compute a single statistic on the vector (ignoring Nothing and NaN values).
-
-   Arguments:
-   - statistic: Statistic to calculate.
-Vector.compute : Statistic -> Any
-Vector.compute self statistic=Statistic.Count =
-    self.compute_bulk [statistic] . first
-
-## ICON column_add
-   Compute statistics on the vector (ignoring Nothing and NaN values).
-
-   Arguments:
-   - statistics: Set of statistics to calculate.
-Vector.compute_bulk : Vector Statistic -> Vector Any
-Vector.compute_bulk self statistics=[Statistic.Count, Statistic.Sum] =
-    Statistic.compute_bulk self statistics
-
-## GROUP Statistics
-   ICON math
-   Compute a single running statistic on the vector (ignoring Nothing and NaN
-   values).
-
-   Arguments:
-   - statistic: Statistic to calculate.
-Vector.running : Statistic -> Vector Any
-Vector.running self statistic=Statistic.Count =
-    Statistic.running self statistic
-
-## ICON math
-   Compute a set running statistics on the vector (ignoring Nothing and NaN
-   values).
-
-   Arguments:
-   - statistics: Set of statistics to calculate.
-Vector.running_bulk : Vector Statistic -> Vector Any
-Vector.running_bulk self statistics=[Statistic.Count, Statistic.Sum] =
-    Statistic.running_bulk self statistics
-
-## GROUP Statistics
-   ICON column_add
-   Assigns a rank to each value of data, dealing with equal values according to
-   the method.
-
-   Arguments:
-   - method: Method used to deal with equal values.
-Vector.rank_data : Rank_Method -> Vector
-Vector.rank_data self method=Rank_Method.Average =
-    Statistic.rank_data self method
 
 ## PRIVATE
 compute_fold current value = if is_valid value then current.increment value else current

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Statistics.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Statistics.enso
@@ -403,7 +403,7 @@ is_valid v = case v of
 ## PRIVATE
 type Accumulator
     ## PRIVATE
-    new : Boolean -> Integer -> Accumulator
+    new : Boolean -> Integer -> Boolean -> Accumulator
     new min_max=True moments=0 calc_product=False = Accumulator.Value 0 min_max Nothing Nothing (Vector.fill moments 0) calc_product Nothing
 
     ## PRIVATE

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Statistics/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Statistics/Extensions.enso
@@ -1,0 +1,57 @@
+import project.Any.Any
+import project.Data.Statistics.Rank_Method
+import project.Data.Statistics.Statistic
+import project.Data.Vector.Vector
+
+## GROUP Statistics
+   ICON transform4
+   Compute a single statistic on the vector (ignoring Nothing and NaN values).
+
+   Arguments:
+   - statistic: Statistic to calculate.
+Vector.compute : Statistic -> Any
+Vector.compute self statistic:Statistic=..Count =
+    self.compute_bulk [statistic] . first
+
+## ICON column_add
+   Compute statistics on the vector (ignoring Nothing and NaN values).
+
+   Arguments:
+   - statistics: Set of statistics to calculate.
+@statistics Statistic.bulk_widget
+Vector.compute_bulk : Vector Statistic -> Vector Any
+Vector.compute_bulk self statistics:Vector=[..Count, ..Sum] =
+    Statistic.compute_bulk self statistics
+
+## GROUP Statistics
+   ICON math
+   Compute a single running statistic on the vector (ignoring Nothing and NaN
+   values).
+
+   Arguments:
+   - statistic: Statistic to calculate.
+Vector.running : Statistic -> Vector Any
+Vector.running self statistic:Statistic=..Count =
+    Statistic.running self statistic
+
+## ICON math
+   Compute a set running statistics on the vector (ignoring Nothing and NaN
+   values).
+
+   Arguments:
+   - statistics: Set of statistics to calculate.
+@statistics Statistic.bulk_widget
+Vector.running_bulk : Vector Statistic -> Vector Any
+Vector.running_bulk self statistics:Statistic=[..Count, ..Sum] =
+    Statistic.running_bulk self statistics
+
+## GROUP Statistics
+   ICON column_add
+   Assigns a rank to each value of data, dealing with equal values according to
+   the method.
+
+   Arguments:
+   - method: Method used to deal with equal values.
+Vector.rank_data : Rank_Method -> Vector
+Vector.rank_data self method:Rank_Method=..Average =
+    Statistic.rank_data self method

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -1150,7 +1150,7 @@ Text.drop self range=(Index_Sub_Range.First 1) =
          example_case_with_locale = "i".to_case Upper (Locale.new "tr") == "İ"
 @locale Locale.default_widget
 Text.to_case : Case -> Locale -> Text
-Text.to_case self case_option=Case.Lower locale=Locale.default = case case_option of
+Text.to_case self case_option:Case=..Lower locale:Locale=Locale.default = case case_option of
     Case.Lower -> UCharacter.toLowerCase locale.java_locale self
     Case.Upper -> UCharacter.toUpperCase locale.java_locale self
     Case.Title -> UCharacter.toTitleCase locale.java_locale self Nothing

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -1,5 +1,4 @@
 import project.Any.Any
-import project.Data.Index_Sub_Range as Index_Sub_Range_Module
 import project.Data.Index_Sub_Range.Index_Sub_Range
 import project.Data.Locale.Locale
 import project.Data.Range.Range
@@ -35,6 +34,7 @@ import project.Nothing.Nothing
 import project.Panic.Panic
 import project.System.Internal.Reporting_Stream_Decoder_Helper
 from project.Data.Boolean import Boolean, False, True
+from project.Data.Index_Sub_Range import invert_range_selection
 from project.Data.Json import Invalid_JSON, JS_Object, Json
 from project.Data.Numbers import Float, Integer, Number, Number_Parse_Error
 from project.Data.Range.Extensions import all
@@ -46,12 +46,12 @@ polyglot java import com.ibm.icu.lang.UCharacter
 polyglot java import com.ibm.icu.text.BreakIterator
 polyglot java import java.lang.StringBuilder
 polyglot java import org.enso.base.encoding.Encoding_Utils
-polyglot java import org.enso.base.text.ResultWithWarnings
-polyglot java import org.enso.base.Text_Utils
 polyglot java import org.enso.base.Regex_Utils
-polyglot java import org.enso.base.WithProblems
 polyglot java import org.enso.base.text.GraphemeSpan
+polyglot java import org.enso.base.text.ResultWithWarnings
 polyglot java import org.enso.base.text.Utf16Span
+polyglot java import org.enso.base.Text_Utils
+polyglot java import org.enso.base.WithProblems
 
 ## GROUP Text
    ICON text
@@ -1113,7 +1113,7 @@ Text.drop self range=(Index_Sub_Range.First 1) =
         _ : Codepoint_Ranges ->
             sorted_char_ranges_to_remove = ranges.sorted_and_distinct_ranges
             char_length = Text_Utils.char_length self
-            inverted = Index_Sub_Range_Module.invert_range_selection sorted_char_ranges_to_remove char_length needs_sorting=False
+            inverted = invert_range_selection sorted_char_ranges_to_remove char_length needs_sorting=False
             slice_text self inverted
 
 ## ALIAS lower, proper, title, upper

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -458,7 +458,7 @@ Text.tokenize self pattern="." case_sensitivity=Case_Sensitivity.Sensitive =
        $0: the entire match string
        $&: the entire match string
        $n: the nth group
-       $<foo>: Named group `foo`
+       $&lt;foo&gt;: Named group `foo`
 
    Arguments:
    - term: The `Text` or `Regex` to find.
@@ -515,7 +515,7 @@ Text.tokenize self pattern="." case_sensitivity=Case_Sensitivity.Sensitive =
    > Example
      Regexp replace.
 
-     '<a href="url">content</a>'.replace '<a href="(.*?)">(.*?)</a>'.to_regex '$2 is at $1'== 'content is at url'
+         '<a href="url">content</a>'.replace '<a href="(.*?)">(.*?)</a>'.to_regex '$2 is at $1'== 'content is at url'
 @term make_regex_text_widget
 Text.replace : Text | Regex -> Text -> Case_Sensitivity -> Boolean -> Text ! Illegal_Argument
 Text.replace self term:(Text | Regex) replacement:Text (case_sensitivity:Case_Sensitivity=Case_Sensitivity.Default) only_first:Boolean=False =

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
@@ -247,7 +247,7 @@ type Regex
            $0: the entire match string
            $&: the entire match string
            $n: the nth group
-           $<foo>: Named group `foo`
+           $&lt;foo&gt;: Named group `foo`
 
        > Example
          Replace letters in the text "aa".

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Function.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Function.enso
@@ -71,7 +71,9 @@ type Function
    - x: the value to return.
 
    > Example
-     five = Function.identity 5 # returns number 5
+     Create a function always returning the provided argument and apply it to 5.
+
+         five = Function.identity 5
 identity : Any -> Any
 identity x = x
 
@@ -83,7 +85,10 @@ identity x = x
    - f function that takes two arguments
 
    > Example
-    IO.println <| Function.flip (+) "world" "hello" # Prints 'helloworld'
+     Create a function that concatenates two strings in reverse order and print the result.
+
+       # Prints 'helloworld'
+       IO.println <| Function.flip (+) "world" "hello"
 flip : (Any -> Any -> Any) -> (Any -> Any -> Any)
 flip f = (x -> y -> f y x)
 
@@ -95,7 +100,8 @@ flip f = (x -> y -> f y x)
    - x constant value to return
 
    > Example
-    IO.println <| [1, 2, 3].map (Function.const 7) # Prints '[7, 7, 7]'
+
+       IO.println <| [1, 2, 3].map (Function.const 7) # Prints '[7, 7, 7]'
 const : Any -> Any -> Any
 const x ~f =
     black_hole ~_ = Nothing

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Main.enso
@@ -23,6 +23,7 @@ export project.Data.Ordering.Natural_Order
 export project.Data.Ordering.Ordering
 export project.Data.Pair.Pair
 export project.Data.Range.Range
+export project.Data.Raw_Response
 export project.Data.Regression
 export project.Data.Set.Set
 export project.Data.Sort_Direction.Sort_Direction
@@ -33,8 +34,8 @@ export project.Data.Text.Line_Ending_Style.Line_Ending_Style
 export project.Data.Text.Location.Location
 export project.Data.Text.Matching_Mode.Matching_Mode
 export project.Data.Text.Normalization.Normalization
-export project.Data.Text.Regex.Regex
 export project.Data.Text.Regex.Named_Pattern.Named_Pattern
+export project.Data.Text.Regex.Regex
 export project.Data.Text.Text
 export project.Data.Text.Text_Cleanse.Cleansable_Text
 export project.Data.Text.Text_Cleanse.Text_Cleanse
@@ -95,7 +96,6 @@ from project.Data.Index_Sub_Range.Index_Sub_Range export First, Last
 from project.Data.Json.Extensions export all
 from project.Data.Numbers export Float, Integer, Number
 from project.Data.Range.Extensions export all
-from project.Data export Raw_Response
 from project.Data.Statistics export all hiding to_moment_statistic, wrap_java_call, calculate_correlation_statistics, calculate_spearman_rank, calculate_correlation_statistics_matrix, compute_fold, empty_value, is_valid
 from project.Data.Text.Extensions export all
 from project.Data.Text.Regex export regex
@@ -105,4 +105,3 @@ from project.Meta.Enso_Project export enso_project
 from project.Network.Extensions export all
 from project.System.File_Format export Auto_Detect, Bytes, File_Format, Infer, JSON_Format, Plain_Text_Format
 from project.System.File_Format.Plain_Text_Format export Plain_Text
-

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Main.enso
@@ -27,6 +27,8 @@ export project.Data.Raw_Response
 export project.Data.Regression
 export project.Data.Set.Set
 export project.Data.Sort_Direction.Sort_Direction
+export project.Data.Statistics.Rank_Method
+export project.Data.Statistics.Statistic
 export project.Data.Text.Case.Case
 export project.Data.Text.Case_Sensitivity.Case_Sensitivity
 export project.Data.Text.Encoding.Encoding
@@ -96,7 +98,7 @@ from project.Data.Index_Sub_Range.Index_Sub_Range export First, Last
 from project.Data.Json.Extensions export all
 from project.Data.Numbers export Float, Integer, Number
 from project.Data.Range.Extensions export all
-from project.Data.Statistics export all hiding to_moment_statistic, wrap_java_call, calculate_correlation_statistics, calculate_spearman_rank, calculate_correlation_statistics_matrix, compute_fold, empty_value, is_valid
+from project.Data.Statistics.Extensions export all
 from project.Data.Text.Extensions export all
 from project.Data.Text.Regex export regex
 from project.Errors.Problem_Behavior.Problem_Behavior export all

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/Response_Body.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP/Response_Body.enso
@@ -16,6 +16,7 @@ import project.Network.URI.URI
 import project.Nothing.Nothing
 import project.Runtime.Context
 import project.Runtime.Managed_Resource.Managed_Resource
+import project.System.Advanced.Restartable_Input_Stream.Restartable_Input_Stream
 import project.System.File.Advanced.Temporary_File.Temporary_File
 import project.System.File.Existing_File_Behavior.Existing_File_Behavior
 import project.System.File.File
@@ -29,7 +30,6 @@ import project.System.File_Format.Infer
 import project.System.File_Format.Plain_Text_Format
 import project.System.File_Format_Metadata.File_Format_Metadata
 import project.System.Input_Stream.Input_Stream
-import project.System.Advanced.Restartable_Input_Stream.Restartable_Input_Stream
 from project.Data.Boolean import Boolean, False, True
 from project.Data.Text.Extensions import all
 from project.Metadata.Choice import Option

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/Output_Stream.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/Output_Stream.enso
@@ -14,8 +14,8 @@ from project.System.Input_Stream import close_stream
 
 polyglot java import java.io.ByteArrayOutputStream
 polyglot java import java.io.OutputStream as Java_Output_Stream
-polyglot java import org.enso.base.encoding.ReportingStreamEncoder
 polyglot java import org.enso.base.encoding.Encoding_Utils
+polyglot java import org.enso.base.encoding.ReportingStreamEncoder
 
 ## PRIVATE
    An output stream, allowing for interactive writing of contents.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -168,7 +168,7 @@ type DB_Table
     @selector Widget_Helpers.make_column_name_selector
     @index (t-> Widget.Numeric_Input minimum=0 maximum=t.row_count-1)
     get_value : Text | Integer -> Integer -> Any -> Any
-    get_value self selector:Integer=0 index:Integer=0 ~if_missing=Nothing =
+    get_value self selector:(Text | Integer)=0 index:Integer=0 ~if_missing=Nothing =
         col = self.get selector if_missing=Nothing
         if Nothing == col then if_missing else col.get index if_missing
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Table.enso
@@ -2411,6 +2411,7 @@ type DB_Table
        - prefix: Prefix to add to the column names. If `Nothing` then the column
          name is used.
     @column Widget_Helpers.make_column_name_selector
+    @fields (Widget.Vector_Editor item_editor=Widget.Text_Input item_default='""')
     expand_column : Text | Integer -> Vector | Nothing -> Text | DB_Table -> DB_Table ! Type_Error
     expand_column self column fields=Nothing prefix=Nothing =
             _ = [column, fields, prefix]

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
@@ -29,6 +29,8 @@ import Standard.Database.Internal.IR.Order_Descriptor.Order_Descriptor
 import Standard.Database.Internal.IR.Query.Query
 import Standard.Database.Internal.IR.SQL_Expression.SQL_Expression
 import Standard.Database.Internal.IR.SQL_Join_Kind.SQL_Join_Kind
+## TODO replace with custom one
+import Standard.Database.Internal.Postgres.Postgres_Error_Mapper.Postgres_Error_Mapper
 import Standard.Database.Internal.Replace_Params.Replace_Params
 import Standard.Database.Internal.SQL_Type_Mapping.SQL_Type_Mapping
 import Standard.Database.Internal.SQL_Type_Reference.SQL_Type_Reference
@@ -40,9 +42,6 @@ import Standard.Database.SQL_Type.SQL_Type
 from Standard.Database.Errors import SQL_Error, Unsupported_Database_Operation
 from Standard.Database.Internal.IR.Operation_Metadata import Date_Period_Metadata
 from Standard.Database.Internal.Statement_Setter import fill_hole_default
-
-# TODO replace with custom one
-import Standard.Database.Internal.Postgres.Postgres_Error_Mapper.Postgres_Error_Mapper
 
 import project.Internal.Snowflake_Type_Mapping.Snowflake_Type_Mapping
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Column_Operation.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Column_Operation.enso
@@ -79,24 +79,24 @@ type Column_Operation
 ## PRIVATE
 Simple_Expression.from (that:Column_Operation) =
     derived = case that of
-        Column_Operation.Add input rhs -> Simple_Expression.From input (Simple_Calculation.Add rhs)
-        Column_Operation.Subtract input rhs -> Simple_Expression.From input (Simple_Calculation.Subtract rhs)
-        Column_Operation.Multiply input rhs -> Simple_Expression.From input (Simple_Calculation.Multiply rhs)
-        Column_Operation.Divide input rhs -> Simple_Expression.From input (Simple_Calculation.Divide rhs)
-        Column_Operation.Mod input rhs -> Simple_Expression.From input (Simple_Calculation.Mod rhs)
-        Column_Operation.Power input rhs -> Simple_Expression.From input (Simple_Calculation.Power rhs)
-        Column_Operation.Round input precision use_bankers -> Simple_Expression.From input (Simple_Calculation.Round precision use_bankers)
-        Column_Operation.Ceil input -> Simple_Expression.From input Simple_Calculation.Ceil
-        Column_Operation.Floor input -> Simple_Expression.From input Simple_Calculation.Floor
-        Column_Operation.Truncate input -> Simple_Expression.From input Simple_Calculation.Truncate
-        Column_Operation.Min input rhs -> Simple_Expression.From input (Simple_Calculation.Min rhs)
-        Column_Operation.Max input rhs -> Simple_Expression.From input (Simple_Calculation.Max rhs)
-        Column_Operation.Date_Add input length period -> Simple_Expression.From input (Simple_Calculation.Date_Add length period)
-        Column_Operation.Date_Part input period -> Simple_Expression.From input (Simple_Calculation.Date_Part period)
-        Column_Operation.Date_Diff input end period -> Simple_Expression.From input (Simple_Calculation.Date_Diff end period)
-        Column_Operation.Not input -> Simple_Expression.From input Simple_Calculation.Not
-        Column_Operation.And input rhs -> Simple_Expression.From input (Simple_Calculation.And rhs)
-        Column_Operation.Or input rhs -> Simple_Expression.From input (Simple_Calculation.Or rhs)
-        Column_Operation.If input condition true_value false_value -> Simple_Expression.From input (Simple_Calculation.If condition true_value false_value)
-        Column_Operation.Trim input where what -> Simple_Expression.From input (Simple_Calculation.Trim where what)
+        Column_Operation.Add input rhs -> Simple_Expression.Simple_Expr input (Simple_Calculation.Add rhs)
+        Column_Operation.Subtract input rhs -> Simple_Expression.Simple_Expr input (Simple_Calculation.Subtract rhs)
+        Column_Operation.Multiply input rhs -> Simple_Expression.Simple_Expr input (Simple_Calculation.Multiply rhs)
+        Column_Operation.Divide input rhs -> Simple_Expression.Simple_Expr input (Simple_Calculation.Divide rhs)
+        Column_Operation.Mod input rhs -> Simple_Expression.Simple_Expr input (Simple_Calculation.Mod rhs)
+        Column_Operation.Power input rhs -> Simple_Expression.Simple_Expr input (Simple_Calculation.Power rhs)
+        Column_Operation.Round input precision use_bankers -> Simple_Expression.Simple_Expr input (Simple_Calculation.Round precision use_bankers)
+        Column_Operation.Ceil input -> Simple_Expression.Simple_Expr input Simple_Calculation.Ceil
+        Column_Operation.Floor input -> Simple_Expression.Simple_Expr input Simple_Calculation.Floor
+        Column_Operation.Truncate input -> Simple_Expression.Simple_Expr input Simple_Calculation.Truncate
+        Column_Operation.Min input rhs -> Simple_Expression.Simple_Expr input (Simple_Calculation.Min rhs)
+        Column_Operation.Max input rhs -> Simple_Expression.Simple_Expr input (Simple_Calculation.Max rhs)
+        Column_Operation.Date_Add input length period -> Simple_Expression.Simple_Expr input (Simple_Calculation.Date_Add length period)
+        Column_Operation.Date_Part input period -> Simple_Expression.Simple_Expr input (Simple_Calculation.Date_Part period)
+        Column_Operation.Date_Diff input end period -> Simple_Expression.Simple_Expr input (Simple_Calculation.Date_Diff end period)
+        Column_Operation.Not input -> Simple_Expression.Simple_Expr input Simple_Calculation.Not
+        Column_Operation.And input rhs -> Simple_Expression.Simple_Expr input (Simple_Calculation.And rhs)
+        Column_Operation.Or input rhs -> Simple_Expression.Simple_Expr input (Simple_Calculation.Or rhs)
+        Column_Operation.If input condition true_value false_value -> Simple_Expression.Simple_Expr input (Simple_Calculation.If condition true_value false_value)
+        Column_Operation.Trim input where what -> Simple_Expression.Simple_Expr input (Simple_Calculation.Trim where what)
     Warning.attach (Deprecated.Warning "Standard.Table.Column_Operation.Column_Operation" "" "Deprecated: `Column_Operation` has been replaced by `Simple_Expression`.") derived

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Delimited/Delimited_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Delimited/Delimited_Format.enso
@@ -112,8 +112,8 @@ type Delimited_Format
 
     ## PRIVATE
        Clone the instance with some properties overridden.
-    clone : Quote_Style -> Headers -> (Data_Formatter|Nothing) -> Boolean -> (Text|Nothing) -> (Text|Nothing) -> Delimited_Format
-    clone self (encoding:Encoding = self.encoding) (quote_style=self.quote_style) (headers:Headers=self.headers) (value_formatter=self.value_formatter) (keep_invalid_rows=self.keep_invalid_rows) (line_endings=self.line_endings) (comment_character=self.comment_character) =
+    clone : Encoding -> Quote_Style -> Headers -> (Data_Formatter|Nothing) -> Boolean -> (Text|Nothing) -> (Text|Nothing) -> Delimited_Format
+    clone self (encoding:Encoding = self.encoding) (quote_style:Quote_Style=self.quote_style) (headers:Headers=self.headers) (value_formatter=self.value_formatter) (keep_invalid_rows:Boolean=self.keep_invalid_rows) (line_endings=self.line_endings) (comment_character=self.comment_character) =
         Delimited_Format.Delimited self.delimiter encoding self.skip_rows self.row_limit quote_style headers value_formatter keep_invalid_rows line_endings comment_character
 
     ## ICON data_input

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Workbook.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Workbook.enso
@@ -72,7 +72,11 @@ type Excel_Workbook
 
     ## PRIVATE
        Creates an Excel_Workbook connection.
-    Value (excel_connection_resource_ref : Ref (Managed_Resource ReadOnlyExcelConnection)) (file:(File|Temporary_File|Nothing)) xls_format:Boolean
+    private Value (excel_connection_resource_ref : Ref (Managed_Resource ReadOnlyExcelConnection)) (file:(File|Temporary_File|Nothing)) internal_xls_format:Boolean
+
+    ## Is the Workbook in the old XLS format?
+    xls_format : Boolean
+    xls_format self = self.internal_xls_format
 
     ## PRIVATE
        ICON metadata

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Table_Conversions.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Table_Conversions.enso
@@ -20,6 +20,7 @@ import project.Table.Table
    Arguments:
    - fields: a Vector of Text representing the names of fields to look up.
      If `Nothing` then all fields found are added.
+@fields (Widget.Vector_Editor item_editor=Widget.Text_Input item_default='""')
 Vector.to_table : Vector | Nothing -> Table ! Type_Error
 Vector.to_table self fields=Nothing =
     Table.from_objects self fields
@@ -51,6 +52,7 @@ Date_Range.to_table self name:Text=self.default_column_name =
    Arguments:
    - fields: a Vector of Text representing the names of fields to look up.
      If `Nothing` then all fields found are added.
+@fields (Widget.Vector_Editor item_editor=Widget.Text_Input item_default='""')
 JS_Object.to_table : Vector | Nothing -> Table ! Type_Error
 JS_Object.to_table self fields=Nothing =
     self.to Table fields
@@ -77,6 +79,7 @@ JS_Object.to_table self fields=Nothing =
              json = Examples.simple_table_json
              headers = Examples.simple_table_json_headers
              Table.from_objects json headers
+@fields (Widget.Vector_Editor item_editor=Widget.Text_Input item_default='""')
 Table.from_objects : Any -> Vector | Nothing -> Table
 Table.from_objects value (fields : Vector | Nothing = Nothing) =
     Expand_Objects_Helpers.create_table_from_objects value fields

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Table_Conversions.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Table_Conversions.enso
@@ -4,7 +4,7 @@ import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Errors.Unimplemented.Unimplemented
 import Standard.Base.System.File.Generic.Writable_File.Writable_File
-from Standard.Base.Metadata import make_single_choice
+from Standard.Base.Metadata import make_single_choice, Widget
 
 import project.Errors.Invalid_JSON_Format
 import project.Internal.Expand_Objects_Helpers

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Add_Running.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Add_Running.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Errors.Common.Unsupported_Argument_Types
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
+from Standard.Base.Data.Statistics import check_running_support
 
 import project.Column.Column
 import project.Internal.Add_Row_Number

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Widget_Helpers.enso
@@ -13,8 +13,8 @@ import project.Join_Kind.Join_Kind
 import project.Sort_Column.Sort_Column
 import project.Table.Table
 import project.Value_Type.Auto
-import project.Value_Type.Value_Type
 import project.Value_Type.By_Type
+import project.Value_Type.Value_Type
 from project.Extensions.Table_Conversions import all
 
 ## PRIVATE
@@ -94,7 +94,7 @@ make_column_name_multi_selector table display:Display=Display.Always add_regex:B
 
 ## PRIVATE
    Make a column reference by name selector.
-make_column_ref_by_name_selector : Table -> Display -> Boolean -> Boolean -> Boolean -> Boolean -> Boolean -> Boolean -> Widget
+make_column_ref_by_name_selector : Table -> Display -> Boolean -> Boolean -> Boolean -> Boolean -> Boolean -> Widget
 make_column_ref_by_name_selector table display:Display=..Always add_text:Boolean=False add_regex:Boolean=False add_number:Boolean=False add_boolean:Boolean=False add_named_pattern:Boolean=False =
     text = if add_text then [Option "<Text Value>" "''"] else []
     regex = if add_regex then [Option "<Regular Expression>" "(regex '')"] else []

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
@@ -29,4 +29,3 @@ from project.Constants export all
 from project.Expression export expr
 from project.Extensions.Column_Vector_Extensions export all
 from project.Extensions.Table_Conversions export all
-from project.Simple_Expression export simple_expr

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
@@ -29,3 +29,4 @@ from project.Constants export all
 from project.Expression export expr
 from project.Extensions.Column_Vector_Extensions export all
 from project.Extensions.Table_Conversions export all
+from project.Simple_Expression export simple_expr

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Simple_Expression.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Simple_Expression.enso
@@ -14,13 +14,13 @@ import project.Internal.Widget_Helpers
 from project.Internal.Filter_Condition_Helpers import make_filter_column
 
 ## Defines a simple expression based off an input column and an operation to perform.
-simple_expr : (Column_Ref|Expression|Any) -> (Simple_Calculation) -> Simple_Expression
-simple_expr (input : Column_Ref|Expression|Any = (..Index 0)) (operation : Simple_Calculation = ..Copy) =
-    Simple_Expression.From input operation
-
-## Defines a simple expression based off an input column and an operation to perform.
 type Simple_Expression
-    ## A simple expression based off an input column and an operation to perform.
+    ## PRIVATE
+       A simple expression based off an input column and an operation to perform.
+    Simple_Expr (input : Column_Ref|Expression|Any = (..Index 0)) (operation : Simple_Calculation = ..Copy)
+
+    ## PRIVATE
+       A simple expression based off an input column and an operation to perform.
     From (input : Column_Ref|Expression|Any = (..Index 0)) (operation : Simple_Calculation = ..Copy)
 
     ## PRIVATE
@@ -106,7 +106,7 @@ type Simple_Expression
             builder.append (Option "text_length" "..Text_Length")
             builder.append (Option "format" "..Format" [["format", make_format_chooser include_number=True]])
 
-        derived = Option "<Simple Expression>" "simple_expr" [["input", with_all_types], ["operation", Single_Choice options]]
+        derived = Option "<Simple Expression>" "..Simple_Expr" [["input", with_all_types], ["operation", Single_Choice options]]
 
         Single_Choice [text, number, boolean, expression, derived] display=display
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Simple_Expression.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Simple_Expression.enso
@@ -14,6 +14,11 @@ import project.Internal.Widget_Helpers
 from project.Internal.Filter_Condition_Helpers import make_filter_column
 
 ## Defines a simple expression based off an input column and an operation to perform.
+simple_expr : (Column_Ref|Expression|Any) -> (Simple_Calculation) -> Simple_Expression
+simple_expr (input : Column_Ref|Expression|Any = (..Index 0)) (operation : Simple_Calculation = ..Copy) =
+    Simple_Expression.From input operation
+
+## Defines a simple expression based off an input column and an operation to perform.
 type Simple_Expression
     ## A simple expression based off an input column and an operation to perform.
     From (input : Column_Ref|Expression|Any = (..Index 0)) (operation : Simple_Calculation = ..Copy)
@@ -101,7 +106,7 @@ type Simple_Expression
             builder.append (Option "text_length" "..Text_Length")
             builder.append (Option "format" "..Format" [["format", make_format_chooser include_number=True]])
 
-        derived = Option "<Simple Expression>" "..From" [["input", with_all_types], ["operation", Single_Choice options]]
+        derived = Option "<Simple Expression>" "simple_expr" [["input", with_all_types], ["operation", Single_Choice options]]
 
         Single_Choice [text, number, boolean, expression, derived] display=display
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -1412,6 +1412,7 @@ type Table
        - prefix: Prefix to add to the column names. If `Nothing` then the column
          name is used.
     @column Widget_Helpers.make_column_name_selector
+    @fields (Widget.Vector_Editor item_editor=Widget.Text_Input item_default='""')
     expand_column : Text | Integer -> (Vector Text) | Nothing -> Prefix_Name -> Table ! Type_Error | No_Such_Column | Index_Out_Of_Bounds
     expand_column self (column : Text | Integer) (fields : (Vector Text) | Nothing = Nothing) (prefix : Prefix_Name = Prefix_Name.Column_Name) =
         Expand_Objects_Helpers.expand_column self column fields prefix
@@ -3124,10 +3125,12 @@ Text.from (that : Table) (format:Delimited_Format = Delimited_Format.Delimited '
 
 ## PRIVATE
    Conversion method to a Table from a Vector.
+@fields (Widget.Vector_Editor item_editor=Widget.Text_Input item_default='""')
 Table.from (that:Vector) (fields : (Vector | Nothing) = Nothing) = that.to_table fields
 
 ## PRIVATE
    Conversion method to a Table from a JS_Object.
+@fields (Widget.Vector_Editor item_editor=Widget.Text_Input item_default='""')
 Table.from (that:JS_Object) (fields : (Vector | Nothing) = Nothing) =
     Table.from_objects that fields
 

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -2871,7 +2871,7 @@ type Table
     @term (Widget_Helpers.make_column_ref_by_name_selector add_regex=True add_text=True add_named_pattern=True)
     @new_text (Widget_Helpers.make_column_ref_by_name_selector add_text=True)
     text_replace : Vector (Integer | Text | Regex | By_Type) | Text | Integer | Regex | By_Type -> Text | Column | Column_Ref | Expression | Regex -> Text | Column | Column_Ref | Expression -> Case_Sensitivity -> Boolean -> Column
-    text_replace self columns (term : Text | Column | Column_Ref | Expression | Regex | By_Type = "") (new_text : Text | Column | Column_Ref | Expression = "") case_sensitivity:Case_Sensitivity=..Sensitive only_first:Boolean=False =
+    text_replace self columns (term : Text | Column | Column_Ref | Expression | Regex = "") (new_text : Text | Column | Column_Ref | Expression = "") case_sensitivity:Case_Sensitivity=..Sensitive only_first:Boolean=False =
         table_ref = Table_Ref.from self
         resolved_term = table_ref.resolve term
         resolved_new_text = table_ref.resolve new_text

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -300,7 +300,7 @@ type Table
     @selector Widget_Helpers.make_column_name_selector
     @index (t-> Widget.Numeric_Input minimum=0 maximum=t.row_count-1)
     get_value : Text | Integer -> Integer -> Any -> Any
-    get_value self selector:Integer=0 index:Integer=0 ~if_missing=Nothing =
+    get_value self selector:(Text | Integer)=0 index:Integer=0 ~if_missing=Nothing =
         col = self.get selector if_missing=Nothing
         if Nothing == col then if_missing else col.get index if_missing
 

--- a/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Core_Spec.enso
@@ -192,7 +192,7 @@ add_specs suite_builder setup =
             t1 = table_builder [["X", [1,2,3]]]
             t2 = t1.set (t1.at "X" * 100) as="Y"
             t3 = t2.set (expr "[X] + 10") as="Z"
-            t4 = t3.set (Simple_Expression.From (Column_Ref.Name "X") (Simple_Calculation.Add 1000)) as="X"
+            t4 = t3.set (Simple_Expression.Simple_Expr (Column_Ref.Name "X") (Simple_Calculation.Add 1000)) as="X"
 
             t4.at "X" . to_vector . should_equal [1001, 1002, 1003]
             t4.at "Y" . to_vector . should_equal [100, 200, 300]

--- a/test/Table_Tests/src/Common_Table_Operations/Derived_Columns_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Derived_Columns_Spec.enso
@@ -38,186 +38,190 @@ add_specs suite_builder setup =
 
         group_builder.specify "arithmetics" <|
             t = table_builder [["A", [1, 2]], ["B", [10, 40]]]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") Simple_Calculation.Copy) "C" . at "C" . to_vector . should_equal [1, 2]
+            t.set (..Simple_Expr (..Name "A") ..Copy) "C" . at "C" . to_vector . should_equal [1, 2]
+
+            ## Confirm the old From constructor works.
             t.set (Simple_Expression.From (Column_Ref.Name "A") Simple_Calculation.Copy) "C" . at "C" . to_vector . should_equal [1, 2]
             t.set (..From (..Name "A") ..Copy) "C" . at "C" . to_vector . should_equal [1, 2]
 
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Add (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [11, 42]
-            t.set (..From (..Name "A") (..Add (..Name "B"))) "C" . at "C" . to_vector . should_equal [11, 42]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Add (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [11, 42]
+            t.set (..Simple_Expr (..Name "A") (..Add (..Name "B"))) "C" . at "C" . to_vector . should_equal [11, 42]
 
-            t.set (Simple_Expression.From 100 (Simple_Calculation.Add (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [110, 140]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Add 100)) "C" . at "C" . to_vector . should_equal [101, 102]
-            t.set (Simple_Expression.From 23 (Simple_Calculation.Add 100)) "C" . at "C" . to_vector . should_equal [123, 123]
+            t.set (Simple_Expression.Simple_Expr 100 (Simple_Calculation.Add (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [110, 140]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Add 100)) "C" . at "C" . to_vector . should_equal [101, 102]
+            t.set (Simple_Expression.Simple_Expr 23 (Simple_Calculation.Add 100)) "C" . at "C" . to_vector . should_equal [123, 123]
 
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Subtract (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [-9, -38]
-            t.set (Simple_Expression.From 100 (Simple_Calculation.Subtract (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [90, 60]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Subtract 100)) "C" . at "C" . to_vector . should_equal [-99, -98]
-            t.set (Simple_Expression.From 23 (Simple_Calculation.Subtract 100)) "C" . at "C" . to_vector . should_equal [-77, -77]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Subtract (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [-9, -38]
+            t.set (Simple_Expression.Simple_Expr 100 (Simple_Calculation.Subtract (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [90, 60]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Subtract 100)) "C" . at "C" . to_vector . should_equal [-99, -98]
+            t.set (Simple_Expression.Simple_Expr 23 (Simple_Calculation.Subtract 100)) "C" . at "C" . to_vector . should_equal [-77, -77]
 
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Multiply (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [10, 80]
-            t.set (Simple_Expression.From 100 (Simple_Calculation.Multiply (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [1000, 4000]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Multiply 100)) "C" . at "C" . to_vector . should_equal [100, 200]
-            t.set (Simple_Expression.From 23 (Simple_Calculation.Multiply 100)) "C" . at "C" . to_vector . should_equal [2300, 2300]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Multiply (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [10, 80]
+            t.set (Simple_Expression.Simple_Expr 100 (Simple_Calculation.Multiply (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [1000, 4000]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Multiply 100)) "C" . at "C" . to_vector . should_equal [100, 200]
+            t.set (Simple_Expression.Simple_Expr 23 (Simple_Calculation.Multiply 100)) "C" . at "C" . to_vector . should_equal [2300, 2300]
 
-            t.set (Simple_Expression.From (Column_Ref.Name "B") (Simple_Calculation.Divide (Column_Ref.Name "A"))) "C" . at "C" . to_vector . should_equal [10, 20]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Divide (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [0.1, 0.05]
-            t.set (Simple_Expression.From 1 (Simple_Calculation.Divide (Column_Ref.Name "A"))) "C" . at "C" . to_vector . should_equal [1, 0.5]
-            t.set (Simple_Expression.From 1 (Simple_Calculation.Divide 2)) "C" . at "C" . to_vector . should_equal [0.5, 0.5]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "B") (Simple_Calculation.Divide (Column_Ref.Name "A"))) "C" . at "C" . to_vector . should_equal [10, 20]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Divide (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [0.1, 0.05]
+            t.set (Simple_Expression.Simple_Expr 1 (Simple_Calculation.Divide (Column_Ref.Name "A"))) "C" . at "C" . to_vector . should_equal [1, 0.5]
+            t.set (Simple_Expression.Simple_Expr 1 (Simple_Calculation.Divide 2)) "C" . at "C" . to_vector . should_equal [0.5, 0.5]
 
             t2 = table_builder [["A", [23, 42]], ["B", [10, 3]]]
-            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Mod (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [3, 0]
-            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Mod 10)) "C" . at "C" . to_vector . should_equal [3, 2]
-            t2.set (Simple_Expression.From 7 (Simple_Calculation.Mod 5)) "C" . at "C" . to_vector . should_equal [2, 2]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Mod (Column_Ref.Name "B"))) "C" . at "C" . to_vector . should_equal [3, 0]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Mod 10)) "C" . at "C" . to_vector . should_equal [3, 2]
+            t2.set (Simple_Expression.Simple_Expr 7 (Simple_Calculation.Mod 5)) "C" . at "C" . to_vector . should_equal [2, 2]
 
-            t.set (Simple_Expression.From (Column_Ref.Name "B") (Simple_Calculation.Power (Column_Ref.Name "A"))) "C" . at "C" . to_vector . should_equal [10, 1600]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Power 3)) "C" . at "C" . to_vector . should_equal [1, 8]
-            t.set (Simple_Expression.From 2 (Simple_Calculation.Power (Column_Ref.Name "A"))) "C" . at "C" . to_vector . should_equal [2, 4]
-            t.set (Simple_Expression.From 3 (Simple_Calculation.Power 4)) "C" . at "C" . to_vector . should_equal [81, 81]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "B") (Simple_Calculation.Power (Column_Ref.Name "A"))) "C" . at "C" . to_vector . should_equal [10, 1600]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Power 3)) "C" . at "C" . to_vector . should_equal [1, 8]
+            t.set (Simple_Expression.Simple_Expr 2 (Simple_Calculation.Power (Column_Ref.Name "A"))) "C" . at "C" . to_vector . should_equal [2, 4]
+            t.set (Simple_Expression.Simple_Expr 3 (Simple_Calculation.Power 4)) "C" . at "C" . to_vector . should_equal [81, 81]
 
-            Test.expect_panic Type_Error <| t.set (Simple_Expression.From "x" (Simple_Calculation.Subtract "y"))
-            t.set (Simple_Expression.From 42 (Simple_Calculation.Add "y")) . should_fail_with Illegal_Argument
+            Test.expect_panic Type_Error <| t.set (Simple_Expression.Simple_Expr "x" (Simple_Calculation.Subtract "y"))
+            t.set (Simple_Expression.Simple_Expr 42 (Simple_Calculation.Add "y")) . should_fail_with Illegal_Argument
 
         group_builder.specify "rounding" <|
             t = table_builder [["A", [1.13333, 122.74463, 32.52424, -12.7]]]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") Simple_Calculation.Round) "Z" . at "Z" . to_vector . should_equal [1, 123, 33, -13]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Round precision=1)) "Z" . at "Z" . to_vector . should_equal [1.1, 122.7, 32.5, -12.7]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Round precision=-1)) "Z" . at "Z" . to_vector . should_equal [0, 120, 30, -10]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") Simple_Calculation.Round) "Z" . at "Z" . to_vector . should_equal [1, 123, 33, -13]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Round precision=1)) "Z" . at "Z" . to_vector . should_equal [1.1, 122.7, 32.5, -12.7]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Round precision=-1)) "Z" . at "Z" . to_vector . should_equal [0, 120, 30, -10]
 
-            t.set (Simple_Expression.From (Column_Ref.Name "A") Simple_Calculation.Ceil) "Z" . at "Z" . to_vector . should_equal [2, 123, 33, -12]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") Simple_Calculation.Floor) "Z" . at "Z" . to_vector . should_equal [1, 122, 32, -13]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") Simple_Calculation.Truncate) "Z" . at "Z" . to_vector . should_equal [1, 122, 32, -12]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") Simple_Calculation.Ceil) "Z" . at "Z" . to_vector . should_equal [2, 123, 33, -12]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") Simple_Calculation.Floor) "Z" . at "Z" . to_vector . should_equal [1, 122, 32, -13]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") Simple_Calculation.Truncate) "Z" . at "Z" . to_vector . should_equal [1, 122, 32, -12]
 
-            t.set (Simple_Expression.From "1.23" Simple_Calculation.Round) . should_fail_with Invalid_Value_Type
-            t.set (Simple_Expression.From "1.23" Simple_Calculation.Truncate) . should_fail_with Invalid_Value_Type
+            t.set (Simple_Expression.Simple_Expr "1.23" Simple_Calculation.Round) . should_fail_with Invalid_Value_Type
+            t.set (Simple_Expression.Simple_Expr "1.23" Simple_Calculation.Truncate) . should_fail_with Invalid_Value_Type
 
         group_builder.specify "date/time" pending=pending_datetime <|
             t = table_builder [["A", [Date_Time.new 2023 1 12 12 45, Date_Time.new 2020 5 12 1 45]], ["B", [Date_Time.new 2023 1 15 18 45, Date_Time.new 2020 6 12 22 20]], ["x", [1, 3]]]
 
             # TODO ticket for truncate for DB
             if setup.is_database.not then
-                t.set (Simple_Expression.From (Column_Ref.Name "A") Simple_Calculation.Truncate) "Z" . at "Z" . to_vector . should_equal [Date.new 2023 1 12, Date.new 2020 5 12]
-                t.set (Simple_Expression.From (Date_Time.new 1999 12 10 14 55 11) Simple_Calculation.Truncate) "Z" . at "Z" . to_vector . should_equal [Date.new 1999 12 10, Date.new 1999 12 10]
+                t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") Simple_Calculation.Truncate) "Z" . at "Z" . to_vector . should_equal [Date.new 2023 1 12, Date.new 2020 5 12]
+                t.set (Simple_Expression.Simple_Expr (Date_Time.new 1999 12 10 14 55 11) Simple_Calculation.Truncate) "Z" . at "Z" . to_vector . should_equal [Date.new 1999 12 10, Date.new 1999 12 10]
 
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Date_Add (Column_Ref.Name "x"))) "Z" . at "Z" . to_vector . should_equal_tz_agnostic [Date_Time.new 2023 1 13 12 45, Date_Time.new 2020 5 15 1 45]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Date_Add 10 Date_Period.Year)) "Z" . at "Z" . to_vector . should_equal_tz_agnostic [Date_Time.new 2033 1 12 12 45, Date_Time.new 2030 5 12 1 45]
-            t.set (Simple_Expression.From (Date_Time.new 2001 12 15 11 00) (Simple_Calculation.Date_Add 10 Time_Period.Minute)) "Z" . at "Z" . to_vector . should_equal_tz_agnostic [Date_Time.new 2001 12 15 11 10, Date_Time.new 2001 12 15 11 10]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Date_Add (Column_Ref.Name "x"))) "Z" . at "Z" . to_vector . should_equal_tz_agnostic [Date_Time.new 2023 1 13 12 45, Date_Time.new 2020 5 15 1 45]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Date_Add 10 Date_Period.Year)) "Z" . at "Z" . to_vector . should_equal_tz_agnostic [Date_Time.new 2033 1 12 12 45, Date_Time.new 2030 5 12 1 45]
+            t.set (Simple_Expression.Simple_Expr (Date_Time.new 2001 12 15 11 00) (Simple_Calculation.Date_Add 10 Time_Period.Minute)) "Z" . at "Z" . to_vector . should_equal_tz_agnostic [Date_Time.new 2001 12 15 11 10, Date_Time.new 2001 12 15 11 10]
 
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Date_Diff (Column_Ref.Name "B") Date_Period.Day)) "Z" . at "Z" . to_vector . should_equal [3, 31]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Date_Part Date_Period.Year)) "Z" . at "Z" . to_vector . should_equal [2023, 2020]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Date_Part Time_Period.Minute)) "Z" . at "Z" . to_vector . should_equal [45, 45]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Date_Diff (Column_Ref.Name "B") Date_Period.Day)) "Z" . at "Z" . to_vector . should_equal [3, 31]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Date_Part Date_Period.Year)) "Z" . at "Z" . to_vector . should_equal [2023, 2020]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Date_Part Time_Period.Minute)) "Z" . at "Z" . to_vector . should_equal [45, 45]
 
             t2 = table_builder [["C", [Date.new 2002 12 10, Date.new 2005 01 01]], ["D", [Time_Of_Day.new 12 45, Time_Of_Day.new 01 01]]]
-            t2.set (Simple_Expression.From (Column_Ref.Name "C") (Simple_Calculation.Date_Add 5 Date_Period.Month)) "Z" . at "Z" . to_vector . should_equal [Date.new 2003 5 10, Date.new 2005 6 01]
-            t2.set (Simple_Expression.From (Column_Ref.Name "D") (Simple_Calculation.Date_Add 15 Time_Period.Hour)) "Z" . at "Z" . to_vector . should_equal [Time_Of_Day.new 03 45, Time_Of_Day.new 16 01]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "C") (Simple_Calculation.Date_Add 5 Date_Period.Month)) "Z" . at "Z" . to_vector . should_equal [Date.new 2003 5 10, Date.new 2005 6 01]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "D") (Simple_Calculation.Date_Add 15 Time_Period.Hour)) "Z" . at "Z" . to_vector . should_equal [Time_Of_Day.new 03 45, Time_Of_Day.new 16 01]
 
-            t2.set (Simple_Expression.From (Column_Ref.Name "C") (Simple_Calculation.Date_Diff (Date.new 2003) Date_Period.Year)) "Z" . at "Z" . to_vector . should_equal [0, -2]
-            t2.set (Simple_Expression.From (Column_Ref.Name "D") (Simple_Calculation.Date_Diff (Time_Of_Day.new 13) Time_Period.Minute)) "Z" . at "Z" . to_vector . should_equal [15, 59+(60*11)]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "C") (Simple_Calculation.Date_Diff (Date.new 2003) Date_Period.Year)) "Z" . at "Z" . to_vector . should_equal [0, -2]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "D") (Simple_Calculation.Date_Diff (Time_Of_Day.new 13) Time_Period.Minute)) "Z" . at "Z" . to_vector . should_equal [15, 59+(60*11)]
 
-            t2.set (Simple_Expression.From (Column_Ref.Name "C") (Simple_Calculation.Date_Part Date_Period.Year)) "Z" . at "Z" . to_vector . should_equal [2002, 2005]
-            t2.set (Simple_Expression.From (Column_Ref.Name "D") (Simple_Calculation.Date_Part Time_Period.Minute)) "Z" . at "Z" . to_vector . should_equal [45, 1]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "C") (Simple_Calculation.Date_Part Date_Period.Year)) "Z" . at "Z" . to_vector . should_equal [2002, 2005]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "D") (Simple_Calculation.Date_Part Time_Period.Minute)) "Z" . at "Z" . to_vector . should_equal [45, 1]
 
             # error handling
-            t2.set (Simple_Expression.From (Column_Ref.Name "C") (Simple_Calculation.Date_Part Time_Period.Second)) . should_fail_with Illegal_Argument
-            t2.set (Simple_Expression.From (Column_Ref.Name "D") (Simple_Calculation.Date_Add 5 Date_Period.Year)) . should_fail_with Illegal_Argument
-            t.set (Simple_Expression.From (Column_Ref.Name "x") (Simple_Calculation.Date_Part Date_Period.Year)) . should_fail_with Invalid_Value_Type
-            Test.expect_panic Type_Error <| t2.set (Simple_Expression.From 42 (Simple_Calculation.Date_Diff "x" Date_Period.Year))
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "C") (Simple_Calculation.Date_Part Time_Period.Second)) . should_fail_with Illegal_Argument
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "D") (Simple_Calculation.Date_Add 5 Date_Period.Year)) . should_fail_with Illegal_Argument
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "x") (Simple_Calculation.Date_Part Date_Period.Year)) . should_fail_with Invalid_Value_Type
+            Test.expect_panic Type_Error <| t2.set (Simple_Expression.Simple_Expr 42 (Simple_Calculation.Date_Diff "x" Date_Period.Year))
 
         group_builder.specify "boolean" <|
             t = table_builder [["A", [True, False]], ["T", [True, True]]]
 
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.And (Column_Ref.Name "T"))) "Z" . at "Z" . to_vector . should_equal [True, False]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.And False)) "Z" . at "Z" . to_vector . should_equal [False, False]
-            t.set (Simple_Expression.From True (Simple_Calculation.And True)) "Z" . at "Z" . to_vector . should_equal [True, True]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.And (Column_Ref.Name "T"))) "Z" . at "Z" . to_vector . should_equal [True, False]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.And False)) "Z" . at "Z" . to_vector . should_equal [False, False]
+            t.set (Simple_Expression.Simple_Expr True (Simple_Calculation.And True)) "Z" . at "Z" . to_vector . should_equal [True, True]
 
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Or (Column_Ref.Name "T"))) "Z" . at "Z" . to_vector . should_equal [True, True]
-            t.set (Simple_Expression.From False (Simple_Calculation.Or (Column_Ref.Name "A"))) "Z" . at "Z" . to_vector . should_equal [True, False]
-            t.set (Simple_Expression.From False (Simple_Calculation.Or False)) "Z" . at "Z" . to_vector . should_equal [False, False]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Or (Column_Ref.Name "T"))) "Z" . at "Z" . to_vector . should_equal [True, True]
+            t.set (Simple_Expression.Simple_Expr False (Simple_Calculation.Or (Column_Ref.Name "A"))) "Z" . at "Z" . to_vector . should_equal [True, False]
+            t.set (Simple_Expression.Simple_Expr False (Simple_Calculation.Or False)) "Z" . at "Z" . to_vector . should_equal [False, False]
 
-            t.set (Simple_Expression.From (Column_Ref.Name "A") Simple_Calculation.Not) "Z" . at "Z" . to_vector . should_equal [False, True]
-            t.set (Simple_Expression.From False Simple_Calculation.Not) "Z" . at "Z" . to_vector . should_equal [True, True]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") Simple_Calculation.Not) "Z" . at "Z" . to_vector . should_equal [False, True]
+            t.set (Simple_Expression.Simple_Expr False Simple_Calculation.Not) "Z" . at "Z" . to_vector . should_equal [True, True]
 
-            t.set (Simple_Expression.From 42 (Simple_Calculation.And True)) . should_fail_with Invalid_Value_Type
-            Test.expect_panic Type_Error <| t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Or "x"))
+            t.set (Simple_Expression.Simple_Expr 42 (Simple_Calculation.And True)) . should_fail_with Invalid_Value_Type
+            Test.expect_panic Type_Error <| t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Or "x"))
 
         group_builder.specify "if" <|
             t = table_builder [["A", [1, 100]], ["B", [10, 40]], ["C", [23, 55]]]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Greater than=(Column_Ref.Name "B")))) "Z" . at "Z" . to_vector . should_equal [False, True]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Greater than=(Column_Ref.Name "B") Filter_Action.Remove))) "Z" . at "Z" . to_vector . should_equal [True, False]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Greater than=20) "T" "F")) "Z" . at "Z" . to_vector . should_equal ["F", "T"]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Less than=20) (Column_Ref.Name "B") (Column_Ref.Name "C"))) "Z" . at "Z" . to_vector . should_equal [10, 55]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Greater than=(Column_Ref.Name "B")))) "Z" . at "Z" . to_vector . should_equal [False, True]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Greater than=(Column_Ref.Name "B") Filter_Action.Remove))) "Z" . at "Z" . to_vector . should_equal [True, False]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Greater than=20) "T" "F")) "Z" . at "Z" . to_vector . should_equal ["F", "T"]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Less than=20) (Column_Ref.Name "B") (Column_Ref.Name "C"))) "Z" . at "Z" . to_vector . should_equal [10, 55]
 
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Greater than="X") "T" "F")) . should_fail_with Invalid_Value_Type
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Greater than="X") "T" "F")) . should_fail_with Invalid_Value_Type
 
             t2 = table_builder [["A", ["a", "c"]], ["B", ["c", "b"]], ["C", [23, 55]]]
-            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Greater than=(Column_Ref.Name "B")))) "Z" . at "Z" . to_vector . should_equal [False, True]
-            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Greater than=(Column_Ref.Name "B")) (Column_Ref.Name "C") 0)) "Z" . at "Z" . to_vector . should_equal [0, 55]
-            t2.set (Simple_Expression.From "A" (Simple_Calculation.If (Filter_Condition.Greater than="B") (Column_Ref.Name "C") 0)) "Z" . at "Z" . to_vector . should_equal [0, 0]
-            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Equal_Ignore_Case "C") "==" "!=")) "Z" . at "Z" . to_vector . should_equal ["!=", "=="]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Greater than=(Column_Ref.Name "B")))) "Z" . at "Z" . to_vector . should_equal [False, True]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Greater than=(Column_Ref.Name "B")) (Column_Ref.Name "C") 0)) "Z" . at "Z" . to_vector . should_equal [0, 55]
+            t2.set (Simple_Expression.Simple_Expr "A" (Simple_Calculation.If (Filter_Condition.Greater than="B") (Column_Ref.Name "C") 0)) "Z" . at "Z" . to_vector . should_equal [0, 0]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Equal_Ignore_Case "C") "==" "!=")) "Z" . at "Z" . to_vector . should_equal ["!=", "=="]
 
-            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In ["x", "a", "dd"]) "TT" "FF")) "Z" . at "Z" . to_vector . should_equal ["TT", "FF"]
-            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In []) "TT" "FF")) "Z" . at "Z" . to_vector . should_equal ["FF", "FF"]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In ["x", "a", "dd"]) "TT" "FF")) "Z" . at "Z" . to_vector . should_equal ["TT", "FF"]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In []) "TT" "FF")) "Z" . at "Z" . to_vector . should_equal ["FF", "FF"]
 
             # Passing a column does not work row-by-row, but looks at whole column contents.
-            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In (t2.at "B")) "TT" "FF")) "Z" . at "Z" . to_vector . should_equal ["FF", "TT"]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In (t2.at "B")) "TT" "FF")) "Z" . at "Z" . to_vector . should_equal ["FF", "TT"]
             t3 = table_builder [["x", ["e", "e", "a"]]]
-            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In (t3.at "x")) "TT" "FF")) "Z" . at "Z" . to_vector . should_equal ["TT", "FF"]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In (t3.at "x")) "TT" "FF")) "Z" . at "Z" . to_vector . should_equal ["TT", "FF"]
 
             # Thus, passing a Column_Ref into Is_In is not allowed as it would be confusing.
-            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In (Column_Ref.Name "B")) "TT" "FF")) . should_fail_with Illegal_Argument
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.If (Filter_Condition.Is_In (Column_Ref.Name "B")) "TT" "FF")) . should_fail_with Illegal_Argument
 
         group_builder.specify "text" <|
             t = table_builder [["A", ["  a ", "b"]], ["B", ["c", " d    "]]]
 
-            t.set (Simple_Expression.From (Column_Ref.Name "A") Simple_Calculation.Trim) "Z" . at "Z" . to_vector . should_equal ["a", "b"]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Trim Location.End)) "Z" . at "Z" . to_vector . should_equal ["  a", "b"]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Trim Location.Start)) "Z" . at "Z" . to_vector . should_equal ["a ", "b"]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Trim Location.Both "abc")) "Z" . at "Z" . to_vector . should_equal ["  a ", ""]
-            t.set (Simple_Expression.From "bb aaaa" (Simple_Calculation.Trim Location.Both (Column_Ref.Name "A"))) "Z" . at "Z" . to_vector . should_equal ["bb", " aaaa"]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") Simple_Calculation.Trim) "Z" . at "Z" . to_vector . should_equal ["a", "b"]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Trim Location.End)) "Z" . at "Z" . to_vector . should_equal ["  a", "b"]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Trim Location.Start)) "Z" . at "Z" . to_vector . should_equal ["a ", "b"]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Trim Location.Both "abc")) "Z" . at "Z" . to_vector . should_equal ["  a ", ""]
+            t.set (Simple_Expression.Simple_Expr "bb aaaa" (Simple_Calculation.Trim Location.Both (Column_Ref.Name "A"))) "Z" . at "Z" . to_vector . should_equal ["bb", " aaaa"]
 
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Add (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal ["  a c", "b d    "]
-            t.set (Simple_Expression.From "prefix_" (Simple_Calculation.Add (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal ["prefix_c", "prefix_ d    "]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Add "!")) "Z" . at "Z" . to_vector . should_equal ["  a !", "b!"]
-            t.set (Simple_Expression.From "O" (Simple_Calculation.Add "!")) "Z" . at "Z" . to_vector . should_equal ["O!", "O!"]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Add (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal ["  a c", "b d    "]
+            t.set (Simple_Expression.Simple_Expr "prefix_" (Simple_Calculation.Add (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal ["prefix_c", "prefix_ d    "]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Add "!")) "Z" . at "Z" . to_vector . should_equal ["  a !", "b!"]
+            t.set (Simple_Expression.Simple_Expr "O" (Simple_Calculation.Add "!")) "Z" . at "Z" . to_vector . should_equal ["O!", "O!"]
 
             t2 = table_builder [["A", [42]]]
-            t2.set (Simple_Expression.From (Column_Ref.Name "A") Simple_Calculation.Not) . should_fail_with Invalid_Value_Type
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") Simple_Calculation.Not) . should_fail_with Invalid_Value_Type
 
         group_builder.specify "min/max" <|
             t = table_builder [["A", [1, 20]], ["B", [10, 2]]]
 
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Min (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal [1, 2]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Min 5)) "Z" . at "Z" . to_vector . should_equal [1, 5]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Min (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal [1, 2]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Min 5)) "Z" . at "Z" . to_vector . should_equal [1, 5]
 
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Max (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal [10, 20]
-            t.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Max 5)) "Z" . at "Z" . to_vector . should_equal [5, 20]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Max (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal [10, 20]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Max 5)) "Z" . at "Z" . to_vector . should_equal [5, 20]
 
-            t.set (Simple_Expression.From 2 (Simple_Calculation.Max 5)) "Z" . at "Z" . to_vector . should_equal [5, 5]
-            t.set (Simple_Expression.From 2 (Simple_Calculation.Min 5)) "Z" . at "Z" . to_vector . should_equal [2, 2]
+            t.set (Simple_Expression.Simple_Expr 2 (Simple_Calculation.Max 5)) "Z" . at "Z" . to_vector . should_equal [5, 5]
+            t.set (Simple_Expression.Simple_Expr 2 (Simple_Calculation.Min 5)) "Z" . at "Z" . to_vector . should_equal [2, 2]
 
             t2 = table_builder [["A", ["aardvark", "zebra"]], ["B", ["cat", "dog"]], ["x", [1, 20]]]
-            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Min (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal ["aardvark", "dog"]
-            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Max (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal ["cat", "zebra"]
-            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Min "animal")) "Z" . at "Z" . to_vector . should_equal ["aardvark", "animal"]
-            t2.set (Simple_Expression.From "coyote" (Simple_Calculation.Max (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal ["coyote", "dog"]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Min (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal ["aardvark", "dog"]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Max (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal ["cat", "zebra"]
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Min "animal")) "Z" . at "Z" . to_vector . should_equal ["aardvark", "animal"]
+            t2.set (Simple_Expression.Simple_Expr "coyote" (Simple_Calculation.Max (Column_Ref.Name "B"))) "Z" . at "Z" . to_vector . should_equal ["coyote", "dog"]
 
             # mixed types result in an error
-            t2.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Min 42)) . should_fail_with Invalid_Value_Type
-            t2.set (Simple_Expression.From (Column_Ref.Name "x") (Simple_Calculation.Min "x")) . should_fail_with Invalid_Value_Type
-            t2.set (Simple_Expression.From (Column_Ref.Name "x") (Simple_Calculation.Min (Column_Ref.Name "A"))) . should_fail_with Invalid_Value_Type
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Min 42)) . should_fail_with Invalid_Value_Type
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "x") (Simple_Calculation.Min "x")) . should_fail_with Invalid_Value_Type
+            t2.set (Simple_Expression.Simple_Expr (Column_Ref.Name "x") (Simple_Calculation.Min (Column_Ref.Name "A"))) . should_fail_with Invalid_Value_Type
 
             if pending_datetime.is_nothing then
                 t3 = table_builder [["A", [Date.new 2002 12 10, Date.new 2005 01 01]]]
-                t3.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Min (Date.new 2003))) "Z" . at "Z" . to_vector . should_equal [Date.new 2002 12 10, Date.new 2003 01 01]
-                t3.set (Simple_Expression.From (Column_Ref.Name "A") (Simple_Calculation.Max (Date.new 2003))) "Z" . at "Z" . to_vector . should_equal [Date.new 2003 01 01, Date.new 2005 01 01]
+                t3.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Min (Date.new 2003))) "Z" . at "Z" . to_vector . should_equal [Date.new 2002 12 10, Date.new 2003 01 01]
+                t3.set (Simple_Expression.Simple_Expr (Column_Ref.Name "A") (Simple_Calculation.Max (Date.new 2003))) "Z" . at "Z" . to_vector . should_equal [Date.new 2003 01 01, Date.new 2005 01 01]
 
         group_builder.specify "allows also indexing columns numerically" <|
             t = table_builder [["X", [1, 2]], ["Y", [3, 4]]]
-            t.set (Simple_Expression.From (Column_Ref.Index 0) (Simple_Calculation.Add (Column_Ref.Index 1))) "Z" . at "Z" . to_vector . should_equal [4, 6]
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Index 0) (Simple_Calculation.Add (Column_Ref.Index 1))) "Z" . at "Z" . to_vector . should_equal [4, 6]
 
         group_builder.specify "will forward column resolution errors" <|
             t = table_builder [["X", [1, 2]], ["Y", [3, 4]]]
-            t.set (Simple_Expression.From (Column_Ref.Name "X") (Simple_Calculation.Add (Column_Ref.Name "Z"))) . should_fail_with No_Such_Column
-            t.set (Simple_Expression.From (Column_Ref.Name "zzz") Simple_Calculation.Not) . should_fail_with No_Such_Column
-            t.set (Simple_Expression.From (Column_Ref.Index 42) Simple_Calculation.Not) . should_fail_with Index_Out_Of_Bounds
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "X") (Simple_Calculation.Add (Column_Ref.Name "Z"))) . should_fail_with No_Such_Column
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "zzz") Simple_Calculation.Not) . should_fail_with No_Such_Column
+            t.set (Simple_Expression.Simple_Expr (Column_Ref.Index 42) Simple_Calculation.Not) . should_fail_with Index_Out_Of_Bounds
 
     suite_builder.group prefix+"Unique derived column names" group_builder->
         data = Data.setup create_connection_fn
@@ -230,7 +234,7 @@ add_specs suite_builder setup =
 
         group_builder.specify "Should not disambiguate two derived columns that would otherwise have had the same name, with Set_Mode.Add_Or_Update" <|
             t = table_builder [["X", [1, 2, 3]]]
-            column_op = Simple_Expression.From 2 (Simple_Calculation.Power (Column_Ref.Name "X"))
+            column_op = Simple_Expression.Simple_Expr 2 (Simple_Calculation.Power (Column_Ref.Name "X"))
             t2 = t.set column_op . set column_op
             t2.column_names . should_equal ["X", "[2] ^ [X]"]
             t2.at "X" . to_vector . should_equal [1, 2, 3]
@@ -238,7 +242,7 @@ add_specs suite_builder setup =
 
         group_builder.specify "Should disambiguate two derived columns that would otherwise have had the same name, with Set_Mode.Add" <|
             t = table_builder [["X", [1, 2, 3]]]
-            column_op = Simple_Expression.From 2 (Simple_Calculation.Power (Column_Ref.Name "X"))
+            column_op = Simple_Expression.Simple_Expr 2 (Simple_Calculation.Power (Column_Ref.Name "X"))
             t2 = t.set column_op set_mode=Set_Mode.Add . set column_op set_mode=Set_Mode.Add
             t2.column_names . should_equal ["X", "[2] ^ [X]", "[2] ^ [X] 1"]
             t2.at "X" . to_vector . should_equal [1, 2, 3]
@@ -263,8 +267,8 @@ add_specs suite_builder setup =
 
         group_builder.specify "Should disambiguate between a column reference and a literal string" <|
             t = table_builder [["X", ["a", "b", "c"]]]
-            t2 = t.set (Simple_Expression.From "prefix" (Simple_Calculation.Add (Column_Ref.Name "X")))
-            t3 = t2.set (Simple_Expression.From "prefix" (Simple_Calculation.Add "X"))
+            t2 = t.set (Simple_Expression.Simple_Expr "prefix" (Simple_Calculation.Add (Column_Ref.Name "X")))
+            t3 = t2.set (Simple_Expression.Simple_Expr "prefix" (Simple_Calculation.Add "X"))
 
             t3.column_names . should_equal ['X', "['prefix'] + [X]", "['prefix'] + 'X'"]
             t3.at "['prefix'] + [X]" . to_vector . should_equal ["prefixa", "prefixb", "prefixc"]
@@ -272,20 +276,20 @@ add_specs suite_builder setup =
 
         group_builder.specify "Should not disambiguate if set_mode is Update" <|
             t = table_builder [["X", [1, 2, 3]]]
-            t2 = t.set (Simple_Expression.From (Column_Ref.Name "X") (Simple_Calculation.Add 1)) set_mode=Set_Mode.Update
+            t2 = t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "X") (Simple_Calculation.Add 1)) set_mode=Set_Mode.Update
             t2.column_names . should_equal ["X"]
             t2.at "X" . to_vector . should_equal [2, 3, 4]
 
         group_builder.specify "Should not disambiguate if set_mode is Add_Or_Update" <|
             t = table_builder [["X", [1, 2, 3]], ["[X] + 1", [10, 20, 30]]]
             # set_mode=Set_Mode.Add_Or_Update is the default
-            t2 = t.set (Simple_Expression.From (Column_Ref.Name "X") (Simple_Calculation.Add 1))
+            t2 = t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "X") (Simple_Calculation.Add 1))
             t2.column_names . should_equal ["X", "[X] + 1"]
             t2.at "X" . to_vector . should_equal [1, 2, 3]
             t2.at "[X] + 1" . to_vector . should_equal [2, 3, 4]
 
         group_builder.specify "Should not disambiguate if the new name is explicitly set" <|
             t = table_builder [["X", [1, 2, 3]]]
-            t2 = t.set (Simple_Expression.From (Column_Ref.Name "X") (Simple_Calculation.Add 1)) as="X"
+            t2 = t.set (Simple_Expression.Simple_Expr (Column_Ref.Name "X") (Simple_Calculation.Add 1)) as="X"
             t2.column_names . should_equal ["X"]
             t2.at "X" . to_vector . should_equal [2, 3, 4]


### PR DESCRIPTION
### Pull Request Description

- Linting fixes.
- Adjust doc comments with `<` or `>` in plain text areas to use `&lt;` and `&gt;`.
- Refactor Statistics module and add auto-scoping.
- Add auto-scoping to `Text.to_case`.
- Fix type issue with `Table.get_value`.
- Private constructor for `Excel_Workbook` and move `xls_format` to public method.
- Add `fields` widget to `to_table`.
- Add `simple_expr` to make `Table.set` clearer.

![image](https://github.com/enso-org/enso/assets/4699705/3e21e800-142c-4006-a6c2-dd6196b76c9a)

![image](https://github.com/enso-org/enso/assets/4699705/d40dcbfd-a35e-4849-9e1a-f4a418d562dd)


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
