### PR TITLE
Add today, now and time to expressions

### DIFF
--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
@@ -2564,6 +2564,42 @@ type Column
     naming_helper : Column_Naming_Helper
     naming_helper self = naming_helper
 
+    ## ALIAS count, kurtosis, maximum, mean, median, minimum, mode, skew, standard_deviation, statistic, sum, variance
+       GROUP Standard.Base.Statistics
+       ICON transform4
+       Compute a single statistic on the column.
+
+       Arguments:
+       - statistic: Statistic to calculate.
+    compute : Statistic -> Any
+    compute self statistic:Statistic=..Count =
+        Statistic.compute_bulk self.to_vector [statistic] . first
+
+    ## ALIAS count, kurtosis, maximum, mean, median, minimum, mode, skew, standard_deviation, statistic, sum, variance
+       ICON transform4
+       Compute statistics on the column.
+
+       Arguments:
+       - statistics: Set of statistics to calculate.
+    compute_bulk : Vector Statistic -> Table
+    compute_bulk self statistics=[Statistic.Count, Statistic.Sum] =
+        values = Statistic.compute_bulk self.to_vector statistics
+        names = statistics.map _.to_text
+        Table.from_rows names [values]
+
+    ## ALIAS count, kurtosis, maximum, mean, median, minimum, mode, skew, standard_deviation, statistic, sum, variance
+       GROUP Standard.Base.Statistics
+       ICON transform4
+       Compute a single running statistic on the column.
+
+       Arguments:
+       - statistic: Statistic to calculate.
+       - name: Name of the new column.
+    running : Statistic -> Text -> Column
+    running self statistic:Statistic=..Count name=statistic.to_text+" "+self.name =
+        data = Statistic.running self.to_vector statistic
+        Column.from_vector name data
+
 ## PRIVATE
 
    Folds the vectorized operation over the provided column and values. When more

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Column_Vector_Extensions.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Column_Vector_Extensions.enso
@@ -1,7 +1,6 @@
 from Standard.Base import all
 
 import project.Column.Column
-import project.Table.Table
 
 ## GROUP Standard.Base.Conversions
    ICON convert

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Column_Vector_Extensions.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Extensions/Column_Vector_Extensions.enso
@@ -32,39 +32,3 @@ Range.to_column self name="Range" =
 Date_Range.to_column : Text -> Column
 Date_Range.to_column self name="Date_Range" =
     Column.from_vector name self.to_vector
-
-## ALIAS count, kurtosis, maximum, mean, median, minimum, mode, skew, standard_deviation, statistic, sum, variance
-   GROUP Standard.Base.Statistics
-   ICON transform4
-   Compute a single statistic on the column.
-
-   Arguments:
-   - statistic: Statistic to calculate.
-Column.compute : Statistic -> Any
-Column.compute self statistic=Statistic.Count =
-    Statistic.compute_bulk self.to_vector [statistic] . first
-
-## ALIAS count, kurtosis, maximum, mean, median, minimum, mode, skew, standard_deviation, statistic, sum, variance
-   ICON transform4
-   Compute statistics on the column.
-
-   Arguments:
-   - statistics: Set of statistics to calculate.
-Column.compute_bulk : Vector Statistic -> Table
-Column.compute_bulk self statistics=[Statistic.Count, Statistic.Sum] =
-    values = Statistic.compute_bulk self.to_vector statistics
-    names = statistics.map _.to_text
-    Table.from_rows names [values]
-
-## ALIAS count, kurtosis, maximum, mean, median, minimum, mode, skew, standard_deviation, statistic, sum, variance
-   GROUP Standard.Base.Statistics
-   ICON transform4
-   Compute a single running statistic on the column.
-
-   Arguments:
-   - statistic: Statistic to calculate.
-   - name: Name of the new column.
-Column.running : Statistic -> Text -> Column
-Column.running self statistic=Statistic.Count name=statistic.to_text+" "+self.name =
-    data = Statistic.running self.to_vector statistic
-    Column.from_vector name data

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Main.enso
@@ -24,9 +24,6 @@ export project.Excel.Excel_Workbook.Excel_Workbook
 
 export project.Expression.expr
 
-export project.Extensions.Column_Vector_Extensions.compute
-export project.Extensions.Column_Vector_Extensions.compute_bulk
-export project.Extensions.Column_Vector_Extensions.running
 export project.Extensions.Column_Vector_Extensions.to_column
 export project.Extensions.Table_Conversions.from_objects
 export project.Extensions.Table_Conversions.parse_to_table

--- a/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
+++ b/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
@@ -1,7 +1,9 @@
 package org.enso.table.expressions;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -386,6 +388,11 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
   public Value visitFunction(ExpressionParser.FunctionContext ctx) {
     var name = ctx.IDENTIFIER().getText().toLowerCase();
     var args = ctx.expr().stream().map(this::visit).toArray(Value[]::new);
-    return executeMethod(name, args);
+    return switch(name) {
+      case "today" -> Value.asValue(LocalDate.now());
+      case "now" -> Value.asValue(LocalDateTime.now().atZone(ZoneId.systemDefault()));
+      case "time" -> Value.asValue(LocalTime.now());
+      default -> executeMethod(name, args);
+    };
   }
 }

--- a/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
+++ b/std-bits/table/src/main/java/org/enso/table/expressions/ExpressionVisitorImpl.java
@@ -388,7 +388,7 @@ public class ExpressionVisitorImpl extends ExpressionBaseVisitor<Value> {
   public Value visitFunction(ExpressionParser.FunctionContext ctx) {
     var name = ctx.IDENTIFIER().getText().toLowerCase();
     var args = ctx.expr().stream().map(this::visit).toArray(Value[]::new);
-    return switch(name) {
+    return switch (name) {
       case "today" -> Value.asValue(LocalDate.now());
       case "now" -> Value.asValue(LocalDateTime.now().atZone(ZoneId.systemDefault()));
       case "time" -> Value.asValue(LocalTime.now());


### PR DESCRIPTION
### Pull Request Description

- Allows for creation of a constant for today, now and time inside expressions.

![image](https://github.com/user-attachments/assets/62c7ccee-e4b8-420a-93e1-8215c782f51e)

- Move compute, compute_bulk and running into Column allowing these to be used in expressions.

![image](https://github.com/user-attachments/assets/b78ea37f-3108-4755-be66-d275974a24eb)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
