### PR TITLE
Pan capturing

### DIFF
--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -662,6 +662,7 @@ const groupColors = computed(() => {
     @click="handleClick"
     @dragover.prevent
     @drop.prevent="handleFileDrop($event)"
+    @pointermove.capture="graphNavigator.pointerEventsCapture.pointermove"
     @wheel.capture="graphNavigator.pointerEventsCapture.wheel"
   >
     <div class="layer" :style="{ transform: graphNavigator.transform }">

--- a/app/gui2/src/components/GraphEditor.vue
+++ b/app/gui2/src/components/GraphEditor.vue
@@ -662,6 +662,7 @@ const groupColors = computed(() => {
     @click="handleClick"
     @dragover.prevent
     @drop.prevent="handleFileDrop($event)"
+    @wheel.capture="graphNavigator.pointerEventsCapture.wheel"
   >
     <div class="layer" :style="{ transform: graphNavigator.transform }">
       <GraphNodes

--- a/app/gui2/src/composables/navigator.ts
+++ b/app/gui2/src/composables/navigator.ts
@@ -277,25 +277,23 @@ export function useNavigator(
     scale.skip()
   }
 
-  const { pointerMove, wheelEventType } = useWheelActions(keyboard, WHEEL_CAPTURE_DURATION_MS)
-
-  function handleWheel(e: WheelEvent, continueOnly?: boolean) {
-    const eventType = wheelEventType(e, continueOnly)
-    if (eventType === 'trackpad-zoom') {
-      // OS X trackpad events provide usable rate-of-change information.
-      updateScale((oldValue: number) => oldValue * Math.exp(-e.deltaY / 100))
-    } else if (eventType === 'wheel-zoom') {
-      // Mouse wheel rate information is unreliable. We just step in the direction of the sign.
-      stepZoom(-Math.sign(e.deltaY))
-    } else if (eventType === 'pan') {
+  const { events: wheelEvents, captureEvents: wheelEventsCapture } = useWheelActions(
+    keyboard,
+    WHEEL_CAPTURE_DURATION_MS,
+    (e, inputType) => {
+      if (inputType === 'trackpad') {
+        // OS X trackpad events provide usable rate-of-change information.
+        updateScale((oldValue: number) => oldValue * Math.exp(-e.deltaY / 100))
+      } else {
+        // Mouse wheel rate information is unreliable. We just step in the direction of the sign.
+        stepZoom(-Math.sign(e.deltaY))
+      }
+    },
+    (e) => {
       const delta = new Vec2(e.deltaX, e.deltaY)
       scrollTo(center.value.addScaled(delta, 1 / scale.value))
-    } else {
-      return
-    }
-    e.preventDefault()
-    e.stopPropagation()
-  }
+    },
+  )
 
   return proxyRefs({
     pointerEvents: {
@@ -309,7 +307,6 @@ export function useNavigator(
         eventMousePos.value = eventScreenPos(e)
         panPointer.events.pointermove(e)
         zoomPointer.events.pointermove(e)
-        pointerMove()
       },
       pointerleave() {
         eventMousePos.value = null
@@ -324,14 +321,12 @@ export function useNavigator(
         panPointer.events.pointerdown(e)
         zoomPointer.events.pointerdown(e)
       },
-      wheel: handleWheel,
       contextmenu(e: Event) {
         e.preventDefault()
       },
+      wheel: wheelEvents.wheel,
     },
-    pointerEventsCapture: {
-      wheel: (e: WheelEvent) => handleWheel(e, true),
-    },
+    pointerEventsCapture: wheelEventsCapture,
     keyboardEvents: panArrows.events,
     translate,
     targetCenter: readonly(targetCenter),


### PR DESCRIPTION
Panning or zooming "captures" wheel events. While events are captured, further events of the same type will continue the pan/zoom action. The capture expires if no events are received for 250ms. A trackpad capture also expires if any pointer movement occurs.

https://github.com/enso-org/enso/assets/1047859/688ed136-4562-4c80-803c-14bbcdf1b231

Fixes #10280.

### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
