### PR TITLE
Compute correct root path for Solo users

### DIFF
--- a/app/dashboard/src/App.tsx
+++ b/app/dashboard/src/App.tsx
@@ -543,7 +543,7 @@ function LocalBackendPathSynchronizer() {
   const localBackend = useLocalBackend()
   if (localBackend) {
     if (localRootDirectory != null) {
-      localBackend.rootPath = Path(localRootDirectory)
+      localBackend.setRootPath(Path(localRootDirectory))
     } else {
       localBackend.resetRootPath()
     }

--- a/app/dashboard/src/layouts/AssetsTable.tsx
+++ b/app/dashboard/src/layouts/AssetsTable.tsx
@@ -533,7 +533,7 @@ export default function AssetsTable(props: AssetsTableProps) {
   const isLoading = directories.rootDirectory.isLoading
 
   const assetTree = React.useMemo(() => {
-    const rootPath = 'rootPath' in category ? category.rootPath : backend.rootPath
+    const rootPath = 'rootPath' in category ? category.rootPath : backend.rootPath(user)
 
     // If the root directory is not loaded, then we cannot render the tree.
     // Return null, and wait for the root directory to load.
@@ -634,13 +634,14 @@ export default function AssetsTable(props: AssetsTableProps) {
       rootId,
     )
   }, [
-    directories,
+    category,
+    backend,
+    user,
     rootDirectoryContent,
     rootDirectory,
     rootParentDirectoryId,
-    backend.rootPath,
     rootDirectoryId,
-    category,
+    directories.directories,
   ])
 
   const filter = React.useMemo(() => {

--- a/app/dashboard/src/layouts/CategorySwitcher.tsx
+++ b/app/dashboard/src/layouts/CategorySwitcher.tsx
@@ -210,7 +210,7 @@ function CategorySwitcherItem(props: InternalCategorySwitcherItemProps) {
         case 'local-directory': {
           if (category.type === 'local' || category.type === 'local-directory') {
             const parentDirectory =
-              category.type === 'local' ? localBackend?.rootPath : category.rootPath
+              category.type === 'local' ? localBackend?.rootPath() : category.rootPath
             invariant(parentDirectory != null, 'The Local backend is missing a root directory.')
             const newParentId = newDirectoryId(parentDirectory)
             dispatchAssetEvent({

--- a/app/dashboard/src/layouts/Settings.tsx
+++ b/app/dashboard/src/layouts/Settings.tsx
@@ -69,7 +69,7 @@ export default function Settings() {
   const updateLocalRootPath = useEventCallback((value: string) => {
     setLocalRootDirectory(value)
     if (localBackend) {
-      localBackend.rootPath = projectManager.Path(value)
+      localBackend.setRootPath(projectManager.Path(value))
     }
   })
   const resetLocalRootPath = useEventCallback(() => {

--- a/app/dashboard/src/layouts/Settings/settingsData.tsx
+++ b/app/dashboard/src/layouts/Settings/settingsData.tsx
@@ -238,7 +238,7 @@ export const SETTINGS_TAB_DATA: Readonly<Record<SettingsTabType, SettingsTabData
           {
             type: SettingsEntryType.input,
             nameId: 'localRootPathSettingsInput',
-            getValue: (context) => context.localBackend?.rootPath ?? '',
+            getValue: (context) => context.localBackend?.rootPath() ?? '',
             setValue: async (context, value) => {
               context.updateLocalRootPath(value)
               await Promise.resolve()

--- a/app/dashboard/src/services/LocalBackend.ts
+++ b/app/dashboard/src/services/LocalBackend.ts
@@ -125,7 +125,7 @@ export default class LocalBackend extends Backend {
 
   /** Return the ID of the root directory. */
   override rootDirectoryId(
-    _user: backend.User | null,
+    _user: backend.User,
     _organization: backend.OrganizationInfo | null,
     rootDirectory: backend.Path | null | undefined,
   ): backend.DirectoryId {

--- a/app/dashboard/src/services/LocalBackend.ts
+++ b/app/dashboard/src/services/LocalBackend.ts
@@ -104,12 +104,12 @@ export default class LocalBackend extends Backend {
   }
 
   /** Get the root directory of this Backend. */
-  get rootPath() {
+  override rootPath() {
     return this.projectManager.rootDirectory
   }
 
   /** Set the root directory of this Backend. */
-  set rootPath(value) {
+  setRootPath(value: projectManager.Path) {
     this.projectManager.rootDirectory = value
   }
 

--- a/app/dashboard/src/services/RemoteBackend.ts
+++ b/app/dashboard/src/services/RemoteBackend.ts
@@ -127,7 +127,6 @@ interface RemoteBackendPostOptions {
 /** Class for sending requests to the Cloud backend API endpoints. */
 export default class RemoteBackend extends Backend {
   readonly type = backend.BackendType.remote
-  readonly rootPath = 'enso://'
   private defaultVersions: Partial<Record<backend.VersionType, DefaultVersionInfo>> = {}
   private user: object.Mutable<backend.User> | null = null
 
@@ -171,6 +170,21 @@ export default class RemoteBackend extends Backend {
       const status = response?.status
 
       throw new backend.NetworkError(message, status)
+    }
+  }
+
+  /** The path to the root directory of this {@link Backend}. */
+  override rootPath(user: backend.User | null) {
+    switch (user?.plan ?? null) {
+      case null:
+      case backend.Plan.free:
+      case backend.Plan.solo: {
+        return `enso://Users/${user?.name ?? ''}`
+      }
+      case backend.Plan.team:
+      case backend.Plan.enterprise: {
+        return 'enso://'
+      }
     }
   }
 

--- a/app/dashboard/src/services/RemoteBackend.ts
+++ b/app/dashboard/src/services/RemoteBackend.ts
@@ -174,12 +174,12 @@ export default class RemoteBackend extends Backend {
   }
 
   /** The path to the root directory of this {@link Backend}. */
-  override rootPath(user: backend.User | null) {
-    switch (user?.plan ?? null) {
-      case null:
+  override rootPath(user: backend.User) {
+    switch (user.plan) {
+      case undefined:
       case backend.Plan.free:
       case backend.Plan.solo: {
-        return `enso://Users/${user?.name ?? ''}`
+        return `enso://Users/${user.name}`
       }
       case backend.Plan.team:
       case backend.Plan.enterprise: {
@@ -190,14 +190,14 @@ export default class RemoteBackend extends Backend {
 
   /** Return the ID of the root directory. */
   override rootDirectoryId(
-    user: backend.User | null,
+    user: backend.User,
     organization: backend.OrganizationInfo | null,
   ): backend.DirectoryId | null {
-    switch (user?.plan ?? null) {
-      case null:
+    switch (user.plan) {
+      case undefined:
       case backend.Plan.free:
       case backend.Plan.solo: {
-        return user?.rootDirectoryId ?? null
+        return user.rootDirectoryId
       }
       case backend.Plan.team:
       case backend.Plan.enterprise: {

--- a/app/ide-desktop/common/src/services/Backend.ts
+++ b/app/ide-desktop/common/src/services/Backend.ts
@@ -1310,10 +1310,10 @@ export default abstract class Backend {
   abstract readonly type: BackendType
 
   /** The path to the root directory of this {@link Backend}. */
-  abstract rootPath(user: User | null): string
+  abstract rootPath(user: User): string
   /** Return the ID of the root directory, if known. */
   abstract rootDirectoryId(
-    user: User | null,
+    user: User,
     organization: OrganizationInfo | null,
     localRootDirectory: Path | null | undefined,
   ): DirectoryId | null

--- a/app/ide-desktop/common/src/services/Backend.ts
+++ b/app/ide-desktop/common/src/services/Backend.ts
@@ -1310,7 +1310,7 @@ export default abstract class Backend {
   abstract readonly type: BackendType
 
   /** The path to the root directory of this {@link Backend}. */
-  abstract readonly rootPath: string
+  abstract rootPath(user: User | null): string
   /** Return the ID of the root directory, if known. */
   abstract rootDirectoryId(
     user: User | null,


### PR DESCRIPTION
### Pull Request Description
- Change paths for cloud assets for users on Solo plan to be `enso://User/<username>/<path>` instead of the legacy `enso://<username>/<path>`

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
