### PR TITLE
 When there are no pendingItems for a KEEP_ALIVE period, stop RequestQueue observer thread

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/RuntimeManagementCleanupTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/RuntimeManagementCleanupTest.java
@@ -1,13 +1,16 @@
 package org.enso.interpreter.test.instrument;
 
+import static org.junit.Assert.fail;
+
 import org.junit.Test;
 
 public final class RuntimeManagementCleanupTest {
 
   @Test
   public void cleanUp() throws InterruptedException {
+    var cnt = 0;
     for (var i = 0; i < 100; i++) {
-      var cnt = 0;
+      cnt = 0;
       for (var threadStack : Thread.getAllStackTraces().entrySet()) {
         if (threadStack.getKey().getName().startsWith("Thread-")) {
           System.err.println(threadStack.getKey().getName());
@@ -19,10 +22,11 @@ public final class RuntimeManagementCleanupTest {
       }
       System.err.println("Found " + cnt + " suspicious threads");
       if (cnt == 0) {
-        break;
+        return;
       }
       System.gc();
       Thread.sleep(100);
     }
+    fail("There are still " + cnt + " suspicious threads");
   }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/RuntimeManagementCleanupTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/RuntimeManagementCleanupTest.java
@@ -1,0 +1,28 @@
+package org.enso.interpreter.test.instrument;
+
+import org.junit.Test;
+
+public final class RuntimeManagementCleanupTest {
+
+  @Test
+  public void cleanUp() throws InterruptedException {
+    for (var i = 0; i < 100; i++) {
+      var cnt = 0;
+      for (var threadStack : Thread.getAllStackTraces().entrySet()) {
+        if (threadStack.getKey().getName().startsWith("Thread-")) {
+          System.err.println(threadStack.getKey().getName());
+          for (var frame : threadStack.getValue()) {
+            System.err.println("  " + frame);
+          }
+          cnt++;
+        }
+      }
+      System.err.println("Found " + cnt + " suspicious threads");
+      if (cnt == 0) {
+        break;
+      }
+      System.gc();
+      Thread.sleep(100);
+    }
+  }
+}

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/RuntimeManagementCleanupTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/RuntimeManagementCleanupTest.java
@@ -2,6 +2,8 @@ package org.enso.interpreter.test.instrument;
 
 import static org.junit.Assert.fail;
 
+import java.io.OutputStream;
+import java.io.PrintStream;
 import org.junit.Test;
 
 public final class RuntimeManagementCleanupTest {
@@ -9,18 +11,19 @@ public final class RuntimeManagementCleanupTest {
   @Test
   public void cleanUp() throws InterruptedException {
     var cnt = 0;
-    for (var i = 0; i < 100; i++) {
+    for (var i = 1; i < 100; i++) {
       cnt = 0;
+      var err = i % 10 == 0 ? System.err : new PrintStream(OutputStream.nullOutputStream());
       for (var threadStack : Thread.getAllStackTraces().entrySet()) {
         if (threadStack.getKey().getName().startsWith("Thread-")) {
-          System.err.println(threadStack.getKey().getName());
+          err.println(threadStack.getKey().getName());
           for (var frame : threadStack.getValue()) {
-            System.err.println("  " + frame);
+            err.println("  " + frame);
           }
           cnt++;
         }
       }
-      System.err.println("Found " + cnt + " suspicious threads");
+      err.println("Found " + cnt + " suspicious threads");
       if (cnt == 0) {
         return;
       }

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/RuntimeManagementTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/RuntimeManagementTest.scala
@@ -6,19 +6,13 @@ import org.enso.common.{LanguageInfo, MethodNames}
 
 import scala.ref.WeakReference
 import scala.util.Try
-import org.scalatest.BeforeAndAfterAll
 
-class RuntimeManagementTest extends InterpreterTest with BeforeAndAfterAll {
+class RuntimeManagementTest extends InterpreterTest {
   override def subject: String = "Enso Code Execution"
-
-  override protected def afterAll(): Unit = {
-    RuntimeManagementTest.toClose.forEach(_.close())
-  }
 
   override def specify(implicit
     interpreterContext: InterpreterContext
   ): Unit = {
-    RuntimeManagementTest.toClose.add(interpreterContext)
 
     "Interrupt threads through Thread#interrupt()" in {
       val langCtx = interpreterContext
@@ -53,9 +47,7 @@ class RuntimeManagementTest extends InterpreterTest with BeforeAndAfterAll {
       }
 
       def runTest(n: Int = 5): Unit = {
-        val threads = 0
-          .until(n)
-          .map(_ => new Thread(runnable, "RuntimeManagementTest-Thread"))
+        val threads = 0.until(n).map(_ => new Thread(runnable))
         threads.foreach(_.start())
         var reportedCount = 0
         while (reportedCount < n) {
@@ -204,9 +196,4 @@ class RuntimeManagementTest extends InterpreterTest with BeforeAndAfterAll {
       totalOut should contain theSameElementsAs all
     }
   }
-}
-
-object RuntimeManagementTest {
-  val toClose: java.util.Set[InterpreterContext] =
-    new java.util.HashSet[InterpreterContext]
 }


### PR DESCRIPTION
### Pull Request Description

Fixes #10804 by automatically stopping the thread that calls `RequestQueue.remove` when all resources are finalized and there is no pending item for a given KEEP_ALIVE period.

### Important Notes

8569776d5ec284874ceab0f9d8afe47435f829bd adds a test that verifies no unnamed thread (e.g. `Thread-xyz`) is pending when the test running. Execute as
```
sbt:runtime-integration-tests> testOnly *RuntimeManagement*
```
hoping the tests run in the right order (they probably do as `scalatest` runs Scala first and JUnit later), the second test would fail prior to the a670f04 fix with:
```
Thread-11
  java.base@21.0.2/jdk.internal.misc.Unsafe.park(Native Method)
  java.base@21.0.2/java.util.concurrent.locks.LockSupport.park(LockSupport.java:371)
  java.base@21.0.2/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:519)
  java.base@21.0.2/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3780)
  java.base@21.0.2/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3725)
  java.base@21.0.2/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1707)
  java.base@21.0.2/java.lang.ref.ReferenceQueue.await(ReferenceQueue.java:67)
  java.base@21.0.2/java.lang.ref.ReferenceQueue.remove0(ReferenceQueue.java:158)
  java.base@21.0.2/java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:234)
  app/org.enso.runtime/org.enso.interpreter.runtime.ResourceManager$ProcessItems.run(ResourceManager.java:221)
  java.base@21.0.2/java.lang.Thread.runWith(Thread.java:1596)
  java.base@21.0.2/java.lang.Thread.run(Thread.java:1583)
  app/org.graalvm.truffle/com.oracle.truffle.polyglot.SystemThread.run(SystemThread.java:68)
Thread-12
  java.base@21.0.2/jdk.internal.misc.Unsafe.park(Native Method)
  java.base@21.0.2/java.util.concurrent.locks.LockSupport.park(LockSupport.java:371)
  java.base@21.0.2/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:519)
  java.base@21.0.2/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3780)
  java.base@21.0.2/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3725)
  java.base@21.0.2/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1707)
  java.base@21.0.2/java.lang.ref.ReferenceQueue.await(ReferenceQueue.java:67)
  java.base@21.0.2/java.lang.ref.ReferenceQueue.remove0(ReferenceQueue.java:158)
  java.base@21.0.2/java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:234)
  app/org.enso.runtime/org.enso.interpreter.runtime.ResourceManager$ProcessItems.run(ResourceManager.java:221)
  java.base@21.0.2/java.lang.Thread.runWith(Thread.java:1596)
  java.base@21.0.2/java.lang.Thread.run(Thread.java:1583)
  app/org.graalvm.truffle/com.oracle.truffle.polyglot.SystemThread.run(SystemThread.java:68)
Found 2 suspicious threads
```
With the a670f04 both tests (`RuntimeManagementTest` and `RuntimeManagementCleanupTest` succeed).

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
