### PR TITLE
Remove TailCall.TailPosition.NotTail metadata.

### DIFF
--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
@@ -104,10 +104,8 @@ public final class PassPersistance {
     @Override
     protected TailCall.TailPosition readObject(Input in)
         throws IOException, ClassNotFoundException {
-      var b = in.readBoolean();
-      return b
-          ? org.enso.compiler.pass.analyse.TailCall$TailPosition$Tail$.MODULE$
-          : org.enso.compiler.pass.analyse.TailCall$TailPosition$NotTail$.MODULE$;
+      in.readBoolean();
+      return org.enso.compiler.pass.analyse.TailCall$TailPosition$Tail$.MODULE$;
     }
   }
 

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/PassPersistance.java
@@ -66,6 +66,7 @@ import scala.Tuple2$;
 @Persistable(clazz = Graph.Link.class, id = 1266, allowInlining = false)
 @Persistable(clazz = TypeInference.class, id = 1280)
 @Persistable(clazz = FramePointerAnalysis$.class, id = 1281)
+@Persistable(clazz = TailCall$TailPosition$Tail$.class, id = 1282)
 public final class PassPersistance {
   private PassPersistance() {}
 
@@ -87,25 +88,6 @@ public final class PassPersistance {
       return b
           ? org.enso.compiler.pass.resolve.IgnoredBindings$State$Ignored$.MODULE$
           : org.enso.compiler.pass.resolve.IgnoredBindings$State$NotIgnored$.MODULE$;
-    }
-  }
-
-  @ServiceProvider(service = Persistance.class)
-  public static final class PersistTail extends Persistance<TailCall.TailPosition> {
-    public PersistTail() {
-      super(TailCall.TailPosition.class, true, 1102);
-    }
-
-    @Override
-    protected void writeObject(TailCall.TailPosition obj, Output out) throws IOException {
-      out.writeBoolean(obj.isTail());
-    }
-
-    @Override
-    protected TailCall.TailPosition readObject(Input in)
-        throws IOException, ClassNotFoundException {
-      in.readBoolean();
-      return org.enso.compiler.pass.analyse.TailCall$TailPosition$Tail$.MODULE$;
     }
   }
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/TailCall.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/TailCall.scala
@@ -210,6 +210,7 @@ case object TailCall extends IRPass {
             )
         )
       case err: Diagnostic => updateMetaIfInTailPosition(isInTailPosition, err)
+      case _ => expressionWithWarning
     }
   }
 

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/TailCall.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/TailCall.scala
@@ -210,7 +210,7 @@ case object TailCall extends IRPass {
             )
         )
       case err: Diagnostic => updateMetaIfInTailPosition(isInTailPosition, err)
-      case _ => expressionWithWarning
+      case _               => expressionWithWarning
     }
   }
 

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/TailCallTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/TailCallTest.scala
@@ -135,7 +135,7 @@ class TailCallTest extends CompilerTest {
       implicit val ctx: InlineContext = mkNoTailContext
       val ir                          = code.preprocessExpression.get.analyse
 
-      ir.getMetadata(TailCall) shouldEqual Some(TailPosition.NotTail)
+      ir.getMetadata(TailCall) shouldEqual None
     }
 
     "mark the value of a tail assignment as non-tail" in {
@@ -146,9 +146,7 @@ class TailCallTest extends CompilerTest {
           |""".stripMargin.preprocessExpression.get.analyse
           .asInstanceOf[Expression.Binding]
       binding.getMetadata(TailCall) shouldEqual Some(TailPosition.Tail)
-      binding.expression.getMetadata(TailCall) shouldEqual Some(
-        TailPosition.NotTail
-      )
+      binding.expression.getMetadata(TailCall) shouldEqual None
 
     }
   }
@@ -175,9 +173,7 @@ class TailCallTest extends CompilerTest {
 
     "mark the other expressions in the function as not tail" in {
       fnBody.expressions.foreach(expr =>
-        expr.getMetadata(TailCall) shouldEqual Some(
-          TailPosition.NotTail
-        )
+        expr.getMetadata(TailCall) shouldEqual None
       )
     }
 
@@ -254,16 +250,12 @@ class TailCallTest extends CompilerTest {
         .returnValue
         .asInstanceOf[Case.Expr]
 
-      caseExpr.getMetadata(TailCall) shouldEqual Some(
-        TailPosition.NotTail
-      )
+      caseExpr.getMetadata(TailCall) shouldEqual None
       caseExpr.branches.foreach(branch => {
         val branchExpression =
           branch.expression.asInstanceOf[Application.Prefix]
 
-        branchExpression.getMetadata(TailCall) shouldEqual Some(
-          TailPosition.NotTail
-        )
+        branchExpression.getMetadata(TailCall) shouldEqual None
       })
     }
 
@@ -317,16 +309,14 @@ class TailCallTest extends CompilerTest {
       val pattern            = caseBranch.pattern.asInstanceOf[Pattern.Constructor]
       val patternConstructor = pattern.constructor
 
-      pattern.getMetadata(TailCall) shouldEqual Some(TailPosition.NotTail)
-      patternConstructor.getMetadata(TailCall) shouldEqual Some(
-        TailPosition.NotTail
-      )
+      pattern.getMetadata(TailCall) shouldEqual None
+      patternConstructor.getMetadata(TailCall) shouldEqual None
       pattern.fields.foreach(f => {
-        f.getMetadata(TailCall) shouldEqual Some(TailPosition.NotTail)
+        f.getMetadata(TailCall) shouldEqual None
 
         f.asInstanceOf[Pattern.Name]
           .name
-          .getMetadata(TailCall) shouldEqual Some(TailPosition.NotTail)
+          .getMetadata(TailCall) shouldEqual None
       })
     }
   }
@@ -389,7 +379,7 @@ class TailCallTest extends CompilerTest {
       nonTailCallBody.expressions.head
         .asInstanceOf[Expression.Binding]
         .expression
-        .getMetadata(TailCall) shouldEqual Some(TailPosition.NotTail)
+        .getMetadata(TailCall) shouldEqual None
     }
   }
 
@@ -422,9 +412,7 @@ class TailCallTest extends CompilerTest {
 
     "mark the block expressions as not tail" in {
       block.expressions.foreach(expr =>
-        expr.getMetadata(TailCall) shouldEqual Some(
-          TailPosition.NotTail
-        )
+        expr.getMetadata(TailCall) shouldEqual None
       )
     }
 

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -984,7 +984,7 @@ class IrToTruffle(
     expression: Expression
   ): BaseNode.TailStatus = {
     val isTailPosition =
-      expression.getMetadata(TailCall).contains(TailCall.TailPosition.Tail)
+      expression.getMetadata(TailCall).isDefined
     val isTailAnnotated = TailCall.isTailAnnotated(expression)
     if (isTailPosition) {
       if (isTailAnnotated) {


### PR DESCRIPTION

### Pull Request Description

`TailCall.TailPosition.NotTail` metadata is attached to every `IR` element that is not in tail position. Which is true for most IR elements. This is inefficient and unnecessary. This PR removes this metadata and keeps only `TailCall.TailPosition.Tail`. This removes few bytes from `MetadataStorage` from most of IR elements

### Important Notes

To check whether `ir` element is not in tail position, we used to check it with something like this `ir.getMetadata(TailCall) == Some(TailCall.TailPosition.NotTail)`, now, we simply can do it with `ir.getMetadata(TailCall) == None`

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
