### PR TITLE
Better error message for unresolved symbol

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/SymbolResolutionTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/SymbolResolutionTest.java
@@ -1,10 +1,17 @@
 package org.enso.interpreter.test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.net.URI;
 import org.enso.common.MethodNames;
+import org.enso.interpreter.runtime.error.PanicException;
+import org.enso.test.utils.ContextUtils;
+import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Source;
 import org.junit.Test;
 
@@ -114,5 +121,28 @@ public class SymbolResolutionTest extends ContextTest {
     var result = module.invokeMember(MethodNames.Module.EVAL_EXPRESSION, "entry_point");
     assertTrue(result.isNumber());
     assertEquals(44, result.asInt());
+  }
+
+  // https://github.com/enso-org/enso/issues/10748
+  @Test
+  public void unresolvedSymbolErrorMessage() {
+    var code =
+        """
+        type My_Type
+            static_method = 23
+
+        main =
+            static_method
+        """;
+    try (var ctx = ContextUtils.createDefaultContext()) {
+      try {
+        var res = ContextUtils.evalModule(ctx, code);
+        fail("Should throw exception. Instead got: " + res);
+      } catch (PolyglotException ex) {
+        var panic = (PanicException) ContextUtils.unwrapValue(ctx, ex.getGuestObject());
+        var errMsg = panic.getPayload().toString();
+        assertThat(errMsg, allOf(containsString("The name"), containsString("could not be found")));
+      }
+    }
   }
 }

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/GlobalNamesTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/GlobalNamesTest.scala
@@ -232,5 +232,27 @@ class GlobalNamesTest extends CompilerTest {
       }
       unresolved.map(_.name) shouldEqual List("here")
     }
+
+    "should be detected when trying to use static method without type" in {
+      implicit val ctx: ModuleContext = mkModuleContext._1
+
+      val ir =
+        """
+          |type My_Type
+          |    static_method = 23
+          |main =
+          |    static_method
+          |""".stripMargin.preprocessModule.analyse
+
+      val unresolved = ir.preorder.collect {
+        case errors.Resolution(
+              name,
+              _: errors.Resolution.ResolverError,
+              _
+            ) =>
+          name
+      }
+      unresolved.map(_.name) shouldEqual List("static_method")
+    }
   }
 }

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/GlobalNamesTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/GlobalNamesTest.scala
@@ -2,6 +2,7 @@ package org.enso.compiler.test.pass.resolve
 
 import org.enso.compiler.Passes
 import org.enso.compiler.context.{FreshNameSupply, ModuleContext}
+import org.enso.compiler.core.IR
 import org.enso.compiler.core.Implicits.AsMetadata
 import org.enso.compiler.core.ir.Expression
 import org.enso.compiler.core.ir.Function
@@ -187,6 +188,35 @@ class GlobalNamesTest extends CompilerTest {
         Resolution(ResolvedModule(ctx.moduleReference()))
       )
     }
+
+    "resolve type in static method call" in {
+      implicit val ctx: ModuleContext = mkModuleContext._1
+      val ir =
+        """
+          |type My_Type
+          |    method x = x
+          |
+          |main =
+          |    My_Type.method 42
+          |""".stripMargin.preprocessModule.analyse
+      val allGlobNames = collectAllGlobalNames(ir)
+      allGlobNames shouldNot be(null)
+      allGlobNames.size shouldBe 1
+      allGlobNames.head._1 shouldBe a[Name.Literal]
+      allGlobNames.head._1.asInstanceOf[Name.Literal].name shouldEqual "My_Type"
+      allGlobNames.head._2.target.qualifiedName.item shouldEqual "My_Type"
+    }
+  }
+
+  private def collectAllGlobalNames(
+    moduleIr: Module
+  ): Seq[(IR, Resolution)] = {
+    moduleIr
+      .preorder()
+      .collect { case ir: IR =>
+        ir.getMetadata(GlobalNames).map((ir, _))
+      }
+      .flatten
   }
 
   "Undefined names" should {

--- a/test/AWS_Tests/src/Redshift_Spec.enso
+++ b/test/AWS_Tests/src/Redshift_Spec.enso
@@ -36,7 +36,7 @@ type Data
     teardown self = self.connection.close
 
 
-add_redshift_specific_specs suite_builder create_connection_fn =
+add_redshift_specific_specs suite_builder create_connection_fn setup =
     suite_builder.group "[Redshift] Info" group_builder->
         data = Data.setup create_connection_fn
 
@@ -74,7 +74,6 @@ add_database_specs suite_builder create_connection_fn =
     materialize = .read
 
     Common_Spec.add_specs suite_builder prefix create_connection_fn default_connection
-    add_redshift_specific_specs suite_builder create_connection_fn
 
     common_selection = Common_Table_Operations.Main.Test_Selection.Config supports_case_sensitive_columns=True order_by_unicode_normalization_by_default=True allows_mixed_type_comparisons=False supports_decimal_type=True run_advanced_edge_case_tests_by_default=False
     aggregate_selection = Common_Table_Operations.Aggregate_Spec.Test_Selection.Config first_last_row_order=False aggregation_problems=False date_support=False
@@ -86,6 +85,7 @@ add_database_specs suite_builder create_connection_fn =
         (agg_in_memory_table.take (..First 0)).select_into_database_table default_connection.get (Name_Generator.random_name "Agg_Empty") primary_key=Nothing temporary=True
 
     setup = Common_Table_Operations.Main.Test_Setup.Config prefix agg_table_fn empty_agg_table_fn table_builder materialize is_database=True test_selection=common_selection aggregate_test_selection=aggregate_selection create_connection_func=create_connection_fn light_table_builder=light_table_builder
+    add_redshift_specific_specs suite_builder create_connection_fn setup
     Common_Table_Operations.Main.add_specs suite_builder setup
     IR_Spec.add_specs suite_builder setup prefix default_connection.get
 


### PR DESCRIPTION
Fixes #10748

### Pull Request Description

In the similar case to
```
from Standard.Base import all

type My_Type
    Value x
    static_method = 23

main =
    IO.println static_method
```

catches the unresolved symbol error during the compilation, rather than inside `TruffleToIr`. The old behavior recognizes this error inside `TruffleToIr` and fails with a cryptic error message. This PR recognizes this error inside `GlobalNames` compiler pass and throws a readable compiler error.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
