### PR TITLE
Inline doc comment is a compiler error

### DIFF
--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ErrorCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ErrorCompilerTest.java
@@ -623,6 +623,28 @@ public class ErrorCompilerTest extends CompilerTests {
         ir, Syntax.UnexpectedExpression$.MODULE$, "Unexpected expression", 0, 41);
   }
 
+  @Test
+  public void inlineDocCommentIsNotAllowed_1() {
+    var ir = parse("""
+        main args =
+            v = 42 ## meh
+            v
+        """);
+    assertSingleSyntaxError(
+        ir, Syntax.UnexpectedExpression$.MODULE$, "Unexpected expression", 23, 29);
+  }
+
+  @Test
+  public void inlineDocCommentIsNotAllowed_2() {
+    var ir = parse("""
+        main args =
+            v = 42
+            v ## meh
+        """);
+    assertSingleSyntaxError(
+        ir, Syntax.UnexpectedExpression$.MODULE$, "Unexpected expression", 29, 35);
+  }
+
   private void assertSingleSyntaxError(
       Module ir, Syntax.Reason type, String msg, int start, int end) {
     var errors = assertIR(ir, Syntax.class, 1);

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
@@ -28,7 +28,6 @@ import org.enso.compiler.core.ir.expression.Foreign;
 import org.enso.compiler.core.ir.expression.Operator;
 import org.enso.compiler.core.ir.expression.Section;
 import org.enso.compiler.core.ir.expression.errors.Syntax;
-import org.enso.compiler.core.ir.expression.errors.Syntax.UnexpectedExpression$;
 import org.enso.compiler.core.ir.module.scope.Definition;
 import org.enso.compiler.core.ir.module.scope.Export;
 import org.enso.compiler.core.ir.module.scope.Import;
@@ -731,10 +730,6 @@ final class TreeToIr {
         }
         case Tree.App app -> {
           var expr = translateExpression(app.getArg(), false);
-          if (expr == null) {
-            return translateSyntaxError(app.getArg(),
-                UnexpectedExpression$.MODULE$);
-          }
           var loc = getIdentifiedLocation(app.getArg());
           args.add(new CallArgument.Specified(Option.empty(), expr, loc, meta()));
           tree = app.getFunc();

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
@@ -28,6 +28,7 @@ import org.enso.compiler.core.ir.expression.Foreign;
 import org.enso.compiler.core.ir.expression.Operator;
 import org.enso.compiler.core.ir.expression.Section;
 import org.enso.compiler.core.ir.expression.errors.Syntax;
+import org.enso.compiler.core.ir.expression.errors.Syntax.UnexpectedExpression$;
 import org.enso.compiler.core.ir.module.scope.Definition;
 import org.enso.compiler.core.ir.module.scope.Export;
 import org.enso.compiler.core.ir.module.scope.Import;
@@ -730,6 +731,10 @@ final class TreeToIr {
         }
         case Tree.App app -> {
           var expr = translateExpression(app.getArg(), false);
+          if (expr == null) {
+            return translateSyntaxError(app.getArg(),
+                UnexpectedExpression$.MODULE$);
+          }
           var loc = getIdentifiedLocation(app.getArg());
           args.add(new CallArgument.Specified(Option.empty(), expr, loc, meta()));
           tree = app.getFunc();

--- a/lib/java/test-utils/src/main/java/org/enso/test/utils/ContextUtils.java
+++ b/lib/java/test-utils/src/main/java/org/enso/test/utils/ContextUtils.java
@@ -189,6 +189,9 @@ public final class ContextUtils {
     var source = Source.newBuilder(LanguageInfo.ID, src, moduleName + ".enso").buildLiteral();
     var module = ctx.eval(source);
     var runtimeMod = (org.enso.interpreter.runtime.Module) unwrapValue(ctx, module);
+    if (runtimeMod.getIr() == null) {
+      runtimeMod.compileScope(leakContext(ctx));
+    }
     return runtimeMod.getIr();
   }
 

--- a/lib/rust/parser/debug/tests/parse.rs
+++ b/lib/rust/parser/debug/tests/parse.rs
@@ -169,6 +169,7 @@ fn doc_comments() {
          (Documented
           (#((Section " Test indent handling")) #(() ()))
           (Function (Ident foo) #((() (Ident bar) () ())) () (Ident foo))))));
+    expect_invalid_node("expression ## unexpected doc comment on same line");
 }
 
 

--- a/lib/rust/parser/src/syntax/tree.rs
+++ b/lib/rust/parser/src/syntax/tree.rs
@@ -830,6 +830,7 @@ pub enum SyntaxError {
     PatternUnexpectedExpression,
     PatternUnexpectedDot,
     CaseOfInvalidCase,
+    DocumentationUnexpectedNonInitial,
 }
 
 impl From<SyntaxError> for Cow<'static, str> {
@@ -864,6 +865,7 @@ impl From<SyntaxError> for Cow<'static, str> {
             PatternUnexpectedExpression => "Expression invalid in a pattern",
             PatternUnexpectedDot => "In a pattern, the dot operator can only be used in a qualified name",
             CaseOfInvalidCase => "Invalid case expression.",
+            DocumentationUnexpectedNonInitial => "Unexpected documentation at end of line",
         })
         .into()
     }


### PR DESCRIPTION
### Pull Request Description

Fix NPE thrown when compiling source with inline documentation comments, like
```
main args =
    v = 42 ## meh
    v
```

### Important Notes

- Handled by the rust parser as syntax error
- When translating the input from the rust parser, we treat it as an unexpected expression - added tests.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
