### PR TITLE
Remove pool of FileManager actors

### DIFF
--- a/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/boot/MainModule.scala
@@ -222,7 +222,7 @@ class MainModule(serverConfig: LanguageServerConfig, logLevel: Level) {
     new ContentRootManagerWrapper(languageServerConfig, contentRootManagerActor)
 
   lazy val fileManager = system.actorOf(
-    FileManager.pool(
+    FileManager.props(
       languageServerConfig.fileManager,
       contentRootManagerWrapper,
       fileSystem,

--- a/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/FileManager.scala
+++ b/engine/language-server/src/main/scala/org/enso/languageserver/filemanager/FileManager.scala
@@ -2,7 +2,6 @@ package org.enso.languageserver.filemanager
 
 import akka.actor.{Actor, Props}
 import akka.pattern.pipe
-import akka.routing.SmallestMailboxPool
 import com.typesafe.scalalogging.LazyLogging
 import org.enso.languageserver.data.FileManagerConfig
 import org.enso.languageserver.effect._
@@ -323,13 +322,4 @@ object FileManager {
     exec: Exec[BlockingIO]
   ): Props =
     Props(new FileManager(config, contentRootManager, fs, exec))
-
-  def pool(
-    config: FileManagerConfig,
-    contentRootManager: ContentRootManager,
-    fs: FileSystem,
-    exec: Exec[BlockingIO]
-  ): Props =
-    SmallestMailboxPool(config.parallelism)
-      .props(props(config, contentRootManager, fs, exec))
 }


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #10970 

Changelog:
- remove: FileManager actors pool

Language Server executes IO on a separate thread pool for blocking operations and does not block the actor

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
