### PR TITLE
Log failure to refresh the Cloud tokens

### DIFF
--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Authentication.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Authentication.enso
@@ -34,6 +34,7 @@ import project.System.File.File
 from project.Data.Boolean import Boolean, False, True
 from project.Data.Text.Extensions import all
 from project.Enso_Cloud.Public_Utils import get_required_field
+from project.Logging import all
 
 polyglot java import org.enso.base.enso_cloud.AuthenticationProvider
 
@@ -67,9 +68,11 @@ type Authentication_Service
 
     ## PRIVATE
     get_access_token self -> Text =
-        is_still_valid = self.auth_data.get.expire_at > (Date_Time.now + token_early_refresh_period)
+        expiry_date = self.auth_data.get.expire_at
+        is_still_valid = expiry_date > (Date_Time.now + token_early_refresh_period)
         if is_still_valid then self.auth_data.get.access_token else
             # The token has expired or will expire soon, so we need to refresh it.
+            Authentication_Service.log_message "Access token expires at "+expiry_date.to_display_text+", so we are refreshing it."
             self.force_refresh
             self.auth_data.get.access_token
 
@@ -139,7 +142,9 @@ type Refresh_Token_Data
         payload = JS_Object.from_pairs [["ClientId", self.client_id], ["AuthFlow", "REFRESH_TOKEN_AUTH"], ["AuthParameters", auth_parameters]]
         response = Context.Output.with_enabled <| HTTP.post self.refresh_url body=(Request_Body.Json payload) headers=headers
             . catch HTTP_Error error-> case error of
-                HTTP_Error.Status_Error status _ _ ->
+                HTTP_Error.Status_Error status message _ ->
+                    Authentication_Service.log_message level=..Warning "Refresh token request failed with status "+status.to_text+": "+(message.if_nothing "<no message>")+"."
+
                     # If the status code is 400-499, then most likely the reason is that the session has expired, so we ask the user to log in again.
                     if (400 <= status.code) && (status.code < 500) then Panic.throw (Cloud_Session_Expired.Error error) else
                         # Otherwise, we fail with the generic error that gives more details.

--- a/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Authentication.enso
+++ b/distribution/lib/Standard/Base/0.0.0-dev/src/Enso_Cloud/Internal/Authentication.enso
@@ -145,8 +145,8 @@ type Refresh_Token_Data
                 HTTP_Error.Status_Error status message _ ->
                     Authentication_Service.log_message level=..Warning "Refresh token request failed with status "+status.to_text+": "+(message.if_nothing "<no message>")+"."
 
-                    # If the status code is 400-499, then most likely the reason is that the session has expired, so we ask the user to log in again.
-                    if (400 <= status.code) && (status.code < 500) then Panic.throw (Cloud_Session_Expired.Error error) else
+                    # As per OAuth specification, an expired refresh token should result in a 401 status code: https://www.rfc-editor.org/rfc/rfc6750.html#section-3.1
+                    if status.code == 401 then Panic.throw (Cloud_Session_Expired.Error error) else
                         # Otherwise, we fail with the generic error that gives more details.
                         Panic.throw (Enso_Cloud_Error.Connection_Error error)
                 _ -> Panic.throw (Enso_Cloud_Error.Connection_Error error)


### PR DESCRIPTION
### Pull Request Description

- Trying to debug #11145, I'm adding logging of when token is refreshed and when that fails, with possibly some details that are included in the response.
- Also, the expired case is now narrowed down from 400-499 to just 401 as that's what [OAuth spec](https://www.rfc-editor.org/rfc/rfc6750.html#section-3.1) says is the correct status code for expired token. Other errors are reported as unexpected error, with more details.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
