### PR TITLE
Test parallelism in EnsoParser. Using `synchronized` to avoid it.

### DIFF
--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/EnsoParser.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/EnsoParser.java
@@ -23,31 +23,31 @@ public final class EnsoParser implements AutoCloseable {
   }
 
   @Override
-  public void close() throws Exception {
+  public synchronized void close() throws Exception {
     if (parser != null) {
       parser.close();
     }
   }
 
-  public Module compile(CharSequence src) {
+  public synchronized Module compile(CharSequence src) {
     var tree = parser.parse(src);
     return generateIR(tree);
   }
 
-  public Tree parse(CharSequence src) {
+  public synchronized Tree parse(CharSequence src) {
     return parser.parse(src);
   }
 
-  public Module generateIR(Tree t) {
+  public synchronized Module generateIR(Tree t) {
     return TreeToIr.MODULE.translate(t);
   }
 
-  public Module generateModuleIr(Tree t, Map<Location, UUID> idMap) {
+  public synchronized Module generateModuleIr(Tree t, Map<Location, UUID> idMap) {
     var treeToIr = new TreeToIr(idMap);
     return treeToIr.translate(t);
   }
 
-  public scala.Option<Expression> generateIRInline(Tree t) {
+  public synchronized scala.Option<Expression> generateIRInline(Tree t) {
     return TreeToIr.MODULE.translateInline(t);
   }
 }

--- a/engine/runtime-parser/src/test/java/org/enso/compiler/core/EnsoParserMultiThreadedTest.java
+++ b/engine/runtime-parser/src/test/java/org/enso/compiler/core/EnsoParserMultiThreadedTest.java
@@ -1,0 +1,52 @@
+package org.enso.compiler.core;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ForkJoinPool;
+import org.enso.compiler.core.ir.Module;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EnsoParserMultiThreadedTest {
+  private EnsoParser parser;
+
+  @Before
+  public void initParser() throws Exception {
+    parser = new EnsoParser();
+  }
+
+  @After
+  public void closeParser() throws Exception {
+    parser.close();
+  }
+
+  @Test
+  public void stressLoadFromManyThreads() throws Exception {
+    List<Callable<Module>> cases = new ArrayList<>();
+    final var testCases = 1000;
+    for (var i = 0; i < 2 * testCases; i++) {
+      var number = i % testCases;
+      var code =
+          """
+            from Standard.Base import all
+            main = %n
+            """
+              .replace("%n", "" + number);
+      cases.add(
+          () -> {
+            return parser.compile(code);
+          });
+    }
+
+    var results = ForkJoinPool.commonPool().invokeAll(cases);
+
+    for (var i = 0; i < testCases; i++) {
+      var r1 = results.get(i).get();
+      var r2 = results.get(testCases + i).get();
+
+      EnsoParserTest.assertIR("Run #" + i + " should produce identical IR", r1, r2);
+    }
+  }
+}


### PR DESCRIPTION
### Pull Request Description

Introducing a stress test in 137abbc237c52965b55311ebcd3624ac5bf46fae to check how `EnsoParser` behaves under heavy multi-threaded load (it crashes the JVM running the test). Next commit 12d08c8cc22eab80212c9d7d04e625ef9cfca7a5 adds `synchronized` to `EnsoParser` method to provide simplest possible fix for `release/2024.4` branch.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
