### PR TITLE
Use a class for styling rather than <a>

### DIFF
--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -407,7 +407,7 @@ function toLinkField(fieldName: string): ColDef {
     tooltipValueGetter: () => {
       return `Double click to view this ${newNodeSelectorValues.value.tooltipValue} in a separate component`
     },
-    cellRenderer: (params: any) => `<a> ${params.value} </a>`,
+    cellRenderer: (params: any) => `<div class='link'> ${params.value} </div>`,
   }
 }
 
@@ -701,12 +701,12 @@ onUnmounted(() => {
 /* Tag selectors are inefficient to compute, and should be replaced with a class selector
  * if possible.
  * See https://vuejs.org/api/sfc-css-features.html#scoped-style-tips */
-:deep(a) {
+:deep(.link) {
   color: blue;
   text-decoration: underline;
 }
 
-:deep(a):hover {
+:deep(.link):hover {
   color: darkblue;
 }
 </style>


### PR DESCRIPTION
### Pull Request Description

this changes from using `<a>` to `<div class='link'>` for the cells with on double click behaviour in the table viz

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
