### PR TITLE
Align Enso launcher with Truffle's AbstractLanguageLauncher

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2350,7 +2350,7 @@ lazy val `runtime-fat-jar` =
     .settings(
       libraryDependencies ++= {
         val graalMods =
-          GraalVM.modules.map(_.withConfigurations(Some(Runtime.name)))
+          GraalVM.modules.map(_.withConfigurations(Some(Compile.name)))
         val langMods =
           GraalVM.langsPkgs.map(_.withConfigurations(Some(Runtime.name)))
         val logbackMods =

--- a/build.sbt
+++ b/build.sbt
@@ -2517,6 +2517,7 @@ lazy val `engine-runner` = project
     commands += WithDebugCommand.withDebug,
     inConfig(Compile)(truffleRunOptionsSettings),
     libraryDependencies ++= Seq(
+      "org.graalvm.sdk"         % "launcher-common"         % graalMavenPackagesVersion,
       "org.graalvm.polyglot"    % "polyglot"                % graalMavenPackagesVersion,
       "org.graalvm.sdk"         % "polyglot-tck"            % graalMavenPackagesVersion % Provided,
       "commons-cli"             % "commons-cli"             % commonsCliVersion,

--- a/engine/runner/src/main/java/org/enso/runner/ContextFactory.java
+++ b/engine/runner/src/main/java/org/enso/runner/ContextFactory.java
@@ -35,6 +35,7 @@ import org.slf4j.event.Level;
  * @param warningsLimit maximal number of warnings reported to the user
  */
 final class ContextFactory {
+  private final Context.Builder initialBuilder;
   private String projectRoot;
   private InputStream in;
   private OutputStream out;
@@ -51,10 +52,12 @@ final class ContextFactory {
   private int warningsLimit = 100;
   private java.util.Map<String, String> options = java.util.Collections.emptyMap();
 
-  private ContextFactory() {}
+  private ContextFactory(Context.Builder b) {
+    this.initialBuilder = b;
+  }
 
-  public static ContextFactory create() {
-    return new ContextFactory();
+  public static ContextFactory create(Context.Builder b) {
+    return new ContextFactory(b);
   }
 
   public ContextFactory projectRoot(String projectRoot) {
@@ -139,7 +142,7 @@ final class ContextFactory {
     var julLogLevel = Converter.toJavaLevel(logLevel);
     var logLevelName = julLogLevel.getName();
     var builder =
-        Context.newBuilder()
+        initialBuilder
             .allowExperimentalOptions(true)
             .allowAllAccess(true)
             .allowHostAccess(new HostAccessFactory().allWithTypeMapping())

--- a/engine/runtime-fat-jar/src/main/java/module-info.java
+++ b/engine/runtime-fat-jar/src/main/java/module-info.java
@@ -9,6 +9,7 @@ open module org.enso.runtime {
   // works.
   requires org.enso.profiling;
   requires org.enso.ydoc;
+  requires org.graalvm.launcher;
   requires org.graalvm.polyglot;
   requires org.graalvm.truffle;
   requires static org.slf4j;

--- a/project/GraalVM.scala
+++ b/project/GraalVM.scala
@@ -21,6 +21,8 @@ object GraalVM {
     * When invoking the `java` command, these modules need to be put on the module-path.
     */
   val modules: Seq[ModuleID] = Seq(
+    "org.graalvm.sdk"      % "launcher-common"  % version,
+    "org.graalvm.shadowed" % "jline"            % version,
     "org.graalvm.sdk"      % "nativeimage"      % version,
     "org.graalvm.sdk"      % "word"             % version,
     "org.graalvm.sdk"      % "jniutils"         % version,


### PR DESCRIPTION
### Pull Request Description

Closes #5298 by extending `AbstractLanguageLauncher` and thus inheriting all its functionality common for other Truffle language implementations.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [ ] Unit tests have been written where possible.
