### PR TITLE
Fix issues with Date.new Widgets and Some Viz Fixes.

### DIFF
--- a/app/gui2/src/components/visualizations/JSONVisualization/JsonValueWidget.vue
+++ b/app/gui2/src/components/visualizations/JSONVisualization/JsonValueWidget.vue
@@ -15,6 +15,11 @@ const emit = defineEmits<{
     :data="props.data"
     @createProjection="emit('createProjection', $event)"
   />
+  <JsonPrimitiveWidget
+    v-else-if="props.data && typeof props.data === 'object'&& (props.data as any).type === 'Nothing'"
+    :data="null"
+    @createProjection="emit('createProjection', $event)"
+  />
   <JsonObjectWidget
     v-else-if="props.data && typeof props.data === 'object'"
     :data="props.data"

--- a/app/gui2/src/components/visualizations/JSONVisualization/JsonValueWidget.vue
+++ b/app/gui2/src/components/visualizations/JSONVisualization/JsonValueWidget.vue
@@ -16,9 +16,10 @@ const emit = defineEmits<{
     @createProjection="emit('createProjection', $event)"
   />
   <JsonPrimitiveWidget
-    v-else-if="props.data && typeof props.data === 'object'&& (props.data as any).type === 'Nothing'"
+    v-else-if="
+      props.data && typeof props.data === 'object' && (props.data as any).type === 'Nothing'
+    "
     :data="null"
-    @createProjection="emit('createProjection', $event)"
   />
   <JsonObjectWidget
     v-else-if="props.data && typeof props.data === 'object'"

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json.enso
@@ -125,11 +125,13 @@ to_json_node value =
     case value of
         Nothing -> NullNode.getInstance
         b : Boolean -> BooleanNode.valueOf b
-        n : Integer -> LongNode.valueOf(n)
+        n : Integer ->
+            js_obj = n.to_js_object
+            if js_obj.is_a JS_Object then to_json_node js_obj else LongNode.valueOf n
         f : Float   ->
-            if f.is_nan || f.is_infinite then NullNode.getInstance else DoubleNode.valueOf(f)
+            if f.is_nan || f.is_infinite then NullNode.getInstance else DoubleNode.valueOf f
         t : Text    ->
-            TextNode.valueOf(t)
+            TextNode.valueOf t
         v : Vector  ->
             n = ArrayNode.new JsonNodeFactory.instance
             v.each e-> n.add (to_json_node e)

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Json/Extensions.enso
@@ -5,6 +5,7 @@ import project.Data.Json.JS_Object
 import project.Data.Json.Json
 import project.Data.Locale.Locale
 import project.Data.Map.Map
+import project.Data.Decimal.Decimal
 import project.Data.Numbers.Float
 import project.Data.Numbers.Integer
 import project.Data.Numbers.Number
@@ -58,6 +59,12 @@ Number.to_js_object self = case self of
         if self >= -js_max_integer && self < js_max_integer then self else
             JS_Object.from_pairs [["type", "BigInt"], ["value", self.to_text]]
     _ -> self
+
+## PRIVATE
+   Converts the given value to a JSON serializable object.
+Decimal.to_js_object : JS_Object
+Decimal.to_js_object self =
+    JS_Object.from_pairs [["type", "Decimal"], ["value", self.to_text], ["scale", self.scale], ["precision", self.precision]]
 
 ## PRIVATE
    Converts the given value to a JSON serializable object.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
@@ -96,8 +96,8 @@ type Date
          Get the local date of 5th August 1986.
 
              example_new = Date.new 1986 8 5
-    @year Widget.Numeric_Input
-    @month (Widget.Numeric_Input minimum=1 maximum=12)
+    @year (Widget.Numeric_Input display=Display.Always)
+    @month (Widget.Numeric_Input minimum=1 maximum=12 display=Display.Always)
     @day make_day_picker
     new : Integer -> Integer -> Integer -> Date ! Time_Error
     new year:Integer (month:Integer=1) (day:Integer=1) =
@@ -875,4 +875,4 @@ private make_day_picker cache=Nothing =
     max = if month.is_nothing then 31 else
         if month != 2 || year.is_nothing then days.at (month - 1) else
             if Date.new year month 1 . is_leap_year then 29 else 28
-    Widget.Numeric_Input minimum=1 maximum=max
+    Widget.Numeric_Input minimum=1 maximum=max display=Display.Always

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
@@ -1,9 +1,13 @@
+import project.Data.Json.JS_Object
 import project.Data.Numbers.Integer
 import project.Data.Numbers.Number
 import project.Data.Pair.Pair
 import project.Data.Text.Text
 import project.Data.Vector.Vector
+import project.Meta
 import project.Nothing.Nothing
+from project.Data.Json.Extensions import all
+from project.Data.Range.Extensions import all
 
 from project.Data.Boolean import Boolean, False, True
 
@@ -77,6 +81,23 @@ type Widget
 
     ## Describes a file chooser.
     File_Browse existing_only:Boolean=True label:(Nothing | Text)=Nothing display:Display=Display.When_Modified action:File_Action=File_Action.Open file_types:(Vector Pair)=[Pair.new "All Files" "*.*"]
+
+    ## PRIVATE
+       Override the to_js_object and don't include Nothing.
+    to_js_object : JS_Object
+    to_js_object self =
+        type_pair = [["type", Meta.type_of self . to_text]]
+
+        m = Meta.meta self
+        cons = m.constructor
+        cons_pair = [["constructor", cons.name]]
+
+        fs = m.fields
+        field_names = cons.fields
+        field_pairs = 0.up_to field_names.length . filter (i-> fs.at i . is_nothing . not) . map i->
+            [field_names.at i, fs.at i . to_js_object]
+
+        JS_Object.from_pairs (type_pair + cons_pair + field_pairs)
 
 ## PRIVATE
 make_single_choice : Vector -> Display -> Widget

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Helpers.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Helpers.enso
@@ -8,6 +8,8 @@ from Standard.Table import Column, Table
 import project.Id.Id
 import project.Table as Table_Visualization
 from project.Text import get_lazy_visualization_text_window
+from project.Table.Visualization import make_json_for_value
+
 
 ## PRIVATE
    Specifies that the builtin Table visualization should be used for any type,
@@ -70,6 +72,12 @@ Any.map_valid self f = f self
    - val: a value that will be evaluated and returned if `self` is an error.
 Any.catch_ : Any -> Any
 Any.catch_ self ~val = self.catch Any (_-> val)
+
+## PRIVATE
+   Returns a Text used to display this value in the IDE.
+Nothing.to_default_visualization_data : Text
+Nothing.to_default_visualization_data self =
+    '{"type": "Nothing"}'
 
 ## PRIVATE
    Returns a display representation of the dataflow error on which it is called.


### PR DESCRIPTION
### Pull Request Description

- Do not include nothing values for optional parameters when serializing widgets.
- Serialize Nothing as `{"type": "Nothing"}` for the default JSON viz.
- Add JS Object support for decimal.
- Fix `to_json` for large integers

![image](https://github.com/enso-org/enso/assets/4699705/88a404a3-537d-4be7-9a47-c896d2f8b378)

![image](https://github.com/enso-org/enso/assets/4699705/ce09955e-b377-431a-aca3-28f442c772a6)

![image](https://github.com/enso-org/enso/assets/4699705/d0c99a0b-1964-4874-8d87-41979a17a359)

![image](https://github.com/enso-org/enso/assets/4699705/32ade951-0921-4837-9c35-9b60488f863f)

![image](https://github.com/enso-org/enso/assets/4699705/f0fba27a-dfcc-4f17-a883-deb23757f74e)


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
