### PR TITLE
Add retries when fetching tableau artifacts in sbt

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,7 @@ Cargo.toml
 /build.sbt @4e6 @jaroslavtulach @hubertp @Akirathan
 /distribution/ @4e6 @jdunkerley @radeusgd @GregoryTravis @AdRiley @marthasharkey
 /engine/ @4e6 @jaroslavtulach @hubertp @Akirathan
-/project/ @4e6 @jaroslavtulach @hubertp
+/project/ @4e6 @jaroslavtulach @hubertp @Akirathan
 /tools/ @4e6 @jaroslavtulach @radeusgd @hubertp
 
 # Enso Libraries

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,5 +8,6 @@ libraryDependencies += "io.circe"                   %% "circe-yaml"         % "0
 libraryDependencies += "commons-io"                  % "commons-io"         % "2.12.0"
 libraryDependencies += "nl.gn0s1s"                  %% "bump"               % "0.1.3"
 libraryDependencies += "com.google.googlejavaformat" % "google-java-format" % "1.18.1"
+libraryDependencies += "com.softwaremill.retry"     %% "retry"              % "0.3.6"
 
 scalacOptions ++= Seq("-deprecation", "-feature")


### PR DESCRIPTION
Seeing frequent network failures when fetching tableau artifacts e.g., https://github.com/enso-org/enso/actions/runs/10705660288/job/29681570936#step:7:918
https://github.com/enso-org/enso/actions/runs/10705424455/job/29680779254#step:7:1180 or
https://github.com/enso-org/enso/actions/runs/10705424455/job/29680779874#step:7:1143

Network failures are OK but we shouldn't kill builds immediately because of that. Let's try harder.
