### PR TITLE
`IfThenElse` IR instead of `if_then_else` function invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 
 #### Enso Language & Runtime
 
+- [Special handling of if ... then ... else construct][11365]
 - [Enso is "conversion and equality oriented" language][14133]
 - [Moving >, >=, <, <= to types where such operators make sense][14017]
 - [Moving warning releated methods outside of `Any`][13978]
@@ -90,6 +91,7 @@
 - [Update to GraalVM 25.0.1][14233]
 - [Apply block argument to non-application expression][14249]
 
+[11365]: https://github.com/enso-org/enso/pull/11365
 [14133]: https://github.com/enso-org/enso/pull/14133
 [14017]: https://github.com/enso-org/enso/pull/14017
 [14003]: https://github.com/enso-org/enso/pull/14003

--- a/distribution/lib/Standard/Test/0.0.0-dev/src/Faker.enso
+++ b/distribution/lib/Standard/Test/0.0.0-dev/src/Faker.enso
@@ -192,7 +192,7 @@ type Faker
         sign = if self.integer 0 2 == 0 then 1 else -1
         mantissa = self.float 0 max_mantissa
         exponent = self.integer 0 max_exponent+1
-        sign * mantissa * (2.0 ^ exponent)
+        (2.0 ^ exponent) * sign * mantissa
 
     ## ---
        group: Standard.Base.Random

--- a/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
+++ b/distribution/lib/Standard/Visualization/0.0.0-dev/src/Table/Visualization.enso
@@ -414,15 +414,17 @@ _make_json_for_value val level=0 = case val of
             prepared = if table.column_count > 5 then truncated + ["… " + (table.column_count - 5).to_text+ " more"] else truncated
             "Table{" + table.row_count.to_text + " rows x [" + (prepared.join ", ") + "]}"
     col : Column ->
-        if level != 0 then "Column{" +col.name + ": " + col.row_count.to_text + " rows}" else
+        if level != 0 then "Column{" + col.name + ": " + col.row_count.to_text + " rows}" else
             items = _make_json_for_value col.to_vector level
             "Column{" + col.name + ": " + items + "}"
-    table : DB_Table ->
+    db_table : DB_Table ->
+        table = db_table : Table
         if level != 0 then "DB_Table{" + table.column_count.to_text + " columns}" else
             truncated = table.columns.take 5 . map _.name
             prepared = if table.column_count > 5 then truncated + ["… " + (table.column_count - 5).to_text+ " more"] else truncated
             "DB_Table{" + table.row_count.to_text + " rows x [" + (prepared.join ", ") + "]}"
-    col : DB_Column ->
+    db_col : DB_Column ->
+        col = db_col : Column
         if level != 0 then "DB_Column{"+col.name+"}" else
             "DB_Column{" + col.name + ": " + col.length.to_text + " rows}"
     f : Function -> "[Function "+f.to_text+"]"

--- a/engine/runtime-compiler-dump-igv/src/main/java/org/enso/compiler/dump/igv/EnsoModuleAST.java
+++ b/engine/runtime-compiler-dump-igv/src/main/java/org/enso/compiler/dump/igv/EnsoModuleAST.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.UUID;
-
 import org.enso.compiler.core.IR;
 import org.enso.compiler.core.ir.CallArgument;
 import org.enso.compiler.core.ir.DefinitionArgument;

--- a/engine/runtime-compiler-dump-igv/src/main/java/org/enso/compiler/dump/igv/EnsoModuleAST.java
+++ b/engine/runtime-compiler-dump-igv/src/main/java/org/enso/compiler/dump/igv/EnsoModuleAST.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.UUID;
+
 import org.enso.compiler.core.IR;
 import org.enso.compiler.core.ir.CallArgument;
 import org.enso.compiler.core.ir.DefinitionArgument;
@@ -413,6 +414,10 @@ final class EnsoModuleAST {
         var litNode = buildTree(litPat.literal());
         createEdge(node, litNode, "literal");
         yield node;
+      }
+      case Pattern.Bool boolPat -> {
+        Map<String, Object> props = Map.of("condition", boolPat.condition());
+        yield newNode(boolPat, props);
       }
       case Pattern.Name name -> {
         Map<String, Object> props = Map.of("patternName", name.name().name());

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/IfThenElseToCaseOf.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/IfThenElseToCaseOf.java
@@ -58,6 +58,7 @@ public final class IfThenElseToCaseOf implements MiniPassFactory {
               Case.Branch.builder()
                   .pattern(truePattern)
                   .expression(ife.trueBranch())
+                  .location(ife.trueBranch().identifiedLocation())
                   .terminalBranch(true)
                   .build();
           Expression elseExpr;
@@ -71,10 +72,15 @@ public final class IfThenElseToCaseOf implements MiniPassFactory {
               Case.Branch.builder()
                   .pattern(falsePattern)
                   .expression(elseExpr)
+                  .location(elseExpr.identifiedLocation())
                   .terminalBranch(true)
                   .build();
           var branches = List.of(trueBranch, elseBranch);
-          yield Case.Expr.builder().scrutinee(ife.cond()).branches(asScala(branches)).build();
+          yield Case.Expr.builder()
+              .scrutinee(ife.cond())
+              .location(ife.identifiedLocation())
+              .branches(asScala(branches))
+              .build();
         }
         default -> ir;
       };

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/IfThenElseToCaseOf.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/IfThenElseToCaseOf.java
@@ -1,0 +1,96 @@
+package org.enso.compiler.pass.analyse;
+
+import static org.enso.scala.wrapper.ScalaConversions.asScala;
+
+import java.util.List;
+import org.enso.compiler.context.InlineContext;
+import org.enso.compiler.context.ModuleContext;
+import org.enso.compiler.core.ir.Empty;
+import org.enso.compiler.core.ir.Expression;
+import org.enso.compiler.core.ir.Literal;
+import org.enso.compiler.core.ir.MetadataStorage;
+import org.enso.compiler.core.ir.Name;
+import org.enso.compiler.core.ir.Pattern;
+import org.enso.compiler.core.ir.expression.Case;
+import org.enso.compiler.core.ir.expression.IfThenElse;
+import org.enso.compiler.pass.IRProcessingPass;
+import org.enso.compiler.pass.MiniIRPass;
+import org.enso.compiler.pass.MiniPassFactory;
+import scala.Option;
+import scala.collection.immutable.Seq;
+import scala.jdk.javaapi.CollectionConverters;
+
+/** Converts {@link IfThenElse} to {@code case ... of} statement. */
+public final class IfThenElseToCaseOf implements MiniPassFactory {
+  public static final IfThenElseToCaseOf INSTANCE = new IfThenElseToCaseOf();
+
+  private IfThenElseToCaseOf() {}
+
+  @Override
+  public Seq<IRProcessingPass> precursorPasses() {
+    List<IRProcessingPass> passes = List.of();
+    return CollectionConverters.asScala(passes).toList();
+  }
+
+  @Override
+  public Seq<IRProcessingPass> invalidatedPasses() {
+    return CollectionConverters.asScala(List.<IRProcessingPass>of()).toList();
+  }
+
+  @Override
+  public MiniIRPass createForInlineCompilation(InlineContext inlineContext) {
+    return MINI_PASS;
+  }
+
+  @Override
+  public MiniIRPass createForModuleCompilation(ModuleContext moduleContext) {
+    return MINI_PASS;
+  }
+
+  private static final Mini MINI_PASS = new Mini();
+
+  private static final class Mini extends MiniIRPass {
+    Mini() {}
+
+    @Override
+    public Expression transformExpression(Expression ir) {
+      return switch (ir) {
+        case IfThenElse ife -> {
+          var lit =
+              Literal.Number$.MODULE$.apply(
+                  Option.empty(),
+                  "5432",
+                  ife.cond().identifiedLocation(),
+                  ife.cond().passData().copy());
+          var truePattern = new Pattern.Literal(lit, null, ife.passData());
+          var trueBranch =
+              Case.Branch.builder()
+                  .pattern(truePattern)
+                  .expression(ife.trueBranch())
+                  .terminalBranch(true)
+                  .build();
+          Expression elseExpr;
+          if (ife.falseBranchOrNull() == null) {
+            elseExpr = new Empty(null);
+          } else {
+            elseExpr = ife.falseBranchOrNull();
+          }
+          var anyPattern =
+              Pattern.Name$.MODULE$.apply(
+                  Name.Blank$.MODULE$.apply(null, new MetadataStorage()),
+                  null,
+                  new MetadataStorage());
+          var elseBranch =
+              Case.Branch.builder()
+                  .pattern(anyPattern)
+                  .expression(elseExpr)
+                  .terminalBranch(true)
+                  .build();
+          var branches = List.of(trueBranch, elseBranch);
+          yield Case.Expr.builder().scrutinee(ife.cond()).branches(asScala(branches)).build();
+        }
+        default -> ir;
+      };
+    }
+  }
+}

--- a/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/IfThenElseToCaseOf.java
+++ b/engine/runtime-compiler/src/main/java/org/enso/compiler/pass/analyse/IfThenElseToCaseOf.java
@@ -7,16 +7,13 @@ import org.enso.compiler.context.InlineContext;
 import org.enso.compiler.context.ModuleContext;
 import org.enso.compiler.core.ir.Empty;
 import org.enso.compiler.core.ir.Expression;
-import org.enso.compiler.core.ir.Literal;
 import org.enso.compiler.core.ir.MetadataStorage;
-import org.enso.compiler.core.ir.Name;
 import org.enso.compiler.core.ir.Pattern;
 import org.enso.compiler.core.ir.expression.Case;
 import org.enso.compiler.core.ir.expression.IfThenElse;
 import org.enso.compiler.pass.IRProcessingPass;
 import org.enso.compiler.pass.MiniIRPass;
 import org.enso.compiler.pass.MiniPassFactory;
-import scala.Option;
 import scala.collection.immutable.Seq;
 import scala.jdk.javaapi.CollectionConverters;
 
@@ -56,13 +53,7 @@ public final class IfThenElseToCaseOf implements MiniPassFactory {
     public Expression transformExpression(Expression ir) {
       return switch (ir) {
         case IfThenElse ife -> {
-          var lit =
-              Literal.Number$.MODULE$.apply(
-                  Option.empty(),
-                  "5432",
-                  ife.cond().identifiedLocation(),
-                  ife.cond().passData().copy());
-          var truePattern = new Pattern.Literal(lit, null, ife.passData());
+          var truePattern = new Pattern.Bool(true, null, ife.passData());
           var trueBranch =
               Case.Branch.builder()
                   .pattern(truePattern)
@@ -75,14 +66,10 @@ public final class IfThenElseToCaseOf implements MiniPassFactory {
           } else {
             elseExpr = ife.falseBranchOrNull();
           }
-          var anyPattern =
-              Pattern.Name$.MODULE$.apply(
-                  Name.Blank$.MODULE$.apply(null, new MetadataStorage()),
-                  null,
-                  new MetadataStorage());
+          var falsePattern = new Pattern.Bool(false, null, new MetadataStorage());
           var elseBranch =
               Case.Branch.builder()
-                  .pattern(anyPattern)
+                  .pattern(falsePattern)
                   .expression(elseExpr)
                   .terminalBranch(true)
                   .build();

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/Passes.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/Passes.scala
@@ -58,6 +58,7 @@ class Passes(config: CompilerConfig) {
             )
           } else List())
     ++ List(
+      IfThenElseToCaseOf.INSTANCE,
       ShadowedPatternFields.INSTANCE,
       UnreachableMatchBranches.INSTANCE,
       NestedPatternMatch,

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/AliasAnalysis.scala
@@ -830,8 +830,8 @@ case object AliasAnalysis extends IRPass {
           ),
           fields = cons.fields.map(analysePattern(_, builder))
         )
-      case literalPattern: Pattern.Literal =>
-        literalPattern
+      case literalPattern: Pattern.Literal => literalPattern
+      case boolPattern: Pattern.Bool       => boolPattern
       case typePattern: Pattern.Type =>
         typePattern.copy(
           name = analyseName(

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/analyse/DataflowAnalysis.scala
@@ -699,6 +699,8 @@ case object DataflowAnalysis extends IRPass {
           .updateMetadata(new MetadataPair(this, info))
       case literal: Pattern.Literal =>
         literal.updateMetadata(new MetadataPair(this, info))
+      case bool: Pattern.Bool =>
+        bool.updateMetadata(new MetadataPair(this, info))
       case Pattern.Type(name, tpe, _, _) =>
         val nameDep = asStatic(name)
         info.dependents.updateAt(nameDep, Set(patternDep))

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/NestedPatternMatch.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/desugar/NestedPatternMatch.scala
@@ -348,6 +348,7 @@ case object NestedPatternMatch extends IRPass {
             )
         }
       case _: Pattern.Literal => false
+      case _: Pattern.Bool    => false
       case _: Pattern.Type    => false
       case _: errors.Pattern  => false
       case _: Pattern.Documentation =>

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/lint/UnusedBindings.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/lint/UnusedBindings.scala
@@ -308,6 +308,7 @@ case object UnusedBindings extends IRPass {
         } else pattern
       case literal: Pattern.Literal =>
         literal
+      case bool: Pattern.Bool  => bool
       case err: errors.Pattern => err
 
       case _: Pattern.Documentation =>

--- a/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/IgnoredBindings.scala
+++ b/engine/runtime-compiler/src/main/scala/org/enso/compiler/pass/resolve/IgnoredBindings.scala
@@ -343,6 +343,7 @@ case object IgnoredBindings extends IRPass {
           fields = fields.map(resolvePattern(_, supply))
         )
       case literal: Pattern.Literal => literal
+      case bool: Pattern.Bool       => bool
       case typed @ Pattern.Type(name, _, _, _) =>
         if (isIgnore(name)) {
           val newName = supply

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/IfThenElseTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/IfThenElseTest.java
@@ -12,10 +12,10 @@ import com.oracle.truffle.api.library.ExportMessage;
 import org.enso.test.utils.ContextUtils;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Value;
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.AllOf;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class IfThenElseTest {
@@ -63,6 +63,20 @@ public class IfThenElseTest {
   }
 
   @Test
+  public void indexSubRange() throws Exception {
+    var code =
+        """
+        check step first = case step of
+          _ -> "Every " + step.to_display_text + (if first == 0 then "" else " from " + first.to_display_text)
+        """;
+
+    var check = ctxRule.getMethodFromModule(code, "check");
+
+    assertEquals("Every Prefix", check.execute("Prefix", 0).asString());
+    assertEquals("Every Count from 1", check.execute("Count", 1).asString());
+  }
+
+  @Test
   public void variableDefinedInElse() {
     var code =
         """
@@ -97,6 +111,44 @@ public class IfThenElseTest {
           AllOf.allOf(
               Matchers.containsString("The name `xt` could not be found"),
               Matchers.containsString("6:5: error")));
+    }
+  }
+
+  @Test
+  public void variableInMultipleIfBranches() throws Exception {
+    var code =
+        """
+        check x =
+            if x then
+                xt = "Yes"
+            if x.not then
+                xt = "No"
+            "Hooo"
+        """;
+    var check = ctxRule.getMethodFromModule(code, "check");
+
+    assertEquals("Hooo", check.execute(true).asString());
+    assertEquals("Hooo", check.execute(false).asString());
+  }
+
+  @Test
+  public void variableNotVisibleAfterBranches() throws Exception {
+    var code =
+        """
+        check x =
+            if x then
+                xt = "Yes"
+            if x.not then
+                xt = "No"
+            xt
+        """;
+    try {
+      var check = ctxRule.getMethodFromModule(code, "check");
+      var res = check.execute(true);
+      fail("The code should not compile, but returned: " + res);
+    } catch (PolyglotException ex) {
+      MatcherAssert.assertThat(
+          ex.getMessage(), Matchers.containsString("name `xt` could not be found"));
     }
   }
 
@@ -141,7 +193,6 @@ public class IfThenElseTest {
     assertEquals("No", check.execute("Ne").asString());
   }
 
-  @Ignore
   @Test
   public void truffleObjectConvertibleToBooleanIsSupported() {
     var code =
@@ -281,5 +332,27 @@ public class IfThenElseTest {
     } catch (PolyglotException ex) {
       assertEquals(txt, ex.getMessage());
     }
+  }
+
+  @Test
+  public void dontOverrideVariablesFromOuterScope() throws Exception {
+    var code =
+        """
+        type Hello
+            World msg good
+
+            join self init =
+                if self.good then "Ciao" else
+                    x = init
+                    x + self.msg
+
+        hello state =
+            Hello.World "World" state . join "Hello "
+        """;
+
+    var hello = ctxRule.getMethodFromModule(code, "hello");
+
+    assertEquals("Ciao", hello.execute(true).asString());
+    assertEquals("Hello World", hello.execute(false).asString());
   }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/RootNamesTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/RootNamesTest.java
@@ -86,12 +86,13 @@ public class RootNamesTest {
             .map(l -> l.substring(7))
             .collect(Collectors.toSet());
 
-    assertEquals("Few closures: " + closures, 2, closures.size());
+    assertEquals("Few closures: " + closures, 3, closures.size());
     assertTrue(
         "Fully qualified name for method: " + closures,
         closures.contains("factorial::factorial::fac"));
     assertTrue(
         "Name with dots for local method: " + closures, closures.contains("factorial.fac.acc"));
+    assertTrue("if/then/else: " + closures, closures.contains("if_then_else"));
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/asserts/AssertionsTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/asserts/AssertionsTest.java
@@ -9,6 +9,8 @@ import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.List;
 import org.enso.interpreter.runtime.EnsoContext;
 import org.enso.test.utils.ContextUtils;
@@ -83,12 +85,15 @@ public class AssertionsTest {
           """);
       fail("Should throw Assertion_Error");
     } catch (PolyglotException e) {
-      assertThat(e.getStackTrace().length, greaterThan(5));
-      assertThat(e.getStackTrace()[0].toString(), containsString("Panic"));
-      assertThat(e.getStackTrace()[1].toString(), containsString("Runtime.assert"));
+      var stack = new StringWriter();
+      e.printStackTrace(new PrintWriter(stack));
+      assertThat(stack.toString(), e.getStackTrace().length, greaterThan(5));
+      assertThat(stack.toString(), e.getStackTrace()[0].toString(), containsString("Panic"));
+      assertThat(
+          stack.toString(), e.getStackTrace()[1].toString(), containsString("Runtime.assert"));
       // Ignore the next two frames as they are implementation details
-      assertThat(e.getStackTrace()[4].toString(), containsString("foo"));
-      assertThat(e.getStackTrace()[5].toString(), containsString("main"));
+      assertThat(stack.toString(), e.getStackTrace()[4].toString(), containsString("foo"));
+      assertThat(stack.toString(), e.getStackTrace()[5].toString(), containsString("main"));
     }
   }
 

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/asserts/AssertionsTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/asserts/AssertionsTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.number.OrderingComparison.greaterThan;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -85,15 +84,7 @@ public class AssertionsTest {
           """);
       fail("Should throw Assertion_Error");
     } catch (PolyglotException e) {
-      var stack = new StringWriter();
-      e.printStackTrace(new PrintWriter(stack));
-      assertThat(stack.toString(), e.getStackTrace().length, greaterThan(5));
-      assertThat(stack.toString(), e.getStackTrace()[0].toString(), containsString("Panic"));
-      assertThat(
-          stack.toString(), e.getStackTrace()[1].toString(), containsString("Runtime.assert"));
-      // Ignore the next two frames as they are implementation details
-      assertThat(stack.toString(), e.getStackTrace()[4].toString(), containsString("foo"));
-      assertThat(stack.toString(), e.getStackTrace()[5].toString(), containsString("main"));
+      assertStack(e, "Panic", "Runtime.assert", "foo", "main");
     }
   }
 
@@ -138,5 +129,30 @@ public class AssertionsTest {
             """);
     assertTrue(res.isNumber());
     assertThat(res.asInt(), is(23));
+  }
+
+  private static void assertStack(Throwable e, String... sampleWords) {
+    var stack = new StringWriter();
+    e.printStackTrace(new PrintWriter(stack));
+
+    var lineNumber = 0;
+    for (var i = 0; i < sampleWords.length; i++) {
+      while (true) {
+        if (e.getStackTrace().length <= lineNumber) {
+          fail(
+              "Cannot find "
+                  + sampleWords[i]
+                  + " (from "
+                  + sampleWords
+                  + ") in:\n"
+                  + stack.toString());
+        }
+        var line = e.getStackTrace()[lineNumber++].toString();
+        if (line.contains(sampleWords[i])) {
+          // found another requested sample
+          break;
+        }
+      }
+    }
   }
 }

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/AvoidIdInstrumentationTagTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/AvoidIdInstrumentationTagTest.java
@@ -81,7 +81,7 @@ public class AvoidIdInstrumentationTagTest {
         from Standard.Base import all
 
         operator13 = [ 1973, 1975, 2005, 2006 ]
-        operator15 = operator13.map year-> if year < 2000 then [255, 100] else if year < 2010 then [0, 255] else [0, 100]
+        operator15 = operator13.map year-> (year < 2000).if_then_else [255, 100] ((year < 2010).if_then_else [0, 255] [0, 100])
         """;
     var src = Source.newBuilder("enso", code, "YearLambda.enso").build();
     var module = ctxRule.eval(src);

--- a/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/InsightForEnsoTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/interpreter/test/instrument/InsightForEnsoTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.Map;
@@ -94,10 +95,10 @@ public class InsightForEnsoTest {
     assertEquals(120, res.asInt());
 
     var msgs = ctxRule.getOut();
-    assertNotEquals("Step one: " + msgs, -1, msgs.indexOf("n=5 v=1 acc=function"));
-    assertNotEquals("Step two: " + msgs, -1, msgs.indexOf("n=4 v=5 acc=function"));
-    assertNotEquals("3rd step: " + msgs, -1, msgs.indexOf("n=3 v=20 acc=function"));
-    assertNotEquals("4th step: " + msgs, -1, msgs.indexOf("n=2 v=60 acc=function"));
+    assertContainsAll("Step one: " + msgs, msgs, "n=5", "v=1", "acc=function");
+    assertContainsAll("Step two: " + msgs, msgs, "n=4", "v=5", "acc=function");
+    assertContainsAll("3rd step: " + msgs, msgs, "n=3", "v=20", "acc=function");
+    assertContainsAll("4th step: " + msgs, msgs, "n=2", "v=60", "acc=function");
 
     assertNotEquals(
         "Uninitialized variables (seen as JavaScript null) aren't there: " + msgs,
@@ -185,5 +186,19 @@ public class InsightForEnsoTest {
       assertTrue(
           "Switch call sooner than second constructor:\n" + msgs, switchInitCall < secondCons);
     }
+  }
+
+  private void assertContainsAll(String msg, String text, String... expected) {
+    NEXT_LINE:
+    for (var line : text.split("\n")) {
+      for (var w : expected) {
+        if (line.indexOf(w) == -1) {
+          continue NEXT_LINE;
+        }
+      }
+      // found all expected
+      return;
+    }
+    fail(msg);
   }
 }

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/PassesTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/PassesTest.scala
@@ -10,6 +10,7 @@ import org.enso.compiler.pass.analyse.{
   AliasAnalysis,
   AmbiguousImportsAnalysis,
   BindingAnalysis,
+  IfThenElseToCaseOf,
   ImportSymbolAnalysis,
   PrivateConstructorAnalysis,
   PrivateModuleAnalysis
@@ -69,6 +70,7 @@ class PassesTest extends CompilerTest {
           AmbiguousImportsAnalysis.INSTANCE,
           PrivateModuleAnalysis.INSTANCE,
           PrivateConstructorAnalysis.INSTANCE,
+          IfThenElseToCaseOf.INSTANCE,
           ShadowedPatternFields.INSTANCE,
           UnreachableMatchBranches.INSTANCE,
           NestedPatternMatch,

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/TailCallMegaPass.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/TailCallMegaPass.scala
@@ -431,6 +431,7 @@ case object TailCallMegaPass extends IRPass {
             fields      = fields.map(analysePattern)
           )
       case literal: Pattern.Literal => literal
+      case bool: Pattern.Bool       => bool
       case tpePattern @ Pattern.Type(name, tpe, _, _) =>
         tpePattern
           .copy(

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/TailCallTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/analyse/TailCallTest.scala
@@ -236,13 +236,18 @@ class TailCallTest extends MiniPassTest {
             .body
             .asInstanceOf[Function.Lambda]
             .body
-          fnBody
+          val inBlock = fnBody
             .asInstanceOf[Expression.Block]
             .returnValue
-            .asInstanceOf[Application.Prefix]
-            .arguments
-            .apply(2)
-            .value
+          val caseExpr = inBlock
+            .asInstanceOf[Expression.Block]
+            .returnValue
+          val elseBranch = caseExpr
+            .asInstanceOf[Case.Expr]
+            .branches
+            .apply(1)
+            .expression
+          elseBranch
             .asInstanceOf[Expression.Block]
             .returnValue
             .asInstanceOf[Application.Prefix]

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/LambdaShorthandToLambdaTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/desugar/LambdaShorthandToLambdaTest.scala
@@ -11,7 +11,7 @@ import org.enso.compiler.core.ir.{
   Literal,
   Name
 }
-import org.enso.compiler.core.ir.expression.{Application, Case}
+import org.enso.compiler.core.ir.expression.{Application, Case, IfThenElse}
 import org.enso.compiler.pass.desugar.LambdaShorthandToLambda
 import org.enso.compiler.pass.{
   MiniIRPass,
@@ -193,18 +193,15 @@ class LambdaShorthandToLambdaTest extends CompilerTest {
           |if _ then a
           |""".stripMargin.preprocessExpression.get.desugar
 
-      ir shouldBe an[Function.Lambda]
+      ir shouldBe an[IfThenElse]
       ir.location shouldBe defined
-      val irFn = ir.asInstanceOf[Function.Lambda]
+      val ite = ir.asInstanceOf[IfThenElse]
+
+      val irFn = ite.condition.asInstanceOf[Function.Lambda]
       val irFnArgName =
         irFn.arguments.head.asInstanceOf[DefinitionArgument.Specified].name
 
-      irFn.body shouldBe an[Application.Prefix]
-      val app = irFn.body.asInstanceOf[Application.Prefix]
-      val arg1Name = app.arguments.head
-        .asInstanceOf[CallArgument.Specified]
-        .value
-        .asInstanceOf[Name.Literal]
+      val arg1Name = irFn.body.asInstanceOf[Name.Literal]
 
       irFnArgName.name shouldEqual arg1Name.name
     }

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/LambdaShorthandArgsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/LambdaShorthandArgsTest.scala
@@ -12,6 +12,7 @@ class LambdaShorthandArgsTest extends InterpreterTest {
     "work for simple applications" in {
       val code =
         """
+          |from Standard.Base import all
           |main =
           |    f = a -> b -> c -> a + b - c
           |    g = f _ 5 5
@@ -56,7 +57,7 @@ class LambdaShorthandArgsTest extends InterpreterTest {
           |Number.if_then_else self = ~t -> ~f -> if self == 0 then t else f
           |
           |main =
-          |    f = if _ then 10 else 5
+          |    f = _.if_then_else 10 5
           |    res1 = f 0
           |    res2 = f 1
           |    res1 - res2

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/LambdaTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/LambdaTest.scala
@@ -12,6 +12,7 @@ class LambdaTest extends InterpreterTest {
     "take arguments and use them in their bodies" in {
       val code =
         """
+          |from Standard.Base import all
           |main = x -> x * x
           |""".stripMargin
 
@@ -143,7 +144,7 @@ class LambdaTest extends InterpreterTest {
           |
           |main =
           |    lam = (x = 10) -> x
-          |    fn = a -> if a then lam else fn (a-1)
+          |    fn = a -> a.if_then_else lam (fn (a-1))
           |
           |    fn 10
           |""".stripMargin

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/MixfixFunctionsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/MixfixFunctionsTest.scala
@@ -12,13 +12,14 @@ class MixfixFunctionsTest extends InterpreterTest {
     "be able to be defined as a method" in {
       val code =
         """
+          |from Standard.Base import all
           |type Foo
           |    Mk_Foo a
           |
           |Foo.if_then self = x -> case self of
           |    Foo.Mk_Foo a -> a + x
           |
-          |main = if Foo.Mk_Foo 2 then 8
+          |main = (Foo.Mk_Foo 2).if_then 8
           |""".stripMargin
 
       eval(code) shouldEqual 10
@@ -33,7 +34,7 @@ class MixfixFunctionsTest extends InterpreterTest {
           |Foo.if_then_else self = a -> b -> case self of
           |    Foo.Mk_Foo x y -> x + y + a + b
           |
-          |main = if (Foo.Mk_Foo 1 2) then 3 else 4
+          |main = (Foo.Mk_Foo 1 2).if_then_else 3 4
           |""".stripMargin
 
       eval(code) shouldEqual 10

--- a/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/methodgen/MapExpressionsMethodGenerator.java
+++ b/engine/runtime-parser-processor/src/main/java/org/enso/runtime/parser/processor/methodgen/MapExpressionsMethodGenerator.java
@@ -396,7 +396,7 @@ public final class MapExpressionsMethodGenerator {
     Utils.hardAssert(!(field instanceof OptionListField));
     Utils.hardAssert(!(field instanceof OptionField));
     var nullableCheck = "";
-    if (field.isNullable()) {
+    if (!field.isNullable()) {
       nullableCheck =
           """
           if (${fieldName} == null) {
@@ -404,7 +404,8 @@ public final class MapExpressionsMethodGenerator {
               "Field ${fieldName} must not be null. It was annotated with "
               + "@IRChild(required = true).");
           }
-          """;
+          """
+              .replace("${fieldName}", field.getName());
     }
     var code =
         """

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
@@ -27,6 +27,7 @@ import org.enso.compiler.core.ir.expression.Application;
 import org.enso.compiler.core.ir.expression.Case;
 import org.enso.compiler.core.ir.expression.Comment;
 import org.enso.compiler.core.ir.expression.Foreign;
+import org.enso.compiler.core.ir.expression.IfThenElse;
 import org.enso.compiler.core.ir.expression.Operator;
 import org.enso.compiler.core.ir.expression.Section;
 import org.enso.compiler.core.ir.expression.errors.Syntax;
@@ -1034,6 +1035,26 @@ final class TreeToIr {
           sep = "_";
         }
         var fullName = fnName.toString();
+        if ("if_then_else".equals(fullName) && args.size() == 3) {
+          var ifArg = args.apply(2);
+          var trueArg = args.apply(1);
+          var falseArg = args.apply(0);
+          if (falseArg == null) {
+            yield translateSyntaxError(app, new Syntax.UnsupportedSyntax("Missing else branch"));
+          }
+          yield new IfThenElse(
+              ifArg.value(),
+              trueArg.value(),
+              falseArg.value(),
+              getIdentifiedLocation(tree),
+              meta());
+        }
+        if ("if_then".equals(fullName) && args.size() == 2) {
+          var ifArg = args.apply(1);
+          var trueArg = args.apply(0);
+          yield new IfThenElse(
+              ifArg.value(), trueArg.value(), null, getIdentifiedLocation(tree), meta());
+        }
         if (fullName.equals(FREEZE_MACRO_IDENTIFIER)) {
           yield translateExpression(app.getSegments().get(0).getBody(), false);
         } else if (fullName.equals(SKIP_MACRO_IDENTIFIER)) {

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/IrPersistance.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/IrPersistance.java
@@ -43,6 +43,7 @@ import scala.collection.immutable.Seq;
 @Persistable(clazz = Name.Blank.class, id = 711)
 @Persistable(clazz = Name.GenericAnnotation.class, id = 712)
 @Persistable(clazz = Name.SelfType.class, id = 713)
+@Persistable(clazz = Empty.class, id = 750)
 @Persistable(clazz = Expression.Block.class, id = 751)
 @Persistable(clazz = Expression.Binding.class, id = 752)
 @Persistable(clazz = Application.Prefix.class, id = 753)

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/IrPersistance.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/IrPersistance.java
@@ -55,6 +55,7 @@ import scala.collection.immutable.Seq;
 @Persistable(clazz = Pattern.Name.class, id = 764)
 @Persistable(clazz = Pattern.Literal.class, id = 765)
 @Persistable(clazz = Pattern.Type.class, id = 766)
+@Persistable(clazz = Pattern.Bool.class, id = 767)
 @Persistable(clazz = Method.Conversion.class, id = 771)
 @Persistable(clazz = Set.Union.class, id = 772)
 @Persistable(clazz = Set.Intersection.class, id = 773)

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/expression/IfThenElse.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/ir/expression/IfThenElse.java
@@ -1,0 +1,54 @@
+package org.enso.compiler.core.ir.expression;
+
+import org.enso.compiler.core.ir.Expression;
+import org.enso.compiler.core.ir.IdentifiedLocation;
+import org.enso.compiler.core.ir.MetadataStorage;
+import org.enso.runtime.parser.dsl.GenerateFields;
+import org.enso.runtime.parser.dsl.GenerateIR;
+import org.enso.runtime.parser.dsl.IRChild;
+
+/** Enso if/then(else) expression. */
+@GenerateIR(interfaces = {Expression.class})
+public final class IfThenElse extends IfThenElseGen {
+  @GenerateFields
+  public IfThenElse(
+      @IRChild Expression condition,
+      @IRChild Expression trueBranch,
+      @IRChild(required = false) Expression falseBranchOrNull,
+      IdentifiedLocation identifiedLocation,
+      MetadataStorage passData) {
+    super(condition, trueBranch, falseBranchOrNull, identifiedLocation, passData);
+  }
+
+  public Expression cond() {
+    return condition();
+  }
+
+  public IfThenElse copy(Expression cond) {
+    return builder(this).condition(cond).build();
+  }
+
+  public IfThenElse copy(Expression cond, Expression trueBranch, Expression falseBranchOrNull) {
+    return builder(this)
+        .condition(cond)
+        .trueBranch(trueBranch)
+        .falseBranchOrNull(falseBranchOrNull)
+        .build();
+  }
+
+  public scala.Option<Expression> falseBranch() {
+    return scala.Option.apply(falseBranchOrNull());
+  }
+
+  @Override
+  public String showCode(int indent) {
+    var newIndent = indent + indentLevel;
+    var headerStr = "if " + cond().showCode(0) + " then\n" + trueBranch().showCode(newIndent);
+    var elseStr =
+        switch (falseBranchOrNull()) {
+          case Expression f -> " ".repeat(indent) + "else\n" + f.showCode(newIndent);
+          case null -> "";
+        };
+    return headerStr + "\n" + elseStr;
+  }
+}

--- a/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Pattern.scala
+++ b/engine/runtime-parser/src/main/scala/org/enso/compiler/core/ir/Pattern.scala
@@ -398,6 +398,93 @@ object Pattern {
     override def showCode(indent: Int): String = literal.showCode(indent)
   }
 
+  /** True/False pattern.
+    *
+    * @param passData any pass metadata associated with the node
+    */
+  sealed case class Bool(
+    condition: Boolean,
+    override val identifiedLocation: IdentifiedLocation,
+    override val passData: MetadataStorage = new MetadataStorage()
+  ) extends Pattern
+      with LazyDiagnosticStorage
+      with LazyId {
+
+    /** Creates a copy of `this`.
+      *
+      * @param condition    the boolean value to check for
+      * @param location    the source location for this IR node
+      * @param passData    any pass metadata associated with the node
+      * @param diagnostics compiler diagnostics for this node
+      * @param id          the identifier for the new node
+      * @return a copy of `this`, updated with the provided values
+      */
+    def copy(
+      condition: Boolean                   = condition,
+      location: Option[IdentifiedLocation] = location,
+      passData: MetadataStorage            = passData,
+      diagnostics: DiagnosticStorage       = diagnostics,
+      id: UUID @Identifier                 = id
+    ): Bool = {
+      if (
+        condition != this.condition
+        || location != this.location
+        || (passData ne this.passData)
+        || diagnostics != this.diagnostics
+        || id != this.id
+      ) {
+        val res = Bool(condition, location.orNull, passData)
+        res.diagnostics = diagnostics
+        res.id          = id
+        res
+      } else this
+    }
+
+    /** @inheritdoc */
+    override def duplicate(
+      keepLocations: Boolean   = true,
+      keepMetadata: Boolean    = true,
+      keepDiagnostics: Boolean = true,
+      keepIdentifiers: Boolean = false
+    ): Bool =
+      copy(
+        location = if (keepLocations) location else None,
+        passData =
+          if (keepMetadata) passData.duplicate else new MetadataStorage(),
+        diagnostics = if (keepDiagnostics) diagnosticsCopy else null,
+        id          = if (keepIdentifiers) id else null
+      )
+
+    /** @inheritdoc */
+    override def mapExpressions(
+      fn: java.util.function.Function[Expression, Expression]
+    ): Bool = {
+      this
+    }
+
+    /** String representation. */
+    override def toString: String =
+      s"""
+         |Case.Pattern.Bool(
+         |condition = $condition,
+         |location = $location,
+         |passData = ${this.showPassData},
+         |diagnostics = $diagnostics,
+         |id = $id
+         |)
+         |""".toSingleLine
+
+    /** @inheritdoc */
+    override def setLocation(location: Option[IdentifiedLocation]): Bool =
+      copy(location = location)
+
+    /** @inheritdoc */
+    override def children: List[IR] = List()
+
+    /** @inheritdoc */
+    override def showCode(indent: Int): String = " ".repeat(indent) + condition
+  }
+
   /** A type pattern.
     *
     * A type pattern matches on types. Type pattern is composed of two parts:

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/NumericLiteralBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/NumericLiteralBranchNode.java
@@ -23,8 +23,10 @@ public abstract class NumericLiteralBranchNode extends BranchNode {
     this.literal = literal;
   }
 
-  public static NumericLiteralBranchNode build(
-      long literal, RootCallTarget branch, boolean terminalBranch) {
+  public static BranchNode build(long literal, RootCallTarget branch, boolean terminalBranch) {
+    if (literal == 5432) {
+      return BooleanBranchNode.build(true, branch, terminalBranch);
+    }
     return NumericLiteralBranchNodeGen.create(literal, branch, terminalBranch);
   }
 

--- a/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/NumericLiteralBranchNode.java
+++ b/engine/runtime/src/main/java/org/enso/interpreter/node/controlflow/caseexpr/NumericLiteralBranchNode.java
@@ -23,10 +23,8 @@ public abstract class NumericLiteralBranchNode extends BranchNode {
     this.literal = literal;
   }
 
-  public static BranchNode build(long literal, RootCallTarget branch, boolean terminalBranch) {
-    if (literal == 5432) {
-      return BooleanBranchNode.build(true, branch, terminalBranch);
-    }
+  public static NumericLiteralBranchNode build(
+      long literal, RootCallTarget branch, boolean terminalBranch) {
     return NumericLiteralBranchNodeGen.create(literal, branch, terminalBranch);
   }
 

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -1376,7 +1376,9 @@ private[runtime] class IrToTruffle(
           val scrutineeNode =
             this.run(caseExpr.scrutinee, subjectToInstrumentation)
 
-          val maybeCases    = caseExpr.branches.map(processCaseBranch)
+          val maybeCases = caseExpr.branches.map(b =>
+            processCaseBranch(b, subjectToInstrumentation)
+          )
           val allCasesValid = maybeCases.forall(_.isRight)
 
           if (allCasesValid) {
@@ -1417,7 +1419,8 @@ private[runtime] class IrToTruffle(
       *         the match is invalid
       */
     def processCaseBranch(
-      branch: Case.Branch
+      branch: Case.Branch,
+      subjectToInstrumentation: Boolean
     ): Either[BadPatternMatch, BranchNode] = {
       val scopeInfo = childScopeInfo("case branch", branch)
       def frameInfo() = branch
@@ -1441,7 +1444,8 @@ private[runtime] class IrToTruffle(
           val branchCodeNode = childProcessor.processFunctionBody(
             arg,
             branch.expression,
-            branch.location
+            branch.location,
+            subjectToInstrumentation = subjectToInstrumentation
           )
 
           val branchNode =
@@ -1452,7 +1456,8 @@ private[runtime] class IrToTruffle(
           val branchCodeNode = childProcessor.processFunctionBody(
             Nil,
             branch.expression,
-            branch.location
+            branch.location,
+            subjectToInstrumentation = subjectToInstrumentation
           )
           val node = BooleanBranchNode.build(
             condition,
@@ -1474,7 +1479,8 @@ private[runtime] class IrToTruffle(
           val branchCodeNode = childProcessor.processFunctionBody(
             fieldsAsArgs,
             branch.expression,
-            branch.location
+            branch.location,
+            subjectToInstrumentation = subjectToInstrumentation
           )
 
           constructor match {
@@ -1637,7 +1643,8 @@ private[runtime] class IrToTruffle(
           val branchCodeNode = childProcessor.processFunctionBody(
             Nil,
             branch.expression,
-            branch.location
+            branch.location,
+            subjectToInstrumentation = subjectToInstrumentation
           )
 
           literalPattern.literal match {
@@ -1707,7 +1714,8 @@ private[runtime] class IrToTruffle(
                   val branchCodeNode = childProcessor.processFunctionBody(
                     argOfType,
                     branch.expression,
-                    branch.location
+                    branch.location,
+                    subjectToInstrumentation = subjectToInstrumentation
                   )
                   Right(
                     CatchTypeBranchNode.build(
@@ -1745,7 +1753,8 @@ private[runtime] class IrToTruffle(
                 val branchCodeNode = childProcessor.processFunctionBody(
                   argOfType,
                   branch.expression,
-                  branch.location
+                  branch.location,
+                  subjectToInstrumentation = subjectToInstrumentation
                 )
                 Right(
                   PolyglotSymbolTypeBranchNode.build(
@@ -2278,10 +2287,18 @@ private[runtime] class IrToTruffle(
       arguments: List[DefinitionArgument],
       body: Expression,
       location: Option[IdentifiedLocation],
-      binding: Boolean = false
+      binding: Boolean                  = false,
+      subjectToInstrumentation: Boolean = false
     ): CreateFunctionNode = {
       val bodyBuilder =
-        new BuildFunctionBody(scopeName, arguments, body, null, None, true)
+        new BuildFunctionBody(
+          scopeName,
+          arguments,
+          body,
+          null,
+          None,
+          subjectToInstrumentation
+        )
       val fnRootNode = ClosureRootNode.build(
         language,
         scope,
@@ -2290,7 +2307,7 @@ private[runtime] class IrToTruffle(
         makeSource(scopeBuilder.getModule),
         makeLocation(location),
         scopeName,
-        true,
+        subjectToInstrumentation,
         binding
       )
       val callTarget = fnRootNode.getCallTarget

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -1367,7 +1367,7 @@ private[runtime] class IrToTruffle(
       * @param caseExpr the case expression to generate code for
       * @return the truffle nodes corresponding to `caseExpr`
       */
-    def processCase(
+    private def processCase(
       caseExpr: Case,
       subjectToInstrumentation: Boolean
     ): RuntimeExpression =
@@ -1418,7 +1418,7 @@ private[runtime] class IrToTruffle(
       * @return the truffle nodes correspondingg to `caseBranch` or an error if
       *         the match is invalid
       */
-    def processCaseBranch(
+    private def processCaseBranch(
       branch: Case.Branch,
       subjectToInstrumentation: Boolean
     ): Either[BadPatternMatch, BranchNode] = {
@@ -1431,7 +1431,10 @@ private[runtime] class IrToTruffle(
         .asInstanceOf[FrameVariableNames]
       val childProcessor =
         this.createChild(
-          "case_branch",
+          branch.pattern match {
+            case _ : Pattern.Bool=> "if_then_else"
+            case _ => "case_branch"
+          },
           () => scopeInfo().scope,
           "case " + currentVarName,
           frameInfo

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -1432,8 +1432,8 @@ private[runtime] class IrToTruffle(
       val childProcessor =
         this.createChild(
           branch.pattern match {
-            case _ : Pattern.Bool=> "if_then_else"
-            case _ => "case_branch"
+            case _: Pattern.Bool => "if_then_else"
+            case _               => "case_branch"
           },
           () => scopeInfo().scope,
           "case " + currentVarName,

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -1448,6 +1448,18 @@ private[runtime] class IrToTruffle(
             CatchAllBranchNode.build(branchCodeNode.getCallTarget, true)
 
           Right(branchNode)
+        case Pattern.Bool(condition, _, _) =>
+          val branchCodeNode = childProcessor.processFunctionBody(
+            Nil,
+            branch.expression,
+            branch.location
+          )
+          val node = BooleanBranchNode.build(
+            condition,
+            branchCodeNode.getCallTarget,
+            branch.terminalBranch
+          )
+          Right(node)
         case cons @ Pattern.Constructor(constructor, _, _, _) =>
           if (!cons.isDesugared) {
             throw new CompilerError(

--- a/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
+++ b/engine/runtime/src/main/scala/org/enso/interpreter/runtime/IrToTruffle.scala
@@ -2281,7 +2281,7 @@ private[runtime] class IrToTruffle(
       binding: Boolean = false
     ): CreateFunctionNode = {
       val bodyBuilder =
-        new BuildFunctionBody(scopeName, arguments, body, null, None, false)
+        new BuildFunctionBody(scopeName, arguments, body, null, None, true)
       val fnRootNode = ClosureRootNode.build(
         language,
         scope,
@@ -2290,7 +2290,7 @@ private[runtime] class IrToTruffle(
         makeSource(scopeBuilder.getModule),
         makeLocation(location),
         scopeName,
-        false,
+        true,
         binding
       )
       val callTarget = fnRootNode.getCallTarget

--- a/test/Base_Tests/src/Data/Complex_Helpers.enso
+++ b/test/Base_Tests/src/Data/Complex_Helpers.enso
@@ -12,7 +12,7 @@ type Complex_Comparator
         if x.im==0 && y.im==0 then Ordering.compare x.re y.re else
             Nothing
     hash x:Complex = if x.im == 0 then Ordering.hash x.re else
-        7*x.re + 11*x.im
+        x.re*7 + x.im*11
 
 ## uses the explicit conversion defined in this private module
 Complex.as_complex_and_float self =


### PR DESCRIPTION
### Pull Request Description

Fixes #9165 by recognizing `if/then/else` in a special way. Introduces new `IfThenElse` `IR` element to represent both `if_then_else` as well as `if_then` cases. Such element is then converted to `Case.Expr` to make it compatible (from a point of IR passes) with existing infrastructure.

### It has to be Boolean!

The condition of `if then else` controlflow construct has to yield a `Boolean`-like value. No dispatch to `if_then_else` method happens anymore. Use `v.if_then_else (trueAction) (falseAction)` if you insist on the method dispatch semantics. More [details available](https://github.com/enso-org/enso/pull/11365#issuecomment-2424625097).

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
- [x] Unit tests have been written where possible.
    - [x] Discontinuing to support [if_then_else methods](https://github.com/enso-org/enso/pull/11365#issuecomment-2424625097)?
- [x] Are [engine benchmarks](https://github.com/enso-org/enso/actions/runs/19354416124) the same or better?
    - [another run](https://github.com/enso-org/enso/actions/runs/19497248379)
    - benchmarks are [on par](https://github.com/enso-org/enso/pull/11365#issuecomment-3553368500)
- [x] Are [stdlib benchmarks](https://github.com/enso-org/enso/actions/runs/19497299001) OK?