### PR TITLE
Reenable "Local" settings tab

### DIFF
--- a/app/dashboard/src/layouts/CategorySwitcher.tsx
+++ b/app/dashboard/src/layouts/CategorySwitcher.tsx
@@ -303,7 +303,7 @@ export default function CategorySwitcher(props: CategorySwitcherProps) {
                     variant="icon"
                     icon={SettingsIcon}
                     aria-label={getText('changeLocalRootDirectoryInSettings')}
-                    className="hidden group-hover:block"
+                    className="opacity-0 transition-opacity group-hover:opacity-100"
                     onPress={() => {
                       // eslint-disable-next-line @typescript-eslint/naming-convention
                       setSearchParams({ 'cloud-ide_SettingsTab': '"local"' })

--- a/app/dashboard/src/layouts/CategorySwitcher.tsx
+++ b/app/dashboard/src/layouts/CategorySwitcher.tsx
@@ -1,11 +1,14 @@
 /** @file Switcher to choose the currently visible assets table category. */
 import * as React from 'react'
 
+import { useSearchParams } from 'react-router-dom'
+
 import type * as text from 'enso-common/src/text'
 
 import CloudIcon from '#/assets/cloud.svg'
 import ComputerIcon from '#/assets/computer.svg'
 import RecentIcon from '#/assets/recent.svg'
+import SettingsIcon from '#/assets/settings.svg'
 import Trash2Icon from '#/assets/trash2.svg'
 
 import * as mimeTypes from '#/data/mimeTypes'
@@ -15,6 +18,7 @@ import * as offlineHooks from '#/hooks/offlineHooks'
 import * as authProvider from '#/providers/AuthProvider'
 import * as backendProvider from '#/providers/BackendProvider'
 import * as modalProvider from '#/providers/ModalProvider'
+import { TabType, useSetPage } from '#/providers/ProjectsProvider'
 import * as textProvider from '#/providers/TextProvider'
 
 import AssetEventType from '#/events/AssetEventType'
@@ -168,6 +172,8 @@ export default function CategorySwitcher(props: CategorySwitcherProps) {
   const { getText } = textProvider.useText()
   const { isOffline } = offlineHooks.useOffline()
   const dispatchAssetEvent = eventListProvider.useDispatchAssetEvent()
+  const setPage = useSetPage()
+  const [, setSearchParams] = useSearchParams()
 
   const localBackend = backendProvider.useLocalBackend()
   /** The list of *visible* categories. */
@@ -284,8 +290,25 @@ export default function CategorySwitcher(props: CategorySwitcherProps) {
                   <div className="ml-[15px] mr-1 border-r border-primary/20" />
                   {element}
                 </div>
-              ) : (
+              ) : data.category !== Category.local ? (
                 element
+              ) : (
+                <div key={data.category} className="group flex items-center self-stretch">
+                  {element}
+                  <div className="grow" />
+                  <ariaComponents.Button
+                    size="medium"
+                    variant="icon"
+                    icon={SettingsIcon}
+                    aria-label={getText('changeLocalRootDirectoryInSettings')}
+                    className="hidden group-hover:block"
+                    onPress={() => {
+                      // eslint-disable-next-line @typescript-eslint/naming-convention
+                      setSearchParams({ 'cloud-ide_SettingsTab': '"local"' })
+                      setPage(TabType.settings)
+                    }}
+                  />
+                </div>
               )
             })}
           </div>

--- a/app/dashboard/src/layouts/CategorySwitcher.tsx
+++ b/app/dashboard/src/layouts/CategorySwitcher.tsx
@@ -293,9 +293,11 @@ export default function CategorySwitcher(props: CategorySwitcherProps) {
               ) : data.category !== Category.local ? (
                 element
               ) : (
-                <div key={data.category} className="group flex items-center self-stretch">
+                <div
+                  key={data.category}
+                  className="group flex items-center justify-between self-stretch"
+                >
                   {element}
-                  <div className="grow" />
                   <ariaComponents.Button
                     size="medium"
                     variant="icon"

--- a/app/dashboard/src/layouts/Settings/settingsData.tsx
+++ b/app/dashboard/src/layouts/Settings/settingsData.tsx
@@ -231,7 +231,7 @@ export const SETTINGS_TAB_DATA: Readonly<Record<SettingsTabType, SettingsTabData
   },
   [SettingsTabType.local]: {
     nameId: 'localSettingsTab',
-    settingsTab: SettingsTabType.organization,
+    settingsTab: SettingsTabType.local,
     icon: ComputerIcon,
     visible: context => context.localBackend != null,
     sections: [
@@ -376,6 +376,7 @@ export const SETTINGS_DATA: SettingsData = [
     tabs: [
       SETTINGS_TAB_DATA[SettingsTabType.account],
       SETTINGS_TAB_DATA[SettingsTabType.organization],
+      SETTINGS_TAB_DATA[SettingsTabType.local],
     ],
   },
   {

--- a/app/ide-desktop/common/src/text/english.json
+++ b/app/ide-desktop/common/src/text/english.json
@@ -411,6 +411,7 @@
   "noResultsFound": "No results found.",
   "enableVersionChecker": "Enable Version Checker",
   "enableVersionCheckerDescription": "Show a dialog if the current version of the desktop app does not match the latest version.",
+  "changeLocalRootDirectoryInSettings": "Change your root folder in Settings.",
 
   "deleteLabelActionText": "delete the label '$0'",
   "deleteSelectedAssetActionText": "delete '$0'",


### PR DESCRIPTION
### Pull Request Description
- Re-enable the "Local" settings tab
  - It contains a single input to change the root directory of 
- Add settings icon to jump to "Local" settings tab, next to "Local" category

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
