### PR TITLE
Scatterplot- new node functionality

### DIFF
--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -8,7 +8,6 @@ import { Pattern } from '@/util/ast/match'
 import { getTextWidthBySizeAndFamily } from '@/util/measurement'
 import { VisualizationContainer, defineKeybinds } from '@/util/visualizationBuiltins'
 import { computed, ref, watch, watchEffect, watchPostEffect } from 'vue'
-import { Item } from 'yjs'
 
 export const name = 'Scatter Plot'
 export const icon = 'points'
@@ -191,6 +190,7 @@ const shouldAnimate = ref(false)
 const xDomain = ref([0, 1])
 const yDomain = ref([0, 1])
 const selectionEnabled = ref(false)
+const createNewNodeEnabled = ref(false)
 
 const isBrushing = computed(() => brushExtent.value != null)
 const xScale = computed(() =>
@@ -586,6 +586,7 @@ const createNewNodes = () => {
 // === Update contents ===
 
 watchPostEffect(() => {
+  console.log(isBrushing.value)
   const xScale_ = xScale.value
   const yScale_ = yScale.value
   const plotData = getPlotData(data.value) as Point[]
@@ -729,6 +730,7 @@ function zoomToSelected(override?: boolean) {
     yDomain.value = [yMin, yMax]
   }
   endBrushing()
+  createNewNodeEnabled.value = true
 }
 
 useEvent(document, 'keydown', bindings.handler({ zoomToSelected: () => zoomToSelected() }))
@@ -749,7 +751,12 @@ useEvent(document, 'keydown', bindings.handler({ zoomToSelected: () => zoomToSel
         :disabled="brushExtent == null"
         @click.stop="zoomToSelected"
       />
-      <SvgButton name="add" title="filter to selected points" @click.stop="createNewNodes" />
+      <SvgButton
+        name="add"
+        title="Create new component with selected points"
+        :disabled="!createNewNodeEnabled"
+        @click.stop="createNewNodes"
+      />
     </template>
     <div ref="containerNode" class="ScatterplotVisualization">
       <svg :width="width" :height="height">

--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -540,51 +540,15 @@ const filterPattern = computed(() => Pattern.parse('__ (..Between __ __)'))
 const makeFilterPattern = (
   module: Ast.MutableModule,
   columnName: string,
-  minVal: number | Date,
-  maxVal: number | Date,
+  min: number,
+  max: number,
 ) => {
-  const min =
-    typeof minVal === 'number' ?
-      Ast.tryNumberToEnso(minVal, module)!
-    : makeTimePattern(minVal, module)
-  const max =
-    typeof maxVal === 'number' ?
-      Ast.tryNumberToEnso(maxVal, module)!
-    : makeTimePattern(maxVal, module)
-  return filterPattern.value.instantiateCopied([Ast.TextLiteral.new(columnName), min, max])
+  return filterPattern.value.instantiateCopied([
+    Ast.TextLiteral.new(columnName),
+    Ast.tryNumberToEnso(min, module)!,
+    Ast.tryNumberToEnso(max, module)!,
+  ])
 }
-
-const makeTimePattern = (val: Date, module: Ast.MutableModule) => {
-  switch (data.value.x_value_type) {
-    case 'Time':
-      return timePattern.value.instantiateCopied([
-        Ast.tryNumberToEnso(val.getHours(), module)!,
-        Ast.tryNumberToEnso(val.getMinutes(), module)!,
-        Ast.tryNumberToEnso(val.getSeconds(), module)!,
-      ])
-    case 'Date_Time':
-      return dateTimePattern.value.instantiateCopied([
-        Ast.tryNumberToEnso(val.getFullYear(), module)!,
-        Ast.tryNumberToEnso(val.getMonth(), module)!,
-        Ast.tryNumberToEnso(val.getDate(), module)!,
-        Ast.tryNumberToEnso(val.getHours(), module)!,
-        Ast.tryNumberToEnso(val.getMinutes(), module)!,
-        Ast.tryNumberToEnso(val.getSeconds(), module)!,
-      ])
-    default:
-      return datePattern.value.instantiateCopied([
-        Ast.tryNumberToEnso(val.getFullYear(), module)!,
-        Ast.tryNumberToEnso(val.getMonth(), module)!,
-        Ast.tryNumberToEnso(val.getDate(), module)!,
-      ])
-  }
-}
-
-const datePattern = computed(() => Pattern.parse('(Date.new __ __ __)'))
-
-const dateTimePattern = computed(() => Pattern.parse('(Date_Time.new __ __ __ __ __ __)'))
-
-const timePattern = computed(() => Pattern.parse('(Time_Of_Day.new __ __ __'))
 
 function getAstPatternFilter(columnName: string, min: number, max: number) {
   return Pattern.new((ast) =>
@@ -622,7 +586,6 @@ function createNode(rowNumber: number) {
 // === Update contents ===
 
 watchPostEffect(() => {
-  console.log(isBrushing.value)
   const xScale_ = xScale.value
   const yScale_ = yScale.value
   const plotData = getPlotData(data.value) as Point[]

--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -545,7 +545,7 @@ function createNode(rowNumber: number) {
   }
 }
 
-const filterPattern = computed(() => Pattern.parse('____ (..Between ____ ____)'))
+const filterPattern = computed(() => Pattern.parse('__ (..Between __ __)'))
 
 const makeFilterPattern = (
   module: Ast.MutableModule,

--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -559,7 +559,7 @@ function getAstPatternFilter(columnName: string, min: number, max: number) {
   )
 }
 
-const createNewNodes = () => {
+const createNewFilterNode = () => {
   const xAxisLabel = data.value.axis.x.label
   const items = data.value.data.map((d) => d.x)
   const min = Math.min(...items)
@@ -754,7 +754,7 @@ useEvent(document, 'keydown', bindings.handler({ zoomToSelected: () => zoomToSel
         name="add"
         title="Create new component with selected points"
         :disabled="!createNewNodeEnabled"
-        @click.stop="createNewNodes"
+        @click.stop="createNewFilterNode"
       />
     </template>
     <div ref="containerNode" class="ScatterplotVisualization">

--- a/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
+++ b/app/gui2/src/components/visualizations/ScatterplotVisualization.vue
@@ -55,6 +55,7 @@ interface Data {
   focus: Focus | undefined
   points: PointsConfiguration
   data: Point[]
+  get_row_method: string
   is_multi_series?: boolean
 }
 
@@ -164,7 +165,8 @@ const data = computed<Data>(() => {
   // eslint-disable-next-line camelcase
   const is_multi_series: boolean = !!rawData.is_multi_series
   // eslint-disable-next-line camelcase
-  return { axis, points, data, focus, is_multi_series }
+  const get_row_method: string = rawData.get_row_method || 'get_row'
+  return { axis, points, data, focus, is_multi_series, get_row_method }
 })
 
 const containerNode = ref<HTMLElement>()
@@ -574,7 +576,8 @@ const createNewFilterNode = () => {
 }
 
 function createNode(rowNumber: number) {
-  const pattern = getAstPattern(rowNumber, 'get_row')
+  const selector = data.value.get_row_method
+  const pattern = getAstPattern(rowNumber, selector)
   if (pattern) {
     config.createNodes({
       content: pattern,

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
@@ -162,7 +162,7 @@ Table.axes self all_fields =
 ## PRIVATE
 Vector.point_data : Vector
 Vector.point_data self  =
-    self.map_with_index i-> elem-> JS_Object.from_pairs [[Point_Data.X.name, i], [Point_Data.Y.name, elem]]
+    self.map_with_index i-> elem-> JS_Object.from_pairs [[Point_Data.X.name, i], [Point_Data.Y.name, elem], [Point_Data.Row_Number.name, i]]
 
 ## PRIVATE
 bound_data bounds data = case bounds of
@@ -224,13 +224,13 @@ json_from_table table bounds limit =
     fields_for_axes = get_axes_field number_of_numeric_cols
     axes = table.axes fields_for_axes
     is_multi_series = number_of_numeric_cols > 0
-    JS_Object.from_pairs [[data_field, data], [axis_field, axes], ["is_multi_series", is_multi_series]] . to_json
+    JS_Object.from_pairs [[data_field, data], [axis_field, axes], ["is_multi_series", is_multi_series], ["get_row_method", "get_row"]] . to_json
 
 ## PRIVATE
 json_from_vector : Vector Any -> Vector Integer | Nothing -> Integer | Nothing -> Text
 json_from_vector vec bounds limit =
     data = vec.point_data |> bound_data bounds |> limit_data limit
-    JS_Object.from_pairs [[data_field, data], [axis_field, Nothing], ["is_multi_series", False]] . to_json
+    JS_Object.from_pairs [[data_field, data], [axis_field, Nothing], ["is_multi_series", False], ["get_row_method", "at"]] . to_json
 
 ## PRIVATE
 

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Scatter_Plot.enso
@@ -49,10 +49,13 @@ type Point_Data
     Size
 
     ## PRIVATE
+    Row_Number
+
+    ## PRIVATE
 
        Returns all recognized point data fields.
     all_fields : Vector
-    all_fields = [Point_Data.X, Point_Data.Y, Point_Data.Color, Point_Data.Shape, Point_Data.Label, Point_Data.Size]
+    all_fields = [Point_Data.X, Point_Data.Y, Point_Data.Color, Point_Data.Shape, Point_Data.Label, Point_Data.Size, Point_Data.Row_Number]
 
     ## PRIVATE
     recognized_names : Vector
@@ -89,6 +92,9 @@ type Point_Data
             is_good c = (self.is_recognized c).not
 
             candidates.find if_missing=candidates.first is_good
+        Point_Data.Row_Number ->
+            Point_Data.iota table.row_count
+            
         _ -> Error.throw No_Fallback_Column
 
     ## PRIVATE

--- a/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
+++ b/test/Visualization_Tests/src/Scatter_Plot_Spec.enso
@@ -35,32 +35,32 @@ add_specs suite_builder =
             row_1  = [11 , 10 ]
             row_2  = [21 , 20 ]
             table  = Table.from_rows header [row_1, row_2]
-            expect table (labels 'α' 'ω') '[{"x":11,"y":10},{"x":21,"y":20}]'
+            expect table (labels 'α' 'ω') '[{"x":11,"y":10, "row_number": 0},{"x":21,"y":20, "row_number": 1}]'
 
         group_builder.specify "recognizes all relevant columns" <|
             header = ['x' , 'y' , 'size' , 'shape'  , 'label' , 'color' ]
             row_1 =  [11  , 10  , 50     , 'square' , 'label' , 'ff0000']
             table = Table.from_rows header [row_1]
-            expect table (labels 'x' 'y') '[{"color":"ff0000","label":"label","shape":"square","size":50,"x":11,"y":10}]'
+            expect table (labels 'x' 'y') '[{"color":"ff0000","label":"label","shape":"square","size":50,"x":11,"y":10, "row_number": 0}]'
 
         group_builder.specify "is case-insensitive" <|
             header = ['X' , 'Y' , 'Size' , 'Shape'  , 'Label' , 'Color' ]
             row_1 =  [11  , 10  , 50     , 'square' , 'label' , 'ff0000']
             table = Table.from_rows header [row_1]
-            expect table (labels 'X' 'Y') '[{"color":"ff0000","label":"label","shape":"square","size":50,"x":11,"y":10}]'
+            expect table (labels 'X' 'Y') '[{"color":"ff0000","label":"label","shape":"square","size":50,"x":11,"y":10, "row_number": 0}]'
 
         group_builder.specify "uses first unrecognized numeric column as `y` fallback" <|
             header = ['x' , 'size' , 'name'   , 'z' , 'ω']
             row_1 =  [11  , 50     , 'circul' ,  20 ,  30]
             table = Table.from_rows header [row_1]
-            expect table (labels_multi 'x' 'z' 'ω') '[{"size":50,"x":11,"y":20,"(y_multi 0)":30}]' 'true'
+            expect table (labels_multi 'x' 'z' 'ω') '[{"size":50,"x":11,"y":20,"(y_multi 0)":30, "row_number": 0}]' 'true'
 
         group_builder.specify "provided only recognized columns" <|
             header = ['x', 'y' , 'bar' , 'size']
             row_1 =  [11 , 10  , 'aa'  , 40    ]
             row_2 =  [21 , 20  , 'bb'  , 50    ]
             table = Table.from_rows header [row_1, row_2]
-            expect table (labels 'x' 'y') '[{"size":40,"x":11,"y":10},{"size":50,"x":21,"y":20}]'
+            expect table (labels 'x' 'y') '[{"size":40,"x":11,"y":10, "row_number": 0},{"size":50,"x":21,"y":20, "row_number": 1}]'
 
         group_builder.specify "provided only recognized columns within bounds" <|
             header = ['x', 'y' , 'bar' , 'size']
@@ -71,14 +71,14 @@ add_specs suite_builder =
             table = Table.from_rows header [row_1, row_2, row_3, row_4]
             bounds = [0,5,25,25]
             text = Scatter_Plot.process_to_json_text table bounds
-            expect_text text (labels 'x' 'y') '[{"size":40,"x":11,"y":10},{"size":50,"x":21,"y":20}]'
+            expect_text text (labels 'x' 'y') '[{"size":40,"x":11,"y":10, "row_number": 0},{"size":50,"x":21,"y":20, "row_number": 1}]'
 
         group_builder.specify "used default index for `x` if none set" <|
             header = [ 'y'  , 'bar' , 'size']
             row_1 =  [ 10   , 'aa'  , 40    ]
             row_2 =  [ 20   , 'bb'  , 50    ]
             table = Table.from_rows header [row_1, row_2]
-            expect table (labels index 'y') '[{"size":40,"x":0,"y":10},{"size":50,"x":1,"y":20}]'
+            expect table (labels index 'y') '[{"size":40,"x":0,"y":10, "row_number": 0},{"size":50,"x":1,"y":20, "row_number": 1}]'
 
         group_builder.specify "using indices for x if given a vector" <|
             vector = [0,10,20]


### PR DESCRIPTION
On double click of a point it will create a new node of that row 

![6105-scatterplot-on-click-new-node](https://github.com/user-attachments/assets/f21a2b69-2323-42fa-aa9b-07e662758d8e)

When zoomed into points add new node of those filtered points 

![6105-scatterplot-filter-down-new-node](https://github.com/user-attachments/assets/7a64d554-d911-442c-a104-22c66d0c1e8f)



### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
