### PR TITLE
only show filter/sort node button if node is a table

### DIFF
--- a/app/gui2/src/components/TableVizToolbar.vue
+++ b/app/gui2/src/components/TableVizToolbar.vue
@@ -26,6 +26,7 @@ const props = defineProps<{
   }
   sortModel: SortModel[]
   isDisabled: boolean
+  isFilterSortNodeEnabled: boolean
 }>()
 
 const emit = defineEmits<{
@@ -204,7 +205,7 @@ const changeFormat = (option: TextFormatOptions) => {
     </DropdownMenu>
   </div>
 
-  <div class="sortFilterNode">
+  <div v-if="isFilterSortNodeEnabled" class="sortFilterNode">
     <SvgButton
       name="add"
       title="Create new component(s) with the current grid's sort and filters applied to the workflow"

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -183,6 +183,9 @@ const newNodeSelectorValues = computed(() => {
   }
 })
 
+const isFilterSortNodeEnabled =
+  config.nodeType === TABLE_NODE_TYPE || config.nodeType === DB_TABLE_NODE_TYPE
+
 const numberFormatGroupped = new Intl.NumberFormat(undefined, {
   style: 'decimal',
   maximumFractionDigits: 12,
@@ -597,6 +600,7 @@ onMounted(() => {
         :filterModel="filterModel"
         :sortModel="sortModel"
         :isDisabled="!isCreateNodeEnabled"
+        :isFilterSortNodeEnabled="isFilterSortNodeEnabled"
         @changeFormat="(i) => updateTextFormat(i)"
       />
     </template>

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -183,8 +183,9 @@ const newNodeSelectorValues = computed(() => {
   }
 })
 
-const isFilterSortNodeEnabled =
-  config.nodeType === TABLE_NODE_TYPE || config.nodeType === DB_TABLE_NODE_TYPE
+const isFilterSortNodeEnabled = computed(
+  () => config.nodeType === TABLE_NODE_TYPE || config.nodeType === DB_TABLE_NODE_TYPE,
+)
 
 const numberFormatGroupped = new Intl.NumberFormat(undefined, {
   style: 'decimal',


### PR DESCRIPTION
This hides the `+` button on the table viz toolbar if the node type is not table or db table 

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
