### PR TITLE
Wheel/pan zooming maintains pointer scene pos

### DIFF
--- a/app/gui2/src/composables/navigator.ts
+++ b/app/gui2/src/composables/navigator.ts
@@ -284,22 +284,32 @@ export function useNavigator(
     scale.skip()
   }
 
+  /**
+   * Translate the viewport as necessary to ensure that a particular client point corresponds to the same scene point
+   * before and after running the provided function.
+   */
+  function maintainingScenePosAtClientPoint<T>(clientPos: Vec2, f: () => T): T {
+    const scenePos0 = clientToScenePos(clientPos)
+    const result = f()
+    const scenePos1 = clientToScenePos(clientPos)
+    targetCenter.value = center.value.add(scenePos0.sub(scenePos1))
+    center.skip()
+    return result
+  }
+
   const { events: wheelEvents, captureEvents: wheelEventsCapture } = useWheelActions(
     keyboard,
     WHEEL_CAPTURE_DURATION_MS,
     (e, inputType) => {
-      const clientPos = eventScreenPos(e)
-      const scenePos = clientToScenePos(clientPos)
-      if (inputType === 'trackpad') {
-        // OS X trackpad events provide usable rate-of-change information.
-        updateScale((oldValue: number) => oldValue * Math.exp(-e.deltaY / 100))
-      } else {
-        // Mouse wheel rate information is unreliable. We just step in the direction of the sign.
-        stepZoom(-Math.sign(e.deltaY))
-      }
-      const scenePos1 = clientToScenePos(clientPos)
-      targetCenter.value = center.value.add(scenePos.sub(scenePos1))
-      center.skip()
+      maintainingScenePosAtClientPoint(eventScreenPos(e), () => {
+        if (inputType === 'trackpad') {
+          // OS X trackpad events provide usable rate-of-change information.
+          updateScale((oldValue: number) => oldValue * Math.exp(-e.deltaY / 100))
+        } else {
+          // Mouse wheel rate information is unreliable. We just step in the direction of the sign.
+          stepZoom(-Math.sign(e.deltaY))
+        }
+      })
     },
     (e) => {
       const delta = new Vec2(e.deltaX, e.deltaY)

--- a/app/gui2/src/composables/navigator.ts
+++ b/app/gui2/src/composables/navigator.ts
@@ -288,6 +288,8 @@ export function useNavigator(
     keyboard,
     WHEEL_CAPTURE_DURATION_MS,
     (e, inputType) => {
+      const clientPos = eventScreenPos(e)
+      const scenePos = clientToScenePos(clientPos)
       if (inputType === 'trackpad') {
         // OS X trackpad events provide usable rate-of-change information.
         updateScale((oldValue: number) => oldValue * Math.exp(-e.deltaY / 100))
@@ -295,6 +297,9 @@ export function useNavigator(
         // Mouse wheel rate information is unreliable. We just step in the direction of the sign.
         stepZoom(-Math.sign(e.deltaY))
       }
+      const scenePos1 = clientToScenePos(clientPos)
+      targetCenter.value = center.value.add(scenePos.sub(scenePos1))
+      center.skip()
     },
     (e) => {
       const delta = new Vec2(e.deltaX, e.deltaY)


### PR DESCRIPTION
### Pull Request Description

When zooming with the mouse wheel or trackpad gesture, translate the viewport position to keep the same scene point under the cursor.

Implements #10420.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
