### PR TITLE
Disable linting passes for IDE and repl

### DIFF
--- a/engine/common/src/main/java/org/enso/common/ContextFactory.java
+++ b/engine/common/src/main/java/org/enso/common/ContextFactory.java
@@ -25,6 +25,7 @@ import org.slf4j.event.Level;
  * @param disablePrivateCheck If `private` keyword should be disabled.
  * @param enableStaticAnalysis whether or not to enable static type checking
  * @param strictErrors whether or not to use strict errors
+ * @param disableLinting whether or not linting passes should run during compilation
  * @param useGlobalIrCacheLocation whether or not to use the global IR cache location
  * @param options additional options for the Context
  * @param executionEnvironment optional name of the execution environment to use during execution
@@ -42,6 +43,7 @@ public final class ContextFactory {
   private boolean disablePrivateCheck;
   private boolean enableStaticAnalysis;
   private boolean strictErrors;
+  private boolean disableLinting;
   private boolean useGlobalIrCacheLocation = true;
   private boolean enableAutoParallelism;
   private String executionEnvironment;
@@ -109,6 +111,11 @@ public final class ContextFactory {
     return this;
   }
 
+  public ContextFactory disableLinting(boolean disableLinting) {
+    this.disableLinting = disableLinting;
+    return this;
+  }
+
   public ContextFactory useGlobalIrCacheLocation(boolean useGlobalIrCacheLocation) {
     this.useGlobalIrCacheLocation = useGlobalIrCacheLocation;
     return this;
@@ -147,6 +154,7 @@ public final class ContextFactory {
             .allowHostAccess(allWithTypeMapping())
             .option(RuntimeOptions.PROJECT_ROOT, projectRoot)
             .option(RuntimeOptions.STRICT_ERRORS, Boolean.toString(strictErrors))
+            .option(RuntimeOptions.DISABLE_LINTING, Boolean.toString(disableLinting))
             .option(RuntimeOptions.WAIT_FOR_PENDING_SERIALIZATION_JOBS, "true")
             .option(
                 RuntimeOptions.USE_GLOBAL_IR_CACHE_LOCATION,

--- a/engine/common/src/main/java/org/enso/common/RuntimeOptions.java
+++ b/engine/common/src/main/java/org/enso/common/RuntimeOptions.java
@@ -51,6 +51,11 @@ public final class RuntimeOptions {
   public static final OptionDescriptor INTERACTIVE_MODE_DESCRIPTOR =
       OptionDescriptor.newBuilder(INTERACTIVE_MODE_KEY, INTERACTIVE_MODE).build();
 
+  public static final String DISABLE_LINTING = optionName("disableLinting");
+  public static final OptionKey<Boolean> DISABLE_LINTING_KEY = new OptionKey<>(false);
+  public static final OptionDescriptor DISABLE_LINTING_DESCRIPTOR =
+          OptionDescriptor.newBuilder(DISABLE_LINTING_KEY, DISABLE_LINTING).build();
+
   public static final String INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION =
       interpreterOptionName("sequentialCommandExecution");
   public static final OptionKey<Boolean> INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION_KEY =
@@ -150,6 +155,7 @@ public final class RuntimeOptions {
               ENABLE_PROJECT_SUGGESTIONS_DESCRIPTOR,
               ENABLE_GLOBAL_SUGGESTIONS_DESCRIPTOR,
               INTERACTIVE_MODE_DESCRIPTOR,
+              DISABLE_LINTING_DESCRIPTOR,
               LANGUAGE_HOME_OVERRIDE_DESCRIPTOR,
               EDITION_OVERRIDE_DESCRIPTOR,
               INTERPRETER_SEQUENTIAL_COMMAND_EXECUTION_DESCRIPTOR,

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -308,7 +308,6 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
   val extraOptions = new java.util.HashMap[String, String]()
   extraOptions.put(RuntimeServerInfo.ENABLE_OPTION, "true")
   extraOptions.put(RuntimeOptions.INTERACTIVE_MODE, "true")
-  extraOptions.put(RuntimeOptions.DISABLE_LINTING, "true")
   extraOptions.put(
     RuntimeOptions.LOG_MASKING,
     Masking.isMaskingEnabled.toString
@@ -324,6 +323,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
     .projectRoot(serverConfig.contentRootPath)
     .logLevel(logLevel)
     .strictErrors(false)
+    .disableLinting(false)
     .out(stdOut)
     .err(stdErr)
     .in(stdIn)

--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -308,6 +308,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
   val extraOptions = new java.util.HashMap[String, String]()
   extraOptions.put(RuntimeServerInfo.ENABLE_OPTION, "true")
   extraOptions.put(RuntimeOptions.INTERACTIVE_MODE, "true")
+  extraOptions.put(RuntimeOptions.DISABLE_LINTING, "true")
   extraOptions.put(
     RuntimeOptions.LOG_MASKING,
     Masking.isMaskingEnabled.toString

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -926,6 +926,7 @@ public final class Main {
                 .logLevel(logLevel)
                 .logMasking(logMasking)
                 .enableIrCaches(enableIrCaches)
+                .disableLinting(true)
                 .enableStaticAnalysis(enableStaticAnalysis)
                 .build());
     var mainModule = context.evalModule(dummySourceToTriggerRepl, replModuleName);

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Passes.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Passes.scala
@@ -33,9 +33,8 @@ class Passes(config: CompilerConfig) {
       ComplexType,
       FunctionBinding,
       GenerateMethodBodies,
-      BindingAnalysis,
-      ModuleNameConflicts
-    )
+      BindingAnalysis
+    ) ++ (if (config.isLintingDisabled) Nil else List(ModuleNameConflicts))
   )
 
   val globalTypingPasses = new PassGroup(
@@ -95,18 +94,15 @@ class Passes(config: CompilerConfig) {
       DataflowAnalysis,
       CachePreferenceAnalysis,
       GenericAnnotations
-    )
-  )
-
-  val lintingPasses = new PassGroup(
-    List(
-      UnusedBindings,
-      NoSelfInStatic
-    ) ++ (if (config.staticTypeInferenceEnabled) {
-            List(
-              TypeInference.INSTANCE
-            )
-          } else Nil)
+    ) ++ (if (config.isLintingDisabled) {
+            Nil
+          } else {
+            List(UnusedBindings, NoSelfInStatic)
+          }) ++ (if (config.staticTypeInferenceEnabled) {
+                   List(
+                     TypeInference.INSTANCE
+                   )
+                 } else Nil)
   )
 
   /** A list of the compiler phases, in the order they should be run.
@@ -120,7 +116,7 @@ class Passes(config: CompilerConfig) {
       moduleDiscoveryPasses,
       globalTypingPasses,
       functionBodyPasses
-    ) ++ (if (config.isLintingDisabled) Nil else List(lintingPasses))
+    )
 
   /** The ordered representation of all passes run by the compiler. */
   val allPassOrdering: List[IRPass] = passOrdering.flatMap(_.passes)

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/data/CompilerConfig.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/data/CompilerConfig.scala
@@ -10,6 +10,7 @@ import java.io.PrintStream
   * @param privateCheckEnabled whether or not private keyword is enabled
   * @param staticTypeInferenceEnabled whether or not type inference is enabled
   * @param isStrictErrors if true, presence of any Error in IR will result in an exception
+  * @oaram isLintingDisabled if true, compilation should not run any linting passes
   * @param outputRedirect redirection of the output of warnings and errors of compiler
   */
 case class CompilerConfig(
@@ -18,6 +19,7 @@ case class CompilerConfig(
   privateCheckEnabled: Boolean        = true,
   staticTypeInferenceEnabled: Boolean = false,
   isStrictErrors: Boolean             = false,
+  isLintingDisabled: Boolean          = false,
   outputRedirect: Option[PrintStream] = None
 ) {
   def parallelParsing: Boolean = false

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/TypeInferenceTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/TypeInferenceTest.java
@@ -1157,8 +1157,8 @@ public class TypeInferenceTest extends CompilerTest {
 
     Module rawModule = parse(src.getCharacters());
 
-    var compilerConfig = new CompilerConfig(false, true, true, true, true, Option.empty());
-    var passes = new Passes(compilerConfig, Option.empty());
+    var compilerConfig = new CompilerConfig(false, true, true, true, true, false, Option.empty());
+    var passes = new Passes(compilerConfig);
     @SuppressWarnings("unchecked")
     var passConfig =
         new PassConfiguration((Seq<PassConfiguration.ConfigPair<?>>) Seq$.MODULE$.empty());

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/PassesTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/PassesTest.scala
@@ -14,7 +14,11 @@ import org.enso.compiler.pass.analyse.{
   PrivateModuleAnalysis
 }
 import org.enso.compiler.pass.desugar._
-import org.enso.compiler.pass.lint.{ModuleNameConflicts, ShadowedPatternFields}
+import org.enso.compiler.pass.lint.{
+  ModuleNameConflicts,
+  ShadowedPatternFields,
+  UnusedBindings
+}
 import org.enso.compiler.pass.optimise.UnreachableMatchBranches
 import org.enso.compiler.pass.resolve._
 
@@ -77,6 +81,14 @@ class PassesTest extends CompilerTest {
 
     "return `None` if the pass doesn't exists" in {
       passes.getPrecursors(Pass1) should not be defined
+    }
+  }
+
+  "Compiler pass ordering slicing" should {
+    val passes = new Passes(defaultConfig.copy(isLintingDisabled = true))
+
+    "not include linting passes when disabled" in {
+      passes.allPassOrdering should not contain UnusedBindings
     }
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/EnsoLanguage.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/EnsoLanguage.java
@@ -233,7 +233,13 @@ public final class EnsoLanguage extends TruffleLanguage<EnsoContext> {
       var outputRedirect = new ByteArrayOutputStream();
       var redirectConfigWithStrictErrors =
           new CompilerConfig(
-              false, false, true, false, true, scala.Option.apply(new PrintStream(outputRedirect)));
+              false,
+              false,
+              true,
+              false,
+              true,
+              false,
+              scala.Option.apply(new PrintStream(outputRedirect)));
       var moduleContext =
           new ModuleContext(
               module.asCompilerModule(),

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/EnsoContext.java
@@ -148,6 +148,7 @@ public final class EnsoContext {
             !isPrivateCheckDisabled,
             isStaticTypeAnalysisEnabled,
             getOption(RuntimeOptions.STRICT_ERRORS_KEY),
+            getOption(RuntimeOptions.DISABLE_LINTING_KEY),
             scala.Option.empty());
     this.home = home;
     this.builtins = new Builtins(this);

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -11,7 +11,7 @@ from a desired _edition_. The root directory of the docker build context can be
 provided in the `docker build` command:
 
 ```bash
-docker build -t <my-custom-name> -f tools/ci/docker/DockerFile --build-context docker-tools=tools/ci/docker built-distribution/enso-engine-$VERSION-linux-amd64/enso-$VERSION
+docker build -t <my-custom-name> -f tools/ci/docker/Dockerfile --build-context docker-tools=tools/ci/docker built-distribution/enso-engine-$VERSION-linux-amd64/enso-$VERSION
 ```
 
 where for a locally built distribution on Linux it would be `VERSION=0.0.0-dev`.


### PR DESCRIPTION


### Pull Request Description

There is no need to generate unused variables warnings or other linting for IDE and repl users. By default linting is enabled during compilation and for those use-cases it is now disabled via runtime options.

Closes #9883 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
