### PR TITLE
Fix cached method pointers in expression updates

### DIFF
--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeErrorsTest.scala
@@ -925,16 +925,7 @@ class RuntimeErrorsTest
       TestMessages.update(
         contextId,
         xId,
-        ConstantsGen.INTEGER,
-        methodCall = Some(
-          Api.MethodCall(
-            Api.MethodPointer(
-              "Standard.Base.Error",
-              "Standard.Base.Error.Error",
-              "throw"
-            )
-          )
-        )
+        ConstantsGen.INTEGER
       ),
       TestMessages.update(
         contextId,

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeServerTest.scala
@@ -1160,6 +1160,127 @@ class RuntimeServerTest
     )
   }
 
+  it should "send method pointer updates of when autoscope constructor changes to a value" in {
+    val contextId  = UUID.randomUUID()
+    val requestId  = UUID.randomUUID()
+    val moduleName = "Enso_Test.Test.Main"
+
+    val metadata = new Metadata
+    val idA      = metadata.addItem(44, 3, "aa")
+
+    val code =
+      """type Xyz
+        |
+        |type T
+        |    A
+        |
+        |main =
+        |    a = test Xyz
+        |    a
+        |
+        |test t:(Xyz | T) = t
+        |""".stripMargin.linesIterator.mkString("\n")
+    val contents = metadata.appendToCode(code)
+    val mainFile = context.writeMain(contents)
+
+    metadata.assertInCode(idA, code, "Xyz")
+
+    // create context
+    context.send(Api.Request(requestId, Api.CreateContextRequest(contextId)))
+    context.receive shouldEqual Some(
+      Api.Response(requestId, Api.CreateContextResponse(contextId))
+    )
+
+    // open file
+    context.send(
+      Api.Request(requestId, Api.OpenFileRequest(mainFile, contents))
+    )
+    context.receive shouldEqual Some(
+      Api.Response(Some(requestId), Api.OpenFileResponse)
+    )
+
+    // push main
+    context.send(
+      Api.Request(
+        requestId,
+        Api.PushContextRequest(
+          contextId,
+          Api.StackItem.ExplicitCall(
+            Api.MethodPointer(moduleName, moduleName, "main"),
+            None,
+            Vector()
+          )
+        )
+      )
+    )
+    context.receiveN(3) should contain theSameElementsAs Seq(
+      Api.Response(requestId, Api.PushContextResponse(contextId)),
+      TestMessages.update(
+        contextId,
+        idA,
+        "Enso_Test.Test.Main.Xyz"
+      ),
+      context.executionComplete(contextId)
+    )
+
+    // Modify the file /Xyz/..A/
+    context.send(
+      Api.Request(
+        Api.EditFileNotification(
+          mainFile,
+          Seq(
+            model.TextEdit(
+              model.Range(model.Position(6, 13), model.Position(6, 16)),
+              "..A"
+            )
+          ),
+          execute = true,
+          idMap   = None
+        )
+      )
+    )
+
+    context.receiveN(3) should contain theSameElementsAs Seq(
+      TestMessages.pending(contextId, idA),
+      TestMessages.update(
+        contextId,
+        idA,
+        "Enso_Test.Test.Main.T",
+        Api.MethodCall(
+          Api.MethodPointer("Enso_Test.Test.Main", "Enso_Test.Test.Main.T", "A")
+        )
+      ),
+      context.executionComplete(contextId)
+    )
+
+    // Modify the file /..A/Xyz/
+    context.send(
+      Api.Request(
+        Api.EditFileNotification(
+          mainFile,
+          Seq(
+            model.TextEdit(
+              model.Range(model.Position(6, 13), model.Position(6, 16)),
+              "Xyz"
+            )
+          ),
+          execute = true,
+          idMap   = None
+        )
+      )
+    )
+
+    context.receiveN(3) should contain theSameElementsAs Seq(
+      TestMessages.pending(contextId, idA),
+      TestMessages.update(
+        contextId,
+        idA,
+        "Enso_Test.Test.Main.Xyz"
+      ),
+      context.executionComplete(contextId)
+    )
+  }
+
   it should "send method pointer updates of builtin operators" in {
     val contextId  = UUID.randomUUID()
     val requestId  = UUID.randomUUID()
@@ -3926,7 +4047,6 @@ class RuntimeServerTest
         contextId,
         idMainA,
         ConstantsGen.TEXT,
-        Api.MethodCall(Api.MethodPointer(moduleName, moduleName, "hie")),
         fromCache   = false,
         typeChanged = true
       ),

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeTypesTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeTypesTest.scala
@@ -370,7 +370,6 @@ class RuntimeTypesTest
       TestMessages.panic(
         contextId,
         id_x,
-        Api.MethodCall(Api.MethodPointer(moduleName, s"$moduleName.T", "C")),
         Api.ExpressionUpdate.Payload.Panic("Compile_Error", List(id_x)),
         builtin = true
       ),


### PR DESCRIPTION
### Pull Request Description

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

close #11028

Changelog:
- update: hide cached method pointer info in expression updates of evaluated values

### Important Notes


https://github.com/user-attachments/assets/861bb2c8-7613-4fcf-a976-0e37acff4ec0



<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
