### PR TITLE
Avoid dependency on org.graalvm.collections

### DIFF
--- a/engine/runtime-language-arrow/src/main/java/org/enso/interpreter/arrow/runtime/ArrowCastToFixedSizeArrayFactory.java
+++ b/engine/runtime-language-arrow/src/main/java/org/enso/interpreter/arrow/runtime/ArrowCastToFixedSizeArrayFactory.java
@@ -14,7 +14,6 @@ import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import org.enso.interpreter.arrow.LogicalLayout;
-import org.graalvm.collections.Pair;
 
 @ExportLibrary(InteropLibrary.class)
 public class ArrowCastToFixedSizeArrayFactory implements TruffleObject {
@@ -45,7 +44,7 @@ public class ArrowCastToFixedSizeArrayFactory implements TruffleObject {
         throws UnsupportedMessageException, ArityException, UnsupportedTypeException {
       var unit = LogicalLayout.Date32;
       var pair = pointer(args, iop, unit);
-      return new ArrowFixedArrayDate(pair.getLeft(), pair.getRight(), unit);
+      return new ArrowFixedArrayDate(pair.buffer(), pair.at(), unit);
     }
 
     @Specialization(guards = "receiver.getLayout() == Date64")
@@ -56,7 +55,7 @@ public class ArrowCastToFixedSizeArrayFactory implements TruffleObject {
         throws UnsupportedMessageException, ArityException, UnsupportedTypeException {
       var unit = LogicalLayout.Date64;
       var pair = pointer(args, iop, unit);
-      return new ArrowFixedArrayDate(pair.getLeft(), pair.getRight(), unit);
+      return new ArrowFixedArrayDate(pair.buffer(), pair.at(), unit);
     }
 
     @Specialization(guards = "receiver.getLayout() == Int8")
@@ -67,7 +66,7 @@ public class ArrowCastToFixedSizeArrayFactory implements TruffleObject {
         throws UnsupportedMessageException, ArityException, UnsupportedTypeException {
       var unit = LogicalLayout.Int8;
       var pair = pointer(args, iop, unit);
-      return new ArrowFixedArrayInt(pair.getLeft(), pair.getRight(), unit);
+      return new ArrowFixedArrayInt(pair.buffer(), pair.at(), unit);
     }
 
     @Specialization(guards = "receiver.getLayout() == Int16")
@@ -78,7 +77,7 @@ public class ArrowCastToFixedSizeArrayFactory implements TruffleObject {
         throws UnsupportedMessageException, ArityException, UnsupportedTypeException {
       var unit = LogicalLayout.Int16;
       var pair = pointer(args, iop, unit);
-      return new ArrowFixedArrayInt(pair.getLeft(), pair.getRight(), unit);
+      return new ArrowFixedArrayInt(pair.buffer(), pair.at(), unit);
     }
 
     @Specialization(guards = "receiver.getLayout() == Int32")
@@ -89,7 +88,7 @@ public class ArrowCastToFixedSizeArrayFactory implements TruffleObject {
         throws UnsupportedMessageException, ArityException, UnsupportedTypeException {
       var unit = LogicalLayout.Int32;
       var pair = pointer(args, iop, unit);
-      return new ArrowFixedArrayInt(pair.getLeft(), pair.getRight(), unit);
+      return new ArrowFixedArrayInt(pair.buffer(), pair.at(), unit);
     }
 
     @Specialization(guards = "receiver.getLayout() == Int64")
@@ -100,12 +99,11 @@ public class ArrowCastToFixedSizeArrayFactory implements TruffleObject {
         throws UnsupportedMessageException, ArityException, UnsupportedTypeException {
       var unit = LogicalLayout.Int64;
       var pair = pointer(args, iop, unit);
-      return new ArrowFixedArrayInt(pair.getLeft(), pair.getRight(), unit);
+      return new ArrowFixedArrayInt(pair.buffer(), pair.at(), unit);
     }
 
     @CompilerDirectives.TruffleBoundary
-    private static Pair<ByteBufferDirect, Integer> pointer(
-        Object[] args, InteropLibrary interop, SizeInBytes unit)
+    private static BufferInt pointer(Object[] args, InteropLibrary interop, SizeInBytes unit)
         throws ArityException, UnsupportedTypeException, UnsupportedMessageException {
       if (args.length < 2) {
         throw ArityException.create(2, 3, args.length);
@@ -125,12 +123,12 @@ public class ArrowCastToFixedSizeArrayFactory implements TruffleObject {
           throw UnsupportedTypeException.create(
               new Object[] {args[2]}, "Address of non-null bitmap is invalid");
         }
-        return Pair.create(
+        return new BufferInt(
             ByteBufferDirect.fromAddress(
                 interop.asLong(args[0]), interop.asLong(args[2]), capacity, unit),
             capacity);
       } else {
-        return Pair.create(
+        return new BufferInt(
             ByteBufferDirect.fromAddress(interop.asLong(args[0]), capacity, unit), capacity);
       }
     }
@@ -145,4 +143,6 @@ public class ArrowCastToFixedSizeArrayFactory implements TruffleObject {
       return "unknown layout: " + layout.toString();
     }
   }
+
+  private record BufferInt(ByteBufferDirect buffer, int at) {}
 }


### PR DESCRIPTION
### Pull Request Description

I am trying to compile Enso with GraalVM 24.2.0 snapshot to verify that https://github.com/oracle/graal/pull/8266 changes would work for Enso. Among the problems I am facing is a dependency on `org.graalvm.collections` because of using `Pair`. I don't think we need such dependency. Let's avoid it by using our own `record` with two components. 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to execute
