### PR TITLE
Move annotations into fields of Function and ConstructorDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@
 [11235]: https://github.com/enso-org/enso/pull/11235
 [11255]: https://github.com/enso-org/enso/pull/11255
 
+#### Enso Language & Runtime
+
+- [Arguments in constructor definitions may now be on their own lines][11374]
+
+[11374]: https://github.com/enso-org/enso/pull/11374
+
 # Enso 2024.4
 
 #### Enso IDE

--- a/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres.enso
+++ b/distribution/lib/Standard/Database/0.0.0-dev/src/Connection/Postgres.enso
@@ -30,7 +30,14 @@ type Postgres
        - use_ssl: Whether to use SSL (defaults to `SSL_Mode.Prefer`).
        - client_cert: The client certificate to use or `Nothing` if not needed.
     @credentials Credentials.default_widget
-    Server (host:Text=default_postgres_host) (port:Integer=default_postgres_port) (database:Text=default_postgres_database) (schema:Text="") (credentials:(Credentials|Nothing)=Nothing) (use_ssl:SSL_Mode=SSL_Mode.Prefer) (client_cert:(Client_Certificate|Nothing)=Nothing)
+    Server
+        host : Text = default_postgres_host
+        port : Integer = default_postgres_port
+        database : Text = default_postgres_database
+        schema : Text = ""
+        credentials : Credentials|Nothing = Nothing
+        use_ssl : SSL_Mode = SSL_Mode.Prefer
+        client_cert : Client_Certificate|Nothing = Nothing
 
     ## PRIVATE
        Attempt to resolve the constructor.

--- a/distribution/lib/Standard/Table/0.0.0-dev/src/Data_Formatter.enso
+++ b/distribution/lib/Standard/Table/0.0.0-dev/src/Data_Formatter.enso
@@ -59,9 +59,9 @@ type Data_Formatter
        - time_formats: Expected time formats.
        - true_values: Values representing True.
        - false_values: Values representing False.
-    @datetime_formats (make_vector_widget make_date_time_format_selector)
-    @date_formats (make_vector_widget make_date_format_selector)
-    @time_formats (make_vector_widget make_time_format_selector)
+    @datetime_formats make_vector_widget make_date_time_format_selector
+    @date_formats make_vector_widget make_date_format_selector
+    @time_formats make_vector_widget make_time_format_selector
     Value trim_values:Boolean=True allow_leading_zeros:Boolean=False decimal_point:Text|Auto=Auto thousand_separator:Text='' allow_exponential_notation:Boolean=False datetime_formats:(Vector Date_Time_Formatter)=[Date_Time_Formatter.default_enso_zoned_date_time] date_formats:(Vector Date_Time_Formatter)=[Date_Time_Formatter.iso_date] time_formats:(Vector Text)=[Date_Time_Formatter.iso_time] true_values:(Vector Text)=["True","true","TRUE"] false_values:(Vector Text)=["False","false","FALSE"]
 
     ## PRIVATE
@@ -120,9 +120,9 @@ type Data_Formatter
        - datetime_formats: Expected datetime formats.
        - date_formats: Expected date formats.
        - time_formats: Expected time formats.
-    @datetime_formats (make_vector_widget make_date_time_format_selector)
-    @date_formats (make_vector_widget make_date_format_selector)
-    @time_formats (make_vector_widget make_time_format_selector)
+    @datetime_formats make_vector_widget make_date_time_format_selector
+    @date_formats make_vector_widget make_date_format_selector
+    @time_formats make_vector_widget make_time_format_selector
     with_datetime_formats : (Vector Date_Time_Formatter | Date_Time_Formatter) -> (Vector Date_Time_Formatter | Date_Time_Formatter) -> (Vector Date_Time_Formatter | Date_Time_Formatter) -> Data_Formatter
     with_datetime_formats self datetime_formats:(Vector | Date_Time_Formatter)=self.datetime_formats date_formats:(Vector | Date_Time_Formatter)=self.date_formats time_formats:(Vector | Date_Time_Formatter)=self.time_formats =
         convert_formats formats =

--- a/docs/syntax/types.md
+++ b/docs/syntax/types.md
@@ -297,6 +297,18 @@ below.
   fully support currying - e.g. one can create `fn = Maybe.Just` and later apply
   two to it (`fn 2`) to obtain new atom.
 
+  Constructor arguments may be defined on the same line as above (similarly to
+  the syntax for defining functions); alternatively, each argument may be
+  defined on its own line in an indented block following the constructor name.
+  This can make complex constructor definitions easier to read:
+
+  ```ruby
+  type Maybe
+      Nothing
+      Just
+          value : Integer
+  ```
+
 - **Autoscoped Constructors:** Referencing constructors via their type name may
   lead to long and boilerplate code. To simplify referencing constructors when
   the _context is known_ a special `..` syntax is supported. Should there be a

--- a/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ErrorCompilerTest.java
+++ b/engine/runtime-integration-tests/src/test/java/org/enso/compiler/test/ErrorCompilerTest.java
@@ -25,14 +25,14 @@ public class ErrorCompilerTest extends CompilerTests {
   }
 
   @Test
-  public void brokenAnnotation() throws Exception {
+  public void brokenAnnotationMissingArgument() throws Exception {
     var ir = parse("""
     @anno
     fn = 10
     """);
 
     assertSingleSyntaxError(
-        ir, Syntax.UnexpectedExpression$.MODULE$, "Unexpected expression", 0, 13);
+        ir, Syntax.UnexpectedExpression$.MODULE$, "Unexpected expression", 0, 5);
   }
 
   @Test

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/ModuleAnnotationsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/compiler/test/pass/resolve/ModuleAnnotationsTest.scala
@@ -7,6 +7,7 @@ import org.enso.compiler.core.ir.Function
 import org.enso.compiler.core.ir.Module
 import org.enso.compiler.core.ir.Name
 import org.enso.compiler.core.ir.expression.Comment
+import org.enso.compiler.core.ir.expression.errors
 import org.enso.compiler.core.ir.module.scope.Definition
 import org.enso.compiler.core.ir.module.scope.definition
 import org.enso.compiler.pass.{PassConfiguration, PassGroup, PassManager}
@@ -184,7 +185,7 @@ class ModuleAnnotationsTest extends CompilerTest {
       ir.bindings.head shouldBe a[Definition.SugaredType]
       val typ = ir.bindings.head.asInstanceOf[Definition.SugaredType]
       typ.body.length shouldEqual 3
-      typ.body(0) shouldBe an[Name.GenericAnnotation]
+      typ.body(0) shouldBe an[errors.Syntax]
       typ.body(1) shouldBe an[Comment]
       typ.body(2) shouldBe a[Definition.Data]
     }

--- a/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/ConstructorsTest.scala
+++ b/engine/runtime-integration-tests/src/test/scala/org/enso/interpreter/test/semantic/ConstructorsTest.scala
@@ -104,5 +104,30 @@ class ConstructorsTest extends InterpreterTest {
           |""".stripMargin
       eval(testCode) shouldEqual 55
     }
+
+    "support argument-definition lines" in {
+      val testCode =
+        """import Standard.Base.Nothing.Nothing
+          |import Standard.Base.Any.Any
+          |
+          |type C2
+          |    Cons2
+          |        # Each argument may be specified on its own indented line.
+          |        a
+          |        # Blank lines (or plain comments) are allowed between arguments.
+          |        b
+          |
+          |Nothing.genList = i -> if i == 0 then Nil2 else C2.Cons2 i (Nothing.genList (i - 1))
+          |
+          |type Nil2
+          |
+          |Nothing.sumList = list -> case list of
+          |  C2.Cons2 h t -> h + Nothing.sumList t
+          |  Nil2 -> 0
+          |
+          |main = Nothing.sumList (Nothing.genList 10)
+          |""".stripMargin
+      eval(testCode) shouldEqual 55
+    }
   }
 }

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
@@ -307,13 +307,19 @@ final class TreeToIr {
     var constructorName = buildName(cons, cons.getConstructor());
     var cAt = getIdentifiedLocation(cons);
     var isPrivate = cons.getPrivate() != null;
-    List<DefinitionArgument> args;
+    ArrayList<DefinitionArgument> args = new ArrayList<>();
     try {
-      args = translateArgumentsDefinition(cons.getArguments());
+      for (var arg : cons.getArguments())
+        args.add(translateArgumentDefinition(arg));
+      for (var argLine : cons.getBlock()) {
+        if (argLine.getArgument() instanceof ArgumentDefinition arg)
+          args.add(translateArgumentDefinition(arg));
+      }
     } catch (SyntaxException ex) {
       return join(ex.toError(), appendTo);
     }
-    final var def = new Definition.Data(constructorName, args, nil(), isPrivate, cAt, meta());
+    var argList = CollectionConverters.asScala(args.iterator()).toList();
+    var def = new Definition.Data(constructorName, argList, nil(), isPrivate, cAt, meta());
     return join(def, appendTo);
   }
 

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
@@ -38,7 +38,6 @@ import org.enso.syntax2.ArgumentDefinition;
 import org.enso.syntax2.Base;
 import org.enso.syntax2.DocComment;
 import org.enso.syntax2.FunctionAnnotation;
-import org.enso.syntax2.FunctionTypeSignature;
 import org.enso.syntax2.Line;
 import org.enso.syntax2.Parser;
 import org.enso.syntax2.TextElement;

--- a/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
+++ b/engine/runtime-parser/src/main/java/org/enso/compiler/core/TreeToIr.java
@@ -37,6 +37,8 @@ import org.enso.compiler.core.ir.module.scope.imports.Polyglot;
 import org.enso.syntax2.ArgumentDefinition;
 import org.enso.syntax2.Base;
 import org.enso.syntax2.DocComment;
+import org.enso.syntax2.FunctionAnnotation;
+import org.enso.syntax2.FunctionTypeSignature;
 import org.enso.syntax2.Line;
 import org.enso.syntax2.Parser;
 import org.enso.syntax2.TextElement;
@@ -271,17 +273,6 @@ final class TreeToIr {
         yield translateModuleSymbol(anno.getExpression(), join(annotation, appendTo));
       }
 
-      case Tree.Annotated anno -> {
-        if (anno.getArgument() == null) {
-          yield join(translateSyntaxError(anno, Syntax.UnexpectedExpression$.MODULE$), appendTo);
-        } else {
-          var annotationArgument = translateExpression(anno.getArgument());
-          var annotation = new Name.GenericAnnotation(anno.getAnnotation().codeRepr(),
-              annotationArgument, getIdentifiedLocation(anno), meta());
-          yield translateModuleSymbol(anno.getExpression(), join(annotation, appendTo));
-        }
-      }
-
       case Tree.Documented doc -> {
         var comment = translateComment(doc, doc.getDocumentation());
         yield translateModuleSymbol(doc.getExpression(), join(comment, appendTo));
@@ -309,7 +300,10 @@ final class TreeToIr {
     return res.reverse();
   }
 
-  IR translateConstructorDefinition(Tree.ConstructorDefinition cons) {
+  List<IR> translateConstructorDefinition(Tree.ConstructorDefinition cons, List<IR> appendTo) {
+    for (var annoLine : cons.getAnnotationLines()) {
+        appendTo = join(translateAnnotation(annoLine.getAnnotation()), appendTo);
+    }
     var constructorName = buildName(cons, cons.getConstructor());
     var cAt = getIdentifiedLocation(cons);
     var isPrivate = cons.getPrivate() != null;
@@ -317,9 +311,10 @@ final class TreeToIr {
     try {
       args = translateArgumentsDefinition(cons.getArguments());
     } catch (SyntaxException ex) {
-      return ex.toError();
+      return join(ex.toError(), appendTo);
     }
-    return new Definition.Data(constructorName, args, nil(), isPrivate, cAt, meta());
+    final var def = new Definition.Data(constructorName, args, nil(), isPrivate, cAt, meta());
+    return join(def, appendTo);
   }
 
   /**
@@ -344,8 +339,7 @@ final class TreeToIr {
     return switch (inputAst) {
       case null -> appendTo;
 
-      case Tree.ConstructorDefinition cons ->
-          join(translateConstructorDefinition(cons), appendTo);
+      case Tree.ConstructorDefinition cons -> translateConstructorDefinition(cons, appendTo);
 
       case Tree.TypeDef def -> {
         var ir = translateSyntaxError(def, Syntax.UnexpectedDeclarationInType$.MODULE$);
@@ -386,15 +380,8 @@ final class TreeToIr {
       case Tree.AnnotatedBuiltin anno -> {
         var ir = new Name.BuiltinAnnotation("@" + anno.getAnnotation().codeRepr(),
             getIdentifiedLocation(anno), meta());
-        var annotation = translateAnnotation(ir, anno.getExpression(), nil());
+        var annotation = translateBuiltinAnnotation(ir, anno.getExpression(), nil());
         yield join(annotation, appendTo);
-      }
-
-      case Tree.Annotated anno -> {
-        var annotationArgument = translateExpression(anno.getArgument());
-        var annotation = new Name.GenericAnnotation(anno.getAnnotation().codeRepr(),
-            annotationArgument, getIdentifiedLocation(anno), meta());
-        yield translateTypeBodyExpression(anno.getExpression(), join(annotation, appendTo));
       }
 
       default -> {
@@ -455,8 +442,21 @@ final class TreeToIr {
     }
   }
 
+  private Definition translateAnnotation(FunctionAnnotation anno) {
+    if (anno.getArgument() == null) {
+      return translateSyntaxError(getIdentifiedLocation(anno), Syntax.UnexpectedExpression$.MODULE$);
+    } else {
+      var annotationArgument = translateExpression(anno.getArgument());
+      return new Name.GenericAnnotation(anno.getAnnotation().codeRepr(),
+              annotationArgument, getIdentifiedLocation(anno), meta());
+    }
+  }
+
   private List<Definition> translateMethodBinding(Tree.Function fn, List<Definition> appendTo)
       throws SyntaxException {
+    for (var annoLine : fn.getAnnotationLines()) {
+      appendTo = join(translateAnnotation(annoLine.getAnnotation()), appendTo);
+    }
     if (fn.getSignatureLine() instanceof TypeSignatureLine sigLine) {
       appendTo = join(translateMethodTypeSignature(sigLine.getSignature()), appendTo);
     }
@@ -489,6 +489,9 @@ final class TreeToIr {
   }
 
   private List<IR> translateTypeMethodBinding(Tree.Function fun, List<IR> appendTo) {
+    for (var annoLine : fun.getAnnotationLines()) {
+      appendTo = join(translateAnnotation(annoLine.getAnnotation()), appendTo);
+    }
     if (fun.getSignatureLine() instanceof TypeSignatureLine sigLine) {
       appendTo = join(translateTypeSignature(sigLine.getSignature()), appendTo);
     }
@@ -1013,7 +1016,7 @@ final class TreeToIr {
       case Tree.AnnotatedBuiltin anno -> {
         var ir = new Name.BuiltinAnnotation("@" + anno.getAnnotation().codeRepr(),
             getIdentifiedLocation(anno), meta());
-        yield translateAnnotation(ir, anno.getExpression(), nil());
+        yield translateBuiltinAnnotation(ir, anno.getExpression(), nil());
       }
       // Documentation can be attached to an expression in a few cases, like if someone documents a line of an
       // `ArgumentBlockApplication`. The documentation is ignored.
@@ -1095,6 +1098,9 @@ final class TreeToIr {
         appendTo.add(translateAssignment(assign));
       }
       case Tree.Function fun -> {
+        for (var annoLine : fun.getAnnotationLines()) {
+          appendTo.add((Expression)translateAnnotation(annoLine.getAnnotation()));
+        }
         if (fun.getSignatureLine() instanceof TypeSignatureLine sigLine) {
           appendTo.add(translateTypeSignatureToOprApp(sigLine.getSignature()));
         }
@@ -1340,22 +1346,22 @@ final class TreeToIr {
     return new Application.Prefix(pref.function(), withBlockArgs, pref.hasDefaultsSuspended(), pref.identifiedLocation(), meta());
   }
 
-  private Application.Prefix translateAnnotation(Name.BuiltinAnnotation ir, Tree expr,
+  private Application.Prefix translateBuiltinAnnotation(Name.BuiltinAnnotation ir, Tree expr,
       List<CallArgument> callArgs) {
     return switch (expr) {
       case Tree.App fn -> {
         var fnAsArg = translateCallArgument(fn.getArg());
-        yield translateAnnotation(ir, fn.getFunc(), join(fnAsArg, callArgs));
+        yield translateBuiltinAnnotation(ir, fn.getFunc(), join(fnAsArg, callArgs));
       }
       case Tree.NamedApp fn -> {
         var fnAsArg = translateCallArgument(fn);
-        yield translateAnnotation(ir, fn.getFunc(), join(fnAsArg, callArgs));
+        yield translateBuiltinAnnotation(ir, fn.getFunc(), join(fnAsArg, callArgs));
       }
       case Tree.ArgumentBlockApplication fn -> {
         var fnAsArg = translateCallArgument(fn.getLhs());
         var arg = translateCallArgument(expr);
         callArgs = join(fnAsArg, join(arg, callArgs));
-        yield translateAnnotation(ir, null, callArgs);
+        yield translateBuiltinAnnotation(ir, null, callArgs);
       }
       case null -> {
         yield new Application.Prefix(ir, callArgs, false, ir.identifiedLocation(), meta());
@@ -1363,7 +1369,7 @@ final class TreeToIr {
       default -> {
         var arg = translateCallArgument(expr);
         callArgs = join(arg, callArgs);
-        yield translateAnnotation(ir, null, callArgs);
+        yield translateBuiltinAnnotation(ir, null, callArgs);
       }
     };
   }
@@ -1865,9 +1871,10 @@ final class TreeToIr {
   }
 
   private IdentifiedLocation expandToContain(IdentifiedLocation encapsulating, IdentifiedLocation inner) {
-    if (encapsulating == null || inner == null) {
+    if (encapsulating == null)
+      return inner;
+    if (inner == null)
       return encapsulating;
-    }
 
     if (encapsulating.start() > inner.start() || encapsulating.end() < inner.end()) {
       var start = Math.min(encapsulating.start(), inner.start());
@@ -1935,6 +1942,17 @@ final class TreeToIr {
     var location = new Location(begin_, end_);
     var uuid = idMap.get(location);
     return new IdentifiedLocation(begin_, end_, uuid);
+  }
+
+  private IdentifiedLocation getIdentifiedLocation(FunctionAnnotation anno) {
+    final var start = getIdentifiedLocation(anno.getOperator());
+    IdentifiedLocation end;
+    if (anno.getArgument() != null) {
+      end = getIdentifiedLocation(anno.getArgument());
+    } else {
+      end = getIdentifiedLocation(anno.getAnnotation());
+    }
+    return expandToContain(start, end);
   }
 
   private IdentifiedLocation getIdentifiedLocation(TypeSignature sig) {

--- a/lib/rust/parser/src/syntax/operator/annotations.rs
+++ b/lib/rust/parser/src/syntax/operator/annotations.rs
@@ -12,6 +12,7 @@ use crate::syntax::token::Associativity;
 use crate::syntax::token::Ident;
 use crate::syntax::token::Variant;
 use crate::syntax::tree;
+use crate::syntax::tree::FunctionAnnotation;
 use crate::syntax::tree::SyntaxError;
 use crate::syntax::treebuilding::Spacing;
 use crate::syntax::treebuilding::SpacingLookaheadTokenConsumer;
@@ -49,7 +50,8 @@ impl<'s> Annotation<'s> {
         if ident.is_type {
             Tree::annotated_builtin(operator, ident, default(), operand)
         } else {
-            Tree::annotated(operator, ident, operand, default(), default())
+            Tree::annotation(FunctionAnnotation { operator, annotation: ident, argument: operand })
+                .with_error(SyntaxError::AnnotationUnexpectedInExpression)
         }
     }
 }

--- a/lib/rust/prelude/macros/src/tagged_enum.rs
+++ b/lib/rust/prelude/macros/src/tagged_enum.rs
@@ -185,6 +185,7 @@ pub fn run(
             impl #impl_generics #enum_name #ty_generics #where_clause {
                 /// Constructor.
                 #[inline(always)]
+                #[allow(clippy::too_many_arguments)]
                 pub fn #variant_snake_ident(#(#names: #types),*) -> Self {
                     Self::#variant_name (#cons)
                 }
@@ -207,6 +208,7 @@ pub fn run(
             /// Constructor.
             #[inline(always)]
             #[allow(non_snake_case)]
+            #[allow(clippy::too_many_arguments)]
             pub fn #variant_name #impl_generics (#(#names: #types),*)
             -> #variant_name #ty_generics #where_clause {
                 #variant_name { #(#names),* }


### PR DESCRIPTION
### Pull Request Description

Move annotations into fields of Function and ConstructorDefinition.

### Important Notes

New syntax: Constructor argument-definition lines
- Each argument in a type-constructor definition may be specified on its own (indented) line.

Relaxed syntax: Unparenthesized arguments to annotations
- A generic annotation now uses the rest of the line as its argument expression; the expression no longer needs to be parenthesized.

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [ ] The documentation has been updated, if necessary.
- [ ] Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.
- [ ] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [ ] Unit tests have been written where possible.
- [ ] If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.
