### PR TITLE
Y-docs: Fix write capability recovery

### DIFF
--- a/app/ydoc-server/src/languageServerSession.ts
+++ b/app/ydoc-server/src/languageServerSession.ts
@@ -659,6 +659,7 @@ class ModulePersistence extends ObservableV2<{ removed: () => void }> {
         }
         return
       }
+      case LsSyncState.CapabilityError:
       case LsSyncState.WriteError:
       case LsSyncState.Synchronized: {
         this.setState(LsSyncState.Closing)


### PR DESCRIPTION
### Pull Request Description

When receiving no write capability in `text/openFile` response, the method returned error without synchronizing, but session state stayed at 'Opening' - this resulted in automatic success on the next retry without actually trying.

Added additional state to handle recovery from missing write capability errors.

### Important Notes

tested by applying the patch below (which simulates problem reported by James):

```diff
diff --git a/app/ydoc-shared/src/languageServer.ts b/app/ydoc-shared/src/languageServer.ts
index e1403f50420247575b437df8c603e5f1701b5e1d..753bbf9f9f449f6130c79040e44607ce0c308f7f 100644
--- a/app/ydoc-shared/src/languageServer.ts
+++ b/app/ydoc-shared/src/languageServer.ts
@@ -3,6 +3,7 @@ import { bytesToHex } from '@noble/hashes/utils'
 import { Client, RequestManager } from '@open-rpc/client-js'
 import debug from 'debug'
 import { ObservableV2 } from 'lib0/observable'
+import { wait } from 'lib0/promise.js'
 import { uuidv4 } from 'lib0/random'
 import { z } from 'zod'
 import { walkFs } from './languageServer/files'
@@ -268,9 +269,25 @@ export class LanguageServer extends ObservableV2<Notifications & TransportEvents
     return this.request('session/initProtocolConnection', { clientId }, false)
   }
 
+  private openCalls = 0
   /** [Documentation](https://github.com/enso-org/enso/blob/develop/docs/language-server/protocol-language-server.md#textopenfile) */
   openTextFile(path: Path): Promise<LsRpcResult<response.OpenTextFile>> {
-    return this.request<response.OpenTextFile>('text/openFile', { path })
+    if (this.openCalls === 0) {
+      this.openCalls = 1
+      return wait(1000).then(() =>
+        Err(new LsRpcError('Simluated timeout', 'text/openFile', { path })),
+      )
+    } else if (this.openCalls === 1) {
+      this.openCalls = 2
+      return this.request<response.OpenTextFile>('text/openFile', { path }).then(value => {
+        if (value.ok) {
+          value.value.writeCapability = null
+        }
+        return value
+      })
+    } else {
+      return this.request<response.OpenTextFile>('text/openFile', { path })
+    }
   }
 
   /** [Documentation](https://github.com/enso-org/enso/blob/develop/docs/language-server/protocol-language-server.md#textclosefile) */
```

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
