### PR TITLE
Initialize Enso Terminal in a background thread

### DIFF
--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -13,6 +13,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -959,12 +962,21 @@ public class Main {
   }
 
   private static MessageTransport replTransport() {
-    var repl = new Repl(makeTerminalForRepl());
+    ThreadFactory factory = (r) -> new Thread(r, "Initialize Enso Terminal");
+    var executor = Executors.newSingleThreadExecutor(factory);
+    var futureRepl = executor.submit(() -> new Repl(makeTerminalForRepl()));
     MessageTransport transport =
-        (uri, peer) ->
-            DebugServerInfo.URI.equals(uri.toString())
-                ? new DebuggerSessionManagerEndpoint(repl, peer)
-                : null;
+        (uri, peer) -> {
+          if (DebugServerInfo.URI.equals(uri.toString())) {
+            try {
+              var repl = futureRepl.get();
+              return new DebuggerSessionManagerEndpoint(repl, peer);
+            } catch (InterruptedException | ExecutionException ex) {
+              logger.error("Cannot initialize REPL transport", ex);
+            }
+          }
+          return null;
+        };
     return transport;
   }
 


### PR DESCRIPTION
### Pull Request Description

Fixes #8688 by starting a background thread to initialize whole JLine infrastructure when executed with `--repl` option..

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests continue to pass
- [x] Startup benchmarks aren't worse (it is unlikely they can get better - since #10709 we no longer initialize JLine when not started with `--repl` option): [initial run](https://github.com/enso-org/enso/actions/runs/10992632130)
