### PR TITLE
Drop per artifact signing

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -350,7 +350,7 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./run ide build --backend-source current-ci-run --gui-upload-artifact false --gui-sign-artifacts false
+      - run: ./run ide build --backend-source current-ci-run --gui-upload-artifact false
         env:
           ENSO_CLOUD_API_URL: ${{ vars.ENSO_CLOUD_API_URL }}
           ENSO_CLOUD_CHAT_URL: ${{ vars.ENSO_CLOUD_CHAT_URL }}
@@ -406,7 +406,7 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./run ide build --backend-source current-ci-run --gui-upload-artifact false --gui-sign-artifacts false
+      - run: ./run ide build --backend-source current-ci-run --gui-upload-artifact false
         env:
           APPLEID: ${{ secrets.APPLE_NOTARIZATION_USERNAME }}
           APPLEIDPASS: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
@@ -470,7 +470,7 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./run ide build --backend-source current-ci-run --gui-upload-artifact false --gui-sign-artifacts false
+      - run: ./run ide build --backend-source current-ci-run --gui-upload-artifact false
         env:
           ENSO_CLOUD_API_URL: ${{ vars.ENSO_CLOUD_API_URL }}
           ENSO_CLOUD_CHAT_URL: ${{ vars.ENSO_CLOUD_CHAT_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -380,7 +380,7 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./run ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}} --gui-sign-artifacts true
+      - run: ./run ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}} --sign-artifacts
         env:
           ENSO_CLOUD_API_URL: ${{ vars.ENSO_CLOUD_API_URL }}
           ENSO_CLOUD_CHAT_URL: ${{ vars.ENSO_CLOUD_CHAT_URL }}
@@ -442,7 +442,7 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./run ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}} --gui-sign-artifacts true
+      - run: ./run ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}} --sign-artifacts
         env:
           APPLEID: ${{ secrets.APPLE_NOTARIZATION_USERNAME }}
           APPLEIDPASS: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
@@ -509,7 +509,7 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./run ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}} --gui-sign-artifacts true
+      - run: ./run ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}} --sign-artifacts
         env:
           APPLEID: ${{ secrets.APPLE_NOTARIZATION_USERNAME }}
           APPLEIDPASS: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
@@ -577,7 +577,7 @@ jobs:
         run: ./run git-clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./run ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}} --gui-sign-artifacts true
+      - run: ./run ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}} --sign-artifacts
         env:
           ENSO_CLOUD_API_URL: ${{ vars.ENSO_CLOUD_API_URL }}
           ENSO_CLOUD_CHAT_URL: ${{ vars.ENSO_CLOUD_CHAT_URL }}

--- a/build/build/src/ci_gen.rs
+++ b/build/build/src/ci_gen.rs
@@ -437,7 +437,7 @@ pub struct UploadIde;
 impl JobArchetype for UploadIde {
     fn job(&self, target: Target) -> Job {
         RunStepsBuilder::new(
-            "ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}} --gui-sign-artifacts true",
+            "ide upload --backend-source release --backend-release ${{env.ENSO_RELEASE_ID}} --sign-artifacts",
         )
         .cleaning(RELEASE_CLEANING_POLICY)
         .customize(with_packaging_steps(target.0))

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -526,7 +526,7 @@ pub struct PackageIde;
 impl JobArchetype for PackageIde {
     fn job(&self, target: Target) -> Job {
         RunStepsBuilder::new(
-            "ide build --backend-source current-ci-run --gui-upload-artifact false --gui-sign-artifacts false",
+            "ide build --backend-source current-ci-run --gui-upload-artifact false",
         )
         .customize(with_packaging_steps(target.0))
         .build_job("Package New IDE", target)

--- a/build/build/src/ide/web.rs
+++ b/build/build/src/ide/web.rs
@@ -262,6 +262,7 @@ impl IdeDesktop {
         ?project_manager,
         ?target_os,
         ?target,
+        ?sign,
         err))]
     pub async fn dist(
         &self,

--- a/build/build/src/source.rs
+++ b/build/build/src/source.rs
@@ -31,7 +31,6 @@ pub struct BuildSource<Target: IsTarget> {
     pub input:                  Target::BuildInput,
     /// Whether to upload the resulting artifact as CI artifact.
     pub should_upload_artifact: bool,
-    pub should_sign_artifacts:  bool,
 }
 
 /// Describes how to get a target.

--- a/build/cli/src/arg.rs
+++ b/build/cli/src/arg.rs
@@ -83,7 +83,6 @@ pub trait IsTargetSource {
     const RELEASE_DESIGNATOR_NAME: &'static str;
     const ARTIFACT_NAME_NAME: &'static str;
     const UPLOAD_ARTIFACT_NAME: &'static str;
-    const SIGN_ARTIFACTS: &'static str;
     const DEFAULT_OUTPUT_PATH: &'static str;
 
     type BuildInput: Clone + Debug + PartialEq + Args + Send + Sync;
@@ -105,7 +104,6 @@ macro_rules! source_args_hlp {
             const RELEASE_DESIGNATOR_NAME: &'static str = concat!($prefix, "-", "release");
             const ARTIFACT_NAME_NAME: &'static str = concat!($prefix, "-", "artifact-name");
             const UPLOAD_ARTIFACT_NAME: &'static str = concat!($prefix, "-", "upload-artifact");
-            const SIGN_ARTIFACTS: &'static str = concat!($prefix, "-", "sign-artifacts");
             const DEFAULT_OUTPUT_PATH: &'static str = concat!("dist/", $prefix);
 
             type BuildInput = $inputs;
@@ -281,16 +279,6 @@ pub struct BuildDescription<Target: IsTargetSource> {
         action = clap::ArgAction::Set
     )]
     pub upload_artifact: bool,
-    #[clap(
-        name = Target::SIGN_ARTIFACTS,
-        long,
-        enso_env(),
-        default_value_t = ide_ci::actions::workflow::is_in_env(),
-        default_missing_value("true"),
-        num_args(0..=1),
-        action = clap::ArgAction::Set
-    )]
-    pub sign_artifacts:  bool,
 }
 
 #[derive(Args, Clone, PartialEq, Debug)]

--- a/build/cli/src/lib.rs
+++ b/build/cli/src/lib.rs
@@ -140,15 +140,10 @@ impl Processor {
         let span = info_span!("Resolving.", ?target, ?source).entered();
         let destination = source.output_path.output_path;
         let should_upload_artifact = source.build_args.upload_artifact;
-        let should_sign_artifacts = source.build_args.sign_artifacts;
         let source = match source.source {
             arg::SourceKind::Build => T::resolve(self, source.build_args.input)
                 .map_ok(move |input| {
-                    Source::BuildLocally(BuildSource {
-                        input,
-                        should_upload_artifact,
-                        should_sign_artifacts,
-                    })
+                    Source::BuildLocally(BuildSource { input, should_upload_artifact })
                 })
                 .boxed(),
             arg::SourceKind::Local =>
@@ -237,17 +232,13 @@ impl Processor {
         &self,
         job: BuildJob<T>,
     ) -> BoxFuture<'static, Result<BuildTargetJob<T>>> {
-        let BuildJob {
-            input: BuildDescription { input, upload_artifact, sign_artifacts },
-            output_path,
-        } = job;
+        let BuildJob { input: BuildDescription { input, upload_artifact }, output_path } = job;
         let input = self.resolve_inputs::<T>(input);
         async move {
             Ok(WithDestination::new(
                 BuildSource {
                     input:                  input.await?,
                     should_upload_artifact: upload_artifact,
-                    should_sign_artifacts:  sign_artifacts,
                 },
                 output_path.output_path,
             ))


### PR DESCRIPTION
### Pull Request Description

Per artifact signing was an unnecessary parameter. It is sufficient to simply have `--sign-artifacts` parameter to control the action.

Tested locally (previously hindered by my poor understanding of CI build config).

### Important Notes

Previous attempts:
- #11094 
- #11169 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
