### PR TITLE
Detect compilation while benchmarking

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Type.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Type.java
@@ -8,6 +8,7 @@ import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -164,6 +165,7 @@ public final class Type implements EnsoObject {
     return Arrays.copyOf(types, realCount);
   }
 
+  @ExplodeLoop
   private static int fillInTypes(Type self, Type[] fill, EnsoContext ctx) {
     var at = 0;
     for (; ; ) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Type.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Type.java
@@ -159,12 +159,27 @@ public final class Type implements EnsoObject {
     return supertype;
   }
 
+  /**
+   * All types this type represents including super types.
+   *
+   * @param ctx contexts to get Any type (common super class) from
+   * @return a compilation constant array with all types this type represents
+   */
   public final Type[] allTypes(EnsoContext ctx) {
     var types = new Type[3];
     var realCount = fillInTypes(this, types, ctx);
     return Arrays.copyOf(types, realCount);
   }
 
+  /**
+   * Fills the provided {@code fill} array with all types the {@code self} type can represent. E.g.
+   * including super classes.
+   *
+   * @param self the type to "enroll"
+   * @param fill the array to fill
+   * @param ctx context to obtain Any type from
+   * @return number of types put into the {@code fill} array
+   */
   @ExplodeLoop
   private static int fillInTypes(Type self, Type[] fill, EnsoContext ctx) {
     var at = 0;
@@ -186,7 +201,12 @@ public final class Type implements EnsoObject {
       }
       self = self.supertype;
     }
-    throw CompilerDirectives.shouldNotReachHere("Strange type " + self);
+    throw CompilerDirectives.shouldNotReachHere(invalidInTypes(self));
+  }
+
+  @CompilerDirectives.TruffleBoundary
+  private static String invalidInTypes(Type self) {
+    return "Cannot compute allTypes for " + self;
   }
 
   public void generateGetters(EnsoLanguage language) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Type.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/data/Type.java
@@ -168,7 +168,7 @@ public final class Type implements EnsoObject {
   @ExplodeLoop
   private static int fillInTypes(Type self, Type[] fill, EnsoContext ctx) {
     var at = 0;
-    for (; ; ) {
+    while (at < fill.length) {
       fill[at++] = self;
       if (self.supertype == null) {
         if (self.builtin) {
@@ -181,8 +181,12 @@ public final class Type implements EnsoObject {
         fill[at++] = ctx.getBuiltins().any();
         return at;
       }
+      if (self == self.supertype) {
+        return at;
+      }
       self = self.supertype;
     }
+    throw CompilerDirectives.shouldNotReachHere("Strange type " + self);
   }
 
   public void generateGetters(EnsoLanguage language) {

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
@@ -308,7 +308,8 @@ public class BenchProcessor extends AbstractProcessor {
                   public void clearCompilationMessages(IterationParams it) {
                     var round = round(it);
                     if (!messages.isEmpty()) {
-                      compilationLog.append("Before " + it.getType() + "#" + round + ". Cleaning " + messages.size() + " compilation messages\\n");
+                      compilationLog.append("Before " + it.getType() + "#" + round + ". ");
+                      compilationLog.append("Cleaning " + messages.size() + " compilation messages\\n");
                       messages.clear();
                     }
                   }
@@ -320,15 +321,32 @@ public class BenchProcessor extends AbstractProcessor {
                     };
                   }
 
+                  private void dumpMessages() {
+                    for (var lr : messages) {
+                      compilationLog.append(lr.getMessage() + "\\n");
+                    }
+                  }
+
+                  @TearDown(org.openjdk.jmh.annotations.Level.Iteration)
+                  public void dumpCompilationMessages(IterationParams it) {
+                    if (!messages.isEmpty()) {
+                      switch (it.getType()) {
+                        case MEASUREMENT -> {
+                          compilationLog.append("After " + it.getType() + "#" + measurementCounter + ". ");
+                          compilationLog.append("Dumping " + messages.size() + " compilation messages:\\n");
+                          dumpMessages();
+                        }
+                      }
+                    }
+                  }
+
                   @TearDown
                   public void checkNoTruffleCompilation(BenchmarkParams params, IterationParams it) {
                     switch (it.getType()) {
                       case MEASUREMENT -> {
                         if (!messages.isEmpty()) {
                           compilationLog.append("After " + it.getType() + "#" + measurementCounter + ". Found " + messages.size() + " compilation messages.\\n");
-                          for (var lr : messages) {
-                            compilationLog.append(lr.getMessage() + "\\n");
-                          }
+                          dumpMessages();
                           compilationLog.insert(0, "Compilation detected while benchmarking " + params.getBenchmark() + ".\\n");
                           System.err.println(compilationLog.toString());
                         }

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
@@ -307,8 +307,10 @@ public class BenchProcessor extends AbstractProcessor {
                   @Setup(org.openjdk.jmh.annotations.Level.Iteration)
                   public void clearCompilationMessages(IterationParams it) {
                     var round = round(it);
-                    compilationLog.append("Before " + it.getType() + "#" + round + ". Cleaning " + messages.size() + " compilation messages\\n");
-                    messages.clear();
+                    if (!messages.isEmpty()) {
+                      compilationLog.append("Before " + it.getType() + "#" + round + ". Cleaning " + messages.size() + " compilation messages\\n");
+                      messages.clear();
+                    }
                   }
 
                   private int round(IterationParams it) {
@@ -323,12 +325,12 @@ public class BenchProcessor extends AbstractProcessor {
                     switch (it.getType()) {
                       case MEASUREMENT -> {
                         if (!messages.isEmpty()) {
-                          compilationLog.append("Finished " + it.getType() + "#" + measurementCounter + ". Found " + messages.size() + " compilation messages.\\n");
+                          compilationLog.append("After " + it.getType() + "#" + measurementCounter + ". Found " + messages.size() + " compilation messages.\\n");
                           for (var lr : messages) {
                             compilationLog.append(lr.getMessage() + "\\n");
                           }
                           compilationLog.insert(0, "Compilation detected while benchmarking " + params.getBenchmark() + ".\\n");
-                          throw new AssertionError(compilationLog.toString());
+                          System.err.println(compilationLog.toString());
                         }
                       }
                     }

--- a/std-bits/benchmarks/src/main/java/org/enso/benchmarks/libs/LibBenchRunner.java
+++ b/std-bits/benchmarks/src/main/java/org/enso/benchmarks/libs/LibBenchRunner.java
@@ -5,14 +5,12 @@ import org.enso.interpreter.bench.BenchmarksRunner;
 import org.openjdk.jmh.runner.RunnerException;
 
 /**
- * The only purpose for this class is to enable the {@link org.enso.benchmarks.processor.BenchProcessor}
- * to generate JMH sources for the benchmarks in {@code test/Benchmarks} project.
- * For more information see {@code docs/infrastructure/benchmarks.md#Standard-library-benchmarks}.
+ * The only purpose for this class is to enable the {@link
+ * org.enso.benchmarks.processor.BenchProcessor} to generate JMH sources for the benchmarks in
+ * {@code test/Benchmarks} project. For more information see {@code
+ * docs/infrastructure/benchmarks.md#Standard-library-benchmarks}.
  */
-@GenerateBenchSources(
-    projectRootPath = "test/Benchmarks",
-    moduleName = "local.Benchmarks.Main"
-)
+@GenerateBenchSources(projectRootPath = "test/Benchmarks", moduleName = "local.Benchmarks.Main")
 public class LibBenchRunner {
 
   public static void main(String[] args) throws RunnerException {

--- a/test/Benchmarks/src/Vector/Operations.enso
+++ b/test/Benchmarks/src/Vector/Operations.enso
@@ -9,7 +9,7 @@ import project.Vector.Utils
 polyglot java import java.util.Random as Java_Random
 
 
-options = Bench.options . set_warmup (Bench.phase_conf 2 5) . set_measure (Bench.phase_conf 1 5)
+options = Bench.options . set_warmup (Bench.phase_conf 5 5) . set_measure (Bench.phase_conf 1 5)
 
 
 collect_benches = Bench.build builder->


### PR DESCRIPTION
### Pull Request Description

Enables `engine.TruffleCompilation` in `std-benchmarks`, collects the logs and dumps compilation into to `System.err` when a benchmark is influenced by dynamic compilation.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Run benchmarks with _compilation detection_ on: [benchmark run](https://github.com/enso-org/enso/actions/runs/9989745685)
