### PR TITLE
Fix errors in GUI WebSockets

### DIFF
--- a/app/gui2/shared/languageServer.ts
+++ b/app/gui2/shared/languageServer.ts
@@ -160,7 +160,6 @@ export class LanguageServer extends ObservableV2<Notifications & TransportEvents
     }
     transport.on('close', reinitializeCb)
     this.clientScope.onAbort(() => {
-      console.log('aborted')
       this.transport.off('close', reinitializeCb)
       this.transport.close()
     })

--- a/app/gui2/shared/languageServer.ts
+++ b/app/gui2/shared/languageServer.ts
@@ -158,7 +158,7 @@ export class LanguageServer extends ObservableV2<Notifications & TransportEvents
         console.error('Language Server transport error:', error)
       }
     })
-    const reinitializeCb = () => {
+    const onTransportClosed = () => {
       if (!this.shouldReconnect) {
         if (!this.isDisposed) {
           this.dispose()
@@ -169,9 +169,9 @@ export class LanguageServer extends ObservableV2<Notifications & TransportEvents
       console.log('Language Server: WebSocket closed')
       this.scheduleInitializationAfterConnect()
     }
-    transport.on('close', reinitializeCb)
+    transport.on('close', onTransportClosed)
     this.clientScope.onAbort(() => {
-      this.transport.off('close', reinitializeCb)
+      this.transport.off('close', onTransportClosed)
       this.transport.close()
     })
   }

--- a/app/gui2/shared/languageServer.ts
+++ b/app/gui2/shared/languageServer.ts
@@ -159,7 +159,12 @@ export class LanguageServer extends ObservableV2<Notifications & TransportEvents
       }
     })
     const reinitializeCb = () => {
-      if (!this.shouldReconnect) return
+      if (!this.shouldReconnect) {
+        if (!this.isDisposed) {
+          this.dispose()
+        }
+        return
+      }
       this.emit('transport/closed', [])
       console.log('Language Server: WebSocket closed')
       this.scheduleInitializationAfterConnect()
@@ -188,7 +193,7 @@ export class LanguageServer extends ObservableV2<Notifications & TransportEvents
               )
             },
           }).then((result) => {
-            if (!result.ok && !this.isDisposed) {
+            if (!result.ok) {
               result.error.log('Error initializing Language Server RPC')
             }
             resolve(result)
@@ -219,7 +224,9 @@ export class LanguageServer extends ObservableV2<Notifications & TransportEvents
     params: object,
     waitForInit = true,
   ): Promise<LsRpcResult<T>> {
-    if (this.isDisposed) return Err(new LsRpcError('LanguageServer disposed', method, params))
+    if (this.isDisposed) {
+      return Err(new LsRpcError('LanguageServer disposed', method, params))
+    }
     const uuid = uuidv4()
     const now = performance.now()
     try {

--- a/app/gui2/shared/languageServer.ts
+++ b/app/gui2/shared/languageServer.ts
@@ -539,6 +539,15 @@ export class LanguageServer extends ObservableV2<Notifications & TransportEvents
     this.retainCount += 1
   }
 
+  willRelease(abortController: AbortController) {
+    this.transport.on('close', () => {
+      if (!abortController.signal.aborted) {
+        this.release()
+        abortController.abort()
+      }
+    })
+  }
+
   release() {
     if (this.retainCount > 0) {
       this.retainCount -= 1

--- a/app/gui2/shared/languageServer.ts
+++ b/app/gui2/shared/languageServer.ts
@@ -544,17 +544,16 @@ export class LanguageServer extends ObservableV2<Notifications & TransportEvents
     this.retainCount += 1
   }
 
-  willRelease(abortController: AbortController) {
-    this.transport.on(
-      'close',
-      () => {
-        if (!abortController.signal.aborted) {
-          this.release()
-          abortController.abort()
-        }
-      },
-      { once: true },
-    )
+  queueRelease() {
+    const abortController = new AbortController()
+    const release = () => {
+      if (!abortController.signal.aborted) {
+        this.release()
+        abortController.abort()
+      }
+    }
+    this.transport.on('close', release, { once: true })
+    return { forceRelease: release }
   }
 
   release() {

--- a/app/gui2/shared/languageServer.ts
+++ b/app/gui2/shared/languageServer.ts
@@ -575,7 +575,7 @@ export class LanguageServer extends ObservableV2<Notifications & TransportEvents
   }
 
   /** Like `release()`, but unconditionally disposes the AbortScope. */
-  dispose() {
+  private dispose() {
     this.retainCount = 0
     this.clientScope.dispose('Language Server released')
   }

--- a/app/gui2/shared/util/net.ts
+++ b/app/gui2/shared/util/net.ts
@@ -1,8 +1,9 @@
 import { Transport } from '@open-rpc/client-js/build/transports/Transport'
-import type { ObservableV2 } from 'lib0/observable'
+import { type ObservableV2 } from 'lib0/observable'
 import { wait } from 'lib0/promise'
 import { type WebSocketEventMap } from 'partysocket/ws'
 import { type Result, type ResultError } from './data/result'
+import { type AddEventListenerOptions } from './net/ReconnectingWSTransport'
 
 interface Disposable {
   dispose(): void

--- a/app/gui2/shared/util/net.ts
+++ b/app/gui2/shared/util/net.ts
@@ -35,7 +35,7 @@ export class AbortScope {
 
   onAbort(listener: () => void) {
     if (this.signal.aborted) {
-      setTimeout(listener, 0)
+      queueMicrotask(listener)
     } else {
       this.signal.addEventListener('abort', listener, { once: true })
     }
@@ -171,7 +171,15 @@ export function printingCallbacks(successDescription: string, errorDescription: 
 }
 
 export type ReconnectingTransportWithWebsocketEvents = Transport & {
-  on<K extends keyof WebSocketEventMap>(type: K, cb: (event: WebSocketEventMap[K]) => void): void
-  off<K extends keyof WebSocketEventMap>(type: K, cb: (event: WebSocketEventMap[K]) => void): void
+  on<K extends keyof WebSocketEventMap>(
+    type: K,
+    cb: (event: WebSocketEventMap[K]) => void,
+    options?: AddEventListenerOptions,
+  ): void
+  off<K extends keyof WebSocketEventMap>(
+    type: K,
+    cb: (event: WebSocketEventMap[K]) => void,
+    options?: AddEventListenerOptions,
+  ): void
   reconnect(): void
 }

--- a/app/gui2/shared/util/net/ReconnectingWSTransport.ts
+++ b/app/gui2/shared/util/net/ReconnectingWSTransport.ts
@@ -15,6 +15,13 @@ import WS from 'isomorphic-ws'
 import { WebSocket } from 'partysocket'
 import { type WebSocketEventMap } from 'partysocket/ws'
 
+export interface AddEventListenerOptions {
+  capture?: boolean
+  once?: boolean
+  passive?: boolean
+  signal?: AbortSignal
+}
+
 class ReconnectingWebSocketTransport extends Transport {
   public connection: WebSocket
   public uri: string

--- a/app/gui2/shared/util/net/ReconnectingWSTransport.ts
+++ b/app/gui2/shared/util/net/ReconnectingWSTransport.ts
@@ -57,7 +57,6 @@ class ReconnectingWebSocketTransport extends Transport {
   }
 
   public close(): void {
-    console.log(':) closing', this.uri)
     this.connection.close()
   }
 

--- a/app/gui2/src/stores/project/executionContext.ts
+++ b/app/gui2/src/stores/project/executionContext.ts
@@ -274,8 +274,7 @@ export class ExecutionContext extends ObservableV2<ExecutionContextNotification>
   }
 
   dispose() {
-    const abortController = new AbortController()
-    this.lsRpc.willRelease(abortController)
+    const { forceRelease } = this.lsRpc.queueRelease()
     this.queue.pushTask(async (state) => {
       if (state.status === 'created') {
         const result = await this.withBackoff(
@@ -286,10 +285,7 @@ export class ExecutionContext extends ObservableV2<ExecutionContextNotification>
           result.error.log('Failed to destroy execution context')
         }
       }
-      if (!this.lsRpc.isDisposed) {
-        this.lsRpc.release()
-      }
-      abortController.abort()
+      forceRelease()
       return { status: 'not-created' }
     })
   }

--- a/app/gui2/src/stores/project/executionContext.ts
+++ b/app/gui2/src/stores/project/executionContext.ts
@@ -282,11 +282,11 @@ export class ExecutionContext extends ObservableV2<ExecutionContextNotification>
           () => this.lsRpc.destroyExecutionContext(this.id),
           'Destroying execution context',
         )
-        if (!result.ok) {
+        if (!result.ok && !this.lsRpc.isDisposed) {
           result.error.log('Failed to destroy execution context')
         }
       }
-      if (!abortController.signal.aborted) {
+      if (!this.lsRpc.isDisposed) {
         this.lsRpc.release()
       }
       abortController.abort()

--- a/app/gui2/src/stores/project/executionContext.ts
+++ b/app/gui2/src/stores/project/executionContext.ts
@@ -274,7 +274,6 @@ export class ExecutionContext extends ObservableV2<ExecutionContextNotification>
   }
 
   dispose() {
-    const { forceRelease } = this.lsRpc.queueRelease()
     this.queue.pushTask(async (state) => {
       if (state.status === 'created') {
         const result = await this.withBackoff(
@@ -285,7 +284,7 @@ export class ExecutionContext extends ObservableV2<ExecutionContextNotification>
           result.error.log('Failed to destroy execution context')
         }
       }
-      forceRelease()
+      this.lsRpc.release()
       return { status: 'not-created' }
     })
   }

--- a/app/gui2/src/stores/project/executionContext.ts
+++ b/app/gui2/src/stores/project/executionContext.ts
@@ -284,7 +284,9 @@ export class ExecutionContext extends ObservableV2<ExecutionContextNotification>
           result.error.log('Failed to destroy execution context')
         }
       }
-      this.lsRpc.release()
+      if (!this.lsRpc.isDisposed) {
+        this.lsRpc.release()
+      }
       return { status: 'not-created' }
     })
   }

--- a/app/gui2/src/stores/project/index.ts
+++ b/app/gui2/src/stores/project/index.ts
@@ -81,7 +81,7 @@ function createLsRpcConnection(clientId: Uuid, url: string, abort: AbortScope): 
   const connection = new LanguageServer(clientId, transport)
   abort.onAbort(() => {
     connection.stopReconnecting()
-    connection.release()
+    connection.dispose()
   })
   return connection
 }

--- a/app/gui2/src/stores/project/index.ts
+++ b/app/gui2/src/stores/project/index.ts
@@ -79,7 +79,10 @@ function resolveLsUrl(config: GuiConfig): LsUrls {
 function createLsRpcConnection(clientId: Uuid, url: string, abort: AbortScope): LanguageServer {
   const transport = createRpcTransport(url)
   const connection = new LanguageServer(clientId, transport)
-  abort.onAbort(() => connection.release())
+  abort.onAbort(() => {
+    connection.stopReconnecting()
+    connection.release()
+  })
   return connection
 }
 

--- a/app/gui2/src/stores/project/index.ts
+++ b/app/gui2/src/stores/project/index.ts
@@ -81,7 +81,7 @@ function createLsRpcConnection(clientId: Uuid, url: string, abort: AbortScope): 
   const connection = new LanguageServer(clientId, transport)
   abort.onAbort(() => {
     connection.stopReconnecting()
-    connection.dispose()
+    connection.release()
   })
   return connection
 }

--- a/app/gui2/src/stores/project/index.ts
+++ b/app/gui2/src/stores/project/index.ts
@@ -86,7 +86,6 @@ function createLsRpcConnection(clientId: Uuid, url: string, abort: AbortScope): 
 function initializeDataConnection(clientId: Uuid, url: string, abort: AbortScope) {
   const client = createDataWebsocket(url, 'arraybuffer')
   const connection = new DataServer(clientId, client, abort)
-  abort.handleDispose(connection)
   onScopeDispose(() => connection.dispose())
   return connection
 }

--- a/app/gui2/src/stores/suggestionDatabase/index.ts
+++ b/app/gui2/src/stores/suggestionDatabase/index.ts
@@ -131,7 +131,9 @@ class Synchronizer {
       await firstExecution
       const groups = await exponentialBackoff(() => lsRpc.getComponentGroups())
       if (!groups.ok) {
-        groups.error.log('Cannot read component groups. Continuing without gruops.')
+        if (!lsRpc.isDisposed) {
+          groups.error.log('Cannot read component groups. Continuing without groups')
+        }
         return { currentVersion }
       }
       this.groups.value = groups.value.componentGroups.map(

--- a/app/gui2/src/stores/visualization/index.ts
+++ b/app/gui2/src/stores/visualization/index.ts
@@ -227,7 +227,9 @@ export const { provideFn: provideVisualizationStore, injectFn: useVisualizationS
               "If you have custom visualizations, please put them under 'visualizations/'.",
           )
         } else {
-          watching.error.log('Could not load custom visualizations')
+          if (!proj.lsRpcConnection.isDisposed) {
+            watching.error.log('Could not load custom visualizations')
+          }
         }
       }
     })

--- a/app/gui2/src/util/net.ts
+++ b/app/gui2/src/util/net.ts
@@ -189,6 +189,9 @@ export class AsyncQueue<State> {
 /** Create an abort signal that is signalled when containing Vue scope is disposed. */
 export function useAbortScope(): AbortScope {
   const scope = new AbortScope()
-  onScopeDispose(() => scope.dispose('Vue scope disposed.'))
+  onScopeDispose(() => {
+    console.log('.w. vue scope disposed')
+    scope.dispose('Vue scope disposed.')
+  })
   return scope
 }

--- a/app/gui2/src/util/net.ts
+++ b/app/gui2/src/util/net.ts
@@ -189,9 +189,6 @@ export class AsyncQueue<State> {
 /** Create an abort signal that is signalled when containing Vue scope is disposed. */
 export function useAbortScope(): AbortScope {
   const scope = new AbortScope()
-  onScopeDispose(() => {
-    console.log('.w. vue scope disposed')
-    scope.dispose('Vue scope disposed.')
-  })
+  onScopeDispose(() => scope.dispose('Vue scope disposed.'))
   return scope
 }

--- a/app/gui2/src/util/net/dataServer.ts
+++ b/app/gui2/src/util/net/dataServer.ts
@@ -120,20 +120,21 @@ export class DataServer extends ObservableV2<DataServerEvents> {
     return this.initialized
   }
 
-  private initialize() {
-    return exponentialBackoff(() => this.initSession().then(responseAsResult), {
+  private async initialize() {
+    const result = await exponentialBackoff(() => this.initSession().then(responseAsResult), {
       onBeforeRetry: (error, _, delay) => {
         console.warn(
           `Failed to initialize language server binary connection, retrying after ${delay}ms...\n`,
           error,
         )
       },
-    }).then((result) => {
-      if (!result.ok) {
-        result.error.log('Error initializing Language Server Binary Protocol')
-        return result
-      } else return Ok()
     })
+    if (!result.ok) {
+      result.error.log('Error initializing Language Server Binary Protocol')
+      return result
+    } else {
+      return Ok()
+    }
   }
 
   protected async send<T = void>(

--- a/app/ide-desktop/lib/client/src/bin/server.ts
+++ b/app/ide-desktop/lib/client/src/bin/server.ts
@@ -16,7 +16,7 @@ import * as common from 'enso-common'
 import GLOBAL_CONFIG from 'enso-common/src/config.json' assert { type: 'json' }
 import * as contentConfig from 'enso-content-config'
 import * as ydocServer from 'enso-gui2/ydoc-server'
-import * as projectManagement from 'project-management'
+import * as projectManagement from 'enso-project-manager-shim/src/projectManagement'
 
 import * as paths from '../paths'
 
@@ -145,14 +145,17 @@ export class Server {
                         const bundledFiles = fsSync.existsSync(assets)
                             ? await fs.readdir(assets)
                             : []
-                        const rustFFIWasm = bundledFiles.find(name =>
+                        const rustFFIWasmName = bundledFiles.find(name =>
                             /rust_ffi_bg-.*\.wasm/.test(name)
                         )
-                        if (server && rustFFIWasm != null) {
-                            await ydocServer.createGatewayServer(
-                                server,
-                                path.join(assets, rustFFIWasm)
-                            )
+                        const rustFFIWasmPath =
+                            process.env.ELECTRON_DEV_MODE === 'true'
+                                ? path.resolve('../../../gui2/rust-ffi/pkg/rust_ffi_bg.wasm')
+                                : rustFFIWasmName == null
+                                  ? null
+                                  : path.join(assets, rustFFIWasmName)
+                        if (server && rustFFIWasmPath != null) {
+                            await ydocServer.createGatewayServer(server, rustFFIWasmPath)
                         } else {
                             logger.warn('YDocs server is not run, new GUI may not work properly!')
                         }

--- a/app/ide-desktop/lib/dashboard/src/components/dashboard/ProjectIcon.tsx
+++ b/app/ide-desktop/lib/dashboard/src/components/dashboard/ProjectIcon.tsx
@@ -143,14 +143,15 @@ export default function ProjectIcon(props: ProjectIconProps) {
           { executeAsync: false, parentId: item2.parentId, cognitoCredentials: session },
           item2.title,
         ])
-        .then(() =>
-          waitUntilProjectIsReadyMutation.mutateAsync([
+        .then(async () => {
+          const proj = await waitUntilProjectIsReadyMutation.mutateAsync([
             item2.id,
             item2.parentId,
             item2.title,
             abortController.signal,
           ])
-        )
+          return proj
+        })
       setProjectStartupInfo({
         project: projectPromise,
         projectAsset: item2,

--- a/app/ide-desktop/lib/dashboard/src/utilities/Debug.tsx
+++ b/app/ide-desktop/lib/dashboard/src/utilities/Debug.tsx
@@ -9,22 +9,60 @@ import * as debugHooks from '#/hooks/debugHooks'
 // === Debug ===
 // =============
 
+let nextMountId = 0
+let nextRenderId = 0
+
 /** Props for a {@Link Debug}. */
 interface DebugProps {
   readonly name?: string
-  readonly monitorProps?: boolean
+  readonly monitorAll?: boolean
+  readonly monitorMountUnmount?: boolean
   readonly monitorRender?: boolean
+  readonly monitorProps?: boolean
+  readonly monitorPropCalls?: boolean
   readonly children: JSX.Element
 }
 
 /** A component that adds debugging info to its direct child. */
 export default function Debug(props: DebugProps) {
-  const { name, monitorProps = false, monitorRender = false, children } = props
+  const {
+    name,
+    monitorAll = false,
+    monitorMountUnmount = monitorAll,
+    monitorRender = monitorAll,
+    monitorProps = monitorAll,
+    monitorPropCalls = monitorAll,
+    children,
+  } = props
   const childPropsRaw: unknown = children.props
   const childProps: object = typeof childPropsRaw === 'object' ? childPropsRaw ?? {} : {}
   const propsValues: unknown[] = Object.values(childProps)
   const typeRaw: unknown = children.type
-  const typeName = name ?? (typeof typeRaw === 'function' ? typeRaw.name : String(children.type))
+  const typeName =
+    name ??
+    (typeof typeRaw === 'function'
+      ? typeRaw.name
+      : typeof typeRaw === 'object' && typeRaw != null && '$$typeof' in typeRaw
+        ? String(typeRaw.$$typeof)
+        : String(children.type))
+  const typeNameRef = React.useRef(typeName)
+  typeNameRef.current = typeName
+  const monitorMountUnmountRef = React.useRef(monitorMountUnmount)
+  monitorMountUnmountRef.current = monitorMountUnmount
+  const [mountId] = React.useState(() => `(Mount #${nextMountId++})`)
+  const renderId = `(Render #${nextRenderId++})`
+
+  React.useEffect(() => {
+    if (monitorMountUnmountRef.current) {
+      console.log(`[Debug(${typeNameRef.current})] Mounted ${mountId}`)
+    }
+    return () => {
+      if (monitorMountUnmountRef.current) {
+        console.log(`[Debug(${typeNameRef.current})] Unmounted ${mountId}`)
+      }
+    }
+  }, [mountId])
+
   debugHooks.useMonitorDependencies(
     [children.key, ...propsValues],
     typeName,
@@ -32,30 +70,36 @@ export default function Debug(props: DebugProps) {
     monitorProps
   )
 
-  const patchedChildProps = Object.fromEntries(
-    Object.entries(childProps).map(([key, value]: [string, unknown]) => [
-      key,
-      typeof value !== 'function'
-        ? value
-        : (...args: unknown[]) => {
-            console.group(`[Debug(${typeName})] Prop '${key}' called with args: [`, ...args, ']')
-            const result: unknown = value(...args)
-            console.log('Returned', result)
-            console.groupEnd()
-            return result
-          },
-    ])
-  )
+  const patchedChildProps = !monitorPropCalls
+    ? childProps
+    : Object.fromEntries(
+        Object.entries(childProps).map(([key, value]: [string, unknown]) => [
+          key,
+          typeof value !== 'function'
+            ? value
+            : (...args: unknown[]) => {
+                console.group(
+                  `[Debug(${typeName})] Prop '${key}' called with args: [`,
+                  ...args,
+                  ']'
+                )
+                const result: unknown = value(...args)
+                console.log('Returned', result)
+                console.groupEnd()
+                return result
+              },
+        ])
+      )
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const Component = children.type
   if (monitorRender) {
-    console.group(`[Debug(${typeName})] Rendering`, Component, childProps)
+    console.group(`[Debug(${typeName})] Rendering ${renderId}`, Component, childProps)
   }
   const element = <Component {...patchedChildProps} />
   React.useEffect(() => {
     if (monitorRender) {
-      console.log(`[Debug(${typeName})] Finished rendering`)
+      console.log(`[Debug(${typeName})] Finished rendering ${renderId}`)
       console.groupEnd()
     }
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -302,8 +302,7 @@
         "@stripe/stripe-js": "^2.1.10",
         "esbuild-plugin-inline-image": "^0.0.9",
         "eslint-plugin-react": "^7.32.2",
-        "eslint-plugin-react-hooks": "^4.6.0",
-        "is-hidden-file": "^1.1.2"
+        "eslint-plugin-react-hooks": "^4.6.0"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.7.2",
@@ -13779,21 +13778,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-hidden-file": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-hidden-file/-/is-hidden-file-1.1.2.tgz",
-      "integrity": "sha512-WS2Y+gFNWlK8IPAvcvsqa4rwf4kZUqGz3VTpHVhAu4Zvrbk+XPbve/RKacyyVNYxHQulubZshXXlzmfCR7G+WQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "os": [
-        "darwin",
-        "linux",
-        "win32"
-      ],
-      "dependencies": {
-        "cross-spawn": "^7.0.3"
       }
     },
     "node_modules/is-inside-container": {


### PR DESCRIPTION
### Pull Request Description
- Fix https://github.com/enso-org/cloud-v2/issues/1337
- Fix #10381 (same issue)
  - This was caused by queued execution context tasks delaying the disposal of the WebSocket connections - I guess because the WebSocket is closed, either the queue never reaches that point, or retries take too long to reach that point?
  - There was also another issue caused by the Dashboard incorrectly caching the `project`, causing the endpoint URLs to become outdated.

Misc changes:
- Change `Editor.tsx` to not return two different component trees. This avoids React unmounting and re-mounting the GUI app.

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
