### PR TITLE
Fix MacOS Engine CI JVM tests by fixing directory-watcher module config

### DIFF
--- a/lib/java/directory-watcher-wrapper/src/main/java/module-info.java
+++ b/lib/java/directory-watcher-wrapper/src/main/java/module-info.java
@@ -6,5 +6,5 @@ module org.enso.directory.watcher.wrapper {
 
   exports io.methvin.watcher;
   exports io.methvin.watchservice;
-  exports io.methvin.watchservice.jna;
+  opens io.methvin.watchservice.jna;
 }

--- a/lib/java/directory-watcher-wrapper/src/main/java/module-info.java
+++ b/lib/java/directory-watcher-wrapper/src/main/java/module-info.java
@@ -6,4 +6,5 @@ module org.enso.directory.watcher.wrapper {
 
   exports io.methvin.watcher;
   exports io.methvin.watchservice;
+  exports io.methvin.watchservice.jna;
 }


### PR DESCRIPTION
### Pull Request Description

This should fix the `IllegalAccessException` in MacOS engine CI tests (like in https://github.com/enso-org/enso/actions/runs/11051733295/job/30702270581#step:7:6322)

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] Ensure MacOS Engine CI JVM Tests pass
