### PR TITLE
Fix std benchmarks run

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2910,7 +2910,7 @@ lazy val `std-benchmarks` = (project in file("std-bits/benchmarks"))
     },
     addModules := {
       val runtimeModuleName = (`runtime-fat-jar` / javaModuleName).value
-      val arrowModName = (`runtime-language-arrow` / javaModuleName).value
+      val arrowModName      = (`runtime-language-arrow` / javaModuleName).value
       Seq(runtimeModuleName, arrowModName)
     },
     addExports := {

--- a/build.sbt
+++ b/build.sbt
@@ -2895,10 +2895,18 @@ lazy val `std-benchmarks` = (project in file("std-bits/benchmarks"))
       "-J-Dpolyglotimpl.DisableClassPathIsolation=true",
       "-J-Dpolyglot.engine.WarnInterpreterOnly=false"
     ),
-    moduleDependencies := {
-      componentModulesIds.value ++ Seq(
+    modulePath := {
+      val allRuntimeMods = componentModulesPaths.value
+      val otherModIds = Seq(
         "org.slf4j" % "slf4j-nop" % slf4jVersion
       )
+      val requiredMods = JPMSUtils.filterModulesFromUpdate(
+        (Compile / update).value,
+        otherModIds,
+        streams.value.log,
+        shouldContainAll = true
+      )
+      allRuntimeMods ++ requiredMods
     },
     addModules := {
       val runtimeModuleName = (`runtime-fat-jar` / javaModuleName).value

--- a/build.sbt
+++ b/build.sbt
@@ -2902,7 +2902,8 @@ lazy val `std-benchmarks` = (project in file("std-bits/benchmarks"))
     },
     addModules := {
       val runtimeModuleName = (`runtime-fat-jar` / javaModuleName).value
-      Seq(runtimeModuleName)
+      val arrowModName = (`runtime-language-arrow` / javaModuleName).value
+      Seq(runtimeModuleName, arrowModName)
     },
     addExports := {
       Map("org.slf4j.nop/org.slf4j.nop" -> Seq("org.slf4j"))
@@ -2937,6 +2938,10 @@ lazy val `std-benchmarks` = (project in file("std-bits/benchmarks"))
   )
   .dependsOn(`bench-processor`)
   .dependsOn(`runtime-fat-jar`)
+  .dependsOn(`ydoc-server`)
+  .dependsOn(`runtime-language-arrow`)
+  .dependsOn(`syntax-rust-definition`)
+  .dependsOn(`profiling-utils`)
   .dependsOn(`std-table` % "provided")
   .dependsOn(`std-base` % "provided")
   .dependsOn(`benchmark-java-helpers` % "provided")

--- a/build.sbt
+++ b/build.sbt
@@ -2872,7 +2872,7 @@ lazy val `std-benchmarks` = (project in file("std-bits/benchmarks"))
   .settings(
     frgaalJavaCompilerSetting,
     annotationProcSetting,
-    libraryDependencies ++= GraalVM.modules ++ GraalVM.langsPkgs ++ Seq(
+    libraryDependencies ++= GraalVM.modules ++ GraalVM.langsPkgs ++ GraalVM.toolsPkgs ++ Seq(
       "org.openjdk.jmh"      % "jmh-core"                 % jmhVersion,
       "org.openjdk.jmh"      % "jmh-generator-annprocess" % jmhVersion,
       "org.graalvm.polyglot" % "polyglot"                 % graalMavenPackagesVersion,

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
@@ -98,7 +98,7 @@ public class BenchProcessor extends AbstractProcessor {
                 + "' specified in the annotation does not exist or is not readable");
       }
       try (var ctx =
-          Context.newBuilder(LanguageInfo.ID)
+          Context.newBuilder()
               .allowExperimentalOptions(true)
               .allowIO(IOAccess.ALL)
               .allowAllAccess(true)

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
@@ -438,6 +438,8 @@ public class BenchProcessor extends AbstractProcessor {
   }
 
   private void failWithMessage(String msg) {
+    // Better have duplicated error message than none at all
+    System.out.println("[org.enso.benchmarks.processor.BenchProcessor]: ERROR: " + msg);
     processingEnv.getMessager().printMessage(Kind.ERROR, msg);
   }
 }


### PR DESCRIPTION
### Pull Request Description

Fixes `sbt std-benchmarks/run`. The problem was introduced in #10836 - runtime-fat-jar was on module-path as exploded directory with classes, and not as a modular fat jar.

### Important Notes

std-benchmarks started to silently fail recently. For example in https://github.com/enso-org/enso/actions/runs/10533928803/job/29190752771. In the future, we should test this. Tracked in #10901.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] stdlib [benchmark run](https://github.com/enso-org/enso/actions/runs/10590546444) is successful
