### PR TITLE
Clean up credentials file after E2E job.

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -372,6 +372,9 @@ jobs:
           ENSO_TEST_USER: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_USERNAME }}
           ENSO_TEST_USER_PASSWORD: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: rm $HOME/.enso/credentials
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: failure() && runner.os == 'Windows'
         name: List files if failed (Windows)
         run: Get-ChildItem -Force -Recurse
@@ -441,6 +444,9 @@ jobs:
           ENSO_TEST_USER: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_USERNAME }}
           ENSO_TEST_USER_PASSWORD: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: rm $HOME/.enso/credentials
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: failure() && runner.os == 'Windows'
         name: List files if failed (Windows)
         run: Get-ChildItem -Force -Recurse
@@ -505,6 +511,9 @@ jobs:
           DEBUG: "pw:browser log:"
           ENSO_TEST_USER: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_USERNAME }}
           ENSO_TEST_USER_PASSWORD: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: rm %USERPROFILE%\.enso\credentials
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: failure() && runner.os == 'Windows'
         name: List files if failed (Windows)

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -512,7 +512,7 @@ jobs:
           ENSO_TEST_USER: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_USERNAME }}
           ENSO_TEST_USER_PASSWORD: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: rm %USERPROFILE%\.enso\credentials
+      - run: rm $HOME/.enso/credentials
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: failure() && runner.os == 'Windows'

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -553,11 +553,7 @@ impl JobArchetype for PackageIde {
             // authenticated into Enso Cloud. We want to run tests as an authenticated
             // user only when we explicitly set that up, not randomly. So we clean the credentials
             // file.
-            let cloud_credentials_path = if target.0 == OS::Windows {
-                "%USERPROFILE%\\.enso\\credentials"
-            } else {
-                "$HOME/.enso/credentials"
-            };
+            let cloud_credentials_path = "$HOME/.enso/credentials";
             let cleanup_credentials_step = shell(format!("rm {cloud_credentials_path}"));
             steps.push(cleanup_credentials_step);
 

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -547,6 +547,20 @@ impl JobArchetype for PackageIde {
                     "ENSO_TEST_USER_PASSWORD",
                 );
             steps.push(test_step);
+
+            // After the E2E tests run, they create a credentials file in user home directory.
+            // If that file is not cleaned up, future runs of our tests may randomly get
+            // authenticated into Enso Cloud. We want to run tests as an authenticated
+            // user only when we explicitly set that up, not randomly. So we clean the credentials
+            // file.
+            let cloud_credentials_path = if target.0 == OS::Windows {
+                "%USERPROFILE%\\.enso\\credentials"
+            } else {
+                "$HOME/.enso/credentials"
+            };
+            let cleanup_credentials_step = shell(format!("rm {cloud_credentials_path}"));
+            steps.push(cleanup_credentials_step);
+
             steps
         })
         .build_job("Package New IDE", target)


### PR DESCRIPTION
### Pull Request Description

- While #11255 fixes the root cause of #11278, this PR fixes what triggered it - since #11198 our runners were keeping `~/.enso/credentials` file between runs, meaning that some tests were unexpectedly running in 'authenticated' mode. This PR cleans up this file to avoid that.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
