### PR TITLE
Ensure clients get write capability

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/text/CollaborativeBuffer.scala
@@ -914,10 +914,12 @@ class CollaborativeBuffer(
     autoSave: Map[ClientId, (ContentVersion, Cancellable)]
   ): Unit = {
     val writeCapability =
-      if (lockHolder.isEmpty)
-        Some(CapabilityRegistration(CanEdit(bufferPath)))
-      else
-        None
+      lockHolder match {
+        case Some(session) if session.clientId != rpcSession.clientId =>
+          None
+        case _ =>
+          Some(CapabilityRegistration(CanEdit(bufferPath)))
+      }
     sender() ! OpenFileResponse(Right(OpenFileResult(buffer, writeCapability)))
     context.become(
       collaborativeEditing(


### PR DESCRIPTION
### Pull Request Description

When Ydoc requests to open file and encounters a timeout, it will attempt to retry the request. At least that's the behaviour since
 #10787.
Unfortunately, the write lock on the file might be already held and identified by the client id and actor reference. The latter is always determined by the request and therefore spurious. The same client should always be given the same capability, even on retries.

Related to #10579.

