### PR TITLE
Show scrollbars when scene is scrollable

### DIFF
--- a/app/gui2/src/assets/base.css
+++ b/app/gui2/src/assets/base.css
@@ -86,4 +86,5 @@
   --visualization-resize-handle-outside: 3px;
   --right-dock-default-width: 40%;
   --code-editor-default-height: 30%;
+  --scrollbar-scrollable-opacity: 100%;
 }

--- a/app/gui2/src/components/ScrollBar.vue
+++ b/app/gui2/src/components/ScrollBar.vue
@@ -121,10 +121,10 @@ export default {}
 
 <template>
   <div ref="element" class="ScrollBar" :style="scrollBarStyles">
-    <div class="track vertical" @pointerdown.stop="clickTrack.y">
+    <div class="track vertical" :class="{ scrollable: !yFull }" @pointerdown.stop="clickTrack.y">
       <div class="bar vertical" v-on.stop="dragSlider.y" />
     </div>
-    <div class="track horizontal" @pointerdown.stop="clickTrack.x">
+    <div class="track horizontal" :class="{ scrollable: !xFull }" @pointerdown.stop="clickTrack.x">
       <div class="bar horizontal" v-on.stop="dragSlider.x" />
     </div>
   </div>
@@ -190,8 +190,10 @@ export default {}
   background-color: rgba(150 150 150 / 15%);
   transition: opacity 0.2s ease-in;
   opacity: 0;
+  &.scrollable {
+    opacity: var(--scrollbar-scrollable-opacity);
+  }
   &:hover {
-    transition: opacity 0.2s ease-in;
     opacity: 1;
   }
   &:active {


### PR DESCRIPTION
### Pull Request Description

Scrollbars are visible when the viewport does not contain the whole scene, or when hovered (to allow overscroll).

Implements #10681.

https://github.com/user-attachments/assets/5fdbe3a0-34a1-4a06-ab8e-b03c51945fc3

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
