### PR TITLE
Ensure execution is scheduled after compilation

### DIFF
--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/EditFileCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/EditFileCmd.scala
@@ -52,8 +52,9 @@ class EditFileCmd(request: Api.EditFileNotification)
             }
             if (request.execute) {
               ctx.jobControlPlane.abortAllJobs()
-              ctx.jobProcessor.run(new EnsureCompiledJob(Seq(request.path)))
-              executeJobs.foreach(ctx.jobProcessor.run)
+              ctx.jobProcessor
+                .run(new EnsureCompiledJob(Seq(request.path)))
+                .map(_ => executeJobs.foreach(ctx.jobProcessor.run))
             } else if (request.idMap.isDefined) {
               ctx.jobProcessor.run(new EnsureCompiledJob(Seq(request.path)))
             }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/EditFileCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/EditFileCmd.scala
@@ -54,7 +54,7 @@ class EditFileCmd(request: Api.EditFileNotification)
               ctx.jobControlPlane.abortAllJobs()
               ctx.jobProcessor
                 .run(new EnsureCompiledJob(Seq(request.path)))
-                .map(_ => executeJobs.foreach(ctx.jobProcessor.run))
+                .foreach(_ => executeJobs.foreach(ctx.jobProcessor.run))
             } else if (request.idMap.isDefined) {
               ctx.jobProcessor.run(new EnsureCompiledJob(Seq(request.path)))
             }


### PR DESCRIPTION
### Pull Request Description

Scheduling of jobs is asynchronous and nothing prevents it from scheduling execution before compilation leading to stale nodes in GUI. The scenario is easily reproducible by adding a `Thread.sleep` before `EnsureCompiledJob` requests compilation locks.

This change ensures that execution is only scheduled after compilation is finished, when an edit request is being processed.

### Important Notes

This fix was prompted by me getting random stale nodes after edits:
![Screenshot from 2024-08-23 16-53-26](https://github.com/user-attachments/assets/2b017539-c4bf-4d42-b597-216d887a4f4c)
(it would never recover unless another edit was made)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
