### PR TITLE
Increase z-index for dialogs/popovers

### DIFF
--- a/app/dashboard/src/components/AriaComponents/Dialog/Dialog.tsx
+++ b/app/dashboard/src/components/AriaComponents/Dialog/Dialog.tsx
@@ -29,7 +29,7 @@ export interface DialogProps
     Omit<VariantProps<typeof DIALOG_STYLES>, 'scrolledToTop'> {}
 
 const OVERLAY_STYLES = tv({
-  base: 'fixed inset-0 isolate flex items-center justify-center bg-primary/20',
+  base: 'fixed inset-0 isolate flex items-center justify-center bg-primary/20 z-tooltip',
   variants: {
     isEntering: { true: 'animate-in fade-in duration-200 ease-out' },
     isExiting: { true: 'animate-out fade-out duration-200 ease-in' },

--- a/app/dashboard/src/components/AriaComponents/Dialog/Popover.tsx
+++ b/app/dashboard/src/components/AriaComponents/Dialog/Popover.tsx
@@ -28,7 +28,7 @@ export interface PopoverProps
 }
 
 export const POPOVER_STYLES = twv.tv({
-  base: 'shadow-xl w-full overflow-clip',
+  base: 'shadow-xl w-full overflow-clip z-tooltip',
   variants: {
     isEntering: {
       true: 'animate-in fade-in placement-bottom:slide-in-from-top-1 placement-top:slide-in-from-bottom-1 placement-left:slide-in-from-right-1 placement-right:slide-in-from-left-1 ease-out duration-200',
@@ -102,7 +102,10 @@ export function Popover(props: PopoverProps) {
       }
       UNSTABLE_portalContainer={root}
       placement={placement}
-      style={{ zIndex: 'unset' }}
+      style={{
+        // Unset the default z-index set by react-aria-components.
+        zIndex: '',
+      }}
       shouldCloseOnInteractOutside={() => false}
       {...ariaPopoverProps}
     >


### PR DESCRIPTION
### Pull Request Description

This PR increases z-indexes for dialogs and popovers, since we have a set of components, that have z-indexes already and they should be always below the dialogs/popovers

<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
