### PR TITLE
IR caches can be disabled for --compile

### DIFF
--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -609,6 +609,7 @@ public class Main {
    *     compiled
    * @param shouldUseGlobalCache whether or not the compilation result should be written to the
    *     global cache
+   * @param shouldUseIrCaches whether or not IR caches should be used.
    * @param enableStaticAnalysis whether or not static type checking should be enabled
    * @param logLevel the logging level
    * @param logMasking whether or not log masking is enabled
@@ -617,6 +618,7 @@ public class Main {
       String packagePath,
       boolean shouldCompileDependencies,
       boolean shouldUseGlobalCache,
+      boolean shouldUseIrCaches,
       boolean enableStaticAnalysis,
       Level logLevel,
       boolean logMasking) {
@@ -634,7 +636,7 @@ public class Main {
                 .out(System.out)
                 .logLevel(logLevel)
                 .logMasking(logMasking)
-                .enableIrCaches(true)
+                .enableIrCaches(shouldUseIrCaches)
                 .enableStaticAnalysis(enableStaticAnalysis)
                 .strictErrors(true)
                 .useGlobalIrCacheLocation(shouldUseGlobalCache)
@@ -1106,14 +1108,16 @@ public class Main {
     }
 
     if (line.hasOption(COMPILE_OPTION)) {
-      var packagePaths = line.getOptionValue(COMPILE_OPTION);
+      var packagePath = line.getOptionValue(COMPILE_OPTION);
       var shouldCompileDependencies = !line.hasOption(NO_COMPILE_DEPENDENCIES_OPTION);
       var shouldUseGlobalCache = !line.hasOption(NO_GLOBAL_CACHE_OPTION);
+      var shouldUseIrCaches = !line.hasOption(NO_IR_CACHES_OPTION);
 
       compile(
-          packagePaths,
+          packagePath,
           shouldCompileDependencies,
           shouldUseGlobalCache,
+          shouldUseIrCaches,
           line.hasOption(ENABLE_STATIC_ANALYSIS_OPTION),
           logLevel,
           logMasking);

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -219,7 +219,7 @@ public class Main {
             .numberOfArgs(1)
             .argName("file")
             .longOpt(PROFILING_PATH)
-            .desc("The path to the Language Server profiling file.")
+            .desc("The path to the profiling file.")
             .build();
     var lsProfilingTimeOption =
         cliOptionBuilder()
@@ -1208,7 +1208,7 @@ public class Main {
           try {
             sampler.stop();
           } catch (IOException ex) {
-            logger.info("Error stopping sampler", ex);
+            logger.error("Error stopping sampler", ex);
           }
           return BoxedUnit.UNIT;
         });

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Compiler.scala
@@ -791,6 +791,11 @@ class Compiler(
     ir: IRModule,
     moduleContext: ModuleContext
   ): IRModule = {
+    context.log(
+      Level.FINEST,
+      "Passing module {0} with method body passes",
+      moduleContext.module.getName
+    )
     passManager.runPassesOnModule(ir, moduleContext, passes.functionBodyPasses)
   }
 
@@ -798,6 +803,11 @@ class Compiler(
     ir: IRModule,
     moduleContext: ModuleContext
   ): IRModule = {
+    context.log(
+      Level.FINEST,
+      "Passing module {0} with global typing passes",
+      moduleContext.module.getName
+    )
     passManager.runPassesOnModule(ir, moduleContext, passes.globalTypingPasses)
   }
 


### PR DESCRIPTION

### Pull Request Description

Ensures that the following command:
```
enso  --no-global-cache --no-ir-caches --no-compile-dependencies --no-read-ir-caches --compile built-distribution/enso-engine-0.0.0-dev-linux-amd64/enso-0.0.0-dev/lib/Standard/Base/0.0.0-dev/
```
does not load IRs from caches, but actually compiles all the modules in `Standard.Base` library.

### Important Notes

- Add some logging on places, fix some typos.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [X] The documentation has been updated, if necessary.
- [X] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [X] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [X] Unit tests have been written where possible.
