### PR TITLE
Enable IR caches in Language Server

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -324,6 +324,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
     .logLevel(logLevel)
     .strictErrors(false)
     .disableLinting(false)
+    .enableIrCaches(true)
     .out(stdOut)
     .err(stdErr)
     .in(stdIn)


### PR DESCRIPTION
Somehow IR caching got lost and disabled in one of the refactorings.

Should help with #10579.
