### PR TITLE
Use color Google and GitHub icons in Login screen

### DIFF
--- a/app/dashboard/src/pages/authentication/Login.tsx
+++ b/app/dashboard/src/pages/authentication/Login.tsx
@@ -99,7 +99,7 @@ export default function Login() {
               <Button
                 size="large"
                 variant="outline"
-                icon={<img src={GoogleIcon} />}
+                icon={<img src={GoogleIcon} alt={getText('googleIcon')} />}
                 onPress={async () => {
                   await signInWithGoogle()
                 }}
@@ -109,7 +109,7 @@ export default function Login() {
               <Button
                 size="large"
                 variant="outline"
-                icon={<img src={GithubIcon} />}
+                icon={<img src={GithubIcon} alt={getText('gitHubIcon')} />}
                 onPress={async () => {
                   await signInWithGitHub()
                 }}

--- a/app/dashboard/src/pages/authentication/Login.tsx
+++ b/app/dashboard/src/pages/authentication/Login.tsx
@@ -99,7 +99,7 @@ export default function Login() {
               <Button
                 size="large"
                 variant="outline"
-                icon={GoogleIcon}
+                icon={<img src={GoogleIcon} />}
                 onPress={async () => {
                   await signInWithGoogle()
                 }}
@@ -109,7 +109,7 @@ export default function Login() {
               <Button
                 size="large"
                 variant="outline"
-                icon={GithubIcon}
+                icon={<img src={GithubIcon} />}
                 onPress={async () => {
                   await signInWithGitHub()
                 }}

--- a/app/ide-desktop/common/src/text/english.json
+++ b/app/ide-desktop/common/src/text/english.json
@@ -267,6 +267,8 @@
   "reload": "Reload",
   "seeLatestRelease": "See latest release",
   "options": "Options",
+  "googleIcon": "Google icon",
+  "gitHubIcon": "GitHub icon",
 
   "enterSecretPath": "Enter secret path",
   "enterText": "Enter text",


### PR DESCRIPTION
### Pull Request Description
- Make Google and GitHub icons full color again

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
