### PR TITLE
Add `projectsDirectory` parameter to project endpoint

### DIFF
--- a/docs/language-server/project-manager-http-endpoints.md
+++ b/docs/language-server/project-manager-http-endpoints.md
@@ -19,9 +19,9 @@ JSONRPC protocol.
 
 ## `/projects/{project_id}/enso-project?projectsDirectory={projects_path}`
 
-HTTP endpoint that returns the project structure in `.enso-project` format.
-The optional `projectsDirectory` parameter allows the user to specify a custom 
-path to projects' directory (e.g. if it is in a subfolder).
+HTTP endpoint that returns the project structure in `.enso-project` format. The
+optional `projectsDirectory` parameter allows the user to specify a custom path
+to projects' directory (e.g. if it is in a subfolder).
 
 ### `GET`
 

--- a/docs/language-server/project-manager-http-endpoints.md
+++ b/docs/language-server/project-manager-http-endpoints.md
@@ -20,7 +20,8 @@ JSONRPC protocol.
 ## `/projects/{project_id}/enso-project?projectsDirectory={projects_path}`
 
 HTTP endpoint that returns the project structure in `.enso-project` format.
-The subdirectory path to the project is optional.
+The optional `projectsDirectory` parameter allows the user to specify a custom 
+path to projects' directory (e.g. if it is in a subfolder).
 
 ### `GET`
 

--- a/docs/language-server/project-manager-http-endpoints.md
+++ b/docs/language-server/project-manager-http-endpoints.md
@@ -17,7 +17,7 @@ JSONRPC protocol.
 
 <!-- /MarkdownTOC -->
 
-## `/projects/{project_id}/enso-project?subdirectory={subdirectory_path}`
+## `/projects/{project_id}/enso-project?projectsDirectory={projects_path}`
 
 HTTP endpoint that returns the project structure in `.enso-project` format.
 The subdirectory path to the project is optional.

--- a/docs/language-server/project-manager-http-endpoints.md
+++ b/docs/language-server/project-manager-http-endpoints.md
@@ -17,9 +17,10 @@ JSONRPC protocol.
 
 <!-- /MarkdownTOC -->
 
-## `/projects/{project_id}/enso-project`
+## `/projects/{project_id}/enso-project?subdirectory={subdirectory_path}`
 
 HTTP endpoint that returns the project structure in `.enso-project` format.
+The subdirectory path to the project is optional.
 
 ### `GET`
 

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/http/ProjectsEndpoint.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/http/ProjectsEndpoint.scala
@@ -36,7 +36,7 @@ final class ProjectsEndpoint[
 
   private val projectsEndpoint = {
     path("projects" / JavaUUID / "enso-project") { projectId =>
-      parameters("subdirectory".optional) { directory =>
+      parameters("projectsDirectory".optional) { directory =>
         get {
           getEnsoProject(projectId, directory)
         }
@@ -76,11 +76,11 @@ final class ProjectsEndpoint[
 
   private def buildEnsoArchive(
     projectId: UUID,
-    subdirectory: Option[String]
+    projectsDirectory: Option[String]
   ): Future[Either[ProjectRepositoryFailure, Option[EnsoProjectArchive]]] =
     Exec[F].exec {
       projectRepositoryFactory
-        .getProjectRepository(None, subdirectory.map(new File(_)))
+        .getProjectRepository(projectsDirectory.map(new File(_)))
         .findById(projectId)
         .map(projectOpt =>
           projectOpt.map(project =>

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/http/ProjectsEndpoint.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/http/ProjectsEndpoint.scala
@@ -19,8 +19,8 @@ import org.enso.projectmanager.infrastructure.repository.{
   ProjectRepositoryFailure
 }
 
+import java.io.File
 import java.util.UUID
-
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
@@ -30,23 +30,25 @@ final class ProjectsEndpoint[
     extends Endpoint
     with LazyLogging {
 
-  private val projectRepository =
-    projectRepositoryFactory.getProjectRepository(None)
-
   /** @inheritdoc */
   override def route: Route =
     projectsEndpoint
 
   private val projectsEndpoint = {
     path("projects" / JavaUUID / "enso-project") { projectId =>
-      get {
-        getEnsoProject(projectId)
+      parameters("subdirectory".optional) { directory =>
+        get {
+          getEnsoProject(projectId, directory)
+        }
       }
     }
   }
 
-  private def getEnsoProject(projectId: UUID): Route = {
-    onComplete(buildEnsoArchive(projectId)) {
+  private def getEnsoProject(
+    projectId: UUID,
+    directory: Option[String]
+  ): Route =
+    onComplete(buildEnsoArchive(projectId, directory)) {
       case Failure(err) =>
         logger.error(
           "Failure when building an enso-project archive [{}].",
@@ -71,13 +73,14 @@ final class ProjectsEndpoint[
           )
         )
     }
-  }
 
   private def buildEnsoArchive(
-    projectId: UUID
+    projectId: UUID,
+    subdirectory: Option[String]
   ): Future[Either[ProjectRepositoryFailure, Option[EnsoProjectArchive]]] =
     Exec[F].exec {
-      projectRepository
+      projectRepositoryFactory
+        .getProjectRepository(None, subdirectory.map(new File(_)))
         .findById(projectId)
         .map(projectOpt =>
           projectOpt.map(project =>

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/repository/ProjectFileRepositoryFactory.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/repository/ProjectFileRepositoryFactory.scala
@@ -31,4 +31,5 @@ class ProjectFileRepositoryFactory[
       gen
     )
   }
+
 }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/repository/ProjectFileRepositoryFactory.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/repository/ProjectFileRepositoryFactory.scala
@@ -19,12 +19,16 @@ class ProjectFileRepositoryFactory[
 
   /** @inheritdoc */
   override def getProjectRepository(
-    projectsDirectory: Option[File]
+    projectsDirectory: Option[File],
+    projectSubdirectory: Option[File]
   ): ProjectRepository[F] = {
     val projectsPath =
-      projectsDirectory.getOrElse(storageConfig.userProjectsPath)
+      projectsDirectory.getOrElse(storageConfig.userProjectsPath).toPath
     new ProjectFileRepository[F](
-      projectsPath,
+      projectSubdirectory
+        .map(subdir => projectsPath.resolve(subdir.toPath))
+        .getOrElse(projectsPath)
+        .toFile,
       storageConfig.metadata,
       clock,
       fileSystem,

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/repository/ProjectFileRepositoryFactory.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/repository/ProjectFileRepositoryFactory.scala
@@ -19,16 +19,12 @@ class ProjectFileRepositoryFactory[
 
   /** @inheritdoc */
   override def getProjectRepository(
-    projectsDirectory: Option[File],
-    projectSubdirectory: Option[File]
+    projectsDirectory: Option[File]
   ): ProjectRepository[F] = {
     val projectsPath =
-      projectsDirectory.getOrElse(storageConfig.userProjectsPath).toPath
+      projectsDirectory.getOrElse(storageConfig.userProjectsPath)
     new ProjectFileRepository[F](
-      projectSubdirectory
-        .map(subdir => projectsPath.resolve(subdir.toPath))
-        .getOrElse(projectsPath)
-        .toFile,
+      projectsPath,
       storageConfig.metadata,
       clock,
       fileSystem,

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/repository/ProjectRepositoryFactory.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/repository/ProjectRepositoryFactory.scala
@@ -5,5 +5,12 @@ trait ProjectRepositoryFactory[F[+_, +_]] {
 
   def getProjectRepository(
     projectsDirectory: Option[File]
+  ): ProjectRepository[F] =
+    getProjectRepository(projectsDirectory, None)
+
+  def getProjectRepository(
+    projectsDirectory: Option[File],
+    projectSubdirectory: Option[File]
   ): ProjectRepository[F]
+
 }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/repository/ProjectRepositoryFactory.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/repository/ProjectRepositoryFactory.scala
@@ -5,12 +5,6 @@ trait ProjectRepositoryFactory[F[+_, +_]] {
 
   def getProjectRepository(
     projectsDirectory: Option[File]
-  ): ProjectRepository[F] =
-    getProjectRepository(projectsDirectory, None)
-
-  def getProjectRepository(
-    projectsDirectory: Option[File],
-    projectSubdirectory: Option[File]
   ): ProjectRepository[F]
 
 }


### PR DESCRIPTION
### Pull Request Description

This change adds a possibility to pass an optional parameter describing full path to projects' directory, in addition to the required project id.

Enables GUI to fix #10453.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
