### PR TITLE
Re-compile module if IdMap is present

### DIFF
--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -25,11 +25,7 @@ import org.enso.compiler.core.EnsoParser
 import org.enso.compiler.data.CompilerConfig
 import org.enso.compiler.pass.PassManager
 import org.enso.compiler.pass.analyse._
-import org.enso.compiler.phase.{
-  IdMapProcessor,
-  ImportResolver,
-  ImportResolverAlgorithm
-}
+import org.enso.compiler.phase.{ImportResolver, ImportResolverAlgorithm}
 import org.enso.editions.LibraryName
 import org.enso.pkg.QualifiedName
 import org.enso.common.CompilationStage
@@ -562,24 +558,11 @@ class Compiler(
     )
     context.updateModule(module, _.resetScope())
 
-    if (useCaches) {
-      if (context.deserializeModule(this, module)) {
-        val updatedIr =
-          IdMapProcessor.updateIr(
-            context.getIr(module),
-            context.getIdMap(module)
-          )
-        if (updatedIr != null) {
-          context.updateModule(
-            module,
-            u => {
-              u.ir(updatedIr)
-              u.compilationStage(CompilationStage.AFTER_STATIC_PASSES)
-            }
-          )
-        }
-        return
-      }
+    if (
+      useCaches && context.getIdMap(module) == null && context
+        .deserializeModule(this, module)
+    ) {
+      return
     }
 
     uncachedParseModule(module, isGenDocs)


### PR DESCRIPTION
### Pull Request Description

Loading IR caches and IdMap for a module don't play very well. Rather than complicating logic and introducing yet another re-compilation request let's not even attempt to deserialize a module if IdMap is present. The cost of compiling a single module (right now containing the project itself) is negligble, compared to a possibility of bugs that we've encountered so far.


### Important Notes

Closes #11020 and renders #11024 obsolete.
Note that the deserialized module would need to re-run passes from DataflowAnalysis, at least; cache invalidation, which is where the problem originates from, depends on up-to-date metadata.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
