### PR TITLE
Make sure unrecognized CLI command message is printed

### DIFF
--- a/engine/runner/src/main/java/org/enso/runner/Main.java
+++ b/engine/runner/src/main/java/org/enso/runner/Main.java
@@ -518,7 +518,7 @@ public class Main {
   }
 
   /** Prints the help message to the standard output. */
-  private static void printHelp() {
+  void printHelp() {
     new HelpFormatter().printHelp(LanguageInfo.ID, CLI_OPTIONS);
   }
 
@@ -1435,6 +1435,7 @@ public class Main {
           System.currentTimeMillis() - startParsing);
       return line;
     } catch (Exception e) {
+      println(e.getMessage());
       printHelp();
       throw exitFail();
     }

--- a/engine/runner/src/test/java/org/enso/runner/EngineMainTest.java
+++ b/engine/runner/src/test/java/org/enso/runner/EngineMainTest.java
@@ -3,6 +3,7 @@ package org.enso.runner;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -16,6 +17,21 @@ public class EngineMainTest {
   @Rule public TemporaryFolder tempDir = new TemporaryFolder();
 
   private final List<String> linesOut = new ArrayList<>();
+
+  @Test
+  public void unknownCommandBecauseTwoAreConcatenated() throws Exception {
+    var m = new MainMock();
+    try {
+      var file = tempDir.newFile("some.enso");
+      var line = m.preprocessArguments("--repl --inspect", "--run", file.getAbsolutePath());
+      m.mainEntry(line, Level.INFO, false);
+    } catch (ExitCode ex) {
+      assertEquals("Execution fails", 1, ex.exitCode);
+      assertEquals("One line printed", 1, linesOut.size());
+      assertEquals("Unrecognized option: --repl --inspect", linesOut.get(0));
+      assertTrue("Also help was printed", m.helpPrinted);
+    }
+  }
 
   @Test
   public void cannotUseReplAndInspectAtOnce() throws Exception {
@@ -76,6 +92,8 @@ public class EngineMainTest {
   }
 
   private final class MainMock extends Main {
+    boolean helpPrinted;
+
     @Override
     RuntimeException doExit(int exitCode) {
       throw new ExitCode(exitCode);
@@ -84,6 +102,11 @@ public class EngineMainTest {
     @Override
     void println(String msg) {
       linesOut.add(msg);
+    }
+
+    @Override
+    void printHelp() {
+      helpPrinted = true;
     }
   }
 


### PR DESCRIPTION
### Pull Request Description

It has been noticed, while working on #11355, that errors that happen while parsing CLI arguments aren't presented to the user. Using `println` to spit them out.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
