### PR TITLE
Benchmark static site generator does not include so many records

### DIFF
--- a/tools/performance/engine-benchmarks/website_regen.py
+++ b/tools/performance/engine-benchmarks/website_regen.py
@@ -16,8 +16,8 @@ from bench_tool.remote_cache import SyncRemoteCache
 from bench_tool.website import generate_bench_website
 
 # The inception date of the benchmarks, i.e., the date of the first benchmark run.
-ENGINE_SINCE = datetime.fromisoformat("2022-12-01")
-STDLIB_SINCE = datetime.fromisoformat("2023-08-22")
+ENGINE_SINCE = datetime.fromisoformat("2024-04-01")
+STDLIB_SINCE = datetime.fromisoformat("2024-04-01")
 
 _logger = logging.getLogger("website_regen")
 


### PR DESCRIPTION
### Pull Request Description

Limit the starting date to fetch the benchmarks from to 01-04-2024. As of today, [Upload Benchmarks GH Action](https://github.com/enso-org/enso/actions/workflows/bench-upload.yml) is [failing](https://github.com/enso-org/enso/actions/runs/10896413686/job/30236182995#step:6:6303) because it tries to push a HTML file bigger than 100 MB.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] After merge, ensure that Benchmark Upload job succeeds
