### PR TITLE
Re-enable IR caching in Language Server

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -324,7 +324,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
     .logLevel(logLevel)
     .strictErrors(false)
     .disableLinting(false)
-    .enableIrCaches(false) // Until #10921 is fixed
+    .enableIrCaches(true)
     .out(stdOut)
     .err(stdErr)
     .in(stdIn)

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -575,7 +575,6 @@ class Compiler(
             u => {
               u.resetScope()
               u.ir(updatedIr)
-              u.compilationStage(CompilationStage.AFTER_PARSING)
             }
           )
         }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -573,7 +573,6 @@ class Compiler(
           context.updateModule(
             module,
             u => {
-              u.resetScope()
               u.ir(updatedIr)
             }
           )

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -574,6 +574,7 @@ class Compiler(
             module,
             u => {
               u.ir(updatedIr)
+              u.compilationStage(CompilationStage.AFTER_STATIC_PASSES)
             }
           )
         }


### PR DESCRIPTION
### Pull Request Description

When an IR loaded from cache is being run through the same passes, "interesting" errors may happen. We must ensure that IR is not run through phases that have already done their transformations.

With this change, I'm no longer seeing failures after project startup.

### Important Notes

Did some testing/benchmarking on sample projects. 
Time to parse/load stdlibs' components (only) has been reduced from ~8seconds to ~2seconds.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
