### PR TITLE
Ag grid boolean inference turned off for mixed type column

### DIFF
--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -423,6 +423,14 @@ function toField(name: string, valueType?: ValueType | null | undefined): ColDef
       setAriaSort: () => {},
     },
     headerTooltip: displayValue ? displayValue : '',
+    cellDataType: !(valType === 'Mixed'),
+  }
+}
+
+function toRowField(name: string, valueType?: ValueType | null | undefined) {
+  return {
+    ...toField(name, valueType),
+    cellDataType: false,
   }
 }
 
@@ -567,8 +575,8 @@ watchEffect(() => {
     const dataHeader =
       ('header' in data_ ? data_.header : [])?.map((v, i) => {
         const valueType = data_.value_type ? data_.value_type[i] : null
-        if (config.nodeType === ROW_NODE_TYPE && v === 'column') {
-          return toLinkField(v)
+        if (config.nodeType === ROW_NODE_TYPE) {
+          return v === 'column' ? toLinkField(v) : toRowField(v, valueType, data_)
         }
         return toField(v, valueType)
       }) ?? []

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -423,7 +423,6 @@ function toField(name: string, valueType?: ValueType | null | undefined): ColDef
       setAriaSort: () => {},
     },
     headerTooltip: displayValue ? displayValue : '',
-    cellDataType: !(valType === 'Mixed'),
   }
 }
 
@@ -576,7 +575,7 @@ watchEffect(() => {
       ('header' in data_ ? data_.header : [])?.map((v, i) => {
         const valueType = data_.value_type ? data_.value_type[i] : null
         if (config.nodeType === ROW_NODE_TYPE) {
-          return v === 'column' ? toLinkField(v) : toRowField(v, valueType, data_)
+          return v === 'column' ? toLinkField(v) : toRowField(v, valueType)
         }
         return toField(v, valueType)
       }) ?? []


### PR DESCRIPTION
### Pull Request Description
If one value in a column is a boolean ag-grid renders all values in the column as a checkbox when cellDataTypes is true. This becomes a problem when getting a row of mixed type, so in this situation cellDataType will be set to false. 

Bug:
![row-mixed-type-bug-problem](https://github.com/user-attachments/assets/5fcdd96d-8422-4370-b71e-94181ac42e2e)


Fix:
![row-mixed-type-bug-fix](https://github.com/user-attachments/assets/9ad18d1b-1b55-4351-a3ee-57a390b91fc4)



### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
