### PR TITLE
Fix S3 spec

### DIFF
--- a/test/AWS_Tests/src/S3_Spec.enso
+++ b/test/AWS_Tests/src/S3_Spec.enso
@@ -485,7 +485,7 @@ add_specs suite_builder =
             new_file = S3_File.new "s3://"+bucket_name+"/examples/no-write-permissions-here.txt" credentials=test_credentials
             r = "Hello".write new_file
             r.should_fail_with S3_Error
-            r.catch.to_display_text . should_contain "Access Denied"
+            r.catch.to_display_text . should_contain "AccessDenied"
 
         group_builder.specify "should fail to open an output stream if Output context is not enabled" <|
             Context.Output.with_disabled <|


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

Fixes the issue with the S3 test on CI:
```
- [FAILED] should fail to write a file if permissions are lacking [1108ms]
         Reason: The value (S3 Error: User: arn:aws:iam::539646847106:user/enso_ci_s3_tester is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::enso-data-samples/examples/no-write-permissions-here.txt.bak" because no identity-based policy allows the s3:PutObject action (AccessDenied)) did not contain the element (Access Denied) (at /runner/_work/enso/enso/test/AWS_Tests/src/S3_Spec.enso:488:13-68).
```

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
