### PR TITLE
Text editing ranges specified in UTF16 code units

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -629,6 +629,7 @@ lazy val `text-buffer` = project
   .configs(Test)
   .settings(
     frgaalJavaCompilerSetting,
+    commands += WithDebugCommand.withDebug,
     libraryDependencies ++= Seq(
       "org.scalatest"  %% "scalatest"  % scalatestVersion  % Test,
       "org.scalacheck" %% "scalacheck" % scalacheckVersion % Test

--- a/docs/language-server/protocol-language-server.md
+++ b/docs/language-server/protocol-language-server.md
@@ -1006,8 +1006,8 @@ The range of `1` is
 ```
 
 For unicode characters, the range is measured in code units, for example given
-the function with the old key emoji `🗝` argument consisting of two unicode code
-units `\uD83D` and `\uDDDD`.
+the function with the old key emoji `foo 🗝 = ...` argument consisting of two
+unicode code units `\uD83D` and `\uDDDD`.
 
 ```rust
 0|foo \uD83D\uDDDD = ...

--- a/docs/language-server/protocol-language-server.md
+++ b/docs/language-server/protocol-language-server.md
@@ -1005,6 +1005,25 @@ The range of `1` is
 }
 ```
 
+For unicode characters, the range is measured in code units, for example given
+the function with the old key emoji `🗝` argument consisting of two unicode code
+units `\uD83D` and `\uDDDD`.
+
+```rust
+0|foo \uD83D\uDDDD = ...
+  ^^^^^^^^^^^^^^^^^^
+  01234     5     67
+```
+
+The range of old key emoji `🗝` argument is
+
+```typescript
+{
+    start: { line: 0, character: 4},
+    end: { line: 0, character: 6}
+}
+```
+
 #### Format
 
 ```typescript

--- a/lib/scala/text-buffer/src/main/scala/org/enso/text/editing/RopeTextEditor.scala
+++ b/lib/scala/text-buffer/src/main/scala/org/enso/text/editing/RopeTextEditor.scala
@@ -3,8 +3,7 @@ package org.enso.text.editing
 import org.enso.text.buffer.Rope
 import org.enso.text.editing.model.TextEdit
 
-/** Instance of the [[TextEditor]] type class for the [[Rope]] type.
-  */
+/** Instance of the [[TextEditor]] type class for the [[Rope]] type. */
 object RopeTextEditor extends TextEditor[Rope] {
 
   /** Edits a buffer.
@@ -27,7 +26,7 @@ object RopeTextEditor extends TextEditor[Rope] {
       if (diff.range.start.character > 0)
         buffer.lines
           .drop(diff.range.start.line)
-          .codePoints
+          .characters
           .take(diff.range.start.character)
       else
         Rope.empty
@@ -36,11 +35,11 @@ object RopeTextEditor extends TextEditor[Rope] {
   }
 
   private def cutOutTail(buffer: Rope, diff: TextEdit): Rope = {
-    val codePoints = buffer.lines
+    val characters = buffer.lines
       .drop(diff.range.end.line)
-      .codePoints
-    if (codePoints.length < diff.range.end.character) Rope.empty
-    else codePoints.drop(diff.range.end.character)
+      .characters
+    if (characters.length < diff.range.end.character) Rope.empty
+    else characters.drop(diff.range.end.character)
   }
 
   /** Returns a number of lines in a buffer.

--- a/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/EditorOpsSpec.scala
+++ b/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/EditorOpsSpec.scala
@@ -32,10 +32,11 @@ class EditorOpsSpec extends AnyFlatSpec with Matchers with EitherValues {
 
   it should "be able to apply diffs with unicode symbols" in {
     //given
+    val oldKeyEmoji       = "\uD83D\uDDDD"
     val signaturePosition = Range(Position(2, 12), Position(2, 13))
-    val signatureDiff     = TextEdit(signaturePosition, "\uD83D\uDDDD")
+    val signatureDiff     = TextEdit(signaturePosition, oldKeyEmoji)
     val bodyPosition      = Range(Position(2, 22), Position(2, 23))
-    val bodyDiff          = TextEdit(bodyPosition, "\uD83D\uDDDD")
+    val bodyDiff          = TextEdit(bodyPosition, oldKeyEmoji)
     val diffs             = List(signatureDiff, bodyDiff)
     //when
     val result = EditorOps.applyEdits(testSnippet, diffs)

--- a/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/EditorOpsSpec.scala
+++ b/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/EditorOpsSpec.scala
@@ -86,4 +86,17 @@ class EditorOpsSpec extends AnyFlatSpec with Matchers with EitherValues {
     result.map(_.toString) mustBe Right("foo")
   }
 
+  it should "be able to edit text with emoji" in {
+    //given
+    val oldKeyEmoji       = "\uD83D\uDDDD"
+    val variationSelector = "\uFE0F"
+    val codeToEdit        = Rope(s"$oldKeyEmoji$variationSelector")
+    val range             = Range(Position(0, 1), Position(0, 1))
+    val diff              = TextEdit(range, "xyz")
+    //when
+    val result = EditorOps.applyEdits(codeToEdit, Seq(diff))
+    //then
+    result.map(_.toString) mustBe Right("\uD83D\uDDDDxyz\uFE0F")
+  }
+
 }

--- a/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/EditorOpsSpec.scala
+++ b/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/EditorOpsSpec.scala
@@ -7,25 +7,28 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 
+@annotation.nowarn("msg=Unicode escapes")
 class EditorOpsSpec extends AnyFlatSpec with Matchers with EitherValues {
 
   "An editor" should "be able to apply multiple diffs" in {
     //given
-    val signaturePosition = Range(Position(2, 12), Position(2, 13))
+    val signaturePosition = Range(Position(2, 12 + 1), Position(2, 13 + 1))
     val signatureDiff     = TextEdit(signaturePosition, "arg")
-    val bodyPosition      = Range(Position(2, 23), Position(2, 24))
+    val bodyPosition      = Range(Position(2, 23 + 1), Position(2, 24 + 1))
     val bodyDiff          = TextEdit(bodyPosition, "arg")
     val diffs             = List(signatureDiff, bodyDiff)
     //when
     val result = EditorOps.applyEdits(testSnippet, diffs)
     //then
-    result.map(_.toString) mustBe Right("""
-                                          |main =
-                                          |    apply = arg f -> f arg
-                                          |    adder = a b -> a + b
-                                          |    plusOne = apply (f = adder 1)
-                                          |    result = plusOne 10
-                                          |    result""".stripMargin)
+    result.map(_.toString) mustBe Right(
+      """
+        |main =
+        |    apply = \uD83D\uDDDDarg f -> f arg
+        |    adder = a b -> a + b
+        |    plusOne = apply (f = adder 1)
+        |    result = plusOne 10
+        |    result""".stripMargin
+    )
   }
 
   it should "take into account applied so far edits when validate next diff" in {

--- a/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/RopeTextEditorSpec.scala
+++ b/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/RopeTextEditorSpec.scala
@@ -99,7 +99,7 @@ class RopeTextEditorSpec extends AnyFlatSpec with Matchers {
     //given
     //0x0001F4AF
     val utf32Text           = Rope("unicode: \ud83d\udcaf end")
-    val positionInCodeUnits = Range(Position(0, 9), Position(0, 10))
+    val positionInCodeUnits = Range(Position(0, 9), Position(0, 11))
     //0x0001F449
     val diff = TextEdit(positionInCodeUnits, "\ud83d\udc49")
     //when

--- a/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/TestData.scala
+++ b/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/TestData.scala
@@ -2,13 +2,12 @@ package org.enso.text.editing
 
 import org.enso.text.buffer.Rope
 
-@annotation.nowarn("msg=Unicode escapes")
 object TestData {
 
   val code =
     """
       |main =
-      |    apply = \uD83D\uDDDDv f -> f v
+      |    apply = v f -> f v
       |    adder = a b -> a + b
       |    plusOne = apply (f = adder 1)
       |    result = plusOne 10

--- a/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/TestData.scala
+++ b/lib/scala/text-buffer/src/test/scala/org/enso/text/editing/TestData.scala
@@ -2,12 +2,13 @@ package org.enso.text.editing
 
 import org.enso.text.buffer.Rope
 
+@annotation.nowarn("msg=Unicode escapes")
 object TestData {
 
   val code =
     """
       |main =
-      |    apply = v f -> f v
+      |    apply = \uD83D\uDDDDv f -> f v
       |    adder = a b -> a + b
       |    plusOne = apply (f = adder 1)
       |    result = plusOne 10


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

related #10678

Changelog:
- update: text editing expects Unicode code units when specifying text ranges
- test: text editing with emojis

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
