### PR TITLE
Fix edge cut off in plan select at first

### DIFF
--- a/app/dashboard/src/components/AriaComponents/Text/Text.tsx
+++ b/app/dashboard/src/components/AriaComponents/Text/Text.tsx
@@ -69,6 +69,7 @@ export const TEXT_STYLE = twv.tv({
     },
     transform: {
       none: '',
+      normal: 'normal-case',
       capitalize: 'capitalize',
       lowercase: 'lowercase',
       uppercase: 'uppercase',

--- a/app/dashboard/src/modules/payments/components/PlanSelector/PlanSelector.tsx
+++ b/app/dashboard/src/modules/payments/components/PlanSelector/PlanSelector.tsx
@@ -83,7 +83,7 @@ export function PlanSelector(props: PlanSelectorProps) {
         className: 'w-full snap-x overflow-auto rounded-4xl scroll-hidden',
       })}
     >
-      <div className="inline-flex min-w-full gap-6 p-6">
+      <div className="inline-grid min-w-full grid-cols-1fr gap-6 p-6 md:grid-cols-2 xl:grid-cols-4">
         {PLANS.map((newPlan) => {
           const paywallLevel = getPaywallLevel(newPlan)
           const userPaywallLevel = getPaywallLevel(userPlan)
@@ -96,7 +96,7 @@ export function PlanSelector(props: PlanSelectorProps) {
             return (
               <Card
                 key={newPlan}
-                className="min-w-72 flex-1 snap-center"
+                className="min-w-64 snap-center"
                 features={planProps.features}
                 subtitle={planProps.subtitle}
                 title={planProps.title}

--- a/app/dashboard/src/modules/payments/components/PlanSelector/components/SubscribeButton.tsx
+++ b/app/dashboard/src/modules/payments/components/PlanSelector/components/SubscribeButton.tsx
@@ -69,12 +69,12 @@ export function SubscribeButton(props: SubscribeButtonProps) {
     if (isDowngrade) {
       // eslint-disable-next-line no-restricted-syntax
       return (
-        <>
-          {getText('downgradeInfo')}{' '}
+        <Text transform="none">
           <Button variant="link" href={getSalesEmail() + `?subject=Downgrade%20our%20plan`}>
             {getText('contactSales')}
-          </Button>
-        </>
+          </Button>{' '}
+          {getText('downgradeInfo')}
+        </Text>
       )
     }
 
@@ -99,29 +99,31 @@ export function SubscribeButton(props: SubscribeButtonProps) {
 
   return (
     <div className="w-full text-center">
-      <DialogTrigger
-        {...(disabled ? { defaultOpen: false }
-        : defaultOpen == null ? {}
-        : { defaultOpen })}
-      >
-        <Button fullWidth isDisabled={disabled} variant={variant} size="medium" rounded="full">
-          {buttonText}
-        </Button>
-
-        <PlanSelectorDialog
-          plan={plan}
-          planName={planName}
-          features={features}
-          onSubmit={onSubmit}
-          isTrialing={canTrial}
-          title={getText('upgradeTo', getText(plan))}
-        />
-      </DialogTrigger>
-
       {isDowngrade && (
-        <Text transform="capitalize" className="my-0.5">
+        <Text transform="normal" className="my-0.5">
           {description}
         </Text>
+      )}
+
+      {!isDowngrade && (
+        <DialogTrigger
+          {...(disabled ? { defaultOpen: false }
+          : defaultOpen == null ? {}
+          : { defaultOpen })}
+        >
+          <Button fullWidth isDisabled={disabled} variant={variant} size="medium" rounded="full">
+            {buttonText}
+          </Button>
+
+          <PlanSelectorDialog
+            plan={plan}
+            planName={planName}
+            features={features}
+            onSubmit={onSubmit}
+            isTrialing={canTrial}
+            title={getText('upgradeTo', getText(plan))}
+          />
+        </DialogTrigger>
       )}
     </div>
   )

--- a/app/ide-desktop/common/src/text/english.json
+++ b/app/ide-desktop/common/src/text/english.json
@@ -604,8 +604,7 @@
   "SLSA": "Enso Software License And Services Agreement",
   "slsaLicenseAgreementDescription1": "This Order is governed by the Software License and Service Agreement found at",
   "slsaLicenseAgreementDescription2": ", (the “Agreement”). All capitalized terms used in this Customer Order but not otherwise defined herein shall have the meanings set forth in the Agreement.\n                      Except as expressly provided in the Agreement, Products and Services purchased under this Customer Order are non-cancelable and non-refundable.",
-
-  "downgradeInfo": "Looking for downgrade options?",
+  "downgradeInfo": "to downgrade",
 
   "someAgreementsHaveBeenUpdated": "Some agreements have been updated. Please re-read and agree to continue.",
   "licenseAgreementTitle": "Enso Terms of Service",


### PR DESCRIPTION
### Pull Request Description

- Closes: enso-org/cloud-v2#1454

This PR fixes the Plan selector grid. Also it aligns cards vertically

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
