### PR TITLE
Fix initialization after reconnecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   updated actual code][10857]
 - [Added fullscreen modes to documentation editor and code editor][10876]
 - [Fixed issue with node name assignment when uploading multiple files.][10979]
+- [Fixed issue where drag'n'dropped files were not uploaded in cloud
+  projects.][11014]
 
 [10774]: https://github.com/enso-org/enso/pull/10774
 [10814]: https://github.com/enso-org/enso/pull/10814
@@ -21,6 +23,7 @@
 [10857]: https://github.com/enso-org/enso/pull/10857
 [10876]: https://github.com/enso-org/enso/pull/10876
 [10979]: https://github.com/enso-org/enso/pull/10979
+[11014]: https://github.com/enso-org/enso/pull/11014
 
 #### Enso Standard Library
 

--- a/app/gui2/src/util/net.ts
+++ b/app/gui2/src/util/net.ts
@@ -8,12 +8,17 @@ import {
 
 export { AbortScope, MockWebSocketTransport }
 
+const WS_OPTIONS = {
+  // We do not want to enqueue any messages, because after reconnecting we have to initProtocol again.
+  maxEnqueuedMessages: 0,
+}
+
 export function createRpcTransport(url: string): ReconnectingWebSocketTransport {
   if (url.startsWith('mock://')) {
     const mockName = url.slice('mock://'.length)
     return new MockWebSocketTransport(mockName)
   } else {
-    const transport = new ReconnectingWebSocketTransport(url)
+    const transport = new ReconnectingWebSocketTransport(url, WS_OPTIONS)
     return transport
   }
 }
@@ -24,7 +29,7 @@ export function createDataWebsocket(url: string, binaryType: 'arraybuffer' | 'bl
     mockWs.binaryType = binaryType
     return mockWs
   } else {
-    const websocket = new ReconnectingWebSocket(url, undefined, { maxEnqueuedMessages: 0 })
+    const websocket = new ReconnectingWebSocket(url, undefined, WS_OPTIONS)
     websocket.binaryType = binaryType
     return websocket as WebSocket
   }

--- a/app/gui2/src/util/net.ts
+++ b/app/gui2/src/util/net.ts
@@ -24,7 +24,7 @@ export function createDataWebsocket(url: string, binaryType: 'arraybuffer' | 'bl
     mockWs.binaryType = binaryType
     return mockWs
   } else {
-    const websocket = new ReconnectingWebSocket(url)
+    const websocket = new ReconnectingWebSocket(url, undefined, { maxEnqueuedMessages: 0 })
     websocket.binaryType = binaryType
     return websocket as WebSocket
   }

--- a/app/gui2/src/util/net/dataServer.ts
+++ b/app/gui2/src/util/net/dataServer.ts
@@ -99,7 +99,7 @@ export class DataServer extends ObservableV2<DataServerEvents> {
     })
 
     if (websocket.readyState === WebSocket.OPEN) this.initialized = this.initialize()
-    else this.scheduleInitializationAfterConnect()
+    else this.initialized = this.scheduleInitializationAfterConnect()
   }
 
   dispose() {

--- a/app/gui2/src/util/net/dataServer.ts
+++ b/app/gui2/src/util/net/dataServer.ts
@@ -98,7 +98,8 @@ export class DataServer extends ObservableV2<DataServerEvents> {
       this.scheduleInitializationAfterConnect()
     })
 
-    this.initialized = this.initialize()
+    if (websocket.readyState === WebSocket.OPEN) this.initialized = this.initialize()
+    else this.scheduleInitializationAfterConnect()
   }
 
   dispose() {

--- a/app/ydoc-shared/src/util/net/ReconnectingWSTransport.ts
+++ b/app/ydoc-shared/src/util/net/ReconnectingWSTransport.ts
@@ -23,7 +23,10 @@ export class ReconnectingWebSocketTransport extends WebSocketTransport {
   constructor(uri: string) {
     super(uri)
     this.uri = uri
-    this._reconnectingConnection = new WebSocket(uri, undefined, { WebSocket: WS })
+    this._reconnectingConnection = new WebSocket(uri, undefined, {
+      WebSocket: WS,
+      maxEnqueuedMessages: 0,
+    })
     // Make sure that the WebSocketTransport implementation uses this version of socket.
     this.connection = this._reconnectingConnection as any
   }

--- a/app/ydoc-shared/src/util/net/ReconnectingWSTransport.ts
+++ b/app/ydoc-shared/src/util/net/ReconnectingWSTransport.ts
@@ -7,7 +7,7 @@
 import { WebSocketTransport } from '@open-rpc/client-js'
 import WS from 'isomorphic-ws'
 import { WebSocket } from 'partysocket'
-import ReconnectingWebSocket, { type WebSocketEventMap } from 'partysocket/ws'
+import ReconnectingWebSocket, { Options, type WebSocketEventMap } from 'partysocket/ws'
 
 export { ReconnectingWebSocket }
 
@@ -20,12 +20,12 @@ export interface AddEventListenerOptions {
 
 export class ReconnectingWebSocketTransport extends WebSocketTransport {
   private _reconnectingConnection: ReconnectingWebSocket
-  constructor(uri: string) {
+  constructor(uri: string, wsOptions: Options = {}) {
     super(uri)
     this.uri = uri
     this._reconnectingConnection = new WebSocket(uri, undefined, {
       WebSocket: WS,
-      maxEnqueuedMessages: 0,
+      ...wsOptions,
     })
     // Make sure that the WebSocketTransport implementation uses this version of socket.
     this.connection = this._reconnectingConnection as any


### PR DESCRIPTION
### Pull Request Description

Fixes #10948

The problem was in the binary reconnecting: we sent the first "initProtocol" message, but the connection was reset, and then we try to initialize again. While looking good, the problem was that the party websocket we use queued the first initProtocol message and re-send it by itself on reconnect. Our initProtocol was also sent, but it did not get any response, blocking any further request like `writeBytes`.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
