### PR TITLE
Don't NPE when Throwable is missing message

### DIFF
--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ExecuteJob.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ExecuteJob.scala
@@ -6,6 +6,8 @@ import org.enso.interpreter.instrument.execution.{Executable, RuntimeContext}
 import org.enso.interpreter.runtime.state.ExecutionEnvironment
 import org.enso.polyglot.runtime.Runtime.Api
 
+import java.util.logging.Level
+
 /** A job responsible for executing a call stack for the provided context.
   *
   * @param contextId an identifier of a context to execute
@@ -31,11 +33,25 @@ class ExecuteJob(
       runImpl
     } catch {
       case t: Throwable =>
+        ctx.executionService.getLogger.log(Level.SEVERE, "Failed to execute", t)
+        val errorMsg = if (t.getMessage == null) {
+          if (t.getCause == null) {
+            t.getClass.toString
+          } else {
+            val cause = t.getCause
+            if (cause.getMessage == null) {
+              cause.getClass.toString
+            } else {
+              cause.getMessage
+            }
+          }
+        } else t.getMessage
+
         ctx.endpoint.sendToClient(
           Api.Response(
             Api.ExecutionFailed(
               contextId,
-              Api.ExecutionResult.Failure(t.getMessage, None)
+              Api.ExecutionResult.Failure(errorMsg, None)
             )
           )
         )


### PR DESCRIPTION
### Pull Request Description

Looks like `Throwable` thrown by the execution may be missing a message, which later crashes when we want to send it over the wire. Added some guards to prevent NPE.

### Important Notes

Closes, I think, #11100.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
