### PR TITLE
Visualise excelwork book sheets, db tables/schemas and add node adding gets to query them 

### DIFF
--- a/app/gui2/src/components/visualizations/JSONVisualization/JsonObjectWidget.vue
+++ b/app/gui2/src/components/visualizations/JSONVisualization/JsonObjectWidget.vue
@@ -1,13 +1,18 @@
 <script lang="ts" setup>
 import JsonValueWidget from '@/components/visualizations/JSONVisualization/JsonValueWidget.vue'
+import { useVisualizationConfig } from '@/providers/visualizationConfig'
 import { computed } from 'vue'
 
 const props = defineProps<{ data: object }>()
 const emit = defineEmits<{
   createProjection: [path: (string | number)[][]]
 }>()
+const config = useVisualizationConfig()
 
 const MAX_INLINE_LENGTH = 40
+const JSON_OBJECT_TYPE = 'Standard.Base.Data.Json.JS_Object'
+
+const isClickThroughEnabled = config.nodeType === JSON_OBJECT_TYPE
 
 const block = computed(() => JSON.stringify(props.data).length > MAX_INLINE_LENGTH)
 
@@ -32,7 +37,7 @@ function entryTitle(key: string) {
       class="field clickable"
       @click.stop="emit('createProjection', [$event.shiftKey ? Object.keys(props.data) : [key]])"
     >
-      <span class="key" v-text="JSON.stringify(key)" />:
+      <span :class="[isClickThroughEnabled ? 'key-link' : 'key']" v-text="JSON.stringify(key)" />:
       <JsonValueWidget
         :data="value"
         @createProjection="emit('createProjection', [[key], ...$event])"
@@ -73,5 +78,9 @@ function entryTitle(key: string) {
 }
 .key {
   color: darkred;
+}
+.key-link {
+  color: blue;
+  text-decoration: underline;
 }
 </style>

--- a/app/gui2/src/components/visualizations/JSONVisualization/JsonObjectWidget.vue
+++ b/app/gui2/src/components/visualizations/JSONVisualization/JsonObjectWidget.vue
@@ -1,18 +1,13 @@
 <script lang="ts" setup>
 import JsonValueWidget from '@/components/visualizations/JSONVisualization/JsonValueWidget.vue'
-import { useVisualizationConfig } from '@/providers/visualizationConfig'
 import { computed } from 'vue'
 
 const props = defineProps<{ data: object }>()
 const emit = defineEmits<{
   createProjection: [path: (string | number)[][]]
 }>()
-const config = useVisualizationConfig()
 
 const MAX_INLINE_LENGTH = 40
-const JSON_OBJECT_TYPE = 'Standard.Base.Data.Json.JS_Object'
-
-const isClickThroughEnabled = config.nodeType === JSON_OBJECT_TYPE
 
 const block = computed(() => JSON.stringify(props.data).length > MAX_INLINE_LENGTH)
 
@@ -37,7 +32,7 @@ function entryTitle(key: string) {
       class="field clickable"
       @click.stop="emit('createProjection', [$event.shiftKey ? Object.keys(props.data) : [key]])"
     >
-      <span :class="[isClickThroughEnabled ? 'key-link' : 'key']" v-text="JSON.stringify(key)" />:
+      <span class="key" v-text="JSON.stringify(key)" />:
       <JsonValueWidget
         :data="value"
         @createProjection="emit('createProjection', [[key], ...$event])"
@@ -77,10 +72,11 @@ function entryTitle(key: string) {
   content: ',';
 }
 .key {
-  color: darkred;
-}
-.key-link {
   color: blue;
   text-decoration: underline;
+}
+.viewonly .key {
+  color: darkred;
+  text-decoration: none;
 }
 </style>

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -681,7 +681,7 @@ onUnmounted(() => {
 
 a {
   color: blue;
-  text-decoration: underline !important;
+  text-decoration: underline;
 }
 a:hover {
   color: darkblue;

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -39,7 +39,7 @@ export const defaultPreprocessor = [
   '1000',
 ] as const
 
-type Data = Error | Matrix | ObjectMatrix | UnknownTable | Excel_Workbook
+type Data = Error | Matrix | ObjectMatrix | UnknownTable | Excel_Workbook | SQLite_Connection
 
 interface Error {
   type: undefined
@@ -65,6 +65,14 @@ interface Excel_Workbook {
   column_count: number
   all_rows_count: number
   sheet_names: string[]
+  json: unknown[][]
+}
+
+interface SQLite_Connection {
+  type: 'SQLite_Connection'
+  column_count: number
+  all_rows_count: number
+  schemas: string[]
   json: unknown[][]
 }
 
@@ -401,6 +409,9 @@ watchEffect(() => {
   } else if (data_.type === 'Excel_Workbook') {
     columnDefs = [toLinkField('Value')]
     rowData = data_.sheet_names.map((name) => ({ Value: name }))
+  } else if (data_.type === 'SQLite_Connection') {
+    columnDefs = [toLinkField('Value')]
+    rowData = data_.schemas.map((name) => ({ Value: name }))
   } else if (Array.isArray(data_.json)) {
     columnDefs = [toLinkField(INDEX_FIELD_NAME), toField('Value')]
     rowData = data_.json.map((row, i) => ({ [INDEX_FIELD_NAME]: i, Value: toRender(row) }))

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -114,6 +114,7 @@ const config = useVisualizationConfig()
 
 const INDEX_FIELD_NAME = '#'
 const TABLE_NODE_TYPE = 'Standard.Table.Table.Table'
+const DB_TABLE_NODE_TYPE = 'Standard.Database.DB_Table.DB_Table'
 const VECTOR_NODE_TYPE = 'Standard.Base.Data.Vector.Vector'
 const COLUMN_NODE_TYPE = 'Standard.Table.Column.Column'
 const EXCEL_WORKBOOK_NODE_TYPE = 'Standard.Table.Excel.Excel_Workbook.Excel_Workbook'
@@ -313,7 +314,8 @@ const getTablePattern = (index: number) =>
   )
 
 function createNode(params: CellClickedEvent) {
-  if (config.nodeType === TABLE_NODE_TYPE) {
+  console.log(config.nodeType)
+  if (config.nodeType === TABLE_NODE_TYPE || config.nodeType === DB_TABLE_NODE_TYPE) {
     config.createNodes({
       content: getTablePattern(params.data[INDEX_FIELD_NAME]),
       commit: true,
@@ -336,7 +338,7 @@ function createNode(params: CellClickedEvent) {
       identifierAction = 'query'
       break
   }
-  if (selector && identifierAction) {
+  if (selector !== undefined && identifierAction) {
     config.createNodes({
       content: getAstPattern(selector, identifierAction),
       commit: true,

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -119,6 +119,7 @@ const DB_TABLE_NODE_TYPE = 'Standard.Database.DB_Table.DB_Table'
 const VECTOR_NODE_TYPE = 'Standard.Base.Data.Vector.Vector'
 const COLUMN_NODE_TYPE = 'Standard.Table.Column.Column'
 const EXCEL_WORKBOOK_NODE_TYPE = 'Standard.Table.Excel.Excel_Workbook.Excel_Workbook'
+const ROW_NODE_TYPE = 'Standard.Table.Row.Row'
 const SQLITE_CONNECTIONS_NODE_TYPE =
   'Standard.Database.Internal.SQLite.SQLite_Connection.SQLite_Connection'
 
@@ -315,7 +316,6 @@ const getTablePattern = (index: number) =>
   )
 
 function createNode(params: CellClickedEvent) {
-  console.log(config.nodeType)
   if (config.nodeType === TABLE_NODE_TYPE || config.nodeType === DB_TABLE_NODE_TYPE) {
     config.createNodes({
       content: getTablePattern(params.data[INDEX_FIELD_NAME]),
@@ -328,6 +328,10 @@ function createNode(params: CellClickedEvent) {
     case COLUMN_NODE_TYPE:
     case VECTOR_NODE_TYPE:
       selector = params.data[INDEX_FIELD_NAME]
+      identifierAction = 'at'
+      break
+    case ROW_NODE_TYPE:
+      selector = params.data['column']
       identifierAction = 'at'
       break
     case EXCEL_WORKBOOK_NODE_TYPE:
@@ -351,8 +355,9 @@ function toLinkField(fieldName: string): ColDef {
   return {
     field: fieldName,
     onCellDoubleClicked: (params) => createNode(params),
-    tooltipValueGetter: (p: ITooltipParams) =>
-      'Double click to view this value/row in seperate node',
+    tooltipValueGetter: (p: ITooltipParams) => {
+      return 'Double click to view this value/row in seperate node'
+    },
   }
 }
 
@@ -435,6 +440,9 @@ watchEffect(() => {
     const dataHeader =
       ('header' in data_ ? data_.header : [])?.map((v, i) => {
         const valueType = data_.value_type ? data_.value_type[i] : null
+        if (config.nodeType === ROW_NODE_TYPE) {
+          return toLinkField(v)
+        }
         return toField(v, valueType)
       }) ?? []
 

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -17,7 +17,7 @@ import type {
   ColumnResizedEvent,
   ICellRendererParams,
 } from 'ag-grid-community'
-import type { ColDef, GridOptions, HeaderValueGetterParams } from 'ag-grid-enterprise'
+import type { ColDef, GridOptions } from 'ag-grid-enterprise'
 import {
   computed,
   onMounted,

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -139,7 +139,6 @@ const defaultColDef = {
   filter: true,
   resizable: true,
   minWidth: 25,
-  headerValueGetter: (params: HeaderValueGetterParams) => params.colDef.field,
   cellRenderer: cellRenderer,
   cellClass: cellClass,
 }
@@ -178,6 +177,7 @@ const newNodeSelectorValues = computed(() => {
   let selector
   let identifierAction
   let tooltipValue
+  let headerName
   switch (config.nodeType) {
     case COLUMN_NODE_TYPE:
     case VECTOR_NODE_TYPE:
@@ -194,23 +194,24 @@ const newNodeSelectorValues = computed(() => {
       selector = 'Value'
       identifierAction = 'read'
       tooltipValue = 'sheet'
+      headerName = 'Sheets'
       break
     case SQLITE_CONNECTIONS_NODE_TYPE:
     case POSTGRES_CONNECTIONS_NODE_TYPE:
       selector = 'Value'
       identifierAction = 'query'
       tooltipValue = 'table'
+      headerName = 'Tables'
       break
     case TABLE_NODE_TYPE:
     case DB_TABLE_NODE_TYPE:
-      selector = null
-      identifierAction = null
       tooltipValue = 'row'
   }
   return {
     selector,
     identifierAction,
     tooltipValue,
+    headerName,
   }
 })
 
@@ -380,13 +381,14 @@ function createNode(params: CellClickedEvent) {
 
 function toLinkField(fieldName: string): ColDef {
   return {
+    headerName:
+      newNodeSelectorValues.value.headerName ? newNodeSelectorValues.value.headerName : fieldName,
     field: fieldName,
     onCellDoubleClicked: (params) => createNode(params),
     tooltipValueGetter: () => {
       return `Double click to view this ${newNodeSelectorValues.value.tooltipValue} in a separate node`
     },
-    cellStyle: { cursor: 'pointer' },
-    cellRenderer: (params: any) => `<a> ${params.value} </a>`,
+    cellRenderer: (params: any) => `<a href='#'> ${params.value} </a>`,
   }
 }
 
@@ -469,7 +471,7 @@ watchEffect(() => {
     const dataHeader =
       ('header' in data_ ? data_.header : [])?.map((v, i) => {
         const valueType = data_.value_type ? data_.value_type[i] : null
-        if (config.nodeType === ROW_NODE_TYPE) {
+        if (config.nodeType === ROW_NODE_TYPE && v === 'column') {
           return toLinkField(v)
         }
         return toField(v, valueType)
@@ -675,5 +677,13 @@ onUnmounted(() => {
 <style>
 .TableVisualization > .ag-theme-alpine > .ag-root-wrapper.ag-layout-normal {
   border-radius: 0 0 var(--radius-default) var(--radius-default);
+}
+
+a {
+  color: blue;
+  text-decoration: underline !important;
+}
+a:hover {
+  color: darkblue;
 }
 </style>

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -70,6 +70,7 @@ interface Excel_Workbook {
 
 interface ObjectMatrix {
   type: 'Object_Matrix'
+  column_count: number
   all_rows_count: number
   json: object[]
   value_type: ValueType[]

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -124,6 +124,8 @@ const TABLE_NODE_TYPE = 'Standard.Table.Table.Table'
 const VECTOR_NODE_TYPE = 'Standard.Base.Data.Vector.Vector'
 const COLUMN_NODE_TYPE = 'Standard.Table.Column.Column'
 const EXCEL_WORKBOOK_NODE_TYPE = 'Standard.Table.Excel.Excel_Workbook.Excel_Workbook'
+const SQLITE_CONNECTIONS_NODE_TYPE =
+  'Standard.Database.Internal.SQLite.SQLite_Connection.SQLite_Connection'
 
 const rowLimit = ref(0)
 const page = ref(0)
@@ -306,6 +308,14 @@ const getExcelWorkbookPattern = (sheetName: string) =>
     ),
   )
 
+const getSqliteConnectionsWorkbookPattern = (sheetName: string) =>
+  Pattern.new((ast) =>
+    Ast.App.positional(
+      Ast.PropertyAccess.new(ast.module, ast, Ast.identifier('query')!),
+      Ast.TextLiteral.new(sheetName, ast.module)!,
+    ),
+  )
+
 const getTablePattern = (index: number) =>
   Pattern.new((ast) =>
     Ast.OprApp.new(
@@ -338,6 +348,12 @@ function createNode(params: CellClickedEvent) {
   if (config.nodeType === EXCEL_WORKBOOK_NODE_TYPE) {
     config.createNodes({
       content: getExcelWorkbookPattern(params.data['Value']),
+      commit: true,
+    })
+  }
+  if (config.nodeType === SQLITE_CONNECTIONS_NODE_TYPE) {
+    config.createNodes({
+      content: getSqliteConnectionsWorkbookPattern(params.data['Value']),
       commit: true,
     })
   }

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -121,6 +121,8 @@ const EXCEL_WORKBOOK_NODE_TYPE = 'Standard.Table.Excel.Excel_Workbook.Excel_Work
 const ROW_NODE_TYPE = 'Standard.Table.Row.Row'
 const SQLITE_CONNECTIONS_NODE_TYPE =
   'Standard.Database.Internal.SQLite.SQLite_Connection.SQLite_Connection'
+const POSTGRES_CONNECTIONS_NODE_TYPE =
+  'Standard.Database.Internal.Postgres.Postgres_Connection.Postgres_Connection'
 
 const rowLimit = ref(0)
 const page = ref(0)
@@ -186,6 +188,7 @@ const newNodeSelector = computed(() => {
       selector = 'Value'
       break
     case SQLITE_CONNECTIONS_NODE_TYPE:
+    case POSTGRES_CONNECTIONS_NODE_TYPE:
       selector = 'Value'
       break
   }
@@ -206,6 +209,7 @@ const newNodeAction = computed(() => {
       identifierAction = 'read'
       break
     case SQLITE_CONNECTIONS_NODE_TYPE:
+    case POSTGRES_CONNECTIONS_NODE_TYPE:
       identifierAction = 'query'
       break
   }
@@ -224,6 +228,7 @@ const onClickTooltipValue = computed(() => {
       val = 'sheet'
       break
     case SQLITE_CONNECTIONS_NODE_TYPE:
+    case POSTGRES_CONNECTIONS_NODE_TYPE:
       val = 'table'
       break
     case TABLE_NODE_TYPE:
@@ -376,6 +381,7 @@ const getTablePattern = (index: number) =>
   )
 
 function createNode(params: CellClickedEvent) {
+  console.log(config.nodeType)
   if (config.nodeType === TABLE_NODE_TYPE || config.nodeType === DB_TABLE_NODE_TYPE) {
     config.createNodes({
       content: getTablePattern(params.data[INDEX_FIELD_NAME]),

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -381,7 +381,6 @@ const getTablePattern = (index: number) =>
   )
 
 function createNode(params: CellClickedEvent) {
-  console.log(config.nodeType)
   if (config.nodeType === TABLE_NODE_TYPE || config.nodeType === DB_TABLE_NODE_TYPE) {
     config.createNodes({
       content: getTablePattern(params.data[INDEX_FIELD_NAME]),

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -39,7 +39,7 @@ export const defaultPreprocessor = [
   '1000',
 ] as const
 
-type Data = Error | Matrix | ObjectMatrix | UnknownTable
+type Data = Error | Matrix | ObjectMatrix | UnknownTable | Excel_Workbook
 
 interface Error {
   type: undefined
@@ -60,9 +60,16 @@ interface Matrix {
   value_type: ValueType[]
 }
 
+interface Excel_Workbook {
+  type: 'Excel_Workbook'
+  column_count: number
+  all_rows_count: number
+  sheet_names: string[]
+  json: unknown[][]
+}
+
 interface ObjectMatrix {
   type: 'Object_Matrix'
-  column_count: number
   all_rows_count: number
   json: object[]
   value_type: ValueType[]
@@ -374,6 +381,9 @@ watchEffect(() => {
     }
     rowData = addRowIndex(data_.json)
     isTruncated.value = data_.all_rows_count !== data_.json.length
+  } else if (data_.type === 'Excel_Workbook') {
+    columnDefs = [{ field: 'Value' }]
+    rowData = data_.sheet_names.map((name) => ({ Value: name }))
   } else if (Array.isArray(data_.json)) {
     columnDefs = [indexField(), toField('Value')]
     rowData = data_.json.map((row, i) => ({ [INDEX_FIELD_NAME]: i, Value: toRender(row) }))

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -397,6 +397,7 @@ function toLinkField(fieldName: string): ColDef {
     tooltipValueGetter: () => {
       return `Double click to view this ${onClickTooltipValue.value} in seperate node`
     },
+    cellStyle: { cursor: 'pointer' },
   }
 }
 

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -16,6 +16,7 @@ import type {
   CellClickedEvent,
   ColumnResizedEvent,
   ICellRendererParams,
+  ITooltipParams,
 } from 'ag-grid-community'
 import type { ColDef, GridOptions, HeaderValueGetterParams } from 'ag-grid-enterprise'
 import {
@@ -347,7 +348,12 @@ function createNode(params: CellClickedEvent) {
 }
 
 function toLinkField(fieldName: string): ColDef {
-  return { field: fieldName, onCellClicked: (params) => createNode(params) }
+  return {
+    field: fieldName,
+    onCellDoubleClicked: (params) => createNode(params),
+    tooltipValueGetter: (p: ITooltipParams) =>
+      'Double click to view this value/row in seperate node',
+  }
 }
 
 /** Return a human-readable representation of an object. */

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
@@ -331,4 +331,3 @@ parse_postgres_encoding encoding_name =
         fallback.catch Any _->
             warning = Unsupported_Database_Encoding.Warning "The database is using an encoding ("+encoding_name.to_display_text+") that is currently not supported by Enso. Falling back to UTF-8. Column/table names may not be mapped correctly if they contain unsupported characters."
             Warning.attach warning Encoding.utf_8
-            

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
@@ -286,6 +286,11 @@ type Postgres_Connection
     save_as_data_link self destination (on_existing_file:Existing_File_Behavior = Existing_File_Behavior.Error) =
         self.data_link_setup.save_as_data_link destination on_existing_file
 
+    ## PRIVATE
+      Converts this value to a JSON serializable object.
+    to_js_object : JS_Object
+    to_js_object self =
+        JS_Object.from_pairs [["type", "SQLite_Connection"], ["links", self.connection.tables.at "Name" . to_vector]]    
 
 ## PRIVATE
 get_encoding_name : JDBC_Connection.JDBC_Connection -> Text

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
@@ -290,7 +290,7 @@ type Postgres_Connection
       Converts this value to a JSON serializable object.
     to_js_object : JS_Object
     to_js_object self =
-        JS_Object.from_pairs [["type", "SQLite_Connection"], ["links", self.connection.tables.at "Name" . to_vector]]    
+        JS_Object.from_pairs [["type", "Postgres_Connection"], ["links", self.connection.tables.at "Name" . to_vector]]    
 
 ## PRIVATE
 get_encoding_name : JDBC_Connection.JDBC_Connection -> Text

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
@@ -331,3 +331,4 @@ parse_postgres_encoding encoding_name =
         fallback.catch Any _->
             warning = Unsupported_Database_Encoding.Warning "The database is using an encoding ("+encoding_name.to_display_text+") that is currently not supported by Enso. Falling back to UTF-8. Column/table names may not be mapped correctly if they contain unsupported characters."
             Warning.attach warning Encoding.utf_8
+            

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
@@ -266,3 +266,9 @@ type SQLite_Connection
        on the 'subclasses'.
     base_connection : Connection
     base_connection self = self.connection
+
+    ## PRIVATE
+       Converts this value to a JSON serializable object.
+    to_js_object : JS_Object
+    to_js_object self =
+        JS_Object.from_pairs [["type", "SQLite_Connection"], ["schemas", self.connection.tables.at "Name" . to_vector]]

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
@@ -271,4 +271,4 @@ type SQLite_Connection
        Converts this value to a JSON serializable object.
     to_js_object : JS_Object
     to_js_object self =
-        JS_Object.from_pairs [["type", "SQLite_Connection"], ["schemas", self.connection.tables.at "Name" . to_vector]]
+        JS_Object.from_pairs [["type", "SQLite_Connection"], ["links", self.connection.tables.at "Name" . to_vector]]

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Workbook.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Workbook.enso
@@ -311,8 +311,9 @@ type Excel_Workbook
        Provides a JS object representation for use in visualizations.
     to_js_object : JS_Object
     to_js_object self =
+        values=(self.tables.at "Name" . to_vector)
         additional_fields = case self.file of
-            regular_file : File -> [["file", regular_file.path]]
+            regular_file : File -> [["file", regular_file.path], ["sheet_names", values]]
             _ -> []
         JS_Object.from_pairs <|
             [["type", "Excel_Workbook"], ["xls_format", self.xls_format]] + additional_fields

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -164,7 +164,7 @@ make_json_for_other x =
         pairs = [['_display_text_', x.to_display_text]] + js_value.field_names.map f-> [f, make_json_for_value (js_value.get f)]
         JS_Object.from_pairs pairs
     links = if js_value.is_a JS_Object . not then Nothing else
-        if js_value.contains_key 'links' then ['links', js_value.get 'links'] else Nothing
+        if js_value.contains_key 'links' then js_value.get 'links' else Nothing
     JS_Object.from_pairs [["json", value], ["links", links]]
 
 ## PRIVATE

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -50,11 +50,7 @@ prepare_visualization y max_rows=1000 =
             js_value = x.to_js_object
             JS_Object.from_pairs [["json", js_value], ["sheet_names", x . sheet_names], ["type", "Excel_Workbook"]]
         _ ->
-            js_value = x.to_js_object
-            value = if js_value.is_a JS_Object . not then js_value else
-                pairs = [['_display_text_', x.to_display_text]] + js_value.field_names.map f-> [f, make_json_for_value (js_value.get f)]
-                JS_Object.from_pairs pairs
-            JS_Object.from_pairs [["json", value]]
+            make_json_for_other x
 
     result.to_text
 
@@ -160,6 +156,16 @@ make_json_for_table dataframe all_rows_count include_index_col =
     has_index_col = ["has_index_col", include_index_col]
     pairs       = [header, value_type, data, all_rows, has_index_col, ["type", "Table"]]
     JS_Object.from_pairs pairs
+
+make_json_for_other : Any -> JS_Object
+make_json_for_other x =
+    js_value = x.to_js_object
+    value = if js_value.is_a JS_Object . not then js_value else
+        pairs = [['_display_text_', x.to_display_text]] + js_value.field_names.map f-> [f, make_json_for_value (js_value.get f)]
+        JS_Object.from_pairs pairs
+    links = if js_value.is_a JS_Object . not then Nothing else
+        if js_value.contains_key 'links' then ['links', js_value.get 'links'] else Nothing
+    JS_Object.from_pairs [["json", value], ["links", links]]
 
 ## PRIVATE
    Create JSON serialization of values for the table.

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -163,9 +163,9 @@ make_json_for_other x =
     value = if js_value.is_a JS_Object . not then js_value else
         pairs = [['_display_text_', x.to_display_text]] + js_value.field_names.map f-> [f, make_json_for_value (js_value.get f)]
         JS_Object.from_pairs pairs
-    links = if js_value.is_a JS_Object . not then Nothing else
-        if js_value.contains_key 'links' then js_value.get 'links' else Nothing
-    JS_Object.from_pairs [["json", value], ["links", links]]
+    additional_fields = if js_value.is_a JS_Object . not then [] else
+        if js_value.contains_key 'links' then [["links", js_value.get 'links']] else []
+    JS_Object.from_pairs <| [["json", value]] + additional_fields
 
 ## PRIVATE
    Create JSON serialization of values for the table.

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -2,7 +2,7 @@ from Standard.Base import all
 import Standard.Base.Data.Vector.Builder
 
 import Standard.Table.Row.Row
-from Standard.Table import Column, Table
+from Standard.Table import Column, Table, Excel_Workbook
 
 import Standard.Database.DB_Column.DB_Column
 import Standard.Database.DB_Table.DB_Table
@@ -46,6 +46,9 @@ prepare_visualization y max_rows=1000 =
             JS_Object.from_pairs [["json", value]]
         _ : Number ->
             JS_Object.from_pairs [["json", make_json_for_value x]]
+        _ : Excel_Workbook ->
+            js_value = x.to_js_object
+            JS_Object.from_pairs [["json", js_value], ["sheet_names", x . sheet_names], ["type", "Excel_Workbook"]]
         _ ->
             js_value = x.to_js_object
             value = if js_value.is_a JS_Object . not then js_value else

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -36,6 +36,12 @@ type Foo
     to_js_object : JS_Object
     to_js_object self = JS_Object.from_pairs [["x", self.x]]
 
+type FooLink
+    Value x
+
+    to_js_object : JS_Object
+    to_js_object self = JS_Object.from_pairs [["x", self.x], ["links", ["a", "b", "c"]]]    
+
 
 add_specs suite_builder =
     make_json header data all_rows value_type has_index_col =
@@ -99,6 +105,11 @@ add_specs suite_builder =
             vis = Visualization.prepare_visualization (Foo.Value 42) 2
             json = JS_Object.from_pairs [["json", JS_Object.from_pairs [["_display_text_", (Foo.Value 42).to_display_text],["x", 42]]]]
             vis . should_equal json.to_text
+
+        group_builder.specify "should handle datatypes with links" <|
+            vis = Visualization.prepare_visualization (FooLink.Value "test-value")
+            json = JS_Object.from_pairs [["json", JS_Object.from_pairs [["_display_text_", (FooLink.Value "test-value").to_display_text],["x", "test-value"], ["links", "[a, b, c]"]]], ["links", ["a", "b", "c"]]]
+            vis . should_equal json.to_text    
 
         group_builder.specify "should visualize value type info" <|
             make_json vt =

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -107,8 +107,9 @@ add_specs suite_builder =
             vis . should_equal json.to_text
 
         group_builder.specify "should handle datatypes with links" <|
-            vis = Visualization.prepare_visualization (FooLink.Value "test-value")
-            json = JS_Object.from_pairs [["json", JS_Object.from_pairs [["_display_text_", (FooLink.Value "test-value").to_display_text],["x", "test-value"], ["links", "[a, b, c]"]]], ["links", ["a", "b", "c"]]]
+            example = FooLink.Value "test-value"
+            vis = Visualization.prepare_visualization example
+            json = JS_Object.from_pairs [["json", JS_Object.from_pairs [["_display_text_", example.to_display_text],["x", "test-value"], ["links", "[a, b, c]"]]], ["links", ["a", "b", "c"]]]
             vis . should_equal json.to_text    
 
         group_builder.specify "should visualize value type info" <|

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -36,7 +36,7 @@ type Foo
     to_js_object : JS_Object
     to_js_object self = JS_Object.from_pairs [["x", self.x]]
 
-type FooLink
+type Foo_Link
     Value x
 
     to_js_object : JS_Object

--- a/test/Visualization_Tests/src/Table_Spec.enso
+++ b/test/Visualization_Tests/src/Table_Spec.enso
@@ -107,7 +107,7 @@ add_specs suite_builder =
             vis . should_equal json.to_text
 
         group_builder.specify "should handle datatypes with links" <|
-            example = FooLink.Value "test-value"
+            example = Foo_Link.Value "test-value"
             vis = Visualization.prepare_visualization example
             json = JS_Object.from_pairs [["json", JS_Object.from_pairs [["_display_text_", example.to_display_text],["x", "test-value"], ["links", "[a, b, c]"]]], ["links", ["a", "b", "c"]]]
             vis . should_equal json.to_text    


### PR DESCRIPTION
### Pull Request Description
changes to current table (and db table) on index click:
- node added on double click 
- tooltip added
- cursor changes to pointer 
- styled as a link

![7473-table-w-links](https://github.com/enso-org/enso/assets/170310417/5e60c177-3f83-4db7-be86-fa8a9d493204)


Row table types:
Added on click to show value 
![7473-row-links](https://github.com/enso-org/enso/assets/170310417/82f878ea-420d-4308-99bf-c77a6340a8c3)



Excel Workbook connections
- show sheet names in column 
- sheet names are clickable that add a 'read' node for the corresponding sheet 
- Shown in table with header title: Sheets 

![7473-excel-links-sheets](https://github.com/enso-org/enso/assets/170310417/748f524e-5cca-4c20-b458-132af9a57ec1)


SQLite Connection:
- shows available schemas in column 
- schemas are clickable that add a 'query' node for the corresponding schema/table 
![7473-sql-lite-links](https://github.com/enso-org/enso/assets/170310417/21a8006f-c462-4128-874d-05380d3bab00)


Postgres Connection:
- shows available tables in a column 
- tables are clickable and add a 'query' node for the corresponding table 
![7473-postgres-links](https://github.com/enso-org/enso/assets/170310417/66b134ff-80fd-4995-b445-505919e25cfa)

JS_Object
- style keys as links 
![7473-json-links](https://github.com/enso-org/enso/assets/170310417/9ec17c85-c1f4-42ab-b40a-06d6bc29d54f)


<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
