### PR TITLE
Method return type checks avoid conversion when the type fits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,10 @@
 #### Enso Language & Runtime
 
 - [Print out warnings associated with local variables][10842]
+- [Method return type checks avoid conversion when the type fits][10882]
 
 [10842]: https://github.com/enso-org/enso/pull/10842
+[10882]: https://github.com/enso-org/enso/pull/10882
 
 # Enso 2024.3
 

--- a/test/Base_Tests/src/Main.enso
+++ b/test/Base_Tests/src/Main.enso
@@ -5,6 +5,7 @@ from Standard.Test import all
 import project.Semantic.Any_Spec
 import project.Semantic.Case_Spec
 import project.Semantic.Conversion_Spec
+import project.Semantic.Conversion_Database_Spec
 import project.Semantic.Default_Args_Spec
 import project.Semantic.Error_Spec
 import project.Semantic.Import_Loop.Spec as Import_Loop_Spec
@@ -103,6 +104,7 @@ main filter=Nothing =
         Function_Spec.add_specs suite_builder
         Case_Spec.add_specs suite_builder
         Conversion_Spec.add_specs suite_builder
+        Conversion_Database_Spec.add_specs suite_builder
         Default_Args_Spec.add_specs suite_builder
         Error_Spec.add_specs suite_builder
         Environment_Spec.add_specs suite_builder

--- a/test/Base_Tests/src/Semantic/Conversion_Database_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Conversion_Database_Spec.enso
@@ -1,0 +1,82 @@
+from Standard.Base import all
+from Standard.Test import all
+
+
+#class Connection a where
+#    get_tables :: a -> [String]
+
+type Connection
+    private By value dict
+
+    get_tables self = self.dict.get_tables self.value
+
+    new value dict =
+        Connection.By value dict
+
+type Snowflake_Connection
+    private Details details:Snowflake_Connection_Details
+
+    get_warehouses self  -> Vector Text = ["SNOWFLAKE_WAREHOUSE"]
+
+# database_connect :: Connection c => Connection_Details d c => d -> c
+database_connect details:Any -> Connection =
+    Connection.from details
+
+# data Snowflake_Connection_Details = Snowflake_Connection_Details String String String -- username, password etc.
+type Snowflake_Connection_Details
+    Value username:Text password:Text etc:Text
+
+two_roles_of_snowflake_connection -> Pair Text =
+    # let snowflake_connection = database_connect (Snowflake_Connection_Details "foo" "bar" "baz")
+    details = Snowflake_Connection_Details.Value "foo" "bar" "baz"
+    snowflake_connection = database_connect details
+
+    # get_tables is methods from Connection type
+    # it is there because `database_connect` returns Connection
+    r1 = snowflake_connection.get_tables
+    # get_warehouses is a method from Snowflake_Connection type
+    # it has been "mixed in" in Connection.from (that:Snowflake_Connection)
+    r2 = snowflake_connection.get_warehouses
+
+    Pair.new r1.to_text r2.to_text
+
+# data Snowflake_Connection = Snowflake_Connection_Impl -- here we'd have internals of the connection
+#instance Connection Snowflake_Connection where
+#    get_tables c = ["some Snowflake table"] -- we'd call JDBC here ofc.
+
+type Snowflake_Connection_Impl
+    get_tables self c:Snowflake_Connection =
+        ["some Snowflake table for "+c.to_text]
+
+Connection.from (that:Snowflake_Connection_Details) =
+    c = Snowflake_Connection.Details that
+    mixin = c:(Snowflake_Connection & Connection)
+    mixin
+
+Connection.from (that:Snowflake_Connection) =
+    Connection.new that Snowflake_Connection_Impl
+
+#
+# running
+#
+
+main =
+    pair = two_roles_of_snowflake_connection
+    IO.println pair.first
+    IO.println pair.second
+
+#
+# testing
+#
+
+add_specs suite_builder =
+    suite_builder.group "Conversion Database Example" group_builder->
+        group_builder.specify "snowflake_connection plays two roles" <|
+            pair = two_roles_of_snowflake_connection
+
+            pair.first . should_contain "some Snowflake table for"
+            pair.first . should_contain "Snowflake_Connection_Details"
+            pair.first . should_contain "foo"
+            pair.first . should_contain "bar"
+            pair.first . should_contain "baz"
+            pair.second . should_equal "[SNOWFLAKE_WAREHOUSE]"

--- a/test/Base_Tests/src/Semantic/Conversion_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Conversion_Spec.enso
@@ -98,6 +98,20 @@ type Fool
 
 Fool.from (that : Any) = Fool.Value that
 
+type Mixin
+    Value mix:Text
+
+    text_and_mixin t:Text =
+        mixin = t:(Text & Mixin)
+        mixin
+
+    text_and_mixin_with_check t:Text -> Mixin =
+        v = Mixin.text_and_mixin t
+        v
+
+Mixin.from (that:Text) = Mixin.Value that
+Mixin.from (that:Any) = Mixin.text_and_mixin that.to_text
+
 type Blob
     Text c:Text
     Binary b:File
@@ -449,6 +463,38 @@ add_specs suite_builder =
                 x.to_text . should_equal "{FOOL "+now.to_text+"}"
 
             do_duration now
+
+        group_builder.specify "Returning Text & Mixin from method" <|
+            m = Mixin.text_and_mixin "hi there"
+
+            m:Text . should_equal "hi there"
+            (m:Mixin).mix . should_equal "hi there"
+
+            Meta.type_of (m:Text) . should_equal Text
+            Meta.type_of (m:Mixin) . should_equal Mixin
+            Meta.type_of m . should_equal Text
+
+        group_builder.specify "Returning Text & Mixin from method with check" <|
+            m = Mixin.text_and_mixin_with_check "hi there"
+
+            m:Text . should_equal "hi there"
+            (m:Mixin).mix . should_equal "hi there"
+
+            Meta.type_of (m:Text) . should_equal Text
+            Meta.type_of (m:Mixin) . should_equal Mixin
+            Meta.type_of m . should_equal Text
+
+        group_builder.specify "Returning Text & Mixin from Conversion method" <|
+            v = 42
+            m = v:Mixin
+
+            m:Text . should_equal "42"
+            (m:Mixin).mix . should_equal "42"
+
+            Meta.type_of (m:Text) . should_equal Text
+            Meta.type_of (m:Mixin) . should_equal Mixin
+            Meta.type_of m . should_equal Text
+
 
     suite_builder.group "Autoscoped Constructors" group_builder->
 


### PR DESCRIPTION
### Pull Request Description

Discussion about _type classes_ revealed that Enso is able to support Haskell 8 type classes with a single variable. However more complicated type classes (enabled with `-XMultiParamTypeClasses` and by default on in Haskell 9) are more complicated. Turns out one may do it at the end, but only with _intersection types_ returned from functions and conversion methods. This PR enables such behavior.

### Related

- relaxes checks in #10468
- relaxes #8502
- builds on #7769
- keeps semantics of #7796

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
