### PR TITLE
Keep subscription payment form open until plan is successful

### DIFF
--- a/app/dashboard/src/components/ErrorBoundary.tsx
+++ b/app/dashboard/src/components/ErrorBoundary.tsx
@@ -77,10 +77,15 @@ export function ErrorDisplay(props: ErrorDisplayProps): React.JSX.Element {
     status = isOffline ? 'info' : 'error',
   } = props
 
+  const message = errorUtils.getMessageOrToString(error)
   const stack = errorUtils.tryGetStack(error)
 
   return (
     <result.Result className="h-full" status={status} title={title} subtitle={subtitle}>
+      <ariaComponents.Text color="danger" variant="body">
+        {getText('errorColon')}
+        {message}
+      </ariaComponents.Text>
       <ariaComponents.ButtonGroup align="center">
         <ariaComponents.Button
           variant="submit"

--- a/app/dashboard/src/modules/payments/components/AddPaymentMethodForm.tsx
+++ b/app/dashboard/src/modules/payments/components/AddPaymentMethodForm.tsx
@@ -78,10 +78,6 @@ export function AddPaymentMethodForm<
           })
       }
     },
-    onSuccess: async (paymentMethod) => {
-      await onSubmit?.(paymentMethod.paymentMethod.id)
-      cardElement?.clear()
-    },
   })
 
   // No idea if it's safe or not, but outside of the function everything is fine
@@ -95,7 +91,12 @@ export function AddPaymentMethodForm<
     <ariaComponents.Form
       method="dialog"
       form={formInstance}
-      onSubmit={() => createPaymentMethodMutation.mutateAsync()}
+      onSubmit={() =>
+        createPaymentMethodMutation.mutateAsync().then(async ({ paymentMethod }) => {
+          await onSubmit?.(paymentMethod.id)
+          cardElement?.clear()
+        })
+      }
     >
       <ariaComponents.Form.Field name="card" fullWidth label={getText('bankCardLabel')}>
         <stripeReact.CardElement

--- a/app/dashboard/src/pages/authentication/ErrorScreen.tsx
+++ b/app/dashboard/src/pages/authentication/ErrorScreen.tsx
@@ -1,4 +1,4 @@
-/** @file A loading screen, displayed while the user is logging in. */
+/** @file A screen displaying an error. */
 import * as React from 'react'
 
 import * as textProvider from '#/providers/TextProvider'
@@ -16,7 +16,7 @@ export interface ErrorScreenProps {
   readonly error: unknown
 }
 
-/** A loading screen. */
+/** A screen displaying an error. */
 export default function ErrorScreen(props: ErrorScreenProps) {
   const { error } = props
   const { getText } = textProvider.useText()

--- a/app/dashboard/src/pages/subscribe/Subscribe/Subscribe.tsx
+++ b/app/dashboard/src/pages/subscribe/Subscribe/Subscribe.tsx
@@ -1,19 +1,13 @@
 /** @file A page in which the currently active payment plan can be changed. */
-import * as React from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 
-import * as router from 'react-router-dom'
-
+import { DASHBOARD_PATH, SUBSCRIBE_SUCCESS_PATH } from '#/appUtils'
 import Back from '#/assets/arrow_left.svg'
-
-import * as appUtils from '#/appUtils'
-
-import * as authProvider from '#/providers/AuthProvider'
-import * as textProvider from '#/providers/TextProvider'
-
-import * as ariaComponents from '#/components/AriaComponents'
-
-import * as paymentModule from '#/modules/payments'
-import * as backendModule from '#/services/Backend'
+import { Button, Text } from '#/components/AriaComponents'
+import { PlanSelector } from '#/modules/payments'
+import { useFullUserSession } from '#/providers/AuthProvider'
+import { useText } from '#/providers/TextProvider'
+import { isPlan } from '#/services/Backend'
 
 /** A page in which the currently active payment plan can be changed.
  *
@@ -29,45 +23,38 @@ import * as backendModule from '#/services/Backend'
  * paymentStatus: 'no_payment_required' || 'paid' || 'unpaid' }`).
  */
 export function Subscribe() {
-  const { getText } = textProvider.useText()
-  const navigate = router.useNavigate()
-  const { user } = authProvider.useFullUserSession()
+  const { getText } = useText()
+  const navigate = useNavigate()
+  const { user } = useFullUserSession()
 
-  const [searchParams] = router.useSearchParams()
+  const [searchParams] = useSearchParams()
 
   const maybePlan = searchParams.get('plan')
 
-  const chosenPlan = backendModule.isPlan(maybePlan) ? maybePlan : null
+  const chosenPlan = isPlan(maybePlan) ? maybePlan : null
 
   return (
     <div className="flex h-full w-full flex-col overflow-y-auto bg-hover-bg">
       <div className="mx-auto mt-16 flex w-full min-w-96 max-w-[1400px] flex-col items-start justify-center p-12">
         <div className="flex flex-col items-start">
-          <ariaComponents.Button
-            variant="icon"
-            size="medium"
-            icon={Back}
-            href={appUtils.DASHBOARD_PATH}
-            className="-ml-2"
-          >
+          <Button variant="icon" size="medium" icon={Back} href={DASHBOARD_PATH} className="-ml-2">
             {getText('returnToDashboard')}
-          </ariaComponents.Button>
+          </Button>
 
-          <ariaComponents.Text.Heading
-            level={1}
-            variant="custom"
-            className="mb-5 self-start text-start text-4xl"
-          >
+          <Text.Heading level={1} variant="custom" className="mb-5 self-start text-start text-4xl">
             {getText('subscribeTitle')}
-          </ariaComponents.Text.Heading>
+          </Text.Heading>
         </div>
 
-        <paymentModule.PlanSelector
+        <PlanSelector
           plan={chosenPlan}
           showFreePlan={false}
           userPlan={user.plan}
           onSubscribeSuccess={(plan) => {
-            navigate({ pathname: appUtils.SUBSCRIBE_SUCCESS_PATH, search: `plan=${plan}` })
+            navigate({
+              pathname: SUBSCRIBE_SUCCESS_PATH,
+              search: new URLSearchParams({ plan }).toString(),
+            })
           }}
         />
       </div>

--- a/app/dashboard/src/pages/subscribe/SubscribeSuccess.tsx
+++ b/app/dashboard/src/pages/subscribe/SubscribeSuccess.tsx
@@ -10,7 +10,7 @@ import * as ariaComponents from '#/components/AriaComponents'
 import * as result from '#/components/Result'
 
 import { PLAN_TO_TEXT_ID } from '#/modules/payments'
-import * as backend from '#/services/Backend'
+import { Plan, isPlan } from '#/services/Backend'
 
 // ========================
 // === SubscribeSuccess ===
@@ -21,9 +21,9 @@ export function SubscribeSuccess() {
   const { getText } = textProvider.useText()
   const [searchParams] = routerDom.useSearchParams()
   const navigate = routerDom.useNavigate()
-  const plan = searchParams.get('plan') ?? backend.Plan.solo
+  const plan = searchParams.get('plan') ?? Plan.solo
 
-  if (!backend.isPlan(plan)) {
+  if (!isPlan(plan)) {
     return <router.Navigate to={appUtils.DASHBOARD_PATH} replace />
   } else {
     return (

--- a/app/ide-desktop/common/src/text/english.json
+++ b/app/ide-desktop/common/src/text/english.json
@@ -355,6 +355,7 @@
   "versionX": "Version $0",
   "version": "Version",
   "build": "Build",
+  "errorColon": "Error: ",
   "electronVersion": "Electron",
   "chromeVersion": "Chrome",
   "userAgent": "User Agent",


### PR DESCRIPTION
### Pull Request Description
- Keep payment form open until `plan` on `users/me` matches the new plan being upgraded to
  - 3 second delay between fetches on `users/me`
  - 30 second timeout after which an error message is displayed
  - Note that currently this just keeps the form submit button spinning for longer, rather than having an extra dedicated full-page loading spinner.

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
