### PR TITLE
Fix Data Catalog showing spinners when refetching

### DIFF
--- a/app/dashboard/.prettierignore
+++ b/app/dashboard/.prettierignore
@@ -1,3 +1,4 @@
 playwright-report/
 playwright/.cache/
+test-results/
 dist/

--- a/app/dashboard/src/layouts/AssetsTable.tsx
+++ b/app/dashboard/src/layouts/AssetsTable.tsx
@@ -999,8 +999,7 @@ export default function AssetsTable(props: AssetsTableProps) {
     ],
     { queryKey: [], staleTime: 0, meta: { persist: false } }
   )
-  const isLoading =
-    rootDirectoryQuery.isLoading || rootDirectoryQuery.isPending || rootDirectoryQuery.isFetching
+  const isLoading = rootDirectoryQuery.isLoading || rootDirectoryQuery.isPending
 
   React.useEffect(() => {
     if (isLoading) {

--- a/app/dashboard/src/layouts/AssetsTable.tsx
+++ b/app/dashboard/src/layouts/AssetsTable.tsx
@@ -999,7 +999,7 @@ export default function AssetsTable(props: AssetsTableProps) {
     ],
     { queryKey: [], staleTime: 0, meta: { persist: false } }
   )
-  const isLoading = rootDirectoryQuery.isLoading || rootDirectoryQuery.isPending
+  const isLoading = rootDirectoryQuery.isLoading
 
   React.useEffect(() => {
     if (isLoading) {


### PR DESCRIPTION
### Pull Request Description
- Fix https://github.com/enso-org/cloud-v2/issues/1400
  - The code was incorrectly changed to  consider `isFetching` as a loading state (`isFetching` actually represents the state when there is already cached (stale) data, but updated data is being fetched.)

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
