### PR TITLE
Set stack size to 16M

### DIFF
--- a/distribution/bin/enso
+++ b/distribution/bin/enso
@@ -1,5 +1,5 @@
 COMP_PATH=$(dirname "$0")/../component
 
-JAVA_OPTS="--add-opens=java.base/java.nio=ALL-UNNAMED $JAVA_OPTS"
+JAVA_OPTS="--add-opens=java.base/java.nio=ALL-UNNAMED -Xss16M $JAVA_OPTS"
 exec java --module-path $COMP_PATH $JAVA_OPTS -m org.enso.runner/org.enso.runner.Main "$@"
 exit

--- a/distribution/bin/enso.bat
+++ b/distribution/bin/enso.bat
@@ -1,5 +1,5 @@
 @echo off
 set comp-dir=%~dp0\..\component
-set JAVA_OPTS=%JAVA_OPTS% --add-opens=java.base/java.nio=ALL-UNNAMED
+set JAVA_OPTS=%JAVA_OPTS% --add-opens=java.base/java.nio=ALL-UNNAMED -Xss16M
 java --module-path %comp-dir% -Dpolyglot.compiler.IterativePartialEscape=true %JAVA_OPTS% -m org.enso.runner/org.enso.runner.Main %*
 exit /B %errorlevel%

--- a/distribution/manifest.template.yaml
+++ b/distribution/manifest.template.yaml
@@ -3,3 +3,4 @@ minimum-project-manager-version: 2023.2.1-nightly.2023.11.2
 jvm-options:
   - value: "-Dgraal.PrintGraph=Network"
   - value: "--add-opens=java.base/java.nio=ALL-UNNAMED"
+  - value: "-Xss16M"


### PR DESCRIPTION
### Pull Request Description

This PR attempts to fix the SQLServer tests which seem to be right on the limit of the default stack size.

Before this change

runEngineDistribution --run C:/Code/enso/test/Microsoft_Tests/src/SQLServer_Spec.enso shown.in.the.doc.example

would stack overflow indeterministically.

If I make this change -Xss512k then that test always stack overflows.

I'm not quite sure why I need to add this change here as .jvmopts looks to already attempts to set the stack size to 16M.


### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
