### PR TITLE
Wip/mk/scatter plot visual improvements

### DIFF
--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -575,7 +575,7 @@ var svg = d3.select('#plot_legend')
 svg
   .append('circle')
   .attr('cx', 90)
-  .attr('cy', height.value - boxHeight.value + 20)
+  .attr('cy', height.value - boxHeight.value - 20)
   .attr('r', 6)
   .style('fill', '#69b3a2')
 svg

--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -399,18 +399,18 @@ function startZoom(event: d3.D3ZoomEvent<Element, unknown>) {
   actionStartYScale = yScale.value.copy()
 }
 
-const brush = computed(() =>
-  d3
-    .brush()
-    .extent([
-      [0, 0],
-      [boxWidth.value, boxHeight.value],
-    ])
-    .on('start brush', (event: d3.D3BrushEvent<unknown>) => {
-      brushExtent.value = event.selection ?? undefined
-    }),
-)
-watchEffect(() => d3Brush.value.call(brush.value))
+// const brush = computed(() =>
+//   d3
+//     .brush()
+//     .extent([
+//       [0, 0],
+//       [boxWidth.value, boxHeight.value],
+//     ])
+//     .on('start brush', (event: d3.D3BrushEvent<unknown>) => {
+//       brushExtent.value = event.selection ?? undefined
+//     }),
+// )
+// watchEffect(() => d3Brush.value.call(brush.value))
 
 watch([boxWidth, boxHeight], () => (shouldAnimate.value = false))
 
@@ -483,6 +483,15 @@ function getPlotData(data: Data) {
   return data2
 }
 
+function getTooltipMessage(point: Point) {
+  if (data.value.is_multi_series) {
+    const axis = data.value.axis
+    const label = point.series ? axis[point.series].label : ''
+    return `${point.x}, ${point.y}, ${label}`
+  }
+  return `${point.x}, ${point.y}`
+}
+
 // === Update contents ===
 
 watchPostEffect(() => {
@@ -495,6 +504,9 @@ watchPostEffect(() => {
     .selectAll<SVGPathElement, unknown>('path')
     .data(plotData)
     .join((enter) => enter.append('path'))
+    .call((data) => {
+      return data.append('title').text((d) => getTooltipMessage(d))
+    })
     .transition()
     .duration(animationDuration.value)
     .attr(
@@ -532,7 +544,7 @@ watchPostEffect(() => {
     .attr('cx', function (d, i) {
       return 90 + i * 120
     })
-    .attr('cy', height.value - boxHeight.value - 20)
+    .attr('cy', height.value - boxHeight.value - 30)
     .attr('r', 6)
     .style('fill', function (d) {
       return color(d)
@@ -546,7 +558,7 @@ watchPostEffect(() => {
     .attr('x', function (d, i) {
       return 100 + i * 120
     })
-    .attr('y', height.value - boxHeight.value - 20)
+    .attr('y', height.value - boxHeight.value - 30)
     .style('font-size', '15px')
     .text(function (d) {
       return `${d.substr(0, 10)}...`

--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -158,7 +158,7 @@ const data = computed<Data>(() => {
   const points = rawData.points ?? { labels: 'visible' }
   const focus: Focus | undefined = rawData.focus
   // eslint-disable-next-line camelcase
-  const is_multi_series: boolean = Boolean(rawData.is_multi_series)
+  const is_multi_series: boolean = !!rawData.is_multi_series
   // eslint-disable-next-line camelcase
   return { axis, points, data, focus, is_multi_series }
 })
@@ -186,9 +186,6 @@ const shouldAnimate = ref(false)
 const xDomain = ref([0, 1])
 const yDomain = ref([0, 1])
 const selectionEnabled = ref(false)
-const enableSelection = () => {
-  selectionEnabled.value = !selectionEnabled.value
-}
 
 const isBrushing = computed(() => brushExtent.value != null)
 const xScale = computed(() =>
@@ -407,8 +404,6 @@ function startZoom(event: d3.D3ZoomEvent<Element, unknown>) {
 }
 
 const brush = computed(() => {
-  selectionEnabled.value
-
   if (!selectionEnabled.value) {
     return d3.brush().extent([
       [0, 0],
@@ -672,7 +667,11 @@ useEvent(document, 'keydown', bindings.handler({ zoomToSelected: () => zoomToSel
 <template>
   <VisualizationContainer :belowToolbar="true">
     <template #toolbar>
-      <SvgButton name="add" title="Enable Selection" @click="enableSelection()" />
+      <SvgButton
+        name="add"
+        title="Enable Selection"
+        @click="selectionEnabled = !selectionEnabled"
+      />
       <SvgButton name="show_all" title="Fit All" @click.stop="zoomToSelected(false)" />
       <SvgButton
         name="zoom"

--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -570,33 +570,38 @@ function zoomToSelected(override?: boolean) {
   endBrushing()
 }
 
+const series = Object.keys(data.value.axis).filter((s) => s != 'x')
 var svg = d3.select('#plot_legend')
 
+var color = d3.scaleOrdinal().domain(series).range(d3.schemeCategory10).domain(series)
+
 svg
+  .selectAll('dots')
+  .data(series)
+  .enter()
   .append('circle')
-  .attr('cx', 90)
+  .attr('cx', function (d, i) {
+    return 90 + i * 120
+  })
   .attr('cy', height.value - boxHeight.value - 20)
   .attr('r', 6)
-  .style('fill', '#69b3a2')
+  .style('fill', function (d) {
+    return color(d)
+  })
+
 svg
-  .append('circle')
-  .attr('cx', 240)
-  .attr('cy', height.value - boxHeight.value - 20)
-  .attr('r', 6)
-  .style('fill', '#404080')
-svg
+  .selectAll('labels')
+  .data(series)
+  .enter()
   .append('text')
-  .attr('x', 110)
+  .attr('x', function (d, i) {
+    return 100 + i * 120
+  })
   .attr('y', height.value - boxHeight.value - 20)
-  .text('variable A')
   .style('font-size', '15px')
-  .attr('alignment-baseline', 'middle')
-svg
-  .append('text')
-  .attr('x', 250)
-  .attr('y', height.value - boxHeight.value - 20)
-  .text('variable B')
-  .style('font-size', '15px')
+  .text(function (d) {
+    return d
+  })
   .attr('alignment-baseline', 'middle')
 
 useEvent(document, 'keydown', bindings.handler({ zoomToSelected: () => zoomToSelected() }))

--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -566,6 +566,8 @@ watchPostEffect(() => {
     .map((s) => {
       return data.value.axis[s as keyof AxesConfiguration].label
     })
+  const formatLabel = (string: string) =>
+    string.length > 10 ? `${string.substr(0, 10)}...` : string
   const colorLegendScale = (d: string) => {
     const color = d3
       .scaleOrdinal()
@@ -601,9 +603,7 @@ watchPostEffect(() => {
     })
     .attr('y', 10)
     .style('font-size', '15px')
-    .text(function (d) {
-      return `${d.substr(0, 10)}...`
-    })
+    .text((d) => formatLabel(d))
     .attr('alignment-baseline', 'middle')
     .call((labels) => labels.append('title').text((d) => d))
 })

--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -187,7 +187,6 @@ const xDomain = ref([0, 1])
 const yDomain = ref([0, 1])
 const selectionEnabled = ref(false)
 const enableSelection = () => {
-  console.log('TOGGLED')
   selectionEnabled.value = !selectionEnabled.value
 }
 
@@ -533,7 +532,13 @@ watchPostEffect(() => {
   const yScale_ = yScale.value
   const plotData = getPlotData(data.value) as Point[]
   const series = Object.keys(data.value.axis).filter((s) => s != 'x')
-  const colorScale = d3.scaleOrdinal(d3.schemeCategory10).domain(series)
+  const colorScale = (d: string) => {
+    const color = d3.scaleOrdinal(d3.schemeCategory10).domain(series)
+    if (data.value.is_multi_series) {
+      return color(d)
+    }
+    return DEFAULT_FILL_COLOR
+  }
   d3Points.value
     .selectAll<SVGPathElement, unknown>('path')
     .data(plotData)

--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -565,7 +565,6 @@ watchPostEffect(() => {
     })
 
   const legend = d3Legend.value
-  const color = d3.scaleOrdinal().domain(series2).range(d3.schemeCategory10).domain(series2)
 
   legend
     .selectAll('dots')
@@ -577,9 +576,7 @@ watchPostEffect(() => {
     })
     .attr('cy', 10)
     .attr('r', 6)
-    .style('fill', function (d) {
-      return color(d)
-    })
+    .style('fill', (d) => colorScale(d))
 
   legend
     .selectAll('labels')

--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -438,10 +438,6 @@ watchEffect(() => {
   }
 })
 
-watch([selectionEnabled], () => {
-  brush.effect.trigger()
-})
-
 watch([boxWidth, boxHeight], () => (shouldAnimate.value = false))
 
 /** Helper function to match a d3 shape from its name. */
@@ -497,12 +493,11 @@ watchPostEffect(() =>
 )
 
 function getPlotData(data: Data) {
-  const data2 = data.data
   const axis = data.axis
   if (data.is_multi_series) {
     const series = Object.keys(axis).filter((s) => s != 'x')
     const transformedData = series.flatMap((s) =>
-      data2.map((d) => ({
+      data.data.map((d) => ({
         x: d.x,
         y: d[s as keyof Point],
         series: s,
@@ -510,7 +505,7 @@ function getPlotData(data: Data) {
     )
     return transformedData
   }
-  return data2
+  return data.data
 }
 
 function getTooltipMessage(point: Point) {
@@ -566,7 +561,7 @@ watchPostEffect(() => {
       .attr('y', (d) => yScale_(d.y) + POINT_LABEL_PADDING_Y_PX)
   }
 
-  const series2 = Object.keys(data.value.axis)
+  const seriesLabels = Object.keys(data.value.axis)
     .filter((s) => s != 'x')
     .map((s) => {
       return data.value.axis[s as keyof AxesConfiguration].label
@@ -576,7 +571,7 @@ watchPostEffect(() => {
 
   legend
     .selectAll('dots')
-    .data(series2)
+    .data(seriesLabels)
     .enter()
     .append('circle')
     .attr('cx', function (d, i) {
@@ -588,7 +583,7 @@ watchPostEffect(() => {
 
   legend
     .selectAll('labels')
-    .data(series2)
+    .data(seriesLabels)
     .enter()
     .append('text')
     .attr('x', function (d, i) {

--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -577,9 +577,6 @@ const series = Object.keys(data.value.axis)
   })
 
 var svg = d3.select('#plot_legend')
-
-const textWidth = Math.max(...series.map((el) => el.length)) * 4
-
 var color = d3.scaleOrdinal().domain(series).range(d3.schemeCategory10).domain(series)
 
 svg

--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -570,8 +570,15 @@ function zoomToSelected(override?: boolean) {
   endBrushing()
 }
 
-const series = Object.keys(data.value.axis).filter((s) => s != 'x')
+const series = Object.keys(data.value.axis)
+  .filter((s) => s != 'x')
+  .map((s) => {
+    return data.value.axis[s].label
+  })
+
 var svg = d3.select('#plot_legend')
+
+const textWidth = Math.max(...series.map((el) => el.length)) * 4
 
 var color = d3.scaleOrdinal().domain(series).range(d3.schemeCategory10).domain(series)
 
@@ -600,9 +607,10 @@ svg
   .attr('y', height.value - boxHeight.value - 20)
   .style('font-size', '15px')
   .text(function (d) {
-    return d
+    return `${d.substr(0, 10)}...`
   })
   .attr('alignment-baseline', 'middle')
+  .call((labels) => labels.append('title').text((d) => d))
 
 useEvent(document, 'keydown', bindings.handler({ zoomToSelected: () => zoomToSelected() }))
 </script>

--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -517,7 +517,10 @@ function getPlotData(data: Data) {
 function getTooltipMessage(point: Point) {
   if (data.value.is_multi_series) {
     const axis = data.value.axis
-    const label = point.series && point.series in axis ? axis[point.series].label : ''
+    const label =
+      point.series && point.series in axis ?
+        axis[point.series as keyof AxesConfiguration].label
+      : ''
     return `${point.x}, ${point.y}, ${label}`
   }
   return `${point.x}, ${point.y}`
@@ -561,7 +564,7 @@ watchPostEffect(() => {
   const series2 = Object.keys(data.value.axis)
     .filter((s) => s != 'x')
     .map((s) => {
-      return data.value.axis[s].label
+      return data.value.axis[s as keyof AxesConfiguration].label
     })
 
   const legend = d3Legend.value

--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -566,7 +566,17 @@ watchPostEffect(() => {
     .map((s) => {
       return data.value.axis[s as keyof AxesConfiguration].label
     })
-
+  const colorLegendScale = (d: string) => {
+    const color = d3
+      .scaleOrdinal()
+      .domain(seriesLabels)
+      .range(d3.schemeCategory10)
+      .domain(seriesLabels)
+    if (data.value.is_multi_series) {
+      return color(d)
+    }
+    return DEFAULT_FILL_COLOR
+  }
   const legend = d3Legend.value
 
   legend
@@ -579,7 +589,7 @@ watchPostEffect(() => {
     })
     .attr('cy', 10)
     .attr('r', 6)
-    .style('fill', (d) => colorScale(d))
+    .style('fill', (d) => colorLegendScale(d))
 
   legend
     .selectAll('labels')

--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -564,17 +564,13 @@ watchPostEffect(() => {
       })
     const formatLabel = (string: string) =>
       string.length > 10 ? `${string.substr(0, 10)}...` : string
-    const colorLegendScale = (d: string) => {
-      const color = d3
-        .scaleOrdinal()
-        .domain(seriesLabels)
-        .range(d3.schemeCategory10)
-        .domain(seriesLabels)
-      if (data.value.is_multi_series) {
-        return color(d)
-      }
-      return DEFAULT_FILL_COLOR
-    }
+
+    const color = d3
+      .scaleOrdinal<string>()
+      .domain(seriesLabels)
+      .range(d3.schemeCategory10)
+      .domain(seriesLabels)
+
     const legend = d3Legend.value
 
     legend
@@ -587,7 +583,7 @@ watchPostEffect(() => {
       })
       .attr('cy', 10)
       .attr('r', 6)
-      .style('fill', (d) => colorLegendScale(d))
+      .style('fill', (d) => color(d) || DEFAULT_FILL_COLOR)
 
     legend
       .selectAll('labels')

--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -512,10 +512,6 @@ watchPostEffect(() => {
       .attr('x', (d) => xScale_(d.x) + POINT_LABEL_PADDING_X_PX)
       .attr('y', (d) => yScale_(d.y) + POINT_LABEL_PADDING_Y_PX)
   }
-  if (data.value.is_multi_series) {
-    // set legend
-  }
-  console.log({ data: data.value })
 })
 
 // ======================
@@ -574,6 +570,35 @@ function zoomToSelected(override?: boolean) {
   endBrushing()
 }
 
+var svg = d3.select('#plot_legend')
+
+svg
+  .append('circle')
+  .attr('cx', 90)
+  .attr('cy', height.value - boxHeight.value + 20)
+  .attr('r', 6)
+  .style('fill', '#69b3a2')
+svg
+  .append('circle')
+  .attr('cx', 240)
+  .attr('cy', height.value - boxHeight.value - 20)
+  .attr('r', 6)
+  .style('fill', '#404080')
+svg
+  .append('text')
+  .attr('x', 110)
+  .attr('y', height.value - boxHeight.value - 20)
+  .text('variable A')
+  .style('font-size', '15px')
+  .attr('alignment-baseline', 'middle')
+svg
+  .append('text')
+  .attr('x', 250)
+  .attr('y', height.value - boxHeight.value - 20)
+  .text('variable B')
+  .style('font-size', '15px')
+  .attr('alignment-baseline', 'middle')
+
 useEvent(document, 'keydown', bindings.handler({ zoomToSelected: () => zoomToSelected() }))
 </script>
 
@@ -588,8 +613,8 @@ useEvent(document, 'keydown', bindings.handler({ zoomToSelected: () => zoomToSel
         @click.stop="zoomToSelected"
       />
     </template>
-    <div ref="containerNode" class="ScatterplotVisualization" @pointerdown.stop>
-      <svg :width="width" :height="height">
+    <div ref="containerNode" class="ScatterplotVisualization">
+      <svg id="plot_legend" :width="width" :height="height">
         <g :transform="`translate(${margin.left}, ${margin.top})`">
           <defs>
             <clipPath id="clip">
@@ -628,6 +653,7 @@ useEvent(document, 'keydown', bindings.handler({ zoomToSelected: () => zoomToSel
 .ScatterplotVisualization {
   user-select: none;
   display: flex;
+  flex-direction: column;
 }
 
 .ScatterplotVisualization .selection {

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
@@ -133,7 +133,8 @@ Table.point_data self all_fields =
    Returns the number of numeric columns for the plot.
 Table.numeric_column_count : Number
 Table.numeric_column_count self =
-    columns = self.columns . filter (c-> c.is_numeric && c.name != Point_Data.Size.name)
+    check_for_size c = c.name.equals_ignore_case Point_Data.Size.name != True
+    columns = self.columns . filter (c-> c.is_numeric && check_for_size c)
     columns.length
 
 ## PRIVATE

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
@@ -216,7 +216,8 @@ json_from_table table bounds limit =
     data = table.point_data fields_for_plot |> bound_data bounds |> limit_data limit
     fields_for_axes = get_axes_field number_of_numeric_cols
     axes = table.axes fields_for_axes
-    JS_Object.from_pairs [[data_field, data], [axis_field, axes]] . to_json
+    is_mulit_series = number_of_numeric_cols > 0
+    JS_Object.from_pairs [[data_field, data], [axis_field, axes], ["is_multi_series", is_mulit_series]] . to_json
 
 ## PRIVATE
 json_from_vector : Vector Any -> Vector Integer | Nothing -> Integer | Nothing -> Text

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
@@ -223,7 +223,7 @@ json_from_table table bounds limit =
 json_from_vector : Vector Any -> Vector Integer | Nothing -> Integer | Nothing -> Text
 json_from_vector vec bounds limit =
     data = vec.point_data |> bound_data bounds |> limit_data limit
-    JS_Object.from_pairs [[data_field, data], [axis_field, Nothing]] . to_json
+    JS_Object.from_pairs [[data_field, data], [axis_field, Nothing], ["is_multi_series", False]] . to_json
 
 ## PRIVATE
 

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
@@ -217,8 +217,8 @@ json_from_table table bounds limit =
     data = table.point_data fields_for_plot |> bound_data bounds |> limit_data limit
     fields_for_axes = get_axes_field number_of_numeric_cols
     axes = table.axes fields_for_axes
-    is_mulit_series = number_of_numeric_cols > 0
-    JS_Object.from_pairs [[data_field, data], [axis_field, axes], ["is_multi_series", is_mulit_series]] . to_json
+    is_multi_series = number_of_numeric_cols > 0
+    JS_Object.from_pairs [[data_field, data], [axis_field, axes], ["is_multi_series", is_multi_series]] . to_json
 
 ## PRIVATE
 json_from_vector : Vector Any -> Vector Integer | Nothing -> Integer | Nothing -> Text

--- a/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
+++ b/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
@@ -10,18 +10,18 @@ from Standard.Test import all
 import project
 
 add_specs suite_builder =
-    expect_text text axis_expected_text data_expected_text =
+    expect_text text axis_expected_text data_expected_text is_multi =
         json = Json.parse text
-        json.field_names.should_equal ['data', 'axis']
+        json.field_names.should_equal ['data', 'axis', 'is_multi_series']
 
-        expect_text = '{"axis": ' + axis_expected_text + ', "data": ' + data_expected_text + '}'
+        expect_text = '{"axis": ' + axis_expected_text + ', "data": ' + data_expected_text + ', "is_multi_series": ' + is_multi + '}'
         expected_result = Json.parse expect_text
 
         json.should_equal expected_result
 
-    expect value axis_expected_text data_expected_text =
+    expect value axis_expected_text data_expected_text (is_multi='false') =
         text = Scatter_Plot.process_to_json_text value
-        expect_text text axis_expected_text data_expected_text
+        expect_text text axis_expected_text data_expected_text is_multi
 
     index = Scatter_Plot.index_name
     axis label = JS_Object.from_pairs [['label',label]]
@@ -53,7 +53,7 @@ add_specs suite_builder =
             header = ['x' , 'size' , 'name'   , 'z' , 'ω']
             row_1 =  [11  , 50     , 'circul' ,  20 ,  30]
             table = Table.from_rows header [row_1]
-            expect table (labels_multi 'x' 'z' 'ω') '[{"size":50,"x":11,"y":20,"(y_multi 0)":30}]'
+            expect table (labels_multi 'x' 'z' 'ω') '[{"size":50,"x":11,"y":20,"(y_multi 0)":30}]' 'true'
 
         group_builder.specify "provided only recognized columns" <|
             header = ['x', 'y' , 'bar' , 'size']
@@ -88,7 +88,7 @@ add_specs suite_builder =
             vector = [0,10,20,30]
             text = Scatter_Plot.process_to_json_text vector limit=2
             json = Json.parse text
-            json.field_names.should_equal ['data','axis']
+            json.field_names.should_equal ['data','axis', 'is_multi_series']
             data = json.get 'data'
             data.should_be_a Vector
             data.length . should_equal 2
@@ -97,7 +97,7 @@ add_specs suite_builder =
             vector = (-15).up_to 15 . map (x -> x * x)
             text = Scatter_Plot.process_to_json_text vector limit=10
             json = Json.parse text
-            json.field_names.should_equal ['data','axis']
+            json.field_names.should_equal ['data','axis', 'is_multi_series']
             data = json.get 'data'
             data.should_be_a Vector
             data.length . should_equal 10


### PR DESCRIPTION
This adds multi series support to the scatter plot 

- all numeric columns will be plotted with either column 'X' or the left most numeric column being used as the x-axis 
- colours are set as the default d3 colours 
- a legend at the top of the plot shows what colour is which 'series' or column 
- the legends labels will be cropped at 10 chars but has a tooltip for full column name 

The plot now has, by default, a 'normal' cursor to allow the user to hover over points to show a tooltip whoch displays it's details.
Clicking the '+' button changes the cursor to use the d3 brush allowing the user to zoom in on parts of the plot

![10933-scatter-plot-v1](https://github.com/user-attachments/assets/4cff8275-80cc-4bfd-9bd7-663c6a4f3405)

<img width="481" alt="image" src="https://github.com/user-attachments/assets/0275e8c7-9a11-4aa6-9d24-2d9f30b15783">

![10933-scatter-plot-v1-1](https://github.com/user-attachments/assets/8a281d6b-792c-44bd-a6cb-77a41ec72227)



### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
