### PR TITLE
Make sqlserver temp tables work

### DIFF
--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
@@ -26,6 +26,7 @@ import Standard.Database.SQL.SQL_Builder
 import Standard.Database.SQL_Statement.SQL_Statement
 import Standard.Database.SQL_Type.SQL_Type
 from Standard.Database.Errors import SQL_Error, Unsupported_Database_Operation
+from Standard.Database.Dialect import Temp_Table_Style
 
 import project.Database.Redshift.Internal.Redshift_Error_Mapper.Redshift_Error_Mapper
 
@@ -146,9 +147,9 @@ type Redshift_Dialect
     supports_float_round_decimal_places self = False
 
     ## PRIVATE
-       Specifies whether the Database supports CREATE TEMPORARY TABLE syntax.
-    suppports_temporary_table_syntax : Boolean
-    suppports_temporary_table_syntax self = True
+       Specifies how the database creates temp tables.
+    temp_table_style : Temp_Table_Style
+    temp_table_style self = Temp_Table_Style.Temporary_Table
 
     ## PRIVATE
     adapt_unified_column : Internal_Column -> Value_Type -> (SQL_Expression -> SQL_Type_Reference) -> Internal_Column

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -398,7 +398,8 @@ type Connection
     execute : Text | SQL_Statement -> Integer
     execute self query =
         Execution_Context.Output.if_enabled disabled_message="Executing update queries is forbidden as the Output context is disabled." panic=False <|
-            self.jdbc_connection.execute query
+            result = self.jdbc_connection.execute query
+            result.second.getUpdateCount
 
     ## PRIVATE
        Drops a table.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -399,7 +399,9 @@ type Connection
     execute self query =
         Execution_Context.Output.if_enabled disabled_message="Executing update queries is forbidden as the Output context is disabled." panic=False <|
             result = self.jdbc_connection.execute query
-            result.second.getUpdateCount
+            stmt = result.second
+            check_statement_is_allowed self stmt
+            stmt.getUpdateCount
 
     ## PRIVATE
        Drops a table.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -386,6 +386,21 @@ type Connection
                     result
 
     ## PRIVATE
+       ADVANCED
+
+       Executes a raw query. If the query was inserting, updating or
+       deleting rows, the number of affected rows is returned; otherwise it
+       returns 0 for other types of queries (like creating or altering tables).
+
+       Arguments:
+       - query: either raw SQL code as Text or an instance of SQL_Statement
+         representing the query to execute.
+    execute : Text | SQL_Statement -> Integer
+    execute self query =
+        Execution_Context.Output.if_enabled disabled_message="Executing update queries is forbidden as the Output context is disabled." panic=False <|
+            self.jdbc_connection.execute query
+
+    ## PRIVATE
        Drops a table.
 
        Arguments:

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Dialect.enso
@@ -164,9 +164,9 @@ type Dialect
         Unimplemented.throw "This is an interface only."
 
     ## PRIVATE
-       Specifies whether the Database supports CREATE TEMPORARY TABLE syntax.
-    suppports_temporary_table_syntax : Boolean
-    suppports_temporary_table_syntax self =
+       Specifies how the database creates temp tables.
+    temp_table_style : Temp_Table_Style
+    temp_table_style self =
          Unimplemented.throw "This is an interface only."
 
     ## PRIVATE
@@ -293,3 +293,12 @@ default_fetch_primary_key connection table_name =
         selected = keys_table.select_columns ["COLUMN_NAME", "KEY_SEQ"] case_sensitivity=Case_Sensitivity.Insensitive reorder=True
         key_column_names = selected.sort 1 . at 0 . to_vector
         if key_column_names.is_empty then Nothing else key_column_names
+
+## PRIVATE
+type Temp_Table_Style
+      ## PRIVATE
+         The temporary table is created using a create table statement.
+      Temporary_Table
+      ## PRIVATE
+         The temporary table is created using a # table name.
+      Hash_Prefix

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Dialect.enso
@@ -299,6 +299,7 @@ type Temp_Table_Style
       ## PRIVATE
          The temporary table is created using a create table statement.
       Temporary_Table
+      
       ## PRIVATE
          The temporary table is created using a # table name.
       Hash_Prefix

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Base_Generator.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Base_Generator.enso
@@ -12,6 +12,7 @@ import project.Internal.IR.SQL_Expression.SQL_Expression
 import project.Internal.IR.SQL_Join_Kind.SQL_Join_Kind
 import project.SQL.SQL_Builder
 from project.Errors import Unsupported_Database_Operation
+from project.Dialect import Temp_Table_Style
 from project.Internal.IR.Operation_Metadata import Row_Number_Metadata
 
 type Dialect_Operations
@@ -587,7 +588,7 @@ generate_create_table dialect name columns primary_key temporary =
     column_definitions = columns.map (generate_column_description dialect)
     modifiers = if primary_key.is_nothing then [] else
         [SQL_Builder.code ", PRIMARY KEY (" ++ SQL_Builder.join ", " (primary_key.map dialect.wrap_identifier) ++ ")"]
-    table_type = if temporary && dialect.suppports_temporary_table_syntax then "TEMPORARY TABLE" else "TABLE"
+    table_type = if temporary && dialect.temp_table_style == Temp_Table_Style.Temporary_Table then "TEMPORARY TABLE" else "TABLE"
     create_prefix = SQL_Builder.code ("CREATE "+table_type+" ") ++ dialect.wrap_identifier name
     create_body = (SQL_Builder.join ", " column_definitions) ++ (SQL_Builder.join "" modifiers)
     create_prefix ++ " (" ++ create_body ++ ")"

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/JDBC_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/JDBC_Connection.enso
@@ -121,6 +121,9 @@ type JDBC_Connection
        Executes the provided SQL.
     execute : Text | SQL_Statement -> Any
     execute self query:(Text | SQL_Statement) = self.synchronized <| profile_sql_if_enabled self query.to_text <|
+        compiled_query = case query of
+            _ : Text -> query
+            SQL_Statement.Value _ -> query.prepare.first
         self.with_connection java_connection->
             stmt = java_connection.createStatement
             handle_illegal_state caught_panic =
@@ -130,9 +133,9 @@ type JDBC_Connection
                 Panic.throw caught_panic
             result = Panic.catch Illegal_State handler=handle_illegal_state <|
                 Panic.catch Any handler=handle_any <|
-                    stmt.execute query.prepare.first
+                    stmt.execute compiled_query
             result.if_not_error <|
-                stmt
+                [result, stmt]
 
     ## PRIVATE
        Given a prepared statement, gets the column names and types for the

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/JDBC_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/JDBC_Connection.enso
@@ -119,6 +119,9 @@ type JDBC_Connection
 
     ## PRIVATE
        Executes the provided SQL.
+       Typically this shouldn't be used and with_prepared_statement should be preferred.
+       It is needed for SQLServer temp table creation where we need to execute a raw SQL statement
+       outside of a stored procedure.
     execute : Text | SQL_Statement -> Any
     execute self query:(Text | SQL_Statement) = self.synchronized <| profile_sql_if_enabled self query.to_text <|
         compiled_query = case query of

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/JDBC_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/JDBC_Connection.enso
@@ -118,6 +118,23 @@ type JDBC_Connection
                 go compiled.first compiled.second
 
     ## PRIVATE
+       Executes the provided SQL.
+    execute : Text | SQL_Statement -> Any
+    execute self query:(Text | SQL_Statement) = self.synchronized <| profile_sql_if_enabled self query.to_text <|
+        self.with_connection java_connection->
+            stmt = java_connection.createStatement
+            handle_illegal_state caught_panic =
+                Error.throw (Illegal_Argument.Error caught_panic.payload.message)
+            handle_any caught_panic =
+                stmt.close
+                Panic.throw caught_panic
+            result = Panic.catch Illegal_State handler=handle_illegal_state <|
+                Panic.catch Any handler=handle_any <|
+                    stmt.execute query.prepare.first
+            result.if_not_error <|
+                stmt
+
+    ## PRIVATE
        Given a prepared statement, gets the column names and types for the
        result set.
     raw_fetch_columns : Text | SQL_Statement -> Boolean -> Statement_Setter -> Any

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
@@ -246,6 +246,22 @@ type Postgres_Connection
         self.connection.execute_update query
 
     ## PRIVATE
+       ADVANCED
+       GROUP Standard.Base.Output
+       ICON data_output
+
+       Executes a raw query. If the query was inserting, updating or
+       deleting rows, the number of affected rows is returned; otherwise it
+       returns 0 for other types of queries (like creating or altering tables).
+
+       Arguments:
+       - query: either raw SQL code as Text or an instance of SQL_Statement
+         representing the query to execute.
+    execute : Text | SQL_Statement -> Integer
+    execute self query =
+        self.connection.execute query
+
+    ## PRIVATE
        Access the dialect.
     dialect self = self.connection.dialect
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
@@ -38,6 +38,7 @@ import project.SQL.SQL_Fragment
 import project.SQL_Statement.SQL_Statement
 import project.SQL_Type.SQL_Type
 from project.Errors import SQL_Error, Unsupported_Database_Operation
+from project.Dialect import Temp_Table_Style
 from project.Internal.IR.Operation_Metadata import Date_Period_Metadata
 
 polyglot java import java.sql.Types
@@ -183,9 +184,9 @@ type Postgres_Dialect
     supports_float_round_decimal_places self = False
 
     ## PRIVATE
-       Specifies whether the Database supports CREATE TEMPORARY TABLE syntax.
-    suppports_temporary_table_syntax : Boolean
-    suppports_temporary_table_syntax self = True
+       Specifies how the database creates temp tables.
+    temp_table_style : Temp_Table_Style
+    temp_table_style self = Temp_Table_Style.Temporary_Table
 
     ## PRIVATE
        There is a bug in Postgres type inference, where if we unify two

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
@@ -232,6 +232,22 @@ type SQLite_Connection
         self.connection.execute_update query
 
     ## PRIVATE
+       ADVANCED
+       GROUP Standard.Base.Output
+       ICON data_output
+
+       Executes a raw query. If the query was inserting, updating or
+       deleting rows, the number of affected rows is returned; otherwise it
+       returns 0 for other types of queries (like creating or altering tables).
+
+       Arguments:
+       - query: either raw SQL code as Text or an instance of SQL_Statement
+         representing the query to execute.
+    execute : Text | SQL_Statement -> Integer
+    execute self query =
+        self.connection.execute query
+
+    ## PRIVATE
        Access the dialect.
     dialect self = self.connection.dialect
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
@@ -32,6 +32,7 @@ import project.SQL.SQL_Builder
 import project.SQL_Statement.SQL_Statement
 import project.SQL_Type.SQL_Type
 from project.Errors import SQL_Error, Unsupported_Database_Operation
+from project.Dialect import Temp_Table_Style
 
 ## PRIVATE
 
@@ -193,9 +194,9 @@ type SQLite_Dialect
     supports_float_round_decimal_places self = True
 
     ## PRIVATE
-       Specifies whether the Database supports CREATE TEMPORARY TABLE syntax.
-    suppports_temporary_table_syntax : Boolean
-    suppports_temporary_table_syntax self = True
+       Specifies how the database creates temp tables.
+    temp_table_style : Temp_Table_Style
+    temp_table_style self = Temp_Table_Style.Temporary_Table
 
     ## PRIVATE
        SQLite allows mixed type columns, but we want our columns to be uniform.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Internal_Core.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Internal_Core.enso
@@ -24,7 +24,6 @@ from project.Internal.Upload.Helpers.SQL_Helpers import make_batched_insert_temp
 ## PRIVATE
    Assumes the output context is enabled for it to work.
    Creates a table in the Database and returns its name.
-   For temporary tables in dialects that use the # notation takes a table name without the # and returns it with the #.
 internal_create_table_structure connection table_name structure primary_key temporary on_problems:Problem_Behavior -> Text =
     aligned_structure = align_structure connection structure
     resolved_primary_key = resolve_primary_key aligned_structure primary_key

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Internal_Core.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Internal_Core.enso
@@ -23,14 +23,21 @@ from project.Internal.Upload.Helpers.SQL_Helpers import make_batched_insert_temp
 ## PRIVATE
    Assumes the output context is enabled for it to work.
    Creates a table in the Database and returns its name.
+   For temporry tables in dialects that use the # notation takes a table name without the # and returns it with the #.
 internal_create_table_structure connection table_name structure primary_key temporary on_problems:Problem_Behavior -> Text =
     aligned_structure = align_structure connection structure
     resolved_primary_key = resolve_primary_key aligned_structure primary_key
     validate_structure connection.base_connection.column_naming_helper aligned_structure <|
-        create_table_statement = prepare_create_table_statement connection table_name aligned_structure resolved_primary_key temporary on_problems
+        resolved_table_name = case temporary of
+            False -> table_name
+            True -> case connection.dialect.temp_table_style of
+                Temp_Table_Style.Temporary_Table -> table_name
+                Temp_Table_Style.Hash_Prefix -> "#" + table_name
+            
+        create_table_statement = prepare_create_table_statement connection resolved_table_name aligned_structure resolved_primary_key temporary on_problems
         update_result = create_table_statement.if_not_error <|
             connection.execute_update create_table_statement
-        final_result = update_result.if_not_error table_name
+        final_result = update_result.if_not_error resolved_table_name
         final_result.catch SQL_Error sql_error->
             if connection.dialect.get_error_mapper.is_table_already_exists_error sql_error then Error.throw (Table_Already_Exists.Error table_name) else final_result
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Internal_Core.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Internal_Core.enso
@@ -14,6 +14,7 @@ import project.Internal.In_Transaction.In_Transaction
 import project.Internal.IR.Query.Query
 import project.SQL_Query.SQL_Query
 from project.Errors import SQL_Error, Table_Already_Exists, Unsupported_Database_Operation
+from project.Dialect import Temp_Table_Style
 from project.Internal.Upload.Helpers.Argument_Checks import resolve_primary_key
 from project.Internal.Upload.Helpers.Constants import default_batch_size
 from project.Internal.Upload.Helpers.Error_Helpers import handle_upload_errors, internal_translate_known_upload_errors

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Internal_Core.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Internal_Core.enso
@@ -24,21 +24,15 @@ from project.Internal.Upload.Helpers.SQL_Helpers import make_batched_insert_temp
 ## PRIVATE
    Assumes the output context is enabled for it to work.
    Creates a table in the Database and returns its name.
-   For temporry tables in dialects that use the # notation takes a table name without the # and returns it with the #.
+   For temporary tables in dialects that use the # notation takes a table name without the # and returns it with the #.
 internal_create_table_structure connection table_name structure primary_key temporary on_problems:Problem_Behavior -> Text =
     aligned_structure = align_structure connection structure
     resolved_primary_key = resolve_primary_key aligned_structure primary_key
     validate_structure connection.base_connection.column_naming_helper aligned_structure <|
-        resolved_table_name = case temporary of
-            False -> table_name
-            True -> case connection.dialect.temp_table_style of
-                Temp_Table_Style.Temporary_Table -> table_name
-                Temp_Table_Style.Hash_Prefix -> "#" + table_name
-            
-        create_table_statement = prepare_create_table_statement connection resolved_table_name aligned_structure resolved_primary_key temporary on_problems
+        create_table_statement = prepare_create_table_statement connection table_name aligned_structure resolved_primary_key temporary on_problems
         update_result = create_table_statement.if_not_error <|
-            connection.execute_update create_table_statement
-        final_result = update_result.if_not_error resolved_table_name
+            connection.execute create_table_statement
+        final_result = update_result.if_not_error table_name
         final_result.catch SQL_Error sql_error->
             if connection.dialect.get_error_mapper.is_table_already_exists_error sql_error then Error.throw (Table_Already_Exists.Error table_name) else final_result
 
@@ -70,11 +64,12 @@ type Table_Upload_Operation
    - row_limit: if set, only the first `row_limit` rows will be uploaded.
 internal_upload_table : DB_Table | Table -> Connection -> Text -> Nothing | Vector Text -> Boolean -> Boolean -> Nothing | Vector Column_Description ->  Problem_Behavior -> Integer | Nothing -> Table_Upload_Operation
 internal_upload_table source_table connection (table_name : Text) (primary_key : Nothing | Vector Text) (temporary : Boolean) (remove_after_transaction : Boolean = False) structure_hint=Nothing (on_problems:Problem_Behavior=..Report_Error) (row_limit : Integer | Nothing = Nothing) -> Table_Upload_Operation =
+    resolved_table_name = resolve_temp_table_name connection temporary table_name
     case source_table of
         _ : Table ->
-            internal_upload_in_memory_table source_table connection table_name primary_key temporary remove_after_transaction structure_hint on_problems row_limit
+            internal_upload_in_memory_table source_table connection resolved_table_name primary_key temporary remove_after_transaction structure_hint on_problems row_limit
         _ : DB_Table ->
-            internal_upload_database_table source_table connection table_name primary_key temporary remove_after_transaction structure_hint on_problems row_limit
+            internal_upload_database_table source_table connection resolved_table_name primary_key temporary remove_after_transaction structure_hint on_problems row_limit
         _ ->
             Panic.throw <| Illegal_Argument.Error ("Unsupported table type: " + Meta.get_qualified_type_name source_table)
 
@@ -136,3 +131,11 @@ internal_upload_database_table (source_table : DB_Table) connection table_name p
 check_outside_transaction =
     if In_Transaction.is_in_transaction then
         Panic.throw (Illegal_State.Error "Preparing Table_Upload_Operation should itself be called outside of transaction. This is a bug in the Database library.")
+
+## PRIVATE
+resolve_temp_table_name connection:Connection temporary:Boolean table_name:Text -> Text =
+    case temporary of
+        False -> table_name
+        True -> case connection.dialect.temp_table_style of
+            Temp_Table_Style.Temporary_Table -> table_name
+            Temp_Table_Style.Hash_Prefix -> "#" + table_name

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Internal_Core.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Internal_Core.enso
@@ -132,7 +132,7 @@ check_outside_transaction =
         Panic.throw (Illegal_State.Error "Preparing Table_Upload_Operation should itself be called outside of transaction. This is a bug in the Database library.")
 
 ## PRIVATE
-resolve_temp_table_name connection:Connection temporary:Boolean table_name:Text -> Text =
+resolve_temp_table_name connection temporary:Boolean table_name:Text -> Text =
     case temporary of
         False -> table_name
         True -> case connection.dialect.temp_table_style of

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Internal_Core.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Upload/Operations/Internal_Core.enso
@@ -134,7 +134,11 @@ check_outside_transaction =
 ## PRIVATE
 resolve_temp_table_name connection temporary:Boolean table_name:Text -> Text =
     case temporary of
-        False -> table_name
+        False -> case table_name.starts_with "#" of
+            True -> Error.throw <| Illegal_Argument.Error ("Table name cannot start with '#': " + table_name)
+            False -> table_name
         True -> case connection.dialect.temp_table_style of
             Temp_Table_Style.Temporary_Table -> table_name
-            Temp_Table_Style.Hash_Prefix -> "#" + table_name
+            Temp_Table_Style.Hash_Prefix -> case table_name.starts_with "#" of
+                True -> table_name
+                False -> "#" + table_name

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Connection.enso
@@ -238,6 +238,21 @@ type SQLServer_Connection
     execute_update self query =
         self.connection.execute_update query
 
+    ## ADVANCED
+       GROUP Standard.Base.Output
+       ICON data_output
+
+       Executes a raw query. If the query was inserting, updating or
+       deleting rows, the number of affected rows is returned; otherwise it
+       returns 0 for other types of queries (like creating or altering tables).
+
+       Arguments:
+       - query: either raw SQL code as Text or an instance of SQL_Statement
+         representing the query to execute.
+    execute : Text | SQL_Statement -> Integer
+    execute self query =
+        self.connection.execute query
+
     ## PRIVATE
        Access the dialect.
     dialect self = self.connection.dialect

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Connection.enso
@@ -238,7 +238,8 @@ type SQLServer_Connection
     execute_update self query =
         self.connection.execute_update query
 
-    ## ADVANCED
+    ## PRIVATE
+       ADVANCED
        GROUP Standard.Base.Output
        ICON data_output
 

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -39,6 +39,7 @@ import Standard.Database.SQL.SQL_Fragment
 import Standard.Database.SQL_Statement.SQL_Statement
 import Standard.Database.SQL_Type.SQL_Type
 from Standard.Database.Errors import SQL_Error, Unsupported_Database_Operation
+from Standard.Database.Dialect import Temp_Table_Style
 from Standard.Database.Internal.IR.Operation_Metadata import Date_Period_Metadata
 from Standard.Database.Internal.Statement_Setter import fill_hole_default
 
@@ -195,9 +196,9 @@ type SQLSever_Dialect
     supports_float_round_decimal_places self = True
 
     ## PRIVATE
-       Specifies whether the Database supports CREATE TEMPORARY TABLE syntax.
-    suppports_temporary_table_syntax : Boolean
-    suppports_temporary_table_syntax self = False
+       Specifies how the database creates temp tables.
+    temp_table_style : Temp_Table_Style
+    temp_table_style self = Temp_Table_Style.Hash_Prefix
     
     ## PRIVATE
     adapt_unified_column : Internal_Column -> Value_Type -> (SQL_Expression -> SQL_Type_Reference) -> Internal_Column

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Connection.enso
@@ -266,6 +266,22 @@ type Snowflake_Connection
         self.connection.execute_update query
 
     ## PRIVATE
+       ADVANCED
+       GROUP Standard.Base.Output
+       ICON data_output
+
+       Executes a raw query. If the query was inserting, updating or
+       deleting rows, the number of affected rows is returned; otherwise it
+       returns 0 for other types of queries (like creating or altering tables).
+
+       Arguments:
+       - query: either raw SQL code as Text or an instance of SQL_Statement
+         representing the query to execute.
+    execute : Text | SQL_Statement -> Integer
+    execute self query =
+        self.connection.execute query
+
+    ## PRIVATE
        Access the dialect.
     dialect self = self.connection.dialect
 

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
@@ -40,6 +40,7 @@ import Standard.Database.SQL.SQL_Fragment
 import Standard.Database.SQL_Statement.SQL_Statement
 import Standard.Database.SQL_Type.SQL_Type
 from Standard.Database.Errors import SQL_Error, Unsupported_Database_Operation
+from Standard.Database.Dialect import Temp_Table_Style
 from Standard.Database.Internal.IR.Operation_Metadata import Date_Period_Metadata
 from Standard.Database.Internal.Statement_Setter import fill_hole_default
 
@@ -206,9 +207,9 @@ type Snowflake_Dialect
     supports_float_round_decimal_places self = True
 
     ## PRIVATE
-       Specifies whether the Database supports CREATE TEMPORARY TABLE syntax.
-    suppports_temporary_table_syntax : Boolean
-    suppports_temporary_table_syntax self = True
+       Specifies how the database creates temp tables.
+    temp_table_style : Temp_Table_Style
+    temp_table_style self = Temp_Table_Style.Temporary_Table
 
     ## PRIVATE
     adapt_unified_column : Internal_Column -> Value_Type -> (SQL_Expression -> SQL_Type_Reference) -> Internal_Column

--- a/test/Microsoft_Tests/README.md
+++ b/test/Microsoft_Tests/README.md
@@ -17,9 +17,13 @@ Please set the following environment variables:
 
 The easiest way to test locally is to use a docker image
 
-```docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=<YourStrong@Passw0rd>" -p 1433:1433 --name sql1 --hostname sql1 -d mcr.microsoft.com/mssql/server:2022-latest
+```shell
+docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=<YourStrong@Passw0rd>" -p 1433:1433 --name sql1 --hostname sql1 -d mcr.microsoft.com/mssql/server:2022-latest
+```
 
-Set ENSO_SQLSERVER_DATABASE to tempdb and the defaults will work for everything else. (The user is sa with the above password)
+Set ENSO_SQLSERVER_DATABASE to tempdb and the defaults will work for everything
+else. (The user is sa with the above password)
 
-
+```powershell
+$env:ENSO_SQLSERVER_DATABASE='tempdb'
 ```

--- a/test/Microsoft_Tests/src/SQLServer_Spec.enso
+++ b/test/Microsoft_Tests/src/SQLServer_Spec.enso
@@ -40,8 +40,8 @@ type SQLServer_Info_Data
 
     setup default_connection = SQLServer_Info_Data.Value <|
         connection = default_connection
-        tinfo = Name_Generator.random_name "Tinfo"
-        connection.execute_update 'Create Table "'+tinfo+'" ("strs" VARCHAR(255), "ints" INTEGER, "bools" BIT, "reals" REAL, "floats" FLOAT, "tinyints" TINYINT, "smallints" SMALLINT, "bigints" BIGINT, "times" TIME, "dates" DATE, "datetimes" DATETIME, "smalldatetimes" SMALLDATETIME, "datetime2s" DATETIME2, "datetimeoffsets" DATETIMEOFFSET)'
+        tinfo = "#" + (Name_Generator.random_name "Tinfo")
+        connection.execute 'Create Table "'+tinfo+'" ("strs" VARCHAR(255), "ints" INTEGER, "bools" BIT, "reals" REAL, "floats" FLOAT, "tinyints" TINYINT, "smallints" SMALLINT, "bigints" BIGINT, "times" TIME, "dates" DATE, "datetimes" DATETIME, "smalldatetimes" SMALLDATETIME, "datetime2s" DATETIME2, "datetimeoffsets" DATETIMEOFFSET)'
         t = connection.query (SQL_Query.Table_Name tinfo)
         row1 = ["a", Nothing, False, 1.2, 1.2, 0, 0, 0, Time_Of_Day.new 12 12 12 1 1 1, Date.new 2021 1 1, Date_Time.new 2021 1 1 12 12 12 500 1 1, Date_Time.new 2021 1 1 12 12 12 1 1 1, Date_Time.new 2021 1 1 12 12 12 1 1 1, Date_Time.new 2021 1 1 12 12 12 1 1 1]
         row2 = ["abc", Nothing, Nothing, 1.3, 1.3, 255, 32767, 9223372036854775807, Time_Of_Day.new 7 12 12 1 1 1, Date.new 1999 1 1, Date_Time.new 1999 1 1 12 12 12 1 1 1, Date_Time.new 1999 1 1 12 12 12 1 1 1, Date_Time.new 1999 1 1 12 12 12 1 1 1, Date_Time.new 1999 1 1 12 12 12 1 1 1]
@@ -56,7 +56,7 @@ type SQLServer_Info_Data
         [connection, tinfo, t]
 
     teardown self =
-        self.connection.execute_update 'DROP TABLE "'+self.tinfo+'"'
+        self.connection.execute 'DROP TABLE "'+self.tinfo+'"'
         self.connection.close
 
 get_configured_connection_details =
@@ -127,9 +127,9 @@ add_specs suite_builder =
                     in_memory.at "txt-fixed" . value_type . should_equal (Value_Type.Char size=3 variable_length=False)
 
                 group_builder.specify "test datetime2 precision round trip" <|
-                    name = Name_Generator.random_name "datetime2-test"
+                    name = "#" + (Name_Generator.random_name "datetime2-test")
                     Problems.assume_no_problems <|
-                        data.connection.execute_update 'CREATE TABLE "'+name+'" ("dt2" DATETIME2)'
+                        data.connection.execute 'CREATE TABLE "'+name+'" ("dt2" DATETIME2)'
                     t = data.connection.query (SQL_Query.Table_Name name)
                     row1 = [Date_Time.new 2021 1 1 12 13 14 500 1 1]
                     row2 = [Date_Time.new 2021 1 1 9 12 12 987 654 321]
@@ -143,7 +143,7 @@ add_specs suite_builder =
                     expected_table = Table.from_rows ["dt2"] [expected_row1, expected_row2, expected_row3]
                     returned_table = t.read
                     returned_table.should_equal expected_table
-                    data.connection.execute_update 'DROP TABLE "'+name+'"'
+                    data.connection.execute 'DROP TABLE "'+name+'"'
 
 main filter=Nothing =
     suite = Test.build suite_builder->


### PR DESCRIPTION
### Pull Request Description

Make SQLServer # style temp tables work.

### Important Notes

SQLServer temp tables are scoped to the lifetime of the stored procedure that runs them or the session if they are run outside of a stored procedure. If we use the JDBC method executeUpdate then the call gets wrapped in a sproc and then the temp table is immediately dropped. Instead we need to use the JDBC method execute (as introduced by this change)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
