### PR TITLE
Set live execution environment for REPL

### DIFF
--- a/engine/common/src/main/java/org/enso/common/ContextFactory.java
+++ b/engine/common/src/main/java/org/enso/common/ContextFactory.java
@@ -3,6 +3,7 @@ package org.enso.common;
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.HashMap;
 import java.util.Map;
 import org.enso.logger.Converter;
 import org.enso.logger.JulHandler;
@@ -50,7 +51,7 @@ public final class ContextFactory {
   private String executionEnvironment;
   private String checkForWarnings;
   private int warningsLimit = 100;
-  private java.util.Map<String, String> options = java.util.Collections.emptyMap();
+  private java.util.Map<String, String> options = new HashMap<>();
   private boolean enableDebugServer;
 
   private ContextFactory() {}

--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -960,6 +960,7 @@ public class Main {
                 .messageTransport(replTransport())
                 .enableDebugServer(true)
                 .logLevel(logLevel)
+                .executionEnvironment("live")
                 .logMasking(logMasking)
                 .enableIrCaches(enableIrCaches)
                 .disableLinting(true)


### PR DESCRIPTION
Fixes #9034

### Pull Request Description

Ensures that the execution environment for REPL is set as `live` and not `design`.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] The documentation has been updated, if necessary.
- [x] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] Unit tests have been written where possible.
- [x] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
