### PR TITLE
Must specify `--repl` to enable debug server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 - [Enforce conversion method return type][10468]
 - [Renaming launcher executable to ensoup][10535]
 - [Space-precedence does not apply to value-level operators][10597]
+- [Must specify `--repl` to enable debug server][10709]
 
 [10468]: https://github.com/enso-org/enso/pull/10468
 [10535]: https://github.com/enso-org/enso/pull/10535
 [10597]: https://github.com/enso-org/enso/pull/10597
+[10709]: https://github.com/enso-org/enso/pull/10709
 
 #### Enso IDE
 

--- a/engine/runner/src/test/java/org/enso/runner/EngineMainTest.java
+++ b/engine/runner/src/test/java/org/enso/runner/EngineMainTest.java
@@ -1,0 +1,46 @@
+package org.enso.runner;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.slf4j.event.Level;
+
+public class EngineMainTest {
+  private final List<String> linesOut = new ArrayList<>();
+
+  @Test
+  public void cannotUseReplAndInspectAtOnce() throws Exception {
+    try {
+      var m =
+          new Main() {
+            @Override
+            RuntimeException doExit(int code) {
+              throw new ExitCode(code);
+            }
+
+            void println(String line) {
+              linesOut.add(line);
+            }
+          };
+      var file = File.createTempFile("some", ".enso");
+      file.deleteOnExit();
+      var line = m.preprocessArguments("--repl", "--inspect", "--run", file.getAbsolutePath());
+      m.mainEntry(line, Level.INFO, false);
+    } catch (ExitCode ex) {
+      assertEquals("Execution fails", 1, ex.exitCode);
+      assertEquals("One line printed", 1, linesOut.size());
+      assertEquals("Cannot use --inspect and --repl and --run at once", linesOut.get(0));
+    }
+  }
+
+  private static final class ExitCode extends RuntimeException {
+    final int exitCode;
+
+    ExitCode(int exitCode) {
+      this.exitCode = exitCode;
+    }
+  }
+}

--- a/test/Base_Tests/src/Semantic/Runtime_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Runtime_Spec.enso
@@ -1,4 +1,5 @@
 import Standard.Base.Runtime
+import Standard.Base.Runtime.Debug
 import Standard.Base.Data.Numbers.Integer
 import Standard.Base.Any.Any
 import Standard.Base.Nothing.Nothing
@@ -38,6 +39,9 @@ add_specs suite_builder =
 
             r2 = Panic.catch Any (Runtime.with_disabled_context Input environment=Runtime.current_execution_environment  <| in_fn (out_fn 10)) p-> p.payload.to_text
             r2 . should_equal "(Forbidden_Operation.Error 'The Input context is disabled.')"
+    suite_builder.group "Debug" group_builder->
+        group_builder.specify "Debug.breakpoint doesn't stop indefinitly" <|
+            Debug.breakpoint
 
 main filter=Nothing =
     suite = Test.build suite_builder->


### PR DESCRIPTION
### Pull Request Description

By default there is no _debug server_ when `--run` a file or project. As a result using `Standard.Base.Runtime.Debug.breakpoint` is **no-op**. Use one of `--repl` or `--inspect` (but not both) to let a REPL or debugger stop on the _breakpoint statement_.

### Checklist

When using `enso --run ... --inspect` and connecting _Chrome Dev Tools_ hitting `Debug.breakpoint` automatically stops in the debugger.

![Dev Tools](https://github.com/user-attachments/assets/653210bf-bc12-428d-bf1b-7b6f2929570c)

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
