### PR TITLE
Internal tests run with --disable-private-check

### DIFF
--- a/build/build/src/enso.rs
+++ b/build/build/src/enso.rs
@@ -107,6 +107,9 @@ impl BuiltEnso {
             // This flag enables assertions in the JVM. Some of our stdlib tests had in the past
             // failed on Graal/Truffle assertions, so we want to have them triggered.
             .set_env(JAVA_OPTS, &ide_ci::programs::java::Option::EnableAssertions.as_ref())?;
+        if test_path.as_str().contains("_Internal_") {
+            command.arg("--disable-private-check");
+        }
         Ok(command)
     }
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Internal/Extra_Imports.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Internal/Extra_Imports.enso
@@ -9,11 +9,10 @@ private
 polyglot java import java.io.PrintStream
 
 # needed by Util_Spec
-polyglot java import org.enso.base.text.CaseFoldedString
+polyglot java import org.enso.base.text.CaseFoldedString as JCaseFoldedString
 polyglot java import org.enso.base.text.CaseFoldedString.Grapheme
-
-# needed by Comparator_Spec:
-polyglot java import org.enso.base.ObjectComparator
+polyglot java import org.enso.base.Text_Utils as JText_Utils
+polyglot java import com.ibm.icu.text.BreakIterator as JBreakIterator
 
 # often used in tests
 polyglot java import java.util.ArrayList
@@ -26,6 +25,21 @@ polyglot java import java.math.BigInteger
 polyglot java import java.time.LocalDate
 polyglot java import java.time.LocalDateTime
 polyglot java import java.util.function.Function
+polyglot java import java.lang.Exception as JException
 polyglot java import java.lang.Thread
 polyglot java import java.lang.Thread.State
 polyglot java import java.lang.Float
+
+polyglot java import org.enso.base.Stream_Utils as JStream_Utils
+polyglot java import org.enso.base.file_system.File_Utils as JFile_Utils
+polyglot java import org.enso.base.CompareException as JCompareException
+polyglot java import org.enso.base.ObjectComparator as JObjectComparator
+
+Stream_Utils=JStream_Utils
+File_Utils=JFile_Utils
+CompareException=JCompareException
+ObjectComparator=JObjectComparator
+CaseFoldedString=JCaseFoldedString
+Text_Utils=JText_Utils
+BreakIterator=JBreakIterator
+Exception=JException

--- a/project/DistributionPackage.scala
+++ b/project/DistributionPackage.scala
@@ -271,6 +271,19 @@ object DistributionPackage {
     log.info(s"Executing $enso ${args.mkString(" ")}")
     val pb  = new java.lang.ProcessBuilder()
     val all = new java.util.ArrayList[String]()
+    val disablePrivateCheck = {
+      val findRun = args.indexOf("--run")
+      if (findRun >= 0 && findRun + 1 < args.size) {
+        val whatToRun = args(findRun + 1)
+        if (whatToRun.startsWith("test/") && whatToRun.endsWith("_Tests")) {
+          whatToRun.contains("_Internal_")
+        } else {
+          false
+        }
+      } else {
+        false
+      }
+    }
     all.add(enso.getAbsolutePath())
     all.addAll(args.asJava)
     pb.command(all)
@@ -279,6 +292,9 @@ object DistributionPackage {
       pb.environment().put("JAVA_OPTS", "-ea " + WithDebugCommand.DEBUG_OPTION)
     } else {
       pb.environment().put("JAVA_OPTS", "-ea")
+    }
+    if (disablePrivateCheck) {
+      all.add("--disable-private-check")
     }
     pb.inheritIO()
     val p        = pb.start()

--- a/test/Base_Internal_Tests/README.md
+++ b/test/Base_Internal_Tests/README.md
@@ -1,0 +1,2 @@
+This is a set of tests for the `Base` library for Enso that need access
+to library internals. Run with `--disable-private-checks`.

--- a/test/Base_Internal_Tests/README.md
+++ b/test/Base_Internal_Tests/README.md
@@ -1,2 +1,2 @@
-This is a set of tests for the `Base` library for Enso that need access
-to library internals. Run with `--disable-private-checks`.
+This is a set of tests for the `Base` library for Enso that need access to
+library internals. Run with `--disable-private-checks`.

--- a/test/Base_Internal_Tests/package.yaml
+++ b/test/Base_Internal_Tests/package.yaml
@@ -1,0 +1,9 @@
+name: Base_Internal_Tests
+namespace: enso_dev
+enso-version: default
+version: 0.0.1
+license: MIT
+author: enso-dev@enso.org
+maintainer: enso-dev@enso.org
+# Base_Internal_Tests may import stuff from Helpers sibling project. So we need this property here.
+prefer-local-libraries: true

--- a/test/Base_Internal_Tests/src/Comparator_Spec.enso
+++ b/test/Base_Internal_Tests/src/Comparator_Spec.enso
@@ -1,12 +1,10 @@
 from Standard.Base import all
 import Standard.Base.Errors.Common.Incomparable_Values
 
-polyglot java import org.enso.base.ObjectComparator
-
-polyglot java import org.enso.base.CompareException
-
 from Standard.Test import all
 
+import Standard.Base.Internal.Extra_Imports.ObjectComparator
+import Standard.Base.Internal.Extra_Imports.CompareException
 
 # === Test Resources ===
 

--- a/test/Base_Internal_Tests/src/Grapheme_Spec.enso
+++ b/test/Base_Internal_Tests/src/Grapheme_Spec.enso
@@ -1,13 +1,11 @@
 from Standard.Base import all
 
-polyglot java import org.enso.base.Text_Utils
-polyglot java import org.enso.base.text.CaseFoldedString
-polyglot java import com.ibm.icu.text.BreakIterator
+import Standard.Base.Internal.Extra_Imports.Text_Utils
+import Standard.Base.Internal.Extra_Imports.CaseFoldedString
+import Standard.Base.Internal.Extra_Imports.BreakIterator
+import Standard.Base.Internal.Extra_Imports.Exception as JException
 
 from Standard.Test import all
-
-
-polyglot java import java.lang.Exception as JException
 
 add_specs suite_builder =
     suite_builder.group "Text_Utils" group_builder->

--- a/test/Base_Internal_Tests/src/Input_Output_Spec.enso
+++ b/test/Base_Internal_Tests/src/Input_Output_Spec.enso
@@ -44,6 +44,7 @@ add_specs suite_builder =
 
             is.available . should_equal 0
 
+    suite_builder.group "Host File values behaviour in Enso" group_builder->
         group_builder.specify "File in Dictionary supports host objects as keys" <|
             # java.nio.path.Path has proper implementation of hashCode
             dict = Dictionary.singleton (File_Utils.toPath "/home/user/file.txt") 42
@@ -59,7 +60,6 @@ add_specs suite_builder =
             (path3 == path2).should_be_false
 
 
-    suite_builder.group "Internal comparators" group_builder->
 
 foreign js is_like data available = """
     let at = 0

--- a/test/Base_Internal_Tests/src/Input_Output_Spec.enso
+++ b/test/Base_Internal_Tests/src/Input_Output_Spec.enso
@@ -1,0 +1,86 @@
+from Standard.Base import all
+
+from Standard.Test import all
+import Standard.Test.Test_Environment
+
+import Standard.Base.Errors.Illegal_State.Illegal_State
+import Standard.Base.Runtime.Managed_Resource.Managed_Resource
+import Standard.Base.System.Input_Stream.Input_Stream
+
+polyglot java import org.enso.base_test_helpers.RangeStream
+import Standard.Base.Internal.Extra_Imports.Stream_Utils
+import Standard.Base.Internal.Extra_Imports.File_Utils
+
+
+add_specs suite_builder =
+    suite_builder.group "I/O Checks" group_builder->
+        group_builder.specify "read without available" <|
+            stream_like = is_like [20, 5, 1, 10] False
+            is = Stream_Utils.asInputStream stream_like
+            is.available . should_equal 0
+
+            is.read . should_equal 20
+            is.read . should_equal 5
+
+            is.available . should_equal 0
+
+            is.read . should_equal 1
+            is.read . should_equal 10
+
+            is.available . should_equal 0
+
+        group_builder.specify "read with available" <|
+            stream_like = is_like [20, 6, 8, 23] True
+            is = Stream_Utils.asInputStream stream_like
+            is.available . should_equal 4
+
+            is.read . should_equal 20
+            is.read . should_equal 6
+
+            is.available . should_equal 2
+
+            is.read . should_equal 8
+            is.read . should_equal 23
+
+            is.available . should_equal 0
+
+        group_builder.specify "File in Dictionary supports host objects as keys" <|
+            # java.nio.path.Path has proper implementation of hashCode
+            dict = Dictionary.singleton (File_Utils.toPath "/home/user/file.txt") 42
+            dict.get "X" . should_equal Nothing
+            dict.get "A" . should_equal Nothing
+            dict.get (File_Utils.toPath "/home/user/file.txt") . should_equal 42
+
+        group_builder.specify "File equals on host values" <|
+            path1 = File_Utils.toPath "home" . resolve "user" . resolve "file.txt"
+            path2 = File_Utils.toPath "home" . resolve "user" . resolve "file.txt"
+            (path1 == path2).should_be_true
+            path3 = path1.resolve "subfile.txt"
+            (path3 == path2).should_be_false
+
+
+    suite_builder.group "Internal comparators" group_builder->
+
+foreign js is_like data available = """
+    let at = 0
+    let is = {
+        read : function(arr, off, len) {
+          let cnt = 0;
+          while (len-- > 0) {
+            arr[off++] = data[at++];
+            cnt++;
+          }
+          return cnt;
+        }
+    }
+    if (available) {
+      is.available = function() {
+        return data.length - at;
+      };
+    }
+    return is;
+
+main filter=Nothing =
+    suite = Test.build suite_builder->
+        add_specs suite_builder
+    suite.run_with_filter filter

--- a/test/Base_Internal_Tests/src/Main.enso
+++ b/test/Base_Internal_Tests/src/Main.enso
@@ -1,0 +1,15 @@
+from Standard.Base import all
+
+from Standard.Test import all
+
+import project.Input_Output_Spec
+import project.Comparator_Spec
+import project.Grapheme_Spec
+
+main filter=Nothing =
+    suite = Test.build suite_builder->
+        Input_Output_Spec.add_specs suite_builder
+        Comparator_Spec.add_specs suite_builder
+        Grapheme_Spec.add_specs suite_builder
+
+    suite.run_with_filter filter

--- a/test/Base_Tests/src/Data/Dictionary_Spec.enso
+++ b/test/Base_Tests/src/Data/Dictionary_Spec.enso
@@ -5,7 +5,6 @@ import Standard.Base.Errors.No_Such_Key.No_Such_Key
 from Standard.Test import all
 
 polyglot java import java.util.Map as JavaMap
-polyglot java import org.enso.base.file_system.File_Utils
 
 ## Type that violates reflexivity
 type My_Nan
@@ -275,13 +274,6 @@ add_specs suite_builder =
             dict.size.should_equal 1
             dict.get "A" . should_equal 42
             dict.get (js_str "A") . should_equal 42
-
-        group_builder.specify "should support host objects as keys" <|
-            # java.nio.path.Path has proper implementation of hashCode
-            dict = Dictionary.singleton (File_Utils.toPath "/home/user/file.txt") 42
-            dict.get "X" . should_equal Nothing
-            dict.get "A" . should_equal Nothing
-            dict.get (File_Utils.toPath "/home/user/file.txt") . should_equal 42
 
         group_builder.specify "should support Python objects as keys" pending=pending_python_missing <|
             py_obj = py_wrapper 42

--- a/test/Base_Tests/src/Main.enso
+++ b/test/Base_Tests/src/Main.enso
@@ -39,7 +39,6 @@ import project.Data.Locale_Spec
 import project.Data.Maybe_Spec
 import project.Data.Numbers_Spec
 import project.Data.Ordering_Spec
-import project.Data.Ordering.Comparator_Spec
 import project.Data.Ordering.Natural_Order_Spec
 import project.Data.Ordering.Vector_Lexicographic_Order_Spec
 import project.Data.Pair_Spec
@@ -57,7 +56,6 @@ import project.Data.Text.Encoding_Spec
 import project.Data.Text.Parse_Spec
 import project.Data.Text.Regex_Spec
 import project.Data.Text.Span_Spec
-import project.Data.Text.Utils_Spec
 import project.Data.XML.XML_Spec
 
 import project.Data.Vector.Slicing_Helpers_Spec
@@ -137,7 +135,6 @@ main filter=Nothing =
         Numbers_Spec.add_specs suite_builder
         Equals_Spec.add_specs suite_builder
         Ordering_Spec.add_specs suite_builder
-        Comparator_Spec.add_specs suite_builder
         Natural_Order_Spec.add_specs suite_builder
         Vector_Lexicographic_Order_Spec.add_specs suite_builder
         Process_Spec.add_specs suite_builder
@@ -163,7 +160,6 @@ main filter=Nothing =
         Missing_Required_Arguments_Spec.add_specs suite_builder
         Lazy_Generator_Spec.add_specs suite_builder
         Stack_Traces_Spec.add_specs suite_builder
-        Utils_Spec.add_specs suite_builder
         Text_Spec.add_specs suite_builder
         Time_Spec.add_specs suite_builder
         URI_Spec.add_specs suite_builder

--- a/test/Base_Tests/src/Semantic/Equals_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Equals_Spec.enso
@@ -179,13 +179,6 @@ add_specs suite_builder =
             ((CustomEqType.C1 10) == (CustomEqType.C2 7 3)).should_be_true
             ((CustomEqType.C1 0) == (CustomEqType.C2 7 3)).should_be_false
 
-        group_builder.specify "should dispatch to equals on host values" <|
-            path1 = File_Utils.toPath "home" . resolve "user" . resolve "file.txt"
-            path2 = File_Utils.toPath "home" . resolve "user" . resolve "file.txt"
-            (path1 == path2).should_be_true
-            path3 = path1.resolve "subfile.txt"
-            (path3 == path2).should_be_false
-
         group_builder.specify "should return False for different Atoms with same fields" <|
             rect = Rect.Value (Point.Value 1 2) (Point.Value 3 4)
             four_field = FourFieldType.Value 1 2 3 4

--- a/test/Base_Tests/src/System/Input_Stream_Spec.enso
+++ b/test/Base_Tests/src/System/Input_Stream_Spec.enso
@@ -14,24 +14,6 @@ main filter=Nothing =
     suite.run_with_filter filter
 
 
-foreign js is_like data available = """
-    let at = 0
-    let is = {
-        read : function(arr, off, len) {
-          let cnt = 0;
-          while (len-- > 0) {
-            arr[off++] = data[at++];
-            cnt++;
-          }
-          return cnt;
-        }
-    }
-    if (available) {
-      is.available = function() {
-        return data.length - at;
-      };
-    }
-    return is;
 
 add_specs suite_builder = suite_builder.group "Input Stream" group_builder->
     group_builder.specify "should be peekable if backed by memory" <|
@@ -83,32 +65,3 @@ add_specs suite_builder = suite_builder.group "Input Stream" group_builder->
         # The read still succeeds - ensuring there isn't some early EOF
         promoted_stream.read_n_bytes 10 . should_equal [100, 101, 102, 103, 104]
 
-    group_builder.specify "read without available" <|
-        stream_like = is_like [20, 5, 1, 10] False
-        is = Stream_Utils.asInputStream stream_like
-        is.available . should_equal 0
-
-        is.read . should_equal 20
-        is.read . should_equal 5
-
-        is.available . should_equal 0
-
-        is.read . should_equal 1
-        is.read . should_equal 10
-
-        is.available . should_equal 0
-
-    group_builder.specify "read with available" <|
-        stream_like = is_like [20, 6, 8, 23] True
-        is = Stream_Utils.asInputStream stream_like
-        is.available . should_equal 4
-
-        is.read . should_equal 20
-        is.read . should_equal 6
-
-        is.available . should_equal 2
-
-        is.read . should_equal 8
-        is.read . should_equal 23
-
-        is.available . should_equal 0


### PR DESCRIPTION
### Pull Request Description

Introduces `test/Base_Internal_Tests`. Modifies the build scripts to run tests with `--disable-private-check` when name of the test project contains `_Internal_`. Extracted part of #10714.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. 
- [x] Unit tests continue to pass
