### PR TITLE
Don't send expression updates about interrupts

### DIFF
--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/ExecuteExpressionCommand.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/ExecuteExpressionCommand.java
@@ -47,6 +47,10 @@ public final class ExecuteExpressionCommand extends SynchronousCommand {
       ctx.jobControlPlane()
           .abortJobs(
               contextId,
+              "execute expression for expression "
+                  + expressionId
+                  + " in visualization "
+                  + visualizationId,
               job -> {
                 if (job instanceof ExecuteJob e) {
                   return e.visualizationTriggered();

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/InvalidateModulesIndexCommand.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/InvalidateModulesIndexCommand.java
@@ -33,7 +33,9 @@ public final class InvalidateModulesIndexCommand extends AsynchronousCommand {
           try {
             logger.log(Level.FINE, "Invalidating modules, cancelling background jobs");
             ctx.jobControlPlane().stopBackgroundJobs();
-            ctx.jobControlPlane().abortBackgroundJobs(DeserializeLibrarySuggestionsJob.class);
+            ctx.jobControlPlane()
+                .abortBackgroundJobs(
+                    "invalidate modules index", DeserializeLibrarySuggestionsJob.class);
 
             EnsoContext context = ctx.executionService().getContext();
             context

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/SetExecutionEnvironmentCommand.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/command/SetExecutionEnvironmentCommand.java
@@ -50,7 +50,9 @@ public class SetExecutionEnvironmentCommand extends AsynchronousCommand {
               var oldEnvironmentName =
                   ctx.executionService().getContext().getExecutionEnvironment().getName();
               if (!oldEnvironmentName.equals(executionEnvironment.name())) {
-                ctx.jobControlPlane().abortJobs(contextId);
+                ctx.jobControlPlane()
+                    .abortJobs(
+                        contextId, "set execution environment to " + executionEnvironment.name());
                 ctx.locking()
                     .withWriteCompilationLock(
                         this.getClass(),

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/execution/JobControlPlane.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/execution/JobControlPlane.java
@@ -7,7 +7,7 @@ import org.enso.interpreter.instrument.job.Job;
 public interface JobControlPlane {
 
   /** Aborts all interruptible jobs. */
-  void abortAllJobs();
+  void abortAllJobs(String reason);
 
   /**
    * Abort all jobs except the ignored jobs.
@@ -15,7 +15,7 @@ public interface JobControlPlane {
    * @param ignoredJobs the list of jobs to keep in the execution queue
    */
   @SuppressWarnings("unchecked")
-  void abortAllExcept(Class<? extends Job<?>>... ignoredJobs);
+  void abortAllExcept(String reason, Class<? extends Job<?>>... ignoredJobs);
 
   /**
    * Aborts jobs that relates to the specified execution context.
@@ -25,7 +25,7 @@ public interface JobControlPlane {
    *     aborted
    */
   @SuppressWarnings("unchecked")
-  void abortJobs(UUID contextId, Class<? extends Job<?>>... classOf);
+  void abortJobs(UUID contextId, String reason, Class<? extends Job<?>>... classOf);
 
   /**
    * Aborts jobs that relate to the specified execution context.
@@ -34,7 +34,8 @@ public interface JobControlPlane {
    * @param accept filter that selects jobs to be aborted
    */
   @SuppressWarnings("unchecked")
-  void abortJobs(UUID contextId, java.util.function.Function<Job<?>, Boolean> accept);
+  void abortJobs(
+      UUID contextId, String reason, java.util.function.Function<Job<?>, Boolean> accept);
 
   /**
    * Abort provided background jobs.
@@ -42,7 +43,7 @@ public interface JobControlPlane {
    * @param toAbort the list of jobs to abort
    */
   @SuppressWarnings("unchecked")
-  void abortBackgroundJobs(Class<? extends Job<?>>... toAbort);
+  void abortBackgroundJobs(String reason, Class<? extends Job<?>>... toAbort);
 
   /**
    * Starts background jobs processing.

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/VisualizationResult.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/VisualizationResult.java
@@ -1,6 +1,7 @@
 package org.enso.interpreter.instrument.job;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.interop.ExceptionType;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import java.nio.charset.StandardCharsets;
@@ -39,6 +40,15 @@ public final class VisualizationResult {
       }
     } catch (UnsupportedMessageException ignore) {
       throw CompilerDirectives.shouldNotReachHere(ignore);
+    }
+  }
+
+  public static boolean isInterruptedException(Throwable ex) {
+    var iop = InteropLibrary.getUncached();
+    try {
+      return iop.getExceptionType(ex) == ExceptionType.INTERRUPT;
+    } catch (UnsupportedMessageException e) {
+      throw CompilerDirectives.shouldNotReachHere(e);
     }
   }
 

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/VisualizationResult.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/VisualizationResult.java
@@ -46,7 +46,16 @@ public final class VisualizationResult {
   public static boolean isInterruptedException(Throwable ex) {
     var iop = InteropLibrary.getUncached();
     try {
-      return iop.getExceptionType(ex) == ExceptionType.INTERRUPT;
+      var interrupt = iop.getExceptionType(ex) == ExceptionType.INTERRUPT;
+      if (interrupt) {
+        return true;
+      }
+      try {
+        var cause = iop.getExceptionCause(ex);
+        return cause != null && iop.getExceptionType(cause) == ExceptionType.INTERRUPT;
+      } catch (UnsupportedMessageException e) {
+        return false;
+      }
     } catch (UnsupportedMessageException e) {
       throw CompilerDirectives.shouldNotReachHere(e);
     }

--- a/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/VisualizationResult.java
+++ b/engine/runtime-instrument-common/src/main/java/org/enso/interpreter/instrument/job/VisualizationResult.java
@@ -45,6 +45,10 @@ public final class VisualizationResult {
 
   public static boolean isInterruptedException(Throwable ex) {
     var iop = InteropLibrary.getUncached();
+    return isInterruptedException(ex, iop);
+  }
+
+  private static boolean isInterruptedException(Object ex, InteropLibrary iop) {
     try {
       var interrupt = iop.getExceptionType(ex) == ExceptionType.INTERRUPT;
       if (interrupt) {
@@ -52,7 +56,7 @@ public final class VisualizationResult {
       }
       try {
         var cause = iop.getExceptionCause(ex);
-        return cause != null && iop.getExceptionType(cause) == ExceptionType.INTERRUPT;
+        return cause != null && isInterruptedException(cause, iop);
       } catch (UnsupportedMessageException e) {
         return false;
       }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/DestroyContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/DestroyContextCmd.scala
@@ -34,7 +34,7 @@ class DestroyContextCmd(
   }
 
   private def removeContext()(implicit ctx: RuntimeContext): Unit = {
-    ctx.jobControlPlane.abortJobs(request.contextId)
+    ctx.jobControlPlane.abortJobs(request.contextId, "destroy context")
     val contextLock = ctx.locking.getOrCreateContextLock(request.contextId)
     try {
       ctx.locking.withContextLock(

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/EditFileCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/EditFileCmd.scala
@@ -34,7 +34,7 @@ class EditFileCmd(request: Api.EditFileNotification)
           () => {
             logger.log(
               Level.FINEST,
-              "Adding pending file [{0}] edits [{1}] idMap [{2}]",
+              "Adding pending file [{0}] edits [{1}] and IdMap of length {2}",
               Array[Any](
                 MaskedPath(request.path.toPath),
                 request.edits.map(e => (e.range, e.text.length)),
@@ -50,7 +50,7 @@ class EditFileCmd(request: Api.EditFileNotification)
               ctx.state.pendingEdits.updateIdMap(request.path, idMap)
             }
             if (request.execute) {
-              ctx.jobControlPlane.abortAllJobs()
+              ctx.jobControlPlane.abortAllJobs("edit file")
               ctx.jobProcessor
                 .run(compileJob())
                 .foreach(_ => executeJobs.foreach(ctx.jobProcessor.run))

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/InterruptContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/InterruptContextCmd.scala
@@ -23,7 +23,7 @@ class InterruptContextCmd(
   ): Future[Unit] =
     if (doesContextExist) {
       Future {
-        ctx.jobControlPlane.abortJobs(request.contextId)
+        ctx.jobControlPlane.abortJobs(request.contextId, "interrupt context")
         reply(Api.InterruptContextResponse(request.contextId))
       }
     } else {

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/PopContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/PopContextCmd.scala
@@ -43,7 +43,7 @@ class PopContextCmd(
     ec: ExecutionContext
   ): Future[Unit] =
     Future {
-      ctx.jobControlPlane.abortJobs(request.contextId)
+      ctx.jobControlPlane.abortJobs(request.contextId, "pop context")
       val maybeTopItem = ctx.contextManager.pop(request.contextId)
       if (maybeTopItem.isDefined) {
         reply(Api.PopContextResponse(request.contextId))

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/PushContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/PushContextCmd.scala
@@ -46,7 +46,7 @@ class PushContextCmd(
     ec: ExecutionContext
   ): Future[Boolean] =
     Future {
-      ctx.jobControlPlane.abortJobs(request.contextId)
+      ctx.jobControlPlane.abortJobs(request.contextId, "push context")
       val stack = ctx.contextManager.getStack(request.contextId)
       val pushed = request.stackItem match {
         case _: Api.StackItem.ExplicitCall if stack.isEmpty =>

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/RecomputeContextCmd.scala
@@ -35,7 +35,7 @@ class RecomputeContextCmd(
     ec: ExecutionContext
   ): Future[Boolean] = {
     Future {
-      ctx.jobControlPlane.abortJobs(request.contextId)
+      ctx.jobControlPlane.abortJobs(request.contextId, "recompute context")
       val stack = ctx.contextManager.getStack(request.contextId)
       if (stack.isEmpty) {
         reply(Api.EmptyStackError(request.contextId))

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/SetExpressionValueCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/SetExpressionValueCmd.scala
@@ -38,7 +38,9 @@ class SetExpressionValueCmd(request: Api.SetExpressionValueNotification)
                 )
               )
             ctx.state.pendingEdits.enqueue(request.path, pendingApplyEdits)
-            ctx.jobControlPlane.abortAllJobs()
+            ctx.jobControlPlane.abortAllJobs(
+              "set expression value for expression " + request.expressionId
+            )
             ctx.jobProcessor.run(new EnsureCompiledJob(Seq(request.path)))
             executeJobs.foreach(ctx.jobProcessor.run)
             Future.successful(())

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/execution/JobExecutionEngine.scala
@@ -1,5 +1,6 @@
 package org.enso.interpreter.instrument.execution
 
+import com.oracle.truffle.api.TruffleLogger
 import org.enso.interpreter.instrument.InterpreterContext
 import org.enso.interpreter.instrument.job.{BackgroundJob, Job, UniqueJob}
 import org.enso.text.Sha3_224VersionCalculator
@@ -74,6 +75,9 @@ final class JobExecutionEngine(
       versionCalculator = Sha3_224VersionCalculator
     )
 
+  private lazy val logger: TruffleLogger =
+    runtimeContext.executionService.getLogger
+
   /** @inheritdoc */
   override def runBackground[A](job: BackgroundJob[A]): Unit =
     synchronized {
@@ -112,7 +116,7 @@ final class JobExecutionEngine(
         allJobs.foreach { runningJob =>
           runningJob.job match {
             case jobRef: UniqueJob[_] if jobRef.equalsTo(job) =>
-              runtimeContext.executionService.getLogger
+              logger
                 .log(Level.FINEST, s"Cancelling duplicate job [$jobRef].")
               runningJob.future.cancel(jobRef.mayInterruptIfRunning)
             case _ =>
@@ -129,8 +133,11 @@ final class JobExecutionEngine(
   ): Future[A] = {
     val jobId   = UUID.randomUUID()
     val promise = Promise[A]()
-    val logger  = runtimeContext.executionService.getLogger
-    logger.log(Level.FINE, s"Submitting job: {0}...", job)
+    logger.log(
+      Level.FINE,
+      s"Submitting job: {0} with {1} id...",
+      Array(job, jobId)
+    )
     val future = executorService.submit(() => {
       logger.log(Level.FINE, s"Executing job: {0}...", job)
       val before = System.currentTimeMillis()
@@ -166,17 +173,25 @@ final class JobExecutionEngine(
   }
 
   /** @inheritdoc */
-  override def abortAllJobs(): Unit =
-    abortAllExcept()
+  override def abortAllJobs(reason: String): Unit =
+    abortAllExcept(reason)
 
   /** @inheritdoc */
-  override def abortAllExcept(ignoredJobs: Class[_ <: Job[_]]*): Unit = {
+  override def abortAllExcept(
+    reason: String,
+    ignoredJobs: Class[_ <: Job[_]]*
+  ): Unit = {
     val allJobs = runningJobsRef.updateAndGet(_.filterNot(_.future.isCancelled))
     val cancellableJobs = allJobs
       .filter { runningJob =>
         runningJob.job.isCancellable &&
         !ignoredJobs.contains(runningJob.job.getClass)
       }
+    logger.log(
+      Level.FINE,
+      "Aborting {0} jobs because {1}: {2}",
+      Array(cancellableJobs.length, reason, cancellableJobs.map(_.id))
+    )
     cancellableJobs.foreach { runningJob =>
       runningJob.future.cancel(runningJob.job.mayInterruptIfRunning)
     }
@@ -187,6 +202,7 @@ final class JobExecutionEngine(
   /** @inheritdoc */
   override def abortJobs(
     contextId: UUID,
+    reason: String,
     toAbort: Class[_ <: Job[_]]*
   ): Unit = {
     val allJobs     = runningJobsRef.get()
@@ -196,6 +212,11 @@ final class JobExecutionEngine(
         runningJob.job.isCancellable && (toAbort.isEmpty || toAbort
           .contains(runningJob.getClass))
       ) {
+        logger.log(
+          Level.FINE,
+          "Aborting job {0} because {1}",
+          Array(runningJob.id, reason)
+        )
         runningJob.future.cancel(runningJob.job.mayInterruptIfRunning)
       }
     }
@@ -206,12 +227,18 @@ final class JobExecutionEngine(
   /** @inheritdoc */
   override def abortJobs(
     contextId: UUID,
+    reason: String,
     accept: java.util.function.Function[Job[_], java.lang.Boolean]
   ): Unit = {
     val allJobs     = runningJobsRef.get()
     val contextJobs = allJobs.filter(_.job.contextIds.contains(contextId))
     contextJobs.foreach { runningJob =>
       if (runningJob.job.isCancellable && accept.apply(runningJob.job)) {
+        logger.log(
+          Level.FINE,
+          "Aborting job {0} because {1}",
+          Array(runningJob.id, reason)
+        )
         runningJob.future.cancel(runningJob.job.mayInterruptIfRunning)
       }
     }
@@ -219,7 +246,10 @@ final class JobExecutionEngine(
       .interruptThreads()
   }
 
-  override def abortBackgroundJobs(toAbort: Class[_ <: Job[_]]*): Unit = {
+  override def abortBackgroundJobs(
+    reason: String,
+    toAbort: Class[_ <: Job[_]]*
+  ): Unit = {
     val allJobs =
       backgroundJobsRef.updateAndGet(_.filterNot(_.future.isCancelled))
     val cancellableJobs = allJobs
@@ -227,6 +257,11 @@ final class JobExecutionEngine(
         runningJob.job.isCancellable &&
         toAbort.contains(runningJob.job.getClass)
       }
+    logger.log(
+      Level.FINE,
+      "Aborting {0} background jobs because {1}: {2}",
+      Array(cancellableJobs.length, reason, cancellableJobs.map(_.id))
+    )
     cancellableJobs.foreach { runningJob =>
       runningJob.future.cancel(runningJob.job.mayInterruptIfRunning)
     }

--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/job/ProgramExecutionSupport.scala
@@ -390,27 +390,40 @@ object ProgramExecutionSupport {
     ) {
       val payload = value.getValue match {
         case sentinel: PanicSentinel =>
-          Api.ExpressionUpdate.Payload
-            .Panic(
-              ctx.executionService.getExceptionMessage(sentinel.getPanic),
-              ErrorResolver.getStackTrace(sentinel).flatMap(_.expressionId)
-            )
+          Some(
+            Api.ExpressionUpdate.Payload
+              .Panic(
+                ctx.executionService.getExceptionMessage(sentinel.getPanic),
+                ErrorResolver.getStackTrace(sentinel).flatMap(_.expressionId)
+              )
+          )
         case error: DataflowError =>
-          Api.ExpressionUpdate.Payload.DataflowError(
-            ErrorResolver.getStackTrace(error).flatMap(_.expressionId)
+          Some(
+            Api.ExpressionUpdate.Payload.DataflowError(
+              ErrorResolver.getStackTrace(error).flatMap(_.expressionId)
+            )
           )
         case panic: AbstractTruffleException =>
-          Api.ExpressionUpdate.Payload
-            .Panic(
-              VisualizationResult.findExceptionMessage(panic),
-              ErrorResolver.getStackTrace(panic).flatMap(_.expressionId)
+          if (!VisualizationResult.isInterruptedException(panic)) {
+            Some(
+              Api.ExpressionUpdate.Payload.Panic(
+                VisualizationResult.findExceptionMessage(panic),
+                ErrorResolver.getStackTrace(panic).flatMap(_.expressionId)
+              )
             )
+          } else {
+            ctx.executionService.getLogger
+              .log(Level.FINE, "computation of expression has been interrupted")
+            None
+          }
         case warnings: WithWarnings
             if warnings.getValue.isInstanceOf[DataflowError] =>
-          Api.ExpressionUpdate.Payload.DataflowError(
-            ErrorResolver
-              .getStackTrace(warnings.getValue.asInstanceOf[DataflowError])
-              .flatMap(_.expressionId)
+          Some(
+            Api.ExpressionUpdate.Payload.DataflowError(
+              ErrorResolver
+                .getStackTrace(warnings.getValue.asInstanceOf[DataflowError])
+                .flatMap(_.expressionId)
+            )
           )
         case _ =>
           val warnings =
@@ -475,28 +488,30 @@ object ProgramExecutionSupport {
               None
           }
 
-          Api.ExpressionUpdate.Payload.Value(warnings, schema)
+          Some(Api.ExpressionUpdate.Payload.Value(warnings, schema))
       }
-      ctx.endpoint.sendToClient(
-        Api.Response(
-          Api.ExpressionUpdates(
-            contextId,
-            Set(
-              Api.ExpressionUpdate(
-                value.getExpressionId,
-                Option(value.getType),
-                methodCall,
-                value.getProfilingInfo.map { case e: ExecutionTime =>
-                  Api.ProfilingInfo.ExecutionTime(e.getNanoTimeElapsed)
-                }.toVector,
-                value.wasCached(),
-                value.isTypeChanged || value.isFunctionCallChanged,
-                payload
+      payload.foreach { p =>
+        ctx.endpoint.sendToClient(
+          Api.Response(
+            Api.ExpressionUpdates(
+              contextId,
+              Set(
+                Api.ExpressionUpdate(
+                  value.getExpressionId,
+                  Option(value.getType),
+                  methodCall,
+                  value.getProfilingInfo.map { case e: ExecutionTime =>
+                    Api.ProfilingInfo.ExecutionTime(e.getNanoTimeElapsed)
+                  }.toVector,
+                  value.wasCached(),
+                  value.isTypeChanged || value.isFunctionCallChanged,
+                  p
+                )
               )
             )
           )
         )
-      )
+      }
 
       syncState.setExpressionSync(expressionId)
       if (methodCall.isDefined) {

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/instrument/RuntimeAsyncCommandsTest.scala
@@ -249,8 +249,6 @@ class RuntimeAsyncCommandsTest
     val contextId  = UUID.randomUUID()
     val requestId  = UUID.randomUUID()
 
-    println("new context")
-
     val metadata = new Metadata
     metadata.addItem(194, 7)
     val code =


### PR DESCRIPTION
### Pull Request Description

There is no value in sending expression updates involving interrupts to the user:
![Screenshot from 2024-09-30 14-47-17-2](https://github.com/user-attachments/assets/78fca5bf-085d-4c1c-99fb-0acb5f0a31a3)

Adding more logging information to see how aborts affect execution.

Related to #11084.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
