### PR TITLE
Increase backend log-level for e2e tests on Mac

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -441,7 +441,7 @@ jobs:
       - run: corepack pnpm -r --filter enso exec playwright test
         env:
           DEBUG: "pw:browser log:"
-          ENSO_TEST_APP_ARGS: --log-level=DEBUG
+          ENSO_TEST_APP_ARGS: -debug
           ENSO_TEST_USER: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_USERNAME }}
           ENSO_TEST_USER_PASSWORD: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -441,7 +441,7 @@ jobs:
       - run: corepack pnpm -r --filter enso exec playwright test
         env:
           DEBUG: "pw:browser log:"
-          ENSO_TEST_APP_ARGS: -debug
+          ENSO_TEST_APP_ARGS: -debug.verbose
           ENSO_TEST_USER: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_USERNAME }}
           ENSO_TEST_USER_PASSWORD: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -441,6 +441,7 @@ jobs:
       - run: corepack pnpm -r --filter enso exec playwright test
         env:
           DEBUG: "pw:browser log:"
+          ENSO_TEST_APP_ARGS: --log-level DEBUG
           ENSO_TEST_USER: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_USERNAME }}
           ENSO_TEST_USER_PASSWORD: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -441,7 +441,7 @@ jobs:
       - run: corepack pnpm -r --filter enso exec playwright test
         env:
           DEBUG: "pw:browser log:"
-          ENSO_TEST_APP_ARGS: --log-level DEBUG
+          ENSO_TEST_APP_ARGS: --log-level=DEBUG
           ENSO_TEST_USER: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_USERNAME }}
           ENSO_TEST_USER_PASSWORD: ${{ secrets.ENSO_CLOUD_TEST_ACCOUNT_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -536,7 +536,7 @@ impl JobArchetype for PackageIde {
                     // See https://askubuntu.com/questions/1512287/obsidian-appimage-the-suid-sandbox-helper-binary-was-found-but-is-not-configu
                     .with_env("ENSO_TEST_APP_ARGS", "--no-sandbox")
             } else if target.0 == OS::MacOS {
-                shell(TEST_COMMAND).with_env("ENSO_TEST_APP_ARGS", "-debug")
+                shell(TEST_COMMAND).with_env("ENSO_TEST_APP_ARGS", "-debug.verbose")
             } else {
                 shell(TEST_COMMAND)
             };

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -536,8 +536,7 @@ impl JobArchetype for PackageIde {
                     // See https://askubuntu.com/questions/1512287/obsidian-appimage-the-suid-sandbox-helper-binary-was-found-but-is-not-configu
                     .with_env("ENSO_TEST_APP_ARGS", "--no-sandbox")
             } else if target.0 == OS::MacOS {
-                shell(TEST_COMMAND)
-                    .with_env("ENSO_TEST_APP_ARGS", "--log-level DEBUG")
+                shell(TEST_COMMAND).with_env("ENSO_TEST_APP_ARGS", "--log-level DEBUG")
             } else {
                 shell(TEST_COMMAND)
             };

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -536,7 +536,7 @@ impl JobArchetype for PackageIde {
                     // See https://askubuntu.com/questions/1512287/obsidian-appimage-the-suid-sandbox-helper-binary-was-found-but-is-not-configu
                     .with_env("ENSO_TEST_APP_ARGS", "--no-sandbox")
             } else if target.0 == OS::MacOS {
-                shell(TEST_COMMAND).with_env("ENSO_TEST_APP_ARGS", "--log-level DEBUG")
+                shell(TEST_COMMAND).with_env("ENSO_TEST_APP_ARGS", "--log-level=DEBUG")
             } else {
                 shell(TEST_COMMAND)
             };

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -535,6 +535,9 @@ impl JobArchetype for PackageIde {
                 shell(format!("xvfb-run {TEST_COMMAND}"))
                     // See https://askubuntu.com/questions/1512287/obsidian-appimage-the-suid-sandbox-helper-binary-was-found-but-is-not-configu
                     .with_env("ENSO_TEST_APP_ARGS", "--no-sandbox")
+            } else if target.0 == OS::MacOS {
+                shell(TEST_COMMAND)
+                    .with_env("ENSO_TEST_APP_ARGS", "--log-level DEBUG")
             } else {
                 shell(TEST_COMMAND)
             };

--- a/build/build/src/ci_gen/job.rs
+++ b/build/build/src/ci_gen/job.rs
@@ -536,7 +536,7 @@ impl JobArchetype for PackageIde {
                     // See https://askubuntu.com/questions/1512287/obsidian-appimage-the-suid-sandbox-helper-binary-was-found-but-is-not-configu
                     .with_env("ENSO_TEST_APP_ARGS", "--no-sandbox")
             } else if target.0 == OS::MacOS {
-                shell(TEST_COMMAND).with_env("ENSO_TEST_APP_ARGS", "--log-level=DEBUG")
+                shell(TEST_COMMAND).with_env("ENSO_TEST_APP_ARGS", "-debug")
             } else {
                 shell(TEST_COMMAND)
             };


### PR DESCRIPTION
Need more info to debug frequent e2e test failures on MacOS.
Plenty of examples:
- https://github.com/enso-org/enso/actions/runs/11408557801/job/31748564550
- https://github.com/enso-org/enso/actions/runs/11406440897/job/31741927016?pr=11361

And many more.