### PR TITLE
Eliminate Blanks inside of Type.Ascription

### DIFF
--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Table.enso
@@ -185,8 +185,7 @@ type Table
                  row_3 =  [ 3     , True  , 'c'   ]
                  Table.from_rows header [row_1, row_2, row_3]
     @header (Widget.Vector_Editor item_editor=Widget.Text_Input item_default='"Column"')
-    from_rows : Vector -> Vector -> Table
-    from_rows header rows =
+    from_rows header:Vector rows:Vector -> Table =
         columns = header.map_with_index i-> name-> [name, rows.map (_.at i)]
         Table.new columns
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambda.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambda.scala
@@ -70,18 +70,17 @@ case object LambdaShorthandToLambda extends IRPass {
     ir: Module,
     moduleContext: ModuleContext
   ): Module = {
-    val new_bindings = ir.bindings.map {
-      case a =>
-        a.mapExpressions(
-          runExpression(
-            _,
-            InlineContext(
-              moduleContext,
-              freshNameSupply = moduleContext.freshNameSupply,
-              compilerConfig  = moduleContext.compilerConfig
-            )
+    val new_bindings = ir.bindings.map { case a =>
+      a.mapExpressions(
+        runExpression(
+          _,
+          InlineContext(
+            moduleContext,
+            freshNameSupply = moduleContext.freshNameSupply,
+            compilerConfig  = moduleContext.compilerConfig
           )
         )
+      )
     }
     ir.copy(bindings = new_bindings)
   }
@@ -121,9 +120,9 @@ case object LambdaShorthandToLambda extends IRPass {
     freshNameSupply: FreshNameSupply
   ): Expression = {
     ir.transformExpressions {
-      case app: Application     => desugarApplication(app, freshNameSupply)
-      case caseExpr: Case.Expr  => desugarCaseExpr(caseExpr, freshNameSupply)
-      case name: Name           => desugarName(name, freshNameSupply)
+      case app: Application    => desugarApplication(app, freshNameSupply)
+      case caseExpr: Case.Expr => desugarCaseExpr(caseExpr, freshNameSupply)
+      case name: Name          => desugarName(name, freshNameSupply)
     }
   }
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambda.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/LambdaShorthandToLambda.scala
@@ -8,8 +8,7 @@ import org.enso.compiler.core.ir.{
   Function,
   IdentifiedLocation,
   Module,
-  Name,
-  Type
+  Name
 }
 import org.enso.compiler.core.CompilerError
 import org.enso.compiler.core.ir.expression.{Application, Case, Operator}
@@ -72,7 +71,6 @@ case object LambdaShorthandToLambda extends IRPass {
     moduleContext: ModuleContext
   ): Module = {
     val new_bindings = ir.bindings.map {
-      case asc: Type.Ascription => asc
       case a =>
         a.mapExpressions(
           runExpression(
@@ -123,7 +121,6 @@ case object LambdaShorthandToLambda extends IRPass {
     freshNameSupply: FreshNameSupply
   ): Expression = {
     ir.transformExpressions {
-      case asc: Type.Ascription => asc
       case app: Application     => desugarApplication(app, freshNameSupply)
       case caseExpr: Case.Expr  => desugarCaseExpr(caseExpr, freshNameSupply)
       case name: Name           => desugarName(name, freshNameSupply)

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ExecCompilerTest.java
@@ -308,6 +308,27 @@ public class ExecCompilerTest {
   }
 
   @Test
+  public void inlineWithBlanks() throws Exception {
+    var code =
+        """
+    remap rows:Map -> Map =
+        rows.map (_.set_u 5)
+
+    type Map
+        M v u=3
+
+        map self fn = Map.M (fn self)
+        set_u self i = Map.M self.v i
+
+    run n = remap (Map.M n)
+    """;
+    var module = ctx.eval(LanguageInfo.ID, code);
+    var run = module.invokeMember("eval_expression", "run");
+    assertTrue("run is a function", run.canExecute());
+    assertEquals("(M (M 10 5) 3)", run.execute(10).toString());
+  }
+
+  @Test
   public void inlineReturnSignatureOnLocalFunction() throws Exception {
     var module =
         ctx.eval(


### PR DESCRIPTION
### Pull Request Description

Fixes #11090 by processing body of `Type.Ascription` in `LambdaShorthandToLambda` pass.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
