### PR TITLE
Disable check for equals when two objects collide

### DIFF
--- a/lib/java/persistance/src/main/java/org/enso/persist/PerInputImpl.java
+++ b/lib/java/persistance/src/main/java/org/enso/persist/PerInputImpl.java
@@ -217,22 +217,7 @@ final class PerInputImpl implements Input {
     var inData = new PerInputImpl(cache, at);
     var res = p.readWith(inData);
     res = cache.resolveObject(res);
-    var prev = cache.putObjectAt(at, res);
-    if (prev != null) {
-      var bothObjectsAreTheSame = Objects.equals(res, prev);
-      var sb = new StringBuilder();
-      sb.append("Adding at ").append(at).append(" object:\n  ");
-      dumpObject(sb, res);
-      sb.append("\nbut there already is:\n  ");
-      dumpObject(sb, prev);
-      sb.append("\nare they equal: ").append(bothObjectsAreTheSame);
-      var ex = new IOException(sb.toString());
-      if (bothObjectsAreTheSame) {
-        PerUtils.LOG.warn(sb.toString(), ex);
-      } else {
-        throw raise(RuntimeException.class, ex);
-      }
-    }
+    cache.putObjectAt(at, res);
     return res;
   }
 


### PR DESCRIPTION
### Pull Request Description

The check for two `IR` objects to _are they equal_ is broken right now. Let's disable it altogether for the August release.


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
