### PR TITLE
More info when we fail to log AssertError

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -87,9 +87,15 @@ public final class PanicException extends AbstractTruffleException implements En
       info = library.getExceptionMessage(this);
       msg = library.asString(info);
     } catch (AssertionError | UnsupportedMessageException e) {
-      var ctx = EnsoContext.get(null);
-      ctx.getLogger().log(Level.WARNING, "Cannot convert " + info + " to string", e);
-      msg = TypeToDisplayTextNode.getUncached().execute(payload);
+      try {
+        var ctx = EnsoContext.get(null);
+        ctx.getLogger().log(Level.WARNING, "Cannot convert " + info + " to string", e);
+        msg = TypeToDisplayTextNode.getUncached().execute(payload);
+      } catch (AssertionError assertionError) {
+        throw new AssertionError(
+            "Failed to log failed conversion of " + info + " to string and payload " + payload,
+            assertionError);
+      }
     }
     cacheMessage = msg;
     return msg;


### PR DESCRIPTION
### Pull Request Description

Motivation:
```
Caused by: java.lang.AssertionError: No polyglot context is entered. A language or context reference must not be used if there is no polyglot context entered.
	at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotFastThreadLocals.assertValidGet(PolyglotFastThreadLocals.java:481)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotFastThreadLocals$ContextReferenceImpl.get(PolyglotFastThreadLocals.java:513)
 	at org.enso.runtime/org.enso.interpreter.runtime.EnsoContext.get(EnsoContext.java:246)
	at org.enso.runtime/org.enso.interpreter.runtime.error.PanicException.computeMessage(PanicException.java:90)
```

### Important Notes

As encountered randomly in
https://github.com/enso-org/enso/actions/runs/10899315744/job/30244447907?pr=11102#step:7:1252
