### PR TITLE
Fix file open retry in ydocs server

### DIFF
--- a/app/ydoc-server/src/languageServerSession.ts
+++ b/app/ydoc-server/src/languageServerSession.ts
@@ -396,7 +396,7 @@ class ModulePersistence extends ObservableV2<{ removed: () => void }> {
             return Ok()
           }
           case LsSyncState.Closed: {
-            await this.withState(LsSyncState.Opening, async () => {
+            return await this.withState(LsSyncState.Opening, async () => {
               const promise = this.ls.openTextFile(this.path)
               this.setLastAction(promise.then(res => !res.ok && this.setState(LsSyncState.Closed)))
               const result = await promise
@@ -409,7 +409,6 @@ class ModulePersistence extends ObservableV2<{ removed: () => void }> {
               this.syncFileContents(result.value.content, result.value.currentVersion)
               return Ok()
             })
-            return Ok()
           }
           default: {
             assertNever(this.state)


### PR DESCRIPTION
### Pull Request Description

There is a code for exponential back off, but the result with error was lost at one place.

Tested by mocking timeouts in our `lanugageServer.ts`

Fixes #10606 

### Important Notes


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
