### PR TITLE
Move TypeSignature into field of Function

### DIFF
--- a/app/ydoc-shared/src/ast/parse.ts
+++ b/app/ydoc-shared/src/ast/parse.ts
@@ -167,6 +167,10 @@ class Abstractor {
       }
       case RawAst.Tree.Type.Function: {
         const name = this.abstractTree(tree.name)
+        const signatureLine = tree.signatureLine && {
+          signature: this.abstractTypeSignature(tree.signatureLine.signature),
+          newlines: Array.from(tree.signatureLine.newlines, this.abstractToken.bind(this)),
+        }
         const private_ = tree.private && this.abstractToken(tree.private)
         const argumentDefinitions = Array.from(tree.args, arg => ({
           open: arg.open && this.abstractToken(arg.open),
@@ -186,7 +190,15 @@ class Abstractor {
         }))
         const equals = this.abstractToken(tree.equals)
         const body = tree.body !== undefined ? this.abstractTree(tree.body) : undefined
-        node = Function.concrete(this.module, private_, name, argumentDefinitions, equals, body)
+        node = Function.concrete(
+          this.module,
+          signatureLine,
+          private_,
+          name,
+          argumentDefinitions,
+          equals,
+          body,
+        )
         break
       }
       case RawAst.Tree.Type.Ident: {
@@ -406,6 +418,14 @@ class Abstractor {
         return { type: 'token', token: this.abstractToken(raw.text) }
       case RawAst.TextElement.Type.Splice:
         throw new Error('Unreachable: Splice in non-interpolated text field')
+    }
+  }
+
+  private abstractTypeSignature(signature: RawAst.TypeSignature) {
+    return {
+      name: this.abstractTree(signature.name),
+      operator: this.abstractToken(signature.operator),
+      type: this.abstractTree(signature.typeNode),
     }
   }
 }

--- a/app/ydoc-shared/src/ast/tree.ts
+++ b/app/ydoc-shared/src/ast/tree.ts
@@ -449,6 +449,8 @@ type StructuralField<T extends TreeRefs = RawRefs> =
   | TextElement<T>
   | ArgumentDefinition<T>
   | VectorElement<T>
+  | TypeSignature<T>
+  | SignatureLine<T>
 
 /** Type whose fields are all suitable for storage as `Ast` fields. */
 interface FieldObject<T extends TreeRefs> {
@@ -566,6 +568,10 @@ function mapRefs<T extends TreeRefs, U extends TreeRefs>(
   field: VectorElement<T>,
   f: MapRef<T, U>,
 ): VectorElement<U>
+function mapRefs<T extends TreeRefs, U extends TreeRefs>(
+  field: SignatureLine<T>,
+  f: MapRef<T, U>,
+): SignatureLine<U>
 function mapRefs<T extends TreeRefs, U extends TreeRefs>(
   field: FieldData<T>,
   f: MapRef<T, U>,
@@ -2029,7 +2035,19 @@ interface ArgumentType<T extends TreeRefs = RawRefs> {
   type: T['ast']
 }
 
+interface TypeSignature<T extends TreeRefs = RawRefs> {
+  name: T['ast']
+  operator: T['token']
+  type: T['ast']
+}
+
+interface SignatureLine<T extends TreeRefs = RawRefs> {
+  signature: TypeSignature<T>
+  newlines: T['token'][]
+}
+
 export interface FunctionFields {
+  signatureLine: SignatureLine | undefined
   private_: NodeChild<SyncTokenId> | undefined
   name: NodeChild<AstId>
   argumentDefinitions: ArgumentDefinition[]
@@ -2068,6 +2086,7 @@ export class Function extends Ast {
   /** TODO: Add docs */
   static concrete(
     module: MutableModule,
+    signatureLine: SignatureLine<OwnedRefs> | undefined,
     private_: NodeChild<Token> | undefined,
     name: NodeChild<Owned>,
     argumentDefinitions: ArgumentDefinition<OwnedRefs>[],
@@ -2077,6 +2096,7 @@ export class Function extends Ast {
     const base = module.baseObject('Function')
     const id_ = base.get('id')
     const fields = composeFieldData(base, {
+      signatureLine: signatureLine && mapRefs(signatureLine, ownedToRaw(module, id_)),
       private_,
       name: concreteChild(module, name, id_),
       argumentDefinitions: argumentDefinitions.map(def => mapRefs(def, ownedToRaw(module, id_))),
@@ -2098,6 +2118,7 @@ export class Function extends Ast {
     // type methods.
     return MutableFunction.concrete(
       module,
+      undefined,
       undefined,
       unspaced(Ident.newAllowingOperators(module, name)),
       argumentDefinitions,
@@ -2140,7 +2161,15 @@ export class Function extends Ast {
 
   /** TODO: Add docs */
   *concreteChildren(_verbatim?: boolean): IterableIterator<RawNodeChild> {
-    const { private_, name, argumentDefinitions, equals, body } = getAll(this.fields)
+    const { signatureLine, private_, name, argumentDefinitions, equals, body } = getAll(this.fields)
+    if (signatureLine) {
+      const { signature, newlines } = signatureLine
+      const { name, operator, type } = signature
+      yield name
+      yield operator
+      yield type
+      yield* newlines
+    }
     if (private_) yield private_
     yield name
     for (const def of argumentDefinitions) {

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ErrorCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ErrorCompilerTest.java
@@ -322,6 +322,7 @@ public class ErrorCompilerTest extends CompilerTests {
         parse(
             """
     fan_out_to_columns : Table -> Text | Integer -> (Any -> Vector Any) -> | Nothing -> Problem_Behavior -> Table | Nothing
+    fan_out_to_columns table text_or_integer any_to_vector_any wat problem_behavior = Nothing
     """);
     assertSingleSyntaxError(
         ir, Syntax.UnexpectedExpression$.MODULE$, "Unexpected expression", 48, 119);

--- a/lib/rust/parser/debug/src/lib.rs
+++ b/lib/rust/parser/debug/src/lib.rs
@@ -97,9 +97,11 @@ where T: serde::Serialize + Reflect {
     };
     let line = rust_to_meta[&tree::block::Line::reflect().id];
     let operator_line = rust_to_meta[&tree::block::OperatorLine::reflect().id];
+    let type_signature_line = rust_to_meta[&tree::TypeSignatureLine::reflect().id];
     let invalid = rust_to_meta[&tree::Invalid::reflect().id];
     to_s_expr.mapper(line, into_car);
     to_s_expr.mapper(operator_line, into_car);
+    to_s_expr.mapper(type_signature_line, into_car);
     to_s_expr.mapper(invalid, strip_invalid);
     to_s_expr.mapper(text_escape_token, simplify_escape);
     tuplify(to_s_expr.value(ast_ty, &value))

--- a/lib/rust/parser/src/macros/resolver.rs
+++ b/lib/rust/parser/src/macros/resolver.rs
@@ -176,10 +176,11 @@ impl<'s> Finish for ResolverState<'s> {
 
     fn finish(&mut self) -> Self::Result {
         self.finish_current_line();
-        let lines = self.lines.drain(..);
         let tree = match self.root_context {
-            RootContext::Module => syntax::tree::block::parse_module(lines, &mut self.precedence),
-            RootContext::Block => syntax::tree::block::parse_block(lines, &mut self.precedence),
+            RootContext::Module =>
+                syntax::tree::block::parse_module(&mut self.lines, &mut self.precedence),
+            RootContext::Block =>
+                syntax::tree::block::parse_block(&mut self.lines, &mut self.precedence),
         };
         debug_assert!(self.blocks.is_empty());
         debug_assert!(self.lines.is_empty());

--- a/lib/rust/parser/src/syntax/statement.rs
+++ b/lib/rust/parser/src/syntax/statement.rs
@@ -12,14 +12,15 @@ use crate::prelude::*;
 use crate::syntax::item;
 use crate::syntax::maybe_with_error;
 use crate::syntax::operator::Precedence;
-use crate::syntax::statement::function_def::parse_function_decl;
 use crate::syntax::statement::function_def::try_parse_foreign_function;
+use crate::syntax::statement::function_def::FunctionBuilder;
 use crate::syntax::statement::type_def::try_parse_type_def;
 use crate::syntax::token;
 use crate::syntax::tree;
 use crate::syntax::tree::block;
 use crate::syntax::tree::ArgumentDefinition;
 use crate::syntax::tree::SyntaxError;
+use crate::syntax::tree::TypeSignature;
 use crate::syntax::treebuilding::Spacing;
 use crate::syntax::Item;
 use crate::syntax::Token;
@@ -37,12 +38,15 @@ impl<'s> BodyBlockParser<'s> {
     /// Parse the statements in a block.
     pub fn parse_body_block(
         &mut self,
-        lines: impl IntoIterator<Item = item::Line<'s>>,
+        lines: &mut Vec<item::Line<'s>>,
         precedence: &mut Precedence<'s>,
     ) -> Tree<'s> {
-        let lines = lines.into_iter().map(|item::Line { newline, mut items }| block::Line {
-            newline,
-            expression: self.statement_parser.parse_statement(&mut items, 0, precedence),
+        let lines = compound_lines_with_tail_expression(lines, |prefixes, line, is_tail| {
+            if is_tail {
+                self.statement_parser.parse_tail_expression(line, precedence)
+            } else {
+                self.statement_parser.parse_statement(prefixes, line, precedence)
+            }
         });
         Tree::body_block(block::compound_lines(lines).collect())
     }
@@ -50,14 +54,97 @@ impl<'s> BodyBlockParser<'s> {
     /// Parse the declarations and statements at the top level of a module.
     pub fn parse_module(
         &mut self,
-        lines: impl IntoIterator<Item = item::Line<'s>>,
+        lines: &mut Vec<item::Line<'s>>,
         precedence: &mut Precedence<'s>,
     ) -> Tree<'s> {
-        let lines = lines.into_iter().map(|item::Line { newline, mut items }| block::Line {
-            newline,
-            expression: self.statement_parser.parse_module_statement(&mut items, 0, precedence),
+        let lines = compound_lines(lines, |prefixes, line| {
+            self.statement_parser.parse_module_statement(prefixes, line, precedence)
         });
         Tree::body_block(block::compound_lines(lines).collect())
+    }
+}
+
+fn compound_lines<'s>(
+    lines: &mut Vec<item::Line<'s>>,
+    mut parse_line: impl FnMut(
+        &mut Vec<Line<'s, StatementPrefix<'s>>>,
+        item::Line<'s>,
+    ) -> Line<'s, StatementOrPrefix<'s>>,
+) -> Vec<block::Line<'s>> {
+    compound_lines_maybe_with_tail_expression(
+        lines,
+        |prefixes, line, _| parse_line(prefixes, line),
+        None,
+    )
+}
+
+fn compound_lines_with_tail_expression<'s>(
+    lines: &mut Vec<item::Line<'s>>,
+    parse_line: impl FnMut(
+        &mut Vec<Line<'s, StatementPrefix<'s>>>,
+        item::Line<'s>,
+        bool,
+    ) -> Line<'s, StatementOrPrefix<'s>>,
+) -> Vec<block::Line<'s>> {
+    compound_lines_maybe_with_tail_expression(
+        lines,
+        parse_line,
+        lines.iter().enumerate().rfind(|(_, prefix)| !prefix.items.is_empty()).map(|(i, _)| i),
+    )
+}
+
+fn compound_lines_maybe_with_tail_expression<'s>(
+    lines: &mut Vec<item::Line<'s>>,
+    mut parse_line: impl FnMut(
+        &mut Vec<Line<'s, StatementPrefix<'s>>>,
+        item::Line<'s>,
+        bool,
+    ) -> Line<'s, StatementOrPrefix<'s>>,
+    tail_index: Option<usize>,
+) -> Vec<block::Line<'s>> {
+    let mut block_lines = Vec::new();
+    let mut line_prefixes = Vec::new();
+    for (i, line) in lines.drain(..).enumerate() {
+        let is_tail = tail_index == Some(i);
+        match parse_line(&mut line_prefixes, line, is_tail) {
+            Line { newline, content: Some(StatementOrPrefix::Statement(statement)) } => {
+                for Line { newline, content } in line_prefixes.drain(..) {
+                    block_lines.push(block::Line { newline, expression: content.map(Tree::from) })
+                }
+                block_lines.push(block::Line { newline, expression: Some(statement) })
+            }
+            Line { newline, content: Some(StatementOrPrefix::Prefix(prefix)) } =>
+                line_prefixes.push(Line { newline, content: Some(prefix) }),
+            Line { newline, content: None } =>
+                if line_prefixes.is_empty() {
+                    block_lines.push(newline.into());
+                } else {
+                    line_prefixes.push(newline.into());
+                },
+        }
+    }
+    for Line { newline, content } in line_prefixes {
+        block_lines.push(block::Line { newline, expression: content.map(Tree::from) })
+    }
+    block_lines
+}
+
+#[derive(Debug)]
+struct Line<'s, T> {
+    newline: token::Newline<'s>,
+    content: Option<T>,
+}
+
+impl<'s, T> Line<'s, T> {
+    fn map_content<U>(self, f: impl FnOnce(T) -> U) -> Line<'s, U> {
+        let Line { newline, content } = self;
+        Line { newline, content: content.map(f) }
+    }
+}
+
+impl<'s, T> From<token::Newline<'s>> for Line<'s, T> {
+    fn from(newline: token::Newline<'s>) -> Self {
+        Self { newline, content: None }
     }
 }
 
@@ -69,33 +156,49 @@ struct StatementParser<'s> {
 impl<'s> StatementParser<'s> {
     fn parse_statement(
         &mut self,
-        items: &mut Vec<Item<'s>>,
-        start: usize,
+        prefixes: &mut Vec<Line<'s, StatementPrefix<'s>>>,
+        line: item::Line<'s>,
         precedence: &mut Precedence<'s>,
-    ) -> Option<Tree<'s>> {
-        parse_statement(items, start, precedence, &mut self.args_buffer, StatementContext {
+    ) -> Line<'s, StatementOrPrefix<'s>> {
+        parse_statement(prefixes, line, precedence, &mut self.args_buffer, StatementContext {
             evaluation_context: EvaluationContext::Eager,
             visibility_context: VisibilityContext::Private,
+            tail_expression:    false,
+        })
+    }
+
+    fn parse_tail_expression(
+        &mut self,
+        line: item::Line<'s>,
+        precedence: &mut Precedence<'s>,
+    ) -> Line<'s, StatementOrPrefix<'s>> {
+        parse_statement(&mut vec![], line, precedence, &mut self.args_buffer, StatementContext {
+            evaluation_context: EvaluationContext::Eager,
+            visibility_context: VisibilityContext::Private,
+            tail_expression:    true,
         })
     }
 
     fn parse_module_statement(
         &mut self,
-        items: &mut Vec<Item<'s>>,
-        start: usize,
+        prefixes: &mut Vec<Line<'s, StatementPrefix<'s>>>,
+        line: item::Line<'s>,
         precedence: &mut Precedence<'s>,
-    ) -> Option<Tree<'s>> {
-        parse_statement(items, start, precedence, &mut self.args_buffer, StatementContext {
+    ) -> Line<'s, StatementOrPrefix<'s>> {
+        parse_statement(prefixes, line, precedence, &mut self.args_buffer, StatementContext {
             evaluation_context: EvaluationContext::Lazy,
             visibility_context: VisibilityContext::Public,
+            tail_expression:    false,
         })
-        .map(|statement| {
-            let error = match &statement.variant {
-                tree::Variant::Assignment(_) =>
-                    SyntaxError::StmtUnexpectedAssignmentInModuleBody.into(),
-                _ => None,
-            };
-            maybe_with_error(statement, error)
+        .map_content(|statement_or_prefix| {
+            statement_or_prefix.map_statement(|statement| {
+                let error = match &statement.variant {
+                    tree::Variant::Assignment(_) =>
+                        SyntaxError::StmtUnexpectedAssignmentInModuleBody.into(),
+                    _ => None,
+                };
+                maybe_with_error(statement, error)
+            })
         })
     }
 }
@@ -112,45 +215,92 @@ fn scan_private_keywords<'s>(items: impl IntoIterator<Item = impl AsRef<Item<'s>
         .count()
 }
 
+enum StatementPrefix<'s> {
+    TypeSignature(TypeSignature<'s>),
+}
+
+impl<'s> From<StatementPrefix<'s>> for Tree<'s> {
+    fn from(value: StatementPrefix<'s>) -> Self {
+        match value {
+            StatementPrefix::TypeSignature(signature) =>
+                Tree::type_signature_declaration(signature),
+        }
+    }
+}
+
+enum StatementOrPrefix<'s> {
+    Statement(Tree<'s>),
+    Prefix(StatementPrefix<'s>),
+}
+
+impl<'s> StatementOrPrefix<'s> {
+    fn map_statement(self, f: impl FnOnce(Tree<'s>) -> Tree<'s>) -> Self {
+        match self {
+            StatementOrPrefix::Statement(statement) => StatementOrPrefix::Statement(f(statement)),
+            prefix => prefix,
+        }
+    }
+}
+
+impl<'s> From<StatementOrPrefix<'s>> for Tree<'s> {
+    fn from(value: StatementOrPrefix<'s>) -> Self {
+        match value {
+            StatementOrPrefix::Statement(tree) => tree,
+            StatementOrPrefix::Prefix(prefix) => prefix.into(),
+        }
+    }
+}
+
+impl<'s> From<Tree<'s>> for StatementOrPrefix<'s> {
+    fn from(value: Tree<'s>) -> Self {
+        StatementOrPrefix::Statement(value)
+    }
+}
+
 fn parse_statement<'s>(
-    items: &mut Vec<Item<'s>>,
-    statement_start: usize,
+    prefixes: &mut Vec<Line<'s, StatementPrefix<'s>>>,
+    mut line: item::Line<'s>,
     precedence: &mut Precedence<'s>,
     args_buffer: &mut Vec<ArgumentDefinition<'s>>,
     statement_context: StatementContext,
-) -> Option<Tree<'s>> {
+) -> Line<'s, StatementOrPrefix<'s>> {
+    let newline = line.newline;
     use token::Variant;
-    let private_keywords = scan_private_keywords(&items[statement_start..]);
-    let start = statement_start + private_keywords;
+    let private_keywords = scan_private_keywords(&line.items);
+    let start = private_keywords;
+    let items = &mut line.items;
     if let Some(type_def) = try_parse_type_def(items, start, precedence, args_buffer) {
         debug_assert_eq!(items.len(), start);
-        return apply_private_keywords(
-            Some(type_def),
-            items.drain(statement_start..),
-            statement_context.visibility_context,
-        );
+        return Line {
+            newline,
+            content: apply_private_keywords(
+                Some(type_def),
+                items.drain(..),
+                statement_context.visibility_context,
+            )
+            .map(StatementOrPrefix::Statement),
+        };
     }
     let top_level_operator = match find_top_level_operator(&items[start..]) {
         Ok(top_level_operator) => top_level_operator.map(|(i, t)| (i + start, t)),
         Err(e) =>
-            return precedence
-                .resolve_non_section_offset(statement_start, items)
-                .unwrap()
-                .with_error(e)
-                .into(),
+            return Line {
+                newline,
+                content: Some(precedence.resolve_non_section(items).unwrap().with_error(e).into()),
+            },
     };
-    let statement = match top_level_operator {
+    match top_level_operator {
         Some((i, Token { variant: Variant::AssignmentOperator(_), .. })) =>
             parse_assignment_like_statement(
-                items,
-                statement_start,
+                prefixes,
+                item::Line { newline, items: mem::take(items) },
                 start,
                 i,
                 precedence,
                 args_buffer,
                 statement_context,
             )
-            .into(),
+            .map_content(StatementOrPrefix::Statement),
         Some((i, Token { variant: Variant::TypeAnnotationOperator(_), .. })) => {
             let type_ = precedence.resolve_non_section_offset(i + 1, items);
             let operator: token::TypeAnnotationOperator =
@@ -159,53 +309,77 @@ fn parse_statement<'s>(
             let type_ = type_.unwrap_or_else(|| {
                 empty_tree(operator.code.position_after()).with_error(SyntaxError::ExpectedType)
             });
-            if lhs.as_ref().is_some_and(is_qualified_name) {
-                Tree::type_signature(lhs.unwrap(), operator, type_).into()
-            } else {
-                let lhs = lhs.unwrap_or_else(|| {
-                    empty_tree(operator.left_offset.code.position_before())
-                        .with_error(SyntaxError::ExpectedExpression)
-                });
-                Tree::type_annotated(lhs, operator, type_).into()
+            debug_assert!(items.len() <= start);
+            let statement = Some(
+                if lhs.as_ref().is_some_and(is_qualified_name) && !statement_context.tail_expression
+                {
+                    StatementOrPrefix::Prefix(StatementPrefix::TypeSignature(TypeSignature {
+                        name: lhs.unwrap(),
+                        operator,
+                        type_,
+                    }))
+                } else {
+                    let lhs = lhs.unwrap_or_else(|| {
+                        empty_tree(operator.left_offset.code.position_before())
+                            .with_error(SyntaxError::ExpectedExpression)
+                    });
+                    Tree::type_annotated(lhs, operator, type_).into()
+                },
+            );
+            Line {
+                newline,
+                content: apply_private_keywords(
+                    statement,
+                    items.drain(..),
+                    statement_context.visibility_context,
+                ),
             }
         }
         Some(_) => unreachable!(),
-        None => precedence.resolve_offset(start, items),
-    };
-    debug_assert!(items.len() <= start);
-    apply_private_keywords(
-        statement,
-        items.drain(statement_start..),
-        statement_context.visibility_context,
-    )
+        None => {
+            let statement = precedence.resolve_offset(start, items);
+            debug_assert!(items.len() <= start);
+            Line {
+                newline,
+                content: apply_private_keywords(
+                    statement,
+                    items.drain(..),
+                    statement_context.visibility_context,
+                )
+                .map(StatementOrPrefix::Statement),
+            }
+        }
+    }
 }
 
 /// Apply any private keywords that were not already consumed by a statement parser that recognizes
 /// them specifically (such as in a function definition).
-fn apply_private_keywords<'s>(
-    mut statement: Option<Tree<'s>>,
+fn apply_private_keywords<'s, U: From<Tree<'s>> + Into<Tree<'s>>>(
+    mut statement: Option<U>,
     keywords: impl Iterator<Item = Item<'s>>,
     visibility_context: VisibilityContext,
-) -> Option<Tree<'s>> {
+) -> Option<U> {
     for item in keywords {
         let private = Tree::private(item.into_token().unwrap().try_into().unwrap());
-        statement = match statement.take() {
-            Some(statement) => Tree::app(
-                private.with_error(match visibility_context {
-                    VisibilityContext::Public => SyntaxError::StmtUnexpectedPrivateSubject,
-                    VisibilityContext::Private => SyntaxError::StmtUnexpectedPrivateContext,
+        statement = Some(
+            match statement.take() {
+                Some(statement) => Tree::app(
+                    private.with_error(match visibility_context {
+                        VisibilityContext::Public => SyntaxError::StmtUnexpectedPrivateSubject,
+                        VisibilityContext::Private => SyntaxError::StmtUnexpectedPrivateContext,
+                    }),
+                    statement.into(),
+                ),
+                None => maybe_with_error(private, match visibility_context {
+                    // This is the only non-error case in this function: A `private` keyword was
+                    // found not modifying any other statement, and in a context where a `private`
+                    // declaration is allowed; in this case, we emit a `Private` declaration.
+                    VisibilityContext::Public => None,
+                    VisibilityContext::Private => Some(SyntaxError::StmtUnexpectedPrivateContext),
                 }),
-                statement,
-            ),
-            None => maybe_with_error(private, match visibility_context {
-                // This is the only non-error case in this function: A `private` keyword was found
-                // not modifying any other statement, and in a context where a `private` declaration
-                // is allowed; in this case, we emit a `Private` declaration without error.
-                VisibilityContext::Public => None,
-                VisibilityContext::Private => Some(SyntaxError::StmtUnexpectedPrivateContext),
-            }),
-        }
-        .into();
+            }
+            .into(),
+        );
     }
     statement
 }
@@ -214,6 +388,7 @@ fn apply_private_keywords<'s>(
 struct StatementContext {
     evaluation_context: EvaluationContext,
     visibility_context: VisibilityContext,
+    tail_expression:    bool,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -233,19 +408,25 @@ enum VisibilityContext {
 }
 
 fn parse_assignment_like_statement<'s>(
-    items: &mut Vec<Item<'s>>,
-    private_keywords_start: usize,
+    prefixes: &mut Vec<Line<'s, StatementPrefix<'s>>>,
+    mut line: item::Line<'s>,
     start: usize,
     operator: usize,
     precedence: &mut Precedence<'s>,
     args_buffer: &mut Vec<ArgumentDefinition<'s>>,
-    StatementContext { evaluation_context, visibility_context }: StatementContext,
-) -> Tree<'s> {
+    StatementContext { evaluation_context, visibility_context, .. }: StatementContext,
+) -> Line<'s, Tree<'s>> {
+    let items = &mut line.items;
+    let newline = line.newline;
     if operator == start {
-        return precedence
+        let error = precedence
             .resolve_non_section_offset(start, items)
             .unwrap()
             .with_error(SyntaxError::StmtInvalidAssignmentOrMethod);
+        return Line {
+            newline,
+            content: apply_private_keywords(Some(error), items.drain(..), visibility_context),
+        };
     }
 
     let mut expression = precedence.resolve_offset(operator + 1, items);
@@ -269,7 +450,10 @@ fn parse_assignment_like_statement<'s>(
         precedence,
         args_buffer,
     ) {
-        return function;
+        return Line {
+            newline,
+            content: apply_private_keywords(Some(function), items.drain(..), visibility_context),
+        };
     }
     let operator = operator.unwrap();
 
@@ -288,23 +472,33 @@ fn parse_assignment_like_statement<'s>(
         (expression, Some(qn_len)) => Type::Function { expression, qn_len },
         (None, None) => Type::InvalidNoExpressionNoQn,
     } {
-        Type::Assignment { expression } =>
-            parse_assignment(start, items, operator, expression, precedence),
-        Type::Function { expression, qn_len } => {
-            let (qn, args, return_) =
-                parse_function_decl(items, start, qn_len, precedence, args_buffer);
-            let private = (visibility_context != VisibilityContext::Private
-                && private_keywords_start < start)
-                .then(|| items.pop().unwrap().into_token().unwrap().try_into().unwrap());
-
-            Tree::function(private, qn, args, return_, operator, expression)
-        }
-        Type::InvalidNoExpressionNoQn => Tree::opr_app(
-            precedence.resolve_non_section_offset(start, items),
-            Ok(operator.with_variant(token::variant::Operator())),
-            None,
+        Type::Assignment { expression } => Line {
+            newline,
+            content: apply_private_keywords(
+                Some(parse_assignment(start, items, operator, expression, precedence)),
+                items.drain(..),
+                visibility_context,
+            ),
+        },
+        Type::Function { expression, qn_len } => FunctionBuilder::new(
+            item::Line { newline, items: mem::take(items) },
+            start,
+            qn_len,
+            precedence,
+            args_buffer,
         )
-        .with_error(SyntaxError::StmtInvalidAssignmentOrMethod),
+        .build(prefixes, operator, expression, visibility_context),
+        Type::InvalidNoExpressionNoQn => Line {
+            newline,
+            content: Some(
+                Tree::opr_app(
+                    precedence.resolve_non_section(items),
+                    Ok(operator.with_variant(token::variant::Operator())),
+                    None,
+                )
+                .with_error(SyntaxError::StmtInvalidAssignmentOrMethod),
+            ),
+        },
     }
 }
 

--- a/lib/rust/parser/src/syntax/tree/block.rs
+++ b/lib/rust/parser/src/syntax/tree/block.rs
@@ -50,7 +50,7 @@ impl<'s> span::Builder<'s> for Line<'s> {
 
 /// Parse the top-level of a module.
 pub fn parse_module<'s>(
-    lines: impl IntoIterator<Item = item::Line<'s>>,
+    lines: &mut Vec<item::Line<'s>>,
     precedence: &mut operator::Precedence<'s>,
 ) -> Tree<'s> {
     BodyBlockParser::default().parse_module(lines, precedence)
@@ -58,7 +58,7 @@ pub fn parse_module<'s>(
 
 /// Parse a body block.
 pub fn parse_block<'s>(
-    lines: impl IntoIterator<Item = item::Line<'s>>,
+    lines: &mut Vec<item::Line<'s>>,
     precedence: &mut operator::Precedence<'s>,
 ) -> Tree<'s> {
     BodyBlockParser::default().parse_body_block(lines, precedence)

--- a/lib/rust/parser/src/syntax/treebuilding/block.rs
+++ b/lib/rust/parser/src/syntax/treebuilding/block.rs
@@ -50,7 +50,7 @@ where Inner: ItemConsumer<'s> + Finish
             };
             items.push(Item::Tree(match block_context {
                 BlockContext::Body =>
-                    self.block_parser.parse_body_block(lines.into_vec(), &mut child),
+                    self.block_parser.parse_body_block(&mut lines.into_vec(), &mut child),
                 BlockContext::ArgumentOrOperator => {
                     for item::Line { newline, items } in lines.into_vec() {
                         self.block_builder.push(newline, items, &mut child);


### PR DESCRIPTION
### Pull Request Description

Move type-signature lines into `Function` field. Also implements #11293.

Stacked on #11346.

### Important Notes

<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
