### PR TITLE
Do not show loading spinner for created projects

### DIFF
--- a/app/dashboard/src/components/dashboard/ProjectIcon.tsx
+++ b/app/dashboard/src/components/dashboard/ProjectIcon.tsx
@@ -131,6 +131,7 @@ export default function ProjectIcon(props: ProjectIconProps) {
     case backendModule.ProjectState.new:
     case backendModule.ProjectState.closing:
     case backendModule.ProjectState.closed:
+    case backendModule.ProjectState.created:
       return (
         <ariaComponents.Button
           size="custom"
@@ -143,7 +144,6 @@ export default function ProjectIcon(props: ProjectIconProps) {
           onPress={doOpenProject}
         />
       )
-    case backendModule.ProjectState.created:
     case backendModule.ProjectState.openInProgress:
     case backendModule.ProjectState.scheduled:
     case backendModule.ProjectState.provisioned:


### PR DESCRIPTION
### Pull Request Description
- Fix https://github.com/enso-org/cloud-v2/issues/1501
  - The `Created` project state does not mean the project is opening, so the loading spinner should not appear.
  - Regression accidentally introduced by myself in https://github.com/enso-org/enso/commit/609d5abbc07c95b774644edd10c629586c2f9ab5#diff-79e1f8800be680c64a41e2c428927c1f176b728a6a24d5f8c4d02cfc2a3922f9

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
