### PR TITLE
Override CWD in `runEngineDistribution` to the parent of the project being run to avoid warning

### DIFF
--- a/project/DistributionPackage.scala
+++ b/project/DistributionPackage.scala
@@ -9,6 +9,8 @@ import scala.sys.process._
 
 import org.enso.build.WithDebugCommand
 
+import scala.util.Try
+
 object DistributionPackage {
 
   /** File extensions. */
@@ -267,26 +269,36 @@ object DistributionPackage {
   ): Boolean = {
     import scala.collection.JavaConverters._
 
-    val enso = distributionRoot / "bin" / batName("enso")
-    log.info(s"Executing $enso ${args.mkString(" ")}")
-    val pb  = new java.lang.ProcessBuilder()
-    val all = new java.util.ArrayList[String]()
-    val disablePrivateCheck = {
-      val findRun = args.indexOf("--run")
-      if (findRun >= 0 && findRun + 1 < args.size) {
-        val whatToRun = args(findRun + 1)
+    val enso             = distributionRoot / "bin" / batName("enso")
+    val pb               = new java.lang.ProcessBuilder()
+    val all              = new java.util.ArrayList[String]()
+    val runArgumentIndex = locateRunArgument(args)
+    val runArgument      = runArgumentIndex.map(args)
+    val disablePrivateCheck = runArgument match {
+      case Some(whatToRun) =>
         if (whatToRun.startsWith("test/") && whatToRun.endsWith("_Tests")) {
           whatToRun.contains("_Internal_")
         } else {
           false
         }
-      } else {
-        false
-      }
+      case None => false
     }
-    all.add(enso.getAbsolutePath())
+
+    val runArgumentAsFile = runArgument.flatMap(createFileIfValidPath)
+    val projectDirectory  = runArgumentAsFile.flatMap(findProjectRoot)
+    val cwdOverride: Option[File] =
+      projectDirectory.flatMap(findParentFile).map(_.getAbsoluteFile)
+
+    all.add(enso.getAbsolutePath)
     all.addAll(args.asJava)
-    pb.command(all)
+    // Override the working directory of new process to be the parent of the project directory.
+    cwdOverride.foreach { c =>
+      pb.directory(c)
+    }
+    if (cwdOverride.isDefined) {
+      // If the working directory is changed, we need to translate the path - make it absolute.
+      all.set(runArgumentIndex.get + 1, runArgumentAsFile.get.getAbsolutePath)
+    }
     if (args.contains("--debug")) {
       all.remove("--debug")
       pb.environment().put("JAVA_OPTS", "-ea " + WithDebugCommand.DEBUG_OPTION)
@@ -296,7 +308,9 @@ object DistributionPackage {
     if (disablePrivateCheck) {
       all.add("--disable-private-check")
     }
+    pb.command(all)
     pb.inheritIO()
+    log.info(s"Executing ${all.asScala.mkString(" ")}")
     val p        = pb.start()
     val exitCode = p.waitFor()
     if (exitCode != 0) {
@@ -304,6 +318,31 @@ object DistributionPackage {
     }
     exitCode == 0
   }
+
+  /** Returns the index of the next argument after `--run`, if it exists. */
+  private def locateRunArgument(args: Seq[String]): Option[Int] = {
+    val findRun = args.indexOf("--run")
+    if (findRun >= 0 && findRun + 1 < args.size) {
+      Some(findRun + 1)
+    } else {
+      None
+    }
+  }
+
+  /** Returns a file, only if the provided string represented a valid path. */
+  private def createFileIfValidPath(path: String): Option[File] =
+    Try(new File(path)).toOption
+
+  /** Looks for a parent directory that contains `package.yaml`. */
+  private def findProjectRoot(file: File): Option[File] =
+    if (file.isDirectory && (file / "package.yaml").exists()) {
+      Some(file)
+    } else {
+      findParentFile(file).flatMap(findProjectRoot)
+    }
+
+  private def findParentFile(file: File): Option[File] =
+    Option(file.getParentFile)
 
   def runProjectManagerPackage(
     engineRoot: File,


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
