### PR TITLE
Sign artifacts for nightlies/releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -380,7 +380,7 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./run ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}}
+      - run: ./run ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}} --gui-sign-artifacts true
         env:
           ENSO_CLOUD_API_URL: ${{ vars.ENSO_CLOUD_API_URL }}
           ENSO_CLOUD_CHAT_URL: ${{ vars.ENSO_CLOUD_CHAT_URL }}
@@ -442,7 +442,7 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./run ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}}
+      - run: ./run ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}} --gui-sign-artifacts true
         env:
           APPLEID: ${{ secrets.APPLE_NOTARIZATION_USERNAME }}
           APPLEIDPASS: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
@@ -509,7 +509,7 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./run ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}}
+      - run: ./run ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}} --gui-sign-artifacts true
         env:
           APPLEID: ${{ secrets.APPLE_NOTARIZATION_USERNAME }}
           APPLEIDPASS: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
@@ -577,7 +577,7 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./run ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}}
+      - run: ./run ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}} --gui-sign-artifacts true
         env:
           ENSO_CLOUD_API_URL: ${{ vars.ENSO_CLOUD_API_URL }}
           ENSO_CLOUD_CHAT_URL: ${{ vars.ENSO_CLOUD_CHAT_URL }}

--- a/build/build/src/ci_gen.rs
+++ b/build/build/src/ci_gen.rs
@@ -437,7 +437,7 @@ pub struct UploadIde;
 impl JobArchetype for UploadIde {
     fn job(&self, target: Target) -> Job {
         RunStepsBuilder::new(
-            "ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}}",
+            "ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}} --gui-sign-artifacts true",
         )
         .cleaning(RELEASE_CLEANING_POLICY)
         .customize(with_packaging_steps(target.0))


### PR DESCRIPTION
Looks like with #11094 I accidentally disabled it for releases. This change _should_ enable it back.