### PR TITLE
Switch to newer MacOS GitHub runner

### DIFF
--- a/.github/workflows/engine-nightly.yml
+++ b/.github/workflows/engine-nightly.yml
@@ -107,7 +107,7 @@ jobs:
   enso-build-ci-gen-job-ci-check-backend-graal-vm-ce-macos-amd64:
     name: Engine (GraalVM CE) (macos, amd64)
     runs-on:
-      - macos-12
+      - macos-14
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -354,7 +354,7 @@ jobs:
   enso-build-ci-gen-job-jvm-tests-graal-vm-ce-macos-amd64:
     name: JVM Tests (GraalVM CE) (macos, amd64)
     runs-on:
-      - macos-12
+      - macos-14
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -640,7 +640,7 @@ jobs:
   enso-build-ci-gen-job-standard-library-tests-graal-vm-ce-macos-amd64:
     name: Standard Library Tests (GraalVM CE) (macos, amd64)
     runs-on:
-      - macos-12
+      - macos-14
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack

--- a/.github/workflows/engine-nightly.yml
+++ b/.github/workflows/engine-nightly.yml
@@ -107,7 +107,7 @@ jobs:
   enso-build-ci-gen-job-ci-check-backend-graal-vm-ce-macos-amd64:
     name: Engine (GraalVM CE) (macos, amd64)
     runs-on:
-      - macos-14
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -354,7 +354,7 @@ jobs:
   enso-build-ci-gen-job-jvm-tests-graal-vm-ce-macos-amd64:
     name: JVM Tests (GraalVM CE) (macos, amd64)
     runs-on:
-      - macos-14
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -640,7 +640,7 @@ jobs:
   enso-build-ci-gen-job-standard-library-tests-graal-vm-ce-macos-amd64:
     name: Standard Library Tests (GraalVM CE) (macos, amd64)
     runs-on:
-      - macos-14
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack

--- a/.github/workflows/enso4igv.yml
+++ b/.github/workflows/enso4igv.yml
@@ -39,7 +39,7 @@ jobs:
             target/lib/**
 
   build_mac_intel_parser:
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -61,7 +61,7 @@ jobs:
   enso-build-ci-gen-job-build-backend-macos-amd64:
     name: Build Backend (macos, amd64)
     runs-on:
-      - macos-14
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -213,7 +213,7 @@ jobs:
   enso-build-ci-gen-job-gui-build-macos-amd64:
     name: GUI build (macos, amd64)
     runs-on:
-      - macos-14
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -391,7 +391,7 @@ jobs:
     needs:
       - enso-build-ci-gen-job-build-backend-macos-amd64
     runs-on:
-      - macos-14
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -61,7 +61,7 @@ jobs:
   enso-build-ci-gen-job-build-backend-macos-amd64:
     name: Build Backend (macos, amd64)
     runs-on:
-      - macos-12
+      - macos-14
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -213,7 +213,7 @@ jobs:
   enso-build-ci-gen-job-gui-build-macos-amd64:
     name: GUI build (macos, amd64)
     runs-on:
-      - macos-12
+      - macos-14
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -391,7 +391,7 @@ jobs:
     needs:
       - enso-build-ci-gen-job-build-backend-macos-amd64
     runs-on:
-      - macos-12
+      - macos-14
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
     needs:
       - enso-build-ci-gen-draft-release-linux-amd64
     runs-on:
-      - macos-12
+      - macos-14
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -484,7 +484,7 @@ jobs:
       - enso-build-ci-gen-draft-release-linux-amd64
       - enso-build-ci-gen-job-upload-backend-macos-amd64
     runs-on:
-      - macos-12
+      - macos-14
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
     needs:
       - enso-build-ci-gen-draft-release-linux-amd64
     runs-on:
-      - macos-14
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -484,7 +484,7 @@ jobs:
       - enso-build-ci-gen-draft-release-linux-amd64
       - enso-build-ci-gen-job-upload-backend-macos-amd64
     runs-on:
-      - macos-14
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack

--- a/.github/workflows/scala-new.yml
+++ b/.github/workflows/scala-new.yml
@@ -75,7 +75,7 @@ jobs:
   enso-build-ci-gen-job-ci-check-backend-graal-vm-ce-macos-amd64:
     name: Engine (GraalVM CE) (macos, amd64)
     runs-on:
-      - macos-14
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -220,7 +220,7 @@ jobs:
   enso-build-ci-gen-job-jvm-tests-graal-vm-ce-macos-amd64:
     name: JVM Tests (GraalVM CE) (macos, amd64)
     runs-on:
-      - macos-14
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -390,7 +390,7 @@ jobs:
   enso-build-ci-gen-job-standard-library-tests-graal-vm-ce-macos-amd64:
     name: Standard Library Tests (GraalVM CE) (macos, amd64)
     runs-on:
-      - macos-14
+      - macos-13
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack

--- a/.github/workflows/scala-new.yml
+++ b/.github/workflows/scala-new.yml
@@ -75,7 +75,7 @@ jobs:
   enso-build-ci-gen-job-ci-check-backend-graal-vm-ce-macos-amd64:
     name: Engine (GraalVM CE) (macos, amd64)
     runs-on:
-      - macos-12
+      - macos-14
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -220,7 +220,7 @@ jobs:
   enso-build-ci-gen-job-jvm-tests-graal-vm-ce-macos-amd64:
     name: JVM Tests (GraalVM CE) (macos, amd64)
     runs-on:
-      - macos-12
+      - macos-14
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack
@@ -390,7 +390,7 @@ jobs:
   enso-build-ci-gen-job-standard-library-tests-graal-vm-ce-macos-amd64:
     name: Standard Library Tests (GraalVM CE) (macos, amd64)
     runs-on:
-      - macos-12
+      - macos-14
     steps:
       - if: startsWith(runner.name, 'GitHub Actions') || startsWith(runner.name, 'Hosted Agent')
         name: Installing wasm-pack

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -59,7 +59,7 @@ impl RunsOn for RunnerLabel {
             RunnerLabel::Linux => Some("Linux".to_string()),
             RunnerLabel::Windows => Some("Windows".to_string()),
             RunnerLabel::MacOS12 => Some("MacOS12".to_string()),
-            RunnerLabel::MacOS13 => Some("MacOS13".to_string()),
+            RunnerLabel::MacOS14 => Some("MacOS14".to_string()),
             RunnerLabel::MacOSLatest => Some("MacOSLatest".to_string()),
             RunnerLabel::LinuxLatest => Some("LinuxLatest".to_string()),
             RunnerLabel::WindowsLatest => Some("WindowsLatest".to_string()),
@@ -87,7 +87,7 @@ impl RunsOn for OS {
 impl RunsOn for (OS, Arch) {
     fn runs_on(&self) -> Vec<RunnerLabel> {
         match self {
-            (OS::MacOS, Arch::X86_64) => vec![RunnerLabel::MacOS12],
+            (OS::MacOS, Arch::X86_64) => vec![RunnerLabel::MacOS14],
             (os, Arch::X86_64) => runs_on(*os, RunnerType::SelfHosted),
             (OS::MacOS, Arch::AArch64) => {
                 let mut ret = runs_on(OS::MacOS, RunnerType::SelfHosted);

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -58,8 +58,7 @@ impl RunsOn for RunnerLabel {
             RunnerLabel::MacOS => Some("MacOS".to_string()),
             RunnerLabel::Linux => Some("Linux".to_string()),
             RunnerLabel::Windows => Some("Windows".to_string()),
-            RunnerLabel::MacOS12 => Some("MacOS12".to_string()),
-            RunnerLabel::MacOS14 => Some("MacOS14".to_string()),
+            RunnerLabel::MacOS13 => Some("MacOS13".to_string()),
             RunnerLabel::MacOSLatest => Some("MacOSLatest".to_string()),
             RunnerLabel::LinuxLatest => Some("LinuxLatest".to_string()),
             RunnerLabel::WindowsLatest => Some("WindowsLatest".to_string()),
@@ -87,7 +86,7 @@ impl RunsOn for OS {
 impl RunsOn for (OS, Arch) {
     fn runs_on(&self) -> Vec<RunnerLabel> {
         match self {
-            (OS::MacOS, Arch::X86_64) => vec![RunnerLabel::MacOS14],
+            (OS::MacOS, Arch::X86_64) => vec![RunnerLabel::MacOS13],
             (os, Arch::X86_64) => runs_on(*os, RunnerType::SelfHosted),
             (OS::MacOS, Arch::AArch64) => {
                 let mut ret = runs_on(OS::MacOS, RunnerType::SelfHosted);

--- a/build/ci_utils/src/actions/workflow/definition.rs
+++ b/build/ci_utils/src/actions/workflow/definition.rs
@@ -1014,10 +1014,8 @@ pub enum RunnerLabel {
     Windows,
     #[serde(rename = "engine")]
     Engine,
-    #[serde(rename = "macos-12")]
-    MacOS12,
-    #[serde(rename = "macos-14")]
-    MacOS14,
+    #[serde(rename = "macos-13")]
+    MacOS13,
     #[serde(rename = "macos-latest")]
     MacOSLatest,
     #[serde(rename = "ubuntu-latest")]

--- a/build/ci_utils/src/actions/workflow/definition.rs
+++ b/build/ci_utils/src/actions/workflow/definition.rs
@@ -1016,9 +1016,8 @@ pub enum RunnerLabel {
     Engine,
     #[serde(rename = "macos-12")]
     MacOS12,
-    /// macos-13 is the last x64 version of the GitHub-hosted macOS runner.
-    #[serde(rename = "macos-13")]
-    MacOS13,
+    #[serde(rename = "macos-14")]
+    MacOS14,
     #[serde(rename = "macos-latest")]
     MacOSLatest,
     #[serde(rename = "ubuntu-latest")]


### PR DESCRIPTION
### Pull Request Description

- MacOS13 (as 12 is deprecated) and 14/15 need to be large instances if we want x64.

Build seemed fine except for usual playwright fails.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
