### PR TITLE
Avoid calling wasm parser immediately on widget module load.

### DIFF
--- a/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
@@ -64,7 +64,7 @@ function makeLiteralFromUserInput(value: string): Ast.Owned<Ast.MutableTextLiter
   }
 }
 
-const shownLiteral = computed(() => inputTextLiteral.value ?? emptyTextLiteral)
+const shownLiteral = computed(() => inputTextLiteral.value ?? emptyTextLiteral.value)
 const closeToken = computed(() => shownLiteral.value.close ?? shownLiteral.value.open)
 
 const textContents = computed(() => shownLiteral.value.rawTextContent)
@@ -73,7 +73,8 @@ watch(textContents, (value) => (editedContents.value = value))
 </script>
 
 <script lang="ts">
-const emptyTextLiteral = makeNewLiteral('')
+// Computed used intentionally to delay computation until wasm package is loaded.
+const emptyTextLiteral = computed(() => makeNewLiteral(''))
 function makeNewLiteral(value: string) {
   return Ast.TextLiteral.new(value, MutableModule.Transient())
 }


### PR DESCRIPTION
### Pull Request Description

Fixes a race condition causing error in RC4:
```
index-ykDiQPdr.js:38 TypeError: Cannot read properties of undefined (reading '__wbindgen_add_to_stack_pointer')
```

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
