### PR TITLE
Low-hanging perf improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2226,7 +2226,6 @@ lazy val `runtime-compiler` =
       annotationProcSetting,
       (Test / fork) := true,
       libraryDependencies ++= Seq(
-        "com.chuusai"     %% "shapeless"               % shapelessVersion   % "provided",
         "junit"            % "junit"                   % junitVersion       % Test,
         "com.github.sbt"   % "junit-interface"         % junitIfVersion     % Test,
         "org.scalatest"   %% "scalatest"               % scalatestVersion   % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -548,7 +548,6 @@ val scalacticVersion        = "3.3.0-SNAP4"
 val scalaLoggingVersion     = "3.9.4"
 val scalameterVersion       = "0.19"
 val scalatestVersion        = "3.3.0-SNAP4"
-val shapelessVersion        = "2.3.10"
 val slf4jVersion            = JPMSUtils.slf4jVersion
 val sqliteVersion           = "3.42.0.0"
 val tikaVersion             = "2.4.1"

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -64,7 +64,7 @@ import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.time.Clock
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.DurationInt
 
 /** A main module containing all components of the server.
   *
@@ -91,7 +91,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
     new File(serverConfig.contentRootPath)
   )
 
-  private val openAiKey = sys.env.get("OPENAI_API_KEY")
+  private val openAiKey = Option(java.lang.System.getenv("OPENAI_API_KEY"))
   private val openAiCfg = openAiKey.map(AICompletionConfig)
 
   val languageServerConfig = Config(

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/IRPass.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/IRPass.scala
@@ -5,7 +5,6 @@ import org.enso.compiler.core.{CompilerError, IR, Identifier}
 import org.enso.compiler.core.ir.ProcessingPass
 import org.enso.compiler.core.ir.Module
 import org.enso.compiler.core.ir.Expression
-import shapeless.=:!=
 
 import java.util.UUID
 import scala.annotation.unused
@@ -129,7 +128,7 @@ object IRPass {
       * @return `ev`, cast to `T` if it is a `T`
       */
     def as[T <: Metadata: ClassTag](implicit
-      @unused ev: T =:!= Metadata
+      @unused ev: T =!= Metadata
     ): Option[T] = {
       this match {
         case p: T => Some(p)
@@ -146,7 +145,7 @@ object IRPass {
       */
     @throws[CompilerError]
     def unsafeAs[T <: Metadata: ClassTag](implicit
-      @unused ev: T =:!= Metadata
+      @unused ev: T =!= Metadata
     ): T = {
       this
         .as[T]
@@ -182,5 +181,19 @@ object IRPass {
       /** @inheritdoc */
       override def duplicate(): Option[Metadata] = Some(this)
     }
+  }
+
+  // https://stackoverflow.com/questions/6909053/enforce-type-difference
+
+  sealed class =!=[A, B]
+
+  trait LowerPriorityImplicits {
+    implicit def equal[A]: =!=[A, A] = sys.error("should not be called")
+  }
+  object =!= extends LowerPriorityImplicits {
+    implicit def nequal[A, B](implicit same: A =:= B = null): =!=[A, B] =
+      if (same != null)
+        sys.error("should not be called explicitly with same type")
+      else new =!=[A, B]
   }
 }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/optimise/LambdaConsolidate.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/optimise/LambdaConsolidate.scala
@@ -418,20 +418,21 @@ case object LambdaConsolidate extends IRPass {
   ): List[DefinitionArgument] = {
     argsWithShadowed.map {
       case (
-            spec @ DefinitionArgument.Specified(name, _, _, _, _, _, _),
+            spec: DefinitionArgument.Specified,
             isShadowed
           ) =>
+        val oldName = spec.name
         val newName =
           if (isShadowed) {
             freshNameSupply
-              .newName(from = Some(name))
+              .newName(from = Some(oldName))
               .copy(
-                location    = name.location,
-                passData    = name.passData,
-                diagnostics = name.diagnostics,
-                id          = name.getId
+                location    = oldName.location,
+                passData    = oldName.passData,
+                diagnostics = oldName.diagnostics,
+                id          = oldName.getId
               )
-          } else name
+          } else oldName
 
         spec.copy(name = newName)
     }

--- a/lib/scala/distribution-manager/src/main/scala/org/enso/distribution/locking/ThreadSafeFileLockManager.scala
+++ b/lib/scala/distribution-manager/src/main/scala/org/enso/distribution/locking/ThreadSafeFileLockManager.scala
@@ -35,7 +35,7 @@ import java.nio.file.Path
   */
 class ThreadSafeFileLockManager(locksRoot: Path) extends ThreadSafeLockManager {
   val fileLockManager = new FileLockManager(locksRoot)
-  val localLocks =
+  lazy val localLocks =
     collection.concurrent.TrieMap.empty[String, ThreadSafeLock]
 
   /** A thread-safe wrapper for a file lock - ensures that the process holds at


### PR DESCRIPTION
### Pull Request Description

- avoid loading shapeless for the sole purpose of having a compile-time
  type inequality
- don't use `sys.env` to avoid some Scala conversions
- lazy initialization of fields

### Important Notes

On a slow machine, so easier to spot.

![Screenshot from 2024-07-05 16-15-06](https://github.com/enso-org/enso/assets/292128/a07f42c5-9bee-492b-aad1-46fab7b6476f)
![Screenshot from 2024-07-05 18-14-53](https://github.com/enso-org/enso/assets/292128/694c4fb1-dfda-4629-8bd3-21c765612ec3)


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
