### PR TITLE
Don't coerce arg passed to electron

### DIFF
--- a/app/ide-desktop/client/electron-builder-config.ts
+++ b/app/ide-desktop/client/electron-builder-config.ts
@@ -105,7 +105,6 @@ export const args: Arguments = await yargs(process.argv.slice(2))
       type: 'boolean',
       description: 'Should signing/notarization be performed (defaults to true)',
       default: true,
-      coerce: (p: string) => p === 'true',
     },
   }).argv
 


### PR DESCRIPTION
Apparently argument was already a bool.
:fingers-crossed: this is the last fix.

Previous attempts:
- #11094 
- #11169 
- #11182