### PR TITLE
Attaching a warning to error is no op

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/WarningsTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/WarningsTest.java
@@ -3,9 +3,11 @@ package org.enso.interpreter.test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.enso.common.LanguageInfo;
 import org.enso.common.MethodNames;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.interpreter.runtime.warning.AppendWarningNode;
@@ -59,8 +61,10 @@ public class WarningsTest {
           var warn2 = Warning.create(ensoContext, "w2", this);
           var value = 42L;
 
-          var with1 = AppendWarningNode.getUncached().executeAppend(null, value, warn1);
-          var with2 = AppendWarningNode.getUncached().executeAppend(null, with1, warn2);
+          var with1 =
+              (WithWarnings) AppendWarningNode.getUncached().executeAppend(null, value, warn1);
+          var with2 =
+              (WithWarnings) AppendWarningNode.getUncached().executeAppend(null, with1, warn2);
 
           assertEquals(value, with1.getValue());
           assertEquals(value, with2.getValue());
@@ -73,7 +77,7 @@ public class WarningsTest {
   @Test
   public void wrapAndUnwrap() {
     var value = 42;
-    WithWarnings without;
+    Object without;
     try {
       without = AppendWarningNode.getUncached().executeAppend(null, 42, new Warning[0]);
     } catch (AssertionError e) {
@@ -153,5 +157,27 @@ public class WarningsTest {
             AllOf.allOf(containsString("warn:once"), containsString("warn:twice")));
       }
     }
+  }
+
+  @Test
+  public void warningOnAnError() throws Exception {
+    var code =
+        """
+    from Standard.Base import Integer, Warning, Error
+    import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
+    from Standard.Base.Errors.Common import Out_Of_Range
+
+    err_warn -> Integer ! Illegal_Argument =
+        v = Warning.attach (Out_Of_Range.Error "qewr") 12
+        case v of
+            _ : Integer -> Error.throw (Illegal_Argument.Error "asdf")
+    """;
+
+    var module = ctx.eval(LanguageInfo.ID, code);
+    var errorWithWarning = module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "err_warn");
+    assertFalse("Something is returned", errorWithWarning.isNull());
+    assertTrue("But it represents an exception object", errorWithWarning.isException());
+    assertEquals(
+        "Standard.Base.Error.Error", errorWithWarning.getMetaObject().getMetaQualifiedName());
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/AppendWarningNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/AppendWarningNode.java
@@ -12,12 +12,14 @@ import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.ConditionProfile;
 import org.enso.interpreter.runtime.EnsoContext;
+import org.enso.interpreter.runtime.data.EnsoObject;
 import org.enso.interpreter.runtime.data.hash.EnsoHashMap;
 import org.enso.interpreter.runtime.data.hash.HashMapInsertAllNode;
 import org.enso.interpreter.runtime.data.hash.HashMapInsertNode;
 import org.enso.interpreter.runtime.data.hash.HashMapSizeNode;
 import org.enso.interpreter.runtime.data.vector.ArrayLikeAtNode;
 import org.enso.interpreter.runtime.data.vector.ArrayLikeLengthNode;
+import org.enso.interpreter.runtime.error.DataflowError;
 
 @GenerateUncached
 public abstract class AppendWarningNode extends Node {
@@ -38,9 +40,9 @@ public abstract class AppendWarningNode extends Node {
    *     It is expected that all the elements in the container are of {@link Warning} class.
    * @return A wrapped object with warnings
    */
-  public abstract WithWarnings executeAppend(VirtualFrame frame, Object object, Object warnings);
+  public abstract EnsoObject executeAppend(VirtualFrame frame, Object object, Object warnings);
 
-  @Specialization
+  @Specialization(guards = "!isError(object)")
   WithWarnings doSingleWarning(
       VirtualFrame frame,
       Object object,
@@ -70,7 +72,7 @@ public abstract class AppendWarningNode extends Node {
     return new WithWarnings(value, warnsLimit, isLimitReached, warnsMap);
   }
 
-  @Specialization
+  @Specialization(guards = "!isError(object)")
   WithWarnings doMultipleWarningsArray(
       VirtualFrame frame,
       Object object,
@@ -106,7 +108,7 @@ public abstract class AppendWarningNode extends Node {
    * This specialization should be the most frequent - just wrapping the given {@code object} with
    * warnings hash map
    */
-  @Specialization(guards = {"!isWithWarns(object)"})
+  @Specialization(guards = {"!isError(object)", "!isWithWarns(object)"})
   WithWarnings doObjectMultipleWarningsHashMap(
       VirtualFrame frame,
       Object object,
@@ -138,7 +140,8 @@ public abstract class AppendWarningNode extends Node {
     return new WithWarnings(withWarnings.value, withWarnings.maxWarnings, isLimitReached, warnsMap);
   }
 
-  @Specialization(guards = {"interop.hasArrayElements(warnings)", "!isWarnArray(warnings)"})
+  @Specialization(
+      guards = {"interop.hasArrayElements(warnings)", "!isError(object)", "!isWarnArray(warnings)"})
   WithWarnings doMultipleWarningsInterop(
       VirtualFrame frame,
       Object object,
@@ -171,6 +174,11 @@ public abstract class AppendWarningNode extends Node {
     return new WithWarnings(value, warnsLimit, isLimitReached, resWarningMap);
   }
 
+  @Specialization(guards = "isError(object)")
+  EnsoObject dontAnnotateError(Object object, Object ignoreWarnings) {
+    return (EnsoObject) object;
+  }
+
   /** Inserts all {@code warnings} to the {@code initialWarningMap}. */
   private EnsoHashMap insertToWarningMap(
       VirtualFrame frame,
@@ -199,11 +207,15 @@ public abstract class AppendWarningNode extends Node {
     return resWarningMap;
   }
 
-  protected static boolean isWarnArray(Object obj) {
+  static boolean isWarnArray(Object obj) {
     return obj instanceof Warning[];
   }
 
-  protected static boolean isWithWarns(Object obj) {
+  static boolean isWithWarns(Object obj) {
     return obj instanceof WithWarnings;
+  }
+
+  static boolean isError(Object obj) {
+    return obj instanceof DataflowError;
   }
 }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/Warning.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/warning/Warning.java
@@ -57,7 +57,7 @@ public final class Warning implements EnsoObject {
       description = "Attaches the given warning to the value.",
       autoRegister = false)
   @Builtin.Specialize
-  public static WithWarnings attach(
+  public static EnsoObject attach(
       EnsoContext ctx,
       Object value,
       Object warning,


### PR DESCRIPTION
### Pull Request Description

Fixes #10736 by avoiding attaching of warnings to `DataflowError`s.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
