### PR TITLE
Replace imports of `tailwind-variants` with imports of `#/utilities/tailwindVariants`

### DIFF
--- a/app/dashboard/src/components/AriaComponents/Inputs/Input/Input.tsx
+++ b/app/dashboard/src/components/AriaComponents/Inputs/Input/Input.tsx
@@ -12,8 +12,6 @@ import {
   type Ref,
 } from 'react'
 
-import type { VariantProps } from 'tailwind-variants'
-
 import * as aria from '#/components/aria'
 import {
   Form,
@@ -30,7 +28,7 @@ import SvgMask from '#/components/SvgMask'
 import { useAutoFocus } from '#/hooks/autoFocusHooks'
 import { mergeRefs } from '#/utilities/mergeRefs'
 import { forwardRef } from '#/utilities/react'
-import type { ExtractFunction } from '#/utilities/tailwindVariants'
+import type { ExtractFunction, VariantProps } from '#/utilities/tailwindVariants'
 import { omit } from 'enso-common/src/utilities/data/object'
 import { INPUT_STYLES } from '../variants'
 

--- a/app/dashboard/src/components/AriaComponents/Inputs/MultiSelector/MultiSelector.tsx
+++ b/app/dashboard/src/components/AriaComponents/Inputs/MultiSelector/MultiSelector.tsx
@@ -1,8 +1,6 @@
 /** @file A horizontal selector supporting multiple input. */
 import { useRef, type CSSProperties, type ForwardedRef, type Ref } from 'react'
 
-import type { VariantProps } from 'tailwind-variants'
-
 import {
   FieldError,
   ListBox,
@@ -20,7 +18,7 @@ import {
 } from '#/components/AriaComponents'
 import { mergeRefs } from '#/utilities/mergeRefs'
 import { forwardRef } from '#/utilities/react'
-import { tv } from '#/utilities/tailwindVariants'
+import { tv, type VariantProps } from '#/utilities/tailwindVariants'
 import { omit, unsafeRemoveUndefined } from 'enso-common/src/utilities/data/object'
 import { MultiSelectorOption } from './MultiSelectorOption'
 

--- a/app/dashboard/src/components/AriaComponents/Inputs/Selector/Selector.tsx
+++ b/app/dashboard/src/components/AriaComponents/Inputs/Selector/Selector.tsx
@@ -1,8 +1,6 @@
 /** @file A horizontal selector. */
 import * as React from 'react'
 
-import type * as twv from 'tailwind-variants'
-
 import { mergeProps, type RadioGroupProps } from '#/components/aria'
 import type { FieldComponentProps } from '#/components/AriaComponents'
 import {
@@ -19,7 +17,7 @@ import { AnimatedBackground } from '#/components/AnimatedBackground'
 import RadioGroup from '#/components/styled/RadioGroup'
 import { mergeRefs } from '#/utilities/mergeRefs'
 import { forwardRef } from '#/utilities/react'
-import { tv } from '#/utilities/tailwindVariants'
+import { tv, type VariantProps } from '#/utilities/tailwindVariants'
 import { SelectorOption } from './SelectorOption'
 
 /** * Props for the Selector component. */
@@ -30,7 +28,7 @@ export interface SelectorProps<Schema extends TSchema, TFieldName extends FieldP
       TFieldName
     >,
     FieldProps,
-    Omit<twv.VariantProps<typeof SELECTOR_STYLES>, 'disabled' | 'invalid'>,
+    Omit<VariantProps<typeof SELECTOR_STYLES>, 'disabled' | 'invalid' | 'variants'>,
     FieldVariantProps {
   readonly items: readonly FieldValues<Schema>[TFieldName][]
   readonly children?: (item: FieldValues<Schema>[TFieldName]) => string

--- a/app/dashboard/src/components/AriaComponents/Switch/Switch.tsx
+++ b/app/dashboard/src/components/AriaComponents/Switch/Switch.tsx
@@ -3,6 +3,8 @@
  *
  * A switch allows a user to turn a setting on or off.
  */
+import { useRef, type CSSProperties, type ForwardedRef } from 'react'
+
 import {
   Switch as AriaSwitch,
   mergeProps,
@@ -10,9 +12,7 @@ import {
 } from '#/components/aria'
 import { mergeRefs } from '#/utilities/mergeRefs'
 import { forwardRef } from '#/utilities/react'
-import type { CSSProperties, ForwardedRef } from 'react'
-import { useRef } from 'react'
-import { tv, type VariantProps } from 'tailwind-variants'
+import { tv, type VariantProps } from '#/utilities/tailwindVariants'
 import { Form, type FieldPath, type FieldProps, type FieldStateProps, type TSchema } from '../Form'
 import { TEXT_STYLE } from '../Text'
 

--- a/app/dashboard/src/components/Result.tsx
+++ b/app/dashboard/src/components/Result.tsx
@@ -1,14 +1,13 @@
 /** @file Display the result of an operation. */
 import * as React from 'react'
 
-import * as twv from 'tailwind-variants'
-
 import Success from '#/assets/check_mark.svg'
 import Error from '#/assets/cross.svg'
 
 import * as ariaComponents from '#/components/AriaComponents'
 import * as loader from '#/components/Loader'
 import SvgMask from '#/components/SvgMask'
+import { tv, type VariantProps } from '#/utilities/tailwindVariants'
 
 // =================
 // === Constants ===
@@ -48,7 +47,7 @@ const STATUS_ICON_MAP: Readonly<Record<Status, StatusIcon>> = {
   },
 }
 
-const RESULT_STYLES = twv.tv({
+const RESULT_STYLES = tv({
   base: 'flex flex-col items-center justify-center max-w-full px-6 py-4 text-center h-[max-content]',
   variants: {
     centered: {
@@ -92,9 +91,7 @@ interface StatusIcon {
 // ==============
 
 /** Props for a {@link Result}. */
-export interface ResultProps
-  extends React.PropsWithChildren,
-    twv.VariantProps<typeof RESULT_STYLES> {
+export interface ResultProps extends React.PropsWithChildren, VariantProps<typeof RESULT_STYLES> {
   readonly className?: string
   readonly title?: React.JSX.Element | string
   readonly subtitle?: React.JSX.Element | string

--- a/app/dashboard/src/components/Stepper/Step.tsx
+++ b/app/dashboard/src/components/Stepper/Step.tsx
@@ -5,13 +5,13 @@
 import * as React from 'react'
 
 import { AnimatePresence, motion } from 'framer-motion'
-import * as tvw from 'tailwind-variants'
 
 import DoneIcon from '#/assets/check_mark.svg'
 
 import * as ariaComponents from '#/components/AriaComponents'
 import SvgMask from '#/components/SvgMask'
 
+import { tv } from '#/utilities/tailwindVariants'
 import * as stepperProvider from './StepperProvider'
 import type { RenderStepProps } from './types'
 import type * as stepperState from './useStepperState'
@@ -31,7 +31,7 @@ export interface StepProps extends RenderStepProps {
   readonly children?: StepProp<React.ReactNode>
 }
 
-const STEP_STYLES = tvw.tv({
+const STEP_STYLES = tv({
   base: 'relative flex items-center gap-2 select-none',
   slots: {
     icon: 'w-6 h-6 border-0.5 flex-none border-current rounded-full flex items-center justify-center transition-colors duration-200',

--- a/app/dashboard/src/components/Stepper/Stepper.tsx
+++ b/app/dashboard/src/components/Stepper/Stepper.tsx
@@ -6,13 +6,13 @@
 import * as React from 'react'
 
 import { AnimatePresence, motion } from 'framer-motion'
-import * as tvw from 'tailwind-variants'
 
 import * as eventCallback from '#/hooks/eventCallbackHooks'
 
 import { ErrorBoundary } from '#/components/ErrorBoundary'
 import { Suspense } from '#/components/Suspense'
 
+import { tv } from '#/utilities/tailwindVariants'
 import { Step } from './Step'
 import { StepContent } from './StepContent'
 import * as stepperProvider from './StepperProvider'
@@ -37,7 +37,7 @@ export interface StepperProps {
     | undefined
 }
 
-const STEPPER_STYLES = tvw.tv({
+const STEPPER_STYLES = tv({
   base: 'flex flex-col items-center w-full gap-4',
   slots: {
     steps: 'flex items-center justify-between w-full',

--- a/app/dashboard/src/modules/payments/components/PlanSelector/components/Card.tsx
+++ b/app/dashboard/src/modules/payments/components/PlanSelector/components/Card.tsx
@@ -5,8 +5,6 @@
  */
 import * as React from 'react'
 
-import * as twv from 'tailwind-variants'
-
 import type * as text from 'enso-common/src/text'
 
 import Check from '#/assets/check_mark.svg'
@@ -15,11 +13,12 @@ import * as textProvider from '#/providers/TextProvider'
 
 import * as ariaComponents from '#/components/AriaComponents'
 import SvgMask from '#/components/SvgMask'
+import { tv, type VariantProps } from '#/utilities/tailwindVariants'
 
 /**
  * Card props
  */
-export interface CardProps extends React.PropsWithChildren, twv.VariantProps<typeof CARD_STYLES> {
+export interface CardProps extends React.PropsWithChildren, VariantProps<typeof CARD_STYLES> {
   /**
    * Card title
    */
@@ -38,7 +37,7 @@ export interface CardProps extends React.PropsWithChildren, twv.VariantProps<typ
   readonly className?: string
 }
 
-export const CARD_STYLES = twv.tv({
+export const CARD_STYLES = tv({
   base: 'flex flex-col border-0.5',
   variants: {
     elevated: {


### PR DESCRIPTION
### Pull Request Description
- Replace imports of `tailwind-variants` with imports of `#/utilities/tailwindVariants`
  - A very minor change, just wanted to do it for consistency's sake

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
