### PR TITLE
Fix width of settings sections when only a single column is visible

### DIFF
--- a/app/dashboard/src/layouts/Settings/SettingsTab.tsx
+++ b/app/dashboard/src/layouts/Settings/SettingsTab.tsx
@@ -80,7 +80,7 @@ export default function SettingsTab(props: SettingsTabProps) {
             <div
               key={i}
               className={tailwindMerge.twMerge(
-                'flex h-fit w-0 flex-1 flex-col gap-settings-subsection pb-12',
+                'flex h-fit flex-1 flex-col gap-settings-subsection pb-12',
                 classes[i],
               )}
             >


### PR DESCRIPTION
### Pull Request Description
- Fix settings columns having zero width when only a single column is visible

### Important Notes
None

### Screenshots
Before:
![image](https://github.com/user-attachments/assets/66e1acee-8515-4a01-95ff-e4be7040102d)

After:
![image](https://github.com/user-attachments/assets/d117a98b-41a5-4a50-abe3-6ea5986bf116)

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
