### PR TITLE
Get ready for `python` and `js` being optional when running `test/Base_Tests`

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/RegexCompileNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/expression/builtin/text/RegexCompileNode.java
@@ -66,6 +66,8 @@ public abstract class RegexCompileNode extends Node {
     try {
       var regex = ctx.parseInternal(src).call();
       return regex;
+    } catch (IllegalStateException ex) {
+      throw ctx.raiseAssertionPanic(this, null, ex);
     } catch (AbstractTruffleException e) {
       Builtins builtins = ctx.getBuiltins();
       String msg = "Regex parse error: " + e.getMessage();

--- a/test/Base_Tests/src/Data/Array_Polyglot_Spec.enso
+++ b/test/Base_Tests/src/Data/Array_Polyglot_Spec.enso
@@ -4,8 +4,10 @@ import Standard.Base.Errors.Common.No_Such_Method
 from Standard.Test import all
 
 
+pending_js_missing = if Polyglot.is_language_installed "js" then Nothing else "Can't run JavaScript tests, language `js` is not installed."
+
 add_specs suite_builder =
-    suite_builder.group "JavaScript Objects, Arrays & Functions" group_builder->
+    suite_builder.group "JavaScript Objects, Arrays & Functions" pending=pending_js_missing group_builder->
         group_builder.specify "Missing method" <|
             Test.expect_panic_with data.missing No_Such_Method
 

--- a/test/Base_Tests/src/Data/Dictionary_Spec.enso
+++ b/test/Base_Tests/src/Data/Dictionary_Spec.enso
@@ -82,6 +82,7 @@ foreign python py_wrapper obj = """
     return MyClass(obj)
 
 pending_python_missing = if Polyglot.is_language_installed "python" then Nothing else "Can't run Python tests, Python is not installed."
+pending_js_missing = if Polyglot.is_language_installed "js" then Nothing else "Can't run JavaScript tests, language `js` is not installed."
 
 def_comp = Standard.Base.Internal.Ordering_Helpers.Default_Comparator
 
@@ -98,7 +99,7 @@ add_specs suite_builder =
     languages = Vector.build builder->
         builder . append ["Enso", _-> Dictionary.empty, Nothing]
         builder . append ["Java", _-> JavaMap.of, Nothing]
-        builder . append ["JavaScript", _-> js_empty_dict, Nothing]
+        builder . append ["JavaScript", _-> js_empty_dict, pending_js_missing]
         builder . append ["Python", _-> py_empty_dict, pending_python_missing]
     languages.each entry->
         lang = entry.get 0
@@ -269,7 +270,7 @@ add_specs suite_builder =
             m.at Nothing . should_equal 1
 
     suite_builder.group "Polyglot keys and values" group_builder->
-        group_builder.specify "should support polyglot keys" <|
+        group_builder.specify "should support polyglot keys" pending=pending_js_missing <|
             dict = Dictionary.singleton (js_str "A") 42
             dict.size.should_equal 1
             dict.get "A" . should_equal 42
@@ -405,7 +406,7 @@ add_specs suite_builder =
             Test.expect_panic_with (py_update_dict dict "A" 2) Any
             dict.get "A" . should_equal 1
 
-        group_builder.specify "should treat JavaScript maps as Enso Dictionaries" <|
+        group_builder.specify "should treat JavaScript maps as Enso Dictionaries" pending=pending_js_missing <|
             js_dict = js_dict_from_vec ["A", 1, "B", 2]
             dict = js_dict.insert "C" 3
             js_dict.to_vector.should_equal [["A", 1], ["B", 2]]
@@ -555,7 +556,7 @@ add_common_specs suite_builder prefix:Text (pending : (Text | Nothing)) (empty_d
             empty_dict.insert Nothing 1 . should_equal (empty_dict.insert Nothing 1)
             empty_dict.insert Nothing 1 . insert Nothing 2 . at Nothing . should_equal 2
 
-        group_builder.specify "should handle JavaScript null as keys" <|
+        group_builder.specify "should handle JavaScript null as keys" pending=pending_js_missing <|
             empty_dict.insert js_null 1 . at Nothing . should_equal 1
 
         group_builder.specify "should handle Python None as keys" pending=pending_python_missing <|

--- a/test/Base_Tests/src/Data/Numbers_Spec.enso
+++ b/test/Base_Tests/src/Data/Numbers_Spec.enso
@@ -50,6 +50,7 @@ float_id : Float -> Float
 float_id f =
     Number_Utils.floatId f
 
+pending_js_missing = if Polyglot.is_language_installed "js" then Nothing else "Can't run JavaScript tests, language `js` is not installed."
 
 add_specs suite_builder =
     eps = 0.000001
@@ -743,8 +744,8 @@ add_specs suite_builder =
     suite_builder.group "BigInts" group_builder->
         expected_value = 2002115494039257055317447151023464523838443110452722331466645440244415760562579268801894716412
 
-        bigint_spec name create mul =
-            group_builder.specify name+" 6 * 7" <|
+        bigint_spec name create mul pending=Nothing =
+            group_builder.specify name+" 6 * 7" pending=pending <|
                 six = create 6
                 seven = create 7
                 both = six*seven
@@ -754,7 +755,7 @@ add_specs suite_builder =
                 seven.is_a Integer . should_be_true
                 both.is_a Integer . should_be_true
 
-            group_builder.specify name+" power of 3 with running_fold" <|
+            group_builder.specify name+" power of 3 with running_fold" pending=pending <|
                 three = create 3
 
                 two_hundred = 1.up_to 200 . running_fold three a->_->
@@ -764,7 +765,7 @@ add_specs suite_builder =
                 sum.is_a Integer . should_be_true
                 sum.div two_hundred.length . should_equal expected_value
 
-            group_builder.specify name+" power of 3 with map" <|
+            group_builder.specify name+" power of 3 with map" pending=pending <|
                 three = create 3
 
                 two_hundred = 1.up_to 200 . map i->
@@ -777,31 +778,31 @@ add_specs suite_builder =
                     v -> Test.fail "Expecting Integer, but got: "+(Meta.type_of v).to_text
                 sum.div two_hundred.length . should_equal expected_value
 
-            group_builder.specify name+" Ordering.compare BigInteger" <|
+            group_builder.specify name+" Ordering.compare BigInteger" pending=pending <|
                     bd1 = create 5
                     bd2 = create 13
                     Ordering.compare bd1 bd2 . should_equal Ordering.Less
                     Ordering.compare bd2 bd1 . should_equal Ordering.Greater
 
-            group_builder.specify name+" < BigInteger" <|
+            group_builder.specify name+" < BigInteger" pending=pending <|
                     bd1 = create 5
                     bd2 = create 13
                     (bd1 < bd2) . should_be_true
                     (bd2 < bd1) . should_be_false
 
-            group_builder.specify name+" <= BigInteger" <|
+            group_builder.specify name+" <= BigInteger" pending=pending <|
                     bd1 = create 5
                     bd2 = create 13
                     (bd1 <= bd2) . should_be_true
                     (bd2 <= bd1) . should_be_false
 
-            group_builder.specify name+" > BigInteger" <|
+            group_builder.specify name+" > BigInteger" pending=pending <|
                     bd1 = create 5
                     bd2 = create 13
                     (bd1 > bd2) . should_be_false
                     (bd2 > bd1) . should_be_true
 
-            group_builder.specify name+" >= BigInteger" <|
+            group_builder.specify name+" >= BigInteger" pending=pending <|
                     bd1 = create 5
                     bd2 = create 13
                     (bd1 >= bd2) . should_be_false
@@ -815,9 +816,10 @@ add_specs suite_builder =
 
         bigint_spec "Enso" (x->x) (*)
         bigint_spec "Java" to_java_bigint java_bigint_mul
-        bigint_spec "JavaScript" to_js_bigint js_bigint_mul
+        bigint_spec "JavaScript" to_js_bigint js_bigint_mul pending_js_missing
 
-        group_builder.specify "Matrix of values" <|
+
+        group_builder.specify "Matrix of values" pending=pending_js_missing <|
             x = to_java_bigint 10
             y = 10
             z = 10.0

--- a/test/Base_Tests/src/Data/Pair_Spec.enso
+++ b/test/Base_Tests/src/Data/Pair_Spec.enso
@@ -4,8 +4,9 @@ import Standard.Base.Errors.Common.Not_Found
 
 from Standard.Test import all
 
+pending_js_missing = if Polyglot.is_language_installed "js" then Nothing else "Can't run JavaScript tests, language `js` is not installed."
 
-type_spec suite_builder name ctor = suite_builder.group name group_builder->
+type_spec suite_builder name ctor pending=Nothing = suite_builder.group name pending=pending group_builder->
     group_builder.specify "should allow mapping" <|
         ctor 1 2 . map x->x+1 . should_equal (ctor 2 3)
 
@@ -113,7 +114,7 @@ add_specs suite_builder =
     type_spec suite_builder "Pair - from Pair.new" Pair.new
     type_spec suite_builder "Pair - from Pair.Value" Pair.Value
     type_spec suite_builder "Pair - from 2-Item Vector" a->b->[a,b]
-    type_spec suite_builder "Pair - from 2-Item JavaScript Array" js_pair
+    type_spec suite_builder "Pair - from 2-Item JavaScript Array" js_pair pending_js_missing
     type_spec suite_builder "Pair - from 2-Item List" a->b->(List.Cons a (List.Cons b List.Nil))
 
 foreign js js_pair a b = """

--- a/test/Base_Tests/src/Data/Polyglot_Spec.enso
+++ b/test/Base_Tests/src/Data/Polyglot_Spec.enso
@@ -10,6 +10,8 @@ polyglot java import java.time.LocalDate
 polyglot java import java.util.function.Function as Java_Function
 polyglot java import org.enso.base_test_helpers.IntHolder
 
+pending_js_missing = if Polyglot.is_language_installed "js" then Nothing else "Can't run JavaScript tests, language `js` is not installed."
+
 add_specs suite_builder = suite_builder.group "Polyglot" group_builder->
     group_builder.specify "should be able to invoke a polyglot method by name and pass arguments" <|
         poly_date = LocalDate.now
@@ -28,20 +30,20 @@ add_specs suite_builder = suite_builder.group "Polyglot" group_builder->
     group_builder.specify "use Double created by constructor" <|
         Polyglot.new Double [42] . should_equal 42
 
-    group_builder.specify "use Integer read from Polyglot object" <|
+    group_builder.specify "use Integer read from JavaScript object" pending=pending_js_missing <|
         (Polyglot.get_member js_meaning "meaning") . should_equal 42
 
-    group_builder.specify "access Integer field from Polyglot object" <|
+    group_builder.specify "access Integer field from JavaScript object" pending=pending_js_missing <|
         js_meaning.meaning . should_equal 42
 
-    group_builder.specify "Execute JavaScript function" <|
+    group_builder.specify "Execute JavaScript function" pending=pending_js_missing <|
         js_plus 3 5 . should_equal 8
 
-    group_builder.specify "Execute JavaScript with insufficient number of arguments" <|
+    group_builder.specify "Execute JavaScript with insufficient number of arguments" pending=pending_js_missing <|
         r = js_plus 3
         r.is_nan . should_be_true
 
-    group_builder.specify "Cannot Execute JavaScript number" <|
+    group_builder.specify "Cannot Execute JavaScript number" pending=pending_js_missing <|
         fourty_two = js_meaning.meaning
         Test.expect_panic Not_Invokable <|
             fourty_two "Cannot invoke"

--- a/test/Base_Tests/src/Data/Time/Date_Part_Spec.enso
+++ b/test/Base_Tests/src/Data/Time/Date_Part_Spec.enso
@@ -3,8 +3,8 @@ from Standard.Base import all
 from Standard.Test import all
 
 
-add_specs suite_builder name create_new_date =
-    suite_builder.group (name + " date part tests")  group_builder->
+add_specs suite_builder name create_new_date pending=Nothing =
+    suite_builder.group (name + " date part tests")  pending=pending group_builder->
         group_builder.specify "should return if a leap year" <|
             create_new_date 2022 8 25 . is_leap_year . should_equal False
             create_new_date 1999 12 31 . is_leap_year . should_equal False

--- a/test/Base_Tests/src/Data/Time/Date_Spec.enso
+++ b/test/Base_Tests/src/Data/Time/Date_Spec.enso
@@ -13,11 +13,13 @@ polyglot java import java.time.format.DateTimeFormatter
 
 add_specs suite_builder =
     spec_with suite_builder "Date" Date.new Date.parse
-    spec_with suite_builder "JavaScriptDate" js_date js_parse
+    if Polyglot.is_language_installed "js" then
+        spec_with suite_builder "JavaScriptDate" js_date js_parse
     if Polyglot.is_language_installed "python" then
         spec_with suite_builder "PythonDate" python_date python_parse pending="https://github.com/enso-org/enso/issues/8913"
     spec_with suite_builder "JavaDate" java_date java_parse
-    spec_with suite_builder "JavaScriptArrayWithADate" js_array_date js_parse
+    if Polyglot.is_language_installed "js" then
+        spec_with suite_builder "JavaScriptArrayWithADate" js_array_date js_parse
 
 spec_with suite_builder name create_new_date parse_date pending=Nothing =
     if pending.is_nothing then Date_Part_Spec.add_specs suite_builder name create_new_date

--- a/test/Base_Tests/src/Data/Time/Date_Time_Spec.enso
+++ b/test/Base_Tests/src/Data/Time/Date_Time_Spec.enso
@@ -20,15 +20,19 @@ polyglot java import java.util.Objects
 def_comp = Standard.Base.Internal.Ordering_Helpers.Default_Comparator
 
 add_specs suite_builder =
+    pending_js_missing = if Polyglot.is_language_installed "js" then Nothing else
+        "Can't run JavaScript tests, language `js` is not installed."
+    pending_python_missing = if Polyglot.is_language_installed "python" then Nothing else
+        "Can't run Python tests, language `python` is not installed."
+
     spec_with suite_builder "Date_Time" enso_datetime Date_Time.parse
-    spec_with suite_builder "JavascriptDate" js_datetime js_parse nanoseconds_loss_in_precision=True
-    if Polyglot.is_language_installed "python" then
-        spec_with suite_builder "PythonDate" python_datetime python_parse nanoseconds_loss_in_precision=True
+    spec_with suite_builder "JavascriptDate" js_datetime js_parse nanoseconds_loss_in_precision=True pending=pending_js_missing
+    spec_with suite_builder "PythonDate" python_datetime python_parse nanoseconds_loss_in_precision=True pending=pending_python_missing
     spec_with suite_builder "JavaZonedDateTime" java_datetime java_parse
-    spec_with suite_builder "JavascriptDataInArray" js_array_datetime js_parse nanoseconds_loss_in_precision=True
+    spec_with suite_builder "JavascriptDataInArray" js_array_datetime js_parse nanoseconds_loss_in_precision=True pending=pending_js_missing
 
     suite_builder.group "Date_Time equality" group_builder->
-        group_builder.specify "should work with values coming from various sources" <|
+        group_builder.specify "should work with values coming from various sources" pending=pending_js_missing <|
             d1 = Date_Time.new 2022 3 4 5 6
             d2 = java_datetime 2022 3 4 5 6
             d1 . should_equal d2
@@ -72,8 +76,8 @@ add_specs suite_builder =
             Date_Time.new 1970 1 1 0 0 0 millisecond=1 microsecond=123 zone=Time_Zone.utc . to_unix_epoch_milliseconds . should_equal 1
             Date_Time.new 2024 1 4 12 35 44 millisecond=123 zone=Time_Zone.utc . to_unix_epoch_milliseconds . should_equal 1704371744123
 
-spec_with suite_builder name create_new_datetime parse_datetime nanoseconds_loss_in_precision=False =
-    suite_builder.group name group_builder->
+spec_with suite_builder name create_new_datetime parse_datetime nanoseconds_loss_in_precision=False pending=Nothing =
+    suite_builder.group name pending=pending group_builder->
 
         group_builder.specify "should create time" <|
             time = create_new_datetime 1970 (zone = Time_Zone.utc)
@@ -740,7 +744,7 @@ spec_with suite_builder name create_new_datetime parse_datetime nanoseconds_loss
             dt3.date_diff dt4 Date_Period.Day . should_equal 0
             dt3.date_diff dt4 Time_Period.Hour . should_equal 23
 
-    Date_Part_Spec.add_specs suite_builder name create_new_datetime
+    Date_Part_Spec.add_specs suite_builder name create_new_datetime pending=pending
 
 js_datetime year month=1 day=1 hour=0 minute=0 second=0 nanosecond=0 zone=Time_Zone.system =
     Panic.catch Any (js_datetime_with_zone year month day hour minute second nanosecond zone) (err -> Error.throw (Time_Error.Error err.payload))

--- a/test/Base_Tests/src/Data/Time/Duration_Spec.enso
+++ b/test/Base_Tests/src/Data/Time/Duration_Spec.enso
@@ -10,6 +10,9 @@ polyglot java import java.time.LocalDate
 polyglot java import java.time.LocalDateTime as Java_DateTime
 
 add_specs suite_builder =
+    pending_js_missing = if Polyglot.is_language_installed "js" then Nothing else
+        "Can't run JavaScript tests, language `js` is not installed."
+
     suite_builder.group "Duration" group_builder->
 
         group_builder.specify "should create interval seconds" <|
@@ -90,10 +93,10 @@ add_specs suite_builder =
         group_builder.specify "Difference of two Java Dates should be an Enso Duration" <|
             (Duration.between (java_datetime 2022 01 01) (java_datetime 2022 01 02) timezone_aware=False).total_hours . should_equal 24
 
-        group_builder.specify "Difference of two JS Dates is an Enso Duration" <|
+        group_builder.specify "Difference of two JS Dates is an Enso Duration" pending=pending_js_missing <|
             (Duration.between (js_datetime 2022 09 01) (js_datetime 2022 09 02) timezone_aware=False).total_hours . should_equal 24
 
-        group_builder.specify "Difference of JS Dates and Java Dates should be Enso Duration" <|
+        group_builder.specify "Difference of JS Dates and Java Dates should be Enso Duration" pending=pending_js_missing <|
             (Duration.between (js_datetime 2022 09 08) (java_datetime 2022 09 09) timezone_aware=False).total_hours . should_equal 24
             (Duration.between (java_datetime 2022 09 09) (js_datetime 2022 09 08) timezone_aware=False).total_hours . should_equal (-24)
 

--- a/test/Base_Tests/src/Data/Vector_Spec.enso
+++ b/test/Base_Tests/src/Data/Vector_Spec.enso
@@ -79,6 +79,8 @@ type_spec suite_builder name alter = suite_builder.group name group_builder->
         if a == 30 then Error.throw (My_Error.Error a) else a+1
     zip_fun a b = if a == 30 then Error.throw (My_Error.Error a) else a+b+1
 
+    pending_js_missing = if Polyglot.is_language_installed "js" then Nothing else
+        "Can't run JavaScript tests, language `js` is not installed."
     pending_python_missing = if Polyglot.is_language_installed "python" then Nothing else
         "Can't run Python tests, Python is not installed."
 
@@ -103,7 +105,7 @@ type_spec suite_builder name alter = suite_builder.group name group_builder->
         const = Vector.fill 4 next
         const.should_equal [0, 0, 0, 0]
 
-    group_builder.specify "should allow creation from arrays without mutability" <|
+    group_builder.specify "should allow creation from arrays without mutability" pending=pending_js_missing <|
         built_from_js = Vector.from_polyglot_array generate_js_array
         built_from_js . should_equal (alter [1, 2, 3, 4, 5])
 
@@ -111,7 +113,7 @@ type_spec suite_builder name alter = suite_builder.group name group_builder->
         built_from_py = Vector.from_polyglot_array generate_py_array
         built_from_py . should_equal (alter [1, 2, 3, 4, Nothing])
 
-    group_builder.specify "should allow creation from nested arrays from JavaScript" <|
+    group_builder.specify "should allow creation from nested arrays from JavaScript" pending=pending_js_missing <|
         built_from_js = Vector.from_polyglot_array generate_nested_js_array
         built_from_js . should_equal (alter [[1, 2, 3], [4, 5]])
 

--- a/test/Base_Tests/src/Runtime/Asserts_Spec.enso
+++ b/test/Base_Tests/src/Runtime/Asserts_Spec.enso
@@ -10,12 +10,15 @@ foreign js js_check = """
     return (4 == 2 + 2)
 
 add_specs suite_builder = suite_builder.group "Asserts" group_builder->
+    pending_js_missing = if Polyglot.is_language_installed "js" then Nothing else
+        "Can't run JavaScript tests, language `js` is not installed."
+
     group_builder.specify "should be enabled in tests" <|
         p = Panic.catch Assertion_Error (Runtime.assert False) err->
             err.payload
         Meta.type_of p . should_be_a Assertion_Error
 
-    group_builder.specify "should be able to take foreign functions as expressions" <|
+    group_builder.specify "should be able to take foreign functions as expressions" pending=pending_js_missing <|
         ret = Runtime.assert js_check
         ret . should_be_a Nothing
 

--- a/test/Base_Tests/src/Semantic/Conversion_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Conversion_Spec.enso
@@ -109,13 +109,16 @@ Blob.from (that:File) = Blob.Binary that
 Blob.from (that:Any) = Blob.Json that
 
 add_specs suite_builder =
+    pending_js_missing = if Polyglot.is_language_installed "js" then Nothing else
+        "Can't run JavaScript tests, language `js` is not installed."
+
     suite_builder.group "Conversion" group_builder->
         group_builder.specify "should be able to convert atoms" <|
             ((Foo.from (Baz.Value 10)).foo + (Foo.from (Bar.Value 20)).foo) . should_equal 30
             Foo.from Quaffle . foo . should_equal "quaffle"
         group_builder.specify "should be able to convert text" <|
             Foo.from "123" . foo . should_equal 3
-        group_builder.specify "should be able to convert foreign text" <|
+        group_builder.specify "should be able to convert foreign text" pending=pending_js_missing <|
             Foo.from (make_str 4) . foo . should_equal 9
         group_builder.specify "should be able to convert numbers" <|
             Foo.from 4 . should_equal (Foo.Value [4, 0, 0, 0])
@@ -164,7 +167,7 @@ add_specs suite_builder =
         group_builder.specify "should support the use of multiple arguments" <|
             Foo.from that=4 second_param=1 2 . should_equal (Foo.Value [4, 2, 1, 0])
 
-        group_builder.specify "should play nicely with polyglot" <|
+        group_builder.specify "should play nicely with polyglot" pending=pending_js_missing <|
             call_function .from Foo . should_equal (Foo.Value 8)
 
         group_builder.specify "should support the meta functions" <|

--- a/test/Base_Tests/src/Semantic/Equals_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Equals_Spec.enso
@@ -134,11 +134,16 @@ foreign js js_obj a b = """
     return m;
 
 add_specs suite_builder =
+    pending_js_missing = if Polyglot.is_language_installed "js" then Nothing else
+        "Can't run JavaScript tests, language `js` is not installed."
+
     suite_builder.group "Operator ==" group_builder->
         group_builder.specify "should handle primitive values" <|
             (2 == (2.0)).should_be_true
             (2 == (2.1)).should_be_false
             (2.0).should_equal 2
+
+        group_builder.specify "should handle primitive JavaScript values" pending=pending_js_missing <|
             (js_true == True).should_be_true
             (js_false == False).should_be_true
             (js_true == False).should_be_false
@@ -241,7 +246,7 @@ add_specs suite_builder =
             x==x . should_be_true
             z==z . should_be_true
 
-        group_builder.specify "should not try to compare members in JS object" <|
+        group_builder.specify "should not try to compare members in JS object" pending=pending_js_missing <|
             x = js_obj 5 3
             y = js_obj 5 3
             z = js_obj 3 5
@@ -266,16 +271,16 @@ add_specs suite_builder =
             y = Java_Big_Integer.new "54024430107564432"
             x==y . should_be_true
 
-        group_builder.specify "JSON is found different" <|
+        group_builder.specify "JSON is found different" pending=pending_js_missing <|
             x = js_json 10 5
             y = js_json 10 5
             x==y . should_be_false
 
-        group_builder.specify "Identical JSON is found equal" <|
+        group_builder.specify "Identical JSON is found equal" pending=pending_js_missing <|
             x = js_json 10 5
             x==x . should_be_true
 
-        group_builder.specify "JavaScript Map is found same" <|
+        group_builder.specify "JavaScript Map is found same" pending=pending_js_missing <|
             x = js_map 10 5
             y = js_map 10 5
             x==y . should_be_true

--- a/test/Base_Tests/src/Semantic/Error_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Error_Spec.enso
@@ -56,6 +56,7 @@ fn_with_tco x =
 global_wrapper_fn =
     fn_with_tco 0
 
+pending_js_missing = if Polyglot.is_language_installed "js" then Nothing else "Can't run JavaScript tests, language `js` is not installed."
 
 add_specs suite_builder =
     suite_builder.group "No Method Errors" group_builder->
@@ -308,7 +309,7 @@ add_specs suite_builder =
                 (Panic.throw (ArrayList.new))
             catch_array . should_equal "[]"
 
-        group_builder.specify "should be able to throw and catch polyglot values"  <|
+        group_builder.specify "should be able to throw and catch polyglot values" pending=pending_js_missing <|
             caught_js_int_panic = Panic.catch Any handler=err->"Any:"+err.payload.to_text <|
                 Panic.catch Integer handler=err->"JS integer:"+err.payload.to_text <|
                     throw_js_int

--- a/test/Base_Tests/src/Semantic/Js_Interop_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Js_Interop_Spec.enso
@@ -79,7 +79,9 @@ foreign js test_array_properties = """
     my_array.index = 0
     return my_array
 
-add_specs suite_builder = suite_builder.group "Polyglot JS" group_builder->
+pending_js_missing = if Polyglot.is_language_installed "js" then Nothing else "Can't run JavaScript tests, language `js` is not installed."
+
+add_specs suite_builder = suite_builder.group "Polyglot JS" pending=pending_js_missing group_builder->
 
     group_builder.specify "should allow declaring module-level methods in JS" <|
         my_method 1 2 . should_equal 3

--- a/test/Base_Tests/src/Semantic/Meta_Location_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Meta_Location_Spec.enso
@@ -10,6 +10,9 @@ type My_Type
     Value foo bar baz
 
 add_specs suite_builder = suite_builder.group "Meta-Value Inspection" group_builder->
+    pending_js_missing = if Polyglot.is_language_installed "js" then Nothing else
+        "Can't run JavaScript tests, language `js` is not installed."
+
     location_pending = case Platform.os of
         Platform.OS.Windows -> "This test is disabled on Windows until issue 1561 is fixed."
         _ -> Nothing
@@ -34,7 +37,7 @@ add_specs suite_builder = suite_builder.group "Meta-Value Inspection" group_buil
     group_builder.specify "should allow to fetch enso project description from a module" <|
         (Project_Description.new Standard.Base.Data.Vector).name.should_equal "Base"
 
-    group_builder.specify "enso_project can be called from polyglot code" <|
+    group_builder.specify "enso_project can be called from polyglot code" pending=pending_js_missing <|
         proj_name = js_proj_name (_ -> enso_project.name)
         proj_name . should_equal "Base_Tests"
 

--- a/test/Base_Tests/src/Semantic/Meta_Location_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Meta_Location_Spec.enso
@@ -19,7 +19,7 @@ add_specs suite_builder = suite_builder.group "Meta-Value Inspection" group_buil
 
     group_builder.specify "should allow to get the source location of a frame" pending=location_pending <|
         src = Meta.get_source_location 0
-        loc = "Meta_Location_Spec.enso:18:15-40"
+        loc = "Meta_Location_Spec.enso:21:15-40"
         src.take (..Last loc.length) . should_equal loc
 
     group_builder.specify "should allow to get qualified type names of values" <|

--- a/test/Base_Tests/src/Semantic/Private_Spec.enso
+++ b/test/Base_Tests/src/Semantic/Private_Spec.enso
@@ -13,6 +13,9 @@ private My_Priv_Type.ext_method self = self.data
 
 
 add_specs spec_builder =
+    pending_js_missing = if Polyglot.is_language_installed "js" then Nothing else
+        "Can't run JavaScript tests, language `js` is not installed."
+
     spec_builder.group "Private constructors" group_builder->
         group_builder.specify "cannot directly call private constructor" <|
             Test.expect_panic Private_Access <| Priv_Type.Cons 42
@@ -38,19 +41,19 @@ add_specs spec_builder =
             obj = Priv_Type.create 42
             obj.get_data . should_equal 42
 
-        group_builder.specify "cannot get private field from JS" <|
+        group_builder.specify "cannot get private field from JS" pending=pending_js_missing <|
             obj = Priv_Type.create 42
             # When JS tries to access a private field, it does not throw a panic, as it does not
             # see the field. It returns undefined.
             ret = js_access_field obj
             ret.is_nothing . should_be_true
 
-        group_builder.specify "can call private constructor via public factory method from JS" <|
+        group_builder.specify "can call private constructor via public factory method from JS" pending=pending_js_missing <|
             create_fn x = Priv_Type.create x
             obj = js_create_obj create_fn
             obj.is_nothing . should_be_false
 
-        group_builder.specify "can get private field via public accessor from JS" <|
+        group_builder.specify "can get private field via public accessor from JS" pending=pending_js_missing <|
             obj = Priv_Type.create 42
             js_access_field_via_getter obj . should_equal 42
 


### PR DESCRIPTION
### Pull Request Description

Let's modify the `Base_Tests` to be able to succeed without JavaScript being installed - **done** in 3298b07dca34164bd031df20b26d49c808c37713

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to with JavaScript tests in JVM mode
- [x] `Base_Tests` pass in _native image_ mode
