### PR TITLE
Remove some catch alls

### DIFF
--- a/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Redshift_Details.enso
+++ b/distribution/lib/Standard/AWS/0.0.0-dev/src/Database/Redshift/Redshift_Details.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Errors.Common.Missing_Argument
+import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Metadata.Widget.Text_Input
 
 import Standard.Database.Connection.Client_Certificate.Client_Certificate
@@ -36,7 +37,7 @@ type Redshift_Details
        Attempt to resolve the constructor.
     resolve : Function -> Redshift_Details | Nothing
     resolve constructor =
-        Panic.catch Any (constructor:Redshift_Details) _->Nothing
+        Panic.catch Type_Error (constructor:Redshift_Details) _->Nothing
 
     ## PRIVATE
        Build the Connection resource.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Filter_Condition.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Data/Filter_Condition.enso
@@ -9,6 +9,7 @@ import project.Data.Vector.Vector
 import project.Error.Error
 import project.Errors.Common.Incomparable_Values
 import project.Errors.Common.Missing_Argument
+import project.Errors.Common.Type_Error
 import project.Errors.Illegal_Argument.Illegal_Argument
 import project.Function.Function
 import project.Meta
@@ -167,7 +168,7 @@ type Filter_Condition
     resolve_auto_scoped filter =
         resolve filter:Filter_Condition = filter
         case filter of
-            _ : Function -> Panic.catch Any (resolve filter) _->filter
+            _ : Function -> Panic.catch Type_Error (resolve filter) _->filter
             _ : Filter_Condition -> filter
             _ -> Panic.throw (Illegal_Argument.Error "The filter condition can either be a Function or a Filter_Condition, but got: "+filter.to_display_text)
 

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
@@ -29,7 +29,8 @@ import project.System.File.File
 from project.Data.Boolean import Boolean, False, True
 from project.Data.Json.Extensions import all
 
-polyglot java import java.lang.Exception as JException
+polyglot java import java.lang.IllegalArgumentException
+polyglot java import java.IO.IOException
 polyglot java import java.net.http.HttpClient
 polyglot java import java.net.http.HttpClient.Builder as ClientBuilder
 polyglot java import java.net.http.HttpClient.Redirect
@@ -112,7 +113,7 @@ type HTTP
             handler caught_panic =
                 exception = caught_panic.payload
                 Error.throw (Request_Error.Error (Meta.type_of exception . to_text) exception.getMessage)
-            Panic.catch JException handler=handler
+            Panic.catch IllegalArgumentException handler=handler <| Panic.catch IOException handler=handler
 
         handle_request_error <| Illegal_Argument.handle_java_exception <| check_output_context <|
             headers = resolve_headers req

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Network/HTTP.enso
@@ -30,7 +30,7 @@ from project.Data.Boolean import Boolean, False, True
 from project.Data.Json.Extensions import all
 
 polyglot java import java.lang.IllegalArgumentException
-polyglot java import java.IO.IOException
+polyglot java import java.io.IOException
 polyglot java import java.net.http.HttpClient
 polyglot java import java.net.http.HttpClient.Builder as ClientBuilder
 polyglot java import java.net.http.HttpClient.Redirect

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/System/File_Format.enso
@@ -7,6 +7,7 @@ import project.Data.Text.Encoding.Encoding
 import project.Data.Text.Text
 import project.Data.Vector.Vector
 import project.Error.Error
+import project.Errors.Common.Type_Error
 import project.Errors.File_Error.File_Error
 import project.Errors.Illegal_Argument.Illegal_Argument
 import project.Errors.Problem_Behavior.Problem_Behavior
@@ -140,7 +141,7 @@ type Plain_Text_Format
        Resolve an unresolved constructor to the actual type.
     resolve : Function -> Plain_Text_Format | Nothing
     resolve constructor =
-        Panic.catch Any (constructor:Plain_Text_Format) _->Nothing
+        Panic.catch Type_Error (constructor:Plain_Text_Format) _->Nothing
 
     ## PRIVATE
        If the File_Format supports reading from the file, return a configured instance.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Data.Numbers.Number_Parse_Error
+import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_State.Illegal_State
 
 import project.Connection.Client_Certificate.Client_Certificate
@@ -34,7 +35,7 @@ type Postgres
        Attempt to resolve the constructor.
     resolve : Function -> Postgres | Nothing
     resolve constructor =
-        Panic.catch Any (constructor:Postgres) _->Nothing
+        Panic.catch Type_Error (constructor:Postgres) _->Nothing
 
     ## PRIVATE
        Build the Connection resource.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Errors.Common.Missing_Argument
+import Standard.Base.Errors.Common.Type_Error
 
 import project.Connection.Connection_Options.Connection_Options
 import project.Connection.SQLite_Connection.SQLite_Connection
@@ -18,7 +19,7 @@ type SQLite
        Attempt to resolve the constructor.
     resolve : Function -> SQLite | Nothing
     resolve constructor =
-        Panic.catch Any (constructor:SQLite) _->Nothing
+        Panic.catch Type_Error (constructor:SQLite) _->Nothing
 
     ## PRIVATE
        Build the Connection resource.

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Format.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/SQLite_Format.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.System.File.Generic.Writable_File.Writable_File
 import Standard.Base.System.File_Format_Metadata.File_Format_Metadata
@@ -21,7 +22,7 @@ type SQLite_Format
        Resolve an unresolved constructor to the actual type.
     resolve : Function -> SQLite_Format | Nothing
     resolve constructor =
-        Panic.catch Any (constructor:SQLite_Format) _->Nothing
+        Panic.catch Type_Error (constructor:SQLite_Format) _->Nothing
 
     ## PRIVATE
        If the File_Format supports reading from the file, return a configured instance.

--- a/distribution/lib/Standard/Image/0.0.0-dev/src/Image_File_Format.enso
+++ b/distribution/lib/Standard/Image/0.0.0-dev/src/Image_File_Format.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.System.File.Generic.Writable_File.Writable_File
 import Standard.Base.System.File_Format_Metadata.File_Format_Metadata
@@ -20,7 +21,7 @@ type Image_File_Format
        Resolve an unresolved constructor to the actual type.
     resolve : Function -> Image_File_Format | Nothing
     resolve constructor =
-        Panic.catch Any (constructor:Image_File_Format) _->Nothing
+        Panic.catch Type_Error (constructor:Image_File_Format) _->Nothing
 
     ## PRIVATE
        If the File_Format supports reading from the file, return a configured instance.

--- a/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Connection/SQLServer_Details.enso
+++ b/distribution/lib/Standard/Microsoft/0.0.0-dev/src/Connection/SQLServer_Details.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Data.Numbers.Number_Parse_Error
 import Standard.Base.Errors.Common.Missing_Argument
+import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Metadata.Widget.Text_Input
 
@@ -25,7 +26,7 @@ type SQLServer_Details
        Attempt to resolve the constructor.
     resolve : Function -> SQLServer_Details | Nothing
     resolve constructor =
-        Panic.catch Any (constructor:SQLServer_Details) _->Nothing
+        Panic.catch Type_Error (constructor:SQLServer_Details) _->Nothing
 
     ## PRIVATE
        Build the Connection resource.

--- a/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Connection/Snowflake_Details.enso
+++ b/distribution/lib/Standard/Snowflake/0.0.0-dev/src/Connection/Snowflake_Details.enso
@@ -1,6 +1,7 @@
 from Standard.Base import all
 import Standard.Base.Data.Numbers.Number_Parse_Error
 import Standard.Base.Errors.Common.Missing_Argument
+import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_State.Illegal_State
 import Standard.Base.Metadata.Widget.Text_Input
 
@@ -28,7 +29,7 @@ type Snowflake_Details
        Attempt to resolve the constructor.
     resolve : Function -> Snowflake_Details | Nothing
     resolve constructor =
-        Panic.catch Any (constructor:Snowflake_Details) _->Nothing
+        Panic.catch Type_Error (constructor:Snowflake_Details) _->Nothing
 
     ## PRIVATE
        Build the Connection resource.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data_Formatter.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data_Formatter.enso
@@ -13,7 +13,7 @@ import project.Value_Type.Auto
 import project.Value_Type.Bits
 import project.Value_Type.Value_Type
 
-polyglot java import java.lang.Exception as Java_Exception
+polyglot java import java.lang.Exception as JException
 polyglot java import java.lang.IllegalArgumentException
 polyglot java import org.enso.table.formatting.AnyObjectFormatter
 polyglot java import org.enso.table.formatting.BooleanFormatter
@@ -215,17 +215,17 @@ type Data_Formatter
 
     ## PRIVATE
     make_date_parser self = self.wrap_base_parser <|
-        Panic.catch Java_Exception handler=(caught_panic-> Error.throw (Illegal_Argument.Error caught_panic.payload.getMessage)) <|
+        Panic.catch JException handler=(caught_panic-> Error.throw (Illegal_Argument.Error caught_panic.payload.getMessage)) <|
             DateParser.new (self.date_formats.map on_problems=No_Wrap .get_java_formatter_for_parsing)
 
     ## PRIVATE
     make_date_time_parser self = self.wrap_base_parser <|
-        Panic.catch Java_Exception handler=(caught_panic-> Error.throw (Illegal_Argument.Error caught_panic.payload.getMessage)) <|
+        Panic.catch JException handler=(caught_panic-> Error.throw (Illegal_Argument.Error caught_panic.payload.getMessage)) <|
             DateTimeParser.new (self.datetime_formats.map on_problems=No_Wrap  .get_java_formatter_for_parsing)
 
     ## PRIVATE
     make_time_of_day_parser self = self.wrap_base_parser <|
-        Panic.catch Java_Exception handler=(caught_panic-> Error.throw (Illegal_Argument.Error caught_panic.payload.getMessage)) <|
+        Panic.catch JException handler=(caught_panic-> Error.throw (Illegal_Argument.Error caught_panic.payload.getMessage)) <|
             TimeOfDayParser.new (self.time_formats.map on_problems=No_Wrap .get_java_formatter_for_parsing)
 
     ## PRIVATE
@@ -289,19 +289,19 @@ type Data_Formatter
     ## PRIVATE
     make_date_formatter self =
         if self.date_formats.is_empty then Error.throw (Illegal_Argument.Error "Formatting dates requires at least one entry in the `date_formats` parameter") else
-            Panic.catch Java_Exception handler=(caught_panic-> Error.throw (Illegal_Argument.Error caught_panic.payload.getMessage)) <|
+            Panic.catch JException handler=(caught_panic-> Error.throw (Illegal_Argument.Error caught_panic.payload.getMessage)) <|
                 DateFormatter.new self.date_formats.first.underlying
 
     ## PRIVATE
     make_time_of_day_formatter self =
         if self.time_formats.is_empty then Error.throw (Illegal_Argument.Error "Formatting times requires at least one entry in the `time_formats` parameter") else
-            Panic.catch Java_Exception handler=(caught_panic-> Error.throw (Illegal_Argument.Error caught_panic.payload.getMessage)) <|
+            Panic.catch JException handler=(caught_panic-> Error.throw (Illegal_Argument.Error caught_panic.payload.getMessage)) <|
                 TimeFormatter.new self.time_formats.first.underlying
 
     ## PRIVATE
     make_date_time_formatter self =
         if self.datetime_formats.is_empty then Error.throw (Illegal_Argument.Error "Formatting date-times requires at least one entry in the `datetime_formats` parameter") else
-            Panic.catch Java_Exception handler=(caught_panic-> Error.throw (Illegal_Argument.Error caught_panic.payload.getMessage)) <|
+            Panic.catch JException handler=(caught_panic-> Error.throw (Illegal_Argument.Error caught_panic.payload.getMessage)) <|
                 DateTimeFormatter.new self.datetime_formats.first.underlying
 
     ## PRIVATE

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Delimited/Delimited_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Delimited/Delimited_Format.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Network.HTTP.Response.Response
 import Standard.Base.System.File.Generic.Writable_File.Writable_File
@@ -65,7 +66,7 @@ type Delimited_Format
        Resolve an unresolved constructor to the actual type.
     resolve : Function -> Delimited_Format | Nothing
     resolve constructor =
-        Panic.catch Any (constructor:Delimited_Format) _->Nothing
+        Panic.catch Type_Error (constructor:Delimited_Format) _->Nothing
 
     ## PRIVATE
        ADVANCED

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Format.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Excel/Excel_Format.enso
@@ -1,5 +1,6 @@
 from Standard.Base import all
 import Standard.Base.Errors.Common.Missing_Argument
+import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.Metadata.Display
 import Standard.Base.System.File.Generic.Writable_File.Writable_File
@@ -82,7 +83,7 @@ type Excel_Format
        Resolve an unresolved constructor to the actual type.
     resolve : Function -> Excel_Format | Nothing
     resolve constructor =
-        Panic.catch Any (constructor:Excel_Format) _->Nothing
+        Panic.catch Type_Error (constructor:Excel_Format) _->Nothing
 
     ## PRIVATE
        ADVANCED

--- a/distribution/lib/Standard/Tableau/0.0.0-dev/src/Tableau_Format.enso
+++ b/distribution/lib/Standard/Tableau/0.0.0-dev/src/Tableau_Format.enso
@@ -1,4 +1,5 @@
 from Standard.Base import all
+import Standard.Base.Errors.Common.Type_Error
 import Standard.Base.Errors.Illegal_Argument.Illegal_Argument
 import Standard.Base.System.File.Generic.Writable_File.Writable_File
 import Standard.Base.System.File_Format_Metadata.File_Format_Metadata
@@ -19,7 +20,7 @@ type Tableau_Format
        Resolve an unresolved constructor to the actual type.
     resolve : Function -> Tableau_Format | Nothing
     resolve constructor =
-        Panic.catch Any (constructor:Tableau_Format) _->Nothing
+        Panic.catch Type_Error (constructor:Tableau_Format) _->Nothing
 
     ## PRIVATE
        ADVANCED

--- a/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
+++ b/std-bits/base/src/main/java/org/enso/base/enso_cloud/EnsoSecretHelper.java
@@ -59,7 +59,7 @@ public final class EnsoSecretHelper extends SecretValueResolver {
       Builder builder,
       URIWithSecrets uri,
       List<Pair<String, HideableValue>> headers)
-      throws IOException, InterruptedException {
+      throws IllegalArgumentException, IOException, InterruptedException {
 
     // Build a new URI with the query arguments.
     URI resolvedURI = resolveURI(uri);

--- a/std-bits/table/src/main/java/org/enso/table/excel/ExcelConnectionPool.java
+++ b/std-bits/table/src/main/java/org/enso/table/excel/ExcelConnectionPool.java
@@ -273,7 +273,7 @@ public class ExcelConnectionPool {
           // If the initialization succeeds, the POIFSFileSystem will be closed by the
           // HSSFWorkbook::close.
           yield new HSSFWorkbook(fs);
-        } catch (Exception e) {
+        } catch (IOException e) {
           fs.close();
           throw e;
         }

--- a/std-bits/tableau/src/main/java/org/enso/tableau/HyperReader.java
+++ b/std-bits/tableau/src/main/java/org/enso/tableau/HyperReader.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.channels.Channels;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,7 +47,7 @@ public class HyperReader {
     if (!Files.exists(HYPER_PATH)) {
       try {
         Files.createDirectories(HYPER_PATH);
-      } catch (Exception e) {
+      } catch (IOException | UnsupportedOperationException | SecurityException e) {
         throw new IOException("Failed to create Hyper directory: " + HYPER_PATH, e);
       }
     }
@@ -75,7 +76,8 @@ public class HyperReader {
               "Unsupported platform: " + OSPlatform.CurrentPlatform);
         }
       }
-    } catch (Exception e) {
+    } catch (IOException | URISyntaxException | InvalidPathException | UnsupportedOperationException
+        | SecurityException e) {
       throw new IOException("Failed to download hyperd.", e);
     }
 
@@ -100,7 +102,7 @@ public class HyperReader {
   }
 
   private static void downloadHyper(String uri, String fileName, boolean setExecutable)
-      throws IOException, URISyntaxException {
+      throws IOException, URISyntaxException, InvalidPathException, UnsupportedOperationException, SecurityException {
     LOGGER.log(Level.INFO, "Downloading Hyper from: " + uri);
     var hyperdFile = HYPER_PATH.resolve(fileName).toFile();
     var url = new URI(uri);

--- a/std-bits/tableau/src/main/java/org/enso/tableau/HyperReader.java
+++ b/std-bits/tableau/src/main/java/org/enso/tableau/HyperReader.java
@@ -76,7 +76,10 @@ public class HyperReader {
               "Unsupported platform: " + OSPlatform.CurrentPlatform);
         }
       }
-    } catch (IOException | URISyntaxException | InvalidPathException | UnsupportedOperationException
+    } catch (IOException
+        | URISyntaxException
+        | InvalidPathException
+        | UnsupportedOperationException
         | SecurityException e) {
       throw new IOException("Failed to download hyperd.", e);
     }
@@ -102,7 +105,11 @@ public class HyperReader {
   }
 
   private static void downloadHyper(String uri, String fileName, boolean setExecutable)
-      throws IOException, URISyntaxException, InvalidPathException, UnsupportedOperationException, SecurityException {
+      throws IOException,
+          URISyntaxException,
+          InvalidPathException,
+          UnsupportedOperationException,
+          SecurityException {
     LOGGER.log(Level.INFO, "Downloading Hyper from: " + uri);
     var hyperdFile = HYPER_PATH.resolve(fileName).toFile();
     var url = new URI(uri);

--- a/test/Table_Tests/src/Database/Common/Audit_Spec.enso
+++ b/test/Table_Tests/src/Database/Common/Audit_Spec.enso
@@ -9,6 +9,8 @@ from Standard.Test import all
 import enso_dev.Base_Tests.Network.Enso_Cloud.Cloud_Tests_Setup.Cloud_Tests_Setup
 from enso_dev.Base_Tests.Network.Enso_Cloud.Audit_Log_Spec import Audit_Log_Event, get_audit_log_events
 
+import project.Database.Postgres_Spec.Temporary_Data_Link_File
+from project.Database.Postgres_Spec import get_configured_connection_details
 from project.Util import all
 
 polyglot java import java.lang.Thread
@@ -90,3 +92,11 @@ add_specs suite_builder prefix ~datalink_to_connection database_pending =
                3. switch to mock cloud (if wanted) and run some queries
                4. inspect logs and search for the asset id
             Error.throw "TODO"
+
+main filter=Nothing =
+    connection_details = get_configured_connection_details
+    pending = if connection_details.is_nothing then "PostgreSQL test database is not configured. See README.md for instructions."
+    data_link_file = Temporary_Data_Link_File.make connection_details
+    suite = Test.build suite_builder->
+        add_specs suite_builder "[PostgreSQL] " data_link_file.get database_pending=pending
+    suite.run_with_filter filter


### PR DESCRIPTION
### Pull Request Description

- Allow Interrupted Exceptions to float out of the web requests.
- Use `Type_Error` rather than Any when catching auto scoping resolving.
- Rename `Java_Exception` to `JException`

### Important Notes


### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
