### PR TITLE
Additional info to debug AccessDenied problems

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3196,6 +3196,9 @@ lazy val `runtime-version-manager` = project
   .dependsOn(`edition-updater`)
   .dependsOn(`distribution-manager`)
 
+/** `process-utils` provides utilities for correctly managing process execution such as providing
+  *  handlers for its stdout/stderr.
+  */
 lazy val `process-utils` = project
   .in(file("lib/scala/process-utils"))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -335,6 +335,7 @@ lazy val enso = (project in file("."))
     `library-manager-test`,
     `connected-lock-manager`,
     `connected-lock-manager-server`,
+    `process-utils`,
     testkit,
     `test-utils`,
     `common-polyglot-core-utils`,
@@ -3137,6 +3138,7 @@ lazy val `library-manager-test` = project
     )
   )
   .dependsOn(`library-manager`)
+  .dependsOn(`process-utils`)
   .dependsOn(`logging-utils` % "test->test")
   .dependsOn(testkit)
   .dependsOn(`logging-service-logback` % "test->test")
@@ -3189,9 +3191,16 @@ lazy val `runtime-version-manager` = project
   .dependsOn(pkg)
   .dependsOn(downloader)
   .dependsOn(cli)
+  .dependsOn(`process-utils`)
   .dependsOn(`version-output`)
   .dependsOn(`edition-updater`)
   .dependsOn(`distribution-manager`)
+
+lazy val `process-utils` = project
+  .in(file("lib/scala/process-utils"))
+  .settings(
+    frgaalJavaCompilerSetting
+  )
 
 lazy val `runtime-version-manager-test` = project
   .in(file("lib/scala/runtime-version-manager-test"))

--- a/engine/launcher/src/main/scala/org/enso/launcher/Launcher.scala
+++ b/engine/launcher/src/main/scala/org/enso/launcher/Launcher.scala
@@ -97,7 +97,7 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
           .get,
         JVMSettings(useSystemJVM, jvmOpts, extraOptions = Seq.empty)
       ) { command =>
-        command.run(inheritStdOutErr = false).get
+        command.runAndCaptureOutput().get
       }
 
     if (exitCode == 0) {
@@ -211,7 +211,7 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
     jvmOpts: Seq[(String, String)],
     additionalArguments: Seq[String]
   ): Int = {
-    val (exitCode, _) = runner
+    runner
       .withCommand(
         runner
           .repl(
@@ -226,7 +226,6 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
       ) { command =>
         command.run().get
       }
-    exitCode
   }
 
   /** Runs an Enso script or project.
@@ -255,7 +254,7 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
     jvmOpts: Seq[(String, String)],
     additionalArguments: Seq[String]
   ): Int = {
-    val (exitCode, _) = runner
+    val exitCode = runner
       .withCommand(
         runner
           .run(
@@ -297,7 +296,7 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
     jvmOpts: Seq[(String, String)],
     additionalArguments: Seq[String]
   ): Int = {
-    val (exitCode, _) = runner
+    val exitCode = runner
       .withCommand(
         runner
           .languageServer(
@@ -335,7 +334,7 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
     jvmOpts: Seq[(String, String)],
     additionalArguments: Seq[String]
   ): Int = {
-    val (exitCode, _) = runner.withCommand(
+    val exitCode = runner.withCommand(
       runner
         .installDependencies(
           versionOverride,
@@ -419,7 +418,6 @@ case class Launcher(cliOptions: GlobalCLIOptions) {
       ) { command =>
         command.run().get
       }
-      ._1
   }
 
   /** Prints the value of `key` from the global configuration.

--- a/engine/launcher/src/test/scala/org/enso/launcher/NativeTest.scala
+++ b/engine/launcher/src/test/scala/org/enso/launcher/NativeTest.scala
@@ -2,7 +2,7 @@ package org.enso.launcher
 
 import org.enso.cli.OS
 import org.enso.runtimeversionmanager.test.NativeTestHelper
-import org.enso.testkit.process.RunResult
+import org.enso.process.RunResult
 import org.scalatest.concurrent.{Signaler, TimeLimitedTests}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.matchers.{MatchResult, Matcher}

--- a/engine/launcher/src/test/scala/org/enso/launcher/upgrade/UpgradeSpec.scala
+++ b/engine/launcher/src/test/scala/org/enso/launcher/upgrade/UpgradeSpec.scala
@@ -9,7 +9,7 @@ import FileSystem.PathSyntax
 import org.enso.cli.OS
 import org.enso.launcher._
 import org.enso.testkit.{FlakySpec, WithTemporaryDirectory}
-import org.enso.testkit.process.{RunResult, WrappedProcess}
+import org.enso.process.{RunResult, WrappedProcess}
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.{BeforeAndAfterAll, Ignore, OptionValues}
 

--- a/lib/scala/library-manager-test/src/main/scala/org/enso/librarymanager/published/repository/DummyRepository.scala
+++ b/lib/scala/library-manager-test/src/main/scala/org/enso/librarymanager/published/repository/DummyRepository.scala
@@ -7,7 +7,7 @@ import org.enso.downloader.archive.TarGzWriter
 import org.enso.editions.Editions.RawEdition
 import org.enso.editions.{Editions, LibraryName}
 import org.enso.pkg.{Package, PackageManager}
-import org.enso.testkit.process.WrappedProcess
+import org.enso.process.WrappedProcess
 import org.enso.yaml.YamlHelper
 
 import java.io.File

--- a/lib/scala/process-utils/src/main/scala/org/enso/process/RunResult.scala
+++ b/lib/scala/process-utils/src/main/scala/org/enso/process/RunResult.scala
@@ -1,4 +1,4 @@
-package org.enso.testkit.process
+package org.enso.process
 
 /** A result of running a process.
   *

--- a/lib/scala/process-utils/src/main/scala/org/enso/process/WrappedProcess.scala
+++ b/lib/scala/process-utils/src/main/scala/org/enso/process/WrappedProcess.scala
@@ -1,4 +1,4 @@
-package org.enso.testkit.process
+package org.enso.process
 
 import java.io._
 import java.util.concurrent.{Semaphore, TimeUnit}
@@ -85,6 +85,29 @@ class WrappedProcess(command: Seq[String], process: Process) {
     if (!acquired) {
       throw new TimeoutException(s"Waiting for `$message` timed out.")
     }
+  }
+
+  /** Appends a message to string builder. */
+  def appendToBuilder(
+    builder: StringBuilder
+  ): Unit = {
+    def handler(line: String, streamType: StreamType): Unit = {
+      streamType match {
+        case StdErr =>
+          builder.append(
+            s"stderr> $line${System.getProperty("line.separator")}"
+          )
+        case StdOut =>
+          builder.append(
+            s"stdout> $line${System.getProperty("line.separator")}"
+          )
+      }
+    }
+
+    this.synchronized {
+      ioHandlers ++= Seq(handler _)
+    }
+
   }
 
   private lazy val inputWriter = new PrintWriter(process.getOutputStream)

--- a/lib/scala/process-utils/src/main/scala/org/enso/process/WrappedProcess.scala
+++ b/lib/scala/process-utils/src/main/scala/org/enso/process/WrappedProcess.scala
@@ -87,8 +87,10 @@ class WrappedProcess(command: Seq[String], process: Process) {
     }
   }
 
-  /** Appends a message to string builder. */
-  def appendToBuilder(
+  /** Registers a handler for stdout/stderr that appends streams to the provided
+    * string builder.
+    */
+  def registerStringBuilderAppendTarget(
     builder: StringBuilder
   ): Unit = {
     def handler(line: String, streamType: StreamType): Unit = {

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/file/BlockingFileSystem.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/file/BlockingFileSystem.scala
@@ -123,12 +123,12 @@ class BlockingFileSystem[F[+_, +_]: Sync: ErrorChannel](
       .mapError(toFsFailure)
 
   private val toFsFailure: Throwable => FileSystemFailure = {
-    case _: FileNotFoundException => FileNotFound
-    case _: NotDirectoryException => NotDirectory
-    case _: NoSuchFileException   => FileNotFound
-    case _: FileExistsException   => FileExists
-    case _: AccessDeniedException => AccessDenied
-    case ex                       => GenericFileSystemFailure(ex.getMessage)
+    case _: FileNotFoundException  => FileNotFound
+    case _: NotDirectoryException  => NotDirectory
+    case _: NoSuchFileException    => FileNotFound
+    case _: FileExistsException    => FileExists
+    case ex: AccessDeniedException => AccessDenied(ex.getFile)
+    case ex                        => GenericFileSystemFailure(ex.getMessage)
   }
 
 }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/file/FileSystemFailure.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/infrastructure/file/FileSystemFailure.scala
@@ -8,7 +8,9 @@ object FileSystemFailure {
 
   /** Signals that a user doesn't have access to a file.
     */
-  case object AccessDenied extends FileSystemFailure
+  case class AccessDenied(file: String) extends FileSystemFailure {
+    override def toString: String = s"AccessDenied[$file]"
+  }
 
   /** Signals that the file cannot be found.
     */

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectCreationService.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectCreationService.scala
@@ -74,20 +74,20 @@ class ProjectCreationService[
           s"Running engine $engineVersion to create project $name at " +
           s"[${MaskedPath(path).applyMasking()}]."
         )
-        command.run().get
+        command.run(inheritStdOutErr = false).get
       }
     }
     .mapRuntimeManagerErrors { other: Throwable =>
       ProjectCreateFailed(other.getMessage)
     }
-    .flatMap { exitCode =>
+    .flatMap { case (exitCode, output) =>
       if (exitCode == 0)
         CovariantFlatMap[F].pure(())
       else
         ErrorChannel[F].fail(
           ProjectCreateFailed(
-            s"The runner used to create the project returned exit code " +
-            s"$exitCode."
+            s"The runner used to create the project returned exit code $exitCode.${System
+              .getProperty("line.separator")}Runner's output: $output"
           )
         )
     }

--- a/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectCreationService.scala
+++ b/lib/scala/project-manager/src/main/scala/org/enso/projectmanager/service/ProjectCreationService.scala
@@ -74,7 +74,7 @@ class ProjectCreationService[
           s"Running engine $engineVersion to create project $name at " +
           s"[${MaskedPath(path).applyMasking()}]."
         )
-        command.run(inheritStdOutErr = false).get
+        command.runAndCaptureOutput().get
       }
     }
     .mapRuntimeManagerErrors { other: Throwable =>

--- a/lib/scala/runtime-version-manager-test/src/main/scala/org/enso/runtimeversionmanager/test/NativeTestHelper.scala
+++ b/lib/scala/runtime-version-manager-test/src/main/scala/org/enso/runtimeversionmanager/test/NativeTestHelper.scala
@@ -1,7 +1,7 @@
 package org.enso.runtimeversionmanager.test
 
 import org.enso.cli.OS
-import org.enso.testkit.process.{RunResult, WrappedProcess}
+import org.enso.process.{RunResult, WrappedProcess}
 
 import java.lang.{ProcessBuilder => JProcessBuilder}
 import scala.jdk.CollectionConverters._

--- a/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Command.scala
+++ b/lib/scala/runtime-version-manager/src/main/scala/org/enso/runtimeversionmanager/runner/Command.scala
@@ -32,16 +32,24 @@ case class Command(command: Seq[String], extraEnv: Seq[(String, String)]) {
     *
     * May return an exception if it is impossible to run the command (for
     * example due to insufficient permissions or nonexistent executable).
+    *
+    * @param timeoutInSeconds timeout specifying how long this thread will wait
+    *                         for the process to finish until it attempts to kill it
     */
-  def runAndCaptureOutput(): Try[(Int, String)] =
+  def runAndCaptureOutput(
+    timeoutInSeconds: Option[Long] = Some(300)
+  ): Try[(Int, String)] =
     wrapError {
       logger.debug("Executing {}", this)
       val processBuilder = builder()
       val process        = processBuilder.start()
       val wrappedProcess = new WrappedProcess(command, process)
       val stringBuilder  = new StringBuilder()
-      wrappedProcess.appendToBuilder(stringBuilder)
-      val result = wrappedProcess.join(waitForDescendants = true, 5 * 60)
+      wrappedProcess.registerStringBuilderAppendTarget(stringBuilder)
+      val result = wrappedProcess.join(
+        waitForDescendants = true,
+        timeoutInSeconds.getOrElse(Long.MaxValue)
+      )
       (result.exitCode, stringBuilder.toString())
     }
 


### PR DESCRIPTION
### Pull Request Description

Plain `Storage failure [AccessDenied].` was rather uninformative when it comes to debugging the underlying problem.
Added more detailed error messages and runners' failures should now sometimes print a detailed message.
References #10662.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
