### PR TITLE
Clean up Text option from read and query

### DIFF
--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Internal/Redshift_Dialect.enso
@@ -104,12 +104,6 @@ type Redshift_Dialect
         Postgres_Dialect.make_order_descriptor internal_column sort_direction text_ordering
 
     ## PRIVATE
-       A heuristic used by `Connection.query` to determine if a given text looks
-       like a SQL query for the given dialect or is rather a table name.
-    is_probably_a_query : Text -> Boolean
-    is_probably_a_query self text = Base_Generator.is_probably_a_query text
-
-    ## PRIVATE
        Returns the mapping between SQL types of this dialect and Enso
        `Value_Type`.
     get_type_mapping : SQL_Type_Mapping

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -216,10 +216,8 @@ type Connection
     query : SQL_Query -> Text -> DB_Table ! Table_Not_Found | SQL_Error
     query self query:SQL_Query alias="" = case query of
         SQL_Query.Table_Name name ->
-            case self.table_naming_helper.is_table_name_valid name of
-                True -> make_table_for_name self name alias
-                False ->
-                    Error.throw (Table_Not_Found.Error name related_query_error=Nothing)
+            table_naming_helper.verify_table_name table_name <|
+                make_table_for_name self name alias
         SQL_Query.Raw_SQL raw_sql -> handle_sql_errors <| alias.if_not_error <|
             self.jdbc_connection.ensure_query_has_no_holes raw_sql . if_not_error <|
                 columns = self.fetch_columns raw_sql Statement_Setter.null

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -525,8 +525,8 @@ make_table_for_name connection name alias internal_temporary_keep_alive_referenc
            warning. We do not want to fail, as we do want to allow the user to
            access any table already present in the database.
         DB_Table_Module.make_table connection name columns ctx on_problems=Problem_Behavior.Report_Warning
-    result.catch SQL_Error sql_error->
-        Error.throw (Table_Not_Found.Error name sql_error)
+    result.catch SQL_Error _->
+        Error.throw (Table_Not_Found.Error name)
 
 ## PRIVATE
 private check_statement_is_allowed connection stmt =

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -202,8 +202,6 @@ type Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
-         If supplied as `Text`, the name is checked against the `tables` list to
-         determine if it is a table or a query.
        - alias: optionally specify a friendly alias for the query.
 
        ! Error Conditions
@@ -214,17 +212,13 @@ type Connection
          - If provided with a `Table_Name` or a text short-hand and the table is
            not found, a `Table_Not_Found` error is raised.
     @query make_table_name_selector
-    query : Text | SQL_Query -> Text -> DB_Table ! Table_Not_Found | SQL_Error
-    query self query alias="" = case query of
-        _ : Text ->
-            result = self.query alias=alias <|
-                if self.table_exists query then (SQL_Query.Table_Name query) else
-                    SQL_Query.Raw_SQL query
-            result.catch SQL_Error sql_error->
-                case self.dialect.is_probably_a_query query of
-                    True -> result
-                    False ->
-                        Error.throw (Table_Not_Found.Error query sql_error treated_as_query=True extra_message="")
+    query : SQL_Query -> Text -> DB_Table ! Table_Not_Found | SQL_Error
+    query self query:SQL_Query alias="" = case query of
+        SQL_Query.Table_Name name ->
+            case self.table_naming_helper.is_table_name_valid name of
+                True -> make_table_for_name self name alias
+                False ->
+                    Error.throw (Table_Not_Found.Error name related_query_error=Nothing)
         SQL_Query.Raw_SQL raw_sql -> handle_sql_errors <| alias.if_not_error <|
             self.jdbc_connection.ensure_query_has_no_holes raw_sql . if_not_error <|
                 columns = self.fetch_columns raw_sql Statement_Setter.null
@@ -242,20 +236,12 @@ type Connection
                 r = DB_Table_Module.make_table self name columns ctx on_problems=Problem_Behavior.Report_Error
                 r.catch Any error->
                     Error.throw (Illegal_Argument.Error "The provided custom SQL query is invalid and may suffer data corruption when being processed, especially if it contains aliased column names, it may not be interpreted correctly. Please ensure the names are unique. The original error was: "+error.to_display_text cause=error)
-        SQL_Query.Table_Name name ->
-            case self.table_naming_helper.is_table_name_valid name of
-                True -> make_table_for_name self name alias
-                False ->
-                    Error.throw (Table_Not_Found.Error name related_query_error=Nothing treated_as_query=False extra_message="")
-
 
     ## PRIVATE
        Execute the query and load the results into memory as a Table.
 
        Arguments:
        - query: name of the table or sql statement to query.
-         If supplied as `Text`, the name is checked against the `tables` list to
-         determine if it is a table or a query.
        - limit: the maximum number of rows to read.
 
        ? Side Effects
@@ -267,8 +253,8 @@ type Connection
          results, the `read` should be wrapped in an execution context check.
     @query make_table_name_selector
     @limit Rows_To_Read.default_widget
-    read : Text | SQL_Query -> Rows_To_Read -> Table ! Table_Not_Found
-    read self query (limit : Rows_To_Read = ..First_With_Warning 1000) =
+    read : SQL_Query -> Rows_To_Read -> Table ! Table_Not_Found
+    read self query:SQL_Query (limit : Rows_To_Read = ..First_With_Warning 1000) =
         self.query query . read max_rows=limit
 
     ## PRIVATE
@@ -513,7 +499,9 @@ make_schema_selector connection include_any:Boolean=False =
 make_table_name_selector : Connection -> Widget
 make_table_name_selector connection =
     tables_to_display = connection.tables.at "Name" . to_vector
-    Single_Choice display=Display.Always values=(tables_to_display.map t-> Option t t.pretty)
+    table_name_values = tables_to_display.map t-> Option t ('..Table_Name ' + t.pretty)
+    values = table_name_values + [Option '<Table_Name>' '..Table_Name ""', Option '<Raw_SQL>' '..Raw_SQL ""']
+    Single_Choice display=Display.Always values=values
 
 ## PRIVATE
 make_structure_creator : Widget
@@ -536,7 +524,7 @@ make_table_for_name connection name alias internal_temporary_keep_alive_referenc
            access any table already present in the database.
         DB_Table_Module.make_table connection name columns ctx on_problems=Problem_Behavior.Report_Warning
     result.catch SQL_Error sql_error->
-        Error.throw (Table_Not_Found.Error name sql_error treated_as_query=False extra_message="")
+        Error.throw (Table_Not_Found.Error name sql_error)
 
 ## PRIVATE
 private check_statement_is_allowed connection stmt =

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -202,6 +202,7 @@ type Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
+         If supplied as `Text` it is treated as a table name.
        - alias: optionally specify a friendly alias for the query.
 
        ! Error Conditions
@@ -242,6 +243,7 @@ type Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
+         If supplied as `Text` it is treated as a table name.
        - limit: the maximum number of rows to read.
 
        ? Side Effects
@@ -499,7 +501,7 @@ make_schema_selector connection include_any:Boolean=False =
 make_table_name_selector : Connection -> Widget
 make_table_name_selector connection =
     tables_to_display = connection.tables.at "Name" . to_vector
-    table_name_values = tables_to_display.map t-> Option t ('..Table_Name ' + t.pretty)
+    table_name_values = tables_to_display.map t-> Option t t.pretty
     values = table_name_values + [Option '<Table_Name>' '..Table_Name ""', Option '<Raw_SQL>' '..Raw_SQL ""']
     Single_Choice display=Display.Always values=values
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -216,6 +216,7 @@ type Connection
     query : SQL_Query -> Text -> DB_Table ! Table_Not_Found | SQL_Error
     query self query:SQL_Query alias="" = case query of
         SQL_Query.Table_Name name ->
+            table_naming_helper = self.base_connection.table_naming_helper
             table_naming_helper.verify_table_name name <|
                 make_table_for_name self name alias
         SQL_Query.Raw_SQL raw_sql -> handle_sql_errors <| alias.if_not_error <|

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Connection.enso
@@ -216,7 +216,7 @@ type Connection
     query : SQL_Query -> Text -> DB_Table ! Table_Not_Found | SQL_Error
     query self query:SQL_Query alias="" = case query of
         SQL_Query.Table_Name name ->
-            table_naming_helper.verify_table_name table_name <|
+            table_naming_helper.verify_table_name name <|
                 make_table_for_name self name alias
         SQL_Query.Raw_SQL raw_sql -> handle_sql_errors <| alias.if_not_error <|
             self.jdbc_connection.ensure_query_has_no_holes raw_sql . if_not_error <|

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Dialect.enso
@@ -86,14 +86,6 @@ type Dialect
         Unimplemented.throw "This is an interface only."
 
     ## PRIVATE
-       A heuristic used by `Connection.query` to determine if a given text looks
-       like a SQL query for the given dialect or is rather a table name.
-    is_probably_a_query : Text -> Boolean
-    is_probably_a_query self text =
-        _ = [text]
-        Unimplemented.throw "This is an interface only."
-
-    ## PRIVATE
        Returns the mapping between SQL types of this dialect and Enso
        `Value_Type`.
     get_type_mapping : SQL_Type_Mapping

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Errors.enso
@@ -133,7 +133,7 @@ type Table_Not_Found
     to_display_text self =
       case self.related_query_error of
          SQL_Error -> "Table " + self.name + " was not found in the database. The query failed with the following error: " + self.related_query_error.to_display_text + "."
-         Nothing -> "Table " + self.name + " was not found in the database."
+         _ -> "Table " + self.name + " was not found in the database."
 
 type Table_Already_Exists
     ## PRIVATE

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Errors.enso
@@ -132,7 +132,7 @@ type Table_Not_Found
     to_display_text : Text
     to_display_text self =
       case self.related_query_error of
-         SQL_Error -> "Table " + self.name + " was not found in the database. The query failed with the following error: " + self.related_query_error.to_display_text + "."
+         _ : SQL_Error -> "Table " + self.name + " was not found in the database. The query failed with the following error: " + self.related_query_error.to_display_text + "."
          _ -> "Table " + self.name + " was not found in the database."
 
 type Table_Already_Exists

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Errors.enso
@@ -125,25 +125,15 @@ type Table_Not_Found
        - table_name: The name of the table that was not found.
        - related_query_error: The error that was thrown when the query looking
          for the table was executed.
-       - treated_as_query: Whether the table name was treated as a raw query
-         string.
-       - extra_message: An extra message to append.
-    Error (name:Text) (related_query_error:SQL_Error|Nothing) (treated_as_query:Boolean) (extra_message:Text)
+    Error (name:Text) (related_query_error:SQL_Error|Nothing)
 
     ## PRIVATE
        Pretty print the table not found error.
     to_display_text : Text
     to_display_text self =
-        base_repr = case self.treated_as_query of
-            True -> "The name " + self.name + " was treated as a query, but the query failed with the following error: " + self.related_query_error.to_display_text + "; if you want to force to use that as a table name, wrap it in `SQL_Query.Table_Name`."
-            False -> "Table " + self.name + " was not found in the database."
-        base_repr + self.extra_message
-
-    ## PRIVATE
-       Creates a copy of this error with a changed `extra_message`.
-    with_changed_extra_message : Text -> Table_Not_Found
-    with_changed_extra_message self new_extra_message =
-        Table_Not_Found.Error self.name self.related_query_error self.treated_as_query new_extra_message
+      case self.related_query_error of
+         SQL_Error -> "Table " + self.name + " was not found in the database. The query failed with the following error: " + self.related_query_error.to_display_text + "."
+         Nothing -> "Table " + self.name + " was not found in the database."
 
 type Table_Already_Exists
     ## PRIVATE

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Errors.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Errors.enso
@@ -123,17 +123,12 @@ type Table_Not_Found
 
        Arguments:
        - table_name: The name of the table that was not found.
-       - related_query_error: The error that was thrown when the query looking
-         for the table was executed.
-    Error (name:Text) (related_query_error:SQL_Error|Nothing)
+    Error (name:Text)
 
     ## PRIVATE
        Pretty print the table not found error.
     to_display_text : Text
-    to_display_text self =
-      case self.related_query_error of
-         _ : SQL_Error -> "Table " + self.name + " was not found in the database. The query failed with the following error: " + self.related_query_error.to_display_text + "."
-         _ -> "Table " + self.name + " was not found in the database."
+    to_display_text self = "Table " + self.name + " was not found in the database."
 
 type Table_Already_Exists
     ## PRIVATE

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Base_Generator.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Base_Generator.enso
@@ -604,12 +604,6 @@ generate_column_description dialect descriptor =
     (dialect.wrap_identifier descriptor.name) ++ " " ++ descriptor.sql_type ++ suffix
 
 ## PRIVATE
-   A heuristic used by `Connection.query` to determine if a given text looks
-   like a SQL query for the given dialect or is rather a table name.
-is_probably_a_query : Text -> Boolean
-is_probably_a_query text = (text.contains "SELECT ") || (text.contains "EXEC ")
-
-## PRIVATE
    option for implementing generate_truncate_table_sql
 truncate_table_delete_from_style : Dialect -> Text -> SQL_Builder
 truncate_table_delete_from_style dialect table_name =

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
@@ -145,8 +145,6 @@ type Postgres_Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
-         If supplied as `Text`, the name is checked against the `tables` list to
-         determine if it is a table or a query.
        - alias: optionally specify a friendly alias for the query.
 
        ! Error Conditions
@@ -157,8 +155,8 @@ type Postgres_Connection
          - If provided with a `Table_Name` or a text short-hand and the table is
            not found, a `Table_Not_Found` error is raised.
     @query make_table_name_selector
-    query : Text | SQL_Query -> Text -> DB_Table ! Table_Not_Found
-    query self query alias="" = self.connection.query query alias
+    query : SQL_Query -> Text -> DB_Table ! Table_Not_Found
+    query self query:SQL_Query alias="" = self.connection.query query alias
 
     ## GROUP Standard.Base.Input
        ICON data_input
@@ -166,8 +164,6 @@ type Postgres_Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
-         If supplied as `Text`, the name is checked against the `tables` list to
-         determine if it is a table or a query.
        - limit: the maximum number of rows to read.
 
        ? Side Effects
@@ -179,8 +175,8 @@ type Postgres_Connection
          results, the `read` should be wrapped in an execution context check.
     @query make_table_name_selector
     @limit Rows_To_Read.default_widget
-    read : Text | SQL_Query -> Rows_To_Read -> Table ! Table_Not_Found
-    read self query (limit : Rows_To_Read = ..First_With_Warning 1000) =
+    read : SQL_Query -> Rows_To_Read -> Table ! Table_Not_Found
+    read self query:SQL_Query (limit : Rows_To_Read = ..First_With_Warning 1000) =
         self.connection.read query limit
 
     ## GROUP Standard.Base.Output

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Connection.enso
@@ -145,6 +145,7 @@ type Postgres_Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
+         If supplied as `Text` it is treated as a table name.
        - alias: optionally specify a friendly alias for the query.
 
        ! Error Conditions
@@ -164,6 +165,7 @@ type Postgres_Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
+         If supplied as `Text` it is treated as a table name.
        - limit: the maximum number of rows to read.
 
        ? Side Effects

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Dialect.enso
@@ -134,12 +134,6 @@ type Postgres_Dialect
         table.updated_context_and_columns new_context new_columns subquery=True
 
     ## PRIVATE
-       A heuristic used by `Connection.query` to determine if a given text looks
-       like a SQL query for the given dialect or is rather a table name.
-    is_probably_a_query : Text -> Boolean
-    is_probably_a_query self text = Base_Generator.is_probably_a_query text
-
-    ## PRIVATE
        Returns the mapping between SQL types of this dialect and Enso
        `Value_Type`.
     get_type_mapping : SQL_Type_Mapping

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
@@ -131,8 +131,6 @@ type SQLite_Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
-         If supplied as `Text`, the name is checked against the `tables` list to
-         determine if it is a table or a query.
        - alias: optionally specify a friendly alias for the query.
 
        ! Error Conditions
@@ -143,8 +141,8 @@ type SQLite_Connection
          - If provided with a `Table_Name` or a text short-hand and the table is
            not found, a `Table_Not_Found` error is raised.
     @query make_table_name_selector
-    query : Text | SQL_Query -> Text -> DB_Table ! Table_Not_Found
-    query self query alias="" = self.connection.query query alias
+    query : SQL_Query -> Text -> DB_Table ! Table_Not_Found
+    query self query:SQL_Query alias="" = self.connection.query query alias
 
     ## GROUP Standard.Base.Input
        ICON data_input
@@ -152,8 +150,6 @@ type SQLite_Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
-         If supplied as `Text`, the name is checked against the `tables` list to
-         determine if it is a table or a query.
        - limit: the maximum number of rows to read.
 
        ? Side Effects
@@ -165,8 +161,8 @@ type SQLite_Connection
          results, the `read` should be wrapped in an execution context check.
     @query make_table_name_selector
     @limit Rows_To_Read.default_widget
-    read : Text | SQL_Query -> Rows_To_Read -> Table ! Table_Not_Found
-    read self query (limit : Rows_To_Read = ..First_With_Warning 1000) =
+    read : SQL_Query -> Rows_To_Read -> Table ! Table_Not_Found
+    read self query:SQL_Query (limit : Rows_To_Read = ..First_With_Warning 1000) =
         self.connection.read query limit
 
     ## GROUP Standard.Base.Output

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Connection.enso
@@ -131,6 +131,7 @@ type SQLite_Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
+         If supplied as `Text` it is treated as a table name.
        - alias: optionally specify a friendly alias for the query.
 
        ! Error Conditions
@@ -150,6 +151,7 @@ type SQLite_Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
+         If supplied as `Text` it is treated as a table name.
        - limit: the maximum number of rows to read.
 
        ? Side Effects

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/SQLite/SQLite_Dialect.enso
@@ -142,12 +142,6 @@ type SQLite_Dialect
         table.updated_context_and_columns new_context new_columns subquery=True
 
     ## PRIVATE
-       A heuristic used by `Connection.query` to determine if a given text looks
-       like a SQL query for the given dialect or is rather a table name.
-    is_probably_a_query : Text -> Boolean
-    is_probably_a_query self text = Base_Generator.is_probably_a_query text
-
-    ## PRIVATE
        Returns the mapping between SQL types of this dialect and Enso
        `Value_Type`.
     get_type_mapping : SQL_Type_Mapping

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/SQL_Query.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/SQL_Query.enso
@@ -9,4 +9,4 @@ type SQL_Query
     Raw_SQL (sql : Text = Missing_Argument.throw "sql")
 
 ## PRIVATE
-SQL_Query.from (name:Text) = SQL_Query.Table_Name name
+SQL_Query.from (that:Text) = SQL_Query.Table_Name that

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/SQL_Query.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/SQL_Query.enso
@@ -7,3 +7,6 @@ type SQL_Query
 
     ## Raw SQL query statement.
     Raw_SQL (sql : Text = Missing_Argument.throw "sql")
+
+## PRIVATE
+SQL_Query.from (name:Text) = SQL_Query.Table_Name name

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Connection.enso
@@ -138,8 +138,6 @@ type SQLServer_Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
-         If supplied as `Text`, the name is checked against the `tables` list to
-         determine if it is a table or a query.
        - alias: optionally specify a friendly alias for the query.
 
        ! Error Conditions
@@ -150,8 +148,8 @@ type SQLServer_Connection
          - If provided with a `Table_Name` or a text short-hand and the table is
            not found, a `Table_Not_Found` error is raised.
     @query make_table_name_selector
-    query : Text | SQL_Query -> Text -> DB_Table ! Table_Not_Found
-    query self query alias="" = self.connection.query query alias
+    query : SQL_Query -> Text -> DB_Table ! Table_Not_Found
+    query self query:SQL_Query alias="" = self.connection.query query alias
 
     ## GROUP Standard.Base.Input
        ICON data_input
@@ -159,8 +157,6 @@ type SQLServer_Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
-         If supplied as `Text`, the name is checked against the `tables` list to
-         determine if it is a table or a query.
        - limit: the maximum number of rows to read.
 
        ? Side Effects
@@ -172,8 +168,8 @@ type SQLServer_Connection
          results, the `read` should be wrapped in an execution context check.
     @query make_table_name_selector
     @limit Rows_To_Read.default_widget
-    read : Text | SQL_Query -> Rows_To_Read -> Table ! Table_Not_Found
-    read self query (limit : Rows_To_Read = ..First_With_Warning 1000) =
+    read : SQL_Query -> Rows_To_Read -> Table ! Table_Not_Found
+    read self query:SQL_Query (limit : Rows_To_Read = ..First_With_Warning 1000) =
         self.connection.read query limit
 
     ## GROUP Standard.Base.Output

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Connection.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Connection.enso
@@ -138,6 +138,7 @@ type SQLServer_Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
+         If supplied as `Text` it is treated as a table name.
        - alias: optionally specify a friendly alias for the query.
 
        ! Error Conditions
@@ -157,6 +158,7 @@ type SQLServer_Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
+         If supplied as `Text` it is treated as a table name.
        - limit: the maximum number of rows to read.
 
        ? Side Effects

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Internal/SQLServer_Dialect.enso
@@ -133,12 +133,6 @@ type SQLSever_Dialect
         table.updated_context_and_columns new_context new_columns subquery=True
 
     ## PRIVATE
-       A heuristic used by `Connection.query` to determine if a given text looks
-       like a SQL query for the given dialect or is rather a table name.
-    is_probably_a_query : Text -> Boolean
-    is_probably_a_query self text = Base_Generator.is_probably_a_query text
-
-    ## PRIVATE
        Returns the mapping between SQL types of this dialect and Enso
        `Value_Type`.
     get_type_mapping : SQL_Type_Mapping

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Connection.enso
@@ -165,8 +165,6 @@ type Snowflake_Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
-         If supplied as `Text`, the name is checked against the `tables` list to
-         determine if it is a table or a query.
        - alias: optionally specify a friendly alias for the query.
 
        ! Error Conditions
@@ -177,8 +175,8 @@ type Snowflake_Connection
          - If provided with a `Table_Name` or a text short-hand and the table is
            not found, a `Table_Not_Found` error is raised.
     @query make_table_name_selector
-    query : Text | SQL_Query -> Text -> DB_Table ! Table_Not_Found
-    query self query alias="" = self.connection.query query alias
+    query : SQL_Query -> Text -> DB_Table ! Table_Not_Found
+    query self query:SQL_Query alias="" = self.connection.query query alias
 
     ## GROUP Standard.Base.Input
        ICON data_input
@@ -186,8 +184,6 @@ type Snowflake_Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
-         If supplied as `Text`, the name is checked against the `tables` list to
-         determine if it is a table or a query.
        - limit: the maximum number of rows to read.
 
        ? Side Effects
@@ -199,8 +195,8 @@ type Snowflake_Connection
          results, the `read` should be wrapped in an execution context check.
     @query make_table_name_selector
     @limit Rows_To_Read.default_widget
-    read : Text | SQL_Query -> Rows_To_Read -> Table ! Table_Not_Found
-    read self query (limit : Rows_To_Read = ..First_With_Warning 1000) =
+    read : SQL_Query -> Rows_To_Read -> Table ! Table_Not_Found
+    read self query:SQL_Query (limit : Rows_To_Read = ..First_With_Warning 1000) =
         self.connection.read query limit
 
     ## GROUP Standard.Base.Output

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Connection.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Connection.enso
@@ -165,6 +165,7 @@ type Snowflake_Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
+         If supplied as `Text` it is treated as a table name.
        - alias: optionally specify a friendly alias for the query.
 
        ! Error Conditions
@@ -184,6 +185,7 @@ type Snowflake_Connection
 
        Arguments:
        - query: name of the table or sql statement to query.
+         If supplied as `Text` it is treated as a table name.
        - limit: the maximum number of rows to read.
 
        ? Side Effects

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Internal/Snowflake_Dialect.enso
@@ -142,12 +142,6 @@ type Snowflake_Dialect
         table.updated_context_and_columns new_context new_columns subquery=True
 
     ## PRIVATE
-       A heuristic used by `Connection.query` to determine if a given text looks
-       like a SQL query for the given dialect or is rather a table name.
-    is_probably_a_query : Text -> Boolean
-    is_probably_a_query self text = Base_Generator.is_probably_a_query text
-
-    ## PRIVATE
        Returns the mapping between SQL types of this dialect and Enso
        `Value_Type`.
     get_type_mapping : SQL_Type_Mapping

--- a/test/Snowflake_Tests/src/Snowflake_Spec.enso
+++ b/test/Snowflake_Tests/src/Snowflake_Spec.enso
@@ -321,11 +321,11 @@ snowflake_specific_spec suite_builder default_connection db_name setup =
             m2.at "ś"   . to_vector . should_equal ["A"]
             m2.at "ś 1" . to_vector . should_equal [2]
 
-            r3 = default_connection.get.query 'SELECT 1 AS "A", 2 AS "A"'
+            r3 = default_connection.get.query (SQL_Query.Raw_SQL 'SELECT 1 AS "A", 2 AS "A"')
             r3.should_fail_with Illegal_Argument
             r3.catch.cause . should_be_a Duplicate_Output_Column_Names
 
-            r4 = default_connection.get.query 'SELECT 1 AS ""'
+            r4 = default_connection.get.query (SQL_Query.Raw_SQL 'SELECT 1 AS ""')
             r4.should_fail_with Illegal_Argument
             r4.catch.to_display_text . should_contain "The provided custom SQL query is invalid and may suffer data corruption"
             r4.catch.to_display_text . should_contain "The name '' is invalid"

--- a/test/Table_Tests/src/Database/Common/Audit_Spec.enso
+++ b/test/Table_Tests/src/Database/Common/Audit_Spec.enso
@@ -60,7 +60,7 @@ add_specs suite_builder prefix ~datalink_to_connection database_pending =
         group_builder.specify "should see Database operations performed manually" <| cloud_setup.with_prepared_environment <|
             audited_connection = datalink_to_connection.read
             query = "SELECT 1 AS A, 2 AS B, "+(Random.integer 0 1000000).to_text+" AS C"
-            t = audited_connection.read query
+            t = audited_connection.read (SQL_Query.Raw_SQL query)
             # Force the connector to perform the query:
             t.at 0 . to_vector . should_equal [1]
 
@@ -80,7 +80,7 @@ add_specs suite_builder prefix ~datalink_to_connection database_pending =
                 locally_audited_connection = datalink_to_connection.read
 
                 # We just check that we can read queries through this connection:
-                locally_audited_connection.read "SELECT 1" . at 0 . to_vector . should_equal [1]
+                locally_audited_connection.read (SQL_Query.Raw_SQL "SELECT 1") . at 0 . to_vector . should_equal [1]
 
         group_builder.specify "should know the asset id of the data link used for the connection" pending="TODO: https://github.com/enso-org/enso/issues/9869" <|
             ## TODO:

--- a/test/Table_Tests/src/Database/Common/Common_Spec.enso
+++ b/test/Table_Tests/src/Database/Common/Common_Spec.enso
@@ -229,22 +229,6 @@ add_specs (suite_builder : Suite_Builder) (prefix : Text) (create_connection_fn 
             m2.at "b" . to_vector . should_equal [5]
             m2.at "a" . should_fail_with No_Such_Column
 
-        group_builder.specify "should allow a shorthand trying to deduce if the query is a table name or an SQL query" <|
-            name = data.t1.name
-            t2 = data.connection.query name
-            t2.read . should_equal data.t1.read
-
-            t3 = data.connection.query ('SELECT "a", "b" FROM "' + name + '" WHERE "a" >= 3')
-            m3 = t3.read
-            m3.column_names . should_equal ["a", "b"]
-            m3.at "a" . to_vector . should_equal [4]
-
-            t5 = data.connection.query data.t4.name
-            m5 = t5.read
-            m5.column_names . should_equal ["X", "Y"]
-            m5.at "X" . to_vector . should_equal ["a", "B"]
-            m5.at "Y" . to_vector . should_equal [2, 5]
-
         group_builder.specify "should report an error depending on input SQL_Query type" <|
             r2 = data.connection.query (SQL_Query.Table_Name "NONEXISTENT-TABLE")
             r2.should_fail_with Table_Not_Found
@@ -257,19 +241,6 @@ add_specs (suite_builder : Suite_Builder) (prefix : Text) (create_connection_fn 
         group_builder.specify "should not allow interpolations in raw user-built queries" <|
             r = data.connection.query (SQL_Query.Raw_SQL "SELECT 1 + ?")
             r.should_fail_with Illegal_Argument
-
-        group_builder.specify "should make a best-effort attempt at returning a reasonable error for the short-hand" <|
-            r2 = data.connection.query "NONEXISTENT-TABLE"
-            r2.should_fail_with Table_Not_Found
-            r2.catch.name . should_equal "NONEXISTENT-TABLE"
-            r2.catch.treated_as_query . should_be_true
-            error_text = r2.catch.to_display_text
-            Test.with_clue "r2.catch.to_display_text = "+error_text <|
-                error_text.starts_with "The name NONEXISTENT-TABLE was treated as a query, but the query failed" . should_be_true
-                error_text.ends_with "wrap it in `SQL_Query.Table_Name`." . should_be_true
-
-            r3 = data.connection.query "SELECT * FROM ........"
-            r3.should_fail_with SQL_Error
 
         group_builder.specify "will fail if the table is modified and a column gets removed" <|
             name = Name_Generator.random_name "removing-column"

--- a/test/Table_Tests/src/Database/Common/Names_Length_Limits_Spec.enso
+++ b/test/Table_Tests/src/Database/Common/Names_Length_Limits_Spec.enso
@@ -62,7 +62,7 @@ add_specs suite_builder prefix create_connection_func =
                     r2 = data.connection.create_table name [Column_Description.Value "X" Value_Type.Integer] temporary=True
                     r2.should_fail_with Name_Too_Long
 
-                data.connection.query (SQL_Query.Table_Name name) . should_fail_with Table_Not_Found
+                data.connection.query (SQL_Query.Table_Name name) . should_fail_with Name_Too_Long
 
             group_builder.specify "should ensure length is measured in small units, even if grapheme length is lower" <|
                 big_grapheme = '\u{1F926}\u{1F3FC}\u200D\u2642\uFE0F'
@@ -115,8 +115,8 @@ add_specs suite_builder prefix create_connection_func =
                 data.connection.query long_name . at "X" . to_vector . should_equal_ignoring_order [1, 2, 3]
 
                 longer_name_with_same_prefix = long_name + ("z" * 10)
-                data.connection.query longer_name_with_same_prefix . should_fail_with Table_Not_Found
-                data.connection.query (SQL_Query.Table_Name longer_name_with_same_prefix) . should_fail_with Table_Not_Found
+                data.connection.query longer_name_with_same_prefix . should_fail_with Name_Too_Long
+                data.connection.query (SQL_Query.Table_Name longer_name_with_same_prefix) . should_fail_with Name_Too_Long
 
         group_builder.specify "should be fine joining tables with long names" <|
             ## If we know the maximum length, we choose a length that will be

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -777,7 +777,7 @@ add_table_specs suite_builder =
                                 connection.should_succeed
                                 Panic.with_finalizer connection.close <|
                                     connection.tables . should_be_a Table
-                                    table = connection.read "SELECT application_name FROM pg_stat_activity"
+                                    table = connection.read (..Raw_SQL "SELECT application_name FROM pg_stat_activity")
                                     application_names = table.at 0 . to_vector
                                     application_names.should_contain my_secret_name
 

--- a/test/Table_Tests/src/Database/Postgres_Spec.enso
+++ b/test/Table_Tests/src/Database/Postgres_Spec.enso
@@ -377,11 +377,11 @@ postgres_specific_spec suite_builder create_connection_fn db_name setup =
             m2.at "ś"   . to_vector . should_equal ["A"]
             m2.at "ś 1" . to_vector . should_equal [2]
 
-            r3 = data.connection.query 'SELECT 1 AS "A", 2 AS "A"'
+            r3 = data.connection.query (..Raw_SQL 'SELECT 1 AS "A", 2 AS "A"')
             r3.should_fail_with Illegal_Argument
             r3.catch.cause . should_be_a Duplicate_Output_Column_Names
 
-            r4 = data.connection.query 'SELECT 1 AS ""'
+            r4 = data.connection.query (..Raw_SQL 'SELECT 1 AS ""')
             r4.should_fail_with SQL_Error
 
     suite_builder.group "[PostgreSQL] Edge Cases" group_builder->
@@ -956,7 +956,7 @@ add_data_link_specs suite_builder =
                 data_link_connection.tables.column_names . should_contain "Name"
 
                 # Test that this is really a DB connection:
-                q = data_link_connection.query 'SELECT 1 AS "A"'
+                q = data_link_connection.query (..Raw_SQL 'SELECT 1 AS "A"')
                 q.column_names . should_equal ["A"]
                 q.at "A" . to_vector . should_equal [1]
 
@@ -1023,7 +1023,7 @@ add_data_link_specs suite_builder =
                 written_data_link_connection = cloud_location.read
                 Panic.with_finalizer written_data_link_connection.close <|
                     written_data_link_connection.tables.column_names . should_contain "Name"
-                    q = written_data_link_connection.query 'SELECT 1 AS "A"'
+                    q = written_data_link_connection.query (..Raw_SQL 'SELECT 1 AS "A"')
                     q.column_names . should_equal ["A"]
                     q.at "A" . to_vector . should_equal [1]
 

--- a/test/Table_Tests/src/Database/SQLite_Spec.enso
+++ b/test/Table_Tests/src/Database/SQLite_Spec.enso
@@ -182,11 +182,11 @@ sqlite_specific_spec suite_builder prefix create_connection_func setup =
             m2.at "ś"   . to_vector . should_equal ["A"]
             m2.at "ś 1" . to_vector . should_equal [2]
 
-            r3 = data.connection.query 'SELECT 1 AS "A", 2 AS "A"'
+            r3 = data.connection.query (..Raw_SQL 'SELECT 1 AS "A", 2 AS "A"')
             r3.should_fail_with Illegal_Argument
             r3.catch.cause . should_be_a Duplicate_Output_Column_Names
 
-            r4 = data.connection.query 'SELECT 1 AS ""'
+            r4 = data.connection.query (..Raw_SQL 'SELECT 1 AS ""')
             r4.should_fail_with Illegal_Argument
             r4.catch.cause . should_be_a Invalid_Column_Names
 

--- a/test/Table_Tests/src/Database/Types/Postgres_Type_Mapping_Spec.enso
+++ b/test/Table_Tests/src/Database/Types/Postgres_Type_Mapping_Spec.enso
@@ -173,11 +173,11 @@ add_specs suite_builder create_connection_fn =
             table_clean = table.remove_warnings
 
             Problems.assume_no_problems <|
-                table_clean.update_rows (data.connection.query 'SELECT decode(\'ffff\', \'hex\') AS "B"') update_action=Update_Action.Insert
+                table_clean.update_rows (data.connection.query (..Raw_SQL 'SELECT decode(\'ffff\', \'hex\') AS "B"')) update_action=Update_Action.Insert
             Problems.assume_no_problems <|
-                table_clean.update_rows (data.connection.query 'SELECT decode(\'caffee\', \'hex\') AS "B"') update_action=Update_Action.Insert
+                table_clean.update_rows (data.connection.query (..Raw_SQL 'SELECT decode(\'caffee\', \'hex\') AS "B"')) update_action=Update_Action.Insert
             Problems.assume_no_problems <|
-                table_clean.update_rows (data.connection.query 'SELECT decode(\'beef\', \'hex\') AS "B"') update_action=Update_Action.Insert
+                table_clean.update_rows (data.connection.query (..Raw_SQL 'SELECT decode(\'beef\', \'hex\') AS "B"')) update_action=Update_Action.Insert
 
             materialized_table = table_clean.read
             materialized_table.at "B" . value_type . should_equal Value_Type.Mixed

--- a/test/Visualization_Tests/src/Widgets/Database_Widgets_Spec.enso
+++ b/test/Visualization_Tests/src/Widgets/Database_Widgets_Spec.enso
@@ -5,6 +5,7 @@ import Standard.Base.Metadata.Widget
 import Standard.Base.Metadata.Display
 
 from Standard.Database import all
+from Standard.Base.Metadata.Choice import Option
 # This ensures that the Redshift connection details are available in the widget.
 from Standard.AWS import all
 
@@ -27,7 +28,8 @@ add_specs suite_builder =
 
     suite_builder.group "Widgets for In-Database Connection with table name sets" group_builder->
         group_builder.specify "works for `query` and `read`" <|
-            choices = ['a_table', 'another', 'mock_table'] . map n-> Choice.Option n n.pretty
+            table_choices = ['a_table', 'another', 'mock_table'] . map n-> Choice.Option n n.pretty
+            choices = table_choices + [Option '<Table_Name>' '..Table_Name ""', Option '<Raw_SQL>' '..Raw_SQL ""']
             expect = [["query", Widget.Single_Choice choices Nothing Display.Always]] . to_json
             Widgets.get_widget_json connection .query ["query"] . should_equal expect
             Widgets.get_widget_json connection .read ["query"] . should_equal expect


### PR DESCRIPTION
### Pull Request Description

The Text option for read and query added some very complex logic to determining what that text was with little benefit for the end user. This PR means if you just pass Text it is always treated as a table name.

![image](https://github.com/user-attachments/assets/9e6d44cf-e9e3-4707-b23f-dcc81e0ad6f2)


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
