### PR TITLE
Fix invalid version of wasm-pack

### DIFF
--- a/build/ci_utils/src/actions/workflow/definition.rs
+++ b/build/ci_utils/src/actions/workflow/definition.rs
@@ -78,7 +78,7 @@ pub fn setup_wasm_pack_step() -> Step {
         uses: Some("jetli/wasm-pack-action@v0.4.0".into()),
         with: Some(step::Argument::Other(BTreeMap::from_iter([(
             "version".into(),
-            "v0.10.2".into(),
+            "v0.12.1".into(),
         )]))),
         r#if: Some(is_github_hosted()),
         ..default()


### PR DESCRIPTION
### Pull Request Description

Long shot to potentially fix wasm-pack/wasm-bindgen generation issues. Hosted MacOS ARM runner uses `0.12.1` and that one works. Maybe this has broken during `wasm-bindgen` upgrade.
Related to #11076.
