### PR TITLE
Disable Graal-based Ydoc temporarily

### DIFF
--- a/engine/language-server/src/main/java/org/enso/languageserver/boot/resource/YdocInitialization.java
+++ b/engine/language-server/src/main/java/org/enso/languageserver/boot/resource/YdocInitialization.java
@@ -11,6 +11,7 @@ public final class YdocInitialization extends LockedInitialization {
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
   private final ComponentSupervisor supervisor;
+  private final String ENABLED_YDOC = "POLYGLOT_YDOC_SERVER";
 
   public YdocInitialization(Executor executor, ComponentSupervisor componentSupervisor) {
     super(executor);
@@ -19,19 +20,27 @@ public final class YdocInitialization extends LockedInitialization {
 
   @Override
   public void initComponent() {
-    logger.debug("Starting Ydoc server...");
-    var applicationConfig = ApplicationConfig.load();
-    var ydoc =
-        Ydoc.builder()
-            .hostname(applicationConfig.ydoc().hostname())
-            .port(applicationConfig.ydoc().port())
-            .build();
-    try {
-      ydoc.start();
-      this.supervisor.registerService(ydoc);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    var ydocEnabled =
+        System.getenv(ENABLED_YDOC) == null
+            ? false
+            : Boolean.parseBoolean(System.getenv(ENABLED_YDOC));
+    if (ydocEnabled) {
+      logger.debug("Starting Ydoc server...");
+      var applicationConfig = ApplicationConfig.load();
+      var ydoc =
+          Ydoc.builder()
+              .hostname(applicationConfig.ydoc().hostname())
+              .port(applicationConfig.ydoc().port())
+              .build();
+      try {
+        ydoc.start();
+        this.supervisor.registerService(ydoc);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+      logger.debug("Started Ydoc server");
+    } else {
+      logger.debug("Reverting to Node.js Ydoc");
     }
-    logger.debug("Started Ydoc server.");
   }
 }


### PR DESCRIPTION
### Pull Request Description

Graal Ydoc implementation is currently not being used locally or in the cloud and giving an impression of a slower startup.
Plus it appears that there some issues in the local connection as well.
To limit the impact of it now, let's make it controllable by the same env variable as GUI is.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
