### PR TITLE
IO.print without new line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - [Mixed Decimal/Float arithmetic now throws an error; mixed comparisons now
   attach warnings.][10725]
 - [Support for creating Atoms in expressions.][10820]
-- [IO.println without new line][10858]
+- [IO.print without new line][10858]
 
 [10614]: https://github.com/enso-org/enso/pull/10614
 [10660]: https://github.com/enso-org/enso/pull/10660

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [Mixed Decimal/Float arithmetic now throws an error; mixed comparisons now
   attach warnings.][10725]
 - [Support for creating Atoms in expressions.][10820]
+- [IO.println without new line][10858]
 
 [10614]: https://github.com/enso-org/enso/pull/10614
 [10660]: https://github.com/enso-org/enso/pull/10660
@@ -31,6 +32,7 @@
 [10733]: https://github.com/enso-org/enso/pull/10733
 [10725]: https://github.com/enso-org/enso/pull/10725
 [10820]: https://github.com/enso-org/enso/pull/10820
+[10858]: https://github.com/enso-org/enso/pull/10858
 
 #### Enso Language & Runtime
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/IO.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/IO.enso
@@ -25,15 +25,29 @@ print_err message = @Builtin_Method "IO.print_err"
    Arguments:
    - message: The message to print. It will have to_text called on it to
      generate a textual representation that is then printed.
-   - ends_with: By default a new line is added to the printed text. It can
-     be changed by specifying different `ends_with` value.
 
    > Example
      Print the message "Oh yes!" to standard output.
 
          IO.println "Oh yes!"
-println : Any -> Text -> Nothing
-println message ends_with='\n' = IO_Helpers.println message ends_with
+println : Any -> Nothing
+println message = IO_Helpers.println message '\n'
+
+## PRIVATE
+   ADVANCED
+   Prints the provided message to standard output without adding a new line at the end.
+
+   Arguments:
+   - message: The message to print. It will have to_text called on it to
+     generate a textual representation that is then printed.
+
+   > Example
+     Print the message "Oh yes!" to standard output using `print` and then `println`.
+
+         IO.print "Oh "
+         IO.println "yes!"
+print : Any -> Nothing
+print message = IO_Helpers.println message ''
 
 ## PRIVATE
    ADVANCED

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/IO.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/IO.enso
@@ -1,6 +1,7 @@
 import project.Any.Any
 import project.Data.Text.Text
 import project.Nothing.Nothing
+import project.Internal.IO_Helpers
 
 ## PRIVATE
    ADVANCED
@@ -24,13 +25,15 @@ print_err message = @Builtin_Method "IO.print_err"
    Arguments:
    - message: The message to print. It will have to_text called on it to
      generate a textual representation that is then printed.
+   - ends_with: By default a new line is added to the printed text. It can
+     be changed by specifying different `ends_with` value.
 
    > Example
      Print the message "Oh yes!" to standard output.
 
          IO.println "Oh yes!"
-println : Any -> Nothing
-println message = @Builtin_Method "IO.println"
+println : Any -> Text -> Nothing
+println message ends_with='\n' = IO_Helpers.println message ends_with
 
 ## PRIVATE
    ADVANCED

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Internal/Extra_Imports.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Internal/Extra_Imports.enso
@@ -4,10 +4,6 @@ private
 # building native image version of Enso with Standard
 # libraries included in
 
-# needed for Standard.Test.Test_Reporter
-# tracked as https://github.com/enso-org/enso/issues/10028
-polyglot java import java.io.PrintStream
-
 # needed by Util_Spec
 polyglot java import org.enso.base.text.CaseFoldedString as JCaseFoldedString
 polyglot java import org.enso.base.text.CaseFoldedString.Grapheme

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Internal/IO_Helpers.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Internal/IO_Helpers.enso
@@ -1,0 +1,3 @@
+private
+
+println message ends_with = @Builtin_Method "IO.println"

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Test_Reporter.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Test_Reporter.enso
@@ -194,17 +194,17 @@ print_progress current_progress total_count status_text =
     truncated_line = if line.length <= progress_width then line else
         line.take (progress_width - 3) + '...'
 
-    Java_System.out.print '\r'
-    Java_System.out.print (' ' * progress_width)
-    Java_System.out.print '\r'
-    Java_System.out.print truncated_line
-    Java_System.out.print '\r'
+    IO.println ends_with='' '\r'
+    IO.println ends_with=''  (' ' * progress_width)
+    IO.println ends_with=''  '\r'
+    IO.println ends_with=''  truncated_line
+    IO.println ends_with=''  '\r'
 
 ## PRIVATE
 clear_progress =
-    Java_System.out.print '\r'
-    Java_System.out.print (' ' * progress_width)
-    Java_System.out.print '\r'
+    IO.println ends_with=''  '\r'
+    IO.println ends_with=''  (' ' * progress_width)
+    IO.println ends_with=''  '\r'
 
 ## PRIVATE
 type Ignore_Progress_Reporter

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Test_Reporter.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Test_Reporter.enso
@@ -194,17 +194,17 @@ print_progress current_progress total_count status_text =
     truncated_line = if line.length <= progress_width then line else
         line.take (progress_width - 3) + '...'
 
-    IO.println ends_with='' '\r'
-    IO.println ends_with=''  (' ' * progress_width)
-    IO.println ends_with=''  '\r'
-    IO.println ends_with=''  truncated_line
-    IO.println ends_with=''  '\r'
+    IO.print '\r'
+    IO.print (' ' * progress_width)
+    IO.print '\r'
+    IO.print truncated_line
+    IO.print '\r'
 
 ## PRIVATE
 clear_progress =
-    IO.println ends_with=''  '\r'
-    IO.println ends_with=''  (' ' * progress_width)
-    IO.println ends_with=''  '\r'
+    IO.print '\r'
+    IO.print (' ' * progress_width)
+    IO.print '\r'
 
 ## PRIVATE
 type Ignore_Progress_Reporter

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/IncrementalUpdatesTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/IncrementalUpdatesTest.java
@@ -3,6 +3,7 @@ package org.enso.interpreter.test.instrument;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.oracle.truffle.api.nodes.Node;
 import java.io.File;
@@ -279,7 +280,7 @@ public class IncrementalUpdatesTest {
     Assert.assertEquals(List.newBuilder().addOne(originalOutput), context.consumeOut());
 
     var allNodesAfterException =
-        nodeCountingInstrument.assertNewNodes("Execution creates some nodes", 20, 35);
+        nodeCountingInstrument.assertNewNodes("Execution creates some nodes", 30, 40);
 
     // push foo call
     context.send(
@@ -354,7 +355,14 @@ public class IncrementalUpdatesTest {
       Class<T> type, Map<Class, java.util.List<Node>> nodes) {
     var intNodes = nodes.get(type);
     assertNotNull("Found LiteralNode in " + nodes, intNodes);
-    assertEquals("Expecting one node: " + intNodes, 1, intNodes.size());
+    assertEquals("Expecting two nodes: " + intNodes, 2, intNodes.size());
+    if (intNodes.get(1) instanceof LiteralNode ln) {
+      var text = ln.executeGeneric(null);
+      assertEquals("The second node is ends_with from IO.println", "\n", text.toString());
+    } else {
+      fail("Expecting literal two nodes: " + intNodes);
+    }
+
     return type.cast(intNodes.get(0));
   }
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
@@ -695,7 +695,20 @@ class RuntimeErrorsTest
         )
       ),
       TestMessages.update(contextId, yId, ConstantsGen.INTEGER),
-      TestMessages.update(contextId, mainResId, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        mainResId,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual Seq("42")
@@ -722,6 +735,7 @@ class RuntimeErrorsTest
         |""".stripMargin.linesIterator.mkString("\n")
     val contents = metadata.appendToCode(code)
     val mainFile = context.writeMain(contents)
+    metadata.assertInCode(mainResId, code, "IO.println y")
 
     // create context
     context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
@@ -780,7 +794,20 @@ class RuntimeErrorsTest
         Api.ExpressionUpdate.Payload.DataflowError(Seq(xId))
       ),
       TestMessages.update(contextId, yId, ConstantsGen.INTEGER),
-      TestMessages.update(contextId, mainResId, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        mainResId,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual Seq("42")
@@ -857,7 +884,20 @@ class RuntimeErrorsTest
         yId,
         Api.ExpressionUpdate.Payload.DataflowError(Seq(xId))
       ),
-      TestMessages.update(contextId, mainResId, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        mainResId,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual Seq("(Error: MyError)")
@@ -1083,7 +1123,20 @@ class RuntimeErrorsTest
         yId,
         Api.ExpressionUpdate.Payload.DataflowError(Seq(xId))
       ),
-      TestMessages.update(contextId, mainResId, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        mainResId,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual Seq("(Error: MyError1)")
@@ -1131,7 +1184,16 @@ class RuntimeErrorsTest
         contextId,
         mainResId,
         ConstantsGen.NOTHING,
-        typeChanged = false
+        typeChanged = false,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
       ),
       context.executionComplete(contextId)
     )
@@ -1208,7 +1270,20 @@ class RuntimeErrorsTest
         yId,
         Api.ExpressionUpdate.Payload.DataflowError(Seq(fooThrowId))
       ),
-      TestMessages.update(contextId, mainResId, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        mainResId,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual Seq("(Error: MyError1)")
@@ -1250,7 +1325,16 @@ class RuntimeErrorsTest
         contextId,
         mainResId,
         ConstantsGen.NOTHING,
-        typeChanged = false
+        typeChanged = false,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
       ),
       context.executionComplete(contextId)
     )
@@ -1428,10 +1512,18 @@ class RuntimeErrorsTest
       TestMessages.panic(
         contextId,
         mainResId,
+        Api.MethodCall(
+          Api.MethodPointer(
+            "Standard.Base.IO",
+            "Standard.Base.IO",
+            "println"
+          )
+        ),
         Api.ExpressionUpdate.Payload.Panic(
           "MyError",
           Seq(xId)
-        )
+        ),
+        false
       ),
       context.executionComplete(contextId)
     )
@@ -1470,7 +1562,20 @@ class RuntimeErrorsTest
           )
         )
       ),
-      TestMessages.update(contextId, mainResId, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        mainResId,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("1234567890123456788")
@@ -1560,10 +1665,18 @@ class RuntimeErrorsTest
       TestMessages.panic(
         contextId,
         mainResId,
+        Api.MethodCall(
+          Api.MethodPointer(
+            "Standard.Base.IO",
+            "Standard.Base.IO",
+            "println"
+          )
+        ),
         Api.ExpressionUpdate.Payload.Panic(
           "Compile error: The name `foo` could not be found.",
           Seq(xId)
-        )
+        ),
+        false
       ),
       context.executionComplete(contextId)
     )
@@ -1612,7 +1725,20 @@ class RuntimeErrorsTest
           )
         )
       ),
-      TestMessages.update(contextId, mainResId, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        mainResId,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("101")
@@ -1701,10 +1827,18 @@ class RuntimeErrorsTest
       TestMessages.panic(
         contextId,
         mainResId,
+        Api.MethodCall(
+          Api.MethodPointer(
+            "Standard.Base.IO",
+            "Standard.Base.IO",
+            "println"
+          )
+        ),
         Api.ExpressionUpdate.Payload.Panic(
           "MyError1",
           Seq(xId)
-        )
+        ),
+        false
       ),
       context.executionComplete(contextId)
     )
@@ -1758,6 +1892,13 @@ class RuntimeErrorsTest
       TestMessages.panic(
         contextId,
         mainResId,
+        Api.MethodCall(
+          Api.MethodPointer(
+            "Standard.Base.IO",
+            "Standard.Base.IO",
+            "println"
+          )
+        ),
         Api.ExpressionUpdate.Payload.Panic(
           "MyError2",
           Seq(xId)
@@ -1845,10 +1986,18 @@ class RuntimeErrorsTest
       TestMessages.panic(
         contextId,
         mainResId,
+        Api.MethodCall(
+          Api.MethodPointer(
+            "Standard.Base.IO",
+            "Standard.Base.IO",
+            "println"
+          )
+        ),
         Api.ExpressionUpdate.Payload.Panic(
           "Integer",
           Seq(xId)
-        )
+        ),
+        false
       ),
       context.executionComplete(contextId)
     )
@@ -1897,7 +2046,21 @@ class RuntimeErrorsTest
           typeChanged = true
         ),
       TestMessages
-        .update(contextId, mainResId, ConstantsGen.NOTHING, typeChanged = true),
+        .update(
+          contextId,
+          mainResId,
+          ConstantsGen.NOTHING,
+          typeChanged = true,
+          methodCall = Some(
+            Api.MethodCall(
+              Api.MethodPointer(
+                "Standard.Base.IO",
+                "Standard.Base.IO",
+                "println"
+              )
+            )
+          )
+        ),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("3")
@@ -2046,7 +2209,16 @@ class RuntimeErrorsTest
       TestMessages.update(
         contextId,
         mainResId,
-        ConstantsGen.NOTHING
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
       ),
       context.executionComplete(contextId)
     )
@@ -2206,7 +2378,18 @@ class RuntimeErrorsTest
     context.receiveNIgnorePendingExpressionUpdates(
       3
     ) should contain theSameElementsAs Seq(
-      TestMessages.update(contextId, x1Id, ConstantsGen.NOTHING_BUILTIN),
+      TestMessages.update(
+        contextId,
+        x1Id,
+        ConstantsGen.NOTHING_BUILTIN,
+        Api.MethodCall(
+          Api.MethodPointer(
+            "Standard.Base.IO",
+            "Standard.Base.IO",
+            "println"
+          )
+        )
+      ),
       TestMessages.update(contextId, mainRes1Id, ConstantsGen.NOTHING_BUILTIN),
       context.executionComplete(contextId)
     )
@@ -2320,7 +2503,18 @@ class RuntimeErrorsTest
     context.receiveNIgnorePendingExpressionUpdates(
       3
     ) should contain theSameElementsAs Seq(
-      TestMessages.update(contextId, x1Id, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        x1Id,
+        ConstantsGen.NOTHING,
+        Api.MethodCall(
+          Api.MethodPointer(
+            "Standard.Base.IO",
+            "Standard.Base.IO",
+            "println"
+          )
+        )
+      ),
       TestMessages.update(contextId, mainRes1Id, ConstantsGen.NOTHING),
       context.executionComplete(contextId)
     )

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeInstrumentTest.scala
@@ -328,7 +328,20 @@ class RuntimeInstrumentTest
         )
       ),
       TestMessages.update(contextId, zExpr, ConstantsGen.INTEGER),
-      TestMessages.update(contextId, mainResExpr, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        mainResExpr,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       TestMessages.update(contextId, mainBody, ConstantsGen.NOTHING),
       context.executionComplete(contextId)
     )
@@ -388,7 +401,20 @@ class RuntimeInstrumentTest
     ) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       TestMessages.update(contextId, xExpr, ConstantsGen.DATE),
-      TestMessages.update(contextId, mainResExpr, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        mainResExpr,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       TestMessages.update(contextId, mainBody, ConstantsGen.NOTHING),
       context.executionComplete(contextId)
     )
@@ -466,7 +492,20 @@ class RuntimeInstrumentTest
         )
       ),
       TestMessages.update(contextId, mainRes1Expr, ConstantsGen.INTEGER),
-      TestMessages.update(contextId, mainResExpr, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        mainResExpr,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       TestMessages.update(contextId, mainBody, ConstantsGen.NOTHING),
       context.executionComplete(contextId)
     )
@@ -722,7 +761,20 @@ class RuntimeInstrumentTest
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       TestMessages.update(contextId, aExpr, ConstantsGen.INTEGER),
       TestMessages.update(contextId, fApp, ConstantsGen.INTEGER),
-      TestMessages.update(contextId, mainRes, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        mainRes,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       TestMessages.update(contextId, mainExpr, ConstantsGen.NOTHING),
       context.executionComplete(contextId)
     )
@@ -786,7 +838,20 @@ class RuntimeInstrumentTest
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       TestMessages.update(contextId, aExpr, ConstantsGen.INTEGER),
       TestMessages.update(contextId, lamArg, ConstantsGen.INTEGER),
-      TestMessages.update(contextId, mainRes, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        mainRes,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       context.executionComplete(contextId)
     )
   }
@@ -847,7 +912,20 @@ class RuntimeInstrumentTest
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       TestMessages.update(contextId, aExpr, ConstantsGen.INTEGER),
       TestMessages.update(contextId, lamArg, ConstantsGen.INTEGER),
-      TestMessages.update(contextId, mainRes, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        mainRes,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("2")

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -2845,7 +2845,20 @@ class RuntimeServerTest
         ConstantsGen.INTEGER,
         Api.MethodCall(Api.MethodPointer(moduleName, moduleName, "bar"))
       ),
-      TestMessages.update(contextId, idMain, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        idMain,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("42")
@@ -2909,7 +2922,20 @@ class RuntimeServerTest
         ConstantsGen.INTEGER,
         Api.MethodCall(Api.MethodPointer(moduleName, moduleName, "bar"))
       ),
-      TestMessages.update(contextId, idMain, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        idMain,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("10")
@@ -3041,7 +3067,20 @@ class RuntimeServerTest
           ConstantsGen.INTEGER,
           Api.MethodCall(Api.MethodPointer(moduleName, moduleName, "foo"))
         ),
-      TestMessages.update(contextId, mainRes, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        mainRes,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("4")
@@ -3096,6 +3135,15 @@ class RuntimeServerTest
           contextId,
           mainRes,
           ConstantsGen.NOTHING,
+          methodCall = Some(
+            Api.MethodCall(
+              Api.MethodPointer(
+                "Standard.Base.IO",
+                "Standard.Base.IO",
+                "println"
+              )
+            )
+          ),
           typeChanged = false
         ),
       TestMessages.update(
@@ -3174,7 +3222,20 @@ class RuntimeServerTest
         ConstantsGen.INTEGER,
         Api.MethodCall(Api.MethodPointer(moduleName, moduleName, "foo"))
       ),
-      TestMessages.update(contextId, mainRes, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        mainRes,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List("4")
@@ -3227,6 +3288,15 @@ class RuntimeServerTest
         contextId,
         mainRes,
         ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        ),
         typeChanged = false
       ),
       context.executionComplete(contextId)
@@ -3359,7 +3429,20 @@ class RuntimeServerTest
     context.receiveNIgnoreStdLib(5) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       TestMessages.update(contextId, idResult, ConstantsGen.INTEGER),
-      TestMessages.update(contextId, idPrintln, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        idPrintln,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       TestMessages.update(contextId, idMain, ConstantsGen.NOTHING),
       context.executionComplete(contextId)
     )
@@ -3388,6 +3471,15 @@ class RuntimeServerTest
         contextId,
         idPrintln,
         ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        ),
         typeChanged = false
       ),
       TestMessages
@@ -3472,7 +3564,20 @@ class RuntimeServerTest
           )
         )
       ),
-      TestMessages.update(contextId, idMainP, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        idMainP,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       TestMessages.update(contextId, idMain, ConstantsGen.NOTHING),
       context.executionComplete(contextId)
     )
@@ -3506,6 +3611,15 @@ class RuntimeServerTest
         contextId,
         idMainP,
         ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        ),
         typeChanged = false
       ),
       TestMessages
@@ -3544,6 +3658,15 @@ class RuntimeServerTest
         contextId,
         idMainP,
         ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        ),
         typeChanged = false
       ),
       TestMessages
@@ -3582,6 +3705,15 @@ class RuntimeServerTest
         contextId,
         idMainP,
         ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        ),
         typeChanged = false
       ),
       TestMessages
@@ -3620,6 +3752,15 @@ class RuntimeServerTest
         contextId,
         idMainP,
         ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        ),
         typeChanged = false
       ),
       TestMessages
@@ -3656,6 +3797,15 @@ class RuntimeServerTest
         contextId,
         idMainP,
         ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        ),
         typeChanged = false
       ),
       TestMessages
@@ -3694,6 +3844,15 @@ class RuntimeServerTest
         contextId,
         idMainP,
         ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        ),
         typeChanged = false
       ),
       TestMessages
@@ -4018,7 +4177,20 @@ class RuntimeServerTest
     context.receiveNIgnoreStdLib(4) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       TestMessages.update(contextId, xId, ConstantsGen.FUNCTION),
-      TestMessages.update(contextId, mainRes, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        mainRes,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       context.executionComplete(contextId)
     )
   }
@@ -4544,7 +4716,20 @@ class RuntimeServerTest
     context.receiveNIgnoreStdLib(4) should contain theSameElementsAs Seq(
       Api.Response(requestId, Api.PushContextResponse(contextId)),
       TestMessages.update(contextId, idText, ConstantsGen.TEXT),
-      TestMessages.update(contextId, idRes, ConstantsGen.NOTHING),
+      TestMessages.update(
+        contextId,
+        idRes,
+        ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        )
+      ),
       context.executionComplete(contextId)
     )
     context.consumeOut shouldEqual List(prompt1)
@@ -4578,6 +4763,15 @@ class RuntimeServerTest
         contextId,
         idRes,
         ConstantsGen.NOTHING,
+        methodCall = Some(
+          Api.MethodCall(
+            Api.MethodPointer(
+              "Standard.Base.IO",
+              "Standard.Base.IO",
+              "println"
+            )
+          )
+        ),
         typeChanged = false
       ),
       context.executionComplete(contextId)
@@ -6699,6 +6893,15 @@ class RuntimeServerTest
           contextId,
           idRes,
           ConstantsGen.NOTHING,
+          methodCall = Some(
+            Api.MethodCall(
+              Api.MethodPointer(
+                "Standard.Base.IO",
+                "Standard.Base.IO",
+                "println"
+              )
+            )
+          ),
           payload = Api.ExpressionUpdate.Payload.Value(
             Some(
               Api.ExpressionUpdate.Payload.Value.Warnings(1, Some("y"), false)

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/DataflowErrorsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/DataflowErrorsTest.scala
@@ -52,7 +52,9 @@ class DataflowErrorsTest extends InterpreterTest {
 
     "be catchable by a user-provided special handling function" in {
       val code =
-        """import Standard.Base.Error.Error
+        """
+          |import Standard.Base.Data.Numbers
+          |import Standard.Base.Error.Error
           |
           |main =
           |    intError = Error.throw 1
@@ -81,6 +83,7 @@ class DataflowErrorsTest extends InterpreterTest {
     "accept a method handle in catch function" in {
       val code =
         """import Standard.Base.Error.Error
+          |import Standard.Base.Data.Numbers
           |import Standard.Base.IO
           |
           |type My_Recovered
@@ -163,6 +166,7 @@ class DataflowErrorsTest extends InterpreterTest {
     "propagate through builtin methods" in {
       val code =
         """import Standard.Base.IO
+          |import Standard.Base.Data.Numbers
           |import Standard.Base.Error.Error
           |
           |type My_Error

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
@@ -94,7 +94,11 @@ public abstract class PrintlnNode extends Node {
 
   @CompilerDirectives.TruffleBoundary
   private void print(PrintStream out, Object str, String nl) {
-    out.print(str + nl);
+    switch (nl) {
+      case "\n" -> out.println(str);
+      case "" -> out.print(str);
+      default -> out.print(str + nl);
+    }
   }
 
   @NeverDefault

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/io/PrintlnNode.java
@@ -32,17 +32,18 @@ public abstract class PrintlnNode extends Node {
           InvokeCallableNode.DefaultsExecutionMode.EXECUTE,
           InvokeCallableNode.ArgumentsExecutionMode.PRE_EXECUTED);
 
-  abstract Object execute(VirtualFrame frame, State state, @AcceptsError Object message);
+  abstract Object execute(VirtualFrame frame, State state, @AcceptsError Object message, Object nl);
 
   @Specialization(guards = "strings.isString(message)")
   Object doPrintText(
       VirtualFrame frame,
       State state,
       Object message,
+      Object nl,
       @Shared("interop") @CachedLibrary(limit = "10") InteropLibrary strings) {
     EnsoContext ctx = EnsoContext.get(this);
     try {
-      print(ctx.getOut(), strings.asString(message));
+      print(ctx.getOut(), strings.asString(message), strings.asString(nl));
     } catch (UnsupportedMessageException e) {
       throw EnsoContext.get(this).raiseAssertionPanic(this, null, e);
     }
@@ -54,6 +55,7 @@ public abstract class PrintlnNode extends Node {
       VirtualFrame frame,
       State state,
       Object message,
+      Object nl,
       @Shared("interop") @CachedLibrary(limit = "10") InteropLibrary strings,
       @CachedLibrary(limit = "10") WarningsLibrary warnings,
       @Cached("buildSymbol()") UnresolvedSymbol symbol,
@@ -68,21 +70,21 @@ public abstract class PrintlnNode extends Node {
       }
     }
 
-    String str;
-    if (strings.isString(probablyStr)) {
-      try {
+    try {
+      String str;
+      if (strings.isString(probablyStr)) {
         str = strings.asString(probablyStr);
-      } catch (UnsupportedMessageException e) {
-        var ctx = EnsoContext.get(this);
-        throw ctx.raiseAssertionPanic(this, null, e);
+      } else {
+        str = fallbackToString(probablyStr);
       }
-    } else {
-      str = fallbackToString(probablyStr);
-    }
 
-    EnsoContext ctx = EnsoContext.get(this);
-    print(ctx.getOut(), str);
-    return ctx.getNothing();
+      EnsoContext ctx = EnsoContext.get(this);
+      print(ctx.getOut(), str, strings.asString(nl));
+      return ctx.getNothing();
+    } catch (UnsupportedMessageException e) {
+      var ctx = EnsoContext.get(this);
+      throw ctx.raiseAssertionPanic(this, null, e);
+    }
   }
 
   @CompilerDirectives.TruffleBoundary
@@ -91,8 +93,8 @@ public abstract class PrintlnNode extends Node {
   }
 
   @CompilerDirectives.TruffleBoundary
-  private void print(PrintStream out, Object str) {
-    out.println(str);
+  private void print(PrintStream out, Object str, String nl) {
+    out.print(str + nl);
   }
 
   @NeverDefault

--- a/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/IO.enso
+++ b/test/micro-distribution/lib/Standard/Base/0.0.0-dev/src/IO.enso
@@ -1,3 +1,7 @@
 print_err message = @Builtin_Method "IO.print_err"
-println message = @Builtin_Method "IO.println"
+println message = print_builtin message '\n'
+print message = print_builtin message ''
 readln = @Builtin_Method "IO.readln"
+
+# PRIVATE
+print_builtin message ends_with = @Builtin_Method "IO.println"


### PR DESCRIPTION
### Pull Request Description

Fixes #10028 by adding `IO.print` function that doesn't add new line at the end of its message.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
