### PR TITLE
Disable UpdatingEditionProvider when running Enso CLI

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -158,7 +158,11 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
   val distributionManager = new DistributionManager(environment)
 
   val editionProvider =
-    EditionManager.makeEditionProvider(distributionManager, Some(languageHome))
+    EditionManager.makeEditionProvider(
+      distributionManager,
+      Some(languageHome),
+      false
+    )
   val editionResolver = EditionResolver(editionProvider)
   val editionReferenceResolver = new EditionReferenceResolver(
     contentRoot.file,

--- a/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
+++ b/engine/language-server/src/test/scala/org/enso/languageserver/websocket/json/BaseServerTest.scala
@@ -347,7 +347,8 @@ abstract class BaseServerTest
     val editionProvider =
       EditionManager.makeEditionProvider(
         distributionManager,
-        Some(languageHome)
+        Some(languageHome),
+        true
       )
     val editionResolver = EditionResolver(editionProvider)
     val editionReferenceResolver = new EditionReferenceResolver(

--- a/engine/runner/src/main/scala/org/enso/runner/DependencyPreinstaller.scala
+++ b/engine/runner/src/main/scala/org/enso/runner/DependencyPreinstaller.scala
@@ -43,7 +43,8 @@ object DependencyPreinstaller {
 
     val editionProvider = EditionManager.makeEditionProvider(
       distributionManager,
-      Some(languageHome)
+      Some(languageHome),
+      true
     )
     val editionResolver = EditionResolver(editionProvider)
     val edition = editionResolver

--- a/lib/scala/edition-updater/src/main/scala/org/enso/editions/updater/UpdatingEditionProvider.scala
+++ b/lib/scala/edition-updater/src/main/scala/org/enso/editions/updater/UpdatingEditionProvider.scala
@@ -38,12 +38,8 @@ class UpdatingEditionProvider(
       case Right(value)     => Right(value)
     }
 
-  /** Finds all editions available on the [[searchPaths]]. */
-  override def findAvailableEditions(): Seq[String] =
-    provider.findAvailableEditions()
-
   /** Finds all available editions, performing an update if asked to. */
-  def findAvailableEditions(update: Boolean): Seq[String] = {
+  override def findAvailableEditions(update: Boolean): Seq[String] = {
     if (update) {
       updater.updateEditions()
     }

--- a/lib/scala/editions/src/main/scala/org/enso/editions/provider/EditionProvider.scala
+++ b/lib/scala/editions/src/main/scala/org/enso/editions/provider/EditionProvider.scala
@@ -15,5 +15,5 @@ trait EditionProvider {
   ): Either[EditionLoadingError, Editions.Raw.Edition]
 
   /** Finds all editions that are currently available. */
-  def findAvailableEditions(): Seq[String]
+  def findAvailableEditions(update: Boolean = false): Seq[String]
 }

--- a/lib/scala/editions/src/main/scala/org/enso/editions/provider/FileSystemEditionProvider.scala
+++ b/lib/scala/editions/src/main/scala/org/enso/editions/provider/FileSystemEditionProvider.scala
@@ -51,7 +51,9 @@ class FileSystemEditionProvider(searchPaths: List[Path])
   }
 
   /** Finds all editions available on the [[searchPaths]]. */
-  override def findAvailableEditions(): Seq[String] =
+  override def findAvailableEditions(
+    ignoreUpdateRequest: Boolean
+  ): Seq[String] =
     searchPaths.flatMap(findEditionsAt).distinct
 
   private def findEditionName(path: Path): Option[String] =

--- a/lib/scala/editions/src/test/scala/org/enso/editions/EditionResolverSpec.scala
+++ b/lib/scala/editions/src/test/scala/org/enso/editions/EditionResolverSpec.scala
@@ -54,7 +54,8 @@ class EditionResolverSpec
     ): Either[EditionLoadingError, Editions.Raw.Edition] =
       editions.get(name).toRight(EditionNotFound(name))
 
-    override def findAvailableEditions(): Seq[String] = editions.keys.toSeq
+    override def findAvailableEditions(update: Boolean): Seq[String] =
+      editions.keys.toSeq
   }
 
   val resolver = EditionResolver(FakeEditionProvider)


### PR DESCRIPTION
### Pull Request Description

Fixes #9231 by using `FileSystemEditionManager` and not `UpdatingEditionManager` to avoid any downloads of editions.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      style guides. 
- [x] Unit tests were updated to pass
