### PR TITLE
Sort toolbar rendering for narrow nodes 

### DIFF
--- a/app/gui2/src/components/TableVizToolbar.vue
+++ b/app/gui2/src/components/TableVizToolbar.vue
@@ -164,7 +164,7 @@ const changeFormat = (option: TextFormatOptions) => {
 </script>
 
 <template>
-  <div>
+  <div class="TableVizToolbar">
     <DropdownMenu v-model:open="open" class="TextFormattingSelector" title="Text Display Options">
       <template #button
         ><div :class="buttonClass">
@@ -204,16 +204,20 @@ const changeFormat = (option: TextFormatOptions) => {
     </DropdownMenu>
   </div>
 
-  <SvgButton
-    name="add"
-    title="Create new component(s) with the current grid's sort and filters applied to the workflow"
-    :disabled="props.isDisabled"
-    @click="createNewNodes()"
-  />
+  <div class="sortFilterNode">
+    <SvgButton
+      name="add"
+      title="Create new component(s) with the current grid's sort and filters applied to the workflow"
+      :disabled="props.isDisabled"
+      @click="createNewNodes()"
+    />
+  </div>
 </template>
 
 <style scoped>
-.TextFormattingSelector {
+.TableVizToolbar {
+  display: flex;
+  flex-direction: row;
   background: var(--color-frame-bg);
   border-radius: 16px;
 }
@@ -266,5 +270,9 @@ const changeFormat = (option: TextFormatOptions) => {
 
 .title {
   padding-left: 2px;
+}
+
+.sortFilterNode {
+  overflow: hidden;
 }
 </style>

--- a/app/gui2/src/components/VisualizationContainer.vue
+++ b/app/gui2/src/components/VisualizationContainer.vue
@@ -266,7 +266,7 @@ const overFlowStyle = computed(() => {
   margin-left: auto;
   margin-right: 8px;
   overflow: hidden;
-  width: calc(var(--node-size-x) - 200px);
+  width: calc(var(--node-size-x) - var(--permanent-toolbar-width));
 }
 
 .node-type {

--- a/app/gui2/src/components/VisualizationContainer.vue
+++ b/app/gui2/src/components/VisualizationContainer.vue
@@ -260,9 +260,13 @@ const overFlowStyle = computed(() => {
 }
 
 .after-toolbars {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
   margin-left: auto;
   margin-right: 8px;
   overflow: hidden;
+  width: calc(var(--node-size-x) - 200px);
 }
 
 .node-type {


### PR DESCRIPTION
Narrow nodes/components had an overlap between the node name and the + button in the table viz. This makes the table viz toolbar mirror other visualisation defined toolbars and hide the overflow as well as preventing the text and button from over lapping 

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
