### PR TITLE
Poor man's hack to deal with stuck index generation

### DIFF
--- a/project/DistributionPackage.scala
+++ b/project/DistributionPackage.scala
@@ -261,9 +261,8 @@ object DistributionPackage {
           if (current > GENERATING_INDEX_TIMEOUT) {
             try {
               val pidOfProcess = pid(runningProcess)
-              @scala.annotation.nowarn("cat=deprecation")
               val in = java.lang.Runtime.getRuntime
-                .exec("jstack " + pidOfProcess)
+                .exec(Array("jstack", pidOfProcess.toString))
                 .getInputStream
 
               System.err.println(IOUtils.toString(in, "UTF-8"))


### PR DESCRIPTION
### Pull Request Description

CI has started experiencing instability when generating libraries indexes. This change ensures that we don't wait 360(!) minutes until it gives up.
For example: https://github.com/enso-org/enso/actions/runs/10820403412/job/30020393671?pr=11038#step:7:3305

When it gets stuck we will force the process to be stopped. Before that we will also attempt to get and print a threaddump.

### Important Notes

A proper diagnosis is in progress, obviously.

