### PR TITLE
Temporary workaround for #10921

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -324,7 +324,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
     .logLevel(logLevel)
     .strictErrors(false)
     .disableLinting(false)
-    .enableIrCaches(true)
+    .enableIrCaches(false) // Until #10921 is fixed
     .out(stdOut)
     .err(stdErr)
     .in(stdIn)


### PR DESCRIPTION
### Pull Request Description

Disabling caching as it seems that loading BindingsMap breaks things.

### Important Notes
Revert of https://github.com/enso-org/enso/pull/10880.
This change would be reverted once a proper fix for #10921 is found.
