### PR TITLE
Mitigate Language Server visualizations DOS scenario on startup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -315,6 +315,7 @@ lazy val enso = (project in file("."))
     `runtime-benchmarks`,
     `runtime-parser`,
     `runtime-compiler`,
+    `runtime-fat-jar`,
     `runtime-suggestions`,
     `runtime-language-epb`,
     `runtime-language-arrow`,

--- a/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/text/OpenBufferHandler.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/requesthandler/text/OpenBufferHandler.scala
@@ -39,22 +39,35 @@ class OpenBufferHandler(
       bufferRegistry ! TextProtocol.OpenBuffer(rpcSession, params.path)
       val cancellable =
         context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
-      context.become(responseStage(id, sender(), cancellable))
+      context.become(responseStage(id, sender(), cancellable, 10))
   }
 
   private def responseStage(
     id: Id,
     replyTo: ActorRef,
-    cancellable: Cancellable
+    cancellable: Cancellable,
+    retries: Int
   ): Receive = {
     case RequestTimeout =>
-      logger.error(
-        "Opening buffer request [{}] for [{}] timed out.",
-        id,
-        rpcSession.clientId
-      )
-      replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
-      context.stop(self)
+      if (retries > 0) {
+        logger.error(
+          "Opening buffer request [{}] for [{}] timed out. Retry attempts left {}...",
+          id,
+          rpcSession.clientId,
+          retries
+        )
+        val newCancellable =
+          context.system.scheduler.scheduleOnce(timeout, self, RequestTimeout)
+        context.become(responseStage(id, replyTo, newCancellable, retries - 1))
+      } else {
+        logger.error(
+          "Opening buffer request [{}] for [{}] timed out.",
+          id,
+          rpcSession.clientId
+        )
+        replyTo ! ResponseError(Some(id), Errors.RequestTimeout)
+        context.stop(self)
+      }
 
     case OpenFileResponse(Right(OpenFileResult(buffer, capability))) =>
       replyTo ! ResponseResult(

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
@@ -46,17 +46,20 @@ final class JobExecutionEngine(
   val jobExecutor: ExecutorService =
     context.newFixedThreadPool(jobParallelism, "job-pool", false)
 
+  private val MaxJobLimit =
+    Integer.MAX_VALUE // Temporary solution to avoid jobs being dropped
+
   val highPriorityJobExecutor: ExecutorService =
     context.newCachedThreadPool(
       "prioritized-job-pool",
       2,
       4,
-      50,
+      MaxJobLimit,
       false
     )
 
   private val backgroundJobExecutor: ExecutorService =
-    context.newCachedThreadPool("background-job-pool", 1, 4, 50, false)
+    context.newCachedThreadPool("background-job-pool", 1, 4, MaxJobLimit, false)
 
   private val runtimeContext =
     RuntimeContext(
@@ -146,7 +149,12 @@ final class JobExecutionEngine(
           logger.log(Level.SEVERE, s"Error executing $job", err)
           throw err
       } finally {
-        runningJobsRef.updateAndGet(_.filterNot(_.id == jobId))
+        val remaining = runningJobsRef.updateAndGet(_.filterNot(_.id == jobId))
+        logger.log(
+          Level.FINEST,
+          "Number of remaining pending jobs: {}",
+          remaining.size
+        )
       }
     })
     val runningJob = RunningJob(jobId, job, future)


### PR DESCRIPTION
### Pull Request Description

For a medium-size project with a lot of visualizations, Language Server will be flooded with visualization requests on startup. Due to an existing limit for the job execution engine, some of those requests might have been silently dropped.
This change lifts that limit until a better fix can be invented.

Additionally, a slow startup might lead to a timeout when serving open file request. This change adds some retries as a fallback mechanism/progress monitoring.

Closes #10538.

### Important Notes
Should fix with the typical scenario visible in the screenshot:
![Screenshot from 2024-07-12 00-00-36](https://github.com/user-attachments/assets/3e37f2a8-254f-4ea9-864d-4b8919696466)


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
