### PR TITLE
Fix breadcrumb height

### DIFF
--- a/app/gui2/src/components/NavBreadcrumbs.vue
+++ b/app/gui2/src/components/NavBreadcrumbs.vue
@@ -9,6 +9,7 @@ import { ref } from 'vue'
 export interface BreadcrumbItem {
   label: string
   active: boolean
+  isCurrentTop: boolean
 }
 const renameError = useToast.error()
 const projectNameEdited = ref(false)
@@ -36,6 +37,7 @@ async function renameBreadcrumb(index: number, newName: string) {
           v-if="index > 0"
           name="arrow_right_head_only"
           :disabled="!breadcrumb.active"
+          :class="{ nonInteractive: breadcrumb.isCurrentTop }"
           class="arrow"
         />
         <NavBreadcrumb
@@ -43,6 +45,7 @@ async function renameBreadcrumb(index: number, newName: string) {
           :active="breadcrumb.active"
           :editing="index === 0 && projectNameEdited"
           :title="index === 0 ? 'Project Name' : ''"
+          :class="{ nonInteractive: breadcrumb.isCurrentTop }"
           class="clickable"
           @click.stop="stackNavigator.handleBreadcrumbClick(index)"
           @update:modelValue="renameBreadcrumb(index, $event)"
@@ -63,8 +66,6 @@ async function renameBreadcrumb(index: number, newName: string) {
   gap: 12px;
   padding-left: 8px;
   padding-right: 10px;
-  padding-top: 4px;
-  padding-bottom: 4px;
 }
 
 .NavBreadcrumbs {
@@ -77,7 +78,7 @@ async function renameBreadcrumb(index: number, newName: string) {
   color: #666666;
 }
 
-.inactive {
-  opacity: 0.4;
+.nonInteractive {
+  pointer-events: none;
 }
 </style>

--- a/app/gui2/src/composables/stackNavigator.ts
+++ b/app/gui2/src/composables/stackNavigator.ts
@@ -13,7 +13,8 @@ export function useStackNavigator(projectStore: ProjectStore, graphStore: GraphS
     return breadcrumbs.value.map((item, index) => {
       const label = stackItemToLabel(item, index === 0)
       const isActive = index < activeStackLength
-      return { label, active: isActive } satisfies BreadcrumbItem
+      const isCurrentTop = index == activeStackLength - 1
+      return { label, active: isActive, isCurrentTop } satisfies BreadcrumbItem
     })
   })
 


### PR DESCRIPTION
### Pull Request Description

Fix the padding of project name / breadcrumbs.

Fixes #10652 (extended menu padding seems to have been fixed already; remaining visual differences are due to icons using different proportions of 16x16 area, `text1` in particular is tall).

### Important Notes

- Also fix a breadcrumb interaction: Top of currently-active stack no longer appears clickable, as clicking it would not do anything.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
