### PR TITLE
Add Coalesce tests and fix In-Memory version

### DIFF
--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/IR/From_Spec.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Internal/IR/From_Spec.enso
@@ -122,6 +122,9 @@ type From_Spec_Comparator
             From_Spec.Table other_table_name _ _ ->
                 if table_name == other_table_name then Ordering.Equal else Nothing
             _ -> Nothing
+        From_Spec.Literal_Values _ _ _ -> case y of
+            From_Spec.Literal_Values _ _ _ ->
+                Nothing 
         _ -> Ordering.compare x y
 
     ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Column.enso
@@ -1007,8 +1007,8 @@ type Column
     coalesce self values =
         vec = Vector.unify_vector_or_element values
         new_name = self.naming_helper.function_name "coalesce" [self]+vec
-        result = if values.is_empty then self else
-            values.fold self acc-> v-> acc.fill_nothing v
+        result = if vec.is_empty then self else
+            vec.fold self acc-> v-> acc.fill_nothing v
         result.rename new_name
 
     ## GROUP Standard.Base.Math

--- a/test/Table_Tests/src/Common_Table_Operations/Coalesce_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Coalesce_Spec.enso
@@ -19,6 +19,12 @@ add_specs suite_builder setup =
     table_builder = setup.light_table_builder
 
     suite_builder.group prefix+"Table.coalesce" group_builder->
+        group_builder.specify "2 columns" <|
+            t = table_builder [["A", [1, 2, Nothing, Nothing]], ["B", [3, Nothing, 4, Nothing]]]
+            colA = t.get "A"
+            colB = t.get "B"
+            result = colA.coalesce colB
+            result.to_vector . should_equal [1, 2, 4, Nothing]
         group_builder.specify "2 columns passing second as vector" <|
             t = table_builder [["A", [1, 2, Nothing, Nothing]], ["B", [3, Nothing, 4, Nothing]]]
             colA = t.get "A"

--- a/test/Table_Tests/src/Common_Table_Operations/Coalesce_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Coalesce_Spec.enso
@@ -65,7 +65,7 @@ add_specs suite_builder setup =
                 False ->
                     result.to_vector . should_equal [1, 2, 4, Nothing]
                     result2.to_vector . should_equal [3, 2, 4, Nothing]
-        group_builder.specify "2 columns from length tables only works In-Memory" <|
+        group_builder.specify "2 columns from different length tables only works In-Memory" <|
             t1 = table_builder [["A", [1, 2, Nothing, Nothing, 3]], ["B", [Nothing, Nothing, Nothing, 99, 99]]]
             t2 = table_builder [["A", [99, Nothing, Nothing, Nothing]], ["B", [3, Nothing, 4, Nothing]]]
             colA = t1.get "A"

--- a/test/Table_Tests/src/Common_Table_Operations/Coalesce_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Coalesce_Spec.enso
@@ -55,3 +55,12 @@ add_specs suite_builder setup =
             colB = t.get "B"
             result = colA.coalesce colB
             result.should_fail_with No_Common_Type
+        group_builder.specify "2 columns of diffferent length" <|
+            t1 = table_builder [["A", [1, 2, Nothing, Nothing, 6]]]
+            t2 = table_builder [["B", [4, Nothing, 5, Nothing]]]
+            colA = t1.get "A"
+            colB = t2.get "B"
+            result = colA.coalesce colB
+            result.to_vector . should_equal [1, 2, 5, Nothing, 6]
+            result2 = colB.coalesce colA
+            result2.to_vector . should_equal [4, 2, 5, Nothing]

--- a/test/Table_Tests/src/Common_Table_Operations/Coalesce_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Coalesce_Spec.enso
@@ -38,3 +38,8 @@ add_specs suite_builder setup =
             colC = t.get "C"
             result = colA.coalesce [colB, colC]
             result.to_vector . should_equal [1, 2, 4, 8]
+        group_builder.specify "column and constant" <|
+            t = table_builder [["A", [1, 2, Nothing, Nothing]]]
+            colA = t.get "A"
+            result = colA.coalesce 42
+            result.to_vector . should_equal [1, 2, 42, 42]

--- a/test/Table_Tests/src/Common_Table_Operations/Coalesce_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Coalesce_Spec.enso
@@ -1,0 +1,27 @@
+from Standard.Base import all
+
+from Standard.Table import all hiding Table
+from Standard.Table.Errors import all
+import Standard.Table.Expression.Expression_Error
+
+import Standard.Database.Internal.IR.SQL_Expression.SQL_Expression
+from Standard.Database.Errors import SQL_Error
+
+from Standard.Test import all
+
+
+from project.Common_Table_Operations.Util import run_default_backend
+
+main filter=Nothing = run_default_backend add_specs filter
+
+add_specs suite_builder setup =
+    prefix = setup.prefix
+    table_builder = setup.light_table_builder
+
+    suite_builder.group prefix+"Table.coalesce" group_builder->
+        group_builder.specify "2 columns passing second as vector" <|
+            t = table_builder [["A", [1, 2, Nothing, Nothing]], ["B", [3, Nothing, 4, Nothing]]]
+            colA = t.get "A"
+            colB = t.get "B"
+            result = colA.coalesce [colB]
+            result.to_vector . should_equal [1, 2, 4, Nothing]

--- a/test/Table_Tests/src/Common_Table_Operations/Coalesce_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Coalesce_Spec.enso
@@ -25,3 +25,10 @@ add_specs suite_builder setup =
             colB = t.get "B"
             result = colA.coalesce [colB]
             result.to_vector . should_equal [1, 2, 4, Nothing]
+        group_builder.specify "2 columns passing second and third as vector" <|
+            t = table_builder [["A", [1, 2, Nothing, Nothing]], ["B", [3, Nothing, 4, Nothing]], ["C", [5, 6, 7, 8]]]
+            colA = t.get "A"
+            colB = t.get "B"
+            colC = t.get "C"
+            result = colA.coalesce [colB, colC]
+            result.to_vector . should_equal [1, 2, 4, 8]

--- a/test/Table_Tests/src/Common_Table_Operations/Coalesce_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Coalesce_Spec.enso
@@ -1,14 +1,10 @@
 from Standard.Base import all
 
 from Standard.Table import all hiding Table
-from Standard.Table.Errors import all
-import Standard.Table.Expression.Expression_Error
-
-import Standard.Database.Internal.IR.SQL_Expression.SQL_Expression
-from Standard.Database.Errors import SQL_Error
+from Standard.Table.Errors import No_Common_Type
+from Standard.Database.Errors import Integrity_Error
 
 from Standard.Test import all
-
 
 from project.Common_Table_Operations.Util import run_default_backend
 
@@ -16,7 +12,7 @@ main filter=Nothing = run_default_backend add_specs filter
 
 add_specs suite_builder setup =
     prefix = setup.prefix
-    table_builder = setup.light_table_builder
+    table_builder = setup.table_builder
 
     suite_builder.group prefix+"Table.coalesce" group_builder->
         group_builder.specify "2 columns" <|
@@ -55,12 +51,31 @@ add_specs suite_builder setup =
             colB = t.get "B"
             result = colA.coalesce colB
             result.should_fail_with No_Common_Type
-        group_builder.specify "2 columns of diffferent length" <|
-            t1 = table_builder [["A", [1, 2, Nothing, Nothing, 6]]]
-            t2 = table_builder [["B", [4, Nothing, 5, Nothing]]]
+        group_builder.specify "2 columns from different tables only works In-Memory" <|
+            t1 = table_builder [["A", [1, 2, Nothing, Nothing]], ["B", [Nothing, Nothing, Nothing, 99]]]
+            t2 = table_builder [["A", [99, Nothing, Nothing, Nothing]], ["B", [3, Nothing, 4, Nothing]]]
             colA = t1.get "A"
             colB = t2.get "B"
             result = colA.coalesce colB
-            result.to_vector . should_equal [1, 2, 5, Nothing, 6]
             result2 = colB.coalesce colA
-            result2.to_vector . should_equal [4, 2, 5, Nothing]
+            case setup.is_database of
+                True ->
+                    result.should_fail_with Integrity_Error
+                    result2.should_fail_with Integrity_Error
+                False ->
+                    result.to_vector . should_equal [1, 2, 4, Nothing]
+                    result2.to_vector . should_equal [3, 2, 4, Nothing]
+        group_builder.specify "2 columns from length tables only works In-Memory" <|
+            t1 = table_builder [["A", [1, 2, Nothing, Nothing, 3]], ["B", [Nothing, Nothing, Nothing, 99, 99]]]
+            t2 = table_builder [["A", [99, Nothing, Nothing, Nothing]], ["B", [3, Nothing, 4, Nothing]]]
+            colA = t1.get "A"
+            colB = t2.get "B"
+            result = colA.coalesce colB
+            result2 = colB.coalesce colA
+            case setup.is_database of
+                True ->
+                    result.should_fail_with Integrity_Error
+                    result2.should_fail_with Integrity_Error
+                False ->
+                    result.to_vector . should_equal [1, 2, 4, Nothing, 3]
+                    result2.to_vector . should_equal [3, 2, 4, Nothing]

--- a/test/Table_Tests/src/Common_Table_Operations/Coalesce_Spec.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Coalesce_Spec.enso
@@ -43,3 +43,15 @@ add_specs suite_builder setup =
             colA = t.get "A"
             result = colA.coalesce 42
             result.to_vector . should_equal [1, 2, 42, 42]
+        group_builder.specify "column and constant and column" <|
+            t = table_builder [["A", [1, 2, Nothing, Nothing]], ["B", [3, Nothing, 4, Nothing]]]
+            colA = t.get "A"
+            colB = t.get "B"
+            result = colA.coalesce [42, colB]
+            result.to_vector . should_equal [1, 2, 42, 42]
+        group_builder.specify "2 columns of diffferent types" <|
+            t = table_builder [["A", [1, 2, Nothing, Nothing]], ["B", ["3", Nothing, "4", Nothing]]]
+            colA = t.get "A"
+            colB = t.get "B"
+            result = colA.coalesce colB
+            result.should_fail_with No_Common_Type

--- a/test/Table_Tests/src/Common_Table_Operations/Main.enso
+++ b/test/Table_Tests/src/Common_Table_Operations/Main.enso
@@ -6,6 +6,7 @@ from Standard.Test import Test
 
 import project.Common_Table_Operations.Add_Row_Number_Spec
 import project.Common_Table_Operations.Aggregate_Spec
+import project.Common_Table_Operations.Coalesce_Spec
 import project.Common_Table_Operations.Column_Name_Edge_Cases_Spec
 import project.Common_Table_Operations.Column_Operations_Spec
 import project.Common_Table_Operations.Core_Spec
@@ -207,5 +208,6 @@ add_specs suite_builder setup =
     Temp_Column_Spec.add_specs suite_builder setup
     Nothing_Spec.add_specs suite_builder setup
     Text_Cleanse_Spec.add_specs suite_builder setup
+    Coalesce_Spec.add_specs suite_builder setup
 
 main filter=Nothing = run_default_backend add_specs filter


### PR DESCRIPTION
### Pull Request Description

Add tests for coalesce and fix the In-memory version

### Important Notes

The distribution/lib/Standard/Database/0.0.0-dev/src/Internal/IR/From_Spec.enso change isn't actually needed for this MR as I switched away from using literal tables for these tests as trying to mix 2 literal tables doesn't look to be supported. The change I added will let any future developers know that.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
