### PR TITLE
Simplify declaration of module path in sbt build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1282,7 +1282,10 @@ lazy val `ydoc-server` = project
       "junit"                      % "junit"                       % junitVersion              % Test,
       "com.github.sbt"             % "junit-interface"             % junitIfVersion            % Test,
       "com.fasterxml.jackson.core" % "jackson-databind"            % jacksonVersion            % Test
-    )
+    ),
+    libraryDependencies ++= {
+      GraalVM.modules ++ GraalVM.jsPkgs ++ GraalVM.chromeInspectorPkgs ++ helidon
+    }
   )
   // `Compile/run` settings are necessary for the `run` task to work.
   // We add it here for convenience so that one can start ydoc-server directly

--- a/build.sbt
+++ b/build.sbt
@@ -1267,14 +1267,18 @@ lazy val `ydoc-server` = project
     Test / fork := true,
     commands += WithDebugCommand.withDebug,
     moduleDependencies := {
-      GraalVM.modules ++ GraalVM.jsPkgs ++ GraalVM.chromeInspectorPkgs ++ helidon ++ Seq(
-        "org.slf4j"      % "slf4j-api"       % slf4jVersion,
-        "ch.qos.logback" % "logback-classic" % logbackClassicVersion,
-        "ch.qos.logback" % "logback-core"    % logbackClassicVersion,
+      helidon ++ Seq(
+        "org.graalvm.polyglot" % "polyglot"        % graalMavenPackagesVersion,
+        "org.graalvm.truffle"  % "truffle-api"     % graalMavenPackagesVersion,
+        "org.slf4j"            % "slf4j-api"       % slf4jVersion,
+        "ch.qos.logback"       % "logback-classic" % logbackClassicVersion,
+        "ch.qos.logback"       % "logback-core"    % logbackClassicVersion,
         (`syntax-rust-definition` / projectID).value,
         (`profiling-utils` / projectID).value
       ),
     },
+    Runtime / moduleDependencies ++=
+      GraalVM.modules ++ GraalVM.jsPkgs ++ GraalVM.chromeInspectorPkgs,
     libraryDependencies ++= Seq(
       "org.graalvm.truffle"        % "truffle-api"                 % graalMavenPackagesVersion % "provided",
       "org.graalvm.polyglot"       % "inspect"                     % graalMavenPackagesVersion % "runtime",
@@ -1285,10 +1289,7 @@ lazy val `ydoc-server` = project
       "junit"                      % "junit"                       % junitVersion              % Test,
       "com.github.sbt"             % "junit-interface"             % junitIfVersion            % Test,
       "com.fasterxml.jackson.core" % "jackson-databind"            % jacksonVersion            % Test
-    ),
-    libraryDependencies ++= {
-      GraalVM.modules ++ GraalVM.jsPkgs ++ GraalVM.chromeInspectorPkgs ++ helidon
-    }
+    )
   )
   // `Compile/run` settings are necessary for the `run` task to work.
   // We add it here for convenience so that one can start ydoc-server directly

--- a/build.sbt
+++ b/build.sbt
@@ -2104,11 +2104,13 @@ lazy val `runtime-benchmarks` =
           "org.slf4j"        % "slf4j-api"                    % slf4jVersion,
           "org.slf4j"        % "slf4j-nop"                    % slf4jVersion,
           "org.netbeans.api" % "org-netbeans-modules-sampler" % netbeansApiVersion,
-          (`runtime-fat-jar` / projectID).value,
           (`ydoc-server` / projectID).value,
           (`syntax-rust-definition` / projectID).value,
           (`profiling-utils` / projectID).value
         )
+      },
+      modulePath += {
+        (`runtime-fat-jar` / assembly / assemblyOutputPath).value
       },
       addModules := {
         val runtimeModuleName = (`runtime-fat-jar` / javaModuleName).value

--- a/build.sbt
+++ b/build.sbt
@@ -1821,19 +1821,9 @@ lazy val `runtime-language-arrow` =
         "org.apache.arrow" % "arrow-memory-netty" % apacheArrowVersion % Test
       ),
       javaModuleName := "org.enso.interpreter.arrow",
-      modulePath := {
-        val updateReport = (Test / update).value
-        JPMSUtils.filterModulesFromUpdate(
-          updateReport,
-          GraalVM.modules,
-          streams.value.log,
-          shouldContainAll = true
-        ) ++ Seq(
-          (LocalProject(
-            "runtime-language-arrow"
-          ) / Compile / productDirectories).value.head
-        )
-      },
+      moduleDependencies := GraalVM.modules,
+      Test / moduleDependencies +=
+        (LocalProject("runtime-language-arrow") / projectID).value,
       Test / patchModules := {
         val testClassesDir = (Test / productDirectories).value.head
         Map(javaModuleName.value -> Seq(testClassesDir))

--- a/build.sbt
+++ b/build.sbt
@@ -1163,6 +1163,9 @@ lazy val `project-manager` = (project in file("lib/scala/project-manager"))
   .dependsOn(testkit % Test)
   .dependsOn(`runtime-version-manager-test` % Test)
   .dependsOn(`logging-service-logback` % "test->test")
+  .dependsOn(`runtime-fat-jar` % Test)
+  .dependsOn(`ydoc-server` % Test)
+  .dependsOn(`profiling-utils` % Test)
 
 /* Note [Classpath Separation]
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/project/JPMSPlugin.scala
+++ b/project/JPMSPlugin.scala
@@ -20,6 +20,11 @@ object JPMSPlugin extends AutoPlugin {
     val addModules = settingKey[Seq[String]](
       "Module names that will be added to --add-modules option"
     )
+    val moduleDependencies = taskKey[Seq[ModuleID]](
+      "Modules dependencies that will be added to --module-path option. List all the sbt modules " +
+      "that should be added on module-path, including internal dependencies. To get ModuleID for a " +
+      "local dependency, use the `projectID` setting."
+    )
     val modulePath = taskKey[Seq[File]](
       "Directories (Jar archives or expanded Jar archives) that will be put into " +
       "--module-path option"
@@ -49,9 +54,22 @@ object JPMSPlugin extends AutoPlugin {
 
   import autoImport._
 
+
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
     addModules := Seq.empty,
-    modulePath := Seq.empty,
+    moduleDependencies := Seq.empty,
+    // modulePath is set based on moduleDependencies
+    modulePath := {
+      val cp = JPMSUtils.filterModulesFromClasspath(
+        // Do not use fullClasspath here - it will result in an infinite recursion
+        // and sbt will not be able to detect the cycle.
+        (Compile / dependencyClasspath).value,
+        (Compile / moduleDependencies).value,
+        streams.value.log,
+        shouldContainAll = true
+      )
+      cp.map(_.data)
+    },
     patchModules := Map.empty,
     addExports := Map.empty,
     addReads := Map.empty,
@@ -74,6 +92,15 @@ object JPMSPlugin extends AutoPlugin {
         (Compile / addExports).value,
         (Compile / addReads).value
       )
+    },
+    Test / modulePath := {
+      val cp = JPMSUtils.filterModulesFromClasspath(
+        (Test / dependencyClasspath).value,
+        (Test / moduleDependencies).value,
+        streams.value.log,
+        shouldContainAll = true
+      )
+      cp.map(_.data)
     },
     Test / javacOptions ++= {
       constructOptions(

--- a/project/JPMSPlugin.scala
+++ b/project/JPMSPlugin.scala
@@ -12,6 +12,22 @@ import java.io.File
   *
   * If this plugin is enabled, and no settings/tasks from this plugin are used, then the plugin will
   * not inject anything into `javaOptions` or `javacOptions`.
+  *
+  * == How to work with this plugin ==
+  * - Specify `moduleDependencies` with something like:
+  *  {{{
+  *  moduleDependencies := Seq(
+  *    "org.apache.commons" % "commons-lang3" % "3.11",
+  *  )
+  *  }}}
+  *  - Ensure that all the module dependencies were gathered by the plugin correctly by
+  *    `print modulePath`.
+  *    - If not, make sure that these dependencies are in `libraryDependencies`.
+  *      Debug this with `print dependencyClasspath`.
+  *
+  * == Caveats ==
+  * - This plugin cannot determine transitive dependencies of modules in `moduleDependencies`.
+  *   As opposed to `libraryDependencies` which automatically gatheres all the transitive dependencies.
   */
 object JPMSPlugin extends AutoPlugin {
   object autoImport {
@@ -117,6 +133,15 @@ object JPMSPlugin extends AutoPlugin {
         (Test / addExports).value,
         (Test / addReads).value
       )
+    },
+    Runtime / modulePath := {
+      val cp = JPMSUtils.filterModulesFromClasspath(
+        (Runtime / dependencyClasspath).value,
+        (Runtime / moduleDependencies).value,
+        streams.value.log,
+        shouldContainAll = true
+      )
+      cp.map(_.data)
     }
   )
 

--- a/project/JPMSPlugin.scala
+++ b/project/JPMSPlugin.scala
@@ -54,7 +54,6 @@ object JPMSPlugin extends AutoPlugin {
 
   import autoImport._
 
-
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
     addModules := Seq.empty,
     moduleDependencies := Seq.empty,

--- a/project/JPMSUtils.scala
+++ b/project/JPMSUtils.scala
@@ -70,9 +70,14 @@ object JPMSUtils {
     })
     if (shouldContainAll) {
       if (ret.size < distinctModules.size) {
-        log.error("Not all modules from classpath were found")
-        log.error(s"Returned (${ret.size}): $ret")
-        log.error(s"Expected: (${distinctModules.size}): $distinctModules")
+        log.error("[JPMSUtils] Not all modules from classpath were found")
+        log.error(
+          "[JPMSUtils] Ensure libraryDependencies and moduleDependencies are correct"
+        )
+        log.error(s"[JPMSUtils] Returned (${ret.size}): $ret")
+        log.error(
+          s"[JPMSUtils] Expected: (${distinctModules.size}): $distinctModules"
+        )
       }
     }
     ret
@@ -107,9 +112,14 @@ object JPMSUtils {
     )
     if (shouldContainAll) {
       if (foundFiles.size < distinctModules.size) {
-        log.error("Not all modules from update were found")
-        log.error(s"Returned (${foundFiles.size}): $foundFiles")
-        log.error(s"Expected: (${distinctModules.size}): $distinctModules")
+        log.error("[JPMSUtils] Not all modules from update were found")
+        log.error(
+          "[JPMSUtils] Ensure libraryDependencies and moduleDependencies are correct"
+        )
+        log.error(s"[JPMSUtils] Returned (${foundFiles.size}): $foundFiles")
+        log.error(
+          s"[JPMSUtils] Expected: (${distinctModules.size}): $distinctModules"
+        )
       }
     }
     foundFiles


### PR DESCRIPTION
Closes #10726

### Pull Request Description

Simplify declarations of module path in the whole sbt build script by introducing a new task key `moduleDependencies` that has the same format as `libraryDependencies`. Everything from `moduleDependencies` will be added on `--module-path` by the `JPMSPlugin`.

Note that it is not possible to derive module path directly from `libraryDependencies` as explained in the [issue comment](https://github.com/enso-org/enso/issues/10726#issuecomment-2293325930).

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
