### PR TITLE
Remove unnecessary chrome flags

### DIFF
--- a/app/ide-desktop/client/src/index.ts
+++ b/app/ide-desktop/client/src/index.ts
@@ -68,20 +68,6 @@ class App {
       }
     })
 
-    electron.app.commandLine.appendSwitch('allow-insecure-localhost', 'true')
-    electron.app.commandLine.appendSwitch('ignore-certificate-errors', 'true')
-    electron.app.commandLine.appendSwitch('ignore-ssl-errors', 'true')
-    electron.app.commandLine.appendSwitch('ignore-certificate-errors-spki-list', 'true')
-    electron.app.on(
-      'certificate-error',
-      (event, _webContents, _url, _error, _certificate, callback) => {
-        // Prevent having error
-        event.preventDefault()
-        // and continue
-        callback(true)
-      },
-    )
-
     const { windowSize, chromeOptions, fileToOpen, urlToOpen } = this.processArguments()
     if (this.args.options.version.value) {
       await this.printVersion()
@@ -226,10 +212,8 @@ class App {
     }
     logger.groupMeasured('Setting Chrome options', () => {
       const perfOpts = this.args.groups.performance.options
-      add('ignore-certificate-errors-spki-list')
-      add('allow-insecure-localhost')
+      // Needed to accept localhost self-signed cert
       add('ignore-certificate-errors')
-      add('ignore-ssl-errors')
       addIf(perfOpts.disableGpuSandbox, 'disable-gpu-sandbox')
       addIf(perfOpts.disableGpuVsync, 'disable-gpu-vsync')
       addIf(perfOpts.disableSandbox, 'no-sandbox')


### PR DESCRIPTION
### Pull Request Description

Fixes #10487 

During my tests, these flags were not needed; without them, electron app displays exactly the same cert warnings as with them:
```
Loading the window address 'https://localhost:8080/?engine.projectManagerUrl=ws%3A%2F%2F127.0.0.1%3A30535'.
[30750:0722/121629.281911:ERROR:cert_verify_proc_builtin.cc(1051)] CertVerifyProcBuiltin for localhost failed:
----- Certificate i=0 (CN=127.0.0.1) -----
ERROR: No matching issuer found
```
in CLI and
![Screenshot from 2024-07-22 10-13-12](https://github.com/user-attachments/assets/82a73c9a-ca46-4880-b94e-e979d30ae97c)

in web console.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
