### PR TITLE
Fix `AssetSearchBar` E2E tests

### DIFF
--- a/app/gui/e2e/dashboard/assetSearchBar.spec.ts
+++ b/app/gui/e2e/dashboard/assetSearchBar.spec.ts
@@ -5,7 +5,7 @@ import * as backend from '#/services/Backend'
 
 import * as actions from './actions'
 
-test.test('tags', async ({ page }) => {
+test.test('tags (positive)', async ({ page }) => {
   await actions.mockAllAndLogin({ page })
   const searchBarInput = actions.locateSearchBarInput(page)
   const tags = actions.locateSearchBarTags(page)
@@ -19,7 +19,14 @@ test.test('tags', async ({ page }) => {
     await positiveTag.click()
     await test.expect(searchBarInput).toHaveValue(text)
   }
+})
 
+test.test('tags (negative)', async ({ page }) => {
+  await actions.mockAllAndLogin({ page })
+  const searchBarInput = actions.locateSearchBarInput(page)
+  const tags = actions.locateSearchBarTags(page)
+
+  await searchBarInput.click()
   await page.keyboard.down('Shift')
   for (const negativeTag of await tags.all()) {
     await searchBarInput.selectText()

--- a/app/gui/e2e/dashboard/assetsTableFeatures.spec.ts
+++ b/app/gui/e2e/dashboard/assetsTableFeatures.spec.ts
@@ -90,6 +90,7 @@ test.test('can drop onto root directory dropzone', ({ page }) =>
     .driveTable.doubleClickRow(0)
     .driveTable.withRows(async (rows, nonAssetRows) => {
       const parentLeft = await actions.getAssetRowLeftPx(rows.nth(0))
+      await test.expect(nonAssetRows.nth(0)).toHaveText(actions.TEXT.thisFolderIsEmpty)
       const childLeft = await actions.getAssetRowLeftPx(nonAssetRows.nth(0))
       test.expect(childLeft, 'Child is indented further than parent').toBeGreaterThan(parentLeft)
     })

--- a/app/gui/playwright.config.ts
+++ b/app/gui/playwright.config.ts
@@ -10,7 +10,7 @@ import { defineConfig } from '@playwright/test'
 import net from 'net'
 
 const DEBUG = process.env.DEBUG_E2E === 'true'
-const TIMEOUT_MS = DEBUG ? 100_000_000 : 30_000
+const TIMEOUT_MS = DEBUG ? 100_000_000 : 60_000
 
 async function findFreePortInRange(min: number, max: number) {
   for (let i = 0; i < 50; i++) {


### PR DESCRIPTION
### Pull Request Description
- Fix https://github.com/enso-org/enso/issues/11368
  - Split "tags" E2E test into two tests to avoid timeout
- Fix https://github.com/enso-org/cloud-v2/issues/1551
  - Fix other flaky E2E tests

### Important Notes
None

### Checklist

Please ensure that the following checklist has been satisfied before submitting the PR:

- [x] ~~The documentation has been updated, if necessary.~~
- [x] ~~Screenshots/screencasts have been attached, if there are any visual changes. For interactive or animated visual changes, a screencast is preferred.~~
- [x] All code follows the
      [Scala](https://github.com/enso-org/enso/blob/develop/docs/style-guide/scala.md),
      [Java](https://github.com/enso-org/enso/blob/develop/docs/style-guide/java.md),
      [TypeScript](https://github.com/enso-org/enso/blob/develop/docs/style-guide/typescript.md),
      and
      [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md)
      style guides. In case you are using a language not listed above, follow the [Rust](https://github.com/enso-org/enso/blob/develop/docs/style-guide/rust.md) style guide.
- [x] ~~Unit tests have been written where possible.~~
- [x] ~~If meaningful changes were made to logic or tests affecting Enso Cloud integration in the libraries, 
      or the Snowflake database integration, a run of the [Extra Tests](https://github.com/enso-org/enso/actions/workflows/extra-nightly-tests.yml) has been scheduled.
  - If applicable, it is suggested to paste a link to a successful run of the Extra Tests.~~
