### PR TITLE
@Override the `hintsLayerNameFor` method to be always activated

### DIFF
--- a/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/enso/EnsoErrorProvider.java
+++ b/tools/enso4igv/src/main/java/org/enso/tools/enso4igv/enso/EnsoErrorProvider.java
@@ -21,6 +21,14 @@ public final class EnsoErrorProvider implements ErrorProvider {
 
     private static final Logger LOG = Logger.getLogger(EnsoErrorProvider.class.getName());
 
+    /** @Override */
+    public String hintsLayerNameFor(Kind kind) {
+        return switch (kind) {
+            case ERRORS -> "lsp:errors";
+            case HINTS -> "lsp:hints";
+        };
+    }
+
     @Override
     public List<? extends Diagnostic> computeErrors(Context ctx) {
         var arr = new ArrayList<Diagnostic>();


### PR DESCRIPTION
### Pull Request Description

Adjusts the Enso4Igv plugin to https://github.com/apache/netbeans/pull/7659 - e.g. "override" `isEnabled()` to tell the NetBeans IDE `ErrorProviderBridge` to always display error from the Enso error provider.

### Important Notes

We still compile against older version of the LSP API - e.g. the `@Override` annotation is just a comment.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Manually verified
