### PR TITLE
Enabling structural equality for MetadataStorage again

### DIFF
--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/core/ir/MetadataStorageTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/core/ir/MetadataStorageTest.scala
@@ -6,6 +6,7 @@ import org.enso.compiler.core.ir.Module
 import org.enso.compiler.core.ir.MetadataStorage
 import org.enso.compiler.core.ir.MetadataStorage._
 import org.enso.compiler.pass.IRPass
+import org.enso.compiler.core.ir.ProcessingPass
 import org.enso.compiler.test.CompilerTest
 import shapeless.test.illTyped
 import scala.jdk.CollectionConverters._
@@ -81,6 +82,20 @@ class MetadataStorageTest extends CompilerTest {
   // === The Tests ============================================================
 
   "The metadata storage" should {
+    "two storages are equal when storages are equal" in {
+      val s1 = new java.util.HashMap[ProcessingPass, ProcessingPass.Metadata]()
+      val s2 = new java.util.HashMap[ProcessingPass, ProcessingPass.Metadata]()
+
+      val m1 = new MetadataStorage(s1)
+      val m2 = new MetadataStorage(s2)
+
+      m1 shouldEqual m2
+
+      s1.put(null, null)
+
+      m1 shouldNot equal(m2)
+    }
+
     "allow adding metadata pairs" in {
       val meta = new MetadataStorage()
 
@@ -159,7 +174,7 @@ class MetadataStorageTest extends CompilerTest {
       meta1.update(TestPass1, meta)
       meta2.update(TestPass1, meta)
 
-      meta1 shouldNot equal(meta2)
+      meta1 shouldEqual meta2
     }
 
     def newMetadataStorage(init: Seq[MetadataPair[_]]): MetadataStorage = {
@@ -201,8 +216,8 @@ class MetadataStorageTest extends CompilerTest {
         )
       )
 
-      meta.duplicate shouldNot equal(meta)
-      meta.duplicate shouldNot equal(expected)
+      meta.duplicate shouldEqual meta
+      meta.duplicate shouldEqual expected
     }
 
     "enforce safe construction" in {

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/MetadataStorage.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/MetadataStorage.java
@@ -214,7 +214,7 @@ public final class MetadataStorage {
       return true;
     }
     if (obj instanceof MetadataStorage other) {
-      return this.metadata == other.metadata;
+      return Objects.equals(this.metadata, other.metadata);
     }
     return false;
   }

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/CallArgument.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/CallArgument.scala
@@ -72,8 +72,8 @@ object CallArgument {
         name != this.name
         || value != this.value
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Specified(name, value, location, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/DefinitionArgument.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/DefinitionArgument.scala
@@ -124,8 +124,8 @@ object DefinitionArgument {
         || defaultValue != this.defaultValue
         || suspended != this.suspended
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Specified(

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Empty.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Empty.scala
@@ -35,8 +35,8 @@ sealed case class Empty(
   ): Empty = {
     if (
       location != this.location
-      || passData != this.passData
-      || diagnostics != this.diagnostics
+      || (passData ne this.passData)
+      || (diagnostics ne this.diagnostics)
       || id != this.id
     ) {
       val res = Empty(location, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Expression.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Expression.scala
@@ -90,8 +90,8 @@ object Expression {
         || returnValue != this.returnValue
         || suspended != this.suspended
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Block(
@@ -231,8 +231,8 @@ object Expression {
         name != this.name
         || expression != this.expression
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Binding(name, expression, location, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Function.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Function.scala
@@ -118,8 +118,8 @@ object Function {
         || body != this.body
         || location != this.location
         || canBeTCO != this.canBeTCO
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res =
@@ -284,8 +284,8 @@ object Function {
         || isPrivate != this.isPrivate
         || location != this.location
         || canBeTCO != this.canBeTCO
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res =

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Literal.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Literal.scala
@@ -65,8 +65,8 @@ object Literal {
         base != this.base
         || value != this.value
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Number(base, value, location, passData)
@@ -197,8 +197,8 @@ object Literal {
       if (
         text != this.text
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Text(text, location, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Module.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Module.scala
@@ -80,8 +80,8 @@ final case class Module(
       || bindings != this.bindings
       || isPrivate != this.isPrivate
       || location != this.location
-      || passData != this.passData
-      || diagnostics != this.diagnostics
+      || (passData ne this.passData)
+      || (diagnostics ne this.diagnostics)
       || id != this.id
     ) {
       val res =

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Name.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Name.scala
@@ -76,8 +76,8 @@ object Name {
         typePointer != this.typePointer
         || methodName != this.methodName
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res =
@@ -246,8 +246,8 @@ object Name {
       if (
         parts != this.parts
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Qualified(parts, location, passData)
@@ -317,8 +317,8 @@ object Name {
     ): Blank = {
       if (
         location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Blank(location, passData)
@@ -399,8 +399,8 @@ object Name {
       if (
         specialName != this.specialName
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Special(specialName, location, passData)
@@ -505,8 +505,8 @@ object Name {
         || isMethod != this.isMethod
         || location != this.location
         || originalName != this.originalName
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Literal(name, isMethod, location, originalName, passData)
@@ -614,8 +614,8 @@ object Name {
       if (
         name != this.name
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = BuiltinAnnotation(name, location, passData)
@@ -709,8 +709,8 @@ object Name {
         name != this.name
         || expression != this.expression
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res =
@@ -820,8 +820,8 @@ object Name {
       if (
         synthetic != this.synthetic
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Self(location, synthetic, passData)
@@ -919,8 +919,8 @@ object Name {
     ): SelfType = {
       if (
         location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = SelfType(location, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Pattern.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Pattern.scala
@@ -66,8 +66,8 @@ object Pattern {
       if (
         name != this.name
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Name(name, location, passData)
@@ -169,8 +169,8 @@ object Pattern {
         constructor != this.constructor
         || fields != this.fields
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Constructor(constructor, fields, location, passData)
@@ -324,8 +324,8 @@ object Pattern {
       if (
         literal != this.literal
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Literal(literal, location, passData)
@@ -429,8 +429,8 @@ object Pattern {
         name != this.name
         || tpe != this.tpe
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Type(name, tpe, location, passData)
@@ -549,8 +549,8 @@ object Pattern {
       if (
         doc != this.doc
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Documentation(doc, location, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Type.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Type.scala
@@ -54,8 +54,8 @@ object Type {
         args != this.args
         || result != this.result
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Function(args, result, location, passData)
@@ -171,8 +171,8 @@ object Type {
         || signature != this.signature
         || comment != this.comment
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Ascription(typed, signature, comment, location, passData)
@@ -286,8 +286,8 @@ object Type {
         typed != this.typed
         || context != this.context
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Context(typed, context, location, passData)
@@ -398,8 +398,8 @@ object Type {
         typed != this.typed
         || error != this.error
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Error(typed, error, location, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/Application.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/Application.scala
@@ -86,8 +86,8 @@ object Application {
         || arguments != this.arguments
         || hasDefaultsSuspended != this.hasDefaultsSuspended
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res =
@@ -203,8 +203,8 @@ object Application {
       if (
         target != this.target
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Force(target, location, passData)
@@ -327,8 +327,8 @@ object Application {
       if (
         expression != this.expression
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Typeset(expression, location, passData)
@@ -430,8 +430,8 @@ object Application {
       if (
         items != this.items
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Sequence(items, location, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/Case.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/Case.scala
@@ -73,8 +73,8 @@ object Case {
         || branches != this.branches
         || isNested != this.isNested
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Expr(scrutinee, branches, isNested, location, passData)
@@ -200,8 +200,8 @@ object Case {
         || expression != this.expression
         || terminalBranch != this.terminalBranch
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Branch(

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/Comment.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/Comment.scala
@@ -62,8 +62,8 @@ object Comment {
       if (
         doc != this.doc
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Documentation(doc, location, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/Error.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/Error.scala
@@ -59,8 +59,8 @@ object Error {
     ): InvalidIR = {
       if (
         ir != this.ir
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = InvalidIR(ir, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/Foreign.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/Foreign.scala
@@ -70,8 +70,8 @@ object Foreign {
         lang != this.lang
         || code != this.code
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Definition(lang, code, location, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/Operator.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/Operator.scala
@@ -72,8 +72,8 @@ object Operator {
         || operator != this.operator
         || right != this.right
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Binary(left, operator, right, location, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/Section.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/Section.scala
@@ -67,8 +67,8 @@ object Section {
         arg != this.arg
         || operator != this.operator
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Left(arg, operator, location, passData)
@@ -174,8 +174,8 @@ object Section {
       if (
         operator != this.operator
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Sides(operator, location, passData)
@@ -277,8 +277,8 @@ object Section {
         operator != this.operator
         || arg != this.arg
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Right(operator, arg, location, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Conversion.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Conversion.scala
@@ -55,8 +55,8 @@ sealed case class Conversion(
     if (
       storedIr != this.storedIr
       || reason != this.reason
-      || passData != this.passData
-      || diagnostics != this.diagnostics
+      || (passData ne this.passData)
+      || (diagnostics ne this.diagnostics)
       || id != this.id
     ) {
       val res = Conversion(storedIr, reason, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/ImportExport.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/ImportExport.scala
@@ -62,8 +62,8 @@ sealed case class ImportExport(
     if (
       ir != this.ir
       || reason != this.reason
-      || passData != this.passData
-      || diagnostics != this.diagnostics
+      || (passData ne this.passData)
+      || (diagnostics ne this.diagnostics)
       || id != this.id
     ) {
       val res = ImportExport(ir, reason, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Pattern.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Pattern.scala
@@ -67,8 +67,8 @@ sealed case class Pattern(
     if (
       originalPattern != this.originalPattern
       || reason != this.reason
-      || passData != this.passData
-      || diagnostics != this.diagnostics
+      || (passData ne this.passData)
+      || (diagnostics ne this.diagnostics)
       || id != this.id
     ) {
       val res = Pattern(originalPattern, reason, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Redefined.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Redefined.scala
@@ -62,8 +62,8 @@ object Redefined {
     ): SelfArg = {
       if (
         location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = SelfArg(location, passData)
@@ -159,8 +159,8 @@ object Redefined {
         targetType != this.targetType
         || sourceType != this.sourceType
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Conversion(targetType, sourceType, location, passData)
@@ -289,8 +289,8 @@ object Redefined {
         typeName != this.typeName
         || methodName != this.methodName
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Method(typeName, methodName, location, passData)
@@ -419,8 +419,8 @@ object Redefined {
         atomName != this.atomName
         || methodName != this.methodName
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = MethodClashWithAtom(
@@ -542,8 +542,8 @@ object Redefined {
       if (
         typeName != this.typeName
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Type(typeName, location, passData)
@@ -649,8 +649,8 @@ object Redefined {
       if (
         name != this.name
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Arg(name, location, passData)
@@ -750,8 +750,8 @@ object Redefined {
     ): Binding = {
       if (
         invalidBinding != this.invalidBinding
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Binding(invalidBinding, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Resolution.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Resolution.scala
@@ -71,8 +71,8 @@ sealed case class Resolution(
     if (
       originalName != this.originalName
       || reason != this.reason
-      || passData != this.passData
-      || diagnostics != this.diagnostics
+      || (passData ne this.passData)
+      || (diagnostics ne this.diagnostics)
       || id != this.id
     ) {
       val res = Resolution(originalName, reason, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Syntax.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Syntax.scala
@@ -63,8 +63,8 @@ sealed case class Syntax(
     if (
       at != this.at
       || reason != this.reason
-      || passData != this.passData
-      || diagnostics != this.diagnostics
+      || (passData ne this.passData)
+      || (diagnostics ne this.diagnostics)
       || id != this.id
     ) {
       val res = Syntax(at, reason, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Unexpected.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/expression/errors/Unexpected.scala
@@ -75,8 +75,8 @@ object Unexpected {
     ): TypeSignature = {
       if (
         ir != this.ir
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = TypeSignature(ir, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/module/scope/Definition.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/module/scope/Definition.scala
@@ -78,8 +78,8 @@ object Definition {
         || params != this.params
         || members != this.members
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Type(name, params, members, location, passData)
@@ -206,8 +206,8 @@ object Definition {
         || annotations != this.annotations
         || isPrivate != this.isPrivate
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Data(
@@ -338,8 +338,8 @@ object Definition {
         || arguments != this.arguments
         || body != this.body
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = SugaredType(

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/module/scope/Export.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/module/scope/Export.scala
@@ -88,8 +88,8 @@ object Export {
         || onlyNames != this.onlyNames
         || isSynthetic != this.isSynthetic
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Module(

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/module/scope/Import.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/module/scope/Import.scala
@@ -97,8 +97,8 @@ object Import {
         || hiddenNames != this.hiddenNames
         || isSynthetic != this.isSynthetic
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Module(

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/module/scope/definition/Method.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/module/scope/definition/Method.scala
@@ -115,8 +115,8 @@ object Method {
         || isPrivate != this.isPrivate
         || isStaticWrapperForInstanceMethod != this.isStaticWrapperForInstanceMethod
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Explicit(
@@ -322,8 +322,8 @@ object Method {
         || isPrivate != this.isPrivate
         || body != this.body
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Binding(
@@ -490,8 +490,8 @@ object Method {
         || sourceTypeName != this.sourceTypeName
         || body != this.body
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Conversion(

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/module/scope/imports/Polyglot.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/module/scope/imports/Polyglot.scala
@@ -55,8 +55,8 @@ sealed case class Polyglot(
       entity != this.entity
       || rename != this.rename
       || location != this.location
-      || passData != this.passData
-      || diagnostics != this.diagnostics
+      || (passData ne this.passData)
+      || (diagnostics ne this.diagnostics)
       || id != this.id
     ) {
       val res = Polyglot(entity, rename, location, passData)

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/type/Set.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/type/Set.scala
@@ -74,8 +74,8 @@ object Set {
         || memberType != this.memberType
         || value != this.value
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Member(label, memberType, value, location, passData)
@@ -202,8 +202,8 @@ object Set {
         left != this.left
         || right != this.right
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Subsumption(left, right, location, passData)
@@ -315,8 +315,8 @@ object Set {
         left != this.left
         || right != this.right
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Equality(left, right, location, passData)
@@ -428,8 +428,8 @@ object Set {
         left != this.left
         || right != this.right
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Concat(left, right, location, passData)
@@ -535,8 +535,8 @@ object Set {
       if (
         operands != this.operands
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Union(operands, location, passData)
@@ -642,8 +642,8 @@ object Set {
         left != this.left
         || right != this.right
         || location != this.location
-        || passData != this.passData
-        || diagnostics != this.diagnostics
+        || (passData ne this.passData)
+        || (diagnostics ne this.diagnostics)
         || id != this.id
       ) {
         val res = Intersection(left, right, location, passData)

--- a/engine/runtime-parser/src/test/java/org/enso/compiler/core/IrPersistanceTest.java
+++ b/engine/runtime-parser/src/test/java/org/enso/compiler/core/IrPersistanceTest.java
@@ -330,6 +330,31 @@ public class IrPersistanceTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
+  public void hashMapLazyEquality() throws Exception {
+    var s1 = new LazyString("Hello");
+    var s2 = new LazyString("World");
+    var map = new HashMap<String, LazyString>();
+    map.put("Hello", s1);
+    map.put("World", s2);
+
+    var doubleMap = java.util.List.of(map, map);
+
+    LazyString.forbidden = true;
+    var out = serde(java.util.List.class, doubleMap, -1);
+
+    var m1 = out.get(0);
+    var m2 = out.get(1);
+
+    assertTrue("Not same: ", m1 != m2);
+    assertTrue("But equal", m1.equals(m2));
+    LazyString.forbidden = false;
+
+    assertEquals("Content equal", map, m1);
+    assertEquals("Content equal", m2, map);
+  }
+
+  @Test
   public void inlineReferenceIsLazy() throws Exception {
     var s1 = new LazyString("Hello");
     var in = new InlineReferenceHolder(Persistance.Reference.of(s1, false));

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerBufferReference.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerBufferReference.java
@@ -1,6 +1,7 @@
 package org.enso.persist;
 
 import java.io.IOException;
+import java.util.Objects;
 import org.enso.persist.PerInputImpl.InputCache;
 import org.enso.persist.Persistance.Reference;
 
@@ -63,5 +64,35 @@ final class PerBufferReference<T> extends Persistance.Reference<T> {
 
   static <V> Reference<V> cached(Persistance<V> p, InputCache buffer, int offset) {
     return new PerBufferReference<>(p, buffer, offset, true);
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 5;
+    hash = 97 * hash + Objects.hashCode(this.p);
+    hash = 97 * hash + Objects.hashCode(this.cache);
+    hash = 97 * hash + this.offset;
+    return hash;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    final PerBufferReference<?> other = (PerBufferReference<?>) obj;
+    if (this.offset != other.offset) {
+      return false;
+    }
+    if (!Objects.equals(this.p, other.p)) {
+      return false;
+    }
+    return Objects.equals(this.cache, other.cache);
   }
 }

--- a/lib/java/persistance/src/main/java/org/enso/persist/PerMemoryReference.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerMemoryReference.java
@@ -1,5 +1,7 @@
 package org.enso.persist;
 
+import java.util.Objects;
+
 sealed class PerMemoryReference<T> extends Persistance.Reference<T>
     permits PerMemoryReference.Deferred {
   static final Persistance.Reference<?> NULL = new PerMemoryReference<>(null);
@@ -16,6 +18,28 @@ sealed class PerMemoryReference<T> extends Persistance.Reference<T>
   @Override
   boolean isDeferredWrite() {
     return Deferred.class == getClass();
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 5;
+    hash = 31 * hash + Objects.hashCode(this.value);
+    return hash;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    final PerMemoryReference<?> other = (PerMemoryReference<?>) obj;
+    return Objects.equals(this.value, other.value);
   }
 
   static final class Deferred<T> extends PerMemoryReference<T> {


### PR DESCRIPTION
### Pull Request Description

Fixes #10985 and #11004 by enabling structural equality for `MetadataStorage` again. 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
