### PR TITLE
Make tab accept the text input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@
   any suggestion with Tab or new button the mode is switched to "code editing",
   where visualization preview is displayed instead.
 - [Drilldown for XML][10824]
+- [Fixed issue where switching edited widget with <kbd>tab</kbd> key did not
+  updated actual code][10857]
 
 [10774]: https://github.com/enso-org/enso/pull/10774
 [10814]: https://github.com/enso-org/enso/pull/10814
 [10824]: https://github.com/enso-org/enso/pull/10824
+[10857]: https://github.com/enso-org/enso/pull/10857
 
 #### Enso Standard Library
 

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
@@ -103,6 +103,7 @@ export const widgetDefinition = defineWidget(
       v-model="editedContents"
       autoSelect
       @keydown.enter.stop="accepted"
+      @keydown.tab.stop="accepted"
       @focusin="editing.start()"
       @input="editing.edit(makeLiteralFromUserInput($event ?? ''))"
     />


### PR DESCRIPTION
### Pull Request Description

Fixes #10855

Added handler for `tab` key. We cannot accept input on blur, as sometimes it should not be accepted (as when user clicks at drop-down option where text widget was providing filtering pattern).

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
