### PR TITLE
Couple of small fixes for vizzes.

### DIFF
--- a/app/gui2/src/components/visualizations/GeoMapVisualization.vue
+++ b/app/gui2/src/components/visualizations/GeoMapVisualization.vue
@@ -175,8 +175,8 @@ function updateState(data: Data) {
     zoom: DEFAULT_MAP_ZOOM,
     pitch: 0,
   }).fitBounds([
-    [center.minX, center.maxY],
-    [center.maxX, center.minY],
+      [center.minX, center.minY],
+      [center.maxX, center.maxY],
     ],
     { padding: 10, maxZoom: DEFAULT_MAX_MAP_ZOOM },
   )

--- a/app/gui2/src/components/visualizations/GeoMapVisualization.vue
+++ b/app/gui2/src/components/visualizations/GeoMapVisualization.vue
@@ -174,7 +174,8 @@ function updateState(data: Data) {
     latitude: center.latitude,
     zoom: DEFAULT_MAP_ZOOM,
     pitch: 0,
-  }).fitBounds([
+  }).fitBounds(
+    [
       [center.minX, center.minY],
       [center.maxX, center.maxY],
     ],

--- a/app/gui2/src/components/visualizations/GeoMapVisualization.vue
+++ b/app/gui2/src/components/visualizations/GeoMapVisualization.vue
@@ -119,6 +119,7 @@ const LABEL_COLOR = `rgba(0, 0, 0, 0.8)`
 const DEFAULT_MAP_STYLE = 'mapbox://styles/mapbox/light-v9'
 
 const DEFAULT_MAP_ZOOM = 11
+const DEFAULT_MAX_MAP_ZOOM = 18
 const ACCENT_COLOR: Color = [78, 165, 253]
 
 const dataPoints = ref<LocationWithPosition[]>([])
@@ -166,9 +167,23 @@ function updateState(data: Data) {
   }
   const center = centerPoint()
 
+  const viewPort = new deck.WebMercatorViewport({
+    width: mapNode.value?.clientWidth ?? 600,
+    height: mapNode.value?.clientHeight ?? 400,
+    longitude: center.longitude,
+    latitude: center.latitude,
+    zoom: DEFAULT_MAP_ZOOM,
+    pitch: 0,
+  }).fitBounds([
+    [center.minX, center.maxY],
+    [center.maxX, center.minY],
+    ],
+    { padding: 10, maxZoom: DEFAULT_MAX_MAP_ZOOM },
+  )
+
   latitude.value = center.latitude
   longitude.value = center.longitude
-  zoom.value = DEFAULT_MAP_ZOOM
+  zoom.value = viewPort.zoom
   mapStyle.value = DEFAULT_MAP_STYLE
   pitch.value = 0
   controller.value = true
@@ -303,16 +318,16 @@ function centerPoint() {
   {
     const xs = dataPoints.value.map((p) => p.position[0])
     minX = Math.min(...xs)
-    maxX = Math.min(...xs)
+    maxX = Math.max(...xs)
   }
   {
     const ys = dataPoints.value.map((p) => p.position[1])
     minY = Math.min(...ys)
-    maxY = Math.min(...ys)
+    maxY = Math.max(...ys)
   }
   let longitude = (minX + maxX) / 2
   let latitude = (minY + maxY) / 2
-  return { latitude, longitude }
+  return { latitude, longitude, minX, maxX, minY, maxY }
 }
 
 /**

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -222,7 +222,7 @@ function formatText(params: ICellRendererParams) {
   const partialMappings = {
     '\r': '<span style="color: #df8800">␍</span> <br>',
     '\n': '<span style="color: #df8800;">␊</span> <br>',
-    '\t': '<span style="white-space: break-spaces;">    </span>',
+    '\t': '<span style="color: #df8800; white-space: break-spaces;">&#8594;  |</span>',
   }
   const fullMappings = {
     '\r': '<span style="color: #df8800">␍</span> <br>',
@@ -233,11 +233,9 @@ function formatText(params: ICellRendererParams) {
   const replaceSpaces =
     textFormatterSelected.value === TextFormatOptions.On ?
       htmlEscaped.replaceAll(' ', '<span style="color: #df8800">&#183;</span>')
-    : htmlEscaped
-        .replace(/ {2,}|^ +| +$/g, function (match: string) {
-          return `<span style="color: #df8800">${'&#183;'.repeat(match.length)}</span>`
-        })
-        .replace(/^\t|\t$/g, '<span style="color: #df8800">&#8594;  |</span>')
+    : htmlEscaped.replace(/ \s+|^ +| +$/g, function (match: string) {
+        return `<span style="color: #df8800">${match.replaceAll(' ', '&#183;')}</span>`
+      })
 
   const replaceReturns = replaceSpaces.replace(
     /\r\n/g,

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -214,6 +214,10 @@ function formatText(params: ICellRendererParams) {
     .replaceAll('&', '&amp;')
     .replaceAll('<', '&lt;')
     .replaceAll('>', '&gt;')
+    .replace(
+      /https?:\/\/([-()_.!~*';/?:@&=+$,A-Za-z0-9])+/g,
+      (url: string) => `<a href="${url}" target="_blank" class="link">${url}</a>`,
+    )
 
   if (textFormatterSelected.value === TextFormatOptions.Off) {
     return htmlEscaped.replace(/^\s+|\s+$/g, '&nbsp;')

--- a/app/gui2/src/components/visualizations/TableVisualization.vue
+++ b/app/gui2/src/components/visualizations/TableVisualization.vue
@@ -210,9 +210,15 @@ function formatNumber(params: ICellRendererParams) {
 }
 
 function formatText(params: ICellRendererParams) {
+  const htmlEscaped = params.value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+
   if (textFormatterSelected.value === TextFormatOptions.Off) {
-    return params.value
+    return htmlEscaped.replace(/^\s+|\s+$/g, '&nbsp;')
   }
+
   const partialMappings = {
     '\r': '<span style="color: #df8800">␍</span> <br>',
     '\n': '<span style="color: #df8800;">␊</span> <br>',
@@ -221,15 +227,17 @@ function formatText(params: ICellRendererParams) {
   const fullMappings = {
     '\r': '<span style="color: #df8800">␍</span> <br>',
     '\n': '<span style="color: #df8800">␊</span> <br>',
-    '\t': '<span style="color: #df8800; white-space: break-spaces;">&#8594;   </span>',
+    '\t': '<span style="color: #df8800; white-space: break-spaces;">&#8594;  |</span>',
   }
 
   const replaceSpaces =
     textFormatterSelected.value === TextFormatOptions.On ?
-      params.value.replaceAll(' ', '<span style="color: #df8800">&#183;</span>')
-    : params.value.replace(/ {2,}/g, function (match: string) {
-        return `<span style="color: #df8800">${'&#183;'.repeat(match.length)}</span>`
-      })
+      htmlEscaped.replaceAll(' ', '<span style="color: #df8800">&#183;</span>')
+    : htmlEscaped
+        .replace(/ {2,}|^ +| +$/g, function (match: string) {
+          return `<span style="color: #df8800">${'&#183;'.repeat(match.length)}</span>`
+        })
+        .replace(/^\t|\t$/g, '<span style="color: #df8800">&#8594;  |</span>')
 
   const replaceReturns = replaceSpaces.replace(
     /\r\n/g,


### PR DESCRIPTION
### Pull Request Description

- Improve logic for white space rendering (render leading/trailing in partial, change the tab rendering).
- Escape HTML characters.
- Fix for the geo viz starting zoom and center.

![image](https://github.com/user-attachments/assets/ac8c8893-14b5-4242-ba82-b821797546a1)

![image](https://github.com/user-attachments/assets/a179b4ad-d295-4783-97d9-803b6958cb95)

![image](https://github.com/user-attachments/assets/e4be7a81-28ff-4e79-b6e0-9aadae059270)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
