### PR TITLE
Speeding up RuntimeVisualizationsTest by one minute

### DIFF
--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeVisualizationsTest.scala
@@ -4166,7 +4166,8 @@ class RuntimeVisualizationsTest extends AnyFlatSpec with Matchers {
         )
       )
       val attachVisualizationResponses =
-        context.receiveNIgnoreExpressionUpdates(3)
+        context.receiveNIgnoreExpressionUpdates(2)
+      attachVisualizationResponses.size should be(2)
       attachVisualizationResponses should contain(
         Api.Response(requestId, Api.VisualizationAttached())
       )


### PR DESCRIPTION
### Pull Request Description

The same test is executed twice and once it receives three responses and once only two. Modifying the test to expect just two.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
- [x] Unit tests run and some run faster by one minute
