### PR TITLE
Fix Numeric Input cooperation with Drop Down

### DIFF
--- a/app/gui2/src/components/GraphEditor/widgets/WidgetNumber.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetNumber.vue
@@ -75,6 +75,12 @@ export const widgetDefinition = defineWidget(
 </script>
 
 <template>
+  <!-- Do not finish edit on blur here!
+  
+  It is tempting, but it breaks the cooperation with possible drop-down widget. Blur may be done on
+  pointerdown, and if it would end the interaction, the drop down would also be hidden, making 
+  any `click` event on it impossible.
+  -->
   <NumericInputWidget
     ref="inputComponent"
     class="WidgetNumber"
@@ -84,7 +90,8 @@ export const widgetDefinition = defineWidget(
     @update:modelValue="setValue"
     @click.stop
     @focus="editHandler.start()"
-    @blur="editHandler.end()"
+    @keydown.enter.stop="editHandler.end()"
+    @keydown.tab.stop="editHandler.end()"
     @input="editHandler.edit($event)"
   />
 </template>

--- a/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
+++ b/app/gui2/src/components/GraphEditor/widgets/WidgetText.vue
@@ -98,6 +98,12 @@ export const widgetDefinition = defineWidget(
 <template>
   <label ref="widgetRoot" class="WidgetText widgetRounded">
     <NodeWidget v-if="shownLiteral.open" :input="WidgetInput.FromAst(shownLiteral.open)" />
+    <!-- Do not finish edit on blur here!
+  
+    It is tempting, but it breaks the cooperation with possible drop-down widget. Blur may be done on
+    pointerdown, and if it would end the interaction, the drop down would also be hidden, making 
+    any `click` event on it impossible.
+    -->
     <AutoSizedInput
       ref="input"
       v-model="editedContents"


### PR DESCRIPTION
### Pull Request Description

Fixes #11063

The blur on Numeric Input was removed in https://github.com/enso-org/enso/pull/10337 and then reintroduced in https://github.com/enso-org/enso/pull/10512. I guess it was to handle `tab` properly, so I added another way of handling `tab` and removed blur again (with explanation).

### Important Notes



### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- ~~[ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- ~~[ ] Unit tests have been written where possible.~~
