### PR TITLE
Benchmark time it takes compile `Standard.Base` library

### DIFF
--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/data/BindingsMap.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/data/BindingsMap.scala
@@ -134,9 +134,7 @@ case class BindingsMap(
     val withImports: Option[BindingsMap] = newMap.flatMap { bindings =>
       val newImports = this._resolvedImports.map { imp =>
         imp.targets.foreach { t =>
-          LibraryName
-            .fromModuleName(t.qualifiedName.toString())
-            .foreach(r.ensurePackageIsLoaded(_));
+          t.toLibraryName.foreach(r.ensurePackageIsLoaded(_));
         }
         imp.toConcrete(moduleMap)
       }
@@ -463,6 +461,16 @@ object BindingsMap {
     override def toAbstract:                       ImportTarget
     override def toConcrete(moduleMap: ModuleMap): Option[ImportTarget]
     def findExportedSymbolsFor(name: String):      List[ResolvedName]
+
+    /** Quicker conversion to library name */
+    private[BindingsMap] lazy val toLibraryName: Option[LibraryName] = {
+      val qnp = qualifiedName.path
+      if (qnp.length >= 2) {
+        Some(LibraryName(qnp(0), qnp(1)))
+      } else {
+        None
+      }
+    }
 
     /** Resolves the symbol with the given name in the context of this import target.
       * Note that it is valid to have multiple resolved names for a single symbol name,

--- a/test/Benchmarks/src/Compiler/Compile.enso
+++ b/test/Benchmarks/src/Compiler/Compile.enso
@@ -9,9 +9,12 @@ type Data
     Value ~enso_bin:File ~std_base:File
 
     bench_compile_base self =
-        self.startup [ "--no-compile-dependencies", "--no-global-cache", "--compile", self.std_base.to_text]
+        self.startup [ "--no-compile-dependencies", "--log-level", "debug", "--no-global-cache", "--compile", self.std_base.to_text]
 
     startup self  args =
+        cache_dir = self.std_base / ".enso" / "cache"
+        cache_dir.delete recursive=True
+
         exe = self.enso_bin
         result = Process.run exe.path args
         case result.exit_code of

--- a/test/Benchmarks/src/Compiler/Compile.enso
+++ b/test/Benchmarks/src/Compiler/Compile.enso
@@ -1,0 +1,67 @@
+from Standard.Base import all
+
+from Standard.Test import Bench
+
+polyglot java import java.lang.System as Java_System
+polyglot java import java.io.File as Java_File
+
+type Data
+    Value ~enso_bin:File ~std_base:File
+
+    bench_compile_base self =
+        self.startup [ "--no-compile-dependencies", "--no-global-cache", "--compile", self.std_base.to_text]
+
+    startup self  args =
+        exe = self.enso_bin
+        result = Process.run exe.path args
+        case result.exit_code of
+            Exit_Code.Failure code ->
+                IO.println "Exit code: "+code.to_text
+                IO.println result.stdout
+                IO.println result.stderr
+                Panic.throw "Exit code: "+code.to_text
+            Exit_Code.Success ->
+                Nothing
+
+collect_benches = Bench.build builder->
+    options = Bench.options . set_warmup (Bench.phase_conf 1 10) . set_measure (Bench.phase_conf 2 10)
+
+
+    data =
+        Data.Value enso_bin (find_lib enso_bin "Base")
+
+    builder.group "Compile" options group_builder->
+        group_builder.specify "Compile_Standard_Base" data.bench_compile_base
+
+find_lib enso_bin:File name:Text namespace="Standard":Text -> File =
+    install_dir = enso_bin . parent . parent
+    lib_no_version = install_dir / "lib" / namespace / name
+    Runtime.assert lib_no_version.is_directory "Found directory "+lib_no_version.to_text
+    lib_with_version = lib_no_version.list . at 0
+    Runtime.assert lib_with_version.is_directory "Found directory "+lib_with_version.to_text
+    lib_with_version
+
+
+enso_bin =
+    find_prefix dir prefix =
+        vec = dir.list name_filter=prefix+"*"
+        if vec.length == 1 then vec.at 0 else
+            msg = "Cannot find " + prefix + "* in " + dir.to_text + '\n'
+            err = dir.list.fold msg t-> f->
+                t + f.to_text + '\n'
+            Panic.throw err
+
+    project_root = File.new enso_project.root.to_text
+    repository_root = project_root . parent . parent
+    built_distribution = find_prefix repository_root "built-distribution"
+    enso_engine = find_prefix built_distribution "enso-engine-"
+    enso = find_prefix enso_engine "enso-"
+    bin = find_prefix enso "bin"
+
+    exe = File.new bin / if Platform.os == Platform.OS.Windows then "enso.bat" else "enso"
+
+    if exe.is_regular_file.not then Panic.throw "Cannot find "+exe.to_text
+
+    exe
+
+main = collect_benches . run_main

--- a/test/Benchmarks/src/Main.enso
+++ b/test/Benchmarks/src/Main.enso
@@ -2,6 +2,7 @@ from Standard.Base import all hiding Range
 from Standard.Test import Bench
 import project.Collections
 import project.Column_Numeric
+import project.Compiler.Compile
 import project.Decimal_Benchmark
 import project.Equality
 import project.Json_Bench
@@ -99,6 +100,7 @@ all_benchmarks =
         # Runtime
         builder.append Panics_And_Errors.collect_benches
 
+        builder.append Compile.collect_benches
         builder.append Startup.collect_benches
         builder.append Sieve.Main.collect_benches
 


### PR DESCRIPTION
### Pull Request Description

Benchmark time it takes to `enso --compile ... Standard/Base` library before speeding it up by [caching libraryName of ImportTarget](https://github.com/enso-org/enso/pull/11355/commits/43021fcef0506bdebc6e9f5a24a7f1a53e4dca3d).

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
- [x] New [benchmark runs](https://github.com/enso-org/enso/actions/runs/11399009701) and [gets improved](https://github.com/enso-org/enso/actions/runs/11400535211) by **10%** by the changes in this PR
