### PR TITLE
Fix invalid `${rust-jni.out}` in Nix flake on non-Linux systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
                 minimal.cargo
                 minimal.rustc
                 targets.x86_64-unknown-linux-musl.latest.rust-std
-              ] else fenix.packages.${system}.minimal;
+              ] else fenix.packages.${system}.minimal.toolchain;
           in
           pkgs.mkShell rec {
             buildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -18,18 +18,19 @@
               dir = ./.;
               sha256 = "sha256-IeUO263mdpDxBzWTY7upaZqX+ODkuK1JLTHdR3ItlkY=";
             };
-	    isOnLinux = pkgs.lib.hasInfix "linux" system;
-	    rust-jni = if isOnLinux then with fenix.packages.${system}; combine [
-              minimal.cargo
-              minimal.rustc
-              targets.x86_64-unknown-linux-musl.latest.rust-std
-            ] else fenix.packages.${system}.minimal;
+            isOnLinux = pkgs.lib.hasInfix "linux" system;
+            rust-jni =
+              if isOnLinux then with fenix.packages.${system}; combine [
+                minimal.cargo
+                minimal.rustc
+                targets.x86_64-unknown-linux-musl.latest.rust-std
+              ] else fenix.packages.${system}.minimal;
           in
           pkgs.mkShell rec {
             buildInputs = with pkgs; [
-	      # === Graal dependencies ===
-	      libxcrypt-legacy
-	    ];
+              # === Graal dependencies ===
+              libxcrypt-legacy
+            ];
 
             packages = with pkgs; [
               # === TypeScript dependencies ===
@@ -46,28 +47,28 @@
             ];
 
             shellHook = ''
-	      SHIMS_PATH=$HOME/.local/share/enso/nix-shims
+              SHIMS_PATH=$HOME/.local/share/enso/nix-shims
               # `sccache` can be used to speed up compile times for Rust crates.
               # `~/.cargo/bin/sccache` is provided by `cargo install sccache`.
               # `~/.cargo/bin` must be in the `PATH` for the binary to be accessible.
               export PATH=$SHIMS_PATH:${rust.out}:$HOME/.cargo/bin:$PATH
-	      export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath buildInputs}:$LD_LIBRARY_PATH"
+              export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath buildInputs}:$LD_LIBRARY_PATH"
 
-	      # `rustup` shim
-	      mkdir -p $SHIMS_PATH
-	      cat <<END > $SHIMS_PATH/rustup
+              # `rustup` shim
+              mkdir -p $SHIMS_PATH
+              cat <<END > $SHIMS_PATH/rustup
               if [ "\$3" = "x86_64-unknown-linux-musl" ]; then
-	        echo 'Installing Nix Rust shims'
-	        ln -s ${rust-jni.out}/bin/rustc $SHIMS_PATH
-	        ln -s ${rust-jni.out}/bin/cargo $SHIMS_PATH
-	      else
-	        echo 'Uninstalling Nix Rust shims (if installed)'
-	        rm -f $SHIMS_PATH/{rustc,cargo}
-	      fi
-END
-	      chmod +x $SHIMS_PATH/rustup
-	      # Uninstall shims if already installed
-	      $SHIMS_PATH/rustup
+                echo 'Installing Nix Rust shims'
+                ln -s ${rust-jni.out}/bin/rustc $SHIMS_PATH
+                ln -s ${rust-jni.out}/bin/cargo $SHIMS_PATH
+              else
+                echo 'Uninstalling Nix Rust shims (if installed)'
+                rm -f $SHIMS_PATH/{rustc,cargo}
+              fi
+              END
+              chmod +x $SHIMS_PATH/rustup
+              # Uninstall shims if already installed
+              $SHIMS_PATH/rustup
             '';
           });
     };


### PR DESCRIPTION
### Pull Request Description

`fenix.packages.${system}.minimal` is a `toolchain` not a `derivation`, so Nix `devShell`s are broken on non-linux systems because the `devShell` expects `${rust-jni.out}` to evaluate to a path. Replacing `fenix.packages.${system}.minimal` with `fenix.packages.${system}.minimal.toolchain` fixes this because `.toolchain` is a `derivation` which has an `.out` field.

Also formats the `flake.nix` since it contains a mixture of tabs and spaces. The two commits are separated for ease-of-review.

cc @somebody1234 
<!--
- Please describe the nature of your PR here, as well as the motivation for it.
- If it fixes an open issue, please mention that issue number here.
-->

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
