### PR TITLE
Eliminate Akka's shutdown hook

### DIFF
--- a/engine/language-server/src/main/resources/application.conf
+++ b/engine/language-server/src/main/resources/application.conf
@@ -23,6 +23,7 @@ akka {
   }
   log-dead-letters = 1
   log-dead-letters-during-shutdown = off
+  jvm-shutdown-hooks = off
   library-extensions = ["akka.stream.SystemMaterializer$"]
   use-slf4j = on
 }


### PR DESCRIPTION
### Pull Request Description

Seeing
```
[WARN] [akka.actor.CoordinatedShutdown] Could not addJvmShutdownHook, due to: Shutdown in progress
```
in the logs.
We are already shutting down resources, including ActorSystem, so no need for Akka to schedule its shutdown.

