### PR TITLE
Don't wait on runtime confirmation when opening files

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
@@ -179,13 +179,10 @@ class CollaborativeBuffer(
         )
       } else {
         logger.warn("Timeout reached when awaiting response from the server")
-        replyTo ! OpenFileResponse(Left(OperationTimeout))
         stop(Map.empty)
       }
     case Api.Response(Some(id), Api.OpenFileResponse) if id == requestId =>
       timeout.cancel()
-      val cap = CapabilityRegistration(CanEdit(bufferPath))
-      replyTo ! OpenFileResponse(Right(OpenFileResult(buffer, Some(cap))))
       unstashAll()
       context.become(
         collaborativeEditing(
@@ -894,6 +891,8 @@ class CollaborativeBuffer(
         self,
         ServerConfirmationTimeout
       )
+    val cap = CapabilityRegistration(CanEdit(bufferPath))
+    replyTo ! OpenFileResponse(Right(OpenFileResult(buffer, Some(cap))))
     context.become(
       waitingOnServerConfirmation(
         requestId,


### PR DESCRIPTION
### Pull Request Description

Ydoc doesn't like delays so if opening a file takes a considerably more time than usual (locking, more files to compile), ydoc will bail and fail to initiialize properly. This is rather trivially reproducible by adding `Thread.sleep(20*000)` to OpenFileCmd but automatic testing is non-trivial.

This commit changes "collaborative buffer" so that it doesn't wait for runtime's response. This is still correct because:
- logic for generating a response is not conditional 
- order of commands is preserved

Closes #10579.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
