### PR TITLE
Decode URL pathname for opened file

### DIFF
--- a/app/dashboard/src/pages/dashboard/Dashboard.tsx
+++ b/app/dashboard/src/pages/dashboard/Dashboard.tsx
@@ -106,10 +106,12 @@ function fileURLToPath(url: string): string | null {
   if (URL.canParse(url)) {
     const parsed = new URL(url)
     if (parsed.protocol === 'file:') {
-      return detect.platform() === detect.Platform.windows ?
+      return decodeURIComponent(
+        detect.platform() === detect.Platform.windows ?
           // On Windows, we must remove leading `/` from URL.
           parsed.pathname.slice(1)
-        : parsed.pathname
+        : parsed.pathname,
+      )
     } else {
       return null
     }


### PR DESCRIPTION
### Pull Request Description
- Attempt to fix an issue where a project opened by double clicking does not URL decode the path to be opened.
  - Unable to properly test as I don't normally use Windows (file associations do not work on Linux as we use an AppImage for that platform.)

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
