### PR TITLE
rename tooltip message, sort sorting for truncated data and re introduce the row label 

### DIFF
--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -656,15 +656,13 @@ onUnmounted(() => {
             v-text="limit"
           ></option>
         </select>
-        <div v-if="showRowCount">
-          <span
-            v-if="isRowCountSelectorVisible && isTruncated"
-            v-text="` of ${rowCount} rows (Sorting/Filtering disabled).`"
-          ></span>
-          <span v-else-if="isRowCountSelectorVisible" v-text="' rows.'"></span>
-          <span v-else-if="rowCount === 1" v-text="'1 row.'"></span>
-          <span v-else v-text="`${rowCount} rows.`"></span>
-        </div>
+        <span
+          v-if="isRowCountSelectorVisible && isTruncated && showRowCount"
+          v-text="` of ${rowCount} rows (Sorting/Filtering disabled).`"
+        ></span>
+        <span v-else-if="isRowCountSelectorVisible && showRowCount" v-text="' rows.'"></span>
+        <span v-else-if="rowCount === 1 && showRowCount" v-text="'1 row.'"></span>
+        <span v-else-if="showRowCount" v-text="`${rowCount} rows.`"></span>
       </div>
       <div ref="tableNode" class="scrollable ag-theme-alpine"></div>
     </div>

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -136,7 +136,7 @@ useAutoBlur(tableNode)
 const widths = reactive(new Map<string, number>())
 const defaultColDef = {
   editable: false,
-  sortable: true as boolean,
+  sortable: true,
   filter: true,
   resizable: true,
   minWidth: 25,
@@ -656,13 +656,15 @@ onUnmounted(() => {
             v-text="limit"
           ></option>
         </select>
-        <span
-          v-if="isRowCountSelectorVisible && isTruncated && showRowCount"
-          v-text="` of ${rowCount} rows (Sorting/Filtering disabled).`"
-        ></span>
-        <span v-else-if="isRowCountSelectorVisible && showRowCount" v-text="' rows.'"></span>
-        <span v-else-if="rowCount === 1 && showRowCount" v-text="'1 row.'"></span>
-        <span v-else-if="showRowCount" v-text="`${rowCount} rows.`"></span>
+        <template v-if="showRowCount">
+          <span
+            v-if="isRowCountSelectorVisible && isTruncated"
+            v-text="` of ${rowCount} rows (Sorting/Filtering disabled).`"
+          ></span>
+          <span v-else-if="isRowCountSelectorVisible" v-text="' rows.'"></span>
+          <span v-else-if="rowCount === 1" v-text="'1 row.'"></span>
+          <span v-else v-text="`${rowCount} rows.`"></span>
+        </template>
       </div>
       <div ref="tableNode" class="scrollable ag-theme-alpine"></div>
     </div>

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -406,7 +406,7 @@ function toLinkField(fieldName: string): ColDef {
     field: fieldName,
     onCellDoubleClicked: (params) => createNode(params),
     tooltipValueGetter: () => {
-      return `Double click to view this ${newNodeSelectorValues.value.tooltipValue} in a separate node`
+      return `Double click to view this ${newNodeSelectorValues.value.tooltipValue} in a separate component`
     },
     cellRenderer: (params: any) => `<a href='#'> ${params.value} </a>`,
   }

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -330,7 +330,7 @@ function toField(name: string, valueType?: ValueType | null | undefined): ColDef
   const menu = `<span ref="eMenu" class="ag-header-icon ag-header-cell-menu-button"> </span>`
   const sort = `
       <span ref="eFilter" class="ag-header-icon ag-header-label-icon ag-filter-icon" aria-hidden="true"></span>
-      <span ref="eSortOrder" class="ag-header-icon ag-sort-order" aria-hidden="true">1</span>
+      <span ref="eSortOrder" class="ag-header-icon ag-sort-order" aria-hidden="true"></span>
       <span ref="eSortAsc" class="ag-header-icon ag-sort-ascending-icon" aria-hidden="true"></span>
       <span ref="eSortDesc" class="ag-header-icon ag-sort-descending-icon" aria-hidden="true"></span>
       <span ref="eSortNone" class="ag-header-icon ag-sort-none-icon" aria-hidden="true"></span>

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -136,7 +136,7 @@ useAutoBlur(tableNode)
 const widths = reactive(new Map<string, number>())
 const defaultColDef = {
   editable: false,
-  sortable: true,
+  sortable: true as boolean,
   filter: true,
   resizable: true,
   minWidth: 25,
@@ -343,7 +343,6 @@ function toField(name: string, valueType?: ValueType | null | undefined): ColDef
     field: name,
     headerComponentParams: {
       template,
-      enableSorting: true,
       setAriaSort: () => {},
     },
     headerTooltip: displayValue ? displayValue : '',


### PR DESCRIPTION
### Pull Request Description
closes #10530 

this renames the tooltip from using 'node' to 'component,

<img width="341" alt="image" src="https://github.com/enso-org/enso/assets/170310417/1ee35556-a982-47aa-99ac-544108b11afe">

![row-label](https://github.com/enso-org/enso/assets/170310417/d81482d9-df49-45da-b447-571a8e9171ea)



### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
