### PR TITLE
Disable IR caching (again)

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -324,7 +324,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
     .logLevel(logLevel)
     .strictErrors(false)
     .disableLinting(false)
-    .enableIrCaches(true)
+    .enableIrCaches(false) // Enable once #11022 is addressed
     .out(stdOut)
     .err(stdErr)
     .in(stdIn)


### PR DESCRIPTION
### Pull Request Description

In light of more problems that IR caching revealed it makes sense to have a stable but slower platform.

### Important Notes

Temporary workaround for #11022 
