### PR TITLE
Avoid AliasAnalysis for Hello_World.enso

### DIFF
--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/data/BindingsMap.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/data/BindingsMap.scala
@@ -52,7 +52,7 @@ case class BindingsMap(
     ensureConvertedToConcrete()
     _resolvedImports
   }
-  def resolvedImports_(v: List[ResolvedImport]): Unit = {
+  def resolvedImports_=(v: List[ResolvedImport]): Unit = {
     _resolvedImports = v
   }
 
@@ -67,7 +67,7 @@ case class BindingsMap(
     ensureConvertedToConcrete()
     _exportedSymbols
   }
-  def exportedSymbols_(v: Map[String, List[ResolvedName]]): Unit = {
+  def exportedSymbols_=(v: Map[String, List[ResolvedName]]): Unit = {
     _exportedSymbols = v
   }
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/data/BindingsMap.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/data/BindingsMap.scala
@@ -134,9 +134,9 @@ case class BindingsMap(
     val withImports: Option[BindingsMap] = newMap.flatMap { bindings =>
       val newImports = this._resolvedImports.map { imp =>
         imp.targets.foreach { t =>
-          r.ensurePackageIsLoaded(
-            LibraryName(t.qualifiedName.path(0), t.qualifiedName.path(1))
-          )
+          LibraryName
+            .fromModuleName(t.qualifiedName.toString())
+            .foreach(r.ensurePackageIsLoaded(_));
         }
         imp.toConcrete(moduleMap)
       }

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/data/BindingsMap.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/data/BindingsMap.scala
@@ -108,14 +108,13 @@ case class BindingsMap(
   private def ensureConvertedToConcrete(): Option[BindingsMap] = {
     val r = pendingRepository
     if (r != null) {
-      val res = toConcrete(r, r.getModuleMap).map { b =>
+      toConcrete(r, r.getModuleMap).map { b =>
         pendingRepository     = null
         this._currentModule   = b._currentModule
         this._exportedSymbols = b._exportedSymbols
         this._resolvedImports = b._resolvedImports
         this
       }
-      res
     } else {
       Some(this)
     }
@@ -127,17 +126,14 @@ case class BindingsMap(
   ): Option[BindingsMap] = {
     val newMap = this._currentModule
       .toConcrete(moduleMap)
-      .map { c =>
-        this._currentModule = c
-        c
-      }
       .map { module =>
-        this.copy(_currentModule = module)
+        this._currentModule = module
+        this
       }
 
     val withImports: Option[BindingsMap] = newMap.flatMap { bindings =>
       val newImports = this._resolvedImports.map { imp =>
-        imp.targets.map { t =>
+        imp.targets.foreach { t =>
           r.ensurePackageIsLoaded(
             LibraryName(t.qualifiedName.path(0), t.qualifiedName.path(1))
           )

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/phase/ImportResolver.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/phase/ImportResolver.scala
@@ -89,9 +89,9 @@ final class ImportResolver(compiler: Compiler) extends ImportResolverForIR {
         val newImportIRs =
           importedModules.map(_._1) ++ syntheticImports.map(_._1)
 
-        currentLocal.resolvedImports_(
+        currentLocal.resolvedImports =
           resolvedImports ++ resolvedSyntheticImports
-        )
+
         val newIr = ir.copy(imports = newImportIRs)
         context.updateModule(
           current,

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/phase/ImportResolver.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/phase/ImportResolver.scala
@@ -11,6 +11,7 @@ import org.enso.common.CompilationStage
 
 import scala.collection.mutable
 import java.io.IOException
+import java.util.logging.Level
 
 /** Runs imports resolution. Starts from a given module and then recursively
   * collects all modules that are reachable from it.
@@ -46,7 +47,12 @@ final class ImportResolver(compiler: Compiler) extends ImportResolverForIR {
           )
           (ir, currentLocal)
         } catch {
-          case _: IOException =>
+          case ex: IOException =>
+            context.logSerializationManager(
+              Level.WARNING,
+              "Deserialization of " + module.getName() + " failed",
+              ex
+            )
             context.updateModule(
               current,
               u => {
@@ -83,8 +89,9 @@ final class ImportResolver(compiler: Compiler) extends ImportResolverForIR {
         val newImportIRs =
           importedModules.map(_._1) ++ syntheticImports.map(_._1)
 
-        currentLocal.resolvedImports =
+        currentLocal.resolvedImports_(
           resolvedImports ++ resolvedSyntheticImports
+        )
         val newIr = ir.copy(imports = newImportIRs)
         context.updateModule(
           current,

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/phase/exports/ExportsResolution.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/phase/exports/ExportsResolution.scala
@@ -166,7 +166,7 @@ class ExportsResolution(private val context: CompilerContext) {
           .flatten
           .distinct
 
-      bindings.exportedSymbols = List(
+      val newSymbols = List(
         ownEntities,
         expSymbolsFromResolvedImps
       ).flatten.distinct
@@ -179,6 +179,7 @@ class ExportsResolution(private val context: CompilerContext) {
           }
           (symbolName, resolvedNames)
         }
+      bindings.exportedSymbols_(newSymbols)
     }
   }
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/phase/exports/ExportsResolution.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/phase/exports/ExportsResolution.scala
@@ -179,7 +179,7 @@ class ExportsResolution(private val context: CompilerContext) {
           }
           (symbolName, resolvedNames)
         }
-      bindings.exportedSymbols_(newSymbols)
+      bindings.exportedSymbols = newSymbols
     }
   }
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/caches/HelloWorldCacheTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/caches/HelloWorldCacheTest.java
@@ -1,0 +1,76 @@
+package org.enso.interpreter.caches;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+import org.enso.common.RuntimeOptions;
+import org.enso.test.utils.ContextUtils;
+import org.graalvm.polyglot.Source;
+import org.junit.Test;
+
+public class HelloWorldCacheTest {
+
+  @Test
+  public void loadingHelloWorldTwiceUsesCaching() throws Exception {
+    var root = new File("../..").getAbsoluteFile();
+    assertTrue("build.sbt exists at " + root, new File(root, "build.sbt").exists());
+    var helloWorld = children(root, "test", "Benchmarks", "src", "Startup", "Hello_World.enso");
+    assertTrue("Hello_World.enso found", helloWorld.exists());
+
+    // the first run may or may not use caches
+    var firstMsgs = executeOnce(helloWorld);
+    assertTrue("Contains hello world:\n" + firstMsgs, firstMsgs.endsWith("Hello World"));
+    // after the first run the caches for Hello_World.enso must be generated
+
+    // the second run must read Hello_World from its .ir file!
+    var secondMsgs = executeOnce(helloWorld);
+    assertTrue("Contains hello world:\n" + secondMsgs, secondMsgs.contains("Hello World"));
+    assertTrue(
+        "Properly deserialized:\n" + secondMsgs,
+        secondMsgs.contains("Deserializing module Hello_World from IR file: true"));
+  }
+
+  private static String executeOnce(File src) throws Exception {
+    var backLog = new ByteArrayOutputStream();
+    var log = new PrintStream(backLog);
+
+    try (var ctx =
+        ContextUtils.defaultContextBuilder()
+            .out(log)
+            .err(log)
+            .logHandler(log)
+            .option(RuntimeOptions.LOG_LEVEL, Level.FINE.getName())
+            .option(RuntimeOptions.DISABLE_IR_CACHES, "false")
+            .option(RuntimeOptions.PROJECT_ROOT, findBenchmarks(src).getAbsolutePath())
+            .build()) {
+      var code = Source.newBuilder("enso", src).build();
+      var res = ContextUtils.evalModule(ctx, code, "main");
+      assertTrue("Result of IO.println is Nothing", res.isNull());
+    }
+    return backLog
+        .toString()
+        .lines()
+        .filter(l -> l.toUpperCase().contains("HELLO"))
+        .collect(Collectors.joining("\n"));
+  }
+
+  private static File children(File f, String... names) {
+    for (var n : names) {
+      f = new File(f, n);
+    }
+    return f;
+  }
+
+  private static File findBenchmarks(File f) {
+    for (; ; ) {
+      if (f.getName().equals("Benchmarks")) {
+        return f;
+      }
+      f = f.getParentFile();
+    }
+  }
+}

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/ImportExportCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/ImportExportCache.java
@@ -237,8 +237,8 @@ public final class ImportExportCache
       var imp = in.readInline(scala.collection.immutable.List.class);
       var sym = in.readInline(scala.collection.immutable.Map.class);
       var map = new BindingsMap(de, cm);
-      map.resolvedImports_(imp);
-      map.exportedSymbols_(sym);
+      map.resolvedImports_$eq(imp);
+      map.exportedSymbols_$eq(sym);
       return map;
     }
   }

--- a/engine/runtime/src/main/java/org/enso/interpreter/caches/ImportExportCache.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/caches/ImportExportCache.java
@@ -237,8 +237,8 @@ public final class ImportExportCache
       var imp = in.readInline(scala.collection.immutable.List.class);
       var sym = in.readInline(scala.collection.immutable.Map.class);
       var map = new BindingsMap(de, cm);
-      map.resolvedImports_$eq(imp);
-      map.exportedSymbols_$eq(sym);
+      map.resolvedImports_(imp);
+      map.exportedSymbols_(sym);
       return map;
     }
   }

--- a/lib/java/test-utils/src/main/java/org/enso/test/utils/ContextUtils.java
+++ b/lib/java/test-utils/src/main/java/org/enso/test/utils/ContextUtils.java
@@ -162,7 +162,19 @@ public final class ContextUtils {
       var b = Source.newBuilder("enso", src, name);
       s = b.buildLiteral();
     }
-    var module = ctx.eval(s);
+    return evalModule(ctx, s, methodName);
+  }
+
+  /**
+   * Evaluates the given source as if it was in a module with given name.
+   *
+   * @param ctx context to evaluate the module at
+   * @param src The source code of the module
+   * @param methodName name of main method to invoke
+   * @return The value returned from the main method of the unnamed module.
+   */
+  public static Value evalModule(Context ctx, Source src, String methodName) {
+    var module = ctx.eval(src);
     var assocType = module.invokeMember(Module.GET_ASSOCIATED_TYPE);
     var method = module.invokeMember(Module.GET_METHOD, assocType, methodName);
     return "main".equals(methodName) ? method.execute() : method.execute(assocType);


### PR DESCRIPTION
### Pull Request Description

Fixes #10843 in an even better way then #10906. At the end of work on #10906 it has been found that `AliasAnalysis` is still used for `Hello_World.enso`. Mostly because when loading its `.ir` cache, we cannot resolve its `Standard.Base.IO` import as nobody loaded the `Standard.Base` package into the system yet. This PR fixes the problem by __delaying resolution of `BindingsMap` internals until one of its getters is called__.

At the end `Hello_World` loads its `.ir` caches properly without invoking any `AliasAnalysis` functionality as verified by checking the logs.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
- [x] Benchmarks are improved - [1st run](https://github.com/enso-org/enso/actions/runs/10733289249) - results [are good](https://github.com/enso-org/enso/pull/10996#issuecomment-2333708114)

### Steps to Reproduce

The ultimate way to verify the behavior is in debugger. Place a breakpoint to `Graph.scala:12` - it should get trigger only once when `LocalScope.empty` is being created. Possibly also for the second time when execution is over and #10842 kicks in (this second case can be disabled by using `--repl` for example).

To reproduce from CLI run twice (first run generates the `.ir` cache) and then checks the logs:
```bash
enso$ ./built-distribution/enso-engine-*/enso-*/bin/enso --run test/Benchmarks/src/Startup/Hello_World.enso
enso$ ./built-distribution/enso-engine-*/enso-*/bin/enso --run test/Benchmarks/src/Startup/Hello_World.enso --log-level debug | grep Hello
```
prior to this PR the log contains:
```
[enso.org.enso.interpreter.runtime.SerializationPool] Unable to load a cache for module [Hello_World].
[enso.org.enso.interpreter.runtime.SerializationPool] Deserializing module Hello_World from IR file: false
[enso.org.enso.compiler.Compiler] Loading module [Hello_World] from source.
[enso.org.enso.compiler.Compiler] Generating code for module [Hello_World].
```
with this PR the log contains:
```
[enso.org.enso.compiler.Compiler] Parsing module [Hello_World].
[enso.org.enso.interpreter.runtime.SerializationPool] Restored IR from cache for module [Hello_World] at stage [AFTER_STATIC_PASSES].
[enso.org.enso.interpreter.runtime.SerializationPool] Deserializing module Hello_World from IR file: true
[enso.org.enso.compiler.Compiler] Generating code for module [Hello_World].
```