### PR TITLE
Resolving `~` in Enso asset paths to user home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 [11151]: https://github.com/enso-org/enso/pull/11151
 
+#### Enso Standard Library
+
+- [The `enso://~` path now resolves to user's home directory in the
+  cloud.][11235]
+
+[11235]: https://github.com/enso-org/enso/pull/11235
+
 # Enso 2024.4
 
 #### Enso IDE

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
@@ -53,19 +53,6 @@ type Enso_File
 
        Arguments:
        - path: The `enso://` path to a file or directory.
-
-       ? Enso Cloud Paths
-
-         The paths consist of the organization (user) name followed by a path to
-         the file/directory delimited by `/`.
-         For example `enso://my_org/some_dir/some-file.txt`.
-
-       ! Work in progress - only existing resources
-
-         Currently the API is only able to resolve paths to existing files or
-         directories. This is a temporary limitation and it will be improved in
-         the future, alongside with implementing the capabilities to write new
-         files.
     new : Text -> Enso_File ! Not_Found
     new (path : Text) =
         Enso_File.Value (Enso_Path.parse path)

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Enso_File.enso
@@ -64,7 +64,7 @@ type Enso_File
        Represents the current user's home directory.
     home : Enso_File
     home -> Enso_File =
-        Enso_File.root /  "Users" / Enso_User.current.name
+        Enso_File.root / "Users" / Enso_User.current.name
 
 
     ## ICON folder

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Enso_Path.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Enso_Path.enso
@@ -63,4 +63,12 @@ type Enso_Path
 
 ## PRIVATE
 normalize segments =
-    Path_Helpers.normalize_segments segments (x->x)
+    after_resolving_dots = Path_Helpers.normalize_segments segments (x->x)
+    starts_with_tilde = after_resolving_dots.take 1 == ["~"]
+    if starts_with_tilde.not then after_resolving_dots else
+        # If after resolution our path starts with `~`, we replace that with a home directory.
+        home_path = Enso_File.home.enso_path
+        new_segments = home_path.path_segments + after_resolving_dots.drop 1
+        ## We need to call normalize again, because technically a path `enso://a/../~/../../~` is a valid path
+           that points to the user home and it should be correctly normalized, but requires numerous passes to do so.
+        @Tail_Call normalize new_segments

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Data_Link_Setup.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Data_Link_Setup.enso
@@ -4,6 +4,7 @@ from Standard.Base import all
 import Standard.Base.Enso_Cloud.Data_Link.Data_Link
 import Standard.Base.Errors.File_Error.File_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
+import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Runtime.Context
 from Standard.Base.Enso_Cloud.Data_Link_Helpers import data_link_extension, secure_value_to_json
 

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Data_Link_Setup.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/Postgres/Postgres_Data_Link_Setup.enso
@@ -53,7 +53,7 @@ prepare_credentials data_link_location:Enso_File details:Postgres -> JS_Object |
             secret_password = case credentials.password of
                 secret : Enso_Secret -> secret
                 plain_text_password : Text ->
-                    secret_location = data_link_location.parent.if_nothing Enso_File.root
+                    secret_location = data_link_location.parent.if_nothing (Error.throw (Illegal_State.Error "Trying to create a secret to store the Data Link password, but the provided data link location: "+data_link_location.to_text+" does not have a parent directory. This should not happen."))
                     location_name = if data_link_location.name.ends_with data_link_extension then data_link_location.name.drop (..Last data_link_extension.length) else data_link_location.name
 
                     create_fresh_secret ix =

--- a/test/AWS_Tests/src/Inter_Backend_File_Operations_Spec.enso
+++ b/test/AWS_Tests/src/Inter_Backend_File_Operations_Spec.enso
@@ -42,7 +42,7 @@ type Temporary_Enso_Cloud_File
     Value ~get
 
     make tmp_dir_name name = Temporary_Enso_Cloud_File.Value <|
-        location = Enso_File.root / tmp_dir_name
+        location = Enso_File.home / tmp_dir_name
         Panic.rethrow <| location.create_directory
         location / ("cloud-"+name)
 

--- a/test/Base_Tests/src/Network/Enso_Cloud/Enso_File_Spec.enso
+++ b/test/Base_Tests/src/Network/Enso_Cloud/Enso_File_Spec.enso
@@ -274,6 +274,17 @@ add_specs suite_builder setup:Cloud_Tests_Setup = suite_builder.group "Enso Clou
         Enso_File.new "enso://~" . should_equal Enso_File.home
         Enso_File.new "enso://~/a/b/c" . should_equal (Enso_File.home / "a/b/c")
 
+        # It also works when resolving a path
+        Enso_File.root / "~" . should_equal Enso_File.home
+        Enso_File.root / "a/../~/b/c" . should_equal (Enso_File.home / "b/c")
+        Enso_File.new "enso://a/../~/b/c" . should_equal (Enso_File.home / "b/c")
+
+        # But a filename only containing ~ is not resolved
+        Enso_File.new "enso://~~~" . should_not_equal Enso_File.home
+
+        # If the `~` is not at the beginning, it is not resolved
+        Enso_File.new "enso://a/b/c/~" . should_not_equal Enso_File.home
+
     group_builder.specify "currently does not support metadata for directories" <|
         # TODO this test should be 'reversed' and merged with above once the metadata is implemented
         dir = test_root.get / "test-directory"

--- a/test/Base_Tests/src/Network/Enso_Cloud/Enso_File_Spec.enso
+++ b/test/Base_Tests/src/Network/Enso_Cloud/Enso_File_Spec.enso
@@ -275,8 +275,8 @@ add_specs suite_builder setup:Cloud_Tests_Setup = suite_builder.group "Enso Clou
         Enso_File.new "enso://~/a/b/c" . should_equal (Enso_File.home / "a/b/c")
 
         # It also works when resolving a path
-        Enso_File.root / "~" . should_equal Enso_File.home
-        Enso_File.root / "a/../~/b/c" . should_equal (Enso_File.home / "b/c")
+        (Enso_File.root / "~") . should_equal Enso_File.home
+        (Enso_File.root / "a/../~/b/c") . should_equal (Enso_File.home / "b/c")
         Enso_File.new "enso://a/../~/b/c" . should_equal (Enso_File.home / "b/c")
 
         # But a filename only containing ~ is not resolved

--- a/test/Base_Tests/src/Network/Enso_Cloud/Enso_File_Spec.enso
+++ b/test/Base_Tests/src/Network/Enso_Cloud/Enso_File_Spec.enso
@@ -270,6 +270,10 @@ add_specs suite_builder setup:Cloud_Tests_Setup = suite_builder.group "Enso Clou
         r.should_fail_with Illegal_Argument
         r.catch.to_display_text . should_contain "Cannot move above root"
 
+    group_builder.specify "resolves ~ to user home" <|
+        Enso_File.new "enso://~" . should_equal Enso_File.home
+        Enso_File.new "enso://~/a/b/c" . should_equal (Enso_File.home / "a/b/c")
+
     group_builder.specify "currently does not support metadata for directories" <|
         # TODO this test should be 'reversed' and merged with above once the metadata is implemented
         dir = test_root.get / "test-directory"

--- a/test/Table_Tests/src/Database/Common/Audit_Spec.enso
+++ b/test/Table_Tests/src/Database/Common/Audit_Spec.enso
@@ -34,7 +34,7 @@ add_specs suite_builder prefix ~datalink_to_connection database_pending =
 
             # Retrying is needed as there may be some delay before the background thread finishes processing the logs.
             Test.with_retries <|
-                Thread.sleep 500
+                Thread.sleep 1000
                 all_events = get_audit_log_events
                 relevant_events = all_events.filter e-> e.message.contains table_name
 


### PR DESCRIPTION
### Pull Request Description

- Closes #11226

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
