### PR TITLE
Add --vm.D cmdline option

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2598,6 +2598,7 @@ lazy val `engine-runner` = project
       "org.jline"               % "jline"                   % jlineVersion,
       "junit"                   % "junit"                   % junitVersion              % Test,
       "com.github.sbt"          % "junit-interface"         % junitIfVersion            % Test,
+      "org.hamcrest"            % "hamcrest-all"            % hamcrestVersion           % Test,
       "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion
     ),
     run / connectInput := true

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -95,6 +95,7 @@ public class Main {
   private static final String AUTO_PARALLELISM_OPTION = "with-auto-parallelism";
   private static final String EXECUTION_ENVIRONMENT_OPTION = "execution-environment";
   private static final String WARNINGS_LIMIT = "warnings-limit";
+  private static final String SYSTEM_PROPERTY = "vm.D";
 
   private static final org.slf4j.Logger logger = LoggerFactory.getLogger(Main.class);
 
@@ -449,6 +450,17 @@ public class Main {
             .desc("Enable static analysis (Experimental type inference).")
             .build();
 
+    var systemPropOption =
+        cliOptionBuilder()
+            .longOpt(SYSTEM_PROPERTY)
+            .argName("<property>=<value>")
+            .desc(
+                "Sets a system property. May be specified multiple times. If `value` is not"
+                    + " specified, 'true' is inserted.")
+            .hasArg(true)
+            .numberOfArgs(1)
+            .build();
+
     var options = new Options();
     options
         .addOption(help)
@@ -495,6 +507,7 @@ public class Main {
         .addOption(executionEnvironmentOption)
         .addOption(warningsLimitOption)
         .addOption(disablePrivateCheckOption)
+        .addOption(systemPropOption)
         .addOption(enableStaticAnalysisOption);
 
     return options;
@@ -1002,6 +1015,21 @@ public class Main {
     if (line.hasOption(VERSION_OPTION)) {
       displayVersion(line.hasOption(JSON_OPTION));
       throw exitSuccess();
+    }
+    if (line.hasOption(SYSTEM_PROPERTY)) {
+      var optionValues = line.getOptionValues(SYSTEM_PROPERTY);
+      for (var optionValue : optionValues) {
+        var items = optionValue.split("=");
+        if (items.length == 2) {
+          System.setProperty(items[0], items[1]);
+        } else if (items.length == 1) {
+          System.setProperty(items[0], "true");
+        } else {
+          System.err.println(
+              "Argument to " + SYSTEM_PROPERTY + " must be in the form <property>=<value>");
+          throw exitFail();
+        }
+      }
     }
 
     if (line.hasOption(NEW_OPTION)) {

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -1342,6 +1342,9 @@ public class Main {
           if (JVM_OPTION.equals(op.getLongOpt())) {
             continue;
           }
+          if (SYSTEM_PROPERTY.equals(op.getLongOpt())) {
+            continue;
+          }
           var longName = op.getLongOpt();
           if (longName != null) {
             commandAndArgs.add("--" + longName);

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -1284,7 +1284,10 @@ public class Main {
       if (jvm == null) {
         jvm = current;
       }
-      if (current == null || !current.equals(jvm)) {
+      var shouldLaunchJvm = current == null || !current.equals(jvm);
+      if (!shouldLaunchJvm) {
+        println(JVM_OPTION + " option has no effect - already running in JVM " + current);
+      } else {
         var loc = Main.class.getProtectionDomain().getCodeSource().getLocation();
         var commandAndArgs = new ArrayList<String>();
         JVM_FOUND:

--- a/engine/runner/src/test/java/org/enso/runner/EngineMainTest.java
+++ b/engine/runner/src/test/java/org/enso/runner/EngineMainTest.java
@@ -2,37 +2,41 @@ package org.enso.runner;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.event.Level;
 
 public class EngineMainTest {
+  @Rule public TemporaryFolder tempDir = new TemporaryFolder();
+
   private final List<String> linesOut = new ArrayList<>();
 
   @Test
   public void cannotUseReplAndInspectAtOnce() throws Exception {
     try {
-      var m =
-          new Main() {
-            @Override
-            RuntimeException doExit(int code) {
-              throw new ExitCode(code);
-            }
-
-            void println(String line) {
-              linesOut.add(line);
-            }
-          };
-      var file = File.createTempFile("some", ".enso");
-      file.deleteOnExit();
+      var m = new MainMock();
+      var file = tempDir.newFile("some.enso");
       var line = m.preprocessArguments("--repl", "--inspect", "--run", file.getAbsolutePath());
       m.mainEntry(line, Level.INFO, false);
     } catch (ExitCode ex) {
       assertEquals("Execution fails", 1, ex.exitCode);
       assertEquals("One line printed", 1, linesOut.size());
       assertEquals("Cannot use --inspect and --repl and --run at once", linesOut.get(0));
+    }
+  }
+
+  private final class MainMock extends Main {
+    @Override
+    RuntimeException doExit(int exitCode) {
+      throw new ExitCode(exitCode);
+    }
+
+    @Override
+    void println(String msg) {
+      linesOut.add(msg);
     }
   }
 


### PR DESCRIPTION
### Pull Request Description

For all the devs that are tired of specifying various JVM system properties via `JAVA_OPTS` env var, this PR adds a new `--vm.D <property>=<value>` cmdline option that is a shorthand for `env JAVA_OPTS='-Dproperty=value'`.

The name `--vm.D` is inspired from standard Truffle launcher:
```bash
$ graalpy --help | grep -e --vm
 --vm.[option]                                Pass options to the host VM. To see available options, use '--help:vm'.

$ graalpy --help:vm | grep -e --vm.D
  --vm.D<property>=<value>                     Sets a system property
```

### Important Notes
```bash
$ enso -h
    --vm.D <<property>=<value>>            Sets a system property. May be
                                           specified multiple times. If
                                           `value` is not specified,
                                           'true' is inserted.
```

For example, to dump graal compilations, one had to:
```bash
env JAVA_OPTS='-Dpolyglot.engine.CompileImmediately=true -Dpolyglot.engine.TraceCompilation=true' enso --run tmp.enso
```

But now, you can only specify:
```bash
enso --vm.D polyglot.engine.CompileImmediately --vm.D polyglot.engine.TraceCompilation --run tmp.enso
```



### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
