### PR TITLE
Yield `UnsupportedMessageException` when context isn't accessible

### DIFF
--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/DataflowError.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/DataflowError.java
@@ -161,7 +161,7 @@ public final class DataflowError extends AbstractTruffleException implements Ens
   @ExportMessage
   Object getExceptionMessage(
       @Cached IndirectInvokeMethodNode payloads,
-      @Cached(value = "toDisplayText(payloads)", allowUncached = true)
+      @Cached(value = "toDisplayText(this.getPayload(), payloads)", allowUncached = true)
           UnresolvedSymbol toDisplayText,
       @CachedLibrary(limit = "3") InteropLibrary strings,
       @Cached TypeToDisplayTextNode typeToDisplayTextNode) {

--- a/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/runtime/error/PanicException.java
@@ -117,9 +117,14 @@ public final class PanicException extends AbstractTruffleException implements En
   @NeverDefault
   static UnresolvedSymbol toDisplayText(IndirectInvokeMethodNode payloads)
       throws UnsupportedMessageException {
-    var ctx = EnsoContext.get(payloads);
-    if (ctx == null) {
-      throw UnsupportedMessageException.create();
+    EnsoContext ctx;
+    try {
+      ctx = EnsoContext.get(payloads);
+      if (ctx == null) {
+        throw UnsupportedMessageException.create();
+      }
+    } catch (Error | Exception e) {
+      throw UnsupportedMessageException.create(e);
     }
     var scope = ctx.getBuiltins().panic().getDefinitionScope();
     return UnresolvedSymbol.build("to_display_text", scope);


### PR DESCRIPTION
### Pull Request Description

More robust fix for #11127 as it turns out #11241 is insufficient.

### Important Notes

@radeusgd has observed yet another error related to lazy evaluation of `computeMessage`:
```
️java.lang.AssertionError: No polyglot context is entered. A language or context reference must not be used if there is no polyglot context entered.
at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotFastThreadLocals.assertValidGet(PolyglotFastThreadLocals.java:481)
at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotFastThreadLocals$ContextReferenceImpl.get(PolyglotFastThreadLocals.java:513)
at org.enso.runtime/org.enso.interpreter.runtime.EnsoContext.get(EnsoContext.java:248)
at org.enso.runtime/org.enso.interpreter.runtime.error.PanicException.toDisplayText(PanicException.java:120)
at org.enso.runtime/org.enso.interpreter.runtime.error.PanicExceptionGen$InteropLibraryExports$Uncached.getExceptionMessage(PanicExceptionGen.java:354)
at org.graalvm.truffle/com.oracle.truffle.api.interop.InteropLibraryGen$Delegate.getExceptionMessage(InteropLibraryGen.java:5000)
at org.graalvm.truffle/com.oracle.truffle.api.interop.InteropLibrary$Asserts.getExceptionMessage(InteropLibrary.java:4755)
at org.graalvm.truffle/com.oracle.truffle.api.interop.InteropLibraryGen$UncachedDispatch.getExceptionMessage(InteropLibraryGen.java:7642)
at org.enso.runtime/org.enso.interpreter.runtime.error.PanicException.computeMessage(PanicException.java:87)
at org.enso.runtime/org.enso.interpreter.runtime.error.PanicException.getMessage(PanicException.java:77)
at org.enso.runner/org.enso.runner.Main.handleRun(Main.java:764)
at org.enso.runner/org.enso.runner.Main.mainEntry(Main.java:1134)
at org.enso.runner/org.enso.runner.Main.lambda$launch$22(Main.java:1477)
at org.enso.runner/org.enso.runner.Main.withProfiling(Main.java:1224)
at org.enso.runner/org.enso.runner.Main.launch(Main.java:1473)
at org.enso.runner/org.enso.runner.Main.launch(Main.java:1425)
at org.enso.runner/org.enso.runner.Main.main(Main.java:1040)
```
even the [handleRun](https://github.com/enso-org/enso/blob/b36fd1c01bb3a2489f43e7276a6e18ef728085db/engine/runner/src/main/java/org/enso/runner/Main.java#L762) tries to _"force computation of the exception message sooner than context is closed"_ it is still not enough. Let's make the `PanicException` more robust.

Anyway, the real problem is _escaping panic exception_ and it has been [reported to GraalVM](https://graalvm.slack.com/archives/D03SWHLPRML/p1727950302662339?thread_ts=1727940783.004599&cid=D03SWHLPRML).

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] No existing tests are affected and we don't have a reproducer yet.
