### PR TITLE
Fail gracefully when a job is already rejected

### DIFF
--- a/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/AttachVisualizationCmd.scala
+++ b/engine/runtime-instrument-common/src/main/scala/org/enso/interpreter/instrument/command/AttachVisualizationCmd.scala
@@ -43,7 +43,7 @@ class AttachVisualizationCmd(
       )
 
     maybeFutureExecutable.flatMap {
-      case None             => Future.successful(())
+      case None | null      => Future.successful(())
       case Some(executable) => ctx.jobProcessor.run(ExecuteJob(executable))
     }
   }


### PR DESCRIPTION
### Pull Request Description

Noticed a random failure in our tests:
```
  pw:browser [pid=2812009][out] [INFO] [2024-10-16T19:56:04.195] [org.enso.languageserver.protocol.json.JsonConnectionController] Session terminated [1e652e5e-9953-480a-8220-c4b4f068379a]. +32ms
  pw:browser [pid=2812009][err] java.util.concurrent.RejectedExecutionException: Task Future(<not completed>) rejected from java.util.concurrent.ThreadPoolExecutor@6846840b[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 2] +40ms
  pw:browser [pid=2812009][err] 	at java.base/java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2081) +1ms
  pw:browser [pid=2812009][err] 	at java.base/java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:841) +0ms
  pw:browser [pid=2812009][err] 	at java.base/java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1376) +0ms
  pw:browser [pid=2812009][err] 	at scala.library@2.13.11/scala.concurrent.impl.ExecutionContextImpl.execute(ExecutionContextImpl.scala:21) +0ms
Error: 1mpw:browser [pid=2812009][out] [ERROR] [2024-10-16T19:56:04.197] [enso.org.enso.interpreter.service.ExecutionService] An error occurred during execution of AttachVisualizationCmd(visualizationId: 97ea02c1-10fa-4e1a-bd8f-bd03a2c36146,expressionId=fcf199e6-d2b1-44b7-be92-a47545d6a593) command +21ms
  pw:browser [pid=2812009][out] scala.MatchError: null +0ms
  pw:browser [pid=2812009][out] 	at org.enso.runtime.instrument.common/org.enso.interpreter.instrument.command.AttachVisualizationCmd.$anonfun$executeCmd$1(AttachVisualizationCmd.scala:45) +0ms
  pw:browser [pid=2812009][out] 	at scala.library@2.13.11/scala.concurrent.impl.Promise$Transformation.run(Promise.scala:470) +0ms
  pw:browser [pid=2812009][out] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) +0ms
  pw:browser [pid=2812009][out] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) +0ms
  pw:browser [pid=2812009][out] 	at java.base/java.lang.Thread.run(Thread.java:1583) +0ms
  pw:browser [pid=2812009][out] 	at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotThread.access$001(PolyglotThread.java:53) +0ms
  pw:browser [pid=2812009][out] 	at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotThread$1.execute(PolyglotThread.java:106) +0ms
```

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
