### PR TITLE
Compute the exception message sooner than context is closed

### DIFF
--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -742,23 +742,30 @@ public class Main {
       factory.checkForWarnings(mainFile.getName().replace(".enso", "") + ".main");
     }
     var context = new PolyglotContext(factory.build());
-
-    if (projectMode) {
-      var result = PackageManager$.MODULE$.Default().loadPackage(file);
-      if (result.isSuccess()) {
-        var s = (scala.util.Success) result;
-        @SuppressWarnings("unchecked")
-        var pkg = (org.enso.pkg.Package<java.io.File>) s.get();
-        var mainModuleName = pkg.moduleNameForFile(pkg.mainFile()).toString();
-        runPackage(context, mainModuleName, file, additionalArgs);
+    try {
+      if (projectMode) {
+        var result = PackageManager$.MODULE$.Default().loadPackage(file);
+        if (result.isSuccess()) {
+          var s = (scala.util.Success) result;
+          @SuppressWarnings("unchecked")
+          var pkg = (org.enso.pkg.Package<java.io.File>) s.get();
+          var mainModuleName = pkg.moduleNameForFile(pkg.mainFile()).toString();
+          runPackage(context, mainModuleName, file, additionalArgs);
+        } else {
+          println(((scala.util.Failure) result).exception().getMessage());
+          throw exitFail();
+        }
       } else {
-        println(((scala.util.Failure) result).exception().getMessage());
-        throw exitFail();
+        runSingleFile(context, file, additionalArgs);
       }
-    } else {
-      runSingleFile(context, file, additionalArgs);
+    } catch (RuntimeException e) {
+      // forces computation of the exception message sooner than context is closed
+      // should work around issues seen at #11127
+      logger.debug("Execution failed with " + e.getMessage());
+      throw e;
+    } finally {
+      context.context().close();
     }
-    context.context().close();
     throw exitSuccess();
   }
 
@@ -1215,7 +1222,7 @@ public class Main {
 
     try {
       return main.call();
-    } catch (IOException ex) {
+    } catch (IOException | RuntimeException ex) {
       throw ex;
     } catch (Exception ex) {
       throw new IOException(ex);

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/PanicsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/PanicsTest.scala
@@ -49,6 +49,29 @@ class PanicsTest extends InterpreterTest {
       consumeOut shouldEqual List("(Error: MyError)")
     }
 
+    "message should be computed soon enough" in {
+      val code =
+        """from Standard.Base import all
+          |
+          |type LM
+          |    V txt
+          |
+          |    to_display_text self =
+          |        res = self.txt + " from exception"
+          |        Panic.throw res
+          |
+          |main = Panic.throw (LM.V "Hi")
+          |""".stripMargin
+
+      try {
+        eval(code)
+      } catch {
+        case ex: InterpreterException =>
+          ex.getMessage() shouldEqual "Hi from exception"
+        case any: Throwable => throw any
+      }
+    }
+
     "catch polyglot errors" in {
       val code =
         """from Standard.Base import all

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/PanicsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/PanicsTest.scala
@@ -49,7 +49,7 @@ class PanicsTest extends InterpreterTest {
       consumeOut shouldEqual List("(Error: MyError)")
     }
 
-    "message should be computed soon enough" in {
+    "message should be computed before leaving the context" in {
       val code =
         """from Standard.Base import all
           |
@@ -65,9 +65,34 @@ class PanicsTest extends InterpreterTest {
 
       try {
         eval(code)
+        fail("Should raise an InterpreterException");
       } catch {
         case ex: InterpreterException =>
           ex.getMessage() shouldEqual "Hi from exception"
+        case any: Throwable => throw any
+      }
+    }
+
+    "panic causing stack overflow in to_display_text should still generate some error message" in {
+      val code =
+        """from Standard.Base import all
+          |
+          |type LM
+          |    V txt
+          |
+          |    to_display_text self =
+          |        res = LM.V (self.txt + "Ex")
+          |        res.to_display_text
+          |
+          |main = Panic.throw (LM.V "Hi")
+          |""".stripMargin
+
+      try {
+        eval(code)
+        fail("Should raise an InterpreterException");
+      } catch {
+        case ex: InterpreterException =>
+          ex.getMessage() shouldEqual "LM"
         case any: Throwable => throw any
       }
     }

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/callable/function/Function.java
@@ -32,6 +32,7 @@ import org.enso.interpreter.runtime.data.vector.ArrayLikeHelpers;
 import org.enso.interpreter.runtime.library.dispatch.TypesLibrary;
 import org.enso.interpreter.runtime.state.State;
 import org.enso.interpreter.runtime.type.Types;
+import org.slf4j.LoggerFactory;
 
 /** A runtime representation of a function object in Enso. */
 @ExportLibrary(InteropLibrary.class)
@@ -202,8 +203,21 @@ public final class Function implements EnsoObject {
         Object[] arguments,
         @Cached InteropApplicationNode interopApplicationNode,
         @CachedLibrary("function") InteropLibrary thisLib) {
-      return interopApplicationNode.execute(
-          function, EnsoContext.get(thisLib).emptyState(), arguments);
+      try {
+        return interopApplicationNode.execute(
+            function, EnsoContext.get(thisLib).emptyState(), arguments);
+      } catch (StackOverflowError err) {
+        CompilerDirectives.transferToInterpreter();
+        var asserts = false;
+        assert asserts = true;
+        var logger = LoggerFactory.getLogger(Function.class);
+        if (asserts) {
+          logger.error("StackOverflowError detected", err);
+        } else {
+          logger.debug("StackOverflowError detected", err);
+        }
+        throw err;
+      }
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -59,6 +59,10 @@ public final class PanicException extends AbstractTruffleException implements En
       throw new IllegalArgumentException("Only interop values are supported: " + payload);
     }
     this.payload = payload;
+    if (CompilerDirectives.inInterpreter()) {
+        getMessage();
+        assert cacheMessage != null;
+    }
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -60,7 +60,7 @@ public final class PanicException extends AbstractTruffleException implements En
       throw new IllegalArgumentException("Only interop values are supported: " + payload);
     }
     this.payload = payload;
-    if (CompilerDirectives.inInterpreter() && location == null) {
+    if (CompilerDirectives.inInterpreter()) {
       cacheMessage = computeMessage();
       assert cacheMessage != null;
     }
@@ -86,13 +86,12 @@ public final class PanicException extends AbstractTruffleException implements En
   @CompilerDirectives.TruffleBoundary
   private String computeMessage() {
     String msg;
-    InteropLibrary library = InteropLibrary.getUncached();
-    Object info = null;
+    var library = InteropLibrary.getUncached();
     try {
-      info = library.getExceptionMessage(this);
+      var info = library.getExceptionMessage(this);
       msg = library.asString(info);
     } catch (AssertionError | UnsupportedMessageException e) {
-      logger().error("Cannot convert " + info + " to string", e);
+      logger().error("Cannot compute message for " + payload, e);
       msg = TypeToDisplayTextNode.getUncached().execute(payload);
     }
     cacheMessage = msg;

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -60,10 +60,6 @@ public final class PanicException extends AbstractTruffleException implements En
       throw new IllegalArgumentException("Only interop values are supported: " + payload);
     }
     this.payload = payload;
-    if (CompilerDirectives.inInterpreter()) {
-      cacheMessage = computeMessage();
-      assert cacheMessage != null;
-    }
   }
 
   /**

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -60,8 +60,8 @@ public final class PanicException extends AbstractTruffleException implements En
     }
     this.payload = payload;
     if (CompilerDirectives.inInterpreter()) {
-        getMessage();
-        assert cacheMessage != null;
+      getMessage();
+      assert cacheMessage != null;
     }
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -86,8 +86,8 @@ public final class PanicException extends AbstractTruffleException implements En
     try {
       var info = library.getExceptionMessage(this);
       msg = library.asString(info);
-    } catch (AssertionError | UnsupportedMessageException e) {
-      logger().error("Cannot compute message for " + payload, e);
+    } catch (StackOverflowError | AssertionError | UnsupportedMessageException e) {
+      logger().atError().log("Cannot compute message for " + payload, e);
       msg = TypeToDisplayTextNode.getUncached().execute(payload);
     }
     cacheMessage = msg;


### PR DESCRIPTION
### Pull Request Description

There is a problem with logging when `TruffleLoggger` is used after its _context is closed_. Alas, that's exactly happening when `PanicException` is thrown. The context is closed first and only then the exception's [getMessage() method](https://github.com/enso-org/enso/blob/a2c853c6e31926807b7e44470ae4d5bbdc68aac9/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java#L87) is invoked trying to call into the _context again_. Following fixes to this problem are provided:
- let's use `slf4j` logger instead of `TruffleLogger` - then the `catch (AssertionError)` dealing with `assert` from Truffle logger can be removed
- let's materialize `PanicException.getMessage()` before we leave the context
- as a bonus also log stacktrace of `StackOverflowError` before leaving the context (observed when `getMessage()` was computed in `PanicException` constructor)

### Important Notes

Accessing Truffle's [ctx.getLogger().log(Level.WARNING however asserts](https://github.com/oracle/graal/blob/master/truffle/src/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLogger.java#L1014) at that moment. That's pretty bad, @tzezula, @chumer, as that means the **actual exception is lost** instead of logged! I used to blame our logging implementation for _swallowing exceptions_ - looks like (at least in this case), `TruffleLogger` is to blame. _Exceptions shouldn't be swallowed_. 

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
