### PR TITLE
Fix list widget reordering

### DIFF
--- a/app/gui2/src/components/widgets/ListWidget.vue
+++ b/app/gui2/src/components/widgets/ListWidget.vue
@@ -183,11 +183,13 @@ function onDragStart(event: DragEvent, index: number) {
 
     const metaMime = encodeMetadataToMime(meta)
     event.dataTransfer.setData(metaMime, '')
-    nextTick(() => {
+    // The code below will remove the item from list; because doing it in the same frame ends drag
+    // immediately, we need to put it in setTimeout (nextTick is not enough).
+    setTimeout(() => {
       updateItemBounds()
       draggedIndex.value = index
       dropInfo.value = { meta, position: currentMousePos }
-    })
+    }, 0)
   }
 }
 


### PR DESCRIPTION
### Pull Request Description

Fixes, but does not close #10651 - I will try adding some e2e tests for dragging (again).

The problem is, that removing/hiding element in the same frame as dragging starts, the drag is stopped immediately. It is presented here: https://jsfiddle.net/1g34jhe9/ (change `HIDE_IN_NEXT_FRAME` to compare).

In our case, the element removal was technically postponed to `nextTick`, but that is not enough after some version bump, as this tick occures after DOM recalculating, not necessarily after _rendering_ - changed it to setTimeout with proper comment.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
