### PR TITLE
Fix background color

### DIFF
--- a/app/ide-desktop/lib/dashboard/e2e/actions.ts
+++ b/app/ide-desktop/lib/dashboard/e2e/actions.ts
@@ -656,6 +656,46 @@ export async function expectNotOpacity0(locator: test.Locator) {
   })
 }
 
+/** A test assertion to confirm that the element is onscreen. */
+export async function expectOnScreen(locator: test.Locator) {
+  await test.test.step('Expect to be onscreen', async () => {
+    await test
+      .expect(async () => {
+        const pageBounds = await locator.evaluate(() => document.body.getBoundingClientRect())
+        const bounds = await locator.evaluate(el => el.getBoundingClientRect())
+        test
+          .expect(
+            bounds.left < pageBounds.right &&
+              bounds.right > pageBounds.left &&
+              bounds.top < pageBounds.bottom &&
+              bounds.bottom > pageBounds.top
+          )
+          .toBe(true)
+      })
+      .toPass()
+  })
+}
+
+/** A test assertion to confirm that the element is onscreen. */
+export async function expectNotOnScreen(locator: test.Locator) {
+  await test.test.step('Expect to not be onscreen', async () => {
+    await test
+      .expect(async () => {
+        const pageBounds = await locator.evaluate(() => document.body.getBoundingClientRect())
+        const bounds = await locator.evaluate(el => el.getBoundingClientRect())
+        test
+          .expect(
+            bounds.left >= pageBounds.right ||
+              bounds.right <= pageBounds.left ||
+              bounds.top >= pageBounds.bottom ||
+              bounds.bottom <= pageBounds.top
+          )
+          .toBe(true)
+      })
+      .toPass()
+  })
+}
+
 // =======================
 // === Mouse utilities ===
 // =======================

--- a/app/ide-desktop/lib/dashboard/e2e/assetPanel.spec.ts
+++ b/app/ide-desktop/lib/dashboard/e2e/assetPanel.spec.ts
@@ -29,15 +29,15 @@ test.test('open and close asset panel', ({ page }) =>
         .createFolder()
         .driveTable.clickRow(0)
         .withAssetPanel(async assetPanel => {
-          await test.expect(assetPanel).not.toBeVisible()
+          await actions.expectNotOnScreen(assetPanel)
         })
         .toggleAssetPanel()
         .withAssetPanel(async assetPanel => {
-          await test.expect(assetPanel).toBeVisible()
+          await actions.expectOnScreen(assetPanel)
         })
         .toggleAssetPanel()
         .withAssetPanel(async assetPanel => {
-          await test.expect(assetPanel).not.toBeVisible()
+          await actions.expectNotOnScreen(assetPanel)
         })
   )
 )

--- a/app/ide-desktop/lib/dashboard/src/components/styled/Checkbox.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/styled/Checkbox.tsx
@@ -19,7 +19,7 @@ export default function Checkbox(props: CheckboxProps) {
   return (
     <FocusRing>
       <aria.Checkbox
-        className="group flex size-3 cursor-pointer overflow-clip rounded-sm text-cloud outline outline-1 outline-primary checkbox"
+        className="group flex size-3 cursor-pointer overflow-clip rounded-sm text-invite outline outline-1 outline-primary checkbox"
         {...props}
       >
         <SvgMask

--- a/app/ide-desktop/lib/dashboard/src/layouts/AssetPanel.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/AssetPanel.tsx
@@ -114,7 +114,7 @@ export default function AssetPanel(props: AssetPanelProps) {
       data-testid="asset-panel"
       className={tailwindMerge.twMerge(
         'p-top-bar-margin pointer-events-none absolute flex h-full w-asset-panel flex-col gap-asset-panel bg-white pl-asset-panel-l transition-[box-shadow] clip-path-left-shadow',
-        isVisible ? 'shadow-soft' : ''
+        isVisible ? 'shadow-softer' : ''
       )}
       onClick={event => {
         event.stopPropagation()

--- a/app/ide-desktop/lib/dashboard/src/layouts/AssetPanel.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/AssetPanel.tsx
@@ -62,6 +62,7 @@ export interface AssetPanelRequiredProps {
 
 /** Props for an {@link AssetPanel}. */
 export interface AssetPanelProps extends AssetPanelRequiredProps {
+  readonly isVisible?: boolean
   readonly isReadonly?: boolean
   readonly category: Category
   readonly dispatchAssetEvent: (event: assetEvent.AssetEvent) => void
@@ -70,7 +71,7 @@ export interface AssetPanelProps extends AssetPanelRequiredProps {
 
 /** A panel containing the description and settings for an asset. */
 export default function AssetPanel(props: AssetPanelProps) {
-  const { backend, isReadonly = false, item, setItem, category } = props
+  const { isVisible, backend, isReadonly = false, item, setItem, category } = props
   const { dispatchAssetEvent, dispatchAssetListEvent } = props
 
   const { getText } = textProvider.useText()
@@ -111,7 +112,10 @@ export default function AssetPanel(props: AssetPanelProps) {
   return (
     <div
       data-testid="asset-panel"
-      className="p-top-bar-margin pointer-events-none absolute flex h-full w-asset-panel flex-col gap-asset-panel bg-selected-frame pl-asset-panel-l"
+      className={tailwindMerge.twMerge(
+        'p-top-bar-margin clip-path-left-shadow pointer-events-none absolute flex h-full w-asset-panel flex-col gap-asset-panel bg-selected-frame pl-asset-panel-l transition-[box-shadow]',
+        isVisible ? 'shadow-soft' : ''
+      )}
       onClick={event => {
         event.stopPropagation()
       }}
@@ -122,10 +126,10 @@ export default function AssetPanel(props: AssetPanelProps) {
           item.item.type !== backendModule.AssetType.directory && (
             <ariaComponents.Button
               size="medium"
-              variant="ghost"
+              variant="bar"
               className={tailwindMerge.twMerge(
                 'pointer-events-auto disabled:opacity-100',
-                tab === AssetPanelTab.versions && 'bg-white opacity-100'
+                tab === AssetPanelTab.versions && 'bg-primary/[8%] opacity-100'
               )}
               onPress={() => {
                 setTab(oldTab =>
@@ -141,11 +145,11 @@ export default function AssetPanel(props: AssetPanelProps) {
         {item != null && item.item.type === backendModule.AssetType.project && (
           <ariaComponents.Button
             size="medium"
-            variant="ghost"
+            variant="bar"
             isDisabled={tab === AssetPanelTab.projectSessions}
             className={tailwindMerge.twMerge(
               'pointer-events-auto disabled:opacity-100',
-              tab === AssetPanelTab.projectSessions && 'bg-white opacity-100'
+              tab === AssetPanelTab.projectSessions && 'bg-primary/[8%] opacity-100'
             )}
             onPress={() => {
               setTab(oldTab =>

--- a/app/ide-desktop/lib/dashboard/src/layouts/AssetPanel.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/AssetPanel.tsx
@@ -113,7 +113,7 @@ export default function AssetPanel(props: AssetPanelProps) {
     <div
       data-testid="asset-panel"
       className={tailwindMerge.twMerge(
-        'p-top-bar-margin clip-path-left-shadow pointer-events-none absolute flex h-full w-asset-panel flex-col gap-asset-panel bg-selected-frame pl-asset-panel-l transition-[box-shadow]',
+        'p-top-bar-margin pointer-events-none absolute flex h-full w-asset-panel flex-col gap-asset-panel bg-frame pl-asset-panel-l transition-[box-shadow] clip-path-left-shadow',
         isVisible ? 'shadow-soft' : ''
       )}
       onClick={event => {

--- a/app/ide-desktop/lib/dashboard/src/layouts/AssetPanel.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/AssetPanel.tsx
@@ -62,7 +62,7 @@ export interface AssetPanelRequiredProps {
 
 /** Props for an {@link AssetPanel}. */
 export interface AssetPanelProps extends AssetPanelRequiredProps {
-  readonly isVisible?: boolean
+  readonly isVisible: boolean
   readonly isReadonly?: boolean
   readonly category: Category
   readonly dispatchAssetEvent: (event: assetEvent.AssetEvent) => void

--- a/app/ide-desktop/lib/dashboard/src/layouts/AssetPanel.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/AssetPanel.tsx
@@ -113,7 +113,7 @@ export default function AssetPanel(props: AssetPanelProps) {
     <div
       data-testid="asset-panel"
       className={tailwindMerge.twMerge(
-        'p-top-bar-margin pointer-events-none absolute flex h-full w-asset-panel flex-col gap-asset-panel bg-frame pl-asset-panel-l transition-[box-shadow] clip-path-left-shadow',
+        'p-top-bar-margin pointer-events-none absolute flex h-full w-asset-panel flex-col gap-asset-panel bg-white pl-asset-panel-l transition-[box-shadow] clip-path-left-shadow',
         isVisible ? 'shadow-soft' : ''
       )}
       onClick={event => {

--- a/app/ide-desktop/lib/dashboard/src/layouts/AssetPanel.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/AssetPanel.tsx
@@ -111,7 +111,7 @@ export default function AssetPanel(props: AssetPanelProps) {
   return (
     <div
       data-testid="asset-panel"
-      className="p-top-bar-margin pointer-events-none absolute flex h-full w-asset-panel flex-col gap-asset-panel bg-frame pl-asset-panel-l"
+      className="p-top-bar-margin pointer-events-none absolute flex h-full w-asset-panel flex-col gap-asset-panel bg-selected-frame pl-asset-panel-l"
       onClick={event => {
         event.stopPropagation()
       }}

--- a/app/ide-desktop/lib/dashboard/src/layouts/AssetProperties.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/AssetProperties.tsx
@@ -21,7 +21,6 @@ import SharedWithColumn from '#/components/dashboard/column/SharedWithColumn'
 import DatalinkInput from '#/components/dashboard/DatalinkInput'
 import Label from '#/components/dashboard/Label'
 import StatelessSpinner, * as statelessSpinner from '#/components/StatelessSpinner'
-import Button from '#/components/styled/Button'
 
 import * as backendModule from '#/services/Backend'
 import type Backend from '#/services/Backend'
@@ -138,8 +137,10 @@ export default function AssetProperties(props: AssetPropertiesProps) {
         >
           {getText('description')}
           {!isReadonly && ownsThisAsset && !isEditingDescription && (
-            <Button
-              image={PenIcon}
+            <ariaComponents.Button
+              size="icon"
+              variant="icon"
+              icon={PenIcon}
               onPress={() => {
                 setIsEditingDescription(true)
                 setQueuedDescripion(item.item.description)
@@ -154,7 +155,7 @@ export default function AssetProperties(props: AssetPropertiesProps) {
           {!isEditingDescription ? (
             <aria.Text className="text">{item.item.description}</aria.Text>
           ) : (
-            <form className="flex flex-col gap-modal" onSubmit={doEditDescription}>
+            <form className="flex flex-col gap-modal pr-4" onSubmit={doEditDescription}>
               <textarea
                 ref={element => {
                   if (element != null && queuedDescription != null) {
@@ -162,8 +163,12 @@ export default function AssetProperties(props: AssetPropertiesProps) {
                     setQueuedDescripion(null)
                   }
                 }}
-                onBlur={doEditDescription}
                 value={description}
+                className="w-full resize-none rounded-default border-0.5 border-primary/20 p-2"
+                onBlur={doEditDescription}
+                onChange={event => {
+                  setDescription(event.currentTarget.value)
+                }}
                 onKeyDown={event => {
                   event.stopPropagation()
                   switch (event.key) {
@@ -179,21 +184,12 @@ export default function AssetProperties(props: AssetPropertiesProps) {
                     }
                   }
                 }}
-                onChange={event => {
-                  setDescription(event.currentTarget.value)
-                }}
-                className="-m-multiline-input-p w-full resize-none rounded-input bg-frame p-multiline-input"
               />
-              <div className="flex gap-2">
-                <ariaComponents.Button
-                  size="custom"
-                  variant="custom"
-                  className="button self-start bg-selected-frame"
-                  onPress={doEditDescription}
-                >
+              <ariaComponents.ButtonGroup>
+                <ariaComponents.Button size="medium" variant="bar" onPress={doEditDescription}>
                   {getText('update')}
                 </ariaComponents.Button>
-              </div>
+              </ariaComponents.ButtonGroup>
             </form>
           )}
         </div>
@@ -259,7 +255,7 @@ export default function AssetProperties(props: AssetPropertiesProps) {
                 setValue={setEditedDatalinkValue}
               />
               {canEditThisAsset && (
-                <div className="flex gap-2">
+                <ariaComponents.ButtonGroup>
                   <ariaComponents.Button
                     size="medium"
                     variant="submit"
@@ -302,7 +298,7 @@ export default function AssetProperties(props: AssetPropertiesProps) {
                   >
                     {getText('cancel')}
                   </ariaComponents.Button>
-                </div>
+                </ariaComponents.ButtonGroup>
               )}
             </>
           )}

--- a/app/ide-desktop/lib/dashboard/src/layouts/AssetProperties.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/AssetProperties.tsx
@@ -261,13 +261,12 @@ export default function AssetProperties(props: AssetPropertiesProps) {
               {canEditThisAsset && (
                 <div className="flex gap-2">
                   <ariaComponents.Button
-                    size="custom"
-                    variant="custom"
+                    size="medium"
+                    variant="submit"
                     isDisabled={isDatalinkDisabled}
                     {...(isDatalinkDisabled
                       ? { title: 'Edit the Datalink before updating it.' }
                       : {})}
-                    className="button bg-invite text-white enabled:active"
                     onPress={() => {
                       void (async () => {
                         if (item.item.type === backendModule.AssetType.datalink) {
@@ -294,10 +293,9 @@ export default function AssetProperties(props: AssetPropertiesProps) {
                     {getText('update')}
                   </ariaComponents.Button>
                   <ariaComponents.Button
-                    size="custom"
-                    variant="custom"
+                    size="medium"
+                    variant="bar"
                     isDisabled={isDatalinkDisabled}
-                    className="button bg-selected-frame enabled:active"
                     onPress={() => {
                       setEditedDatalinkValue(datalinkValue)
                     }}

--- a/app/ide-desktop/lib/dashboard/src/layouts/AssetSearchBar.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/AssetSearchBar.tsx
@@ -298,7 +298,7 @@ export default function AssetSearchBar(props: AssetSearchBarProps) {
           <div className="relative size-4 placeholder" />
           <div
             className={tailwindMerge.twMerge(
-              'pointer-events-none absolute left top z-1 flex w-full flex-col overflow-hidden rounded-default border-0.5 border-primary/20 transition-colors before:absolute before:inset before:backdrop-blur-default hover:before:bg-frame',
+              'pointer-events-none absolute left top z-1 flex w-full flex-col overflow-hidden rounded-default border-0.5 border-primary/20 -outline-offset-1 outline-primary transition-colors before:absolute before:inset  before:backdrop-blur-default group-focus-within:outline group-focus-within:outline-2 hover:before:bg-frame',
               areSuggestionsVisible && 'before:bg-frame'
             )}
           >

--- a/app/ide-desktop/lib/dashboard/src/layouts/Drive.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/Drive.tsx
@@ -346,21 +346,20 @@ export default function Drive(props: DriveProps) {
           <div
             className={tailwindMerge.twMerge(
               'flex flex-col overflow-hidden transition-min-width duration-side-panel ease-in-out',
-              isAssetPanelVisible ? 'min-w-side-panel' : 'invisible min-w'
+              isAssetPanelVisible ? 'min-w-side-panel' : 'min-w'
             )}
           >
-            {isAssetPanelVisible && (
-              <AssetPanel
-                key={assetPanelProps?.item?.item.id}
-                backend={assetPanelProps?.backend ?? null}
-                item={assetPanelProps?.item ?? null}
-                setItem={assetPanelProps?.setItem ?? null}
-                category={category}
-                dispatchAssetEvent={dispatchAssetEvent}
-                dispatchAssetListEvent={dispatchAssetListEvent}
-                isReadonly={category === Category.trash}
-              />
-            )}
+            <AssetPanel
+              isVisible={isAssetPanelVisible}
+              key={assetPanelProps?.item?.item.id}
+              backend={assetPanelProps?.backend ?? null}
+              item={assetPanelProps?.item ?? null}
+              setItem={assetPanelProps?.setItem ?? null}
+              category={category}
+              dispatchAssetEvent={dispatchAssetEvent}
+              dispatchAssetListEvent={dispatchAssetListEvent}
+              isReadonly={category === Category.trash}
+            />
           </div>
         </div>
       )

--- a/app/ide-desktop/lib/dashboard/src/layouts/SearchBar.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/SearchBar.tsx
@@ -6,6 +6,7 @@ import FindIcon from 'enso-assets/find.svg'
 import * as aria from '#/components/aria'
 import FocusArea from '#/components/styled/FocusArea'
 import FocusRing from '#/components/styled/FocusRing'
+import SvgMask from '#/components/SvgMask'
 
 // =================
 // === SearchBar ===
@@ -32,13 +33,10 @@ export default function SearchBar(props: SearchBarProps) {
           data-testid={props['data-testid']}
           {...aria.mergeProps<aria.LabelProps>()(innerProps, {
             className:
-              'group relative flex grow sm:grow-0 sm:basis-[512px] h-row items-center gap-asset-search-bar rounded-full px-input-x text-primary',
+              'group relative flex grow sm:grow-0 sm:basis-[512px] h-row items-center gap-asset-search-bar rounded-full px-input-x text-primary border-0.5 border-primary/20 transition-colors',
           })}
         >
-          <img src={FindIcon} className="relative z-1 placeholder" />
-          <div className="pointer-events-none absolute left top flex w-full flex-col overflow-hidden rounded-default before:absolute before:inset before:bg-frame before:backdrop-blur-default">
-            <div className="padding relative h-row" />
-          </div>
+          <SvgMask src={FindIcon} className="text-primary/30" />
           <FocusRing placement="before">
             <aria.SearchField
               aria-label={label}

--- a/app/ide-desktop/lib/dashboard/src/layouts/SearchBar.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/SearchBar.tsx
@@ -33,7 +33,7 @@ export default function SearchBar(props: SearchBarProps) {
           data-testid={props['data-testid']}
           {...aria.mergeProps<aria.LabelProps>()(innerProps, {
             className:
-              'group relative flex grow sm:grow-0 sm:basis-[512px] h-row items-center gap-asset-search-bar rounded-full px-input-x text-primary border-0.5 border-primary/20 transition-colors',
+              'group relative flex grow sm:grow-0 sm:basis-[512px] h-row items-center gap-asset-search-bar rounded-full px-input-x text-primary border-0.5 border-primary/20 transition-colors focus-within:outline focus-within:outline-2 outline-primary -outline-offset-1',
           })}
         >
           <SvgMask src={FindIcon} className="text-primary/30" />

--- a/app/ide-desktop/lib/dashboard/src/layouts/Settings.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/Settings.tsx
@@ -200,7 +200,7 @@ export default function Settings() {
         <ariaComponents.Text
           variant="h1"
           truncate="1"
-          className="ml-2.5 max-w-lg rounded-full border-0.5 border-primary/20 px-2.5 font-bold"
+          className="ml-2.5 max-w-lg rounded-full bg-white px-2.5 font-bold"
           aria-hidden
         >
           {data.organizationOnly === true ? organization?.name ?? 'your organization' : user.name}

--- a/app/ide-desktop/lib/dashboard/src/layouts/Settings.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/Settings.tsx
@@ -200,7 +200,7 @@ export default function Settings() {
         <ariaComponents.Text
           variant="h1"
           truncate="1"
-          className="ml-2.5 max-w-lg rounded-full bg-frame px-2.5 font-bold"
+          className="ml-2.5 max-w-lg rounded-full border-0.5 border-primary/20 px-2.5 font-bold"
           aria-hidden
         >
           {data.organizationOnly === true ? organization?.name ?? 'your organization' : user.name}

--- a/app/ide-desktop/lib/dashboard/src/layouts/Settings.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/Settings.tsx
@@ -150,7 +150,7 @@ export default function Settings() {
       )
     }
   }, [isQueryBlank, doesEntryMatchQuery, getText, isMatch])
-  const effectiveTab = tabsToShow.includes(tab) ? tab : tabsToShow[0] ?? SettingsTabType.members
+  const effectiveTab = tabsToShow.includes(tab) ? tab : tabsToShow[0] ?? SettingsTabType.account
 
   const data = React.useMemo<settingsData.SettingsTabData>(() => {
     const tabData = settingsData.SETTINGS_TAB_DATA[effectiveTab]
@@ -170,7 +170,11 @@ export default function Settings() {
             return [{ ...section, entries: matchingEntries }]
           }
         })
-        return { ...tabData, sections }
+        return {
+          ...tabData,
+          sections:
+            sections.length === 0 ? [settingsData.SETTINGS_NO_RESULTS_SECTION_DATA] : sections,
+        }
       }
     }
   }, [isQueryBlank, doesEntryMatchQuery, getText, isMatch, effectiveTab])

--- a/app/ide-desktop/lib/dashboard/src/layouts/Settings/settingsData.tsx
+++ b/app/ide-desktop/lib/dashboard/src/layouts/Settings/settingsData.tsx
@@ -52,6 +52,19 @@ export enum SettingsEntryType {
 // === Constants ===
 // =================
 
+export const SETTINGS_NO_RESULTS_SECTION_DATA: SettingsSectionData = {
+  nameId: 'noResultsSettingsSection',
+  heading: false,
+  entries: [
+    {
+      type: SettingsEntryType.custom,
+      render: context => (
+        <div className="grid max-w-[512px] justify-center">{context.getText('noResultsFound')}</div>
+      ),
+    },
+  ],
+}
+
 export const SETTINGS_TAB_DATA: Readonly<Record<SettingsTabType, SettingsTabData>> = {
   [SettingsTabType.account]: {
     nameId: 'accountSettingsTab',

--- a/app/ide-desktop/lib/dashboard/src/tailwind.css
+++ b/app/ide-desktop/lib/dashboard/src/tailwind.css
@@ -448,6 +448,10 @@
 
   @apply font-medium;
 
+  textarea {
+    background: unset;
+  }
+
   kbd {
     font-family: "Enso Prose", "Enso", "M PLUS 1", "Roboto Light", sans-serif;
   }

--- a/app/ide-desktop/lib/dashboard/src/tailwind.css
+++ b/app/ide-desktop/lib/dashboard/src/tailwind.css
@@ -424,7 +424,7 @@
   }
 
   & > * {
-    @apply bg-white/80;
+    @apply bg-white/90;
   }
 }
 

--- a/app/ide-desktop/lib/dashboard/src/text/english.json
+++ b/app/ide-desktop/lib/dashboard/src/text/english.json
@@ -395,6 +395,7 @@
   "hidePassword": "Hide password",
   "showPassword": "Show password",
   "copiedToClipboard": "Copied to clipboard",
+  "noResultsFound": "No results found.",
 
   "deleteLabelActionText": "delete the label '$0'",
   "deleteSelectedAssetActionText": "delete '$0'",
@@ -677,6 +678,7 @@
   "userGroupContextMenuLabel": "User Group context menu",
   "userGroupUserContextMenuLabel": "User Group User context menu",
 
+  "noResultsSettingsSection": "",
   "generalSettingsTabSection": "General",
   "accountSettingsTab": "Account",
   "userAccountSettingsSection": "User Account",

--- a/app/ide-desktop/lib/dashboard/tailwind.config.js
+++ b/app/ide-desktop/lib/dashboard/tailwind.config.js
@@ -454,6 +454,9 @@ inset 0 -36px 51px -51px #00000014`,
           '.clip-path-bottom-shadow': {
             clipPath: `polygon(0 0, 100% 0, 100% calc(100% + 100vh), 0 calc(100% + 100vh))`,
           },
+          '.clip-path-left-shadow': {
+            clipPath: `polygon(-100vw 0, 100% 0, 100% 100%, -100vw 100%)`,
+          },
           '.scroll-hidden': {
             MsOverflowStyle: 'none' /* Internet Explorer 10+ */,
             scrollbarWidth: 'none' /* Firefox */,

--- a/app/ide-desktop/lib/dashboard/tailwind.config.js
+++ b/app/ide-desktop/lib/dashboard/tailwind.config.js
@@ -31,7 +31,6 @@ export default /** @satisfies {import('tailwindcss').Config} */ ({
         label: '#f0f1f3',
         help: '#3f68ce',
         invite: '#0e81d4',
-        cloud: '#0666be',
         share: '#64b526',
         inversed: '#ffffff',
         green: '#3e8b29',

--- a/app/ide-desktop/lib/dashboard/tailwind.config.js
+++ b/app/ide-desktop/lib/dashboard/tailwind.config.js
@@ -361,6 +361,9 @@ export default /** @satisfies {import('tailwindcss').Config} */ ({
         soft: `0 0.5px 2.2px 0px #00000008, 0 1.2px 5.3px 0px #0000000b, \
 0 2.3px 10px 0 #0000000e, 0 4px 18px 0 #00000011, 0 7.5px 33.4px 0 #00000014, \
 0 18px 80px 0 #0000001c`,
+        softer: `0 0.5px 2.2px 0px rgb(0 0 0 / 0.84%), 0 1.2px 5.65px 0px rgb(0 0 0 / 1.21%), \
+0 2.25px 10.64px 0 rgb(0 0 0 / 1.5%), 0 4px 19px 0 rgb(0 0 0 / 1.79%), 0 7.5px 35.5px 0 rgb(0 0 0 / 2.16%), \
+0 18px 85px 0 rgb(0 0 0 / 3%)`,
         'inset-t-lg': `inset 0 1px 1.4px -1.4px #00000002, \
 inset 0 2.4px 3.4px -3.4px #00000003, inset 0 4.5px 6.4px -6.4px #00000004, \
 inset 0 8px 11.4px -11.4px #00000005, inset 0 15px 21.3px -21.3px #00000006, \


### PR DESCRIPTION
### Pull Request Description
- Fix #10393
  - Use correct background color
- Make background of Asset Panel white to match Figma design

### Important Notes
None

### Screenshots

Before:
![image](https://github.com/enso-org/enso/assets/4046547/0f7fedb7-2e97-4187-a33f-c064c001e2b6)

After:
![image](https://github.com/enso-org/enso/assets/4046547/221f48b8-e178-4a29-93a7-d1c6b37c6d87)

Search bar outline:
![image](https://github.com/enso-org/enso/assets/4046547/572cb62f-5a10-4b37-b317-096660f0220d)

Search bar outline in settings:
![image](https://github.com/enso-org/enso/assets/4046547/34ea5fac-6d8c-49a2-a573-f51e7c71dfa5)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
