### PR TITLE
Fix flaky test

### DIFF
--- a/app/gui2/e2e/widgets.spec.ts
+++ b/app/gui2/e2e/widgets.spec.ts
@@ -33,6 +33,7 @@ class DropDownLocator {
   }
 
   async expectVisible(): Promise<void> {
+    await expect(this.dropDown).toHaveCount(1)
     await expect(this.dropDown).toBeVisible()
   }
 


### PR DESCRIPTION
### Pull Request Description

One of our tests was flaky: one check failed immediately because there were two drop-down elements. I've never caught them in the screenshot, so it's probably near-one-frame state caused by some transitioning.

I added a "wait-check" for single drop-down.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
