### PR TITLE
Cache self argument

### DIFF
--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/CachePreferenceAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/CachePreferenceAnalysis.scala
@@ -2,8 +2,10 @@ package org.enso.compiler.pass.analyse
 
 import org.enso.compiler.context.{InlineContext, ModuleContext}
 import org.enso.compiler.core.Implicits.AsMetadata
+import org.enso.compiler.core.ir.CallArgument.Specified
 import org.enso.compiler.core.{CompilerError, ExternalID}
 import org.enso.compiler.core.ir.{
+  CallArgument,
   DefinitionArgument,
   Expression,
   Module,
@@ -12,7 +14,7 @@ import org.enso.compiler.core.ir.{
 }
 import org.enso.compiler.core.ir.module.scope.Definition
 import org.enso.compiler.core.ir.module.scope.definition
-import org.enso.compiler.core.ir.expression.{Comment, Error}
+import org.enso.compiler.core.ir.expression.{Application, Comment, Error}
 import org.enso.compiler.core.ir.MetadataStorage._
 import org.enso.compiler.pass.IRPass
 import org.enso.compiler.pass.desugar._
@@ -151,13 +153,37 @@ case object CachePreferenceAnalysis extends IRPass {
           .updateMetadata(new MetadataPair(this, weights))
       case error: Error =>
         error
+      case app: Application.Prefix =>
+        app.arguments match {
+          case self :: rest =>
+            val newSelf = analyseSelfCallArgument(self, weights)
+            app.copy(arguments = newSelf :: rest)
+          case _ =>
+            app
+        }
       case expr =>
-        expr.getExternalId.collect {
+        expr.getExternalId.foreach {
           case id if !weights.contains(id) => weights.update(id, Weight.Never)
+          case _                           =>
         }
         expr
           .mapExpressions(analyseExpression(_, weights))
           .updateMetadata(new MetadataPair(this, weights))
+    }
+  }
+
+  def analyseSelfCallArgument(
+    callArgument: CallArgument,
+    weights: WeightInfo
+  ): CallArgument = {
+    callArgument.value.getExternalId.foreach(weights.update(_, Weight.Always))
+    callArgument match {
+      case arg: Specified =>
+        arg.copy(value =
+          analyseExpression(arg.value, weights).updateMetadata(
+            new MetadataPair(this, weights)
+          )
+        )
     }
   }
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -4167,9 +4167,11 @@ class RuntimeVisualizationsTest extends AnyFlatSpec with Matchers {
       )
       val attachVisualizationResponses =
         context.receiveNIgnoreExpressionUpdates(3)
-      attachVisualizationResponses should contain allOf (
-        Api.Response(requestId, Api.VisualizationAttached()),
-        context.executionComplete(contextId)
+      attachVisualizationResponses should contain(
+        Api.Response(requestId, Api.VisualizationAttached())
+      )
+      attachVisualizationResponses should not contain context.executionComplete(
+        contextId
       )
       val Some(data) = attachVisualizationResponses.collectFirst {
         case Api.Response(


### PR DESCRIPTION
### Pull Request Description

In order for widgets not to invalidate expression's results and trigger computations, we now cache self argument to which visualizations should be attached to.

It should help with #10730 but there is still a bug in GUI.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
