### PR TITLE
Support re-running failed tests with `runEngineDistribution`

### DIFF
--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Suite.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Suite.enso
@@ -104,7 +104,7 @@ type Suite
         succ_tests = all_results.filter (r-> r.is_success) . length
         failed_tests = all_results.filter (r-> r.is_fail)
         failed_tests_number = failed_tests.length
-        failed_tests_names = failed_tests.map (t-> t.spec_name) . distinct . take 10 . join "|"
+        failed_tests_names = failed_tests.map (t-> t.spec_name.replace ' ' '.') . distinct . take 10 . join "|"
         skipped_tests = all_results.filter (r-> r.is_pending) . length
         pending_groups = matching_specs.filter (p-> p.first.is_pending) . length
         case should_exit of


### PR DESCRIPTION
### Pull Request Description

When I execute tests with
```
sbt:enso> runEngineDistribution --run test/Base_Tests
```
I get a list of failed tests. However they are in a format not suitable for `runEngineDistribution` as they contain spaces. They are surrounded by `'`, however that has no meaning for `runEngineDistribution` either. This PR modifies the printed value to avoid spaces and use Regex's `.` instead. As such I can copy and run:
```
sbt:enso> runEngineDistribution --run test/Base_Tests can.compare.custom.types|should.be.able.to.do.Count,.Minimum.and.Maximum.on.custom.type.with.custom.ordered.comparator
```

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Manually tested to work
