### PR TITLE
Fold output of each benchmark

### DIFF
--- a/build/ci_utils/src/program/command.rs
+++ b/build/ci_utils/src/program/command.rs
@@ -469,8 +469,9 @@ pub fn spawn_log_processor(
                 match String::from_utf8(line_bytes) {
                     Ok(line) => {
                         let line = line.trim_end_matches('\r');
-                        if line.starts_with("::") {
-                            println!("{line}");
+                        if line.starts_with("[info] ::") {
+                            let line_without_prefix = &line[7..];
+                            println!("{line_without_prefix}");
                         } else {
                             info!("{prefix} {line}");
                         }

--- a/build/ci_utils/src/program/command.rs
+++ b/build/ci_utils/src/program/command.rs
@@ -469,7 +469,11 @@ pub fn spawn_log_processor(
                 match String::from_utf8(line_bytes) {
                     Ok(line) => {
                         let line = line.trim_end_matches('\r');
-                        info!("{prefix} {line}");
+                        if line.starts_with("::") {
+                            println!("{line}");
+                        } else {
+                            info!("{prefix} {line}");
+                        }
                     }
                     Err(e) => {
                         error!("{prefix} Failed to decode a line from output: {e}");

--- a/build/ci_utils/src/program/command.rs
+++ b/build/ci_utils/src/program/command.rs
@@ -472,11 +472,10 @@ pub fn spawn_log_processor(
                         let mut command = false;
                         if let Some(command_at) = line.find("::") {
                             if let Some(group_at) = line.find("group") {
-                                // we support:
-                                // ::group
-                                // ::endgroup
+                                // we support: `::group` and `::endgroup` right now
                                 if command_at < group_at && group_at < command_at + 10 {
                                     let line_without_prefix = &line[command_at..];
+                                    // intentionally using println to avoid info!'s prefix
                                     println!("{line_without_prefix}");
                                     command = true;
                                 }

--- a/build/ci_utils/src/program/command.rs
+++ b/build/ci_utils/src/program/command.rs
@@ -469,10 +469,20 @@ pub fn spawn_log_processor(
                 match String::from_utf8(line_bytes) {
                     Ok(line) => {
                         let line = line.trim_end_matches('\r');
-                        if line.starts_with("[info] ::") {
-                            let line_without_prefix = &line[7..];
-                            println!("{line_without_prefix}");
-                        } else {
+                        let mut command = false;
+                        if let Some(command_at) = line.find("::") {
+                            if let Some(group_at) = line.find("group") {
+                                // we support:
+                                // ::group
+                                // ::endgroup
+                                if command_at < group_at && group_at < command_at + 10 {
+                                    let line_without_prefix = &line[command_at..];
+                                    println!("{line_without_prefix}");
+                                    command = true;
+                                }
+                            }
+                        }
+                        if !command {
                             info!("{prefix} {line}");
                         }
                     }

--- a/lib/java/benchmarks-common/src/main/java/org/enso/interpreter/bench/BenchmarksRunner.java
+++ b/lib/java/benchmarks-common/src/main/java/org/enso/interpreter/bench/BenchmarksRunner.java
@@ -5,9 +5,16 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.IterationParams;
+import org.openjdk.jmh.results.BenchmarkResult;
+import org.openjdk.jmh.results.IterationResult;
 import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Defaults;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.format.OutputFormat;
+import org.openjdk.jmh.runner.format.OutputFormatFactory;
 import org.openjdk.jmh.runner.options.CommandLineOptionException;
 import org.openjdk.jmh.runner.options.CommandLineOptions;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
@@ -31,7 +38,10 @@ public class BenchmarksRunner {
       // Do not report results from `compileOnly` mode
       runCompileOnly(cmdOpts.getIncludes());
     } else {
-      Runner jmhRunner = new Runner(cmdOpts);
+      var output =
+          OutputFormatFactory.createFormatInstance(
+              System.out, cmdOpts.verbosity().orElse(Defaults.VERBOSITY));
+      Runner jmhRunner = new Runner(cmdOpts, new GitHubActionsFormat(output));
 
       if (cmdOpts.shouldHelp()) {
         System.err.println("Enso benchmark runner: A modified JMH runner for Enso benchmarks.");
@@ -106,5 +116,77 @@ public class BenchmarksRunner {
 
     Report.writeToFile(report, REPORT_FILE);
     return benchItem;
+  }
+
+  private static final class GitHubActionsFormat implements OutputFormat {
+    private final OutputFormat output;
+
+    GitHubActionsFormat(OutputFormat output) {
+      this.output = output;
+    }
+
+    @Override
+    public void iteration(BenchmarkParams benchParams, IterationParams params, int iteration) {
+      output.iteration(benchParams, params, iteration);
+    }
+
+    @Override
+    public void iterationResult(
+        BenchmarkParams benchParams, IterationParams params, int iteration, IterationResult data) {
+      output.iterationResult(benchParams, params, iteration, data);
+    }
+
+    @Override
+    public void startBenchmark(BenchmarkParams benchParams) {
+      output.println("::group::" + benchParams.getBenchmark());
+    }
+
+    @Override
+    public void endBenchmark(BenchmarkResult result) {
+      output.println("::endgroup::");
+    }
+
+    @Override
+    public void startRun() {
+      output.startRun();
+    }
+
+    @Override
+    public void endRun(Collection<RunResult> result) {
+      output.endRun(result);
+    }
+
+    @Override
+    public void print(String s) {
+      output.print(s);
+    }
+
+    @Override
+    public void println(String s) {
+      output.println(s);
+    }
+
+    @Override
+    public void flush() {
+      output.flush();
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public void verbosePrintln(String s) {
+      output.verbosePrintln(s);
+    }
+
+    @Override
+    public void write(int b) {
+      output.write(b);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+      output.write(b);
+    }
   }
 }

--- a/lib/java/benchmarks-common/src/main/java/org/enso/interpreter/bench/BenchmarksRunner.java
+++ b/lib/java/benchmarks-common/src/main/java/org/enso/interpreter/bench/BenchmarksRunner.java
@@ -26,6 +26,9 @@ public class BenchmarksRunner {
   public static final File REPORT_FILE = new File("./bench-report.xml");
 
   public static void run(String[] args) throws RunnerException {
+    if (args.length == 0) {
+      args = new String[] {"--jvmArgs=-Dbench.all=true"};
+    }
     CommandLineOptions cmdOpts = null;
     try {
       cmdOpts = new CommandLineOptions(args);

--- a/lib/java/benchmarks-common/src/main/java/org/enso/interpreter/bench/BenchmarksRunner.java
+++ b/lib/java/benchmarks-common/src/main/java/org/enso/interpreter/bench/BenchmarksRunner.java
@@ -17,6 +17,7 @@ import org.openjdk.jmh.runner.format.OutputFormat;
 import org.openjdk.jmh.runner.format.OutputFormatFactory;
 import org.openjdk.jmh.runner.options.CommandLineOptionException;
 import org.openjdk.jmh.runner.options.CommandLineOptions;
+import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;
 
@@ -38,10 +39,7 @@ public class BenchmarksRunner {
       // Do not report results from `compileOnly` mode
       runCompileOnly(cmdOpts.getIncludes());
     } else {
-      var output =
-          OutputFormatFactory.createFormatInstance(
-              System.out, cmdOpts.verbosity().orElse(Defaults.VERBOSITY));
-      Runner jmhRunner = new Runner(cmdOpts, new GitHubActionsFormat(output));
+      var jmhRunner = createRunner(cmdOpts);
 
       if (cmdOpts.shouldHelp()) {
         System.err.println("Enso benchmark runner: A modified JMH runner for Enso benchmarks.");
@@ -92,7 +90,7 @@ public class BenchmarksRunner {
             .forks(0);
     includes.forEach(optsBuilder::include);
     var opts = optsBuilder.build();
-    var runner = new Runner(opts);
+    var runner = createRunner(opts);
     try {
       runner.run();
       System.out.println(
@@ -116,6 +114,14 @@ public class BenchmarksRunner {
 
     Report.writeToFile(report, REPORT_FILE);
     return benchItem;
+  }
+
+  private static Runner createRunner(Options cmdOpts) {
+    var output =
+        OutputFormatFactory.createFormatInstance(
+            System.out, cmdOpts.verbosity().orElse(Defaults.VERBOSITY));
+    Runner jmhRunner = new Runner(cmdOpts, new GitHubActionsFormat(output));
+    return jmhRunner;
   }
 
   private static final class GitHubActionsFormat implements OutputFormat {

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
@@ -347,7 +347,7 @@ public class BenchProcessor extends AbstractProcessor {
                   @TearDown
                   public void checkNoTruffleCompilation(BenchmarkParams params) {
                     if (compilationMessagesFound) {
-                      System.err.println(compilationLog.toString());
+                      System.out.println(compilationLog.toString());
                     }
                   }
 

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
@@ -347,12 +347,18 @@ public class BenchProcessor extends AbstractProcessor {
                   @TearDown
                   public void checkNoTruffleCompilation(BenchmarkParams params) {
                     if (compilationMessagesFound) {
+                      var limit = Boolean.getBoolean("bench.all") ? 10 : Integer.MAX_VALUE;
                       for (var l : compilationLog.toString().split("\\n")) {
                         var pipe = l.indexOf('|');
                         if (pipe > 0) {
                           l = l.substring(0, pipe);
                         }
                         System.out.println(l);
+                        if (limit-- <= 0) {
+                          System.out.println("... to see more use:");
+                          System.out.println("benchOnly " + params.getBenchmark());
+                          break;
+                        }
                       }
                     }
                   }

--- a/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
+++ b/lib/scala/bench-processor/src/main/java/org/enso/benchmarks/processor/BenchProcessor.java
@@ -347,7 +347,13 @@ public class BenchProcessor extends AbstractProcessor {
                   @TearDown
                   public void checkNoTruffleCompilation(BenchmarkParams params) {
                     if (compilationMessagesFound) {
-                      System.out.println(compilationLog.toString());
+                      for (var l : compilationLog.toString().split("\\n")) {
+                        var pipe = l.indexOf('|');
+                        if (pipe > 0) {
+                          l = l.substring(0, pipe);
+                        }
+                        System.out.println(l);
+                      }
                     }
                   }
 


### PR DESCRIPTION
### Pull Request Description

This PR improves output of benchmarks run on GitHub Actions CI to group and fold output for each benchmark.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md)
- [x] Benchmarks output improved
    - [x] [engine run](https://github.com/enso-org/enso/actions/runs/10627416248)
    - [x] [stdlib run](https://github.com/enso-org/enso/actions/runs/10627603184)
