### PR TITLE
Separating `list` from `read` function and other small tweaks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 #### Enso Enso Standard Library
 
+- [Reamed `Data.list_directory` to `Data.list`. Removed list support from read
+  methods.][10434]
+
+[10434]: https://github.com/enso-org/enso/pull/10434
+
 # Enso 2024.2
 
 #### Enso IDE

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/S3/S3_File.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/S3/S3_File.enso
@@ -165,14 +165,15 @@ type S3_File
     read : File_Format -> Problem_Behavior -> Any ! S3_Error
     read self format=Auto_Detect (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) =
         if Data_Link.is_data_link self then Data_Link_Helpers.read_data_link self format on_problems else
-            case format of
-                Auto_Detect -> if self.is_directory then format.read self on_problems else
-                    response = translate_file_errors self <| S3.get_object self.s3_path.bucket self.s3_path.key self.credentials delimiter=S3_Path.delimiter
-                    response.decode Auto_Detect
-                _ ->
-                    metadata = File_Format_Metadata.Value path=self.path name=self.name
-                    resolved_format = File_Format.resolve format
-                    self.with_input_stream [File_Access.Read] (stream-> resolved_format.read_stream stream metadata)
+            if self.is_directory then Error.throw (Illegal_Argument.Error "Cannot `read` a directory, use `list`.") else
+                case format of
+                    Auto_Detect ->
+                        response = translate_file_errors self <| S3.get_object self.s3_path.bucket self.s3_path.key self.credentials delimiter=S3_Path.delimiter
+                        response.decode Auto_Detect
+                    _ ->
+                        metadata = File_Format_Metadata.Value path=self.path name=self.name
+                        resolved_format = File_Format.resolve format
+                        self.with_input_stream [File_Access.Read] (stream-> resolved_format.read_stream stream metadata)
 
     ## ALIAS load bytes, open bytes
        ICON data_input

--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/S3/S3_File.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/S3/S3_File.enso
@@ -388,7 +388,7 @@ type S3_File
     list self name_filter:Text="" recursive:Boolean=False =
         check_name_filter action = if name_filter != "" then Unimplemented.throw "S3 listing with name filter is not currently implemented." else action
         check_recursion action = if recursive then Unimplemented.throw "S3 listing with recursion is not currently implemented." else action
-        check_directory action = if self.is_directory.not then Error.throw (S3_Error.Error "Only folders can be listed." self.uri) else action
+        check_directory action = if self.is_directory.not then Error.throw (S3_Error.Error "Cannot `list` a non-directory." self.uri) else action
 
         check_directory <| check_recursion <| check_name_filter <|
             if self.s3_path.bucket == "" then translate_file_errors self <| S3.list_buckets self.credentials . map bucket-> S3_File.Value bucket "" self.credentials else

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
@@ -161,7 +161,7 @@ read_text path (encoding : Encoding = Encoding.default) (on_problems : Problem_B
 @directory Folder_Browse
 list : Text | File -> Text -> Boolean -> Vector File
 list (directory:(Text | File)=enso_project.root) (name_filter:Text="") recursive:Boolean=False =
-    file_obj = File.new path
+    file_obj = File.new directory
     if file_obj.is_directory.not then Error.throw (Illegal_Argument.Error "Cannot `list` a non-directory.") else
         file_obj.list name_filter=name_filter recursive=recursive
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data.enso
@@ -67,12 +67,15 @@ from project.System.File_Format import Auto_Detect, File_Format
          example_xls_to_table = Data.read Examples.xls (..Sheet 'Dates')
 @path Text_Input
 @format File_Format.default_widget
-read : Text | File -> File_Format -> Problem_Behavior -> Any ! File_Error
+read : Text | URI | File -> File_Format -> Problem_Behavior -> Any ! File_Error
 read path format=Auto_Detect (on_problems : Problem_Behavior = Problem_Behavior.Report_Warning) = case path of
     _ : Text -> if Data_Read_Helpers.looks_like_uri path then Data_Read_Helpers.fetch_following_data_links path format=format else
         read (File.new path) format on_problems
     uri : URI -> Data_Read_Helpers.fetch_following_data_links uri format=format
-    _ -> File.new path . read format on_problems
+    _ ->
+        file_obj = File.new path
+        if file_obj.is_directory then Error.throw (Illegal_Argument.Error "Cannot `read` a directory, use `Data.list`.") else
+            file_obj.read format on_problems
 
 ## ALIAS load text, open text
    GROUP Input
@@ -154,11 +157,13 @@ read_text path (encoding : Encoding = Encoding.default) (on_problems : Problem_B
          import Standard.Examples
 
          example_list_files =
-             Data.list_directory Examples.data_dir name_filter="**.md" recursive=True
+             Data.list Examples.data_dir name_filter="**.md" recursive=True
 @directory Folder_Browse
-list_directory : Text | File -> Text -> Boolean -> Vector File
-list_directory (directory:(Text | File)=enso_project.root) (name_filter:Text="") recursive:Boolean=False =
-    (directory:File) . list name_filter=name_filter recursive=recursive
+list : Text | File -> Text -> Boolean -> Vector File
+list (directory:(Text | File)=enso_project.root) (name_filter:Text="") recursive:Boolean=False =
+    file_obj = File.new path
+    if file_obj.is_directory.not then Error.throw (Illegal_Argument.Error "Cannot `list` a non-directory.") else
+        file_obj.list name_filter=name_filter recursive=recursive
 
 ## ALIAS download, http get
    GROUP Input

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Extensions.enso
@@ -981,12 +981,12 @@ Text.contains self term="" case_sensitivity=Case_Sensitivity.Sensitive = case ca
      the new text.
 
    > Example
-     Repeat the string "A" five times.
+     Repeat the text "A" five times.
 
          "A" * 5 == "AAAAA"
 
    > Example
-     Repeat the string "Hello " twice.
+     Repeat the text "Hello " twice.
 
          "Hello " * 2 == "Hello Hello "
 Text.* : Integer -> Text
@@ -1002,12 +1002,12 @@ Text.* self count = self.repeat count
      the new text.
 
    > Example
-     Repeat the string "ABBA" five times.
+     Repeat the text "ABBA" five times.
 
          "ABBA".repeat 5 == "ABBAABBAABBAABBAABBA"
 
    > Example
-     Repeat the string "Hello " twice.
+     Repeat the text "Hello " twice.
 
          "Hello ".repeat 2 == "Hello Hello "
 Text.repeat : Integer -> Text

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Text/Regex.enso
@@ -418,12 +418,6 @@ type Regex
             if should_recompile.not then self else
                 Regex.compile self.pattern case_insensitive
 
-    ## PRIVATE
-
-       Get the original pattern string as a `Text`.
-    pattern_string : Text
-    pattern_string self = self.internal_regex_object.pattern
-
 ## PRIVATE
    Convert the polyglot map to a Map.
 polyglot_map_to_map : Any -> Map Any Any

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Time/Date.enso
@@ -868,11 +868,12 @@ Date.from (that:JS_Object) =
         Error.throw (Illegal_Argument.Error "Invalid JS_Object for Date.from.")
 
 ## PRIVATE
-private make_day_picker cache=Nothing =
+private make_day_picker value cache =
+    _ = value
     year = cache.if_not_nothing <| cache "year"
     month = cache.if_not_nothing <| cache "month"
     days = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
     max = if month.is_nothing then 31 else
         if month != 2 || year.is_nothing then days.at (month - 1) else
-            if Date.new year month 1 . is_leap_year then 29 else 28
+            if Date.new year 1 1 . is_leap_year then 29 else 28
     Widget.Numeric_Input minimum=1 maximum=max display=Display.Always

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
@@ -416,7 +416,7 @@ type Enso_File
 
 ## PRIVATE
 list_assets (parent : Enso_File) -> Vector Existing_Enso_Asset =
-    Existing_Enso_Asset.get_asset_reference_for parent . list_directory
+    Existing_Enso_Asset.get_asset_reference_for parent . list
 
 type Enso_Asset_Type
     ## Represents an Enso project.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
@@ -310,7 +310,7 @@ type Enso_File
        ICON data_input
        Gets a list of assets within self.
     list : Vector Enso_File
-    list self =
+    list self = if self.is_directory.not then Error.throw (Illegal_Argument.Error "Cannot `list` a non-directory.") else
         # Remove secrets from the list - they are handled separately in `Enso_Secret.list`.
         assets = list_assets self . filter f-> f.asset_type != Enso_Asset_Type.Secret
         assets.map asset->

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
@@ -259,7 +259,7 @@ type Enso_File
                 json = Utils.http_request_as_json HTTP_Method.Get asset.internal_uri
                 datalink = Data_Link_Helpers.interpret_json_as_data_link json
                 datalink.read format on_problems
-            Enso_Asset_Type.Directory -> if format == Auto_Detect then self.list else Error.throw (Illegal_Argument.Error "Directories can only be read using the Auto_Detect format.")
+            Enso_Asset_Type.Directory -> Error.throw (Illegal_Argument.Error "Cannot `read` a directory, use `list`.")
             Enso_Asset_Type.File ->
                 read_with_format effective_format =
                     metadata = File_Format_Metadata.from self

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
@@ -416,7 +416,7 @@ type Enso_File
 
 ## PRIVATE
 list_assets (parent : Enso_File) -> Vector Existing_Enso_Asset =
-    Existing_Enso_Asset.get_asset_reference_for parent . list
+    Existing_Enso_Asset.get_asset_reference_for parent . list_directory
 
 type Enso_Asset_Type
     ## Represents an Enso project.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Existing_Enso_Asset.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Existing_Enso_Asset.enso
@@ -98,7 +98,7 @@ type Existing_Enso_Asset
     is_regular_file self = self.asset_type == Enso_Asset_Type.File
 
     ## PRIVATE
-    list self =
+    list_directory self =
         if self.asset_type != Enso_Asset_Type.Directory then Error.throw (Illegal_Argument.Error "Only directories can be listed.") else
              response = Utils.http_request_as_json HTTP_Method.Get self.internal_uri
              assets = get_required_field "assets" response expected_type=Vector

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Existing_Enso_Asset.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Existing_Enso_Asset.enso
@@ -98,7 +98,7 @@ type Existing_Enso_Asset
     is_regular_file self = self.asset_type == Enso_Asset_Type.File
 
     ## PRIVATE
-    list_directory self =
+    list self =
         if self.asset_type != Enso_Asset_Type.Directory then Error.throw (Illegal_Argument.Error "Only directories can be listed.") else
              response = Utils.http_request_as_json HTTP_Method.Get self.internal_uri
              assets = get_required_field "assets" response expected_type=Vector

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Metadata.enso
@@ -94,7 +94,7 @@ type Widget
 
         fs = m.fields
         field_names = cons.fields
-        field_pairs = 0.up_to field_names.length . filter (i-> fs.at i . is_nothing . not) . map i->
+        field_pairs = 0.up_to field_names.length . filter (i-> (field_names.at i == "label") || (fs.at i . is_nothing . not)) . map i->
             [field_names.at i, fs.at i . to_js_object]
 
         JS_Object.from_pairs (type_pair + cons_pair + field_pairs)

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -294,9 +294,10 @@ type File
     read : File_Format -> Problem_Behavior -> Any ! File_Error
     read self format=Auto_Detect (on_problems : Problem_Behavior = ..Report_Warning) =
         if self.exists.not then Error.throw (File_Error.Not_Found self) else
-            if Data_Link.is_data_link self then Data_Link_Helpers.read_data_link self format on_problems else
-                resolved_format = File_Format.resolve format
-                resolved_format.read self on_problems
+            if self.is_directory then Error.throw (Illegal_Argument.Error "Cannot `read` a directory, use `list`.") else
+                if Data_Link.is_data_link self then Data_Link_Helpers.read_data_link self format on_problems else
+                    resolved_format = File_Format.resolve format
+                    resolved_format.read self on_problems
 
     ## ALIAS load bytes, open bytes
        ICON data_input

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File.enso
@@ -790,16 +790,17 @@ type File
                  Examples.data_dir.list name_filter="**.{txt,md}" recursive=True
     list : Text -> Boolean -> Vector File
     list self name_filter:Text="" recursive:Boolean=False =
-        all_files = if recursive then list_descendants self else self.list_immediate_children
-        case name_filter of
-            "" -> all_files
-            _ ->
-                used_filter = if recursive.not || name_filter.contains "**" then name_filter else
-                    (if name_filter.starts_with "*" then "*" else "**/") + name_filter
-                matcher = File_Utils.matchPath "glob:"+used_filter
-                all_files.filter file->
-                    pathStr = self.relativize file . path
-                    File_Utils.matches matcher pathStr
+        if self.is_directory.not then Error.throw (Illegal_Argument.Error "Cannot `list` a non-directory.") else
+            all_files = if recursive then list_descendants self else self.list_immediate_children
+            case name_filter of
+                "" -> all_files
+                _ ->
+                    used_filter = if recursive.not || name_filter.contains "**" then name_filter else
+                        (if name_filter.starts_with "*" then "*" else "**/") + name_filter
+                    matcher = File_Utils.matchPath "glob:"+used_filter
+                    all_files.filter file->
+                        pathStr = self.relativize file . path
+                        File_Utils.matches matcher pathStr
 
     ## GROUP Metadata
        ICON metadata

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
@@ -51,7 +51,7 @@ type Auto_Detect
     ## PRIVATE
        Implements the `File.read` for this `File_Format`
     read : File -> Problem_Behavior -> Any ! File_Error
-    read self file on_problems:Problem_Behavior = if file.is_directory then file.list else
+    read self file on_problems:Problem_Behavior =
         metadata = File_Format_Metadata.from file
         reader = Auto_Detect.get_reading_format metadata
         if reader == Nothing then Error.throw (File_Error.Unsupported_Type file) else

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Column.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/DB_Column.enso
@@ -1455,7 +1455,7 @@ type DB_Column
             params = Replace_Params.Value input_type case_sensitivity only_first
             self.connection.dialect.if_replace_params_supports params <|
                 raw_term = case term of
-                    _ : Regex -> term.pattern_string
+                    _ : Regex -> term.pattern
                     _ -> term
                 new_name = self.naming_helper.function_name "replace" [self, raw_term, new_text]
                 self.make_op "REPLACE" [raw_term, new_text] new_name [term, params]

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
@@ -596,18 +596,18 @@ replace args metadata =
                     _ ->
                         SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ escaped_pattern ++ ", " ++ replacement ++ ")"
         Regex ->
-            pattern_string = SQL_Builder.interpolation raw_pattern.pattern_string
+            pattern = SQL_Builder.interpolation raw_pattern.pattern
             case replace_params.only_first of
                 False -> case replace_params.case_sensitivity of
                     Case_Sensitivity.Insensitive _ ->
-                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern_string ++ ", " ++ replacement ++ ", 'ig')"
+                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern ++ ", " ++ replacement ++ ", 'ig')"
                     _ ->
-                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern_string ++ ", " ++ replacement ++ ", 'g')"
+                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern ++ ", " ++ replacement ++ ", 'g')"
                 True -> case replace_params.case_sensitivity of
                     Case_Sensitivity.Insensitive _ ->
-                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern_string ++ ", " ++ replacement ++ ", 'i')"
+                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern ++ ", " ++ replacement ++ ", 'i')"
                     _ ->
-                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern_string ++ ", " ++ replacement ++ ")"
+                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern ++ ", " ++ replacement ++ ")"
         DB_Column ->
             case replace_params.only_first of
                 False -> case replace_params.case_sensitivity of

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
@@ -596,18 +596,18 @@ replace args metadata =
                     _ ->
                         SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ escaped_pattern ++ ", " ++ replacement ++ ")"
         Regex ->
-            pattern = SQL_Builder.interpolation raw_pattern.pattern
+            pattern_text = SQL_Builder.interpolation raw_pattern.pattern
             case replace_params.only_first of
                 False -> case replace_params.case_sensitivity of
                     Case_Sensitivity.Insensitive _ ->
-                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern ++ ", " ++ replacement ++ ", 'ig')"
+                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern_text ++ ", " ++ replacement ++ ", 'ig')"
                     _ ->
-                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern ++ ", " ++ replacement ++ ", 'g')"
+                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern_text ++ ", " ++ replacement ++ ", 'g')"
                 True -> case replace_params.case_sensitivity of
                     Case_Sensitivity.Insensitive _ ->
-                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern ++ ", " ++ replacement ++ ", 'i')"
+                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern_text ++ ", " ++ replacement ++ ", 'i')"
                     _ ->
-                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern ++ ", " ++ replacement ++ ")"
+                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern_text ++ ", " ++ replacement ++ ")"
         DB_Column ->
             case replace_params.only_first of
                 False -> case replace_params.case_sensitivity of

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
@@ -501,18 +501,18 @@ replace args metadata =
                     _ ->
                         SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ escaped_pattern ++ ", " ++ replacement ++ ", 1, 1)"
         Regex ->
-            pattern_string = SQL_Builder.interpolation raw_pattern.pattern_string
+            pattern = SQL_Builder.interpolation raw_pattern.pattern
             case replace_params.only_first of
                 False -> case replace_params.case_sensitivity of
                     Case_Sensitivity.Insensitive _ ->
-                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern_string ++ ", " ++ replacement ++ ", 1, 0, 'i')"
+                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern ++ ", " ++ replacement ++ ", 1, 0, 'i')"
                     _ ->
-                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern_string ++ ", " ++ replacement ++ ")"
+                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern ++ ", " ++ replacement ++ ")"
                 True -> case replace_params.case_sensitivity of
                     Case_Sensitivity.Insensitive _ ->
-                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern_string ++ ", " ++ replacement ++ ", 1, 1, 'i')"
+                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern ++ ", " ++ replacement ++ ", 1, 1, 'i')"
                     _ ->
-                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern_string ++ ", " ++ replacement ++ ", 1, 1)"
+                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern ++ ", " ++ replacement ++ ", 1, 1)"
         DB_Column ->
             case replace_params.only_first of
                 False -> case replace_params.case_sensitivity of

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
@@ -501,18 +501,18 @@ replace args metadata =
                     _ ->
                         SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ escaped_pattern ++ ", " ++ replacement ++ ", 1, 1)"
         Regex ->
-            pattern = SQL_Builder.interpolation raw_pattern.pattern
+            pattern_text = SQL_Builder.interpolation raw_pattern.pattern
             case replace_params.only_first of
                 False -> case replace_params.case_sensitivity of
                     Case_Sensitivity.Insensitive _ ->
-                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern ++ ", " ++ replacement ++ ", 1, 0, 'i')"
+                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern_text ++ ", " ++ replacement ++ ", 1, 0, 'i')"
                     _ ->
-                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern ++ ", " ++ replacement ++ ")"
+                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern_text ++ ", " ++ replacement ++ ")"
                 True -> case replace_params.case_sensitivity of
                     Case_Sensitivity.Insensitive _ ->
-                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern ++ ", " ++ replacement ++ ", 1, 1, 'i')"
+                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern_text ++ ", " ++ replacement ++ ", 1, 1, 'i')"
                     _ ->
-                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern ++ ", " ++ replacement ++ ", 1, 1)"
+                        SQL_Builder.code "REGEXP_REPLACE(" ++ input ++ ", " ++ pattern_text ++ ", " ++ replacement ++ ", 1, 1)"
         DB_Column ->
             case replace_params.only_first of
                 False -> case replace_params.case_sensitivity of

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
@@ -2686,26 +2686,26 @@ run_vectorized_binary_op_with_fallback_problem_handling column name operand fall
    Arguments:
    - column: The column to get the item from.
    - ix: The index in the column from which to get the item.
-get_item_string : Column -> Integer -> Text
-get_item_string column ix =
+get_item_as_text : Column -> Integer -> Text
+get_item_as_text column ix =
     item = column.getItem ix
     ## TODO This special handling of `Text` is because `"a".to_text` evaluates
        to "'a'" and not just "a". The code can be simplified once the following
        task is implemented:
        https://www.pivotaltracker.com/story/show/181499256
     case item of
-        _ : Text -> normalize_string_for_display item
+        _ : Text -> normalize_text_for_display item
         _ -> item.pretty
 
 ## PRIVATE
-   Ensures that the string can be safely displayed in a terminal.
+   Ensures that the text can be safely displayed in a terminal.
 
    If the string contains special characters, it will be wrapped in quotes and
    the characters escaped. Otherwise, the string is returned as-is.
-normalize_string_for_display string =
-    prettified = string.pretty
-    just_quoted = "'" + string + "'"
-    if prettified == just_quoted then string else prettified
+normalize_text_for_display text =
+    prettified = text.pretty
+    just_quoted = "'" + text + "'"
+    if prettified == just_quoted then text else prettified
 
 ## PRIVATE
    A helper to create a new table consisting of slices of the original table.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Display_Helpers.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Display_Helpers.enso
@@ -1,7 +1,7 @@
 from Standard.Base import all
 
 import project.Table.Table
-from project.Column import get_item_string, normalize_string_for_display
+from project.Column import get_item_as_text, normalize_text_for_display
 
 polyglot java import java.lang.System as Java_System
 
@@ -22,12 +22,12 @@ polyglot java import java.lang.System as Java_System
      codes for rich formatting in the terminal.
 display_table (table : Table) (add_row_index : Boolean) (max_rows_to_show : Integer) (all_rows_count : Integer) (format_terminal : Boolean) -> Text =
     cols = Vector.from_polyglot_array table.java_table.getColumns
-    col_names = cols.map .getName . map normalize_string_for_display
+    col_names = cols.map .getName . map normalize_text_for_display
     col_vals = cols.map .getStorage
     display_rows = table.row_count.min max_rows_to_show
     rows = Vector.new display_rows row_num->
         cols = col_vals.map col->
-            if col.isNothing row_num then "Nothing" else get_item_string col row_num
+            if col.isNothing row_num then "Nothing" else get_item_as_text col row_num
         if add_row_index then [row_num.to_text] + cols else cols
     table_text = case add_row_index of
         True -> print_table [""]+col_names rows 1 format_terminal

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Parse_To_Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Internal/Parse_To_Table.enso
@@ -17,11 +17,11 @@ from project.Errors import Duplicate_Output_Column_Names
 
    See Text.parse_to_table.
 parse_text_to_table : Text | Regex -> Text -> Case_Sensitivity -> Boolean -> Problem_Behavior -> Table ! Type_Error | Regex_Syntax_Error | Illegal_Argument
-parse_text_to_table text regex_or_pattern_string="." case_sensitivity=Case_Sensitivity.Default parse_values=True on_problems=Report_Warning =
+parse_text_to_table text regex_or_pattern="." case_sensitivity=Case_Sensitivity.Default parse_values=True on_problems=Report_Warning =
     case_insensitive = case_sensitivity.is_case_insensitive_in_memory
-    pattern = case regex_or_pattern_string of
-        _ : Regex -> regex_or_pattern_string.recompile case_sensitivity
-        _ : Text -> Regex.compile regex_or_pattern_string case_insensitive=case_insensitive
+    pattern = case regex_or_pattern of
+        _ : Regex -> regex_or_pattern.recompile case_sensitivity
+        _ : Text -> Regex.compile regex_or_pattern case_insensitive=case_insensitive
     matches = pattern.match_all text
 
     columns = case pattern.group_count == 1 of

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -69,7 +69,7 @@ import project.Sort_Column.Sort_Column
 import project.Value_Type.Auto
 import project.Value_Type.By_Type
 import project.Value_Type.Value_Type
-from project.Column import get_item_string, make_storage_builder_for_type, normalize_string_for_display
+from project.Column import make_storage_builder_for_type
 from project.Errors import all
 from project.Internal.Filter_Condition_Helpers import make_filter_column
 from project.Internal.Lookup_Helpers import make_java_lookup_column_description

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Faker.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Faker.enso
@@ -46,9 +46,9 @@ type Faker
                 n = "0123456789".char_vector
                 s = "ABCDFMP ".char_vector
                 template = [l, l, n, n, n, n, n, s]
-                ni_number = Faker.new . string_value template
-    string_value : Vector | Text -> Text
-    string_value self template =
+                ni_number = Faker.new . text_value template
+    text_value : Vector | Text -> Text
+    text_value self template =
         case template of
             _ : Text ->
                  char_vector = template.characters.map c-> case c of
@@ -56,7 +56,7 @@ type Faker
                     "a" -> Faker.lower_case_letters
                     "0" -> Faker.numbers
                     _ -> [c]
-                 self.string_value char_vector
+                 self.text_value char_vector
             _ ->
                 characters = template.map possible_chars->
                     selected_char_ix = self.generator.nextInt possible_chars.length
@@ -73,7 +73,7 @@ type Faker
     alpha : Integer -> Boolean -> Text
     alpha self length=1 upper_case=False =
         alphabet = if upper_case then Faker.upper_case_letters else Faker.lower_case_letters
-        self.string_value <| 0.up_to length . map _->alphabet
+        self.text_value <| 0.up_to length . map _->alphabet
 
     ## GROUP Standard.Base.Random
        ICON random
@@ -85,7 +85,7 @@ type Faker
     alpha_numeric : Integer -> Boolean -> Text
     alpha_numeric self length=1 upper_case=False =
         alphabet = (if upper_case then Faker.upper_case_letters else Faker.lower_case_letters) + Faker.numbers
-        self.string_value <| 0.up_to length . map _->alphabet
+        self.text_value <| 0.up_to length . map _->alphabet
 
     ## GROUP Standard.Base.Random
        ICON random
@@ -96,7 +96,7 @@ type Faker
     hexadecimal : Integer -> Text
     hexadecimal self length=1 =
         alphabet = "0123456789ABCDEF".char_vector
-        self.string_value <| 0.up_to length . map _->alphabet
+        self.text_value <| 0.up_to length . map _->alphabet
 
     ## GROUP Standard.Base.Random
        ICON random

--- a/test/AWS_Tests/src/S3_Spec.enso
+++ b/test/AWS_Tests/src/S3_Spec.enso
@@ -328,7 +328,7 @@ add_specs suite_builder =
                 # But the file cannot be listed:
                 err = new_file.list
                 err.should_fail_with S3_Error
-                err.catch.to_display_text . should_contain "Only folders can be listed"
+                err.catch.to_display_text . should_contain "Cannot `list` a non-directory."
 
             new_file.delete . should_succeed
 

--- a/test/Base_Tests/src/System/File_Spec.enso
+++ b/test/Base_Tests/src/System/File_Spec.enso
@@ -862,7 +862,7 @@ add_specs suite_builder =
             filtered1 = root.list name_filter="s[a-cw]mple.{t?t,md}"
             filtered1.should_equal [root / "sample.txt"]
 
-            filtered2 = Data.list_directory root name_filter="*di*"
+            filtered2 = Data.list root name_filter="*di*"
             filtered2.should_equal [root / "subdirectory"]
 
         group_builder.specify "should list files in a directory recursively" <|

--- a/test/Benchmarks/src/Natural_Order_Sort.enso
+++ b/test/Benchmarks/src/Natural_Order_Sort.enso
@@ -16,7 +16,7 @@ create_unsorted vector_size faker =
     l = Faker.upper_case_letters
     n = Faker.numbers
     template = [l, l, l, n, n, n, n, n, l]
-    0.up_to vector_size . map _->(faker.string_value template)
+    0.up_to vector_size . map _->(faker.text_value template)
 
 
 collect_benches = Bench.build builder->

--- a/test/Benchmarks/src/Number_Parse.enso
+++ b/test/Benchmarks/src/Number_Parse.enso
@@ -10,14 +10,14 @@ type Data
     Value ~float_strings ~int_strings
 
     create vector_size faker =
-        Data.Value (create_float_strings vector_size faker) (create_int_strings vector_size faker)
+        Data.Value (create_float_texts vector_size faker) (create_int_texts vector_size faker)
 
 
-create_float_strings vector_size faker =
+create_float_texts vector_size faker =
     Vector.new vector_size _->(faker.float -1000000000 1000000000).to_text
 
 
-create_int_strings vector_size faker =
+create_int_texts vector_size faker =
     Vector.new vector_size _->(faker.integer -1000000000 1000000000).to_text
 
 

--- a/test/Benchmarks/src/Text/Compare.enso
+++ b/test/Benchmarks/src/Text/Compare.enso
@@ -16,7 +16,7 @@ create_very_short_template character_template =
 
 create_very_short character_template faker =
     very_short_template = create_very_short_template character_template
-    Vector.new 100000 _-> '🤩' + faker.string_value very_short_template
+    Vector.new 100000 _-> '🤩' + faker.text_value very_short_template
 
 
 create_medium_template character_template =
@@ -25,7 +25,7 @@ create_medium_template character_template =
 
 create_medium character_template faker =
     medium_template = create_medium_template character_template
-    Vector.new 10000 _-> faker.string_value medium_template
+    Vector.new 10000 _-> faker.text_value medium_template
 
 
 create_big_template character_template =
@@ -34,14 +34,14 @@ create_big_template character_template =
 
 create_big_random character_template faker =
     big_template = create_big_template character_template
-    Vector.new 100 _-> faker.string_value big_template
+    Vector.new 100 _-> faker.text_value big_template
 
 
 create_big_early_difference character_template faker =
     big_a_codepoint = 65
     big_template = create_big_template character_template
     Vector.new 100 ix->
-        "bb" + (Text.from_codepoints [big_a_codepoint + ix%5]) + "aaa" + (faker.string_value big_template)
+        "bb" + (Text.from_codepoints [big_a_codepoint + ix%5]) + "aaa" + (faker.text_value big_template)
 
 
 create_big_late_difference common_prefix =

--- a/test/Benchmarks/src/Text/Contains.enso
+++ b/test/Benchmarks/src/Text/Contains.enso
@@ -30,7 +30,7 @@ create_alpha_template character_template length =
 
 create_big_random character_template faker =
     big_template = create_alpha_template character_template 10000
-    Vector.new 200 _-> faker.string_value big_template
+    Vector.new 200 _-> faker.text_value big_template
 
 
 collect_benches = Bench.build builder->

--- a/test/Benchmarks/src/Text/Pretty.enso
+++ b/test/Benchmarks/src/Text/Pretty.enso
@@ -26,12 +26,12 @@ create_template length =
 
 create_very_short_random faker =
     very_short_template = create_template 40
-    faker.string_value very_short_template
+    faker.text_value very_short_template
 
 
 create_big_random faker =
     big_template = create_template 100000
-    faker.string_value big_template
+    faker.text_value big_template
 
 
 ## The `Text.pretty` benchmarks check both scenarios where the Texts are

--- a/test/Benchmarks/src/Text/Reverse.enso
+++ b/test/Benchmarks/src/Text/Reverse.enso
@@ -21,12 +21,12 @@ create_template length =
 
 create_very_short_random faker =
     very_short_template = create_template 4
-    faker.string_value very_short_template
+    faker.text_value very_short_template
 
 
 create_big_random faker =
     big_template = create_template 100000
-    faker.string_value big_template
+    faker.text_value big_template
 
 
 ## The `Text.reverse` benchmarks check both scenarios where the Texts are

--- a/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
+++ b/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
@@ -95,11 +95,6 @@ add_specs suite_builder =
             r1.should_fail_with File_Error
             r1.catch.should_be_a File_Error.Not_Found
 
-            directory = enso_project.data
-            r2 = Data.read directory (..Delimited "," headers=True value_formatter=Nothing) Problem_Behavior.Report_Error
-            r2.should_fail_with File_Error
-            r2.catch.should_be_a File_Error.IO_Error
-
         group_builder.specify "should work with all kinds of line endings" <|
             path name = enso_project.data / 'transient' / name
             create_file name ending_style =

--- a/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
+++ b/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
@@ -98,7 +98,7 @@ add_specs suite_builder =
             directory = enso_project.data
             r2 = Data.read directory (..Delimited "," headers=True value_formatter=Nothing) Problem_Behavior.Report_Error
             r2.should_fail_with Illegal_Argument
-            r2.catch.message.shoild_equal "Cannot `read` a directory, use `Data.list`."
+            r2.catch.message.should_equal "Cannot `read` a directory, use `Data.list`."
 
         group_builder.specify "should work with all kinds of line endings" <|
             path name = enso_project.data / 'transient' / name

--- a/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
+++ b/test/Table_Tests/src/IO/Delimited_Read_Spec.enso
@@ -95,6 +95,11 @@ add_specs suite_builder =
             r1.should_fail_with File_Error
             r1.catch.should_be_a File_Error.Not_Found
 
+            directory = enso_project.data
+            r2 = Data.read directory (..Delimited "," headers=True value_formatter=Nothing) Problem_Behavior.Report_Error
+            r2.should_fail_with Illegal_Argument
+            r2.catch.message.shoild_equal "Cannot `read` a directory, use `Data.list`."
+
         group_builder.specify "should work with all kinds of line endings" <|
             path name = enso_project.data / 'transient' / name
             create_file name ending_style =


### PR DESCRIPTION
### Pull Request Description

- Rename `Faker.string_value` to `Faker.text_value`.
- Remove `Regex.pattern_string` as duplicate of `Regex.pattern`.
- Sort the Date picker.
- Rename `Data.list_directory` to `Data.list`.
- Remove support for reading a directory.

![image](https://github.com/enso-org/enso/assets/4699705/b42bb3c9-e63b-49f2-8cdc-4666cb6d968e)

![image](https://github.com/enso-org/enso/assets/4699705/97f49891-5ae5-4f0a-9a41-6200888fcd86)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
